### PR TITLE
Publish docker images for snapshot releases as well

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -64,7 +64,7 @@ jobs:
           HEAD=$(git rev-parse HEAD)
           while ! nix-build -A tools.sed -A tools.jq -A tools.curl nix; do :; done
           echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
-          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '. | map(.tag_name)[]')
+          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '.[] | .tag_name')
           DIR=$(pwd)
           VERSIONS=$(curl 'https://hub.docker.com/v2/repositories/digitalasset/daml-sdk/tags/?page_size=10000' -s)
           # Our docker tags should be stable. Therefore, we only build the image if it has not already

--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -64,7 +64,7 @@ jobs:
           HEAD=$(git rev-parse HEAD)
           while ! nix-build -A tools.sed -A tools.jq -A tools.curl nix; do :; done
           echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
-          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '. | map(select(.prerelease == false)) | map(.tag_name)[]')
+          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '. | map(.tag_name)[]')
           DIR=$(pwd)
           VERSIONS=$(curl 'https://hub.docker.com/v2/repositories/digitalasset/daml-sdk/tags/?page_size=10000' -s)
           # Our docker tags should be stable. Therefore, we only build the image if it has not already


### PR DESCRIPTION
We got a couple of requests for this and given the current release
process this seems very reasonable. Snapshot releases are clearly
marked as such so I think there this is fine.

We could think about differentiating between a stable release version
marked as a prerelease and not publish the docker image for that but
given our current release process where the stable version is based on
an already existing snapshot and therefore testing is very unlikely to
fail when we mark it as stable, that doesn’t seem worth the complexity
here.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
