### PR TITLE
daml2ts: Write package id directly into index.ts

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -213,8 +213,7 @@ daml2ts Daml2TsParams {..} = do
     -- foreign packages as we do.
     dependencies <- nubOrd . concat <$> mapM (writeModuleTs packageSrcDir scope) (NM.toList (packageModules pkg))
     -- Now write package metadata.
-    writePackageIdTs packageSrcDir pkgId
-    writeIndexTs packageSrcDir modules
+    writeIndexTs packageSrcDir pkgId modules
     writeTsConfig packageDir
     writeEsLintConfig packageDir
     writePackageJson packageDir sdkVersion scope dependencies
@@ -567,13 +566,8 @@ onLast f = \case
     [l] -> [f l]
     x : xs -> x : onLast f xs
 
-writePackageIdTs :: FilePath -> PackageId -> IO ()
-writePackageIdTs dir pkgId =
-    T.writeFileUtf8 (dir </> "packageId.ts") $ T.unlines
-      ["export default '" <> unPackageId pkgId <> "';"]
-
-writeIndexTs :: FilePath -> [Module] -> IO ()
-writeIndexTs packageSrcDir modules =
+writeIndexTs :: FilePath -> PackageId -> [Module] -> IO ()
+writeIndexTs packageSrcDir pkgId modules =
   T.writeFileUtf8 (packageSrcDir </> "index.ts") (T.unlines lines)
   where
     lines :: [T.Text]
@@ -586,9 +580,8 @@ writeIndexTs packageSrcDir modules =
         -- NOTE(MH): We produce a lot of _seemingly_ unused variables because
         -- ESLint unfortunately regards `A` in `export import A = B` as unused.
       , "/* eslint-disable @typescript-eslint/no-unused-vars */"
-      , "import __packageId from \"./packageId\""
       , "namespace __All {"
-      , "  export const packageId = __packageId;"
+      , "  export const packageId = '" <> unPackageId pkgId <> "';"
       , "}"
       ]
 

--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2Ts.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2Ts.hs
@@ -180,9 +180,6 @@ tests damlTypes yarn damlc daml2ts davl = testGroup "daml2ts tests"
         assertFileExists (groverTsSrc </> "Grover.ts")
         assertFileExists (groverTsLib </> "Grover.js")
         assertFileExists (groverTsLib </> "Grover.d.ts")
-        assertFileExists (groverTsSrc </> "packageId.ts")
-        assertFileExists (groverTsLib </> "packageId.js")
-        assertFileExists (groverTsLib </> "packageId.d.ts")
 
   , testCaseSteps "DAVL test" $ \step -> withTempDir $ \here -> do
       let daml2tsDir = here </> "daml2ts"


### PR DESCRIPTION
There's no more reason to have the package id in a separate file
`packageId.ts`. This was different before we had an `index.ts`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5195)
<!-- Reviewable:end -->
