### PR TITLE
fix fmt diff

### DIFF
--- a/fmt.sh
+++ b/fmt.sh
@@ -114,7 +114,7 @@ echo "\
 run dade-copyright-headers "$dade_copyright_arg" .
 
 if [ "$hlint_diff" = "true" ]; then
-    changed_haskell_files="$(git diff --name-only origin/master | grep '.hs$')"
+    changed_haskell_files="$(git diff --name-only origin/master | grep '.hs$' || echo "")"
     if [ "" != "$changed_haskell_files" ]; then
         hlint -j4 $changed_haskell_files
     fi


### PR DESCRIPTION
Current implementation fails when no Haskell file has changed due to
grep returning non-0 (for no match).

CHANGELOG_BEGIN
CHANGELOG_END