### PR TITLE
DAML script runner takes CompiledPackages

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -212,7 +212,8 @@ class ReplService(val clients: Participants[LedgerClient], ec: ExecutionContext,
 
     val darMap = dar.all.toMap
     val compiler = Compiler(darMap)
-    val compiledPackages = PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys)).right.get
+    val compiledPackages =
+      PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys)).right.get
     val runner = new Runner(
       compiledPackages,
       Script.Action(scriptExpr, ScriptIds(scriptPackageId)),

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -200,12 +200,15 @@ class ReplService(val clients: Participants[LedgerClient], ec: ExecutionContext,
     val (scriptPackageId, _) = packages.find {
       case (pkgId, pkg) => pkg.modules.contains(DottedName.assertFromString("Daml.Script"))
     }.get
-    val runner = new Runner(
-      dar,
-      ScriptIds(scriptPackageId),
-      ApplicationId("daml repl"),
-      commandUpdater,
-      TimeProvider.UTC)
+    val runner = Runner
+      .fromDar(
+        dar,
+        ScriptIds(scriptPackageId),
+        ApplicationId("daml repl"),
+        commandUpdater,
+        TimeProvider.UTC)
+      .right
+      .get
     var scriptExpr: SExpr = SEVal(
       LfDefRef(
         Identifier(homePackageId, QualifiedName(mod.name, DottedName.assertFromString("expr")))),

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -7,6 +7,7 @@ import akka.actor.ActorSystem
 import akka.stream._
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.auth.TokenHolder
+import com.digitalasset.daml.lf.PureCompiledPackages
 import com.digitalasset.daml.lf.archive.Dar
 import com.digitalasset.daml.lf.archive.Decode
 import com.digitalasset.daml.lf.data.Ref._
@@ -14,7 +15,7 @@ import com.digitalasset.daml.lf.engine.script._
 import com.digitalasset.daml.lf.language.Ast._
 import com.digitalasset.daml.lf.language.{Ast, LanguageVersion}
 import com.digitalasset.daml.lf.speedy.SExpr._
-import com.digitalasset.daml.lf.speedy.{SValue, SExpr}
+import com.digitalasset.daml.lf.speedy.{Compiler, SValue, SExpr}
 import com.digitalasset.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.digitalasset.ledger.api.refinements.ApiTypes.{ApplicationId}
 import com.digitalasset.ledger.api.tls.TlsConfiguration
@@ -200,15 +201,17 @@ class ReplService(val clients: Participants[LedgerClient], ec: ExecutionContext,
     val (scriptPackageId, _) = packages.find {
       case (pkgId, pkg) => pkg.modules.contains(DottedName.assertFromString("Daml.Script"))
     }.get
-    val runner = Runner
-      .fromDar(
-        dar,
-        ScriptIds(scriptPackageId),
-        ApplicationId("daml repl"),
-        commandUpdater,
-        TimeProvider.UTC)
-      .right
-      .get
+
+    val darMap = dar.all.toMap
+    val compiler = Compiler(darMap)
+    val compiledPackages = PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys)).right.get
+
+    val runner = new Runner(
+      compiledPackages,
+      ScriptIds(scriptPackageId),
+      ApplicationId("daml repl"),
+      commandUpdater,
+      TimeProvider.UTC)
     var scriptExpr: SExpr = SEVal(
       LfDefRef(
         Identifier(homePackageId, QualifiedName(mod.name, DottedName.assertFromString("expr")))),

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -106,9 +106,9 @@ object ParticipantsJsonProtocol extends DefaultJsonProtocol {
   implicit val participantsFormat = jsonFormat3(Participants[ApiParameters])
 }
 
-sealed abstract class Script extends Product with Serializable {
-  val scriptIds: ScriptIds
-}
+// DAML script, either an Action that can be executed immediately, or a
+// Function that requires an argument.
+sealed abstract class Script extends Product with Serializable
 object Script {
   final case class Action(expr: SExpr, scriptIds: ScriptIds) extends Script
   final case class Function(expr: SExpr, param: Type, scriptIds: ScriptIds) extends Script {
@@ -169,6 +169,10 @@ object Runner {
     } yield Participants(defaultClient, participantClients, participantParams.party_participants)
   }
 
+  // Executes a DAML script
+  //
+  // Looks for the script in the given DAR, applies the input value as an
+  // argument if provided, and runs the script with the given pariticipants.
   def run(
       dar: Dar[(PackageId, Package)],
       scriptId: Identifier,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -267,7 +267,7 @@ class Runner(
     SubmitAndWaitRequest(Some(commandUpdater.applyOverrides(commands)))
   }
 
-  def run(initialClients: Participants[LedgerClient], script: Script, inputValue: Option[JsValue])(
+  def runWithClients(initialClients: Participants[LedgerClient], script: Script, inputValue: Option[JsValue])(
       implicit ec: ExecutionContext,
       mat: Materializer): Future[SValue] = {
     val scriptExpr: SExpr = (script, inputValue) match {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -169,21 +169,6 @@ object Runner {
     } yield Participants(defaultClient, participantClients, participantParams.party_participants)
   }
 
-  def fromDar(
-      dar: Dar[(PackageId, Package)],
-      scriptIds: ScriptIds,
-      applicationId: ApplicationId,
-      commandUpdater: CommandUpdater,
-      timeProvider: TimeProvider): Either[String, Runner] = {
-    val ifaceDar = dar.map(pkg => InterfaceReader.readInterface(() => \/-(pkg))._2)
-    val darMap = dar.all.toMap
-    val compiler = Compiler(darMap)
-    for {
-      compiledPackages <- PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys))
-    } yield
-      new Runner(compiledPackages, scriptIds, applicationId, commandUpdater, timeProvider)
-  }
-
   def run(
       dar: Dar[(PackageId, Package)],
       scriptId: Identifier,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -105,7 +105,14 @@ object RunnerMain {
         }
         val flow: Future[Unit] = for {
           clients <- Runner.connect(participantParams, clientConfig)
-          _ <- Runner.run(dar, scriptId, inputValue, clients, applicationId, commandUpdater, timeProvider)
+          _ <- Runner.run(
+            dar,
+            scriptId,
+            inputValue,
+            clients,
+            applicationId,
+            commandUpdater,
+            timeProvider)
         } yield ()
 
         flow.onComplete(_ => system.terminate())

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -84,22 +84,6 @@ object RunnerMain {
           fileContent.parseJson
         })
 
-        val script = Script.fromDar(dar, scriptId) match {
-          case Left(err) =>
-            system.terminate
-            sys.exit(1)
-          case Right(x) => x
-        }
-        val runner = try {
-          Runner
-            .fromDar(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)
-            .right
-            .get
-        } catch {
-          case e: Throwable =>
-            system.terminate
-            sys.exit(1)
-        }
         val participantParams = config.participantConfig match {
           case Some(file) => {
             val source = Source.fromFile(file)
@@ -121,7 +105,7 @@ object RunnerMain {
         }
         val flow: Future[Unit] = for {
           clients <- Runner.connect(participantParams, clientConfig)
-          _ <- runner.runWithClients(clients, script, inputValue)
+          _ <- Runner.run(dar, scriptId, inputValue, clients, applicationId, commandUpdater, timeProvider)
         } yield ()
 
         flow.onComplete(_ => system.terminate())

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -121,7 +121,7 @@ object RunnerMain {
         }
         val flow: Future[Unit] = for {
           clients <- Runner.connect(participantParams, clientConfig)
-          _ <- runner.run(clients, script, inputValue)
+          _ <- runner.runWithClients(clients, script, inputValue)
         } yield ()
 
         flow.onComplete(_ => system.terminate())

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -91,7 +91,10 @@ object RunnerMain {
           case Right(x) => x
         }
         val runner = try {
-          new Runner(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)
+          Runner
+            .fromDar(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)
+            .right
+            .get
         } catch {
           case e: Throwable =>
             system.terminate

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -143,13 +143,11 @@ object TestMain extends StrictLogging {
               case (id, script) => {
                 val runner = new Runner(
                   compiledPackages,
-                  script.scriptIds,
+                  script,
                   applicationId,
                   commandUpdater,
                   timeProvider)
-                val testRun: Future[Unit] = for {
-                  _ <- runner.runExpr(clients, script.expr)
-                } yield ()
+                val testRun: Future[Unit] = runner.runWithClients(clients).map(_ => ())
                 // Print test result and remember failure.
                 testRun.onComplete {
                   case Failure(exception) =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -134,7 +134,10 @@ object TestMain extends StrictLogging {
             testScripts.map {
               case script => {
                 val runner =
-                  new Runner(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)
+                  Runner
+                    .fromDar(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)
+                    .right
+                    .get
                 val testRun: Future[Unit] = for {
                   _ <- runner.run(clients, script, None)
                 } yield ()

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -115,7 +115,10 @@ object TestMain extends StrictLogging {
             module.definitions.collect(Function.unlift {
               case (name, defn) => {
                 val id = Identifier(dar.main._1, QualifiedName(moduleName, name))
-                Script.fromDar(dar, id).toOption.filter(_.param.isEmpty)
+                Script.fromDar(dar, id) match {
+                  case Right(script: Script.Action) => Some(script)
+                  case _ => None
+                }
               }
             })
           }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -114,7 +114,8 @@ object TestMain extends StrictLogging {
 
         val darMap = dar.all.toMap
         val compiler = new Compiler(darMap)
-        val compiledPackages = PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys)).right.get
+        val compiledPackages =
+          PureCompiledPackages(darMap, compiler.compilePackages(darMap.keys)).right.get
         val testScripts = dar.main._2.modules.flatMap {
           case (moduleName, module) => {
             module.definitions.collect(Function.unlift {
@@ -141,12 +142,8 @@ object TestMain extends StrictLogging {
           _ <- Future.sequence {
             testScripts.map {
               case (id, script) => {
-                val runner = new Runner(
-                  compiledPackages,
-                  script,
-                  applicationId,
-                  commandUpdater,
-                  timeProvider)
+                val runner =
+                  new Runner(compiledPackages, script, applicationId, commandUpdater, timeProvider)
                 val testRun: Future[Unit] = runner.runWithClients(clients).map(_ => ())
                 // Print test result and remember failure.
                 testRun.onComplete {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -142,7 +142,7 @@ object TestMain extends StrictLogging {
                     .right
                     .get
                 val testRun: Future[Unit] = for {
-                  _ <- runner.run(clients, script, None)
+                  _ <- runner.runWithClients(clients, script, None)
                 } yield ()
                 // Print test result and remember failure.
                 testRun.onComplete {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -113,7 +113,14 @@ class TestRunner(
 
     val testFlow: Future[Unit] = for {
       clients <- clientsF
-      result <- Runner.run(dar, scriptId, inputValue, clients, applicationId, commandUpdater, timeProvider)
+      result <- Runner.run(
+        dar,
+        scriptId,
+        inputValue,
+        clients,
+        applicationId,
+        commandUpdater,
+        timeProvider)
       _ <- expectedLog match {
         case None => Future.unit
         case Some(expectedLogs) =>

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -111,16 +111,9 @@ class TestRunner(
 
     val clientsF = Runner.connect(participantParams, clientConfig)
 
-    val script = Script.fromDar(dar, scriptId) match {
-      case Left(err) => throw new RuntimeException(err)
-      case Right(x) => x
-    }
-    val runner =
-      Runner.fromDar(dar, script.scriptIds, applicationId, commandUpdater, timeProvider).right.get
-
     val testFlow: Future[Unit] = for {
       clients <- clientsF
-      result <- runner.runWithClients(clients, script, inputValue)
+      result <- Runner.run(dar, scriptId, inputValue, clients, applicationId, commandUpdater, timeProvider)
       _ <- expectedLog match {
         case None => Future.unit
         case Some(expectedLogs) =>

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -115,7 +115,8 @@ class TestRunner(
       case Left(err) => throw new RuntimeException(err)
       case Right(x) => x
     }
-    val runner = new Runner(dar, script.scriptIds, applicationId, commandUpdater, timeProvider)
+    val runner =
+      Runner.fromDar(dar, script.scriptIds, applicationId, commandUpdater, timeProvider).right.get
 
     val testFlow: Future[Unit] = for {
       clients <- clientsF

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -120,7 +120,7 @@ class TestRunner(
 
     val testFlow: Future[Unit] = for {
       clients <- clientsF
-      result <- runner.run(clients, script, inputValue)
+      result <- runner.runWithClients(clients, script, inputValue)
       _ <- expectedLog match {
         case None => Future.unit
         case Some(expectedLogs) =>


### PR DESCRIPTION
* Use a sum-type to distinguish DAML scripts that take an argument and those that don't
* Factor out DAML script argument converstion from Json in the the converter module
* Make `Runner` constructor pure
  - `Runner` now depends on `CompiledPackages` instead of `DAR`. This should allow to avoid recompiling everything on every newly entered line in the REPL.
  - `Runner` now depends on `Script.Action` instead of only taking it as an argument to `run`. `Runner` was already specific to a given script due to the dependency on `ScriptIds`. So, there is little value in passing the script in separately. `Script.Action` can be constructed from an `SExpr`, so this doesn't conflict with the REPL use-case.
* Capture the common use-case of running a DAML script in a DAR by identifier in `Runner.run`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
