### PR TITLE
Getting started guide: Invoke daml start directly

### DIFF
--- a/docs/source/app-dev/app-arch.rst
+++ b/docs/source/app-dev/app-arch.rst
@@ -45,7 +45,7 @@ with a JSON API server by running
 
 .. code-block:: bash
 
-  ./daml-start.sh
+  daml start --start-navigator=no
 
 in the root of the project. This is the most simple DAML ledger implementation. Once your
 application matures and becomes ready for production, the ``daml deploy`` command helps you deploy

--- a/docs/source/getting-started/first-feature.rst
+++ b/docs/source/getting-started/first-feature.rst
@@ -21,7 +21,7 @@ There are three parts to building and running the messaging feature:
 
     1. Adding the necessary changes to the DAML model  
     2. Making the corresponding changes in the UI
-    3. Running the new feature. In order to do that we need to terminate the previous ``./daml-start.sh`` process and run it again.  
+    3. Running the new feature. In order to do that we need to terminate the previous ``daml start --start-navigator=no`` process and run it again.
 
 As usual, we must start with the DAML model and base our UI changes on top of that.
 
@@ -180,13 +180,13 @@ Let's give the new functionality a spin.
 Running the New Feature
 =======================
 
-We need to terminate the previous ``./daml-start.sh`` process and run it again, as we need to have a Sandbox instance with a DAR file containing the new feature. As a reminder, by running ``./daml-start.sh`` again we will 
+We need to terminate the previous ``daml start --start-navigator=no`` process and run it again, as we need to have a Sandbox instance with a DAR file containing the new feature. As a reminder, by running ``daml start --start-navigator=no`` again we will
 
   - Compile our DAML code into a *DAR file containing the new feature*
   - Run a fresh instance of the *Sandbox with the new DAR file*
   - Start the HTTP JSON API 
 
-First, navigate to the terminal window where the ``daml-start.sh`` process is running and terminate the active process by hitting ``Ctrl-C``. This shuts down the previous instances of the sandbox. Next in the root ``create-daml-app`` folder run ``./daml-start.sh``.
+First, navigate to the terminal window where the ``daml start --start-navigator=no`` process is running and terminate the active process by hitting ``Ctrl-C``. This shuts down the previous instances of the sandbox. Next in the root ``create-daml-app`` folder run ``daml start --start-navigator=no``.
 
 As mentioned at the beginning of this *Getting Started with DAML* guide, DAML Sandbox uses an in-memory store, which means it loses its state when stopped or restarted. That means that all user data and follower relationships are lost. 
 

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -82,7 +82,7 @@ In one terminal, at the root of the ``create-daml-app`` directory, run the comma
 
     daml start --start-navigator=no
 
-You will know that the command has started successfully when you see the ``INFO  com.digitalasset.http.Main$ - Started server: ServerBinding(/0:0:0:0:0:0:0:0:7575)`` message in the terminal. The command does a few things:
+You will know that the command has started successfully when you see the ``INFO  com.digitalasset.http.Main$ - Started server: ServerBinding(/127.0.0.1:7575)`` message in the terminal. The command does a few things:
 
     1. Compiles the DAML code to a DAR file as in the previous ``daml build`` step.
     2. Starts an instance of the :doc:`Sandbox </tools/sandbox>`, an in-memory ledger useful for development, loaded with our DAR.

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -78,11 +78,11 @@ You should see ``Compiled successfully.`` in the output if everything worked as 
 
 We can now run the app in two steps.
 You'll need two terminal windows running for this.
-In one terminal, at the root of the ``create-daml-app`` directory, run the script::
+In one terminal, at the root of the ``create-daml-app`` directory, run the command::
 
-    ./daml-start.sh
+    daml start --start-navigator=no
 
-You will know that script has run successfully when you see the ``INFO  com.digitalasset.http.Main$ - Started server: ServerBinding(/0:0:0:0:0:0:0:0:7575)`` message in terminal. The script is just shorthand for ``daml start`` with some arguments, which does a few things:
+You will know that the command has started successfully when you see the ``INFO  com.digitalasset.http.Main$ - Started server: ServerBinding(/0:0:0:0:0:0:0:0:7575)`` message in the terminal. The command does a few things:
 
     1. Compiles the DAML code to a DAR file as in the previous ``daml build`` step.
     2. Starts an instance of the :doc:`Sandbox </tools/sandbox>`, an in-memory ledger useful for development, loaded with our DAR.


### PR DESCRIPTION
Since we no can configure arguments we wish to pass to DAML Sandbox
when running `daml start` in `daml.yaml`, we don't need the mysterious
`daml-start.sh` script anymore. That's why
https://github.com/digital-asset/create-daml-app/pull/78
removes the script from `create-daml-app`.

This PR adjust the getting started guide accordingly.

This fixes #4295.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5102)
<!-- Reviewable:end -->
