### PR TITLE
Bump portfile retries

### DIFF
--- a/libs-haskell/da-hs-base/src/DA/PortFile.hs
+++ b/libs-haskell/da-hs-base/src/DA/PortFile.hs
@@ -24,5 +24,4 @@ retryDelayMillis :: Int
 retryDelayMillis = 50
 
 maxRetries :: Int
-maxRetries = 60 * (1000 `div` retryDelayMillis)
-
+maxRetries = 120 * (1000 `div` retryDelayMillis)


### PR DESCRIPTION
We have seen a few test failures where the port file was not written
to in time. Apparently this can takes ages on CI for tests that are
not marked exclusive.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
