### PR TITLE
Switch default DAML-LF target to 1.8

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -37,7 +37,7 @@ version1_8 = V1 $ PointStable 8
 
 -- | The DAML-LF version used by default.
 versionDefault :: Version
-versionDefault = version1_7
+versionDefault = version1_8
 
 -- | The DAML-LF development version.
 versionDev :: Version

--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -1,8 +1,6 @@
 # Copyright (c) 2020 The DAML Authors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-lf_stable_version = "1.7"
+lf_stable_version = "1.8"
 lf_latest_version = "1.8"
 lf_dev_version = "1.dev"
-
-lf_versions = [lf_stable_version, lf_latest_version, lf_dev_version]

--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -147,6 +147,7 @@ da_haskell_test(
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
+        "//compiler/daml-lf-ast",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],


### PR DESCRIPTION
changelog_begin

- [DAML Compiler] The default output DAML-LF target version is now
  1.8. You can target 1.7 by specifying ``--target=1.7`` in the
  ``build-options`` field in your ``daml.yaml``.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
