### PR TITLE
daml2ts: Simplify generated build config

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -60,7 +60,7 @@ configConsts sdkVersion = ConfigConsts
       , (NpmPackageName "typescript", NpmPackageVersion "~3.7.3")
       ]
   , pkgScripts = HMS.fromList
-      [ (ScriptName "build", Script "tsc --build")
+      [ (ScriptName "build", Script "tsc")
       , (ScriptName "lint", Script "eslint --ext .ts --max-warnings 0 src/")
       ]
   }
@@ -636,6 +636,7 @@ writeTsConfig dir =
       [ "compilerOptions" .= object
         [ "target" .= ("es5" :: T.Text)
         , "lib" .= (["dom", "es2015"] :: [T.Text])
+        , "skipLibCheck" .= True
         , "strict" .= True
         , "noUnusedLocals" .= False
         , "noImplicitReturns" .= True


### PR DESCRIPTION
We don't use TypeScript's project references. Hence there's no point in
passing `--build` to `tsc`. Let's stop doing that hence.

By default, the TypeScript compiler type checks the `.d.ts` of all
dependencies of a project. This is painfully slow. For the packages
generated by `daml2ts` it also doesn't make a lot of sense since we control
all dependencies except for `@mojotech/json-type-validation`, which is
written in TypeScript itself and hence has very sane typings anyway.

This default behaviour can be disabled by setting `skipLibCheck` to `true`.
Doing that decreases the compilation time of _every_ single package generated
by `daml2ts` for the DAVL project from ~10s to ~2s. Let's get that time back!

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5085)
<!-- Reviewable:end -->
