### PR TITLE
Ledger api server indexer initializes from ledger_end after restart

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -142,7 +142,7 @@ private class JdbcLedgerDao(
         .as(offset("ledger_end").single)
     }
 
-  private val SQL_SELECT_INITIAL_LEDGER_END = SQL("select external_ledger_end from parameters")
+  private val SQL_SELECT_INITIAL_LEDGER_END = SQL("select ledger_end from parameters")
 
   override def lookupInitialLedgerEnd(): Future[Option[Offset]] =
     dbDispatcher.executeSql("get_initial_ledger_end") { implicit conn =>


### PR DESCRIPTION
by reading parameters.ledger_end column instead of parameters.external_ledger_end.

CHANGELOG_BEGIN
[Ledger API Server]: Upon restart, ledger api server continues consuming unconsumed events rather than all events from beginning.
CHANGELOG_END

Closes #5121

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
