### PR TITLE
Increase the time allowed for DB-backed reset service to complete tests

### DIFF
--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceDatabaseIT.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceDatabaseIT.scala
@@ -18,6 +18,9 @@ import scala.util.Try
 
 abstract class ResetServiceDatabaseIT extends ResetServiceITBase with SandboxFixture {
 
+  // Database-backed reset service is allowed a bit more slack
+  override def spanScaleFactor: Double = 2.0
+
   "ResetService" when {
 
     "run against a database backend" should {


### PR DESCRIPTION
The database-backed reset service can (understandably) go a bit slower than the one backed by the in-memory ledger.

This should help avoiding flaky tests.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
