### PR TITLE
Sandbox: make contract id seeding flag public

### DIFF
--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -56,7 +56,7 @@ The sandbox can be configured to use one or the other scheme with one
 of the following command line options:
 
 - ``--contract-id-seeding=<seeding-mode>``. The Sandbox will use the
-  sending mode `<sending-mode>` to seed the generation of random
+  seeding mode `<seeding-mode>` to seed the generation of random
   contract IDs. Possible seeding modes are:
   * ``no``: The Sandbox uses the ``deterministic`` scheme.
   * ``strong``: The Sandbox uses the ``random`` scheme initialized

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -42,11 +42,11 @@ Contract Identifier Generation
 
 Sandbox supports two contract identifier generator schemes:
 
-* The so-called *deterministic* scheme that deterministically produces
+- The so-called *deterministic* scheme that deterministically produces
   contract identifiers from the state of the underlying ledger.  Those
   identifiers are strings starting with ``#``. 
 
-* The so-called *random* scheme that produces contract identifiers
+- The so-called *random* scheme that produces contract identifiers
   indistinguishable from random. In practice, the schemes use a
   cryptographically secure pseudorandom number generator initialized
   with a truly random seed. Those identifiers are hexadecimal strings
@@ -58,17 +58,21 @@ of the following command line options:
 - ``--contract-id-seeding=<seeding-mode>``. The Sandbox will use the
   seeding mode `<seeding-mode>` to seed the generation of random
   contract identifiers. Possible seeding modes are:
-  * ``no``: The Sandbox uses the ``deterministic`` scheme.
-  * ``strong``: The Sandbox uses the ``random`` scheme initialized
+
+  - ``no``: The Sandbox uses the ``deterministic`` scheme.
+
+  - ``strong``: The Sandbox uses the ``random`` scheme initialized
     with a high-entropy seed. Depending on the underlying operating
     system, the startup of the Sandbox may block as entropy is being
     gathered to generate the seed.
-  * ``weak``: (**For testing purposes only**) The Sandbox uses the
+
+  - ``weak``: (**For testing purposes only**) The Sandbox uses the
     ``random`` scheme initialized with a low entropy seed. This may be
     used in a testing environment to avoid exhausting the system
     entropy pool when a large number of Sandboxes are started in a
     short time interval.
-  * ``static``: (**For testing purposes only**) The sandbox uses the
+
+  - ``static``: (**For testing purposes only**) The sandbox uses the
     ``random`` scheme with a fixed seed. This may be used in testing
     for reproducible runs.
 

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -44,10 +44,10 @@ Sandbox supports two contract identifier generator schemes:
 
 - The so-called *deterministic* scheme that deterministically produces
   contract identifiers from the state of the underlying ledger.  Those
-  identifiers are strings starting with ``#``. 
+  identifiers are strings starting with ``#``.
 
 - The so-called *random* scheme that produces contract identifiers
-  indistinguishable from random. In practice, the schemes use a
+  indistinguishable from random.  In practice, the schemes use a
   cryptographically secure pseudorandom number generator initialized
   with a truly random seed. Those identifiers are hexadecimal strings
   prefixed by ``00``.
@@ -55,26 +55,26 @@ Sandbox supports two contract identifier generator schemes:
 The sandbox can be configured to use one or the other scheme with one
 of the following command line options:
 
-- ``--contract-id-seeding=<seeding-mode>``. The Sandbox will use the
+- ``--contract-id-seeding=<seeding-mode>``.  The Sandbox will use the
   seeding mode `<seeding-mode>` to seed the generation of random
   contract identifiers. Possible seeding modes are:
 
   - ``no``: The Sandbox uses the ``deterministic`` scheme.
 
   - ``strong``: The Sandbox uses the ``random`` scheme initialized
-    with a high-entropy seed. Depending on the underlying operating
+    with a high-entropy seed.  Depending on the underlying operating
     system, the startup of the Sandbox may block as entropy is being
     gathered to generate the seed.
 
-  - ``weak``: (**For testing purposes only**) The Sandbox uses the
-    ``random`` scheme initialized with a low entropy seed. This may be
-    used in a testing environment to avoid exhausting the system
-    entropy pool when a large number of Sandboxes are started in a
-    short time interval.
+  - ``testing-weak``: (**For testing purposes only**) The Sandbox uses
+    the ``random`` scheme initialized with a low entropy seed.  This
+    may be used in a testing environment to avoid exhausting the
+    system entropy pool when a large number of Sandboxes are started
+    in a short time interval.
 
-  - ``static``: (**For testing purposes only**) The sandbox uses the
-    ``random`` scheme with a fixed seed. This may be used in testing
-    for reproducible runs.
+  - ``testing-static``: (**For testing purposes only**) The sandbox
+    uses the ``random`` scheme with a fixed seed. This may be used in
+    testing for reproducible runs.
 
 
 Running with persistence

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -57,7 +57,7 @@ of the following command line options:
 
 - ``--contract-id-seeding=<seeding-mode>``. The Sandbox will use the
   seeding mode `<seeding-mode>` to seed the generation of random
-  contract IDs. Possible seeding modes are:
+  contract identifiers. Possible seeding modes are:
   * ``no``: The Sandbox uses the ``deterministic`` scheme.
   * ``strong``: The Sandbox uses the ``random`` scheme initialized
     with a high-entropy seed. Depending on the underlying operating

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -40,7 +40,7 @@ Here, ``daml sandbox`` tells the SDK Assistant to run ``sandbox`` from the activ
 Contract Identifier Generation
 ******************************
 
-Sandbox supports two contract identifiers generator schemes.
+Sandbox supports two contract identifier generator schemes:
 
 * The so-called *deterministic* scheme that deterministically produces
   contract identifiers from the state of the underlying ledger.  Those
@@ -55,22 +55,22 @@ Sandbox supports two contract identifiers generator schemes.
 The sandbox can be configured to use one or the other scheme with one
 of the following command line options:
 
-- ``--contract-id-seeding=<seeding-mode>``.  The sandbox will use the
+- ``--contract-id-seeding=<seeding-mode>``. The Sandbox will use the
   sending mode `<sending-mode>` to seed the generation of random
-  contract id.  Possible seeding mode are :
+  contract IDs. Possible seeding modes are:
   * ``no``. The sandbox uses ``deterministic`` scheme
-  * ``strong``. The sandbox uses the ``random`` scheme initialized
-    with a high entropy seed. Depending on the underlying operating
-    system, the startup of the sandbox may block as entropy is being
+  * ``strong``: The Sandbox uses the ``random`` scheme initialized
+    with a high-entropy seed. Depending on the underlying operating
+    system, the startup of the Sandbox may block as entropy is being
     gathered to generate the seed.
-  * ``weak``. (**For testing purpose only**) The sandbox uses the
+  * ``weak``: (**For testing purposes only**) The Sandbox uses the
     ``random`` scheme initialized with a low entropy seed. This may be
-    used in testing environment to avoid exhausting the system entropy
-    pool when a large number of sandboxed are started in a short time
-    interval.
-  * ``static``. (**For testing purpose only**) The sandbox uses the
-    ``random`` scheme with a fixed seed. This may be used in a testing
-    to have reproducible run.
+    used in a testing environment to avoid exhausting the system
+    entropy pool when a large number of Sandboxes are started in a
+    short time interval.
+  * ``static``: (**For testing purposes only**) The sandbox uses the
+    ``random`` scheme with a fixed seed. This may be used in testing
+    for reproducible runs.
 
 
 Running with persistence

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -58,7 +58,7 @@ of the following command line options:
 - ``--contract-id-seeding=<seeding-mode>``. The Sandbox will use the
   sending mode `<sending-mode>` to seed the generation of random
   contract IDs. Possible seeding modes are:
-  * ``no``. The sandbox uses ``deterministic`` scheme
+  * ``no``: The Sandbox uses the ``deterministic`` scheme.
   * ``strong``: The Sandbox uses the ``random`` scheme initialized
     with a high-entropy seed. Depending on the underlying operating
     system, the startup of the Sandbox may block as entropy is being

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -37,6 +37,42 @@ Here, ``daml sandbox`` tells the SDK Assistant to run ``sandbox`` from the activ
 
   ``submitMustFail`` is only supported by the test-ledger used by ``daml test`` and the IDE, not by the Sandbox.
 
+Contract Identifier Generation
+******************************
+
+Sandbox supports two contract identifiers generator schemes.
+
+* The so-called *deterministic* scheme that deterministically produces
+  contract identifiers from the state of the underlying ledger.  Those
+  identifiers are strings starting with ``#``. 
+
+* The so-called *random* scheme that produces contract identifiers
+  indistinguishable from random. In practice, the schemes use a
+  cryptographically secure pseudorandom number generator initialized
+  with a truly random seed. Those identifiers are hexadecimal strings
+  prefixed by ``00``.
+
+The sandbox can be configured to use one or the other scheme with one
+of the following command line options:
+
+- ``--contract-id-seeding=<seeding-mode>``.  The sandbox will use the
+  sending mode `<sending-mode>` to seed the generation of random
+  contract id.  Possible seeding mode are :
+  * ``no``. The sandbox uses ``deterministic`` scheme
+  * ``strong``. The sandbox uses the ``random`` scheme initialized
+    with a high entropy seed. Depending on the underlying operating
+    system, the startup of the sandbox may block as entropy is being
+    gathered to generate the seed.
+  * ``weak``. (**For testing purpose only**) The sandbox uses the
+    ``random`` scheme initialized with a low entropy seed. This may be
+    used in testing environment to avoid exhausting the system entropy
+    pool when a large number of sandboxed are started in a short time
+    interval.
+  * ``static``. (**For testing purpose only**) The sandbox uses the
+    ``random`` scheme with a fixed seed. This may be used in a testing
+    to have reproducible run.
+
+
 Running with persistence
 ************************
 

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -142,7 +142,7 @@ conformance_test(
     ],
     server = "//ledger/ledger-on-memory:app",
     server_args = [
-        "--contract-id-seeding=weak",
+        "--contract-id-seeding=testing-weak",
         "--participant participant-id=ssl-test,port=6865",
         "--crt $(rlocation $TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.crt))",
         "--cacrt $(rlocation $TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:ca.crt))",

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -103,7 +103,7 @@ conformance_test(
     ports = [6865],
     server = ":app",
     server_args = [
-        "--contract-id-seeding=weak",
+        "--contract-id-seeding=testing-weak",
         "--participant participant-id=example,port=6865",
     ],
     test_tool_args = [
@@ -122,7 +122,7 @@ conformance_test(
     ],
     server = ":app",
     server_args = [
-        "--contract-id-seeding=weak",
+        "--contract-id-seeding=testing-weak",
         "--participant participant-id=example1,port=6865",
         "--participant participant-id=example2,port=6866",
     ],
@@ -139,7 +139,7 @@ conformance_test(
     ports = [6865],
     server = ":app",
     server_args = [
-        "--contract-id-seeding=weak",
+        "--contract-id-seeding=testing-weak",
         "--participant participant-id=example,port=6865",
     ],
     test_tool_args = [

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -224,7 +224,7 @@ da_scala_test_suite(
             ports = [6865],
             server = ":conformance-test-{}-bin".format(db["name"]),
             server_args = [
-                "--contract-id-seeding=weak",
+                "--contract-id-seeding=testing-weak",
                 "--participant participant-id=conformance-test,port=6865",
             ] + db.get("conformance_test_server_args", []),
             tags = db.get("conformance_test_tags", []),
@@ -240,7 +240,7 @@ da_scala_test_suite(
             ports = [6865],
             server = ":conformance-test-{}-bin".format(db["name"]),
             server_args = [
-                "--contract-id-seeding=weak",
+                "--contract-id-seeding=testing-weak",
                 "--participant participant-id=conformance-test,port=6865",
             ] + db.get("conformance_test_server_args", []),
             tags = db.get("conformance_test_tags", []),

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -127,7 +127,7 @@ object Config {
         .action((file, config) => config.copy(archiveFiles = config.archiveFiles :+ file.toPath))
 
       private val seedingMap =
-        Map[String, Seeding]("weak" -> Seeding.Weak, "strong" -> Seeding.Strong)
+        Map[String, Seeding]("testing-weak" -> Seeding.Weak, "strong" -> Seeding.Strong)
 
       opt[String]("contract-id-seeding")
         .optional()

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -415,7 +415,7 @@ server_conformance_test(
     name = "conformance-test-contract-id-seeding",
     server_args = [
         "--static-time",
-        "--contract-id-seeding=weak",
+        "--contract-id-seeding=testing-weak",
     ],
     servers = SERVERS,
     test_tool_args = [
@@ -432,7 +432,7 @@ NEXT_SERVERS = {
     "memory": {
         "binary": ":sandbox-next-binary",
         "server_args": [
-            "--contract-id-seeding=weak",
+            "--contract-id-seeding=testing-weak",
             "--port=6865",
             "--eager-package-loading",
         ],
@@ -440,7 +440,7 @@ NEXT_SERVERS = {
     "postgresql": {
         "binary": ":sandbox-next-ephemeral-postgresql",
         "server_args": [
-            "--contract-id-seeding=weak",
+            "--contract-id-seeding=testing-weak",
             "--port=6865",
             "--eager-package-loading",
         ],

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -259,8 +259,8 @@ object Cli {
 
       private val seedingMap = Map[String, Option[Seeding]](
         "no" -> None,
-        "static" -> Some(Seeding.Static),
-        "weak" -> Some(Seeding.Weak),
+        "testing-static" -> Some(Seeding.Static),
+        "testing-weak" -> Some(Seeding.Weak),
         "strong" -> Some(Seeding.Strong))
 
       opt[String]("contract-id-seeding")

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -274,7 +274,6 @@ object Cli {
               (),
               s"seeding must be ${seedingMap.keys.mkString(",")}"))
         .action((text, config) => config.copy(seeding = seedingMap(text)))
-        .hidden()
 
       opt[MetricsReporter]("metrics-reporter")
         .optional()


### PR DESCRIPTION
* reveal the Sandbox contract id seeding flag. 
* update the sandbox  documentation accordingly 
* prefix seeding mode `weak` and `static` with `testing-`

This advances the state of #3830

CHANGELOG_BEGIN
- [Sandbox] Add support for random contract identifiers.  See section
  `Contract Identifiers Generation` section in
  docs/source/tools/sandbox.rst
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
