### PR TITLE
Sandbox: Make JdbcLedgerDao create its own execution context.

### DIFF
--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -32,7 +32,7 @@ import org.scalatest.{AsyncWordSpec, BeforeAndAfterEach, Matchers}
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, Future}
 import scala.util.Try
 
 class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with BeforeAndAfterEach {
@@ -221,7 +221,7 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
   private def index(implicit logCtx: LoggingContext): ResourceOwner[LedgerDao] = {
     val jdbcUrl =
       s"jdbc:h2:mem:${getClass.getSimpleName.toLowerCase()}-$testId;db_close_delay=-1;db_close_on_exit=false"
-    JdbcLedgerDao.writeOwner(jdbcUrl, new MetricRegistry, ExecutionContext.global)
+    JdbcLedgerDao.writeOwner(jdbcUrl, new MetricRegistry)
   }
 }
 

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -221,7 +221,7 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
   private def index(implicit logCtx: LoggingContext): ResourceOwner[LedgerDao] = {
     val jdbcUrl =
       s"jdbc:h2:mem:${getClass.getSimpleName.toLowerCase()}-$testId;db_close_delay=-1;db_close_on_exit=false"
-    JdbcLedgerDao.owner(jdbcUrl, new MetricRegistry, ExecutionContext.global)
+    JdbcLedgerDao.writeOwner(jdbcUrl, new MetricRegistry, ExecutionContext.global)
   }
 }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -33,7 +33,7 @@ object ReadOnlySqlLedger {
       metrics: MetricRegistry,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[ReadOnlyLedger] =
     for {
-      ledgerReadDao <- JdbcLedgerDao.readOwner(jdbcUrl, metrics, mat.executionContext)
+      ledgerReadDao <- JdbcLedgerDao.readOwner(jdbcUrl, metrics)
       factory = new Factory(ledgerReadDao)
       ledger <- ResourceOwner.forFutureCloseable(() => factory.createReadOnlySqlLedger(ledgerId))
     } yield ledger

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -16,13 +16,8 @@ import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.health.HealthStatus
 import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
 import com.digitalasset.platform.common.LedgerIdMismatchException
-import com.digitalasset.platform.store.dao.{
-  DbDispatcher,
-  JdbcLedgerDao,
-  LedgerReadDao,
-  MeteredLedgerReadDao
-}
-import com.digitalasset.platform.store.{BaseLedger, DbType, ReadOnlyLedger}
+import com.digitalasset.platform.store.dao.{JdbcLedgerDao, LedgerReadDao}
+import com.digitalasset.platform.store.{BaseLedger, ReadOnlyLedger}
 import com.digitalasset.resources.ProgramResource.StartupException
 import com.digitalasset.resources.ResourceOwner
 
@@ -31,25 +26,17 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 object ReadOnlySqlLedger {
 
-  val maxConnections = 16
-
   //jdbcUrl must have the user/password encoded in form of: "jdbc:postgresql://localhost/test?user=fred&password=secret"
   def owner(
       jdbcUrl: String,
       ledgerId: LedgerId,
       metrics: MetricRegistry,
-  )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[ReadOnlyLedger] = {
-    val dbType = DbType.jdbcType(jdbcUrl)
+  )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[ReadOnlyLedger] =
     for {
-      dbDispatcher <- DbDispatcher.owner(jdbcUrl, maxConnections, metrics)
-      ledgerReadDao = new MeteredLedgerReadDao(
-        JdbcLedgerDao(dbDispatcher, dbType, mat.executionContext),
-        metrics,
-      )
+      ledgerReadDao <- JdbcLedgerDao.readOwner(jdbcUrl, metrics, mat.executionContext)
       factory = new Factory(ledgerReadDao)
       ledger <- ResourceOwner.forFutureCloseable(() => factory.createReadOnlySqlLedger(ledgerId))
     } yield ledger
-  }
 
   private class Factory(ledgerDao: LedgerReadDao)(implicit logCtx: LoggingContext) {
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -61,7 +61,7 @@ final class JdbcIndexerFactory(
   ): ResourceOwner[JdbcIndexer] =
     for {
       materializer <- AkkaResourceOwner.forMaterializer(() => Materializer(actorSystem))
-      ledgerDao <- JdbcLedgerDao.writeOwner(jdbcUrl, metrics, actorSystem.dispatcher)
+      ledgerDao <- JdbcLedgerDao.writeOwner(jdbcUrl, metrics)
       initialLedgerEnd <- ResourceOwner.forFuture(() =>
         initializeLedger(ledgerDao)(materializer, executionContext))
     } yield new JdbcIndexer(initialLedgerEnd, participantId, ledgerDao, metrics)(materializer)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -66,7 +66,7 @@ object SqlLedger {
       if (dbType.supportsParallelWrites) defaultNumberOfShortLivedConnections else 1
     for {
       _ <- ResourceOwner.forFuture(() => new FlywayMigrations(jdbcUrl).migrate())
-      ledgerDao <- JdbcLedgerDao.writeOwner(jdbcUrl, metrics, mat.executionContext)
+      ledgerDao <- JdbcLedgerDao.writeOwner(jdbcUrl, metrics)
       ledger <- ResourceOwner.forFutureCloseable(
         () =>
           new SqlLedgerFactory(ledgerDao).createSqlLedger(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/DbDispatcher.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.platform.store.dao
 
 import java.sql.Connection
-import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
+import java.util.concurrent.{Executor, Executors, TimeUnit}
 
 import com.codahale.metrics.{MetricRegistry, Timer}
 import com.digitalasset.ledger.api.health.{HealthStatus, ReportsHealth}
@@ -18,14 +18,14 @@ import scala.util.control.NonFatal
 final class DbDispatcher private (
     val maxConnections: Int,
     connectionProvider: HikariJdbcConnectionProvider,
-    sqlExecutor: ExecutorService,
+    executor: Executor,
     metrics: MetricRegistry,
 )(implicit logCtx: LoggingContext)
     extends ReportsHealth {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 
-  private val sqlExecution = ExecutionContext.fromExecutorService(sqlExecutor)
+  private val executionContext = ExecutionContext.fromExecutor(executor)
 
   object Metrics {
     val waitAllTimer: Timer = metrics.timer("daml.index.db.all.wait")
@@ -81,30 +81,29 @@ final class DbDispatcher private (
               .error(s"$description: Got an exception while updating timer metrics. Ignoring.", t)
         }
       }
-    }(sqlExecution)
+    }(executionContext)
   }
 }
 
 object DbDispatcher {
   private val logger = ContextualizedLogger.get(this.getClass)
+
   def owner(
       jdbcUrl: String,
       maxConnections: Int,
       metrics: MetricRegistry,
-  )(implicit logCtx: LoggingContext): ResourceOwner[DbDispatcher] = {
+  )(implicit logCtx: LoggingContext): ResourceOwner[DbDispatcher] =
     for {
       connectionProvider <- HikariJdbcConnectionProvider.owner(jdbcUrl, maxConnections, metrics)
-      sqlExecutor <- ResourceOwner.forExecutorService(
+      executor <- ResourceOwner.forExecutorService(
         () =>
           Executors.newFixedThreadPool(
             maxConnections,
             new ThreadFactoryBuilder()
-              .setDaemon(true)
               .setNameFormat("sql-executor-%d")
               .setUncaughtExceptionHandler((_, e) =>
-                logger.error("Got an uncaught exception in SQL executor!", e))
+                logger.error("Uncaught exception in the SQL executor.", e))
               .build()
         ))
-    } yield new DbDispatcher(maxConnections, connectionProvider, sqlExecutor, metrics)
-  }
+    } yield new DbDispatcher(maxConnections, connectionProvider, executor, metrics)
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/DbDispatcher.scala
@@ -15,7 +15,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-final class DbDispatcher(
+final class DbDispatcher private (
     val maxConnections: Int,
     connectionProvider: HikariJdbcConnectionProvider,
     sqlExecutor: ExecutorService,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/LedgerDao.scala
@@ -32,13 +32,15 @@ import scala.concurrent.Future
 
 trait LedgerReadDao extends ReportsHealth {
 
+  def maxConcurrentConnections: Int
+
   /** Looks up the ledger id */
   def lookupLedgerId(): Future[Option[LedgerId]]
 
   /** Looks up the current ledger end */
   def lookupLedgerEnd(): Future[Offset]
 
-  /** Looks up the current external ledger end offset*/
+  /** Looks up the current external ledger end offset */
   def lookupInitialLedgerEnd(): Future[Option[Offset]]
 
   /** Looks up an active or divulged contract if it is visible for the given party. Archived contracts must not be returned by this method */
@@ -167,10 +169,12 @@ trait LedgerReadDao extends ReportsHealth {
 
 trait LedgerWriteDao extends ReportsHealth {
 
+  def maxConcurrentConnections: Int
+
   /**
     * Initializes the ledger. Must be called only once.
     *
-    * @param ledgerId  the ledger id to be stored
+    * @param ledgerId the ledger id to be stored
     */
   def initializeLedger(ledgerId: LedgerId, ledgerEnd: Offset): Future[Unit]
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
@@ -52,6 +52,8 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
       metrics.timer("daml.index.db.remove_expired_deduplication_data")
   }
 
+  override def maxConcurrentConnections: Int = ledgerDao.maxConcurrentConnections
+
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
 
   override def lookupLedgerId(): Future[Option[LedgerId]] =

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -31,10 +31,7 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll { this: Su
     resource = newLoggingContext { implicit logCtx =>
       for {
         _ <- Resource.fromFuture(new FlywayMigrations(jdbcUrl).migrate())
-        dbDispatcher <- DbDispatcher
-          .owner(jdbcUrl, 4, new MetricRegistry)
-          .acquire()
-        dao = JdbcLedgerDao(dbDispatcher, dbType, executionContext)
+        dao <- JdbcLedgerDao.writeOwner(jdbcUrl, new MetricRegistry, executionContext).acquire()
         _ <- Resource.fromFuture(dao.initializeLedger(LedgerId("test-ledger"), Offset.begin))
       } yield dao
     }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -31,7 +31,7 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll { this: Su
     resource = newLoggingContext { implicit logCtx =>
       for {
         _ <- Resource.fromFuture(new FlywayMigrations(jdbcUrl).migrate())
-        dao <- JdbcLedgerDao.writeOwner(jdbcUrl, new MetricRegistry, executionContext).acquire()
+        dao <- JdbcLedgerDao.writeOwner(jdbcUrl, new MetricRegistry).acquire()
         _ <- Resource.fromFuture(dao.initializeLedger(LedgerId("test-ledger"), Offset.begin))
       } yield dao
     }


### PR DESCRIPTION
This was supposed to be a small thing that kind of got away from me.

Pushing `JdbcLedgerDao` operations onto the actor system dispatcher is, well, a bit odd, and could cause bottlenecks. This PR changes that so it creates its own execution context, similar to `DbDispatcher`.

Ideally, I think `JdbcLedgerDao` should be the thing managing the futures, and `DbDispatcher` should be synchronous.

This came about as I was removing `JdbcLedgerDao.apply`, because it's dangerous, and making execution contexts a little more implicit for ease of reading.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
