### PR TITLE
Integrate create-daml-app into the assistant

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -70,6 +70,7 @@ da_haskell_test(
         "//compiler/damlc/daml-opts:daml-opts-types",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
+        "//libs-haskell/test-utils",
     ],
 )
 

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -20,6 +20,7 @@ import qualified Data.ByteString.Lazy.Char8 as BSL (pack)
 import qualified Data.Text.Extended as T
 
 import DA.Bazel.Runfiles
+import DA.Test.Util
 import SdkVersion
 
 main :: IO ()
@@ -246,6 +247,3 @@ callProcessSilent cmd args = do
       hPutStrLn stderr $ unlines ["stdout:", out]
       hPutStrLn stderr $ unlines ["stderr: ", err]
       exitFailure
-
-assertInfixOf :: String -> String -> Assertion
-assertInfixOf needle haystack = assertBool ("Expected " <> show needle <> " in output but but got " <> show haystack) (needle `isInfixOf` haystack)

--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -17,10 +17,12 @@ da_haskell_library(
         "base",
         "bytestring",
         "containers",
+        "conduit",
+        "conduit-extra",
         "directory",
         "extra",
         "filepath",
-        "http-client",
+        "http-conduit",
         "http-types",
         "jwt",
         "monad-loops",
@@ -66,7 +68,7 @@ package_app(
 
 da_haskell_test(
     name = "ledger-tls",
-    srcs = glob(["test/**/*.hs"]),
+    srcs = ["test/DA/Daml/Helper/Test/Tls.hs"],
     data = [
         "daml-helper",
         "//ledger/sandbox:sandbox-binary",
@@ -81,6 +83,31 @@ da_haskell_test(
         "tasty-hunit",
     ],
     main_function = "DA.Daml.Helper.Test.Tls.main",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libs-haskell/bazel-runfiles",
+        "//libs-haskell/da-hs-base",
+        "//libs-haskell/test-utils",
+    ],
+)
+
+# Misc tests for daml-helper that do not deserve their own test suite.
+da_haskell_test(
+    name = "tests",
+    srcs = ["test/DA/Daml/Helper/Test.hs"],
+    data = [
+        "daml-helper",
+    ],
+    hackage_deps = [
+        "base",
+        "directory",
+        "extra",
+        "filepath",
+        "process",
+        "tasty",
+        "tasty-hunit",
+    ],
+    main_function = "DA.Daml.Helper.Test.main",
     visibility = ["//visibility:public"],
     deps = [
         "//libs-haskell/bazel-runfiles",

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test.hs
@@ -26,9 +26,10 @@ main = do
 createDamlAppTests :: FilePath -> TestTree
 createDamlAppTests damlHelper = testGroup "create-daml-app"
     [ testCase "Succeeds with SDK 0.13.55" $ withTempDir $ \dir -> do
+          env <- getEnvironment
           (exit, out, err) <- readCreateProcessWithExitCode
               (proc damlHelper ["create-daml-app", dir </> "foobar"])
-                   { env = Just [("DAML_SDK_VERSION", "0.13.55")] }
+                   { env = Just (("DAML_SDK_VERSION", "0.13.55") : env) }
               ""
           err @?= ""
           assertInfixOf "Created" out
@@ -39,9 +40,10 @@ createDamlAppTests damlHelper = testGroup "create-daml-app"
           -- Note that we do not test 0.0.0 since people
           -- might be tempted to create that tag temporarily for
           -- testing purposes.
+          env <- getEnvironment
           (exit, out, err) <- readCreateProcessWithExitCode
               (proc damlHelper ["create-daml-app", dir </> "foobar"])
-                   { env = Just [("DAML_SDK_VERSION", "0.0.1")] }
+                   { env = Just (("DAML_SDK_VERSION", "0.0.1") : env) }
               ""
           assertInfixOf "not available for SDK version 0.0.1" err
           out @?= ""

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test.hs
@@ -1,0 +1,57 @@
+-- Copyright (c) 2020 The DAML Authors. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Daml.Helper.Test (main) where
+
+import DA.Bazel.Runfiles
+import DA.Test.Util
+import System.Directory
+import System.Environment.Blank
+import System.Exit
+import System.FilePath
+import System.IO.Extra
+import System.Process
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = do
+    setEnv "TASTY_NUM_THREADS" "1" True
+    damlHelper <- locateRunfiles (mainWorkspace </> "daml-assistant" </> "daml-helper" </> exe "daml-helper")
+    defaultMain $
+        testGroup "daml-helper"
+            [ createDamlAppTests damlHelper
+            ]
+
+createDamlAppTests :: FilePath -> TestTree
+createDamlAppTests damlHelper = testGroup "create-daml-app"
+    [ testCase "Succeeds with SDK 0.13.55" $ withTempDir $ \dir -> do
+          (exit, out, err) <- readCreateProcessWithExitCode
+              (proc damlHelper ["create-daml-app", dir </> "foobar"])
+                   { env = Just [("DAML_SDK_VERSION", "0.13.55")] }
+              ""
+          err @?= ""
+          assertInfixOf "Created" out
+          exit @?= ExitSuccess
+          assertBool "daml.yaml does not exist" =<<
+              doesFileExist (dir </> "foobar" </> "daml.yaml")
+    , testCase "Fails with SDK 0.0.1" $ withTempDir $ \dir -> do
+          -- Note that we do not test 0.0.0 since people
+          -- might be tempted to create that tag temporarily for
+          -- testing purposes.
+          (exit, out, err) <- readCreateProcessWithExitCode
+              (proc damlHelper ["create-daml-app", dir </> "foobar"])
+                   { env = Just [("DAML_SDK_VERSION", "0.0.1")] }
+              ""
+          assertInfixOf "not available for SDK version 0.0.1" err
+          out @?= ""
+          exit @?= ExitFailure 1
+    , testCase "Fails if directory already exists" $ withTempDir $ \dir -> do
+          createDirectory (dir </> "foobar")
+          (exit, out, err) <- readCreateProcessWithExitCode
+              (proc damlHelper ["create-daml-app", dir </> "foobar"])
+              ""
+          assertInfixOf "already exists" err
+          out @?= ""
+          exit @?= ExitFailure 1
+    ]

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test.hs
@@ -3,12 +3,14 @@
 
 module DA.Daml.Helper.Test (main) where
 
+import Control.Monad
 import DA.Bazel.Runfiles
 import DA.Test.Util
 import System.Directory
 import System.Environment.Blank
 import System.Exit
 import System.FilePath
+import System.Info
 import System.IO.Extra
 import System.Process
 import Test.Tasty
@@ -17,6 +19,11 @@ import Test.Tasty.HUnit
 main :: IO ()
 main = do
     setEnv "TASTY_NUM_THREADS" "1" True
+    when (os == "darwin") $ do
+        -- x509-system insists on trying to locate `security`
+        -- in PATH to find the root certificate store.
+        mbPath <- getEnv "PATH"
+        setEnv "PATH" (maybe "/usr/bin" ("/usr/bin:" <>) mbPath) True
     damlHelper <- locateRunfiles (mainWorkspace </> "daml-assistant" </> "daml-helper" </> exe "daml-helper")
     defaultMain $
         testGroup "daml-helper"

--- a/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Tls.hs
+++ b/daml-assistant/daml-helper/test/DA/Daml/Helper/Test/Tls.hs
@@ -5,7 +5,7 @@ module DA.Daml.Helper.Test.Tls (main) where
 
 import DA.Bazel.Runfiles
 import DA.Test.Sandbox
-import Data.List.Extra (isInfixOf)
+import DA.Test.Util
 import System.Environment.Blank
 import System.Exit
 import System.FilePath
@@ -75,7 +75,3 @@ main = do
                            assertInfixOf "no parties are known" out
                      ]
            ]
-
-assertInfixOf :: String -> String -> Assertion
-assertInfixOf needle haystack = assertBool ("Expected " <> show needle <> " in output but but got " <> show haystack) (needle `isInfixOf` haystack)
-

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -7,6 +7,7 @@ DAML Assistant (``daml``)
 ``daml`` is a command-line tool that does a lot of useful things related to the SDK. Using ``daml``, you can:
 
 - Create new DAML projects: ``daml new <path to create project in>``
+- Create a new project based on `create-daml-app <https://github.com/digital-asset/create-daml-app>`_: ``daml create-daml-app <path to create project in>``
 - Initialize a DAML project: ``daml init``
 - Compile a DAML project: ``daml build``
 

--- a/libs-haskell/test-utils/BUILD.bazel
+++ b/libs-haskell/test-utils/BUILD.bazel
@@ -15,6 +15,7 @@ da_haskell_library(
         "filepath",
         "process",
         "tasty",
+        "tasty-hunit",
         "text",
     ],
     visibility = ["//visibility:public"],

--- a/libs-haskell/test-utils/DA/Test/Util.hs
+++ b/libs-haskell/test-utils/DA/Test/Util.hs
@@ -4,10 +4,13 @@
 -- | Test utils
 module DA.Test.Util (
     standardizeQuotes,
-    standardizeEoL
+    standardizeEoL,
+    assertInfixOf
 ) where
 
+import Data.List.Extra (isInfixOf)
 import qualified Data.Text as T
+import Test.Tasty.HUnit
 
 standardizeQuotes :: T.Text -> T.Text
 standardizeQuotes msg = let
@@ -19,3 +22,6 @@ standardizeQuotes msg = let
 
 standardizeEoL :: T.Text -> T.Text
 standardizeEoL = T.replace (T.singleton '\r') T.empty
+
+assertInfixOf :: String -> String -> Assertion
+assertInfixOf needle haystack = assertBool ("Expected " <> show needle <> " in output but but got " <> show haystack) (needle `isInfixOf` haystack)

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -10,6 +10,11 @@ commands:
   desc: "Create a new DAML project"
   args: ["new"]
   completion: true
+- name: create-daml-app
+  path: daml-helper/daml-helper
+  desc: "Create a new DAML project based on create-daml-app (experimental)"
+  args: ["create-daml-app"]
+  completion: true
 - name: init
   path: daml-helper/daml-helper
   desc: "Configure a folder as a DAML project"


### PR DESCRIPTION
fixes #4868

changelog_begin

- [DAML Assistant] Add a new ``daml create-daml-app`` command for creating a project based on
  `create-daml-app <https://github.com/digital-asset/create-daml-app>`_.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
