### PR TITLE
Remove ledgerEffectiveTime, maximumRecordTime and default TTL config

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -80,15 +80,13 @@ From a DAML project directory:
       --ledger-port <value>
             Ledger port number
       --address <value>
-            IP address that HTTP JSON API service listens on. Defaults to 0.0.0.0.
+            IP address that HTTP JSON API service listens on. Defaults to 127.0.0.1.
       --http-port <value>
             HTTP JSON API service port number
       --application-id <value>
             Optional application ID to use for ledger registration. Defaults to HTTP-JSON-API-Gateway
       --package-reload-interval <value>
             Optional interval to poll for package updates. Examples: 500ms, 5s, 10min, 1h, 1d. Defaults to 5 seconds
-      --default-ttl <value>
-            Optional Time to Live interval to set if not provided in the command. Examples: 30s, 1min, 1h. Defaults to 30 seconds
       --max-inbound-message-size <value>
             Optional max inbound message size in bytes. Defaults to 4194304
       --query-store-jdbc-config "driver=<JDBC driver class name>,url=<JDBC connection url>,user=<user>,password=<password>,createSchema=<true|false>"
@@ -398,18 +396,14 @@ When creating a new contract, client may specify an optional ``meta`` field:
         "owner": "Alice"
       },
       "meta": {
-      	"commandId": "a unique ID",
-      	"ledgerEffectiveTime": 1579730994499,
-      	"maximumRecordTime": 1579731004499
+      	"commandId": "a unique ID"
       }
     }
 
 Where:
 
-- ``commandId`` -- optional field, a unique string identifying the command;
-- ``ledgerEffectiveTime`` -- optional field, the number of milliseconds from the epoch of ``1970-01-01T00:00:00Z``, an approximation of the wall clock time on the ledger server;
-- ``maximumRecordTime`` -- optional field, the number of milliseconds from the epoch of ``1970-01-01T00:00:00Z``, a deadline for observing this command in the completion stream before it can be considered to have timed out.
- 
+- ``commandId`` -- optional field, a unique string identifying the command.
+
 Exercise by Contract ID
 ***********************
 

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -129,7 +129,6 @@ da_scala_test(
         "//daml-lf/interface",
         "//daml-lf/transaction",
         "//daml-lf/transaction-scalacheck",
-        "//language-support/java/bindings:bindings-java-tests-lib",
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-service/db-backend",

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -3,8 +3,6 @@
 
 package com.digitalasset.http
 
-import java.time.Instant
-
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.ImmArray.ImmArraySeq
 import com.digitalasset.http.ErrorMessages.cannotResolveTemplateId
@@ -31,7 +29,6 @@ import scalaz.syntax.std.option._
 import scalaz.syntax.traverse._
 import scalaz.{-\/, EitherT, Show, \/, \/-}
 
-import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -40,7 +37,7 @@ class CommandService(
     submitAndWaitForTransaction: LedgerClientJwt.SubmitAndWaitForTransaction,
     submitAndWaitForTransactionTree: LedgerClientJwt.SubmitAndWaitForTransactionTree,
     timeProvider: TimeProvider,
-    defaultTimeToLive: FiniteDuration)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext)
     extends StrictLogging {
 
   import CommandService._
@@ -143,19 +140,12 @@ class CommandService(
       meta: Option[domain.CommandMeta],
       command: lav1.commands.Command.Command): lav1.command_service.SubmitAndWaitRequest = {
 
-    val ledgerEffectiveTime: Instant =
-      meta.flatMap(_.ledgerEffectiveTime).getOrElse(timeProvider.getCurrentTime)
-    val maximumRecordTime: Instant = meta
-      .flatMap(_.maximumRecordTime)
-      .getOrElse(ledgerEffectiveTime.plusNanos(defaultTimeToLive.toNanos))
     val commandId: lar.CommandId = meta.flatMap(_.commandId).getOrElse(uniqueCommandId())
 
     Commands.submitAndWaitRequest(
       jwtPayload.ledgerId,
       jwtPayload.applicationId,
       commandId,
-      ledgerEffectiveTime,
-      maximumRecordTime,
       jwtPayload.party,
       command
     )

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
@@ -30,7 +30,6 @@ private[http] final case class Config(
     staticContentConfig: Option[StaticContentConfig] = None,
     accessTokenFile: Option[Path] = None,
     wsConfig: Option[WebsocketConfig] = None,
-    defaultTtl: FiniteDuration = HttpService.DefaultTimeToLive
 )
 
 private[http] object Config {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -49,7 +49,6 @@ import scala.util.control.NonFatal
 object HttpService extends StrictLogging {
 
   val DefaultPackageReloadInterval: FiniteDuration = FiniteDuration(5, "s")
-  val DefaultTimeToLive: FiniteDuration = FiniteDuration(30, "s")
   val DefaultMaxInboundMessageSize: Int = 4194304
 
   private type ET[A] = EitherT[Future, Error, A]
@@ -68,7 +67,6 @@ object HttpService extends StrictLogging {
       staticContentConfig: Option[StaticContentConfig] = None,
       packageReloadInterval: FiniteDuration = DefaultPackageReloadInterval,
       maxInboundMessageSize: Int = DefaultMaxInboundMessageSize,
-      defaultTtl: FiniteDuration = DefaultTimeToLive,
       validateJwt: EndpointsCompanion.ValidateJwt = decodeJwt,
   )(
       implicit asys: ActorSystem,
@@ -113,7 +111,6 @@ object HttpService extends StrictLogging {
         LedgerClientJwt.submitAndWaitForTransaction(client),
         LedgerClientJwt.submitAndWaitForTransactionTree(client),
         TimeProvider.UTC,
-        defaultTtl
       )
 
       contractsService = new ContractsService(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -50,7 +50,6 @@ object Main extends StrictLogging {
         s", jdbcConfig=${config.jdbcConfig.shows}" +
         s", staticContentConfig=${config.staticContentConfig.shows}" +
         s", accessTokenFile=${config.accessTokenFile.toString}" +
-        s", defaultTtl=${config.defaultTtl.toString}" +
         ")")
 
     implicit val asys: ActorSystem = ActorSystem("http-json-ledger-api")
@@ -92,7 +91,6 @@ object Main extends StrictLogging {
         staticContentConfig = config.staticContentConfig,
         packageReloadInterval = config.packageReloadInterval,
         maxInboundMessageSize = config.maxInboundMessageSize,
-        defaultTtl = config.defaultTtl,
       )
 
     discard {
@@ -171,13 +169,6 @@ object Main extends StrictLogging {
         .text(
           s"Optional interval to poll for package updates. Examples: 500ms, 5s, 10min, 1h, 1d. " +
             s"Defaults to ${Config.Empty.packageReloadInterval.toString}")
-
-      opt[Duration]("default-ttl")
-        .action((x, c) => c.copy(defaultTtl = FiniteDuration(x.length, x.unit)))
-        .optional()
-        .text(
-          s"Optional Time to Live interval to set if not provided in the command. Examples: 30s, 1min, 1h. " +
-            s"Defaults to ${Config.Empty.defaultTtl.toString}")
 
       opt[Int]("max-inbound-message-size")
         .action((x, c) => c.copy(maxInboundMessageSize = x))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -3,8 +3,6 @@
 
 package com.digitalasset.http
 
-import java.time.Instant
-
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import com.digitalasset.daml.lf
 import com.digitalasset.daml.lf.data.Ref
@@ -103,8 +101,7 @@ object domain {
 
   final case class CommandMeta(
       commandId: Option[CommandId],
-      ledgerEffectiveTime: Option[Instant],
-      maximumRecordTime: Option[Instant],
+      // TODO(Leo): add Option[WorkflowId] back
   )
 
   final case class CreateCommand[+LfV](

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -232,7 +232,7 @@ object JsonProtocol extends DefaultJsonProtocol {
       domain.SearchForeverRequest(NonEmptyList(single.convertTo[domain.GetActiveContractsRequest]))
   }
 
-  implicit val CommandMetaFormat: RootJsonFormat[domain.CommandMeta] = jsonFormat3(
+  implicit val CommandMetaFormat: RootJsonFormat[domain.CommandMeta] = jsonFormat1(
     domain.CommandMeta)
 
   implicit val CreateCommandFormat: RootJsonFormat[domain.CreateCommand[JsValue]] = jsonFormat3(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Commands.scala
@@ -3,8 +3,6 @@
 
 package com.digitalasset.http.util
 
-import java.time.Instant
-
 import com.digitalasset.ledger.api.refinements.{ApiTypes => lar}
 import com.digitalasset.ledger.api.{v1 => lav1}
 import scalaz.syntax.tag._
@@ -67,8 +65,6 @@ object Commands {
       ledgerId: lar.LedgerId,
       applicationId: lar.ApplicationId,
       commandId: lar.CommandId,
-      ledgerEffectiveTime: Instant,
-      maximumRecordTime: Instant,
       party: lar.Party,
       command: lav1.commands.Command.Command
   ): lav1.command_service.SubmitAndWaitRequest = {

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -3,7 +3,6 @@
 
 package com.digitalasset.http
 
-import com.daml.ledger.javaapi.data.Generators.instantGen
 import com.digitalasset.ledger.api.{v1 => lav1}
 import org.scalacheck.Gen
 import scalaz.{-\/, \/, \/-}
@@ -128,9 +127,7 @@ object Generators {
   def metaGen: Gen[domain.CommandMeta] =
     for {
       commandId <- Gen.option(Gen.identifier.map(domain.CommandId(_)))
-      let <- Gen.option(instantGen)
-      mrt <- Gen.option(instantGen)
-    } yield domain.CommandMeta(commandId, let, mrt)
+    } yield domain.CommandMeta(commandId)
 
   private def genJsObj: Gen[JsObject] =
     Gen.listOf(genJsValPair).map(xs => JsObject(xs.toMap))


### PR DESCRIPTION
- Remove ``ledgerEffectiveTime`` and ``maximumRecordTime`` fields from command ``meta``.
- Remove ``--default-ttl`` command line argument.

The ledger time and TTL are automatically computed by the submission service now.

Closes: #5090.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
