### PR TITLE
DAML-LF: contract id spec

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1000,7 +1000,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       partyEvents.roots.length shouldBe 1
       val bobExercise = partyEvents.events(partyEvents.roots(0))
       val cid =
-        AbsoluteContractId("0b39433a649bebecd3b01d651be38a75923efdb92f34592b5600aee3fec8a8cc3")
+        AbsoluteContractId("00b39433a649bebecd3b01d651be38a75923efdb92f34592b5600aee3fec8a8cc3")
       bobExercise shouldBe
         ExerciseEvent(
           contractId = AbsoluteContractId(originalCoid),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Ordering.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Ordering.scala
@@ -115,7 +115,7 @@ object Ordering extends scala.math.Ordering[SValue] {
     s.forall(x => '0' < x && x < '9' || 'a' < x && x < 'f')
 
   @inline
-  private val underlyingCidDiscriminatorLength = 65
+  private val underlyingCidDiscriminatorLength = 66
 
   private def compareCid(cid1: Ref.ContractIdString, cid2: Ref.ContractIdString): Int = {
     // FIXME https://github.com/digital-asset/daml/issues/2256

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -240,7 +240,7 @@ case class PartialTransaction(
         Value.RelativeContractId(Value.NodeId(nextNodeIdx))
       )(
         hash =>
-          Value.AbsoluteContractId(Ref.ContractIdString.assertFromString("0" + hash.toHexString))
+          Value.AbsoluteContractId(Ref.ContractIdString.assertFromString("00" + hash.toHexString))
       )
       val createNode = Node.NodeCreate(
         nodeSeed,

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -490,8 +490,6 @@ ordering. Text-like literals (``LitText`` and ``LitParty``) are
 ordered lexicographically. In the followinng we will denote the
 corresponding (non-strict) order by ``≤ₗ``.
 
-
-
 Identifiers
 ~~~~~~~~~~~
 
@@ -553,9 +551,6 @@ strings as *package identifiers*.  ::
   Module names
         ModName ::= Name                            -- ModName
 
-  Contract identifiers
-           cid                                      -- ContractId
-
   Package identifiers
            pid  ::=  PackageIdString                -- PkgId
 
@@ -565,12 +560,24 @@ strings as *package identifiers*.  ::
   Package versions
            pversion ::= PackageVersionString        -- PackageVersion
 
-We do not specify an explicit syntax for contract identifiers as it is
-not possible to refer to them statically within a program. In
-practice, contract identifiers can be created dynamically through
-interactions with the underlying ledger. See the `operation semantics
-of update statements <Update Interpretation_>`_ for the formal
-specification of those interactions.
+  V0 Contract identifiers:
+          cidV0  ∈  #[a-zA-Z0-9\._:-#/ ]+           -- V0ContractId
+
+  V1 Contract identifiers:
+          cidV1  ∈  00([0-9a-f][0-9a-f]){32,190}    -- V1ContractId
+
+  Contract identifiers:
+          cid := cidV0 | cidV1                      -- ContractId
+
+Contract identifiers can be created dynamically through interactions
+with the underlying ledger. See the `operation semantics of update
+statements <Update Interpretation_>`_ for the formal specification of
+those interactions. Contract identifiers are naturally ordered
+lexicographically. DAML-LF >= 1.dev programs creates only V1 Contract
+identifiers but can handle identifiers for contracts previously
+created with an older version of DAML-LF. Older version of DAML-LF can
+created both kinds of contract identifiers depending on the
+configuration of the ledger.
 
 Also note that package identifiers are typically `cryptographic hash
 <Package hash_>`_ of the content of the package itself.

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -564,7 +564,7 @@ strings as *package identifiers*.  ::
           cidV0  ∈  #[a-zA-Z0-9\._:-#/ ]+           -- V0ContractId
 
   V1 Contract identifiers:
-          cidV1  ∈  00([0-9a-f][0-9a-f]){32,190}    -- V1ContractId
+          cidV1  ∈  00([0-9a-f][0-9a-f]){32,96}    -- V1ContractId
 
   Contract identifiers:
           cid := cidV0 | cidV1                      -- ContractId

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -572,10 +572,12 @@ strings as *package identifiers*.  ::
 Contract identifiers can be created dynamically through interactions
 with the underlying ledger. See the `operation semantics of update
 statements <Update Interpretation_>`_ for the formal specification of
-those interactions. The version of contract identifiers created by
-DAML-LF engine depends of its configuration. A DAML-LF compliant
-engine should refuse to load DAML-LF >= 1.dev archives when
-configured to produce V0 contract identifier.
+those interactions. Depending on its configuration, a DAML-LF engine
+can produce V0 or V1 contract identifiers.  When configured to produce
+V0 contract identifiers, a DAML-LF compliant engine must refuse to
+load any DAML-LF >= 1.dev archives.  On the contrary, when configured
+to produce V1 contract ids, a DAML-LF compliant engine must accept to
+load any DAML-LF version.
 
 Also note that package identifiers are typically `cryptographic hash
 <Package hash_>`_ of the content of the package itself.

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -572,12 +572,10 @@ strings as *package identifiers*.  ::
 Contract identifiers can be created dynamically through interactions
 with the underlying ledger. See the `operation semantics of update
 statements <Update Interpretation_>`_ for the formal specification of
-those interactions. Contract identifiers are naturally ordered
-lexicographically. DAML-LF >= 1.dev programs creates only V1 Contract
-identifiers but can handle identifiers for contracts previously
-created with an older version of DAML-LF. Older version of DAML-LF can
-created both kinds of contract identifiers depending on the
-configuration of the ledger.
+those interactions. The version of contract identifiers created by
+DAML-LF engine depends of its configuration. A DAML-LF compliant
+engine should refuse to load DAML-LF >= 1.dev archives when
+configured to produce V0 contract identifier.
 
 Also note that package identifiers are typically `cryptographic hash
 <Package hash_>`_ of the content of the package itself.

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.daml.lf
 package value
 
+import com.digitalasset.daml.lf.crypto.Hash
 import com.digitalasset.daml.lf.data.Ref.{ContractIdString, Identifier, Name}
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.LanguageVersion
@@ -349,19 +350,7 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
     */
   sealed trait ContractId
 
-  final case class AbsoluteContractId(coid: ContractIdString) extends ContractId {
-    lazy val discriminator =
-      if (coid.startsWith("00"))
-        crypto.Hash.fromString(coid.slice(2, 66)).toOption
-      else
-        None
-    lazy val suffix: String =
-      if (discriminator.isDefined)
-        Some(coid.drop(66))
-      else
-        None
-  }
-
+  final case class AbsoluteContractId(coid: ContractIdString) extends ContractId
   final case class RelativeContractId(txnid: NodeId) extends ContractId
 
   object ContractId {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -4,7 +4,6 @@
 package com.digitalasset.daml.lf
 package value
 
-import com.digitalasset.daml.lf.crypto.Hash
 import com.digitalasset.daml.lf.data.Ref.{ContractIdString, Identifier, Name}
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.LanguageVersion

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -350,12 +350,16 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
   sealed trait ContractId
 
   final case class AbsoluteContractId(coid: ContractIdString) extends ContractId {
-    lazy val descriminator =
-      if (coid(0) == '0')
-        crypto.Hash.fromString(coid.slice(1, 65)).toOption
+    lazy val discriminator =
+      if (coid.startsWith("00"))
+        crypto.Hash.fromString(coid.slice(2, 66)).toOption
       else
         None
-    lazy val suffix: String = coid.drop(65)
+    lazy val suffix: String =
+      if (discriminator.isDefined)
+        Some(coid.drop(66))
+      else
+        None
   }
 
   final case class RelativeContractId(txnid: NodeId) extends ContractId


### PR DESCRIPTION
This PR specifies the syntax of contract id. 

We choose base16 encoding for the following reasons: 

* We use this encoding already (for packageId, stable offset) 
* Standard 
* Fast encoding/decoding to byte array
* Have the same lexicographical order than the underlying array
* Be conveniently copy/paste in a browser
* Be able to split version prefix (0-2 chars), discriminator (2-66 chars ), and suffix (66-192 chars)
* Be able to the spit (version prefix, discriminator, suffix) easily on string or the byte array representation
* Be without confusing characters (eg we do not have both '0' and 'O')

The main drawback of this choice is the length of the ids. 

This advances the state of #3830 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
