### PR TITLE
Fix bazel rule which generates daml.yaml 

### DIFF
--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 The DAML Authors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
+load("@build_environment//:configuration.bzl", "ghc_version")
 
 _damlc = attr.label(
     allow_single_file = True,
@@ -33,7 +33,7 @@ def _daml_configure_impl(ctx):
             dependencies: []
             build-options: [{target}]
         """.format(
-            sdk = sdk_version,
+            sdk = ghc_version,
             name = project_name,
             version = project_version,
             target = "--target=" + target if (target) else "",


### PR DESCRIPTION
Fix for code added in PR #5070 

Use ghc_version not SDK version. 
sdk_version will break when you are on a snapshot release commit.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
