### PR TITLE
Consistently replace zip by bazel_tools zipper

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -270,17 +270,6 @@ nixpkgs_package(
     repositories = dev_env_nix_repos,
 )
 
-dev_env_tool(
-    name = "zip_dev_env",
-    nix_include = ["bin/zip"],
-    nix_label = "@zip_nix",
-    nix_paths = ["bin/zip"],
-    tools = ["zip"],
-    win_include = ["usr/bin/zip.exe"],
-    win_paths = ["usr/bin/zip.exe"],
-    win_tool = "msys2",
-)
-
 load(
     "@rules_haskell//haskell:ghc_bindist.bzl",
     "haskell_register_ghc_bindists",

--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -75,12 +75,14 @@ LF_VERSIONS = [
             srcs = [":daml_lf_%s_archive_proto_srcs" % version],
             outs = ["daml_lf_%s_archive_proto_zip.zip" % version],
             cmd = """
-                     DESTDIR=protobuf/com/digitalasset/daml_lf_%s &&           \
-                     mkdir -p $$DESTDIR/ &&                                    \
-                     cp $(SRCS) $$DESTDIR/ &&                                  \
-                     $(location @zip_dev_env//:zip) \"$@\" -r $$DESTDIR/
-                   """ % (mangle_for_java(version)),
-            tools = ["@zip_dev_env//:zip"],
+                DESTDIR=protobuf/com/digitalasset/daml_lf_{version};
+                MAPPINGS=()
+                for src in $(SRCS); do
+                    MAPPINGS+=("$$DESTDIR/$$(basename $$src)=$$src")
+                done
+                $(rootpath @bazel_tools//tools/zip:zipper) cC "$@" "$${{MAPPINGS[@]}}"
+            """.format(version = mangle_for_java(version)),
+            tools = ["@bazel_tools//tools/zip:zipper"],
             visibility = ["//visibility:public"],
         ),
         pkg_tar(

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -26,12 +26,10 @@ def sdk_tarball(name, version):
             "//daml-script/daml:daml-script-dars",
             "//daml-assistant/daml-sdk:sdk_deploy.jar",
         ],
-        tools = ["@zip_dev_env//:zip"],
         outs = ["{}.tar.gz".format(name)],
         cmd = """
           # damlc
           VERSION={version}
-          ZIP=$$PWD/$(location @zip_dev_env//:zip)
           OUT=sdk-$$VERSION
           mkdir -p $$OUT
 


### PR DESCRIPTION
`@bazel_tools//tools/zip:zipper` avoids timestamps and other sources of indeterminism when creating an archive, so that the result is reproducible.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
