### PR TITLE
fix tf config for GCP default

### DIFF
--- a/infra/modules/gcp_cdn_bucket/google_storage.tf
+++ b/infra/modules/gcp_cdn_bucket/google_storage.tf
@@ -39,6 +39,13 @@ resource "google_storage_bucket" "default" {
     }
   }
 
+  website {
+    # This doesn't exist, but the property has to have a value, otherwise GCP
+    # sets a default one and Terraform never thinks the config applies cleanly.
+    # I miss AWS.
+    main_page_suffix = "index.html"
+  }
+
   force_destroy = true
 }
 


### PR DESCRIPTION
It looks like GCP doesn't like not having a "page suffix" set, so it sets a default. Except somehow Terraform doesn't know it's a default value, so when trying to plan without the (optional) website value set, Terraform will always find that the deployed state has changed.

With this change, we set it to a value that doesn't exist and won't work, but at least Terraform will see that the deployed state matches the configured one.

Note: this PR is a bit special as far as "changes" go as there will be nothing to apply: applying current master tries to get rid of this website.main_page_suffix value, but it's back on the next run. With this patch, `terraform plan` declares "nothing to apply", so this PR itself won't (need to) be applied.

CHANGELOG_BEGIN
CHANGELOG_END