### PR TITLE
Bumping up http-json tests size to large, adding some extra logging

### DIFF
--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -107,9 +107,10 @@ daml_compile(
     srcs = ["src/test/daml/Account.daml"],
 )
 
+# TODO(Leo): #5108, split tests into two targets: unit and integration
 da_scala_test(
     name = "tests",
-    size = "medium",
+    size = "large",
     srcs = glob(["src/test/scala/**/*.scala"]),
     data = [
         ":Account.dar",

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -318,6 +318,7 @@ class WebSocketService(
       .mapAsync(1) {
         case msg: TextMessage =>
           msg.toStrict(config.maxDuration).map { m =>
+            logger.info(s"request: ${m.text}")
             SprayJson.parse(m.text).liftErr(InvalidUserInput)
           }
         case _ =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -318,7 +318,6 @@ class WebSocketService(
       .mapAsync(1) {
         case msg: TextMessage =>
           msg.toStrict(config.maxDuration).map { m =>
-            logger.info(s"request: ${m.text}")
             SprayJson.parse(m.text).liftErr(InvalidUserInput)
           }
         case _ =>

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
@@ -99,10 +99,11 @@ class WebsocketServiceIntegrationTest
       query: String,
       offset: Option[domain.Offset] = None): Source[Message, NotUsed] = {
     import spray.json._, json.JsonProtocol._
-    val webSocketFlow = Http().webSocketClientFlow(
-      WebSocketRequest(
-        uri = serviceUri.copy(scheme = "ws").withPath(Uri.Path("/v1/stream/query")),
-        subprotocol = validSubprotocol))
+    val uri = serviceUri.copy(scheme = "ws").withPath(Uri.Path("/v1/stream/query"))
+    logger.info(
+      s"---- singleClientQueryStream uri: ${uri.toString}, query: $query, offset: ${offset.toString}")
+    val webSocketFlow =
+      Http().webSocketClientFlow(WebSocketRequest(uri = uri, subprotocol = validSubprotocol))
     offset
       .cata(
         off =>
@@ -116,10 +117,10 @@ class WebsocketServiceIntegrationTest
   private def singleClientFetchStream(
       serviceUri: Uri,
       request: String): Source[Message, NotUsed] = {
-    val webSocketFlow = Http().webSocketClientFlow(
-      WebSocketRequest(
-        uri = serviceUri.copy(scheme = "ws").withPath(Uri.Path("/v1/stream/fetch")),
-        subprotocol = validSubprotocol))
+    val uri = serviceUri.copy(scheme = "ws").withPath(Uri.Path("/v1/stream/fetch"))
+    logger.info(s"---- singleClientFetchStream uri: ${uri.toString}, request: $request")
+    val webSocketFlow =
+      Http().webSocketClientFlow(WebSocketRequest(uri = uri, subprotocol = validSubprotocol))
     Source
       .single(TextMessage(request))
       .via(webSocketFlow)


### PR DESCRIPTION
Related to #5108.

Tried switching to `da_scala_test_suite`, it did not work, need some refactoring to extract test library, test_suite supposed to have no dependencies on other files in the suite.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
