### PR TITLE
Allow for predictable contractIDs and transactionIDs

### DIFF
--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -88,6 +88,7 @@ da_scala_library(
     ],
     deps = [
         "//daml-lf/data",
+        "//daml-lf/transaction",
         "//language-support/scala/bindings",
         "//ledger/ledger-api-common",
         "//ledger/ledger-api-domain",

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -11,6 +11,8 @@ import com.daml.ledger.participant.state.kvutils.app.{
   ParticipantConfig,
   ReadWriteService
 }
+import com.daml.ledger.participant.state.v1.SeedService
+import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.digitalasset.logging.LoggingContext
 import com.digitalasset.resources.{Resource, ResourceOwner}
 import scopt.OptionParser
@@ -51,7 +53,11 @@ object SqlLedgerFactory extends LedgerFactory[ReadWriteService, ExtraConfig] {
       val jdbcUrl = config.extra.jdbcUrl.getOrElse {
         throw new IllegalStateException("No JDBC URL provided.")
       }
-      new SqlLedgerReaderWriter.Owner(config.ledgerId, participantConfig.participantId, jdbcUrl)
+      new SqlLedgerReaderWriter.Owner(
+        config.ledgerId,
+        participantConfig.participantId,
+        jdbcUrl,
+        seedService = SeedService(Seeding.Strong))
         .acquire()
         .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
     }

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
@@ -10,7 +10,8 @@ import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase
 import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase.ParticipantState
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
-import com.daml.ledger.participant.state.v1.{LedgerId, ParticipantId}
+import com.daml.ledger.participant.state.v1.SeedService.Seeding
+import com.daml.ledger.participant.state.v1.{LedgerId, ParticipantId, SeedService}
 import com.digitalasset.logging.LoggingContext
 import com.digitalasset.resources.ResourceOwner
 
@@ -31,5 +32,7 @@ abstract class SqlLedgerReaderWriterIntegrationSpecBase(implementationName: Stri
       participantId,
       jdbcUrl(testId),
       heartbeats = heartbeats,
+      // Using a weak random source to avoid slowdown during tests.
+      seedService = SeedService(Seeding.Weak)
     ).map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
 }

--- a/ledger/participant-state/BUILD.bazel
+++ b/ledger/participant-state/BUILD.bazel
@@ -39,6 +39,7 @@ da_scala_test(
     resources = glob(["src/test/resources/*"]),
     deps = [
         ":participant-state",
+        "//daml-lf/transaction",
         "@maven//:org_scalatest_scalatest_2_12",
     ],
 )

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SeedService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SeedService.scala
@@ -16,6 +16,7 @@ object SeedService {
 
   sealed abstract class Seeding
   object Seeding {
+    case object Static extends Seeding
     case object Weak extends Seeding
     case object Strong extends Seeding
   }
@@ -26,8 +27,21 @@ object SeedService {
         new StrongRandomSeedService
       case Seeding.Weak =>
         new WeakRandomSeedService
+      case Seeding.Static =>
+        new StaticRandomSeedService(0L)
     }
 
+}
+
+// This service uses a fixed seed.
+// Do not use in production
+class StaticRandomSeedService(seed: Long) extends SeedService {
+  val rndGen = new scala.util.Random(seed)
+  override val nextSeed: () => Hash = () => {
+    val weakSeed = Array.ofDim[Byte](32)
+    rndGen.nextBytes(weakSeed)
+    crypto.Hash.assertFromBytes(weakSeed)
+  }
 }
 
 // This service uses a very low entropy seed.

--- a/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/SeedingSpec.scala
+++ b/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/SeedingSpec.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.v1
+
+import org.scalatest.{Matchers, WordSpec}
+
+class SeedingSpec extends WordSpec with Matchers {
+  "StaticRandomSeedService" should {
+    "return the same sequence of random numbers across multiple runs" in {
+      val gen1 = new StaticRandomSeedService(17L)
+      val gen2 = new StaticRandomSeedService(17L)
+
+      val hashes1 = List.fill(100)(gen1.nextSeed())
+      val hashes2 = List.fill(100)(gen2.nextSeed())
+      hashes1 shouldEqual hashes2
+    }
+  }
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -233,6 +233,7 @@ object Cli {
 
       private val seedingMap = Map[String, Option[Seeding]](
         "no" -> None,
+        "static" -> Some(Seeding.Static),
         "weak" -> Some(Seeding.Weak),
         "strong" -> Some(Seeding.Strong))
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -15,6 +15,7 @@ import com.daml.ledger.on.sql.Database.InvalidDatabaseException
 import com.daml.ledger.on.sql.SqlLedgerReaderWriter
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
 import com.daml.ledger.participant.state.v1
+import com.daml.ledger.participant.state.v1.SeedService
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.buildinfo.BuildInfo
 import com.digitalasset.daml.lf.archive.DarReader
@@ -149,6 +150,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   jdbcUrl = ledgerJdbcUrl,
                   timeProvider = timeServiceBackend.getOrElse(TimeProvider.UTC),
                   heartbeats = heartbeats,
+                  seedService = SeedService(seeding)
                 )
                 ledger = new KeyValueParticipantState(readerWriter, readerWriter)
                 ledgerId <- ResourceOwner.forFuture(() =>


### PR DESCRIPTION
- New seeding type "Static" that uses a fixed seed for generating new seeds.
This is only used in Sandbox and Sandbox-next.

- Remove the fuzzing for submission time in Engine.scala

- DAML-on-SQL: Create new log entry IDs from a provided SeedService.
This allows for generating deterministic transaction IDs in
Sandbox-Next.

Fixes #5107

## CHANGELOG_BEGIN

- [Sandbox] Add contract-id-seeding=static to allow for predictable contract IDs. This is useful for documentation,
to be able to refer to a specific contract ID instead of having to write "note down the contract ID you see on the screen. we will use it later."
- [DAML-on-SQL] Derive the next log entry ID using the provided SeedService. This allows us to also deterministically create transactionIds in static time mode together with `--contract-id-seeding=static`. This should only be used for demos or documentation.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
