### PR TITLE
Fix package name

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/package.json
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
-  "name": "build-and-lint",
+  "name": "build-and-lint-test",
   "version": "0.0.1",
-  "description": "Tests for the daml2ts generated 'build-and-lint-pkg'",
+  "description": "Tests exercising '@daml.js/build-and-lint-1.0.0",
   "license": "Apache-2.0",
   "dependencies": {
     "@daml/ledger": "0.0.0",


### PR DESCRIPTION
This is a tiny detail and not critical but fixing it helps a lot with clarity. A recent refactoring renamed the test driver directory `build-and-lint-test` and the intent was to rename the package it contains to `build-and-lint-test` but that didn't happen (the package kept the name `build-and-lint`). This fixes it. 