### PR TITLE
sandbox: Set the Netty channel type to fix a warning.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/EventLoopGroupOwner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/EventLoopGroupOwner.scala
@@ -7,8 +7,9 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
 import com.digitalasset.resources.{Resource, ResourceOwner}
-import io.netty.channel.EventLoopGroup
 import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.nio.{NioServerSocketChannel, NioSocketChannel}
+import io.netty.channel.{Channel, EventLoopGroup, ServerChannel}
 import io.netty.util.concurrent.DefaultThreadFactory
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
@@ -16,6 +17,7 @@ import scala.util.Try
 
 final class EventLoopGroupOwner(threadPoolName: String, parallelism: Int)
     extends ResourceOwner[EventLoopGroup] {
+
   override def acquire()(implicit executionContext: ExecutionContext): Resource[EventLoopGroup] =
     Resource(
       Future(new NioEventLoopGroup(
@@ -29,4 +31,12 @@ final class EventLoopGroupOwner(threadPoolName: String, parallelism: Int)
         promise.future
       }
     )
+}
+
+object EventLoopGroupOwner {
+
+  val clientChannelType: Class[_ <: Channel] = classOf[NioSocketChannel]
+
+  val serverChannelType: Class[_ <: ServerChannel] = classOf[NioServerSocketChannel]
+
 }


### PR DESCRIPTION
Tests would often display this warning:

    io.grpc.netty.NettyChannelBuilder buildTransportFactory
    WARNING: Both EventLoopGroup and ChannelType should be provided or neither should be, otherwise client may not start. Not provided values will use Nio (NioSocketChannel, NioEventLoopGroup) for compatibility. This will cause an Exception in the future.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
