### PR TITLE
Sandbox: Remove duplication in `JdbcIndexerFactory`.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -47,16 +47,18 @@ final class JdbcIndexerFactory(
   ): Future[ResourceOwner[JdbcIndexer]] =
     new FlywayMigrations(jdbcUrl)
       .validate()
-      .map(_ => initialized)
+      .map(_ => initialized())
 
   def migrateSchema(allowExistingSchema: Boolean)(
       implicit executionContext: ExecutionContext
   ): Future[ResourceOwner[JdbcIndexer]] =
     new FlywayMigrations(jdbcUrl)
       .migrate(allowExistingSchema)
-      .map(_ => initialized)
+      .map(_ => initialized())
 
-  private def initialized(implicit executionContext: ExecutionContext): ResourceOwner[JdbcIndexer] =
+  private def initialized()(
+      implicit executionContext: ExecutionContext
+  ): ResourceOwner[JdbcIndexer] =
     for {
       materializer <- AkkaResourceOwner.forMaterializer(() => Materializer(actorSystem))
       ledgerDao <- JdbcLedgerDao.owner(jdbcUrl, metrics, actorSystem.dispatcher)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -52,7 +52,7 @@ final class StandaloneIndexerServer(
 
   private def startIndexer(
       indexer: RecoveringIndexer,
-      initializedIndexerFactory: InitializedJdbcIndexerFactory,
+      initializedIndexerFactory: ResourceOwner[JdbcIndexer],
       actorSystem: ActorSystem,
   )(implicit executionContext: ExecutionContext): Resource[Unit] =
     indexer


### PR DESCRIPTION
### Summary of changes

- Moves the list of parameters from `def owner` to the constructor, because we know everything at construction time and were even passing in `jdbcUrl` twice.
- Removes the `InitializedJdbcIndexerFactory` in favor of a simple function that returns a `ResourceOwner[JdbcIndexer]`.
- Restructures the helper methods a little.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
