### PR TITLE
Remove bzip2 library

### DIFF
--- a/BAZEL-haskell.md
+++ b/BAZEL-haskell.md
@@ -136,7 +136,6 @@ stack_snapshot(
         ...
     ],
     deps = {
-        "bzlib-conduit": ["@bzip2//:libbz2"],
         "digest": ["@com_github_madler_zlib//:libz"],
         "zlib": ["@com_github_madler_zlib//:libz"],
     },

--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -459,7 +459,6 @@ exports_files(["stack.exe"], visibility = ["//visibility:public"])
     stack_snapshot(
         name = "stackage",
         extra_deps = {
-            "bzlib-conduit": ["@bzip2//:libbz2"],
             "digest": ["@com_github_madler_zlib//:libz"],
             "zlib": ["@com_github_madler_zlib//:libz"],
         },
@@ -468,6 +467,7 @@ exports_files(["stack.exe"], visibility = ["//visibility:public"])
                 "ghcide": ["ghc-lib"],
                 "hlint": ["ghc-lib"],
                 "ghc-lib-parser-ex": ["ghc-lib"],
+                "zip": ["disable-bzip2"],
             },
             {
                 "blaze-textual": ["integer-simple"],

--- a/deps.bzl
+++ b/deps.bzl
@@ -91,15 +91,6 @@ def daml_deps():
             sha256 = "6d4d6640ca3121620995ee255945161821218752b551a1a180f4215f7d124d45",
         )
 
-    if "bzip2" not in native.existing_rules():
-        http_archive(
-            name = "bzip2",
-            build_file = "@com_github_digital_asset_daml//3rdparty/c:bzip2.BUILD",
-            strip_prefix = "bzip2-1.0.8",
-            urls = ["https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
-            sha256 = "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269",
-        )
-
     if "io_bazel_rules_go" not in native.existing_rules():
         http_archive(
             name = "io_bazel_rules_go",


### PR DESCRIPTION
This used to be a dependency of our zip library that you couldn’t
disable. However, in the meantime it has gotten a flag to disable
it and we don’t actually use it. Given that the upstream URL is dead
atm now seems like a good time to kill it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
