### PR TITLE
Act on Option2Iterable wart

### DIFF
--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
@@ -26,7 +26,6 @@ import scala.collection.JavaConverters._
   * method it's overloading, meaning that the return type will be
   * boxed even if it's a DAML-LF primitive
   */
-@SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
 object ToValueGenerator {
 
   import Types._

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -64,7 +64,6 @@ final class ApiTransactionService private (
 
   private val subscriptionIdCounter = new AtomicLong()
 
-  @SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
   override def getTransactions(
       request: GetTransactionsRequest): Source[GetTransactionsResponse, NotUsed] =
     withEnrichedLoggingContext(

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITBase.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITBase.scala
@@ -38,7 +38,6 @@ import scala.concurrent.Future
 @SuppressWarnings(
   Array(
     "org.wartremover.warts.Any",
-    "org.wartremover.warts.Option2Iterable",
     "org.wartremover.warts.StringPlusAny"
   ))
 abstract class ScenarioLoadingITBase

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITDivulgence.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/ScenarioLoadingITDivulgence.scala
@@ -21,7 +21,6 @@ import org.scalatest.{Matchers, WordSpec}
 @SuppressWarnings(
   Array(
     "org.wartremover.warts.Any",
-    "org.wartremover.warts.Option2Iterable",
     "org.wartremover.warts.StringPlusAny"
   ))
 class ScenarioLoadingITDivulgence

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/UIBackend.scala
@@ -44,7 +44,7 @@ import scala.util.{Failure, Success, Try}
   * A new UI backend can be implemented by extending [[UIBackend]] and by providing
   * the [[customEndpoints]], [[customRoutes]], [[applicationInfo]] definitions.
   */
-@SuppressWarnings(Array("org.wartremover.warts.Any", "org.wartremover.warts.Option2Iterable"))
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
 abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
 
   def customEndpoints: Set[CustomEndpoint[_]]
@@ -78,7 +78,8 @@ abstract class UIBackend extends LazyLogging with ApplicationInfoJsonSupport {
       case Cookie(cookies) =>
         cookies
           .filter(_.name == "session-id")
-          .flatMap(cookiePair => Session.current(cookiePair.value).map(cookiePair.value -> _))
+          .flatMap(cookiePair =>
+            Session.current(cookiePair.value).map(cookiePair.value -> _).toList)
           .headOption
       case _ =>
         None

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Config.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Config.scala
@@ -22,12 +22,11 @@ import scalaz.Tag
 final case class UserConfig(password: Option[String], party: PartyState, role: Option[String])
 
 /* The configuration has an empty map as default list of users because you can login as party too */
-@SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
 final case class Config(users: Map[String, UserConfig] = Map.empty[String, UserConfig]) {
 
   def userIds: Set[String] = users.keySet
 
-  def roles: Set[String] = users.values.flatMap(_.role)(collection.breakOut)
+  def roles: Set[String] = users.values.flatMap(_.role.toList)(collection.breakOut)
   def parties: Set[PartyState] = users.values.map(_.party)(collection.breakOut)
 }
 
@@ -45,7 +44,7 @@ sealed abstract class ConfigOption {
 final case class DefaultConfig(path: Path) extends ConfigOption
 final case class ExplicitConfig(path: Path) extends ConfigOption
 
-@SuppressWarnings(Array("org.wartremover.warts.Any", "org.wartremover.warts.Option2Iterable"))
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
 object Config {
 
   private[this] val logger = LoggerFactory.getLogger(this.getClass)

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/AsciiTable.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/AsciiTable.scala
@@ -71,8 +71,7 @@ object Maths {
   *    &lt;- 7 ->
   * </pre>
   */
-@SuppressWarnings(
-  Array("org.wartremover.warts.Option2Iterable", "org.wartremover.warts.StringPlusAny"))
+@SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
 final class AsciiTable {
   private var header: Option[Seq[String]] = None
   private val streamBuilder = new StreamBuilder[Seq[String]]

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Exercise.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Exercise.scala
@@ -19,11 +19,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.Try
 
-@SuppressWarnings(
-  Array(
-    "org.wartremover.warts.Product",
-    "org.wartremover.warts.Option2Iterable",
-    "org.wartremover.warts.Serializable"))
+@SuppressWarnings(Array("org.wartremover.warts.Product", "org.wartremover.warts.Serializable"))
 case object Exercise extends SimpleCommand {
   def name: String = "exercise"
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Info.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/commands/Info.scala
@@ -6,7 +6,6 @@ package com.digitalasset.navigator.console.commands
 import java.util.concurrent.TimeUnit
 
 import com.digitalasset.ledger.api.refinements.ApiTypes
-import com.digitalasset.ledger.api.tls.TlsConfiguration
 import com.digitalasset.navigator.console._
 import com.digitalasset.navigator.store.Store._
 import com.digitalasset.navigator.time.TimeProviderType
@@ -17,7 +16,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
 
-@SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
 case object Info extends SimpleCommand {
   def name: String = "info"
 
@@ -112,19 +110,6 @@ case object Info extends SimpleCommand {
       future <- Try((state.store ? GetApplicationStateInfo).mapTo[ApplicationStateInfo]) ~> "Failed to get info"
       info <- Try(Await.result(future, 10.seconds)) ~> "Failed to get info"
     } yield (state, getBanner(state) + "\n" + Pretty.yaml(prettyInfo(info, state)))
-  }
-
-  private def tlsInfo(info: Option[TlsConfiguration]): String = {
-    info
-      .map(c =>
-        if (c.enabled) {
-          val crt = c.keyCertChainFile.map(_ => "CRT")
-          val pem = c.keyFile.map(_ => "PEM")
-          val cacrt = c.trustCertCollectionFile.map(_ => "CACRT")
-          val options = List(crt, pem, cacrt).flatten
-          s"Enabled, using ${options.mkString(", ")}."
-        } else "Disabled.")
-      .getOrElse("Not set.")
   }
 
   def getBanner(state: State): String = {

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/graphql/GraphQLSchema.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/graphql/GraphQLSchema.scala
@@ -41,11 +41,7 @@ case class UserFacingError(message: String)
 }
 
 /** Schema definition for the UI backend GraphQL API. */
-@SuppressWarnings(
-  Array(
-    "org.wartremover.warts.Any",
-    "org.wartremover.warts.Option2Iterable",
-    "org.wartremover.warts.JavaSerializable"))
+@SuppressWarnings(Array("org.wartremover.warts.Any", "org.wartremover.warts.JavaSerializable"))
 final class GraphQLSchema(customEndpoints: Set[CustomEndpoint[_]]) {
 
   implicit private val actorTimeout: Timeout = Timeout(60, TimeUnit.SECONDS)
@@ -586,27 +582,27 @@ final class GraphQLSchema(customEndpoints: Set[CustomEndpoint[_]]) {
             case ContractType.name =>
               ids
                 .map(id => ApiTypes.ContractId(id.toString))
-                .flatMap(ledger.contract(_, context.ctx.templates))
+                .flatMap(ledger.contract(_, context.ctx.templates).toList)
                 .toSeq
             case TemplateType.name =>
               ids
                 .map(id => TemplateStringId(id.toString))
-                .flatMap(context.ctx.templates.templateByStringId)
+                .flatMap(context.ctx.templates.templateByStringId(_).toList)
                 .toSeq
             case CommandType.name =>
               ids
                 .map(id => ApiTypes.CommandId(id.toString))
-                .flatMap(context.ctx.ledger.command(_, context.ctx.templates))
+                .flatMap(context.ctx.ledger.command(_, context.ctx.templates).toList)
                 .toSeq
             case EventType.name =>
               ids
                 .map(id => ApiTypes.EventId(id.toString))
-                .flatMap(context.ctx.ledger.event(_, context.ctx.templates))
+                .flatMap(context.ctx.ledger.event(_, context.ctx.templates).toList)
                 .toSeq
             case TransactionType.name =>
               ids
                 .map(id => ApiTypes.TransactionId(id.toString))
-                .flatMap(context.ctx.ledger.transaction(_, context.ctx.templates))
+                .flatMap(context.ctx.ledger.transaction(_, context.ctx.templates).toList)
                 .toSeq
             case _ => Seq.empty[Node[_]]
           }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Ledger.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/Ledger.scala
@@ -10,7 +10,6 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.util.{Failure, Success, Try}
 
 /** In-memory projection of ledger events. */
-@SuppressWarnings(Array("org.wartremover.warts.Option2Iterable"))
 case class Ledger(
     private val forParty: ApiTypes.Party,
     private val lastTransaction: Option[Transaction],
@@ -176,14 +175,6 @@ case class Ledger(
         eventById = eventById + (event.id -> event)
       )
     }
-  }
-
-  private def contractsByTemplateIdWithout(contractId: ApiTypes.ContractId) = {
-    val entryWithoutContract = for {
-      contract <- contractById.get(contractId)
-      templateContracts <- contractsByTemplateId.get(contract.template.id)
-    } yield contract.template.id -> (templateContracts - contract)
-    contractsByTemplateId ++ entryWithoutContract.toMap
   }
 
   def allContractsCount: Int = {


### PR DESCRIPTION
Some Option2Iterable ignore annotations are not needed, others were needed for unused methods.

In a few occasions we were ignoring the warning for the very purpose for which is was there,
i.e. avoiding an implicit conversion. I'm all for not verifying this rule if we agree we
don't need it.

For ProcessFailedException it was a bit gratuitous, I changed the way in which the exception
message is built.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
