### PR TITLE
Support uploading DARs to the trigger service

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -9,8 +9,9 @@ import java.time.Duration
 import com.digitalasset.platform.services.time.TimeProviderType
 
 case class ServiceConfig(
-    // For now, we only support one dar.
-    darPath: Path,
+    // For convenience, we allow passing in a DAR on startup
+    // as opposed to uploading it dynamically.
+    darPath: Option[Path],
     ledgerHost: String,
     ledgerPort: Int,
     timeProviderType: TimeProviderType,
@@ -22,8 +23,8 @@ object ServiceConfig {
     head("trigger-service")
 
     opt[String]("dar")
-      .required()
-      .action((f, c) => c.copy(darPath = Paths.get(f)))
+      .optional()
+      .action((f, c) => c.copy(darPath = Some(Paths.get(f))))
       .text("Path to the dar file containing the trigger")
 
     opt[String]("ledger-host")

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -12,11 +12,15 @@ import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.FileInfo
 import akka.http.scaladsl.server.Route
 import akka.stream.{KillSwitch, KillSwitches, Materializer}
-import akka.util.Timeout
+import akka.stream.scaladsl.{Source}
+import akka.util.{ByteString, Timeout}
+import java.io.ByteArrayInputStream
 import java.time.Duration
 import java.util.UUID
+import java.util.zip.ZipInputStream
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.io.StdIn
@@ -28,6 +32,7 @@ import spray.json.DefaultJsonProtocol._
 
 import com.digitalasset.daml.lf.CompiledPackages
 import com.digitalasset.daml.lf.archive.{Dar, DarReader, Decode}
+import com.digitalasset.daml.lf.archive.Reader.ParseError
 import com.digitalasset.daml.lf.data.Ref._
 import com.digitalasset.daml.lf.engine.{
   ConcurrentCompiledPackages,
@@ -182,22 +187,7 @@ object Server {
   }
   implicit val triggerParamsFormat = jsonFormat2(TriggerParams)
 
-  def apply(
-      host: String,
-      port: Int,
-      ledgerConfig: LedgerConfig,
-      dar: Dar[(PackageId, Package)],
-  ): Behavior[Message] = Behaviors.setup { ctx =>
-    // http doesn't know about akka typed so provide untyped system
-    implicit val untypedSystem: akka.actor.ActorSystem = ctx.system.toClassic
-    implicit val materializer: Materializer = Materializer(untypedSystem)
-    implicit val esf: ExecutionSequencerFactory =
-      new AkkaExecutionSequencerPool("TriggerService")(untypedSystem)
-
-    var triggers: Map[UUID, ActorRef[TriggerActor.Message]] = Map.empty
-    // Mutable in preparation for dynamic package upload.
-    val compiledPackages: MutableCompiledPackages = ConcurrentCompiledPackages()
-
+  private def addDar(compiledPackages: MutableCompiledPackages, dar: Dar[(PackageId, Package)]) = {
     val darMap = dar.all.toMap
     darMap.foreach {
       case (pkgId, pkg) =>
@@ -212,30 +202,83 @@ object Server {
         }
         go(compiledPackages.addPackage(pkgId, pkg))
     }
+  }
 
+  def apply(
+      host: String,
+      port: Int,
+      ledgerConfig: LedgerConfig,
+      dar: Option[Dar[(PackageId, Package)]],
+  ): Behavior[Message] = Behaviors.setup { ctx =>
+    // http doesn't know about akka typed so provide untyped system
+    implicit val untypedSystem: akka.actor.ActorSystem = ctx.system.toClassic
+    implicit val materializer: Materializer = Materializer(untypedSystem)
+    implicit val esf: ExecutionSequencerFactory =
+      new AkkaExecutionSequencerPool("TriggerService")(untypedSystem)
+
+    var triggers: Map[UUID, ActorRef[TriggerActor.Message]] = Map.empty
+    // Mutable in preparation for dynamic package upload.
+    val compiledPackages: MutableCompiledPackages = ConcurrentCompiledPackages()
+    dar.foreach(addDar(compiledPackages, _))
+
+    // fileUpload seems to trigger that warning and I couldn't find
+    // a way to fix it so we disable the warning.
+    @SuppressWarnings(Array("org.wartremover.warts.Any"))
     val route = concat(
       post {
-        // Start a new trigger given its identifier and the party it should be running as.
-        // Returns a UUID for the newly started trigger.
-        path("start") {
-          entity(as[TriggerParams]) {
-            params =>
-              Trigger.fromIdentifier(compiledPackages, params.identifier) match {
-                case Left(err) =>
-                  complete((StatusCodes.UnprocessableEntity, err))
-                case Right(trigger) =>
-                  val uuid = UUID.randomUUID
-                  val ref = ctx.spawn(
-                    TriggerActor(
-                      TriggerActor.Config(compiledPackages, trigger, ledgerConfig, params.party)),
-                    uuid.toString,
-                  )
-                  triggers = triggers + (uuid -> ref)
-                  complete(uuid.toString)
+        concat(
+          // Start a new trigger given its identifier and the party it should be running as.
+          // Returns a UUID for the newly started trigger.
+          path("start") {
+            entity(as[TriggerParams]) {
+              params =>
+                Trigger.fromIdentifier(compiledPackages, params.identifier) match {
+                  case Left(err) =>
+                    complete((StatusCodes.UnprocessableEntity, err))
+                  case Right(trigger) =>
+                    val uuid = UUID.randomUUID
+                    val ref = ctx.spawn(
+                      TriggerActor(
+                        TriggerActor.Config(compiledPackages, trigger, ledgerConfig, params.party)),
+                      uuid.toString,
+                    )
+                    triggers = triggers + (uuid -> ref)
+                    complete(uuid.toString)
 
-              }
+                }
+            }
+          },
+          // upload a DAR as a multi-part form request with a single field called
+          // "dar".
+          path("upload_dar") {
+//            extractExecutionContext { implicit ec =>
+            fileUpload("dar") {
+              case (metadata: FileInfo, byteSource: Source[ByteString, Any]) =>
+                val byteStringF: Future[ByteString] = byteSource.runFold(ByteString(""))(_ ++ _)
+                onSuccess(byteStringF) {
+                  byteString =>
+                    val inputStream = new ByteArrayInputStream(byteString.toArray)
+                    DarReader()
+                      .readArchive("package-upload", new ZipInputStream(inputStream)) match {
+                      case Failure(err) => complete((StatusCodes.UnprocessableEntity, err))
+                      case Success(encodedDar) =>
+                        try {
+                          val dar = encodedDar.map {
+                            case (pkgId, payload) => Decode.readArchivePayload(pkgId, payload)
+                          }
+                          addDar(compiledPackages, dar)
+                          complete(s"DAR uploaded, main package id: ${dar.main._1}")
+                        } catch {
+                          case e: ParseError => complete((StatusCodes.UnprocessableEntity, e))
+                        }
+                    }
+                }
+              // foreach { byteString =>
+              //   println("GOT REQUEST")
+            }
           }
-        }
+          //        }
+        )
       },
       // Stop a trigger given its UUID
       delete {
@@ -307,7 +350,8 @@ object ServiceMain {
       host: String,
       port: Int,
       ledgerConfig: LedgerConfig,
-      dar: Dar[(PackageId, Package)]): Future[(ServerBinding, ActorSystem[Server.Message])] = {
+      dar: Option[Dar[(PackageId, Package)]])
+    : Future[(ServerBinding, ActorSystem[Server.Message])] = {
     val system: ActorSystem[Server.Message] =
       ActorSystem(Server(host, port, ledgerConfig, dar), "TriggerService")
     // timeout chosen at random, change freely if you see issues
@@ -321,10 +365,16 @@ object ServiceMain {
     ServiceConfig.parse(args) match {
       case None => sys.exit(1)
       case Some(config) =>
-        val encodedDar: Dar[(PackageId, DamlLf.ArchivePayload)] =
-          DarReader().readArchiveFromFile(config.darPath.toFile).get
-        val dar: Dar[(PackageId, Package)] = encodedDar.map {
-          case (pkgId, pkgArchive) => Decode.readArchivePayload(pkgId, pkgArchive)
+        val dar: Option[Dar[(PackageId, Package)]] = config.darPath.map {
+          case darPath =>
+            val encodedDar: Dar[(PackageId, DamlLf.ArchivePayload)] =
+              DarReader().readArchiveFromFile(darPath.toFile) match {
+                case Failure(err) => sys.error(s"Failed to read archive: $err")
+                case Success(dar) => dar
+              }
+            encodedDar.map {
+              case (pkgId, pkgArchive) => Decode.readArchivePayload(pkgId, pkgArchive)
+            }
         }
         val ledgerConfig =
           LedgerConfig(

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -251,7 +251,6 @@ object Server {
           // upload a DAR as a multi-part form request with a single field called
           // "dar".
           path("upload_dar") {
-//            extractExecutionContext { implicit ec =>
             fileUpload("dar") {
               case (metadata: FileInfo, byteSource: Source[ByteString, Any]) =>
                 val byteStringF: Future[ByteString] = byteSource.runFold(ByteString(""))(_ ++ _)
@@ -273,11 +272,8 @@ object Server {
                         }
                     }
                 }
-              // foreach { byteString =>
-              //   println("GOT REQUEST")
             }
           }
-          //        }
         )
       },
       // Stop a trigger given its UUID

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -138,7 +138,6 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
       triggerId <- resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
       resp <- stopTrigger(uri, triggerId)
       _ <- assert(resp.status.isSuccess)
-      // upload dar
     } yield succeed
   }
 
@@ -155,7 +154,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
         _ <- {
           val cmd = Command().withCreate(
             CreateCommand(
-              templateId = Some(Identifier(dar.main._1, "TestTrigger", "A")), // template id
+              templateId = Some(Identifier(dar.main._1, "TestTrigger", "A")),
               createArguments = Some(
                 Record(
                   None,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -3,12 +3,15 @@
 
 package com.digitalasset.daml.lf.engine.trigger
 
-import com.digitalasset.daml.lf.archive.{DarReader, Decode}
+import com.digitalasset.daml.lf.archive.{Dar, DarReader, Decode}
+import com.digitalasset.daml.lf.data.Ref._
+import com.digitalasset.daml.lf.language.Ast.Package
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.util.ByteString
-import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.{FileIO, Sink, Source}
+import java.io.File
 import java.time.Instant
 import java.util.UUID
 import org.scalatest._
@@ -34,7 +37,7 @@ import com.digitalasset.ledger.api.v1.transaction_filter.{
 import com.digitalasset.ledger.client.LedgerClient
 import com.digitalasset.ledger.client.services.commands.CommandUpdater
 
-class ServiceTest extends AsyncFlatSpec with Eventually {
+class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
 
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(15, Seconds)), interval = scaled(Span(1, Seconds)))
@@ -71,9 +74,10 @@ class ServiceTest extends AsyncFlatSpec with Eventually {
   implicit val esf: ExecutionSequencerFactory = new AkkaExecutionSequencerPool(testId)(system)
   implicit val ec: ExecutionContext = system.dispatcher
 
-  def withHttpService[A]: ((Uri, LedgerClient) => Future[A]) => Future[A] =
+  def withHttpService[A](triggerDar: Option[Dar[(PackageId, Package)]])
+    : ((Uri, LedgerClient) => Future[A]) => Future[A] =
     TriggerServiceFixture
-      .withTriggerService[A](testId, List(darPath), dar)
+      .withTriggerService[A](testId, List(darPath), triggerDar)
 
   def startTrigger(uri: Uri, id: String, party: String) = {
     val req = HttpRequest(
@@ -95,40 +99,74 @@ class ServiceTest extends AsyncFlatSpec with Eventually {
     Http().singleRequest(req)
   }
 
-  it should "should fail for non-existent trigger" in withHttpService { (uri: Uri, client) =>
-    for {
-      resp <- startTrigger(uri, s"${dar.main._1}:TestTrigger:foobar", "Alice")
-      body <- {
-        assert(resp.status == StatusCodes.UnprocessableEntity)
-        resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
-      }
-    } yield assert(body == "Could not find name foobar in module TestTrigger")
+  def uploadDar(uri: Uri, file: File) = {
+    val fileContentsSource: Source[ByteString, Any] = FileIO.fromPath(file.toPath)
+    val multipartForm = Multipart.FormData(
+      Multipart.FormData.BodyPart(
+        "dar",
+        HttpEntity.IndefiniteLength(ContentTypes.`application/octet-stream`, fileContentsSource),
+        Map("filename" -> file.toString)))
+    val req = HttpRequest(
+      method = HttpMethods.POST,
+      uri = uri.withPath(Uri.Path(s"/upload_dar")),
+      entity = multipartForm.toEntity
+    )
+    Http().singleRequest(req)
   }
 
-  it should "should enable a trigger on http request" in withHttpService { (uri: Uri, client) =>
-    // start the trigger
+  it should "should fail for non-existent trigger" in withHttpService(Some(dar)) {
+    (uri: Uri, client) =>
+      for {
+        resp <- startTrigger(uri, s"${dar.main._1}:TestTrigger:foobar", "Alice")
+        body <- {
+          assert(resp.status == StatusCodes.UnprocessableEntity)
+          resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
+        }
+      } yield assert(body == "Could not find name foobar in module TestTrigger")
+  }
+
+  it should "find a trigger after uploading it" in withHttpService(None) { (uri: Uri, client) =>
     for {
+      // attempt to start trigger before uploading which fails.
       resp <- startTrigger(uri, s"${dar.main._1}:TestTrigger:trigger", "Alice")
-      triggerId <- {
-        assert(resp.status.isSuccess)
-        resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
-      }
-      // Trigger is running, create an A contract
-      _ <- {
-        val cmd = Command().withCreate(
-          CreateCommand(
-            templateId = Some(Identifier(dar.main._1, "TestTrigger", "A")), // template id
-            createArguments = Some(
-              Record(
-                None,
-                Seq(
-                  RecordField(value = Some(Value().withParty("Alice"))),
-                  RecordField(value = Some(Value().withInt64(42)))))),
-          ))
-        submitCmd(client, "Alice", cmd)
-      }
-      // Query ACS until we see a B contract
-      // format: off
+      _ <- assert(resp.status == StatusCodes.UnprocessableEntity)
+      resp <- uploadDar(uri, darPath)
+      body <- resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
+      _ <- body should startWith("DAR uploaded")
+      resp <- startTrigger(uri, s"${dar.main._1}:TestTrigger:trigger", "Alice")
+      _ <- assert(resp.status.isSuccess)
+      triggerId <- resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
+      resp <- stopTrigger(uri, triggerId)
+      _ <- assert(resp.status.isSuccess)
+      // upload dar
+    } yield succeed
+  }
+
+  it should "should enable a trigger on http request" in withHttpService(Some(dar)) {
+    (uri: Uri, client) =>
+      // start the trigger
+      for {
+        resp <- startTrigger(uri, s"${dar.main._1}:TestTrigger:trigger", "Alice")
+        triggerId <- {
+          assert(resp.status.isSuccess)
+          resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
+        }
+        // Trigger is running, create an A contract
+        _ <- {
+          val cmd = Command().withCreate(
+            CreateCommand(
+              templateId = Some(Identifier(dar.main._1, "TestTrigger", "A")), // template id
+              createArguments = Some(
+                Record(
+                  None,
+                  Seq(
+                    RecordField(value = Some(Value().withParty("Alice"))),
+                    RecordField(value = Some(Value().withInt64(42)))))),
+            ))
+          submitCmd(client, "Alice", cmd)
+        }
+        // Query ACS until we see a B contract
+        // format: off
       _ <- Future {
         val filter = TransactionFilter(List(("Alice", Filters(Some(InclusiveFilters(Seq(Identifier(dar.main._1, "TestTrigger", "B"))))))).toMap)
         eventually {
@@ -141,7 +179,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually {
         }
       }
       // format: on
-      resp <- stopTrigger(uri, triggerId)
-    } yield (assert(resp.status.isSuccess))
+        resp <- stopTrigger(uri, triggerId)
+      } yield (assert(resp.status.isSuccess))
   }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -37,7 +37,7 @@ object TriggerServiceFixture {
   def withTriggerService[A](
       testName: String,
       dars: List[File],
-      dar: Dar[(PackageId, Package)],
+      dar: Option[Dar[(PackageId, Package)]],
   )(testFn: (Uri, LedgerClient) => Future[A])(
       implicit asys: ActorSystem,
       mat: Materializer,


### PR DESCRIPTION
This PR adds a new `upload_dar` endpoint that accepts a DAR as a
multi-part form request and adds it to the list of compiled packages.

I’ve also made the DAR passed in on startup optional now given the new
endpoint.

There is no endpoint for deleting a DAR so far but there is none on
the ledger API either so I think this not particularly urgent.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
