### PR TITLE
sandbox | kvutils/app: Re-use the Materializer in the JdbcIndexer.

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -51,7 +51,6 @@ class Runner[T <: ReadWriteService, Extra](
               _ <- Resource.fromFuture(
                 Future.sequence(config.archiveFiles.map(uploadDar(_, ledger))))
               _ <- new StandaloneIndexerServer(
-                actorSystem,
                 readService = ledger,
                 factory.indexerConfig(participantConfig, config),
                 factory.indexerMetricRegistry(participantConfig, config),

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -33,15 +33,15 @@ class Runner[T <: ReadWriteService, Extra](
     override def acquire()(implicit executionContext: ExecutionContext): Resource[Unit] = {
       val config = factory.manipulateConfig(originalConfig)
 
-      implicit val system: ActorSystem = ActorSystem(
+      implicit val actorSystem: ActorSystem = ActorSystem(
         "[^A-Za-z0-9_\\-]".r.replaceAllIn(name.toLowerCase, "-"))
-      implicit val materializer: Materializer = Materializer(system)
+      implicit val materializer: Materializer = Materializer(actorSystem)
 
       newLoggingContext { implicit logCtx =>
         for {
           // Take ownership of the actor system and materializer so they're cleaned up properly.
           // This is necessary because we can't declare them as implicits in a `for` comprehension.
-          _ <- AkkaResourceOwner.forActorSystem(() => system).acquire()
+          _ <- AkkaResourceOwner.forActorSystem(() => actorSystem).acquire()
           _ <- AkkaResourceOwner.forMaterializer(() => materializer).acquire()
 
           // initialize all configured participants
@@ -51,7 +51,7 @@ class Runner[T <: ReadWriteService, Extra](
               _ <- Resource.fromFuture(
                 Future.sequence(config.archiveFiles.map(uploadDar(_, ledger))))
               _ <- new StandaloneIndexerServer(
-                system,
+                actorSystem,
                 readService = ledger,
                 factory.indexerConfig(participantConfig, config),
                 factory.indexerMetricRegistry(participantConfig, config),

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -31,35 +31,24 @@ import org.mockito.Mockito._
 import org.scalatest.{AsyncWordSpec, BeforeAndAfterEach, Matchers}
 
 import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.concurrent.{Await, Future}
 import scala.util.Try
 
 class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with BeforeAndAfterEach {
   private[this] var testId: UUID = _
 
-  private[this] implicit var actorSystem: ActorSystem = _
-  private[this] implicit var materializer: Materializer = _
-
   override def beforeEach(): Unit = {
     super.beforeEach()
     testId = UUID.randomUUID()
-    actorSystem = ActorSystem(getClass.getSimpleName)
-    materializer = Materializer(actorSystem)
     LogCollector.clear[this.type]
-  }
-
-  override def afterEach(): Unit = {
-    materializer.shutdown()
-    Await.result(actorSystem.terminate(), 10.seconds)
-    super.afterEach()
   }
 
   private def readLog(): Seq[(Level, String)] = LogCollector.read[this.type, RecoveringIndexer]
 
   "indexer" should {
     "index the participant state" in newLoggingContext { implicit logCtx =>
-      participantServer(simpleParticipantState)
+      participantServer(SimpleParticipantState)
         .use { participantState =>
           for {
             _ <- participantState
@@ -92,8 +81,7 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
 
     "index the participant state, even on spurious failures" in newLoggingContext {
       implicit logCtx =>
-        participantServer((ledgerId, participantId) =>
-          simpleParticipantState(ledgerId, participantId).map(failingOften))
+        participantServer(ParticipantStateThatFailsOften)
           .use { participantState =>
             for {
               _ <- participantState
@@ -148,11 +136,8 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
     }
 
     "stop when the kill switch is hit after a failure" in newLoggingContext { implicit logCtx =>
-      participantServer(
-        (ledgerId, participantId) =>
-          simpleParticipantState(ledgerId, participantId).map(failingOften),
-        restartDelay = 10.seconds,
-      ).use { participantState =>
+      participantServer(ParticipantStateThatFailsOften, restartDelay = 10.seconds)
+        .use { participantState =>
           for {
             _ <- participantState
               .allocateParty(
@@ -186,15 +171,8 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
     }
   }
 
-  private def simpleParticipantState(
-      ledgerId: Option[LedgerId],
-      participantId: ParticipantId,
-  )(implicit logCtx: LoggingContext): ResourceOwner[ParticipantState] =
-    new InMemoryLedgerReaderWriter.SingleParticipantOwner(ledgerId, participantId)
-      .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
-
   private def participantServer(
-      newParticipantState: (Option[LedgerId], ParticipantId) => ResourceOwner[ParticipantState],
+      newParticipantState: ParticipantStateFactory,
       restartDelay: FiniteDuration = 100.millis,
   )(implicit logCtx: LoggingContext): ResourceOwner[ParticipantState] = {
     val ledgerId = LedgerString.assertFromString(s"ledger-$testId")
@@ -202,10 +180,10 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
     val jdbcUrl =
       s"jdbc:h2:mem:${getClass.getSimpleName.toLowerCase()}-$testId;db_close_delay=-1;db_close_on_exit=false"
     for {
-      participantState <- newParticipantState(Some(ledgerId), participantId)
       actorSystem <- AkkaResourceOwner.forActorSystem(() => ActorSystem())
+      materializer <- AkkaResourceOwner.forMaterializer(() => Materializer(actorSystem))
+      participantState <- newParticipantState(Some(ledgerId), participantId)(materializer, logCtx)
       _ <- new StandaloneIndexerServer(
-        actorSystem,
         participantState,
         IndexerConfig(
           participantId,
@@ -214,7 +192,7 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
           restartDelay = restartDelay,
         ),
         new MetricRegistry,
-      )
+      )(materializer, logCtx)
     } yield participantState
   }
 
@@ -233,26 +211,49 @@ object RecoveringIndexerIntegrationSpec {
   private def randomSubmissionId(): LedgerString =
     LedgerString.assertFromString(UUID.randomUUID().toString)
 
-  // This spy inserts a failure after each state update to force the RecoveringIndexer to restart.
-  private def failingOften(delegate: ParticipantState): ParticipantState = {
-    var lastFailure: Option[Offset] = None
-    val failingParticipantState = spy(delegate)
-    doAnswer(invocation => {
-      val beginAfter = invocation.getArgument[Option[Offset]](0)
-      delegate.stateUpdates(beginAfter).flatMapConcat {
-        case value @ (_, Heartbeat(_)) =>
-          Source.single(value)
-        case value @ (offset, _) =>
-          if (lastFailure.isEmpty || lastFailure.get < offset) {
-            lastFailure = Some(offset)
-            Source.single(value).concat(Source.failed(new StateUpdatesFailedException))
-          } else {
-            Source.single(value)
-          }
-      }
-    }).when(failingParticipantState).stateUpdates(ArgumentMatchers.any[Option[Offset]]())
-    failingParticipantState
+  private trait ParticipantStateFactory {
+    def apply(ledgerId: Option[LedgerId], participantId: ParticipantId)(
+        implicit materializer: Materializer,
+        logCtx: LoggingContext,
+    ): ResourceOwner[ParticipantState]
   }
 
-  private class StateUpdatesFailedException extends RuntimeException("State updates failed.")
+  private object SimpleParticipantState extends ParticipantStateFactory {
+    override def apply(ledgerId: Option[LedgerId], participantId: ParticipantId)(
+        implicit materializer: Materializer,
+        logCtx: LoggingContext
+    ): ResourceOwner[ParticipantState] =
+      new InMemoryLedgerReaderWriter.SingleParticipantOwner(ledgerId, participantId)
+        .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
+  }
+
+  private object ParticipantStateThatFailsOften extends ParticipantStateFactory {
+    override def apply(ledgerId: Option[LedgerId], participantId: ParticipantId)(
+        implicit materializer: Materializer,
+        logCtx: LoggingContext
+    ): ResourceOwner[ParticipantState] =
+      SimpleParticipantState(ledgerId, participantId)
+        .map { delegate =>
+          var lastFailure: Option[Offset] = None
+          // This spy inserts a failure after each state update to force the indexer to restart.
+          val failingParticipantState = spy(delegate)
+          doAnswer(invocation => {
+            val beginAfter = invocation.getArgument[Option[Offset]](0)
+            delegate.stateUpdates(beginAfter).flatMapConcat {
+              case value @ (_, Heartbeat(_)) =>
+                Source.single(value)
+              case value @ (offset, _) =>
+                if (lastFailure.isEmpty || lastFailure.get < offset) {
+                  lastFailure = Some(offset)
+                  Source.single(value).concat(Source.failed(new StateUpdatesFailedException))
+                } else {
+                  Source.single(value)
+                }
+            }
+          }).when(failingParticipantState).stateUpdates(ArgumentMatchers.any[Option[Offset]]())
+          failingParticipantState
+        }
+
+    private class StateUpdatesFailedException extends RuntimeException("State updates failed.")
+  }
 }

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -208,8 +208,8 @@ object RecoveringIndexerIntegrationSpec {
 
   private val eventually = RetryStrategy.exponentialBackoff(10, 10.millis)
 
-  private def randomSubmissionId(): LedgerString =
-    LedgerString.assertFromString(UUID.randomUUID().toString)
+  private def randomSubmissionId(): SubmissionId =
+    SubmissionId.assertFromString(UUID.randomUUID().toString)
 
   private trait ParticipantStateFactory {
     def apply(ledgerId: Option[LedgerId], participantId: ParticipantId)(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -58,13 +58,11 @@ final class JdbcIndexerFactory(
   ): ResourceOwner[JdbcIndexer] =
     for {
       ledgerDao <- JdbcLedgerDao.writeOwner(jdbcUrl, metrics)
-      initialLedgerEnd <- ResourceOwner.forFuture(() =>
-        initializeLedger(ledgerDao)(materializer, executionContext))
-    } yield new JdbcIndexer(initialLedgerEnd, participantId, ledgerDao, metrics)(materializer)
+      initialLedgerEnd <- ResourceOwner.forFuture(() => initializeLedger(ledgerDao))
+    } yield new JdbcIndexer(initialLedgerEnd, participantId, ledgerDao, metrics)
 
   private def initializeLedger(dao: LedgerDao)(
-      implicit materializer: Materializer,
-      executionContext: ExecutionContext,
+      implicit executionContext: ExecutionContext,
   ): Future[Option[Offset]] =
     for {
       initialConditions <- readService.getLedgerInitialConditions().runWith(Sink.head)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -3,7 +3,7 @@
 
 package com.digitalasset.platform.indexer
 
-import akka.actor.ActorSystem
+import akka.stream.Materializer
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.v1.ReadService
 import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
@@ -12,11 +12,10 @@ import com.digitalasset.resources.{Resource, ResourceOwner}
 import scala.concurrent.ExecutionContext
 
 final class StandaloneIndexerServer(
-    actorSystem: ActorSystem,
     readService: ReadService,
     config: IndexerConfig,
     metrics: MetricRegistry,
-)(implicit logCtx: LoggingContext)
+)(implicit materializer: Materializer, logCtx: LoggingContext)
     extends ResourceOwner[Unit] {
 
   private val logger = ContextualizedLogger.get(this.getClass)
@@ -25,25 +24,24 @@ final class StandaloneIndexerServer(
     val indexerFactory = new JdbcIndexerFactory(
       config.participantId,
       config.jdbcUrl,
-      actorSystem,
       readService,
       metrics,
     )
-    val indexer = new RecoveringIndexer(actorSystem.scheduler, config.restartDelay)
+    val indexer = new RecoveringIndexer(materializer.system.scheduler, config.restartDelay)
     config.startupMode match {
       case IndexerStartupMode.MigrateOnly =>
         Resource.successful(())
       case IndexerStartupMode.MigrateAndStart =>
         Resource
           .fromFuture(indexerFactory.migrateSchema(config.allowExistingSchema))
-          .flatMap(startIndexer(indexer, _, actorSystem))
+          .flatMap(startIndexer(indexer, _))
           .map { _ =>
             logger.debug("Waiting for the indexer to initialize the database.")
           }
       case IndexerStartupMode.ValidateAndStart =>
         Resource
           .fromFuture(indexerFactory.validateSchema())
-          .flatMap(startIndexer(indexer, _, actorSystem))
+          .flatMap(startIndexer(indexer, _))
           .map { _ =>
             logger.debug("Waiting for the indexer to initialize the database.")
           }
@@ -53,7 +51,6 @@ final class StandaloneIndexerServer(
   private def startIndexer(
       indexer: RecoveringIndexer,
       initializedIndexerFactory: ResourceOwner[JdbcIndexer],
-      actorSystem: ActorSystem,
   )(implicit executionContext: ExecutionContext): Resource[Unit] =
     indexer
       .start(() => initializedIndexerFactory.flatMap(_.subscription(readService)).acquire())

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -156,7 +156,6 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                 _ <- ResourceOwner.forFuture(() =>
                   Future.sequence(config.damlPackages.map(uploadDar(_, ledger))))
                 _ <- new StandaloneIndexerServer(
-                  actorSystem = actorSystem,
                   readService = ledger,
                   config = IndexerConfig(
                     ParticipantId,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -111,8 +111,8 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
 
   override def acquire()(implicit executionContext: ExecutionContext): Resource[Port] =
     newLoggingContext { implicit logCtx =>
-      implicit val system: ActorSystem = ActorSystem("sandbox")
-      implicit val materializer: Materializer = Materializer(system)
+      implicit val actorSystem: ActorSystem = ActorSystem("sandbox")
+      implicit val materializer: Materializer = Materializer(actorSystem)
 
       val (timeServiceBackend, heartbeatMechanism) = timeProviderType match {
         case TimeProviderType.Static =>
@@ -126,7 +126,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
       val owner = for {
         // Take ownership of the actor system and materializer so they're cleaned up properly.
         // This is necessary because we can't declare them as implicits within a `for` comprehension.
-        _ <- AkkaResourceOwner.forActorSystem(() => system)
+        _ <- AkkaResourceOwner.forActorSystem(() => actorSystem)
         _ <- AkkaResourceOwner.forMaterializer(() => materializer)
 
         apiServer <- ResettableResourceOwner[ApiServer, (Option[Port], StartupMode)](
@@ -156,7 +156,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                 _ <- ResourceOwner.forFuture(() =>
                   Future.sequence(config.damlPackages.map(uploadDar(_, ledger))))
                 _ <- new StandaloneIndexerServer(
-                  actorSystem = system,
+                  actorSystem = actorSystem,
                   readService = ledger,
                   config = IndexerConfig(
                     ParticipantId,


### PR DESCRIPTION
There's no reason to construct a new one in `StandaloneIndexerServer` when we already have one available in the `Runner`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
