### PR TITLE
Avoid recompiling loaded packages in REPL

### DIFF
--- a/compiler/repl-service/server/BUILD.bazel
+++ b/compiler/repl-service/server/BUILD.bazel
@@ -26,7 +26,6 @@ da_scala_binary(
         "//compiler/repl-service/protos:repl_service_java_proto",
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/data",
-        "//daml-lf/engine",
         "//daml-lf/interpreter",
         "//daml-lf/language",
         "//daml-script/runner:script-runner-lib",

--- a/compiler/repl-service/server/BUILD.bazel
+++ b/compiler/repl-service/server/BUILD.bazel
@@ -26,6 +26,7 @@ da_scala_binary(
         "//compiler/repl-service/protos:repl_service_java_proto",
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//daml-lf/interpreter",
         "//daml-lf/language",
         "//daml-script/runner:script-runner-lib",


### PR DESCRIPTION
This avoids unnecessary recompilation of previously loaded packages.

The REPL service's "load package" method now adds the uploaded package to the `compiledPackages` right away. For this to work packages have to be uploaded in topological order.


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
