### PR TITLE
match terraform with reality

### DIFF
--- a/infra/bazel_cache.tf
+++ b/infra/bazel_cache.tf
@@ -19,16 +19,6 @@ module "bazel_cache" {
   cache_retention_days = 60
 }
 
-// provide a index.html file, so accessing the document root yields something
-// nicer than just a 404.
-resource "google_storage_bucket_object" "index_bazel_cache" {
-  name         = "index.html"
-  bucket       = "${module.bazel_cache.bucket_name}"
-  content      = "${file("${path.module}/files/index_bazel_cache.html")}"
-  content_type = "text/html"
-  depends_on   = ["module.nix_cache"]
-}
-
 // allow rw access for CI writer (see writer.tf)
 resource "google_storage_bucket_iam_member" "bazel_cache_writer" {
   bucket = "${module.bazel_cache.bucket_name}"

--- a/infra/files/index_bazel_cache.html
+++ b/infra/files/index_bazel_cache.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<!-- Copyright (c) 2020 The DAML Authors. All rights reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<title>DAML public Bazel Cache</title>
-
-<h1>DAML public Bazel Cache<h1>

--- a/infra/files/index_nix_cache.html
+++ b/infra/files/index_nix_cache.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<!-- Copyright (c) 2020 The DAML Authors. All rights reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
-<title>DAML public Nix Cache</title>
-
-<h1>DAML public Nix Cache<h1>

--- a/infra/modules/gcp_cdn_bucket/google_storage.tf
+++ b/infra/modules/gcp_cdn_bucket/google_storage.tf
@@ -39,10 +39,6 @@ resource "google_storage_bucket" "default" {
     }
   }
 
-  website {
-    main_page_suffix = "index.html"
-  }
-
   force_destroy = true
 }
 


### PR DESCRIPTION
Our current Terraform setup attempts to create three static files on our GCS buckets. The issue is that these buckets are configured to automatically delete files that are older than X days, and there is no way to exclude specific files from that. Therefore, the created files disappear after some time, and running `terraform plan` suddenly looks like the infrastructure has changed.

Moreover, the added value of these three files seems questionable: two of them provide `index.html` type of functionality for our two caches, whereas the third is automatically created by `nix` when pushing to the cache anyway (if it doesn't exist already).

This PR also reduces the cache eviction time for the nix cache to 60 days, as a full year seemed a bit long.

CHANGELOG_BEGIN
CHANGELOG_END