### PR TITLE
kvutils: Move `ProcessTransactionSubmission` parameters into `#run`.

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -15,8 +15,8 @@ import com.daml.ledger.participant.state.kvutils.committing._
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId}
 import com.digitalasset.daml.lf.data.Time.Timestamp
 import com.digitalasset.daml.lf.engine.Engine
-import com.digitalasset.daml.lf.transaction.{TransactionCoder, TransactionOuterClass}
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
+import com.digitalasset.daml.lf.transaction.{TransactionCoder, TransactionOuterClass}
 import com.digitalasset.daml.lf.value.ValueOuterClass
 import com.digitalasset.daml_lf_dev.DamlLf
 import com.digitalasset.platform.common.metrics.VarGauge
@@ -165,15 +165,14 @@ object KeyValueCommitting {
         )
 
       case DamlSubmission.PayloadCase.TRANSACTION_ENTRY =>
-        ProcessTransactionSubmission(
+        ProcessTransactionSubmission(defaultConfig).run(
           engine,
           entryId,
           recordTime,
-          defaultConfig,
           participantId,
           submission.getTransactionEntry,
           inputState,
-        ).run
+        )
 
       case DamlSubmission.PayloadCase.PAYLOAD_NOT_SET =>
         throw Err.InvalidSubmission("DamlSubmission payload not set")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -165,8 +165,7 @@ object KeyValueCommitting {
         )
 
       case DamlSubmission.PayloadCase.TRANSACTION_ENTRY =>
-        ProcessTransactionSubmission(defaultConfig).run(
-          engine,
+        ProcessTransactionSubmission(defaultConfig, engine).run(
           entryId,
           recordTime,
           participantId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -26,12 +26,14 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConverters._
 
-private[kvutils] case class ProcessTransactionSubmission(defaultConfig: Configuration) {
+private[kvutils] case class ProcessTransactionSubmission(
+    defaultConfig: Configuration,
+    engine: Engine,
+) {
 
   private implicit val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   def run(
-      engine: Engine,
       entryId: DamlLogEntryId,
       recordTime: Timestamp,
       participantId: ParticipantId,


### PR DESCRIPTION
This makes injecting a metric registry much easier, and according to the TODO comment, it was a long time coming.

This should not change any behavior. If it turns out anything is using `inputState` and shouldn't be, that needs to be tackled in a separate PR. This just makes it more obvious.

Part of #5146.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
