### PR TITLE
Use local paths in package dependencies

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -681,7 +681,9 @@ writePackageJson packageDir sdkVersion (Scope scope) depends =
     name = packageNameOfPackageDir packageDir
     dependencies = HMS.fromList [ (NpmPackageName pkg, NpmPackageVersion version)
        | d <- depends
-       , let pkg = scope <> "/" <> unDependency d
+       , let pkgName = unDependency d
+       , let pkg = scope <> "/" <> pkgName
+       , let version = "file:../" <> pkgName
        ]
     packageNameOfPackageDir :: FilePath -> T.Text
     packageNameOfPackageDir packageDir = scope <> "/" <> package

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/package.json
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@daml/ledger": "0.0.0",
     "@daml/types": "0.0.0",
+    "@daml.js/build-and-lint-1.0.0": "file:../daml2ts/build-and-lint-1.0.0",
     "p-event": "^4.1.0"
   },
   "scripts": {


### PR DESCRIPTION
Dependencies between daml2ts generated packages are tracked in package.json files. If `B` depends on `A` for example, before this PR `B`'s package.json would read:
```json
   "dependencies": {
        "@daml.js/A": "0.13.55"
   },
```
After this PR, `B`'s dependency is written using a [local path](https://docs.npmjs.com/files/package.json#local-paths):
```json
   "dependencies": {
        "@daml.js/A": "file:../A"
   },
```
This change is forward compatible  with (and a necessary part of) the effort to remove the need for writing  daml2ts generated package paths  into the `workspaces` field of a project's package.json.
