### PR TITLE
daml2ts: Emphasize differences between internal and external imports

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -24,6 +24,7 @@ import Data.Hashable
 import Control.Monad.Extra
 import DA.Daml.LF.Ast
 import DA.Daml.LF.Ast.Optics
+import Data.Either
 import Data.Tuple.Extra
 import Data.List.Extra
 import Data.Graph
@@ -211,7 +212,7 @@ daml2ts Daml2TsParams {..} = do
     let modules = NM.toList (packageModules pkg)
     -- Write .ts files for the package and harvest references to
     -- foreign packages as we do.
-    dependencies <- nubOrd . concat <$> mapM (writeModuleTs packageSrcDir scope) (NM.toList (packageModules pkg))
+    dependencies <- Set.toList . Set.unions <$> mapM (writeModuleTs packageSrcDir scope) (NM.toList (packageModules pkg))
     -- Now write package metadata.
     writePackageIdTs packageSrcDir pkgId
     writeIndexTs packageSrcDir modules
@@ -221,10 +222,10 @@ daml2ts Daml2TsParams {..} = do
     pure (pkgName, dependencies)
     where
       -- Write the .ts file for a single DAML-LF module.
-      writeModuleTs :: FilePath -> Scope -> Module -> IO [Dependency]
+      writeModuleTs :: FilePath -> Scope -> Module -> IO (Set.Set Dependency)
       writeModuleTs packageSrcDir scope mod = do
         case genModule pkgMap scope pkgId mod of
-          Nothing -> pure []
+          Nothing -> pure Set.empty
           Just (modTxt, ds) -> do
             let outputFile = packageSrcDir </> T.unpack (modPath (unModuleName (moduleName mod))) FP.<.> "ts"
             createDirectoryIfMissing True (takeDirectory outputFile)
@@ -233,25 +234,29 @@ daml2ts Daml2TsParams {..} = do
 
 -- Generate the .ts content for a single module.
 genModule :: Map.Map PackageId (Maybe PackageName, Package) ->
-     Scope -> PackageId -> Module -> Maybe (T.Text, [Dependency])
+     Scope -> PackageId -> Module -> Maybe (T.Text, Set.Set Dependency)
 genModule pkgMap (Scope scope) curPkgId mod
   | null serDefs =
     Nothing -- If no serializable types, nothing to do.
   | otherwise =
     let (defSers, refs) = unzip (map (genDataDef curPkgId mod tpls) serDefs)
-        imports = [ importDecl pkgMap modRef rootPath
-                  | modRef@(pkgRef, _) <- modRefs refs
-                  , let rootPath = pkgRootPath modName pkgRef ]
+        imports = Set.toList ((PRSelf, modName) `Set.delete` Set.unions refs)
+        (internalImports, externalImports) = splitImports imports
+        rootPath =
+          let lenModName = length (unModuleName modName)
+          in if lenModName == 1 then ["."] else replicate (lenModName - 1) ".."
         defs = map biconcat defSers
-        modText = T.unlines $ intercalate [""] $ filter (not . null) $ modHeader : imports : defs
-        depends = [ Dependency $ pkgRefStr pkgMap pkgRef
-                  | (pkgRef, _) <- modRefs refs, pkgRef /= PRSelf ]
+        modText = T.unlines $ intercalate [""] $ filter (not . null) $
+          modHeader
+          : map (externalImportDecl pkgMap) externalImports
+          : map (internalImportDecl rootPath) internalImports
+          : defs
+        depends = Set.fromList $ map (Dependency . pkgRefStr pkgMap . fst) externalImports
    in Just (modText, depends)
   where
     modName = moduleName mod
     tpls = moduleTemplates mod
     serDefs = defDataTypes mod
-    modRefs refs = Set.toList ((PRSelf, modName) `Set.delete` Set.unions refs)
     modHeader =
       [ "// Generated from " <> modPath (unModuleName modName) <> ".daml"
       , "/* eslint-disable @typescript-eslint/camelcase */"
@@ -261,35 +266,34 @@ genModule pkgMap (Scope scope) curPkgId mod
       , "import * as daml from '@daml/types';"
       ]
 
-    -- Calculate an import declaration.
-    importDecl :: Map.Map PackageId (Maybe PackageName, Package) ->
-                      (PackageRef, ModuleName) -> T.Text -> T.Text
-    importDecl pkgMap modRef@(pkgRef, modName) rootPath =
-      "import * as " <>  genModuleRef modRef <> " from '" <>
-      modPath ((rootPath : pkgRefStr pkgMap pkgRef : ["lib" | pkgRef /= PRSelf]) ++ unModuleName modName) <>
-      "';"
+    -- Split the imports into the from the same package and those from another package.
+    splitImports :: [ModuleRef] -> ([ModuleName], [(PackageId, ModuleName)])
+    splitImports refs =
+      let classifyImport (pkgRef, modName) = case pkgRef of
+            PRSelf -> Left modName
+            PRImport pkgId -> Right (pkgId, modName)
+      in
+      partitionEithers (map classifyImport refs)
+
+    -- Calculate an import declaration for a module from the same package.
+    internalImportDecl :: [T.Text] -> ModuleName -> T.Text
+    internalImportDecl rootPath modName =
+      "import * as " <> genModuleRef (PRSelf, modName) <> " from '" <>
+        modPath (rootPath ++ unModuleName modName) <> "';"
+
+    -- Calculate an import declaration for a module from another package.
+    externalImportDecl :: Map.Map PackageId (Maybe PackageName, Package) ->
+                      (PackageId, ModuleName) -> T.Text
+    externalImportDecl pkgMap (pkgId, modName) =
+      "import * as " <> genModuleRef (PRImport pkgId, modName) <> " from '" <>
+        modPath (scope : pkgRefStr pkgMap pkgId : "lib" : unModuleName modName) <> "';"
 
     -- Produce a package name for a package ref.
-    pkgRefStr :: Map.Map PackageId (Maybe PackageName, Package) -> PackageRef -> T.Text
-    pkgRefStr pkgMap = \case
-      PRSelf -> ""
-      PRImport pkgId ->
+    pkgRefStr :: Map.Map PackageId (Maybe PackageName, Package) -> PackageId -> T.Text
+    pkgRefStr pkgMap pkgId =
         case Map.lookup pkgId pkgMap of
           Nothing -> error "IMPOSSIBLE : package map malformed"
           Just (mbPkgName, _) -> packageNameText pkgId mbPkgName
-
-    -- Calculate the root part of a package ref string. For foreign
-    -- imports that's something like '@daml2ts'. For self refences
-    -- something like '../../'.
-    pkgRootPath :: ModuleName -> PackageRef -> T.Text
-    pkgRootPath modName pkgRef =
-      case pkgRef of
-        PRSelf ->
-          if lenModName == 1
-            then "."
-            else modPath $ replicate (lenModName - 1) (T.pack "..")
-        PRImport _ -> scope
-      where lenModName = length (unModuleName modName)
 
 defDataTypes :: Module -> [DefDataType]
 defDataTypes mod = filter (getIsSerializable . dataSerializable) (NM.toList (moduleDataTypes mod))


### PR DESCRIPTION
This prepares a followup change in which I want to import external
dependecies entirely through their `index.ts` file. This will become easier
once the differences between internal and external imports are more
apparent.

Importing external dependencies through their `index.ts` files is part
of a restructuring the file layout in order to solve the bug where we
cannot have modules `A` and `A.B` at the same time.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5197)
<!-- Reviewable:end -->
