### PR TITLE
Engine: sync contract id internal representation with spec

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -304,10 +304,10 @@ case class Conversions(homePackageId: Ref.PackageId) {
 
   def mkContractRef(coid: V.ContractId, templateId: Ref.Identifier): ContractRef =
     coid match {
-      case V.AbsoluteContractId(coid) =>
+      case acoid: V.AbsoluteContractId =>
         ContractRef.newBuilder
           .setRelative(false)
-          .setContractId(coid)
+          .setContractId(acoid.coid)
           .setTemplateId(convertIdentifier(templateId))
           .build
       case V.RelativeContractId(txnid) =>
@@ -320,7 +320,7 @@ case class Conversions(homePackageId: Ref.PackageId) {
 
   def convertContractId(coid: V.ContractId): String =
     coid match {
-      case V.AbsoluteContractId(coid) => coid
+      case acoid: V.AbsoluteContractId => acoid.coid
       case V.RelativeContractId(txnid) => txnid.index.toString
     }
 
@@ -651,8 +651,8 @@ case class Conversions(homePackageId: Ref.PackageId) {
         builder.setEnum(eBuilder.build)
       case V.ValueContractId(coid) =>
         coid match {
-          case V.AbsoluteContractId(acoid) =>
-            builder.setContractId(acoid)
+          case acoid: V.AbsoluteContractId =>
+            builder.setContractId(acoid.coid)
           case V.RelativeContractId(txnid) =>
             builder.setContractId(txnid.index.toString)
         }

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Bytes.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Bytes.scala
@@ -20,7 +20,13 @@ final class Bytes private (protected val value: ByteString) extends AnyVal {
 
   def length: Int = value.size()
 
+  def isEmpty: Boolean = value.isEmpty
+
   def toHexString: Ref.HexString = Ref.HexString.encode(this)
+
+  def startsWith(prefix: Bytes): Boolean = value.startsWith(prefix.value)
+
+  def slice(begin: Int, end: Int): Bytes = new Bytes(value.substring(begin, end))
 
   override def toString: String = s"Bytes($toHexString)"
 
@@ -29,7 +35,9 @@ final class Bytes private (protected val value: ByteString) extends AnyVal {
 
 object Bytes {
 
-  implicit val `Bytes Ordering`: Ordering[Bytes] = {
+  val Empty = new Bytes(ByteString.EMPTY)
+
+  implicit val ordering: Ordering[Bytes] = {
     val comparator = ByteString.unsignedLexicographicalComparator()
     (x, y) =>
       comparator.compare(x.value, y.value)

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/IdString.scala
@@ -91,7 +91,7 @@ sealed abstract class IdString {
     * transactionId, ... We use the same type for those ids, because we
     * construct some by concatenating the others.
     */
-  type LedgerString <: ContractIdString
+  type LedgerString <: String
 
   /** Identifiers for contracts */
   type ContractIdString <: String
@@ -104,7 +104,7 @@ sealed abstract class IdString {
   val PackageId: ConcatenableStringModule[PackageId, HexString]
   val ParticipantId: StringModule[ParticipantId]
   val LedgerString: ConcatenableStringModule[LedgerString, HexString]
-  val ContractIdString: ConcatenableStringModule[ContractIdString, HexString]
+  val ContractIdString: StringModule[ContractIdString]
 }
 
 object IdString {
@@ -264,7 +264,8 @@ private[data] final class IdStringImpl extends IdString {
   /**
     * Legacy contractIds.
     */
-  override type ContractIdString = LedgerString
-  override val ContractIdString: ConcatenableStringModule[LedgerString, HexString] = LedgerString
+  override type ContractIdString = String
+  override val ContractIdString: StringModule[ContractIdString] =
+    new MatchingStringModule("""#[\w._:\-#/ ]{0,254}""")
 
 }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/CommandPreprocessorSpec.scala
@@ -61,7 +61,7 @@ class CommandPreprocessorSpec extends WordSpec with Matchers with TableDrivenPro
       TParty ->
         ValueParty(Ref.Party.assertFromString("Alice")),
       TContractId(TTyCon(recordCon)) ->
-        ValueContractId(AbsoluteContractId(Ref.ContractIdString.assertFromString("contractId"))),
+        ValueContractId(AbsoluteContractId.assertFromString("#contractId")),
       TList(TText) ->
         ValueList(FrontStack(ValueText("a"), ValueText("b"))),
       TTextMap(TBool) ->

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -122,7 +122,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
           BasicTests_WithKey,
           ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
           ) =>
-        Some(toContractId("1"))
+        Some(toContractId("#1"))
       case _ =>
         None
     }
@@ -201,7 +201,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
 
     "translate exercise commands argument including labels" in {
-      val originalCoid = toContractId("1")
+      val originalCoid = toContractId("#1")
       val templateId = Identifier(basicTestsPkgId, "BasicTests:CallablePayout")
       val let = Time.Timestamp.now()
       val command = ExerciseCommand(
@@ -217,7 +217,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
 
     "translate exercise commands argument without labels" in {
-      val originalCoid = "1"
+      val originalCoid = toContractId("#1")
       val templateId = Identifier(basicTestsPkgId, "BasicTests:CallablePayout")
       val let = Time.Timestamp.now()
       val command = ExerciseCommand(
@@ -492,7 +492,11 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     val let = Time.Timestamp.now()
     val transactionSeed = crypto.Hash.deriveTransactionSeed(submissionSeed, participant, let)
     val command =
-      ExerciseCommand(templateId, "1", "Hello", ValueRecord(Some(hello), ImmArray.empty))
+      ExerciseCommand(
+        templateId,
+        toContractId("#1"),
+        "Hello",
+        ValueRecord(Some(hello), ImmArray.empty))
 
     val res = commandTranslator
       .preprocessCommands(Commands(party, ImmArray(command), let, "test"))
@@ -881,7 +885,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
   "exercise callable command" should {
     val submissionSeed = hash("exercise callable command")
-    val originalCoid = "1"
+    val originalCoid = toContractId("#1")
     val templateId = Identifier(basicTestsPkgId, "BasicTests:CallablePayout")
     // we need to fix time as cid are depending on it
     val let = Time.Timestamp.assertFromString("1969-07-20T20:17:00Z")
@@ -950,7 +954,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
             children,
             _,
             _) =>
-          coid shouldBe toContractId(originalCoid)
+          coid shouldBe originalCoid
           consuming shouldBe true
           actingParties shouldBe Set(bob)
           children.map(_.index) shouldBe ImmArray(1)
@@ -1005,7 +1009,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         toContractId("00b39433a649bebecd3b01d651be38a75923efdb92f34592b5600aee3fec8a8cc3")
       bobExercise shouldBe
         ExerciseEvent(
-          contractId = toContractId(originalCoid),
+          contractId = originalCoid,
           templateId = Identifier(basicTestsPkgId, "BasicTests:CallablePayout"),
           choice = "Transfer",
           choiceArgument = assertAsVersionedValue(
@@ -1047,8 +1051,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     // Test a couple of scenarios, with different combination of signatories/observers/actors on the parent action
 
     val submissionSeed = hash("dynamic fetch actors")
-    val fetchedStrCid = "1"
-    val fetchedCid = toContractId(fetchedStrCid)
+    val fetchedCid = toContractId("#1")
     val fetchedStrTid = "BasicTests:Fetched"
     val fetchedTArgs = ImmArray(
       (Some[Name]("sig1"), ValueParty(alice)),
@@ -1059,16 +1062,14 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     val fetcherStrTid = "BasicTests:Fetcher"
     val fetcherTid = Identifier(basicTestsPkgId, fetcherStrTid)
 
-    val fetcher1StrCid = "2"
-    val fetcher1Cid = toContractId(fetcher1StrCid)
+    val fetcher1Cid = toContractId("#2")
     val fetcher1TArgs = ImmArray(
       (Some[Name]("sig"), ValueParty(alice)),
       (Some[Name]("obs"), ValueParty(bob)),
       (Some[Name]("fetcher"), ValueParty(clara)),
     )
 
-    val fetcher2StrCid = "3"
-    val fetcher2Cid = toContractId(fetcher2StrCid)
+    val fetcher2Cid = toContractId("#3")
     val fetcher2TArgs = ImmArray(
       (Some[Name]("sig"), ValueParty(party)),
       (Some[Name]("obs"), ValueParty(alice)),
@@ -1109,7 +1110,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         case (actors, (_, n)) => actors union actFetchActors(n)
       }
 
-    def runExample(cid: String, exerciseActor: Party) = {
+    def runExample(cid: AbsoluteContractId, exerciseActor: Party) = {
       val command = ExerciseCommand(
         fetcherTid,
         cid,
@@ -1139,18 +1140,18 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
     "propagate the parent's signatories and actors (but not observers) when stakeholders" in {
 
-      val Right(tx) = runExample(fetcher1StrCid, clara)
+      val Right(tx) = runExample(fetcher1Cid, clara)
       txFetchActors(tx) shouldBe Set(alice, clara)
     }
 
     "not propagate the parent's signatories nor actors when not stakeholders" in {
 
-      val Right(tx) = runExample(fetcher2StrCid, party)
+      val Right(tx) = runExample(fetcher2Cid, party)
       txFetchActors(tx) shouldBe Set()
     }
 
     "be retained when reinterpreting single fetch nodes" in {
-      val Right(tx) = runExample(fetcher1StrCid, clara)
+      val Right(tx) = runExample(fetcher1Cid, clara)
       val fetchNodes =
         tx.fold(Seq[(NodeId, GenNode.WithTxValue[NodeId, ContractId])]()) {
           case (ns, (nid, n @ NodeFetch(_, _, _, _, _, _, _))) => ns :+ ((nid, n))
@@ -1171,7 +1172,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
     val submissionSeed = hash("reinterpreting fetch nodes")
 
-    val fetchedCid = toContractId("1")
+    val fetchedCid = toContractId("#1")
     val fetchedStrTid = "BasicTests:Fetched"
     val fetchedTid = Identifier(basicTestsPkgId, fetchedStrTid)
 
@@ -1247,7 +1248,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
   }
 
   "fetching contracts that have keys correctly fills in the transaction structure" when {
-    val fetchedCid = AbsoluteContractId(ContractIdString.assertFromString("1"))
+    val fetchedCid = toContractId("#1")
     val now = Time.Timestamp.now()
 
     "fetched via a fetch" in {
@@ -1277,7 +1278,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     "fetched via a fetchByKey" in {
       val fetcherTemplate = "BasicTests:FetcherByKey"
       val fetcherTemplateId = Identifier(basicTestsPkgId, fetcherTemplate)
-      val fetcherCid = AbsoluteContractId(ContractIdString.assertFromString("2"))
+      val fetcherCid = toContractId("#2")
       val fetcherInst = ContractInst(
         TypeConName(basicTestsPkgId, fetcherTemplate),
         assertAsVersionedValue(
@@ -1337,8 +1338,8 @@ object EngineTest {
   private implicit def toName(s: String): Name =
     Name.assertFromString(s)
 
-  private implicit def toContractId(s: String): AbsoluteContractId =
-    AbsoluteContractId(ContractIdString.assertFromString(s))
+  private def toContractId(s: String): AbsoluteContractId =
+    AbsoluteContractId.assertFromString(s)
 
   private def ArrayList[X](as: X*): util.ArrayList[X] = {
     val a = new util.ArrayList[X](as.length)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
@@ -31,7 +31,7 @@ private[engine] class InMemoryPrivateLedgerData extends PrivateLedgerData {
 
   def toContractIdString(txCounter: Int)(r: RelativeContractId): Ref.ContractIdString =
     // It is safe to concatenate numbers and "-" to form a valid ContractId
-    Ref.ContractIdString.assertFromString(s"$txCounter-${r.txnid.index}")
+    Ref.ContractIdString.assertFromString(s"#$txCounter-${r.txnid.index}")
 
   def updateWithAbsoluteContractId(
       tx: GenTransaction.WithTxValue[NodeId, AbsoluteContractId]): Unit =

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -93,7 +93,7 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
         seed = hash("testLargeTransactionOneContract:create", txSize))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
       case N.NodeCreate(_, x: RelativeContractId, _, _, _, _, _) =>
-        AbsoluteContractId(pcs.toContractIdString(pcs.transactionCounter - 1)(x))
+        AbsoluteContractId.V0(pcs.toContractIdString(pcs.transactionCounter - 1)(x))
       case N.NodeCreate(_, x: AbsoluteContractId, _, _, _, _, _) => x
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
@@ -122,7 +122,7 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
         seed = hash("testLargeTransactionManySmallContracts:create", num))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
       case N.NodeCreate(_, x: RelativeContractId, _, _, _, _, _) =>
-        AbsoluteContractId(pcs.toContractIdString(pcs.transactionCounter - 1)(x))
+        AbsoluteContractId.V0(pcs.toContractIdString(pcs.transactionCounter - 1)(x))
       case N.NodeCreate(_, x: AbsoluteContractId, _, _, _, _, _) => x
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }
@@ -151,7 +151,7 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
         seed = hash("testLargeChoiceArgument:create", size))
     val contractId: AbsoluteContractId = firstRootNode(createCmdTx) match {
       case N.NodeCreate(_, x: RelativeContractId, _, _, _, _, _) =>
-        AbsoluteContractId(pcs.toContractIdString(pcs.transactionCounter - 1)(x))
+        AbsoluteContractId.V0(pcs.toContractIdString(pcs.transactionCounter - 1)(x))
       case N.NodeCreate(_, x: AbsoluteContractId, _, _, _, _, _) => x
       case n @ _ => fail(s"Expected NodeCreate, but got: $n")
     }

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -27,6 +27,7 @@ da_scala_library(
         "//daml-lf/language",
         "//daml-lf/transaction",
         "//daml-lf/validation",
+        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_slf4j_slf4j_api",
         "@maven//:org_typelevel_paiges_core_2_12",

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -338,7 +338,7 @@ object Pretty {
 
   def prettyContractId(coid: ContractId): Doc =
     coid match {
-      case AbsoluteContractId(acoid) => text(acoid)
+      case acoid: AbsoluteContractId => text(acoid.coid)
       case RelativeContractId(rcoid) => str(rcoid)
     }
 
@@ -415,7 +415,7 @@ object Pretty {
         }) +
           text(constructor)
       case ValueText(t) => char('"') + text(t) + char('"')
-      case ValueContractId(AbsoluteContractId(acoid)) => text(acoid)
+      case ValueContractId(acoid: AbsoluteContractId) => text(acoid.coid)
       case ValueContractId(RelativeContractId(rcoid)) =>
         char('~') + text(rcoid.toString)
       case ValueUnit => text("<unit>")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -5,7 +5,7 @@ package com.digitalasset.daml.lf.speedy
 
 import com.digitalasset.daml.lf.crypto
 import com.digitalasset.daml.lf.data.Ref.{ChoiceName, Location, Party, TypeConName}
-import com.digitalasset.daml.lf.data.{BackStack, ImmArray, Ref, Time}
+import com.digitalasset.daml.lf.data.{BackStack, ImmArray, Time}
 import com.digitalasset.daml.lf.transaction.{GenTransaction, Node, Transaction => Tx}
 import com.digitalasset.daml.lf.value.Value
 
@@ -238,10 +238,7 @@ case class PartialTransaction(
         } yield crypto.Hash.deriveContractDiscriminator(seed, time, stakeholders)
       val cid = discriminator.fold[Value.ContractId](
         Value.RelativeContractId(Value.NodeId(nextNodeIdx))
-      )(
-        hash =>
-          Value.AbsoluteContractId(Ref.ContractIdString.assertFromString("00" + hash.toHexString))
-      )
+      )(Value.AbsoluteContractId.V1(_))
       val createNode = Node.NodeCreate(
         nodeSeed,
         cid,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -27,7 +27,6 @@ object Ledger {
   private object ScenarioNodeId {
     def apply(commitPrefix: LedgerString, txnid: Transaction.NodeId): ScenarioNodeId =
       txNodeIdToScenarioNodeId(commitPrefix, txnid.index)
-
   }
 
   /** This is the function that we use to turn relative contract ids (which are made of
@@ -64,7 +63,7 @@ object Ledger {
     cid match {
       case acoid: AbsoluteContractId => acoid
       case rcoid: RelativeContractId =>
-        AbsoluteContractId(relativeToScenarioNodeId(commitPrefix, rcoid))
+        AbsoluteContractId.V0.assertFromString(relativeToScenarioNodeId(commitPrefix, rcoid))
     }
 
   def contractIdToAbsoluteContractId(
@@ -183,7 +182,8 @@ object Ledger {
       effectiveAt: Time.Timestamp,
       enrichedTx: EnrichedTransaction,
   ): RichTransaction = {
-    def makeAbs(cid: Value.RelativeContractId) = relativeToContractIdString(commitPrefix, cid)
+    def makeAbs(cid: Value.RelativeContractId) =
+      Ref.ContractIdString.assertFromString(relativeToContractIdString(commitPrefix, cid))
     RichTransaction(
       committer = committer,
       effectiveAt = effectiveAt,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
@@ -63,8 +63,7 @@ class EqualitySpec extends WordSpec with Matchers with TableDrivenPropertyChecks
   private val parties =
     List("alice", "bob").map(SParty compose Ref.Party.assertFromString)
   private val absoluteContractId =
-    List("a", "b")
-      .map(x => SContractId(AbsoluteContractId(Ref.ContractIdString.assertFromString(x))))
+    List("a", "b").map(x => SContractId(AbsoluteContractId.assertFromString("#" + x)))
   private val relativeContractId =
     List(0, 1).map(x => SContractId(RelativeContractId(NodeId(x))))
   private val contractIds = absoluteContractId ++ relativeContractId

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -69,7 +69,7 @@ class OrderingSpec extends WordSpec with Matchers with TableDrivenPropertyChecks
     List("alice", "bob", "carol").map(SParty compose Ref.Party.assertFromString)
   private val absoluteContractId =
     List("a", "b", "c")
-      .map(x => SContractId(Value.AbsoluteContractId(Ref.ContractIdString.assertFromString(x))))
+      .map(x => SContractId(Value.AbsoluteContractId.assertFromString("#" + x)))
 //  private val relativeContractId =
 //    List(0, 1).map(x => SContractId(Value.RelativeContractId(Value.NodeId(x))))
   private val contractIds = absoluteContractId //++ relativeContractId

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -32,7 +32,7 @@ final class Hash private (val bytes: Bytes) {
 object Hash {
 
   private val version = 0.toByte
-  private val underlyingHashLength = 32
+  val underlyingHashLength = 32
 
   private case class HashingError(msg: String) extends Exception with NoStackTrace
 
@@ -76,14 +76,16 @@ object Hash {
   def secureRandom: () => Hash =
     random(assertFromByteArray(SecureRandom.getInstanceStrong.generateSeed(underlyingHashLength)))
 
-  implicit val `Hash Ordering`: Ordering[Hash] =
+  implicit val ordering: Ordering[Hash] =
     Ordering.by(_.bytes)
 
   @throws[HashingError]
-  private[lf] val aCid2String: Value.ContractId => String = {
-    case (Value.AbsoluteContractId(cid)) =>
-      cid
-    case (Value.RelativeContractId(_)) =>
+  private[lf] val aCid2Bytes: Value.ContractId => Bytes = {
+    case cid @ Value.AbsoluteContractId.V1(_, _) =>
+      cid.toBytes
+    case Value.AbsoluteContractId.V0(s) =>
+      Utf8.getBytes(s)
+    case Value.RelativeContractId(_) =>
       error("Hashing of relative contract id is not supported")
   }
 
@@ -91,7 +93,7 @@ object Hash {
   private[lf] val noCid2String: Value.ContractId => Nothing =
     _ => error("Hashing of relative contract id is not supported in contract key")
 
-  private[crypto] sealed abstract class Builder(cid2String: Value.ContractId => String) {
+  private[crypto] sealed abstract class Builder(cid2Bytes: Value.ContractId => Bytes) {
 
     protected def update(a: ByteBuffer): Unit
 
@@ -175,8 +177,11 @@ object Hash {
     }
 
     @throws[HashingError]
-    final def addCid(cid: Value.ContractId): this.type =
-      add(cid2String(cid))
+    final def addCid(cid: Value.ContractId): this.type = {
+      val bytes = cid2Bytes(cid)
+      add(bytes.length)
+      add(bytes)
+    }
 
     // In order to avoid hash collision, this should be used together
     // with another data representing uniquely the type of `value`.
@@ -239,8 +244,8 @@ object Hash {
   // Do not call this method from outside Hash object/
   private[crypto] def builder(
       purpose: Purpose,
-      cid2String: Value.ContractId => String,
-  ): Builder = new Builder(cid2String) {
+      cid2Bytes: Value.ContractId => Bytes,
+  ): Builder = new Builder(cid2Bytes) {
 
     private val md = MessageDigest.getInstance("SHA-256")
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingCoder.scala
@@ -37,7 +37,7 @@ object BlindingCoder {
         for {
           parties <- toPartySet(n.getPartiesList)
           coid <- toContractId(n.getContractId)
-        } yield AbsoluteContractId(coid) -> parties)
+        } yield coid -> parties)
 
     for {
       explicit <- sequence(explicitDisclosure)
@@ -92,7 +92,7 @@ object BlindingCoder {
     }
   }
 
-  private def toContractId(s: String): Either[DecodeError, ContractIdString] =
-    ContractIdString.fromString(s).left.map(err => DecodeError(s"Cannot decode contractId: $err"))
+  private def toContractId(s: String): Either[DecodeError, AbsoluteContractId] =
+    AbsoluteContractId.fromString(s).left.map(err => DecodeError(s"Cannot decode contractId: $err"))
 
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -59,7 +59,7 @@ object CidMapper {
           f: Value.RelativeContractId => Ref.ContractIdString,
       ): Value.ContractId => Value.AbsoluteContractId = {
         case acoid: Value.AbsoluteContractId => acoid
-        case rcoid: Value.RelativeContractId => Value.AbsoluteContractId(f(rcoid))
+        case rcoid: Value.RelativeContractId => Value.AbsoluteContractId.V0(f(rcoid))
       }
     }
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.daml.lf
 package value
 
-import com.digitalasset.daml.lf.data.Ref.{ContractIdString, Identifier, Name}
+import com.digitalasset.daml.lf.data.Ref.{Identifier, Name}
 import com.digitalasset.daml.lf.data._
 import com.digitalasset.daml.lf.language.LanguageVersion
 
@@ -347,9 +347,66 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
     * to be able to use AbsoluteContractId elsewhere, so that we can
     * automatically upcast to ContractId by subtyping.
     */
-  sealed trait ContractId
+  sealed abstract class ContractId
 
-  final case class AbsoluteContractId(coid: ContractIdString) extends ContractId
+  sealed abstract class AbsoluteContractId extends ContractId with Product with Serializable {
+    def coid: String
+  }
+
+  object AbsoluteContractId {
+    final case class V0(coid: Ref.ContractIdString) extends AbsoluteContractId {
+      override def toString: String = s"AbsoluteContractId($coid)"
+    }
+
+    object V0 {
+      def fromString(s: String): Either[String, V0] =
+        Ref.ContractIdString.fromString(s).map(V0(_))
+
+      def assertFromString(s: String): V0 = assertRight(fromString(s))
+    }
+
+    final case class V1(discriminator: crypto.Hash, suffix: Bytes = Bytes.Empty)
+        extends AbsoluteContractId {
+      lazy val toBytes: Bytes = V1.prefix ++ discriminator.bytes ++ suffix
+      lazy val coid: Ref.HexString = toBytes.toHexString
+      override def toString: String = s"AbsoluteContractId($coid)"
+    }
+
+    object V1 {
+
+      val prefix: Bytes = Bytes.assertFromString("00")
+
+      private val suffixStart: Int = crypto.Hash.underlyingHashLength + prefix.length
+
+      def fromString(s: String): Either[String, V1] =
+        Bytes
+          .fromString(s)
+          .flatMap(
+            bytes =>
+              if (bytes.startsWith(prefix) && bytes.length >= suffixStart)
+                crypto.Hash
+                  .fromBytes(bytes.slice(prefix.length, suffixStart))
+                  .map(
+                    V1(_, bytes.slice(suffixStart, bytes.length))
+                  )
+              else
+                Left(s"""cannot parse V1 ContractId "$s""""))
+
+      def assertFromString(s: String): V1 = assertRight(fromString(s))
+
+    }
+
+    def fromString(s: String): Either[String, AbsoluteContractId] =
+      V1.fromString(s)
+        .left
+        .flatMap(_ => V0.fromString(s))
+        .left
+        .map(_ => s"""cannot parse ContractId "$s"""")
+
+    def assertFromString(s: String): AbsoluteContractId =
+      assertRight(fromString(s))
+  }
+
   final case class RelativeContractId(txnid: NodeId) extends ContractId
 
   object ContractId {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -62,8 +62,8 @@ object ValueCoder {
         cid match {
           case RelativeContractId(nid) =>
             Right(Left("~" + nid.index.toString))
-          case AbsoluteContractId(s) =>
-            Right(Left(s))
+          case acoid: AbsoluteContractId =>
+            Right(Left(acoid.coid))
         } else
         cid match {
           case RelativeContractId(nid) =>
@@ -73,8 +73,9 @@ object ValueCoder {
                   .setRelative(true)
                   .setContractId(nid.index.toString)
                   .build))
-          case AbsoluteContractId(s) =>
-            Right(Right(proto.ContractId.newBuilder.setRelative(false).setContractId(s).build))
+          case acoid: AbsoluteContractId =>
+            Right(
+              Right(proto.ContractId.newBuilder.setRelative(false).setContractId(acoid.coid).build))
         }
   }
 
@@ -108,8 +109,8 @@ object ValueCoder {
           idx => Some(RelativeContractId(NodeId(idx)))
         )
 
-    private def stringToCidString(s: String): Either[DecodeError, Ref.ContractIdString] =
-      Ref.ContractIdString
+    private def stringToCidString(s: String): Either[DecodeError, Value.AbsoluteContractId] =
+      Value.AbsoluteContractId
         .fromString(s)
         .left
         .map(_ => //
@@ -129,7 +130,7 @@ object ValueCoder {
           else if (stringForm.startsWith("~"))
             stringToRelativeCid(stringForm.drop(1))
           else
-            stringToCidString(stringForm).map(coid => Some(AbsoluteContractId(coid)))
+            stringToCidString(stringForm).map(Some(_))
         }
       } else {
         if (stringForm.nonEmpty)
@@ -139,7 +140,7 @@ object ValueCoder {
         else if (structForm.getRelative)
           stringToRelativeCid(structForm.getContractId)
         else
-          stringToCidString(structForm.getContractId).map(coid => Some(AbsoluteContractId(coid)))
+          stringToCidString(structForm.getContractId).map(Some(_))
       }
 
   }
@@ -151,10 +152,10 @@ object ValueCoder {
         structForm: ValueOuterClass.ContractId,
     ): Either[DecodeError, Option[AbsoluteContractId]] =
       CidDecoder.decodeOptional(sv, stringForm, structForm).flatMap {
+        case Some(cid: AbsoluteContractId) =>
+          Right(Some(cid))
         case Some(RelativeContractId(_)) =>
           Left(DecodeError("Unexpected relative contractId"))
-        case Some(AbsoluteContractId(coid)) =>
-          Right(Some(AbsoluteContractId(coid)))
         case None =>
           Right(None)
       }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -341,9 +341,9 @@ class HashSpec extends WordSpec with Matchers {
         ).map(VA.party.inj)
       val contractIds =
         List(
-          "07e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5",
-          "59b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b",
-        ).map(x => AbsoluteContractId(Ref.ContractIdString.assertFromString(x)))
+          "0007e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5",
+          "0059b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b",
+        ).map(AbsoluteContractId.V1.assertFromString)
           .map(VA.contractId.inj)
 
       val enumT1 = VA.enum("Color", List("Red", "Green"))._2
@@ -464,10 +464,10 @@ class HashSpec extends WordSpec with Matchers {
           | 274830656c6f7de1daf729d11c57c40ef271a101a831d89e45f034ce7bd71d9d
           |ValueParty(bob)
           | dc1f0fc026d3200a1781f0989dd1801022e028e8afe5d953a033e6d35e8ea50b
-          |ValueContractId(AbsoluteContractId(07e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5))
-          | 399c8d4fb942204c9384a8bda062676d75a3a52080c798f98560b2914af61ad8
-          |ValueContractId(AbsoluteContractId(59b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b))
-          | f05d36c187b003a1c1ca669579bdcf0cfce85ce634029cc533d23d24fd8382a1
+          |ValueContractId(AbsoluteContractId(0007e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5))
+          | 0649b1e1e7f34be457c44146e449299109167b9199101349873142ed05878b96
+          |ValueContractId(AbsoluteContractId(0059b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b))
+          | 0b8c0cc8ebbd56e275b60cf73133387322a42448986dc3858b31eef23098e8e8
           |ValueOptional(None)
           | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
           |ValueOptional(Some(ValueBool(false)))
@@ -538,7 +538,7 @@ class HashSpec extends WordSpec with Matchers {
       val actualOutput = testCases
         .map { value =>
           val hash = Hash
-            .builder(Hash.Purpose.Testing, Hash.aCid2String)
+            .builder(Hash.Purpose.Testing, Hash.aCid2Bytes)
             .addTypedValue(value)
             .build
             .toHexString

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -5,7 +5,7 @@ package com.digitalasset.daml.lf
 package transaction
 
 import com.digitalasset.daml.lf.EitherAssertions
-import com.digitalasset.daml.lf.data.{ImmArray, Ref}
+import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, Party, QualifiedName}
 import com.digitalasset.daml.lf.transaction.Node.{GenNode, NodeCreate, NodeExercises, NodeFetch}
 import com.digitalasset.daml.lf.transaction.{Transaction => Tx, TransactionOuterClass => proto}
@@ -305,7 +305,7 @@ class TransactionCoderSpec
       val node =
         Node.NodeCreate[Value.AbsoluteContractId, Value.VersionedValue[Value.AbsoluteContractId]](
           nodeSeed = None,
-          coid = absCid("test-cid"),
+          coid = absCid("#test-cid"),
           coinst = ContractInst(
             Identifier(
               PackageId.assertFromString("pkg-id"),
@@ -404,6 +404,6 @@ class TransactionCoderSpec
   }
 
   private def absCid(s: String): Value.AbsoluteContractId =
-    Value.AbsoluteContractId(Ref.ContractIdString.assertFromString(s))
+    Value.AbsoluteContractId.assertFromString(s)
 
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -127,7 +127,7 @@ object TransactionSpec {
   ): NodeExercises[String, V.AbsoluteContractId, Value] =
     NodeExercises(
       nodeSeed = None,
-      targetCoid = V.AbsoluteContractId(Ref.ContractIdString.assertFromString("dummyCoid")),
+      targetCoid = V.AbsoluteContractId.assertFromString("#dummyCoid"),
       templateId = Ref.Identifier(
         PackageId.assertFromString("-dummyPkg-"),
         QualifiedName.assertFromString("DummyModule:dummyName"),
@@ -148,7 +148,7 @@ object TransactionSpec {
   val dummyCreateNode: NodeCreate[V.AbsoluteContractId, Value] =
     NodeCreate(
       nodeSeed = None,
-      coid = V.AbsoluteContractId(Ref.ContractIdString.assertFromString("dummyCoid")),
+      coid = V.AbsoluteContractId.assertFromString("#dummyCoid"),
       coinst = ContractInst(
         Ref.Identifier(
           PackageId.assertFromString("-dummyPkg-"),

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -63,7 +63,7 @@ class ValueSpec extends FreeSpec with Matchers with Checkers with GeneratorDrive
       "ensureNoRelCid is used " in {
         val value = VersionedValue(
           ValueVersions.minVersion,
-          ValueContractId(AbsoluteContractId(Ref.ContractIdString.assertFromString("#0:0"))),
+          ValueContractId(AbsoluteContractId.assertFromString("#0:0")),
         )
         val contract = ContractInst(tmplId, value, "agreed")
         value.ensureNoRelCid.map(_.version) shouldBe Right(ValueVersions.minVersion)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -144,7 +144,7 @@ object Converter {
 
   def toContractId(v: SValue): Either[String, AbsoluteContractId] =
     v match {
-      case SContractId(cid @ AbsoluteContractId(_)) => Right(cid)
+      case SContractId(cid: AbsoluteContractId) => Right(cid)
       case _ => Left(s"Expected AbsoluteContractId but got $v")
     }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -47,7 +47,7 @@ object LfValueCodec extends ApiCodecCompressed[AbsoluteContractId](false, false)
     JsString(obj.coid)
   override final def jsValueToApiContractId(json: JsValue) = json match {
     case JsString(s) =>
-      ContractIdString.fromString(s).fold(deserializationError(_), AbsoluteContractId)
+      AbsoluteContractId.fromString(s).fold(deserializationError(_), identity)
     case _ => deserializationError("ContractId must be a string")
   }
 }

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -523,7 +523,7 @@ bucket = VRecord $ Record Nothing
         [ VVariant $ Variant Nothing (ConstructorId "B") (VBool True)
         , VVariant $ Variant Nothing (ConstructorId "I") (VInt 99)
         ]
-    , RecordField "contract"$ VContract (ContractId "xxxxx")
+    , RecordField "contract"$ VContract (ContractId "#xxxxx")
     , RecordField "list"    $ VList []
     , RecordField "int"     $ VInt 42
     , RecordField "decimal" $ VDecimal 123.456

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -6,7 +6,6 @@ package com.digitalasset.http.json
 import java.time.Instant
 
 import akka.http.scaladsl.model.StatusCode
-import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.daml.lf.value.json.ApiCodecCompressed
 import com.digitalasset.http.domain
@@ -93,7 +92,7 @@ object JsonProtocol extends DefaultJsonProtocol {
       JsString(obj.coid)
     protected override final def jsValueToApiContractId(json: JsValue) = json match {
       case JsString(s) =>
-        Ref.ContractIdString fromString s fold (deserializationError(_), AbsoluteContractId)
+        AbsoluteContractId fromString s fold (deserializationError(_), identity)
       case _ => deserializationError("ContractId must be a string")
     }
   }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -721,7 +721,7 @@ abstract class AbstractHttpServiceIntegrationTest
 
   "exercise IOU_Transfer with unknown contractId should return proper error" in withHttpService {
     (uri, encoder, _) =>
-      val contractId = lar.ContractId("NonExistentContractId")
+      val contractId = lar.ContractId("#NonExistentContractId")
       val exerciseJson: JsValue = encodeExercise(encoder)(iouExerciseTransferCommand(contractId))
       postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), exerciseJson)
         .flatMap {
@@ -729,7 +729,7 @@ abstract class AbstractHttpServiceIntegrationTest
             status shouldBe StatusCodes.InternalServerError
             assertStatus(output, StatusCodes.InternalServerError)
             expectedOneErrorMessage(output) should include(
-              "couldn't find contract AbsoluteContractId(NonExistentContractId)")
+              "couldn't find contract AbsoluteContractId(#NonExistentContractId)")
         }: Future[Assertion]
   }
 
@@ -804,7 +804,7 @@ abstract class AbstractHttpServiceIntegrationTest
   private def testExerciseCommandEncodingDecoding(
       encoder: DomainJsonEncoder,
       decoder: DomainJsonDecoder): Assertion = {
-    val command0 = iouExerciseTransferCommand(lar.ContractId("a-contract-ID"))
+    val command0 = iouExerciseTransferCommand(lar.ContractId("#a-contract-ID"))
     val jsVal: JsValue = encodeExercise(encoder)(command0)
     val command1 = decodeExercise(decoder)(jsVal)
     command1.bimap(removeRecordId, identity) should ===(command0)

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/query/ValuePredicateTest.scala
@@ -25,9 +25,8 @@ class ValuePredicateTest
     with TableDrivenPropertyChecks {
   import ValuePredicateTest._
   type Cid = V.AbsoluteContractId
-  private[this] val genCid = Gen.zip(Gen.alphaChar, Gen.alphaStr) map {
-    case (h, t) => V.AbsoluteContractId(Ref.ContractIdString assertFromString (h +: t))
-  }
+  private[this] val genCid = Gen.alphaStr map (t =>
+    V.AbsoluteContractId.V0 assertFromString ('#' +: t))
 
   private[this] val dummyId = Ref.Identifier(
     Ref.PackageId assertFromString "dummy-package-id",

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.http
 package util
 
-import com.digitalasset.daml.lf.data.{ImmArray, Ref}
+import com.digitalasset.daml.lf.data.ImmArray
 import com.digitalasset.daml.lf.value.TypedValueGenerators.genAddend
 import com.digitalasset.daml.lf.value.{Value => V}
 import com.digitalasset.platform.participant.util.LfEngineToApi.lfValueToApiValue
@@ -17,9 +17,8 @@ class ApiValueToLfValueConverterTest
     with Matchers
     with GeneratorDrivenPropertyChecks {
 
-  private[this] val genCid = Gen.zip(Gen.alphaChar, Gen.alphaStr) map {
-    case (h, t) => V.AbsoluteContractId(Ref.ContractIdString assertFromString (h +: t))
-  }
+  private[this] val genCid = Gen.alphaStr map (t =>
+    V.AbsoluteContractId.V0 assertFromString ('#' +: t))
   import ApiValueToLfValueConverterTest._
 
   "apiValueToLfValue" should {

--- a/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
+++ b/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
@@ -440,7 +440,7 @@ final class CommandClientIT
       }
 
       "not accept exercises with bad contract IDs, return INVALID_ARGUMENT" in {
-        val contractId = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef-123"
+        val contractId = "#deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef-123"
         val command =
           submitRequest(
             "Exercise_contract_not_found",

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -126,14 +126,14 @@ final class CommandsValidator(ledgerId: LedgerId) {
         for {
           templateId <- requirePresence(e.value.templateId, "template_id")
           validatedTemplateId <- validateIdentifier(templateId)
-          contractId <- requireLedgerString(e.value.contractId, "contract_id")
+          contractId <- requireAbsoluteContractId(e.value.contractId, "contract_id")
           choice <- requireName(e.value.choice, "choice")
           value <- requirePresence(e.value.choiceArgument, "value")
           validatedValue <- validateValue(value)
         } yield
           ExerciseCommand(
             templateId = validatedTemplateId,
-            contractId = Lf.AbsoluteContractId(contractId),
+            contractId = contractId,
             choiceId = choice,
             argument = validatedValue)
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/FieldValidations.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/FieldValidations.scala
@@ -6,6 +6,7 @@ package com.digitalasset.platform.server.api.validation
 import java.time.Duration
 
 import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.v1.value.Identifier
 import com.digitalasset.platform.server.api.validation.ErrorFactories._
@@ -67,6 +68,13 @@ trait FieldValidations {
 
   def requireLedgerString(s: String): Either[StatusRuntimeException, Ref.LedgerString] =
     Ref.LedgerString.fromString(s).left.map(invalidArgument)
+
+  def requireAbsoluteContractId(
+      s: String,
+      fieldName: String
+  ): Either[StatusRuntimeException, AbsoluteContractId] =
+    if (s.isEmpty) Left(missingField(fieldName))
+    else AbsoluteContractId.fromString(s).left.map(invalidField(fieldName, _))
 
   def requireDottedName(
       s: String,

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/ValueConversionRoundTripTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/ValueConversionRoundTripTest.scala
@@ -56,7 +56,7 @@ class ValueConversionRoundTripTest
 
       val testCases: TableFor1[Sum] = Table(
         "values",
-        Sum.ContractId("coid"),
+        Sum.ContractId("#coid"),
         DomainMocks.values.validApiParty.sum,
         Sum.Int64(Long.MinValue),
         Sum.Int64(0),

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -261,10 +261,10 @@ class SubmitRequestValidatorTest
     "validating contractId values" should {
       "succeed" in {
 
-        val coid = Ref.ContractIdString.assertFromString("coid")
+        val coid = Ref.ContractIdString.assertFromString("#coid")
 
         val input = Value(Sum.ContractId(coid))
-        val expected = Lf.ValueContractId(Lf.AbsoluteContractId(coid))
+        val expected = Lf.ValueContractId(Lf.AbsoluteContractId.V0(coid))
 
         validateValue(input) shouldEqual Right(expected)
       }

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/store/serialization/KeyHasherSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/store/serialization/KeyHasherSpec.scala
@@ -404,11 +404,11 @@ class KeyHasherSpec extends WordSpec with Matchers {
       val contractIds =
         List[Value](
           ValueContractId(
-            AbsoluteContractId(Ref.ContractIdString.assertFromString(
-              "07e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5"))),
+            AbsoluteContractId.assertFromString(
+              "0007e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5")),
           ValueContractId(
-            AbsoluteContractId(Ref.ContractIdString.assertFromString(
-              "59b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b")))
+            AbsoluteContractId.assertFromString(
+              "0059b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b"))
         )
 
       val enums =
@@ -525,10 +525,10 @@ class KeyHasherSpec extends WordSpec with Matchers {
           | e3e40cc57896dcdac6731f60cb1748bd34b45ac0a6e42aa517d41dfea2ff8a88
           |ValueParty(bob)
           | 492f3783b824fb976eac36c0623337a7fd7440b95095581eb81687c71e802943
-          |ValueContractId(AbsoluteContractId(07e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5))
-          | fa24d4f2cd646f7e6d7f4e43813e93106d52df42b4272b007d36ba7c9bf21f6b
-          |ValueContractId(AbsoluteContractId(59b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b))
-          | 65b079e97a8b4804622173ef0c7c86e6bc3b4dbedef9ab7508391b8283279df7
+          |ValueContractId(AbsoluteContractId(0007e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5))
+          | a03a7ce4c418622a2187d068208c5ad32460eb62a56797975f39988e959ca377
+          |ValueContractId(AbsoluteContractId(0059b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b))
+          | 01540890e0cd14209bcc408d019266b711ec85a16dac2e8eb3567f6e041cb86b
           |ValueOptional(None)
           | df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119
           |ValueOptional(Some(ValueBool(false)))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -44,7 +44,7 @@ private[state] object Conversions {
       BaseEncoding.base16.encode(txId.getEntryId.toByteArray)
     // NOTE(JM): Must be in sync with [[absoluteContractIdToLogEntryId]] and
     // [[absoluteContractIdToStateKey]].
-    Ref.ContractIdString.assertFromString(s"$hexTxId:${coid.txnid.index}")
+    Ref.ContractIdString.assertFromString(s"#$hexTxId:${coid.txnid.index}")
   }
 
   def contractIdToStateKey(acoid: AbsoluteContractId): DamlStateKey =
@@ -53,7 +53,7 @@ private[state] object Conversions {
       .build
 
   def decodeContractId(coid: String): AbsoluteContractId =
-    AbsoluteContractId(Ref.ContractIdString.assertFromString(coid))
+    AbsoluteContractId.assertFromString(coid)
 
   def stateKeyToContractId(key: DamlStateKey): AbsoluteContractId =
     decodeContractId(key.getContractId)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -76,7 +76,7 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
     def exerciseCmd(coid: String, templateId: Ref.Identifier): Command =
       ExerciseCommand(
         templateId,
-        Value.AbsoluteContractId(Ref.ContractIdString.assertFromString(coid)),
+        Value.AbsoluteContractId.assertFromString(coid),
         simpleConsumeChoiceid,
         ValueUnit)
 

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
@@ -23,7 +23,7 @@ import com.digitalasset.daml.lf.data.{Bytes, Ref}
   */
 final case class Offset(bytes: Bytes) extends Ordered[Offset] {
   override def compare(that: Offset): Int =
-    Bytes.`Bytes Ordering`.compare(this.bytes, that.bytes)
+    Bytes.ordering.compare(this.bytes, that.bytes)
 
   def toByteArray: Array[Byte] = bytes.toByteArray
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/events/EventIdFormatter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/events/EventIdFormatter.scala
@@ -3,9 +3,10 @@
 
 package com.digitalasset.platform.events
 
-import com.digitalasset.daml.lf.data.Ref.LedgerString
+import com.digitalasset.daml.lf.data.Ref.{ContractIdString, LedgerString}
 import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.daml.lf.types.Ledger
+import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.daml.lf.value.{Value => Lf}
 import com.digitalasset.ledger.EventId
 
@@ -17,14 +18,13 @@ object EventIdFormatter {
 
   case class TransactionIdWithIndex(transactionId: LedgerString, nodeId: Transaction.NodeId)
 
-  def makeAbs(transactionId: LedgerString)(rcoid: Lf.RelativeContractId): LedgerString =
-    fromTransactionId(transactionId, rcoid.txnid)
+  def makeAbs(transactionId: LedgerString)(rcoid: Lf.RelativeContractId): ContractIdString =
+    ContractIdString.assertFromString(fromTransactionId(transactionId, rcoid.txnid))
 
   def makeAbsCoid(transactionId: LedgerString)(coid: Lf.ContractId): Lf.AbsoluteContractId =
     coid match {
-      case a @ Lf.AbsoluteContractId(_) => a
-      case Lf.RelativeContractId(txnid) =>
-        Lf.AbsoluteContractId(fromTransactionId(transactionId, txnid))
+      case a: Lf.AbsoluteContractId => a
+      case r: Lf.RelativeContractId => AbsoluteContractId.V0(makeAbs(transactionId)(r))
     }
 
   // this method defines the EventId format used by the sandbox

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
@@ -19,6 +19,7 @@ import anorm.{
 }
 import com.daml.ledger.participant.state.v1.Offset
 import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.value.Value
 
 object Conversions {
 
@@ -80,12 +81,14 @@ object Conversions {
       implicit strToStm: ToStatement[String]): ToStatement[Ref.ParticipantId] =
     subStringToStatement(strToStm)
 
-  implicit def columnToContractId(implicit c: Column[String]): Column[Ref.ContractIdString] =
-    stringColumnToX(Ref.ContractIdString.fromString)(c)
+  implicit def columnToContractId(implicit c: Column[String]): Column[Value.AbsoluteContractId] =
+    stringColumnToX(Value.AbsoluteContractId.fromString)(c)
 
   implicit def contractIdToStatement(
-      implicit strToStm: ToStatement[String]): ToStatement[Ref.ContractIdString] =
-    subStringToStatement(strToStm)
+      implicit strToStm: ToStatement[String]
+  ): ToStatement[Value.AbsoluteContractId] =
+    (s: PreparedStatement, index: Int, v: Value.AbsoluteContractId) =>
+      strToStm.set(s, index, v.coid)
 
   def emptyStringToNullColumn(implicit c: Column[String]): Column[String] = new Column[String] {
     override def apply(value: Any, meta: MetaDataItem) = value match {
@@ -108,9 +111,9 @@ object Conversions {
       implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[Ref.ParticipantId] =
     subStringMetaParameter(strParamMetaData)
 
-  def contractIdString(columnName: String)(
-      implicit c: Column[String]): RowParser[Ref.ContractIdString] =
-    SqlParser.get[Ref.ContractIdString](columnName)(columnToContractId(c))
+  def contractId(columnName: String)(
+      implicit c: Column[String]): RowParser[Value.AbsoluteContractId] =
+    SqlParser.get[Value.AbsoluteContractId](columnName)(columnToContractId(c))
 
   implicit def contractIdStringMetaParameter(implicit strParamMetaData: ParameterMetaData[String])
     : ParameterMetaData[Ref.ContractIdString] =

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -121,8 +121,7 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
         "name" -> key.templateId.qualifiedName.toString,
         "value_hash" -> keyHasher.hashKeyString(key)
       )
-      .as(ledgerString("contract_id").singleOpt)
-      .map(AbsoluteContractId)
+      .as(contractId("contract_id").singleOpt)
 
   private def storeContract(offset: Long, contract: ActiveContract)(
       implicit connection: Connection): Unit = storeContracts(offset, List(contract))

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
@@ -49,8 +49,7 @@ class V3__Recompute_Key_Hash extends BaseJavaMigration {
       var hasNext: Boolean = rows.next()
 
       def next(): (AbsoluteContractId, GlobalKey) = {
-        val contractId = AbsoluteContractId(
-          Ref.ContractIdString.assertFromString(rows.getString("contract_id")))
+        val contractId = AbsoluteContractId.assertFromString(rows.getString("contract_id"))
         val templateId = Ref.Identifier(
           packageId = Ref.PackageId.assertFromString(rows.getString("package_id")),
           qualifiedName = Ref.QualifiedName.assertFromString(rows.getString("template_name"))

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractKeysSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractKeysSpec.scala
@@ -202,8 +202,8 @@ private[dao] trait JdbcLedgerDaoContractKeysSpec {
           GenTransaction(HashMap.empty, ImmArray.empty),
           Map.empty
         ),
-        Map(AbsoluteContractId(s"contractId$id") -> Set(bob)),
-        List(AbsoluteContractId(s"contractId$id") -> someContractInstance)
+        Map(AbsoluteContractId.assertFromString(s"#contractId$id") -> Set(bob)),
+        List(AbsoluteContractId.assertFromString(s"#contractId$id") -> someContractInstance)
       )
     }
 

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
@@ -25,7 +25,7 @@ private[dao] trait JdbcLedgerDaoContractsSpec {
   it should "be able to persist and load contracts" in {
     val offset = nextOffset()
     val offsetString = offset.toLong
-    val absCid = AbsoluteContractId(s"cId1-$offsetString")
+    val absCid = AbsoluteContractId.assertFromString(s"#cId1-$offsetString")
     val txId = s"trId-$offsetString"
     val workflowId = s"workflowId-$offsetString"
     val let = Instant.now

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoLedgerEntriesSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoLedgerEntriesSpec.scala
@@ -66,7 +66,7 @@ private[dao] trait JdbcLedgerDaoLedgerEntriesSpec extends LoneElement {
 
   it should "be able to persist and load a transaction" in {
     val offset = nextOffset()
-    val absCid = AbsoluteContractId("cId2")
+    val absCid = AbsoluteContractId.assertFromString("#cId2")
     val let = Instant.now
     val txid = "trId2"
     val event1 = event(txid, 1)
@@ -117,7 +117,7 @@ private[dao] trait JdbcLedgerDaoLedgerEntriesSpec extends LoneElement {
   it should "be able to load contracts within a transaction" in {
     val offset = nextOffset()
     val offsetString = offset.toLong
-    val absCid = AbsoluteContractId(s"cId$offsetString")
+    val absCid = AbsoluteContractId.assertFromString(s"#cId$offsetString")
     val let = Instant.now
 
     val transactionId = s"trId$offsetString"

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -186,7 +186,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
     val offset = nextOffset()
     val id = offset.toLong
     val txId = s"trId$id"
-    val absCid = AbsoluteContractId(s"cId$id")
+    val absCid = AbsoluteContractId.assertFromString(s"#cId$id")
     val let = Instant.now
     val eid = event(txId, id)
     offset -> LedgerEntry.Transaction(
@@ -225,7 +225,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
 
   protected def fullyTransient: (Offset, LedgerEntry.Transaction) = {
     val txId = UUID.randomUUID().toString
-    val absCid = AbsoluteContractId(UUID.randomUUID().toString)
+    val absCid = AbsoluteContractId.assertFromString("#" + UUID.randomUUID().toString)
     val let = Instant.now
     val createId = event(txId, 0)
     val exerciseId = event(txId, 1)
@@ -263,8 +263,8 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
     */
   protected def withChildren: (Offset, LedgerEntry.Transaction) = {
     val txId = UUID.randomUUID().toString
-    val absCid1 = AbsoluteContractId(UUID.randomUUID().toString)
-    val absCid2 = AbsoluteContractId(UUID.randomUUID().toString)
+    val absCid1 = AbsoluteContractId.assertFromString("#" + UUID.randomUUID().toString)
+    val absCid2 = AbsoluteContractId.assertFromString("#" + UUID.randomUUID().toString)
     val let = Instant.now
     val createId = event(txId, 0)
     val exerciseId = event(txId, 1)
@@ -332,7 +332,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
           HashMap(
             event(s"transactionId$id", id) -> NodeCreate(
               nodeSeed = None,
-              coid = AbsoluteContractId(s"contractId$id"),
+              coid = AbsoluteContractId.assertFromString(s"#contractId$id"),
               coinst = someContractInstance,
               optLocation = None,
               signatories = Set(party),
@@ -372,7 +372,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
           HashMap(
             event(s"transactionId$id", id) -> NodeExercises(
               nodeSeed = None,
-              targetCoid = AbsoluteContractId(s"contractId${cid.toLong}"),
+              targetCoid = AbsoluteContractId.assertFromString(s"#contractId${cid.toLong}"),
               templateId = someTemplateId,
               choiceId = Ref.ChoiceName.assertFromString("Archive"),
               optLocation = None,
@@ -423,7 +423,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
               KeyWithMaintainers(
                 VersionedValue(ValueVersions.acceptedVersions.head, ValueText(key)),
                 Set(party)),
-              result.map(id => AbsoluteContractId(s"contractId${id.toLong}")),
+              result.map(id => AbsoluteContractId.assertFromString(s"#contractId${id.toLong}")),
             )),
           ImmArray(event(s"transactionId$id", id)),
         ),
@@ -453,7 +453,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         GenTransaction(
           HashMap(
             event(s"transactionId$id", id) -> NodeFetch(
-              coid = AbsoluteContractId(s"contractId${cid.toLong}"),
+              coid = AbsoluteContractId.assertFromString(s"#contractId${cid.toLong}"),
               templateId = someTemplateId,
               optLocation = None,
               actingParties = Some(Set(party)),
@@ -487,8 +487,8 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         GenTransaction(HashMap.empty, ImmArray.empty),
         Map.empty
       ),
-      Map(AbsoluteContractId(s"contractId$id") -> Set(bob)),
-      List(AbsoluteContractId(s"contractId$id") -> someContractInstance)
+      Map(AbsoluteContractId.assertFromString(s"#contractId$id") -> Set(bob)),
+      List(AbsoluteContractId.assertFromString(s"#contractId$id") -> someContractInstance)
     )
   }
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/EventFilterSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/EventFilterSpec.scala
@@ -4,7 +4,7 @@
 package com.digitalasset.platform.index
 
 import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.daml.lf.data.Ref.QualifiedName
+import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.ledger.api.domain.{Filters, InclusiveFilters, TransactionFilter}
 import com.digitalasset.ledger.api.v1.event.{ArchivedEvent, CreatedEvent, Event}
 import com.digitalasset.ledger.api.v1.value.{Identifier, Record}
@@ -18,7 +18,7 @@ final class EventFilterSpec extends WordSpec with Matchers with ScalaFutures wit
   private val otherPartyWhoSeesEvents = Ref.Party.assertFromString("otherParty")
   private val packageId = "myPackage"
   private val eventId = Ref.LedgerString.assertFromString("someEventId")
-  private val contractId = Ref.ContractIdString.assertFromString("someContractId")
+  private val contractId = Value.AbsoluteContractId.assertFromString("#someContractId")
   private val party1 = Ref.Party.assertFromString("party1")
   private val party2 = Ref.Party.assertFromString("party2")
   private val module1 = "module1"
@@ -38,7 +38,7 @@ final class EventFilterSpec extends WordSpec with Matchers with ScalaFutures wit
   private def mkIdent(mod: String, ent: String, pkgId: String = packageId) =
     Ref.Identifier(
       Ref.PackageId.assertFromString(pkgId),
-      QualifiedName(Ref.ModuleName.assertFromString(mod), Ref.DottedName.assertFromString(ent)))
+      Ref.QualifiedName(Ref.ModuleName.assertFromString(mod), Ref.DottedName.assertFromString(ent)))
 
   private val mapping = Map(
     party1 -> getFilter(Seq(module1 -> template1)),
@@ -103,7 +103,7 @@ final class EventFilterSpec extends WordSpec with Matchers with ScalaFutures wit
       Event.Event.Created(
         CreatedEvent(
           eventId,
-          contractId,
+          contractId.coid,
           Some(templateId),
           None,
           Some(Record(None, Seq.empty)),
@@ -118,7 +118,7 @@ final class EventFilterSpec extends WordSpec with Matchers with ScalaFutures wit
       Event.Event.Archived(
         ArchivedEvent(
           eventId,
-          contractId,
+          contractId.coid,
           Some(templateId),
           Seq(party, otherPartyWhoSeesEvents)
         )))

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/TransactionConversionSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/index/TransactionConversionSpec.scala
@@ -3,24 +3,24 @@
 
 package com.digitalasset.platform.index
 
-import com.digitalasset.daml.lf.data.Ref
+import com.digitalasset.daml.lf.value.Value
 import com.digitalasset.ledger.api.v1.event.{ArchivedEvent, CreatedEvent, Event}
 import com.digitalasset.platform.index.TransactionConversion.removeTransient
 import org.scalatest.{Matchers, WordSpec}
 
 final class TransactionConversionSpec extends WordSpec with Matchers {
 
-  private val contractId1 = Ref.ContractIdString.assertFromString("contractId")
-  private val contractId2 = Ref.ContractIdString.assertFromString("contractId2")
-  private def create(contractId: Ref.ContractIdString): Event =
+  private val contractId1 = Value.AbsoluteContractId.assertFromString("#contractId")
+  private val contractId2 = Value.AbsoluteContractId.assertFromString("#contractId2")
+  private def create(contractId: Value.AbsoluteContractId): Event =
     Event(
       Event.Event.Created(
-        CreatedEvent("", contractId, None, None, None, Seq.empty, Seq.empty, Seq.empty, None)))
+        CreatedEvent("", contractId.coid, None, None, None, Seq.empty, Seq.empty, Seq.empty, None)))
 
   private val create1 = create(contractId1)
   private val create2 = create(contractId2)
   private val archive1 = Event(
-    Event.Event.Archived(ArchivedEvent("", contractId1, None, Seq.empty)))
+    Event.Event.Archived(ArchivedEvent("", contractId1.coid, None, Seq.empty)))
 
   "removeTransient" should {
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -87,7 +87,7 @@ class ImplicitPartyAdditionIT
           "CmdId1",
           NodeCreate(
             nodeSeed = None,
-            coid = AbsoluteContractId("cId1"),
+            coid = AbsoluteContractId.assertFromString("#cId1"),
             coinst = ContractInst(
               templateId1,
               textValue("some text"),
@@ -105,7 +105,7 @@ class ImplicitPartyAdditionIT
           "CmdId2",
           NodeExercises(
             nodeSeed = None,
-            targetCoid = AbsoluteContractId("cId1"),
+            targetCoid = AbsoluteContractId.assertFromString("#cId1"),
             templateId = templateId1,
             choiceId = Ref.ChoiceName.assertFromString("choice"),
             optLocation = None,
@@ -125,7 +125,7 @@ class ImplicitPartyAdditionIT
           "fetch-signatory",
           "CmdId3",
           NodeFetch(
-            AbsoluteContractId("cId1"),
+            AbsoluteContractId.assertFromString("#cId1"),
             templateId1,
             None,
             Some(Set("fetch-acting-party")),

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/converter/LedgerApiV1.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.daml.lf.data.LawlessTraversals._
 import com.digitalasset.daml.lf.iface
+import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.daml.lf.value.{Value => V}
 import com.digitalasset.ledger.api.{v1 => V1}
 import com.digitalasset.ledger.api.refinements.ApiTypes
@@ -465,9 +466,9 @@ case object LedgerApiV1 {
     final class NotACoid(message: String) extends RuntimeException(message) with NoStackTrace
     // this is 100% cheating as Value should have Traverse instead
     try Right(value mapContractId { coid =>
-      Ref.ContractIdString fromString coid fold (
+      AbsoluteContractId fromString coid fold (
         e => throw new NotACoid(e),
-        V.AbsoluteContractId
+        identity
       )
     })
     catch { case e: NotACoid => Left(GenericConversionError(e.getMessage)) }

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Converter.scala
@@ -143,7 +143,7 @@ object Converter {
     record(
       contractIdTy,
       ("templateId", fromTemplateTypeRep(triggerIds, templateId)),
-      ("contractId", SContractId(AbsoluteContractId(ContractIdString.assertFromString(contractId))))
+      ("contractId", SContractId(AbsoluteContractId.assertFromString(contractId)))
     )
   }
 
@@ -383,7 +383,7 @@ object Converter {
 
   private def toAbsoluteContractId(v: SValue): Either[String, AbsoluteContractId] = {
     v match {
-      case SContractId(cid @ AbsoluteContractId(_)) => Right(cid)
+      case SContractId(cid: AbsoluteContractId) => Right(cid)
       case _ => Left(s"Expected AbsoluteContractId but got $v")
     }
   }


### PR DESCRIPTION
In this PR, we inline the internal representation of absolute contract id with the daml-lf spec. 

This PR advances the state of #3830.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
