### PR TITLE
daml2ts: Remove "itself" from progress output

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -172,8 +172,10 @@ main = do
             \(pkgId, (mbPkgName, pkg)) -> do
                  let id = unPackageId pkgId
                      pkgName = packageNameText pkgId mbPkgName
-                     asName = if pkgName == id then "itself" else pkgName
-                 T.putStrLn $ "Generating " <> id <> " as " <> asName
+                 let pkgDesc = case mbPkgName of
+                       Nothing -> id
+                       Just pkgName -> unPackageName pkgName <> " (hash: " <> id <> ")"
+                 T.putStrLn $ "Generating " <> pkgDesc
                  daml2ts Daml2TsParams{..}
         setupWorkspace optInputPackageJson optOutputDir dependencies
 


### PR DESCRIPTION
I've received some feedback that the "itself" in
```
Generating <some hash> as itself
```
is confusing. Also, the first noun in each line said what is being
_processed_ not what is being _generated_. I've fixed that too.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5088)
<!-- Reviewable:end -->
