### PR TITLE
faster hlint with fmt.sh --diff

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -14,6 +14,7 @@ eval "$(dev-env/bin/dade-assist)"
 ## Config ##
 is_test=
 scalafmt_args=()
+hlint_diff=false
 dade_copyright_arg=update
 buildifier_target=//:buildifier-fix
 
@@ -59,7 +60,14 @@ USAGE
       ;;
     --scalafmt-diff)
       shift
+      echo "Please use the new --diff flag instead. The --scalafmt-diff one will be removed on April 1."
       scalafmt_args+=(--mode=diff --diff-branch=origin/master)
+      hlint_diff=true
+      ;;
+    --diff)
+      shift
+      scalafmt_args+=(--mode=diff --diff-branch=origin/master)
+      hlint_diff=true
       ;;
     *)
       echo "fmt.sh: unknown argument $1" >&2
@@ -105,18 +113,20 @@ echo "\
 # Check for correct copyrights
 run dade-copyright-headers "$dade_copyright_arg" .
 
-# We have a Bazel test that is meant to run HLint, but we're a little sceptical of it
-# If we get this far, but hlint fails, that's a problem we should fix
-function bad_hlint() {
-  echo "UNEXPECTED HLINT FAILURE: The Bazel rules should have spotted this, please raise a GitHub issue"
-}
-trap bad_hlint EXIT
-for dir in daml-assistant libs-haskell compiler release language-support; do
-  run pushd "$dir"
-  run hlint --git -j4
-  run popd
-done
-trap - EXIT
+if [ "$hlint_diff" = "true" ]; then
+    changed_haskell_files="$(git diff --name-only origin/master | grep '.hs$')"
+    if [ "" != "$changed_haskell_files" ]; then
+        hlint -j4 $changed_haskell_files
+    fi
+else
+    # We have a Bazel test that is meant to run HLint, but we're a little
+    # sceptical of it If we get this far, but hlint fails, that's a problem we
+    # should fix
+    if ! hlint --git -j4; then
+        echo "UNEXPECTED HLINT FAILURE: The Bazel rules should have spotted this, please raise a GitHub issue"
+        exit $?
+    fi
+fi
 
 # check for scala code style
 run scalafmt "${scalafmt_args[@]:-}"


### PR DESCRIPTION
This PR adds new behaviour to the existing --scalafmt-diff flag to also use a diff-based approach for hlint. Consequently, the flag is renamed to the simpler and more generic `--diff`, in a backwards-compatible way.

CHANGELOG_BEGIN
CHANGELOG_END