### PR TITLE
Refactor transaction generation and add utilities

### DIFF
--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
@@ -28,7 +28,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
   it should "return the expected completion for an accepted transaction" in {
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      (offset, tx) <- storeCreateTransaction()
+      (offset, tx) <- store(singleCreate)
       to <- ledgerDao.lookupLedgerEnd()
       (_, response) <- ledgerDao.completions
         .getCommandCompletions(from, to, tx.applicationId.get, Set(tx.submittingParty.get))


### PR DESCRIPTION
Makes storing and generating test transaction more composable (store just takes a generated transaction)

- Add a nonTransient utility method to retrieve contracts that have been created but not consumed as part of a transaction
- Add an addChildren utility method to add children to a transaction to allow to create more complex test transactions
- Add a transaction generator that uses the aforementioned addChildren to create a more complex transaction

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
