### PR TITLE
postgresql-testing: On failure, logs are no longer an `Option`.

### DIFF
--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -209,7 +209,7 @@ object PostgresAround {
           command.mkString("\n"),
           s"\nSTDOUT:\n$stdout",
           s"\nSTDERR:\n$stderr",
-          logs.map(lines => s"\nLogs:\n${lines.mkString("\n")}"),
+          if (logs.isEmpty) "\nLogs: <none>" else s"\nLogs:\n${logs.mkString("\n")}",
         ).mkString("\n"),
         cause,
       )


### PR DESCRIPTION
`logs` used to be an `Option[Seq[String]]`. They were changed to `Seq[String]` with a default of `Seq.empty`, but the code to print them still assumed an `Option`, which means they were printing as "ArrayBuffer(line 1, line 2, line 3)" instead of, well, nicely.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
