### PR TITLE
Reproducible SDK release tarball

### DIFF
--- a/release/util.bzl
+++ b/release/util.bzl
@@ -26,12 +26,10 @@ def sdk_tarball(name, version):
             "//daml-script/daml:daml-script-dars",
             "//daml-assistant/daml-sdk:sdk_deploy.jar",
         ],
-        tools = ["@zip_dev_env//:zip"],
         outs = ["{}.tar.gz".format(name)],
         cmd = """
           # damlc
           VERSION={version}
-          ZIP=$$PWD/$(location @zip_dev_env//:zip)
           OUT=sdk-$$VERSION
           mkdir -p $$OUT
 

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -75,7 +75,7 @@ def sdk_tarball(name, version):
           cp -L $(location //triggers/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/trigger-logback.xml
           cp -L $(location //daml-script/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/script-logback.xml
 
-          tar zcf $@ --format=ustar $$OUT
+          tar c --format=ustar --sort=name --owner=root:0 --group=root:0 --mtime=0 $$OUT | gzip -n > $@
         """.format(version = version),
         visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
The SDK release tarball was created in a way that made it non-reproducible. The invocation of `tar`/`gzip` is changed in the following ways to fix this:
* Pass `--sort=name` to `tar` so that the order of files in the archive is reproducible.
* Pass `--owner/group/mtime` flags to `tar` to avoid metadata that depends on the build environment.
* Pass `-n` to `gzip` to prevent it from writing a timestamp into the produced artifact.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
