### PR TITLE
Getting Started Guide: Update codegen command to SDK 0.13.55

### DIFF
--- a/docs/source/getting-started/app-architecture.rst
+++ b/docs/source/getting-started/app-architecture.rst
@@ -4,12 +4,12 @@
 App Architecture
 ****************
 
-In this section we'll look at the different components of our social network app. The goal is to familiarise you enough to feel comfortable extending the code with a new feature in the next section. There are two main components: 
+In this section we'll look at the different components of our social network app. The goal is to familiarise you enough to feel comfortable extending the code with a new feature in the next section. There are two main components:
 
-  * the DAML model and 
-  * the React/TypeScript frontend. 
-  
-We generate TypeScript code to bridge the two. 
+  * the DAML model and
+  * the React/TypeScript frontend.
+
+We generate TypeScript code to bridge the two.
 
 Overall, the social networking app is following the :ref:`recommended architecture of a fullstack DAML application <recommended-architecture>`. Below you can see a simplified version of the architecture represented in the app.
 
@@ -65,14 +65,14 @@ The last part of the DAML model is the operation to follow users, called a *choi
   :end-before: -- ADDFRIEND_END
 
 DAML contracts are *immutable* (can not be changed in place), so the only way to "update" one is to archive it and create a new instance.
-That is what the ``Follow`` choice does: after checking some preconditions, it archives the current user contract and creates a new one with the new user to follow added to the list. Here is a quick explanation of the code: 
+That is what the ``Follow`` choice does: after checking some preconditions, it archives the current user contract and creates a new one with the new user to follow added to the list. Here is a quick explanation of the code:
 
     - The choice starts with the ``nonconsuming choice`` keyword followed by the choice name ``Follow``.
     - The return type of a choice is defined next. In this case it is ``ContractId User``.
     - After that we declare choice paramteres with ``with`` keyword. Here this is the user we want to start following.
     - The keyword ``controller`` defines the ``Party`` that is allowed to execute the choice. In this case, it is the ``username`` party associated with the ``User`` contract.
     - The ``do`` keyword marks the start of the choice body where its functionality will be written.
-    - After passing some checks current contract is archived with ``archive self`` 
+    - After passing some checks, the current contract is archived with ``archive self``.
     - A new ``User`` contract with the new user we have started following is created (the new user is added to the ``following`` list).
 
 This information should be enough for understanding how choices work in this guide. More detailed information on choices can be found in :doc:`our docs </daml/reference/choices>`).
@@ -88,15 +88,15 @@ TypeScript is a variant of Javascript that provides more support during developm
 In order to build an application on top of DAML, we need a way to refer to our DAML templates and choices in TypeScript.
 We do this using a DAML to TypeScript code generation tool in the DAML SDK.
 
-To run code generation, we first need to compile the DAML model to an archive format (with a ``.dar`` extension).
-Then the command ``daml codegen ts`` takes this file as argument to produce a number of TypeScript files in the specified location.
+To run code generation, we first need to compile the DAML model to an archive format (a ``.dar`` file).
+The ``daml codegen ts`` command then takes this file as argument to produce a number of TypeScript packages in the output folder.
+It also updates our ``package.json`` file with the newly generated dependencies.
 ::
 
     daml build
-    daml codegen ts .daml/dist/create-daml-app-0.1.0.dar -o daml-ts/src
+    daml codegen ts .daml/dist/create-daml-app-0.1.0.dar -o daml-ts -p package.json
 
-We now have TypeScript types and companion objects in the ``daml-ts`` workspace which we can use from our UI code.
-We'll see that next.
+Now we have a TypeScript interface (types and companion objects) to our DAML model, which we'll use in our UI code next.
 
 The UI
 ======
@@ -117,7 +117,7 @@ We'll first look at ``App.tsx``, which is the entry point to our application.
 An important tool in the design of our components is a React feature called `Hooks <https://reactjs.org/docs/hooks-intro.html>`_.
 Hooks allow you to share and update state across components, avoiding having to thread it through manually.
 We take advantage of hooks in particular to share ledger state across components.
-We use custom `DAML React hooks <daml-react/index.html>`_ to query the ledger for contracts, create new contracts, and exercise choices. This is the library you will be using the most when interacting with the ledger [#f1]_ . 
+We use custom `DAML React hooks <daml-react/index.html>`_ to query the ledger for contracts, create new contracts, and exercise choices. This is the library you will be using the most when interacting with the ledger [#f1]_ .
 
 The ``useState`` hook (not specific to DAML) here keeps track of the user's credentials.
 If they are not set, we render the ``LoginScreen`` with a callback to ``setCredentials``.
@@ -166,4 +166,4 @@ You'll see this more as you develop :doc:`your first feature <first-feature>` fo
 
 .. rubric:: Footnotes
 
-.. [#f1] FYI Behind the scenes the DAML React hooks library uses the `DAML Ledger React library <daml-ledger/index.html>`_ to communicate with a ledger implementation via :doc:`HTTP JSON API </json-api/index>`. 
+.. [#f1] FYI Behind the scenes the DAML React hooks library uses the `DAML Ledger React library <daml-ledger/index.html>`_ to communicate with a ledger implementation via :doc:`HTTP JSON API </json-api/index>`.

--- a/docs/source/getting-started/first-feature.rst
+++ b/docs/source/getting-started/first-feature.rst
@@ -4,7 +4,7 @@
 Your First Feature
 ******************
 
-Let's dive into implementing a new feature for our social network app. 
+Let's dive into implementing a new feature for our social network app.
 This will give us a better idea how to develop DAML applications using our template.
 
 At the moment, our app lets us follow users in the network, but we have no way to communicate with them!
@@ -17,9 +17,9 @@ This means:
 
 We will see that DAML lets us implement these guarantees in a direct and intuitive way.
 
-There are three parts to building and running the messaging feature: 
+There are three parts to building and running the messaging feature:
 
-    1. Adding the necessary changes to the DAML model  
+    1. Adding the necessary changes to the DAML model
     2. Making the corresponding changes in the UI
     3. Running the new feature. In order to do that we need to terminate the previous ``daml start --start-navigator=no`` process and run it again.
 
@@ -36,7 +36,7 @@ For the authorization part, we take the following approach: a user Bob can messa
 When Alice starts following Bob back, she gives permission or *authority* to Bob to send her a message.
 
 To implement this workflow, let's start by adding the new *data* for messages.
-Navigate to the ``daml/User.daml`` file and copy the following ``Message`` template to the bottom. 
+Navigate to the ``daml/User.daml`` file and copy the following ``Message`` template to the bottom.
 Indentation is important: it should be at the top level like the original ``User`` template.
 
 .. literalinclude:: code/daml/User.daml
@@ -74,9 +74,10 @@ Since we have changed our DAML code, we also need to rerun the TypeScript code g
 Open a new terminal and run the following commands::
 
   daml build
-  daml codegen ts .daml/dist/create-daml-app-0.1.0.dar -o daml-ts/src
+  daml codegen ts .daml/dist/create-daml-app-0.1.0.dar -o daml-ts -p package.json
 
-As the TypeScript code is generated into the separate ``daml-ts`` workspace which the UI depends on, we need to rebuild the workspaces from the root ``create-daml-app`` folder using::
+Since we've generated new TypeScript packages in the ``daml-ts`` folder, we need to rebuild our project using these dependencies.
+From the root ``create-daml-app`` folder, run::
 
   yarn workspaces run build
 
@@ -184,13 +185,13 @@ We need to terminate the previous ``daml start --start-navigator=no`` process an
 
   - Compile our DAML code into a *DAR file containing the new feature*
   - Run a fresh instance of the *Sandbox with the new DAR file*
-  - Start the HTTP JSON API 
+  - Start the HTTP JSON API
 
 First, navigate to the terminal window where the ``daml start --start-navigator=no`` process is running and terminate the active process by hitting ``Ctrl-C``. This shuts down the previous instances of the sandbox. Next in the root ``create-daml-app`` folder run ``daml start --start-navigator=no``.
 
-As mentioned at the beginning of this *Getting Started with DAML* guide, DAML Sandbox uses an in-memory store, which means it loses its state when stopped or restarted. That means that all user data and follower relationships are lost. 
+As mentioned at the beginning of this *Getting Started with DAML* guide, DAML Sandbox uses an in-memory store, which means it loses its state when stopped or restarted. That means that all user data and follower relationships are lost.
 
-If you have the frontend UI up and running you're all set. In case you don't have the UI running open a new terminal window and navigate to the ``create-daml-app/ui`` folder and run the ``yaml start`` command, which will start the UI. 
+If you have the frontend UI up and running you're all set. In case you don't have the UI running open a new terminal window and navigate to the ``create-daml-app/ui`` folder and run the ``yaml start`` command, which will start the UI.
 
 Once you've done all these changes you should see the same login page as before at http://localhost:3000.
 Once you've logged in, you'll see a familiar UI but with our new *Messages* panel at the bottom!

--- a/docs/source/getting-started/first-feature.rst
+++ b/docs/source/getting-started/first-feature.rst
@@ -81,7 +81,8 @@ From the root ``create-daml-app`` folder, run::
 
   yarn workspaces run build
 
-We should now have an up-to-date TypeScript interface to our DAML model, in particular to the ``Message`` template and ``SendMessage`` choice.
+This may take a couple of minutes.
+The result is an up-to-date TypeScript interface to our DAML model, in particular to the new ``Message`` template and ``SendMessage`` choice.
 
 We can now implement our messaging feature in the UI!
 

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -72,6 +72,7 @@ Now, use Yarn to install the project dependencies and build the app::
     yarn install
     yarn workspaces run build
 
+These steps may take a couple of minutes each (it's worth it!).
 You should see ``Compiled successfully.`` in the output if everything worked as expected.
 
 .. TODO: Give instructions for possible failures.

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -65,7 +65,7 @@ Once the DAR file is created you will see this message in terminal ``Created .da
 Any commands starting with ``daml`` are using the :doc:`DAML Assistant </tools/assistant>`, a command line tool in the DAML SDK for building and running DAML apps.
 In order to connect the UI code to this DAML, we need to run a code generation step::
 
-    daml codegen ts .daml/dist/create-daml-app-0.1.0.dar -o daml-ts/src
+    daml codegen ts .daml/dist/create-daml-app-0.1.0.dar -o daml-ts
 
 Now, use Yarn to install the project dependencies and build the app::
 

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -35,7 +35,7 @@ With that, let's get started!
 Prerequisites
 *************
 
-Please make sure that you have the DAML SDK, Java 8 or higher, and Visual Studio Code (the only supported IDE) installed as per instructions from our :doc:`installation` page. 
+Please make sure that you have the DAML SDK, Java 8 or higher, and Visual Studio Code (the only supported IDE) installed as per instructions from our :doc:`installation` page.
 
 You will also need some common software tools to build and interact with the template project.
 
@@ -65,7 +65,7 @@ Once the DAR file is created you will see this message in terminal ``Created .da
 Any commands starting with ``daml`` are using the :doc:`DAML Assistant </tools/assistant>`, a command line tool in the DAML SDK for building and running DAML apps.
 In order to connect the UI code to this DAML, we need to run a code generation step::
 
-    daml codegen ts .daml/dist/create-daml-app-0.1.0.dar -o daml-ts
+    daml codegen ts .daml/dist/create-daml-app-0.1.0.dar -o daml-ts -p package.json
 
 Now, use Yarn to install the project dependencies and build the app::
 
@@ -100,7 +100,7 @@ The command should automatically open a window in your default browser at http:/
 If it doesn't, just open that link in a web browser.
 (Depending on your firewall settings, you may be asked whether to allow the app to receive network connections. It is safe to accept.)
 
-You should now see the login page for the social network. For simplicity of this app, there is no password or sign-up required.   
+You should now see the login page for the social network. For simplicity of this app, there is no password or sign-up required.
 First enter your name and click *Log in*.
 You should see the main screen with two panels. One for the users you are following and one for your followers.
 Initially these are both empty as you are not following anyone and you don't have any followers!


### PR DESCRIPTION
If you don't do this, running `yarn install` will complain:
```
error Couldn't find package "@daml-ts/create-daml-app-0.1.0@0.13.55" required by "create-daml-app@0.1.0" on the "npm" registry.
```
This was with yarn v1.22.4 - can someone please double-check this please?