### PR TITLE
kvutils: Inject the metrics registry instead of using SharedMetricRegistries.

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -28,6 +28,7 @@ da_scala_library(
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:io_dropwizard_metrics_metrics_core",
     ],
 )
 
@@ -54,6 +55,7 @@ da_scala_test(
         "//libs-scala/resources",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:org_scalactic_scalactic_2_12",
         "@maven//:org_scalatest_scalatest_2_12",
     ],

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -31,8 +31,9 @@ object Main {
         logCtx: LoggingContext,
     ): ResourceOwner[InMemoryLedgerReaderWriter] =
       new InMemoryLedgerReaderWriter.Owner(
-        config.ledgerId,
-        participantConfig.participantId,
+        initialLedgerId = config.ledgerId,
+        participantId = participantConfig.participantId,
+        metricRegistry = metricRegistry(participantConfig, config),
         dispatcher = dispatcher,
         state = state,
       )

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
@@ -7,8 +7,9 @@ import java.time.Instant
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase
-import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase._
+import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase.ParticipantState
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
 import com.daml.ledger.participant.state.v1.{LedgerId, ParticipantId}
 import com.digitalasset.logging.LoggingContext
@@ -24,6 +25,7 @@ class InMemoryLedgerReaderWriterIntegrationSpec
       participantId: ParticipantId,
       testId: String,
       heartbeats: Source[Instant, NotUsed],
+      metricRegistry: MetricRegistry,
   )(implicit logCtx: LoggingContext): ResourceOwner[ParticipantState] =
     new InMemoryLedgerReaderWriter.SingleParticipantOwner(
       ledgerId,

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
@@ -28,6 +28,7 @@ class InMemoryLedgerReaderWriterIntegrationSpec
     new InMemoryLedgerReaderWriter.SingleParticipantOwner(
       ledgerId,
       participantId,
+      metricRegistry,
       heartbeats = heartbeats,
     ).map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
 }

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -201,6 +201,7 @@ da_scala_test_suite(
         "//libs-scala/resources",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:org_flywaydb_flyway_core",
         "@maven//:org_scala_lang_modules_scala_java8_compat_2_12",
         "@maven//:org_scalactic_scalactic_2_12",

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -103,6 +103,7 @@ da_scala_library(
         "@maven//:com_typesafe_play_anorm_2_12",
         "@maven//:com_typesafe_play_anorm_tokenizer_2_12",
         "@maven//:com_zaxxer_HikariCP",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:org_flywaydb_flyway_core",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -56,9 +56,10 @@ object SqlLedgerFactory extends LedgerFactory[ReadWriteService, ExtraConfig] {
       new SqlLedgerReaderWriter.Owner(
         config.ledgerId,
         participantConfig.participantId,
+        metricRegistry(participantConfig, config),
         jdbcUrl,
-        seedService = SeedService(Seeding.Strong))
-        .acquire()
+        seedService = SeedService(Seeding.Strong),
+      ).acquire()
         .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
     }
   }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -9,12 +9,12 @@ import java.util.UUID
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.on.sql.SqlLedgerReaderWriter._
 import com.daml.ledger.on.sql.queries.Queries
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
-import com.daml.ledger.participant.state.kvutils.KVOffset
 import com.daml.ledger.participant.state.kvutils.api.{LedgerEntry, LedgerReader, LedgerWriter}
+import com.daml.ledger.participant.state.kvutils.{Bytes, KVOffset}
 import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator._
@@ -35,6 +35,7 @@ import scala.util.{Failure, Success}
 final class SqlLedgerReaderWriter(
     override val ledgerId: LedgerId = Ref.LedgerString.assertFromString(UUID.randomUUID.toString),
     val participantId: ParticipantId,
+    metricRegistry: MetricRegistry,
     timeProvider: TimeProvider,
     database: Database,
     dispatcher: Dispatcher[Index],
@@ -56,7 +57,11 @@ final class SqlLedgerReaderWriter(
   private val committer = new ValidatingCommitter[Index](
     () => timeProvider.getCurrentTime,
     SubmissionValidator
-      .create(SqlLedgerStateAccess, allocateNextLogEntryId = () => allocateSeededLogEntryId()),
+      .create(
+        SqlLedgerStateAccess,
+        allocateNextLogEntryId = () => allocateSeededLogEntryId(),
+        metricRegistry = metricRegistry,
+      ),
     latestSequenceNo => dispatcher.signalNewHead(latestSequenceNo),
   )
 
@@ -110,10 +115,11 @@ object SqlLedgerReaderWriter {
   class Owner(
       initialLedgerId: Option[LedgerId],
       participantId: ParticipantId,
+      metricRegistry: MetricRegistry,
       jdbcUrl: String,
       timeProvider: TimeProvider = DefaultTimeProvider,
       heartbeats: Source[Instant, NotUsed] = Source.empty,
-      seedService: SeedService
+      seedService: SeedService,
   )(implicit materializer: Materializer, logCtx: LoggingContext)
       extends ResourceOwner[SqlLedgerReaderWriter] {
     override def acquire()(
@@ -129,10 +135,12 @@ object SqlLedgerReaderWriter {
         new SqlLedgerReaderWriter(
           ledgerId,
           participantId,
+          metricRegistry,
           timeProvider,
           database,
           dispatcher,
-          seedService)
+          seedService,
+        )
   }
 
   private def updateOrRetrieveLedgerId(initialLedgerId: Option[LedgerId], database: Database)(

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
@@ -7,6 +7,7 @@ import java.time.Instant
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase
 import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase.ParticipantState
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
@@ -26,6 +27,7 @@ abstract class SqlLedgerReaderWriterIntegrationSpecBase(implementationName: Stri
       participantId: ParticipantId,
       testId: String,
       heartbeats: Source[Instant, NotUsed],
+      metricRegistry: MetricRegistry,
   )(implicit logCtx: LoggingContext): ResourceOwner[ParticipantState] =
     new SqlLedgerReaderWriter.Owner(
       ledgerId,

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
@@ -30,9 +30,10 @@ abstract class SqlLedgerReaderWriterIntegrationSpecBase(implementationName: Stri
     new SqlLedgerReaderWriter.Owner(
       ledgerId,
       participantId,
+      metricRegistry,
       jdbcUrl(testId),
       heartbeats = heartbeats,
       // Using a weak random source to avoid slowdown during tests.
-      seedService = SeedService(Seeding.Weak)
+      seedService = SeedService(Seeding.Weak),
     ).map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
 }

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -77,6 +77,7 @@ da_scala_library(
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:org_scala_lang_modules_scala_java8_compat_2_12",
         "@maven//:org_scalactic_scalactic_2_12",
         "@maven//:org_scalatest_scalatest_2_12",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -137,7 +137,7 @@ class KeyValueCommitting(metricRegistry: MetricRegistry) {
   ): (DamlLogEntry, Map[DamlStateKey, DamlStateValue]) =
     submission.getPayloadCase match {
       case DamlSubmission.PayloadCase.PACKAGE_UPLOAD_ENTRY =>
-        PackageCommitter(engine).run(
+        new PackageCommitter(engine, metricRegistry).run(
           entryId,
           //TODO replace this call with an explicit maxRecordTime from the request once available
           estimateMaximumRecordTime(recordTime),
@@ -148,7 +148,7 @@ class KeyValueCommitting(metricRegistry: MetricRegistry) {
         )
 
       case DamlSubmission.PayloadCase.PARTY_ALLOCATION_ENTRY =>
-        PartyAllocationCommitter.run(
+        new PartyAllocationCommitter(metricRegistry).run(
           entryId,
           //TODO replace this call with an explicit maxRecordTime from the request once available
           estimateMaximumRecordTime(recordTime),
@@ -159,7 +159,7 @@ class KeyValueCommitting(metricRegistry: MetricRegistry) {
         )
 
       case DamlSubmission.PayloadCase.CONFIGURATION_SUBMISSION =>
-        ConfigCommitter(defaultConfig).run(
+        new ConfigCommitter(defaultConfig, metricRegistry).run(
           entryId,
           parseTimestamp(submission.getConfigurationSubmission.getMaximumRecordTime),
           recordTime,
@@ -169,7 +169,7 @@ class KeyValueCommitting(metricRegistry: MetricRegistry) {
         )
 
       case DamlSubmission.PayloadCase.TRANSACTION_ENTRY =>
-        ProcessTransactionSubmission(defaultConfig, engine).run(
+        new ProcessTransactionSubmission(defaultConfig, engine).run(
           entryId,
           recordTime,
           participantId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -169,7 +169,7 @@ class KeyValueCommitting(metricRegistry: MetricRegistry) {
         )
 
       case DamlSubmission.PayloadCase.TRANSACTION_ENTRY =>
-        new ProcessTransactionSubmission(defaultConfig, engine).run(
+        new ProcessTransactionSubmission(defaultConfig, engine, metricRegistry).run(
           entryId,
           recordTime,
           participantId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.participant.state.kvutils
 
 import com.codahale.metrics
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.Conversions._
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.committer.{
@@ -25,16 +26,19 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 
-object KeyValueCommitting {
+class KeyValueCommitting(metricRegistry: MetricRegistry) {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   def packDamlStateKey(key: DamlStateKey): ByteString = key.toByteString
+
   def unpackDamlStateKey(bytes: ByteString): DamlStateKey =
     DamlStateKey.parseFrom(bytes)
 
   def packDamlStateValue(value: DamlStateValue): ByteString = value.toByteString
+
   def unpackDamlStateValue(bytes: Array[Byte]): DamlStateValue =
     DamlStateValue.parseFrom(bytes)
+
   def unpackDamlStateValue(bytes: ByteString): DamlStateValue =
     DamlStateValue.parseFrom(bytes)
 
@@ -317,30 +321,28 @@ object KeyValueCommitting {
   }
 
   private object Metrics {
-    //TODO: Replace with metrics registry object passed in constructor
-    private val registry = metrics.SharedMetricRegistries.getOrCreate("kvutils")
     private val prefix = "kvutils.committer"
 
     // Timer (and count) of how fast submissions have been processed.
-    val runTimer: metrics.Timer = registry.timer(s"$prefix.run_timer")
+    val runTimer: metrics.Timer = metricRegistry.timer(s"$prefix.run_timer")
 
     // Number of exceptions seen.
-    val exceptions: metrics.Counter = registry.counter(s"$prefix.exceptions")
+    val exceptions: metrics.Counter = metricRegistry.counter(s"$prefix.exceptions")
 
     // Counter to monitor how many at a time and when kvutils is processing a submission.
-    val processing: metrics.Counter = registry.counter(s"$prefix.processing")
+    val processing: metrics.Counter = metricRegistry.counter(s"$prefix.processing")
 
     val lastRecordTimeGauge = new VarGauge[String]("<none>")
-    registry.register(s"$prefix.last.record_time", lastRecordTimeGauge)
+    metricRegistry.register(s"$prefix.last.record_time", lastRecordTimeGauge)
 
     val lastEntryIdGauge = new VarGauge[String]("<none>")
-    registry.register(s"$prefix.last.entry_id", lastEntryIdGauge)
+    metricRegistry.register(s"$prefix.last.entry_id", lastEntryIdGauge)
 
     val lastParticipantIdGauge = new VarGauge[String]("<none>")
-    registry.register(s"$prefix.last.participant_id", lastParticipantIdGauge)
+    metricRegistry.register(s"$prefix.last.participant_id", lastParticipantIdGauge)
 
     val lastExceptionGauge = new VarGauge[String]("<none>")
-    registry.register(s"$prefix.last.exception", lastExceptionGauge)
+    metricRegistry.register(s"$prefix.last.exception", lastExceptionGauge)
   }
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -48,20 +48,18 @@ private[committer] trait Committer[Submission, PartialResult] {
   /** The initial internal state passed to first step. */
   protected def init(ctx: CommitContext, subm: Submission): PartialResult
 
-  //TODO: Replace with metrics registry object passed in constructor
-  protected val metricsRegistry: metrics.MetricRegistry =
-    metrics.SharedMetricRegistries.getOrCreate("kvutils")
+  protected val metricRegistry: metrics.MetricRegistry
 
   protected def metricsName(metric: String): String =
     metrics.MetricRegistry.name("kvutils", "committer", committerName, metric)
 
   // These timers are lazy because they rely on `committerName`, which is defined in the subclass
   // and therefore not set at object initialization.
-  private lazy val runTimer: Timer = metricsRegistry.timer(metricsName("run_timer"))
+  private lazy val runTimer: Timer = metricRegistry.timer(metricsName("run_timer"))
   private lazy val stepTimers: Map[StepInfo, Timer] =
     steps.map {
       case (info, _) =>
-        info -> metricsRegistry.timer(metricsName(s"step_timers.$info"))
+        info -> metricRegistry.timer(metricsName(s"step_timers.$info"))
     }.toMap
 
   /** A committer can `run` a submission and produce a log entry and output states. */

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import com.codahale.metrics.Counter
+import com.codahale.metrics.{Counter, MetricRegistry}
 import com.daml.ledger.participant.state.kvutils.Conversions.{
   buildTimestamp,
   configDedupKey,
@@ -22,15 +22,16 @@ private[kvutils] object ConfigCommitter {
 
 }
 
-private[kvutils] case class ConfigCommitter(
-    defaultConfig: Configuration
+private[kvutils] class ConfigCommitter(
+    defaultConfig: Configuration,
+    override protected val metricRegistry: MetricRegistry,
 ) extends Committer[DamlConfigurationSubmission, ConfigCommitter.Result] {
 
   override protected val committerName = "config"
 
   private object Metrics {
-    val accepts: Counter = metricsRegistry.counter(metricsName("accepts"))
-    val rejections: Counter = metricsRegistry.counter(metricsName("rejections"))
+    val accepts: Counter = metricRegistry.counter(metricsName("accepts"))
+    val rejections: Counter = metricRegistry.counter(metricsName("rejections"))
   }
 
   private def rejectionTraceLog(msg: String, submission: DamlConfigurationSubmission): Unit =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -17,7 +17,7 @@ private[kvutils] object ConfigCommitter {
 
   case class Result(
       submission: DamlConfigurationSubmission,
-      currentConfig: (Option[DamlConfigurationEntry], Configuration)
+      currentConfig: (Option[DamlConfigurationEntry], Configuration),
   )
 
 }
@@ -182,8 +182,8 @@ private[kvutils] class ConfigCommitter(
   private def buildRejectionLogEntry(
       ctx: CommitContext,
       submission: DamlConfigurationSubmission,
-      addErrorDetails: DamlConfigurationRejectionEntry.Builder => DamlConfigurationRejectionEntry.Builder)
-    : DamlLogEntry = {
+      addErrorDetails: DamlConfigurationRejectionEntry.Builder => DamlConfigurationRejectionEntry.Builder,
+  ): DamlLogEntry = {
     Metrics.rejections.inc()
     DamlLogEntry.newBuilder
       .setRecordTime(buildTimestamp(ctx.getRecordTime))
@@ -200,7 +200,7 @@ private[kvutils] class ConfigCommitter(
 
   override protected def init(
       ctx: CommitContext,
-      configurationSubmission: DamlConfigurationSubmission
+      configurationSubmission: DamlConfigurationSubmission,
   ): ConfigCommitter.Result =
     ConfigCommitter.Result(
       configurationSubmission,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -18,8 +18,10 @@ import scala.collection.JavaConverters._
 
 private[kvutils] case class PackageCommitter(engine: Engine)
     extends Committer[DamlPackageUploadEntry, DamlPackageUploadEntry.Builder] {
+
+  override protected val committerName = "package_upload"
+
   private object Metrics {
-    // kvutils.PackageCommitter.*
     val preloadTimer: Timer = metricsRegistry.timer(metricsName("preload_timer"))
     val decodeTimer: Timer = metricsRegistry.timer(metricsName("decode_timer"))
     val accepts: Counter = metricsRegistry.counter(metricsName("accepts"))
@@ -152,12 +154,13 @@ private[kvutils] case class PackageCommitter(engine: Engine)
     )
   }
 
-  override def init(
+  override protected def init(
       ctx: CommitContext,
-      uploadEntry: DamlPackageUploadEntry): DamlPackageUploadEntry.Builder =
+      uploadEntry: DamlPackageUploadEntry
+  ): DamlPackageUploadEntry.Builder =
     uploadEntry.toBuilder
 
-  override val steps: Iterable[(StepInfo, Step)] = Iterable(
+  override protected val steps: Iterable[(StepInfo, Step)] = Iterable(
     "authorize_submission" -> authorizeSubmission,
     "validate_entry" -> validateEntry,
     "deduplicate_submission" -> deduplicateSubmission,
@@ -165,8 +168,6 @@ private[kvutils] case class PackageCommitter(engine: Engine)
     "enqueue_preload" -> enqueuePreload,
     "build_log_entry" -> buildLogEntry
   )
-
-  override lazy val committerName = "package_upload"
 
   private def buildRejectionLogEntry(
       ctx: CommitContext,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.participant.state.kvutils.committer
 
 import java.util.concurrent.Executors
 
-import com.codahale.metrics.{Counter, Gauge, Timer}
+import com.codahale.metrics.{Counter, Gauge, MetricRegistry, Timer}
 import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, packageUploadDedupKey}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.digitalasset.daml.lf.archive.Decode
@@ -16,17 +16,19 @@ import com.digitalasset.daml_lf_dev.DamlLf.Archive
 
 import scala.collection.JavaConverters._
 
-private[kvutils] case class PackageCommitter(engine: Engine)
-    extends Committer[DamlPackageUploadEntry, DamlPackageUploadEntry.Builder] {
+private[kvutils] class PackageCommitter(
+    engine: Engine,
+    override protected val metricRegistry: MetricRegistry,
+) extends Committer[DamlPackageUploadEntry, DamlPackageUploadEntry.Builder] {
 
   override protected val committerName = "package_upload"
 
   private object Metrics {
-    val preloadTimer: Timer = metricsRegistry.timer(metricsName("preload_timer"))
-    val decodeTimer: Timer = metricsRegistry.timer(metricsName("decode_timer"))
-    val accepts: Counter = metricsRegistry.counter(metricsName("accepts"))
-    val rejections: Counter = metricsRegistry.counter(metricsName("rejections"))
-    metricsRegistry.gauge(
+    val preloadTimer: Timer = metricRegistry.timer(metricsName("preload_timer"))
+    val decodeTimer: Timer = metricRegistry.timer(metricsName("decode_timer"))
+    val accepts: Counter = metricRegistry.counter(metricsName("accepts"))
+    val rejections: Counter = metricRegistry.counter(metricsName("rejections"))
+    metricRegistry.gauge(
       metricsName("loaded_packages"),
       () =>
         new Gauge[Int] {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -39,7 +39,8 @@ private[kvutils] class PackageCommitter(
 
   private def rejectionTraceLog(
       msg: String,
-      packageUploadEntry: DamlPackageUploadEntry.Builder): Unit =
+      packageUploadEntry: DamlPackageUploadEntry.Builder,
+  ): Unit =
     logger.trace(
       s"Package upload rejected, $msg, correlationId=${packageUploadEntry.getSubmissionId}")
 
@@ -158,7 +159,7 @@ private[kvutils] class PackageCommitter(
 
   override protected def init(
       ctx: CommitContext,
-      uploadEntry: DamlPackageUploadEntry
+      uploadEntry: DamlPackageUploadEntry,
   ): DamlPackageUploadEntry.Builder =
     uploadEntry.toBuilder
 
@@ -174,8 +175,8 @@ private[kvutils] class PackageCommitter(
   private def buildRejectionLogEntry(
       ctx: CommitContext,
       packageUploadEntry: DamlPackageUploadEntry.Builder,
-      addErrorDetails: DamlPackageUploadRejectionEntry.Builder => DamlPackageUploadRejectionEntry.Builder)
-    : DamlLogEntry = {
+      addErrorDetails: DamlPackageUploadRejectionEntry.Builder => DamlPackageUploadRejectionEntry.Builder,
+  ): DamlLogEntry = {
     Metrics.rejections.inc()
     DamlLogEntry.newBuilder
       .setRecordTime(buildTimestamp(ctx.getRecordTime))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import com.codahale.metrics.Counter
+import com.codahale.metrics.{Counter, MetricRegistry}
 import com.daml.ledger.participant.state.kvutils.Conversions.{
   buildTimestamp,
   partyAllocationDedupKey
@@ -11,14 +11,15 @@ import com.daml.ledger.participant.state.kvutils.Conversions.{
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.digitalasset.daml.lf.data.Ref
 
-private[kvutils] case object PartyAllocationCommitter
-    extends Committer[DamlPartyAllocationEntry, DamlPartyAllocationEntry.Builder] {
+private[kvutils] class PartyAllocationCommitter(
+    override protected val metricRegistry: MetricRegistry,
+) extends Committer[DamlPartyAllocationEntry, DamlPartyAllocationEntry.Builder] {
 
   override protected val committerName = "party_allocation"
 
   private object Metrics {
-    val accepts: Counter = metricsRegistry.counter(metricsName("accepts"))
-    val rejections: Counter = metricsRegistry.counter(metricsName("rejections"))
+    val accepts: Counter = metricRegistry.counter(metricsName("accepts"))
+    val rejections: Counter = metricRegistry.counter(metricsName("rejections"))
   }
 
   private def rejectionTraceLog(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
@@ -24,7 +24,7 @@ private[kvutils] class PartyAllocationCommitter(
 
   private def rejectionTraceLog(
       msg: String,
-      partyAllocationEntry: DamlPartyAllocationEntry.Builder
+      partyAllocationEntry: DamlPartyAllocationEntry.Builder,
   ): Unit =
     logger.trace(
       s"Party allocation rejected, $msg, correlationId=${partyAllocationEntry.getSubmissionId}")
@@ -136,8 +136,8 @@ private[kvutils] class PartyAllocationCommitter(
   private def buildRejectionLogEntry(
       ctx: CommitContext,
       partyAllocationEntry: DamlPartyAllocationEntry.Builder,
-      addErrorDetails: DamlPartyAllocationRejectionEntry.Builder => DamlPartyAllocationRejectionEntry.Builder)
-    : DamlLogEntry = {
+      addErrorDetails: DamlPartyAllocationRejectionEntry.Builder => DamlPartyAllocationRejectionEntry.Builder,
+  ): DamlLogEntry = {
     Metrics.rejections.inc()
     DamlLogEntry.newBuilder
       .setRecordTime(buildTimestamp(ctx.getRecordTime))
@@ -153,7 +153,7 @@ private[kvutils] class PartyAllocationCommitter(
 
   override protected def init(
       ctx: CommitContext,
-      partyAllocationEntry: DamlPartyAllocationEntry
+      partyAllocationEntry: DamlPartyAllocationEntry,
   ): DamlPartyAllocationEntry.Builder =
     partyAllocationEntry.toBuilder
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -26,7 +26,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConverters._
 
-private[kvutils] case class ProcessTransactionSubmission(
+private[kvutils] class ProcessTransactionSubmission(
     defaultConfig: Configuration,
     engine: Engine,
 ) {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -108,7 +108,6 @@ class SubmissionValidator[LogResult](
     } yield logResult
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Product", "org.wartremover.warts.Serializable"))
   private def runValidation[T](
       envelope: Bytes,
       correlationId: String,

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -9,6 +9,7 @@ import java.util.UUID
 
 import akka.NotUsed
 import akka.stream.scaladsl.{Sink, Source}
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.KVOffset.{fromLong => toOffset}
 import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase._
 import com.daml.ledger.participant.state.v1.Update._
@@ -56,6 +57,9 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)(
 
   // This can be overriden by tests for those that don't support heartbeats.
   protected val supportsHeartbeats: Boolean = true
+
+  // A metric registry, in case the ledger access layer needs it.
+  protected val metricRegistry: MetricRegistry = new MetricRegistry
 
   protected def participantStateFactory(
       ledgerId: Option[LedgerId],

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -58,14 +58,12 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)(
   // This can be overriden by tests for those that don't support heartbeats.
   protected val supportsHeartbeats: Boolean = true
 
-  // A metric registry, in case the ledger access layer needs it.
-  protected val metricRegistry: MetricRegistry = new MetricRegistry
-
   protected def participantStateFactory(
       ledgerId: Option[LedgerId],
       participantId: ParticipantId,
       testId: String,
       heartbeats: Source[Instant, NotUsed],
+      metricRegistry: MetricRegistry,
   )(implicit logCtx: LoggingContext): ResourceOwner[ParticipantState]
 
   private def participantState: ResourceOwner[ParticipantState] =
@@ -76,7 +74,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)(
       heartbeats: Source[Instant, NotUsed] = Source.empty,
   ): ResourceOwner[ParticipantState] =
     newLoggingContext { implicit logCtx =>
-      participantStateFactory(ledgerId, participantId, testId, heartbeats)
+      participantStateFactory(ledgerId, participantId, testId, heartbeats, new MetricRegistry)
     }
 
   override protected def beforeEach(): Unit = {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -38,7 +38,7 @@ object KVTest {
 
   private[this] val defaultAdditionalContractDataTy = "Party"
 
-  private[this] val metricRegistry = SharedMetricRegistries.getOrCreate("kvutils")
+  private[kvutils] val metricRegistry = SharedMetricRegistries.getOrCreate("kvutils")
 
   private[this] val keyValueCommitting = new KeyValueCommitting(metricRegistry)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.participant.state.kvutils
 
 import java.time.Duration
 
-import com.codahale.metrics.SharedMetricRegistries
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.command.{Command, Commands}
@@ -38,7 +38,7 @@ object KVTest {
 
   private[this] val defaultAdditionalContractDataTy = "Party"
 
-  private[kvutils] val metricRegistry = SharedMetricRegistries.getOrCreate("kvutils")
+  private[kvutils] val metricRegistry = new MetricRegistry
 
   private[this] val keyValueCommitting = new KeyValueCommitting(metricRegistry)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -5,18 +5,19 @@ package com.daml.ledger.participant.state.kvutils
 
 import java.time.Duration
 
+import com.codahale.metrics.SharedMetricRegistries
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.command.{Command, Commands}
 import com.digitalasset.daml.lf.crypto
-import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.data.Time.Timestamp
+import com.digitalasset.daml.lf.data.{ImmArray, Ref}
 import com.digitalasset.daml.lf.engine.Engine
 import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.daml_lf_dev.DamlLf
 import scalaz.State
-import scalaz.syntax.traverse._
 import scalaz.std.list._
+import scalaz.syntax.traverse._
 
 import scala.collection.JavaConverters._
 
@@ -29,12 +30,17 @@ final case class KVTestState(
     damlState: Map[DamlStateKey, DamlStateValue]) {}
 
 object KVTest {
-  import scalaz.State._
+
   import TestHelpers._
+  import scalaz.State._
 
   type KVTest[A] = State[KVTestState, A]
 
   private[this] val defaultAdditionalContractDataTy = "Party"
+
+  private[this] val metricRegistry = SharedMetricRegistries.getOrCreate("kvutils")
+
+  private[this] val keyValueCommitting = new KeyValueCommitting(metricRegistry)
 
   def initialTestState: KVTestState =
     KVTestState(
@@ -112,11 +118,11 @@ object KVTest {
   def getDamlState(key: DamlStateKey): KVTest[Option[DamlStateValue]] =
     gets(s => s.damlState.get(key))
 
-  def submit(submission: DamlSubmission): KVTest[(DamlLogEntryId, DamlLogEntry)] =
+  private def submit(submission: DamlSubmission): KVTest[(DamlLogEntryId, DamlLogEntry)] =
     for {
       testState <- get[KVTestState]
       entryId <- freshEntryId
-      (logEntry, newState) = KeyValueCommitting.processSubmission(
+      (logEntry, newState) = keyValueCommitting.processSubmission(
         engine = testState.engine,
         entryId = entryId,
         recordTime = testState.recordTime,
@@ -131,8 +137,7 @@ object KVTest {
     } yield {
       // Verify that all state touched matches with "submissionOutputs".
       assert(
-        newState.keySet subsetOf
-          KeyValueCommitting.submissionOutputs(entryId, submission)
+        newState.keySet subsetOf keyValueCommitting.submissionOutputs(entryId, submission)
       )
 
       // Verify that we can always process the log entry

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state.kvutils
 
 import java.time.Duration
 
-import com.codahale.metrics
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1.Configuration
 import com.digitalasset.daml.lf.data.Ref
@@ -162,10 +161,9 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
         }, submissionId = Ref.LedgerString.assertFromString("submission-id-1"))
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
-        val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committer.config.accepts").getCount should be >= 1L
-        reg.counter("kvutils.committer.config.rejections").getCount should be >= 1L
-        reg.timer("kvutils.committer.config.run_timer").getCount should be >= 1L
+        metricRegistry.counter("kvutils.committer.config.accepts").getCount should be >= 1L
+        metricRegistry.counter("kvutils.committer.config.rejections").getCount should be >= 1L
+        metricRegistry.timer("kvutils.committer.config.run_timer").getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state.kvutils
 
 import java.io.File
 
-import com.codahale.metrics
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlLogEntry,
   DamlPackageUploadRejectionEntry
@@ -93,10 +92,11 @@ class KVUtilsPackageSpec extends WordSpec with Matchers with BazelRunfiles {
         _ <- submitArchives("simple-archive-submission-1", simpleArchive).map(_._2)
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
-        val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committer.package_upload.accepts").getCount should be >= 1L
-        reg.counter("kvutils.committer.package_upload.rejections").getCount should be >= 1L
-        reg.timer("kvutils.committer.package_upload.run_timer").getCount should be >= 1L
+        metricRegistry.counter("kvutils.committer.package_upload.accepts").getCount should be >= 1L
+        metricRegistry
+          .counter("kvutils.committer.package_upload.rejections")
+          .getCount should be >= 1L
+        metricRegistry.timer("kvutils.committer.package_upload.run_timer").getCount should be >= 1L
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils
 
-import com.codahale.metrics
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlLogEntry,
   DamlPartyAllocationRejectionEntry
@@ -84,10 +83,15 @@ class KVUtilsPartySpec extends WordSpec with Matchers {
         _ <- submitPartyAllocation("submission-1", "bob", p0)
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
-        val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committer.party_allocation.accepts").getCount should be >= 1L
-        reg.counter("kvutils.committer.party_allocation.rejections").getCount should be >= 1L
-        reg.timer("kvutils.committer.party_allocation.run_timer").getCount should be >= 1L
+        metricRegistry
+          .counter("kvutils.committer.party_allocation.accepts")
+          .getCount should be >= 1L
+        metricRegistry
+          .counter("kvutils.committer.party_allocation.rejections")
+          .getCount should be >= 1L
+        metricRegistry
+          .timer("kvutils.committer.party_allocation.run_timer")
+          .getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils
 
-import com.codahale.metrics
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlLogEntry,
   DamlTransactionRejectionEntry
@@ -17,18 +16,18 @@ import com.digitalasset.daml.lf.command.{
   ExerciseCommand
 }
 import com.digitalasset.daml.lf.crypto
-import com.digitalasset.daml.lf.data.{Ref, FrontStack, SortedLookupList}
+import com.digitalasset.daml.lf.data.{FrontStack, Ref, SortedLookupList}
 import com.digitalasset.daml.lf.transaction.Node.NodeCreate
 import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.daml.lf.value.Value.{
   AbsoluteContractId,
-  ValueUnit,
-  ValueParty,
-  ValueOptional,
   ValueList,
-  ValueVariant,
+  ValueOptional,
+  ValueParty,
   ValueRecord,
-  ValueTextMap
+  ValueTextMap,
+  ValueUnit,
+  ValueVariant
 }
 import org.scalatest.{Matchers, WordSpec}
 
@@ -284,12 +283,11 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
       } yield {
         val disputed = DamlTransactionRejectionEntry.ReasonCase.DISPUTED
         // Check that we're updating the metrics (assuming this test at least has been run)
-        val reg = metrics.SharedMetricRegistries.getOrCreate("kvutils")
-        reg.counter("kvutils.committer.transaction.accepts").getCount should be >= 1L
-        reg
+        metricRegistry.counter("kvutils.committer.transaction.accepts").getCount should be >= 1L
+        metricRegistry
           .counter(s"kvutils.committer.transaction.rejections_${disputed.name}")
           .getCount should be >= 1L
-        reg.timer("kvutils.committer.transaction.run_timer").getCount should be >= 1L
+        metricRegistry.timer("kvutils.committer.transaction.run_timer").getCount should be >= 1L
       }
     }
 

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheck.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheck.scala
@@ -8,6 +8,7 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils => Proto, _}
 import com.daml.ledger.participant.state.v1._
 import com.digitalasset.daml.lf.data.Ref
@@ -36,7 +37,7 @@ object IntegrityCheck extends App {
   val filename = args(0)
   println(s"Verifying integrity of $filename...")
 
-  val metricRegistry = metrics.SharedMetricRegistries.getOrCreate("kvutils")
+  val metricRegistry = new MetricRegistry
   // Register JVM related metrics.
   (new metrics.jvm.GarbageCollectorMetricSet).getMetrics.forEach { (k, m) =>
     val _ = metricRegistry.register(s"jvm.gc.$k", m)
@@ -136,7 +137,7 @@ object IntegrityCheck extends App {
 
   // Dump detailed metrics.
   val reporter = metrics.ConsoleReporter
-    .forRegistry(metrics.SharedMetricRegistries.getOrCreate("kvutils"))
+    .forRegistry(metricRegistry)
     .convertRatesTo(TimeUnit.SECONDS)
     .convertDurationsTo(TimeUnit.MILLISECONDS)
     .build

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -210,6 +210,8 @@ object RecoveringIndexerIntegrationSpec {
 
   private val eventually = RetryStrategy.exponentialBackoff(10, 10.millis)
 
+  private val metricRegistry = new MetricRegistry
+
   private def randomSubmissionId(): SubmissionId =
     SubmissionId.assertFromString(UUID.randomUUID().toString)
 
@@ -225,7 +227,7 @@ object RecoveringIndexerIntegrationSpec {
         implicit materializer: Materializer,
         logCtx: LoggingContext
     ): ResourceOwner[ParticipantState] =
-      new InMemoryLedgerReaderWriter.SingleParticipantOwner(ledgerId, participantId)
+      new InMemoryLedgerReaderWriter.SingleParticipantOwner(ledgerId, participantId, metricRegistry)
         .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
   }
 

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -210,8 +210,6 @@ object RecoveringIndexerIntegrationSpec {
 
   private val eventually = RetryStrategy.exponentialBackoff(10, 10.millis)
 
-  private val metricRegistry = new MetricRegistry
-
   private def randomSubmissionId(): SubmissionId =
     SubmissionId.assertFromString(UUID.randomUUID().toString)
 
@@ -227,8 +225,11 @@ object RecoveringIndexerIntegrationSpec {
         implicit materializer: Materializer,
         logCtx: LoggingContext
     ): ResourceOwner[ParticipantState] =
-      new InMemoryLedgerReaderWriter.SingleParticipantOwner(ledgerId, participantId, metricRegistry)
-        .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
+      new InMemoryLedgerReaderWriter.SingleParticipantOwner(
+        ledgerId,
+        participantId,
+        new MetricRegistry,
+      ).map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter))
   }
 
   private object ParticipantStateThatFailsOften extends ParticipantStateFactory {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -153,10 +153,11 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                 readerWriter <- new SqlLedgerReaderWriter.Owner(
                   initialLedgerId = specifiedLedgerId,
                   participantId = ParticipantId,
+                  metricRegistry = metrics,
                   jdbcUrl = ledgerJdbcUrl,
                   timeProvider = timeServiceBackend.getOrElse(TimeProvider.UTC),
                   heartbeats = heartbeats,
-                  seedService = SeedService(seeding)
+                  seedService = SeedService(seeding),
                 )
                 ledger = new KeyValueParticipantState(readerWriter, readerWriter)
                 readService = new TimedReadService(ledger, metrics, ReadServicePrefix)


### PR DESCRIPTION
This is so we can inject the metric registry from the Sandbox.

Part of #5146.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
