### PR TITLE
Allow controlling navigator startup in daml.yaml

### DIFF
--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -140,7 +140,7 @@ Here is what each field means:
   runner when running the ``init-script`` as part of ``daml start``.
 - ``start-navigator``: Controls whether navigator is started as part
   of ``daml start``. Defaults to ``true``. If this is specified as a CLI argument,
-  say ``daml start --start-navigator=yes``, the CLI argument takes precedence over
+  say ``daml start --start-navigator=true``, the CLI argument takes precedence over
   the value in ``daml.yaml``.
 
 ..  TODO (@robin-da) document the dependency syntax

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -139,8 +139,8 @@ Here is what each field means:
 - ``script-options``: a list of options that will be passed to the DAML script
   runner when running the ``init-script`` as part of ``daml start``.
 - ``start-navigator``: Controls whether navigator is started as part
-  of ``daml start``. Defaults to ``true``. If this is specified as a CLI argument
-  to ``daml start --start-navigator=yes``, the CLI argument takes precedence over
+  of ``daml start``. Defaults to ``true``. If this is specified as a CLI argument,
+  say ``daml start --start-navigator=yes``, the CLI argument takes precedence over
   the value in ``daml.yaml``.
 
 ..  TODO (@robin-da) document the dependency syntax

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -138,6 +138,10 @@ Here is what each field means:
 - ``json-api-options``: a list of options that will be passed to the HTTP JSON API in ``daml start``.
 - ``script-options``: a list of options that will be passed to the DAML script
   runner when running the ``init-script`` as part of ``daml start``.
+- ``start-navigator``: Controls whether navigator is started as part
+  of ``daml start``. Defaults to ``true``. If this is specified as a CLI argument
+  to ``daml start --start-navigator=yes``, the CLI argument takes precedence over
+  the value in ``daml.yaml``.
 
 ..  TODO (@robin-da) document the dependency syntax
 


### PR DESCRIPTION
While I’m not entirely convinced the default atm is right, making it
configurable seems like an easier solution than bikeshedding the default.

changelog_begin

- [DAML Assistant] You can now disable starting navigator as part of
  ``daml start`` in your ``daml.yaml`` file by adding ``start-navigator: false``.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
