### PR TITLE
daml2ts: Write module A.B.C into file src/A/B/C/module.ts

### DIFF
--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2Ts.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2Ts.hs
@@ -71,8 +71,15 @@ main = do
 --       grover-1.0/
 --         package.json
 --         tsconfig.json
---         src/ *.ts
---         lib/ *.js
+--         src/
+--           index.ts
+--           Grover/
+--             module.ts
+--         lib/
+--           index.{js,d.ts}
+--           Grover/
+--             module.{js,d.ts}
+--       ...
 --     daml-types  <-- referred to by the "resolutions" field in package.json
 
 tests :: FilePath -> FilePath -> FilePath -> FilePath -> FilePath -> TestTree
@@ -193,7 +200,7 @@ tests damlTypes yarn damlc daml2ts davl = testGroup "daml2ts tests"
         step "daml2ts..."
         setupYarnEnvironment
         daml2tsProject [groverDar, groverDar] daml2tsDir
-        mapM_ (assertTsFileExists groverTs) [ "index", "Grover" ]
+        mapM_ (assertTsFileExists groverTs) [ "index", "Grover" </> "module" ]
 
   , testCaseSteps "DAVL test" $ \step -> withTempDir $ \here -> do
       let daml2tsDir = here </> "daml2ts"
@@ -205,9 +212,9 @@ tests damlTypes yarn damlc daml2ts davl = testGroup "daml2ts tests"
           , davl </> "davl-v5.dar"
           , davl </> "davl-upgrade-v4-v5.dar" ] ++
           ["-o", daml2tsDir]
-        mapM_ (assertTsFileExists (daml2tsDir </> "davl-0.0.4")) [ "index", "DAVL" ]
-        mapM_ (assertTsFileExists (daml2tsDir </> "davl-0.0.5")) [ "index", "DAVL" ]
-        mapM_ (assertTsFileExists (daml2tsDir </> "davl-upgrade-v4-v5-0.0.5")) [ "index", "Upgrade" ]
+        mapM_ (assertTsFileExists (daml2tsDir </> "davl-0.0.4")) [ "index", "DAVL" </> "module" ]
+        mapM_ (assertTsFileExists (daml2tsDir </> "davl-0.0.5")) [ "index", "DAVL" </> "module" ]
+        mapM_ (assertTsFileExists (daml2tsDir </> "davl-upgrade-v4-v5-0.0.5")) [ "index", "Upgrade" </> "module" ]
       step "eslint..."
       withCurrentDirectory daml2tsDir $ do
         pkgs <- (\\ ["package.json", "node_modules"]) <$> listDirectory daml2tsDir


### PR DESCRIPTION
Instead of writing the TypeScript for DAML module `A.B.C` into the file
`src/A/B/C.ts` we now write it into `src/A/B/C/module.ts`. This is in
preparation for also writing a file `src/A/B/C/index.ts`, which
re-exports `src/A/B/C/module` but also `src/A/B/C/D` for each `D`.

We also make sure to use the correct path separator on Windows.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5209)
<!-- Reviewable:end -->
