### PR TITLE
daml2ts: Import external dependencies via their index module

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -239,7 +239,7 @@ genModule pkgMap (Scope scope) curPkgId mod
     Nothing -- If no serializable types, nothing to do.
   | otherwise =
     let (defSers, refs) = unzip (map (genDataDef curPkgId mod tpls) serDefs)
-        imports = Set.toList ((PRSelf, modName) `Set.delete` Set.unions refs)
+        imports = (PRSelf, modName) `Set.delete` Set.unions refs
         (internalImports, externalImports) = splitImports imports
         rootPath =
           let lenModName = length (unModuleName modName)
@@ -247,10 +247,10 @@ genModule pkgMap (Scope scope) curPkgId mod
         defs = map biconcat defSers
         modText = T.unlines $ intercalate [""] $ filter (not . null) $
           modHeader
-          : map (externalImportDecl pkgMap) externalImports
+          : map (externalImportDecl pkgMap) (Set.toList externalImports)
           : map (internalImportDecl rootPath) internalImports
           : defs
-        depends = Set.fromList $ map (Dependency . pkgRefStr pkgMap . fst) externalImports
+        depends = Set.map (Dependency . pkgRefStr pkgMap) externalImports
    in Just (modText, depends)
   where
     modName = moduleName mod
@@ -266,13 +266,13 @@ genModule pkgMap (Scope scope) curPkgId mod
       ]
 
     -- Split the imports into the from the same package and those from another package.
-    splitImports :: [ModuleRef] -> ([ModuleName], [(PackageId, ModuleName)])
-    splitImports refs =
+    splitImports :: Set.Set ModuleRef -> ([ModuleName], Set.Set PackageId)
+    splitImports imports =
       let classifyImport (pkgRef, modName) = case pkgRef of
             PRSelf -> Left modName
-            PRImport pkgId -> Right (pkgId, modName)
+            PRImport pkgId -> Right pkgId
       in
-      partitionEithers (map classifyImport refs)
+      second Set.fromList (partitionEithers (map classifyImport (Set.toList imports)))
 
     -- Calculate an import declaration for a module from the same package.
     internalImportDecl :: [T.Text] -> ModuleName -> T.Text
@@ -282,10 +282,9 @@ genModule pkgMap (Scope scope) curPkgId mod
 
     -- Calculate an import declaration for a module from another package.
     externalImportDecl :: Map.Map PackageId (Maybe PackageName, Package) ->
-                      (PackageId, ModuleName) -> T.Text
-    externalImportDecl pkgMap (pkgId, modName) =
-      "import * as " <> genModuleRef (PRImport pkgId, modName) <> " from '" <>
-        modPath (scope : pkgRefStr pkgMap pkgId : "lib" : unModuleName modName) <> "';"
+                      PackageId -> T.Text
+    externalImportDecl pkgMap pkgId =
+      "import " <> pkgVar pkgId <> " from '" <> scope <> "/" <> pkgRefStr pkgMap pkgId <> "';"
 
     -- Produce a package name for a package ref.
     pkgRefStr :: Map.Map PackageId (Maybe PackageName, Package) -> PackageId -> T.Text
@@ -542,10 +541,13 @@ genTypeCon curModName (Qualified pkgRef modName conParts) =
      where
        modRef = (pkgRef, modName)
 
+pkgVar :: PackageId -> T.Text
+pkgVar pkgId = "pkg" <> unPackageId pkgId
+
 genModuleRef :: ModuleRef -> T.Text
 genModuleRef (pkgRef, modName) = case pkgRef of
-    PRSelf -> modVar "" name
-    PRImport pkgId -> modVar ("pkg" <> unPackageId pkgId <> "_") name
+    PRSelf -> T.intercalate "_" name
+    PRImport pkgId -> T.intercalate "." (pkgVar pkgId : name)
   where
     name = unModuleName modName
 


### PR DESCRIPTION
Instead of reaching into to the internals of external dependencies,
we no import these package via their root `index.ts` file. This gives
us the possibility of the changing the internal structure without
having to think about this kind of import as long as we keep the
interface the same. This is exactly what I plan to do in the next PR
which will fix the `A` vs `A.B` bug.

More precisely, instead of writing two imports like
```typescript
import * as pkgXYZ_A_B from '@daml.js/foo-0.0.1/lib/A/B';
import * as pkgXYZ_C from '@daml.js/foo-0.0.1/lib/C';
```
we only write one import
```typescript
import pkgXYZ from '@daml.js/foo-0.0.1';
```
and replace use sites of `pkgXYZ_A_B` and `pkgXYZ_C` with `pkgXYZ.A.B`
and `pkgXYZ.C`, resp.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5203)
<!-- Reviewable:end -->
