### PR TITLE
Engine: Change type of ExerciseCommand contractId

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/CommandPreprocessor.scala
@@ -171,7 +171,7 @@ private[engine] class CommandPreprocessor(compiledPackages: MutableCompiledPacka
       case CreateCommand(templateId, argument) =>
         preprocessCreate(templateId, argument)
       case ExerciseCommand(templateId, contractId, choiceId, argument) =>
-        preprocessExercise(templateId, Value.AbsoluteContractId(contractId), choiceId, argument)
+        preprocessExercise(templateId, contractId, choiceId, argument)
       case ExerciseByKeyCommand(templateId, contractKey, choiceId, argument) =>
         preprocessExerciseByKey(
           templateId,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -120,7 +120,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
           BasicTests_WithKey,
           ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
           ) =>
-        Some(AbsoluteContractId("1"))
+        Some(toContractId("1"))
       case _ =>
         None
     }
@@ -948,7 +948,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
             children,
             _,
             _) =>
-          coid shouldBe AbsoluteContractId(originalCoid)
+          coid shouldBe toContractId(originalCoid)
           consuming shouldBe true
           actingParties shouldBe Set(bob)
           children.map(_.index) shouldBe ImmArray(1)
@@ -1000,10 +1000,10 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       partyEvents.roots.length shouldBe 1
       val bobExercise = partyEvents.events(partyEvents.roots(0))
       val cid =
-        AbsoluteContractId("00b39433a649bebecd3b01d651be38a75923efdb92f34592b5600aee3fec8a8cc3")
+        toContractId("00b39433a649bebecd3b01d651be38a75923efdb92f34592b5600aee3fec8a8cc3")
       bobExercise shouldBe
         ExerciseEvent(
-          contractId = AbsoluteContractId(originalCoid),
+          contractId = toContractId(originalCoid),
           templateId = Identifier(basicTestsPkgId, "BasicTests:CallablePayout"),
           choice = "Transfer",
           choiceArgument = assertAsVersionedValue(
@@ -1046,7 +1046,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
     val submissionSeed = hash("dynamic fetch actors")
     val fetchedStrCid = "1"
-    val fetchedCid = AbsoluteContractId(fetchedStrCid)
+    val fetchedCid = toContractId(fetchedStrCid)
     val fetchedStrTid = "BasicTests:Fetched"
     val fetchedTArgs = ImmArray(
       (Some[Name]("sig1"), ValueParty(alice)),
@@ -1058,7 +1058,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     val fetcherTid = Identifier(basicTestsPkgId, fetcherStrTid)
 
     val fetcher1StrCid = "2"
-    val fetcher1Cid = AbsoluteContractId(fetcher1StrCid)
+    val fetcher1Cid = toContractId(fetcher1StrCid)
     val fetcher1TArgs = ImmArray(
       (Some[Name]("sig"), ValueParty(alice)),
       (Some[Name]("obs"), ValueParty(bob)),
@@ -1066,7 +1066,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     )
 
     val fetcher2StrCid = "3"
-    val fetcher2Cid = AbsoluteContractId(fetcher2StrCid)
+    val fetcher2Cid = toContractId(fetcher2StrCid)
     val fetcher2TArgs = ImmArray(
       (Some[Name]("sig"), ValueParty(party)),
       (Some[Name]("obs"), ValueParty(alice)),
@@ -1169,7 +1169,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
     val submissionSeed = hash("reinterpreting fetch nodes")
 
-    val fetchedCid = AbsoluteContractId("1")
+    val fetchedCid = toContractId("1")
     val fetchedStrTid = "BasicTests:Fetched"
     val fetchedTid = Identifier(basicTestsPkgId, fetchedStrTid)
 
@@ -1253,8 +1253,8 @@ object EngineTest {
   private implicit def toName(s: String): Name =
     Name.assertFromString(s)
 
-  private implicit def toContractId(s: String): ContractIdString =
-    ContractIdString.assertFromString(s)
+  private implicit def toContractId(s: String): AbsoluteContractId =
+    AbsoluteContractId(ContractIdString.assertFromString(s))
 
   private def ArrayList[X](as: X*): util.ArrayList[X] = {
     val a = new util.ArrayList[X](as.length)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -239,18 +239,20 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
 
   private def toListContainerExerciseCmd(
       templateId: Identifier,
-      contractId: AbsoluteContractId): ExerciseCommand = {
+      contractId: AbsoluteContractId
+  ): ExerciseCommand = {
     val choice = "ToListContainer"
-    val emptyArgs = ValueRecord(None, ImmArray(Seq()))
-    ExerciseCommand(templateId, contractId.coid, choice, (emptyArgs))
+    val emptyArgs = ValueRecord(None, ImmArray.empty)
+    ExerciseCommand(templateId, contractId, choice, (emptyArgs))
   }
 
   private def toListOfIntContainers(
       templateId: Identifier,
-      contractId: AbsoluteContractId): ExerciseCommand = {
+      contractId: AbsoluteContractId
+  ): ExerciseCommand = {
     val choice = "ToListOfIntContainers"
-    val emptyArgs = ValueRecord(None, ImmArray(Seq()))
-    ExerciseCommand(templateId, contractId.coid, choice, (emptyArgs))
+    val emptyArgs = ValueRecord(None, ImmArray.empty)
+    ExerciseCommand(templateId, contractId, choice, (emptyArgs))
   }
 
   private def listUtilCreateCmd(templateId: Identifier): CreateCommand = {
@@ -264,7 +266,7 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
     val choiceDefRef = Identifier(templateId.packageId, qn(s"LargeTransaction:$choice"))
     val damlList = ValueList(FrontStack(elements = List.range(0L, size.toLong).map(ValueInt64)))
     val choiceArgs = ValueRecord(Some(choiceDefRef), ImmArray((None, damlList)))
-    ExerciseCommand(templateId, contractId.coid, choice, (choiceArgs))
+    ExerciseCommand(templateId, contractId, choice, choiceArgs)
   }
 
   private def assertSizeExerciseTransaction(

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/command/Command.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/command/Command.scala
@@ -32,7 +32,7 @@ final case class CreateCommand(templateId: Identifier, argument: Value[Value.Abs
   */
 final case class ExerciseCommand(
     templateId: Identifier,
-    contractId: ContractIdString,
+    contractId: Value.AbsoluteContractId,
     choiceId: ChoiceName,
     argument: Value[Value.AbsoluteContractId],
 ) extends Command

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -134,7 +134,7 @@ final class CommandsValidator(ledgerId: LedgerId) {
         } yield
           ExerciseCommand(
             templateId = validatedTemplateId,
-            contractId = contractId,
+            contractId = Lf.AbsoluteContractId(contractId),
             choiceId = choice,
             argument = validatedValue)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -76,7 +76,7 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     def exerciseCmd(coid: String, templateId: Ref.Identifier): Command =
       ExerciseCommand(
         templateId,
-        Ref.ContractIdString.assertFromString(coid),
+        Value.AbsoluteContractId(Ref.ContractIdString.assertFromString(coid)),
         simpleConsumeChoiceid,
         ValueUnit)
 


### PR DESCRIPTION
tiny refactoring to prepare more radical change in `Value.AbsoluteContractId`.

This PR advances #3830 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
