### PR TITLE
Remove old time model from ledger config

### DIFF
--- a/language-support/hs/bindings/src/DA/Ledger/Convert.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Convert.hs
@@ -223,9 +223,8 @@ raiseGetLedgerConfigurationResponse x =
 raiseLedgerConfiguration :: LL.LedgerConfiguration -> Perhaps LedgerConfiguration
 raiseLedgerConfiguration = \case
     LL.LedgerConfiguration{..} -> do
-        minTtl <- perhaps "min_ttl" ledgerConfigurationMinTtl
-        maxTtl <- perhaps "max_ttl" ledgerConfigurationMaxTtl
-        return $ LedgerConfiguration {minTtl,maxTtl}
+        maxDeduplicationTime <- perhaps "max_deduplication_time" ledgerConfigurationMaxDeduplicationTime
+        return $ LedgerConfiguration {maxDeduplicationTime}
 
 raiseGetActiveContractsResponse :: LL.GetActiveContractsResponse -> Perhaps (AbsOffset,Maybe WorkflowId,[Event])
 raiseGetActiveContractsResponse = \case

--- a/language-support/hs/bindings/src/DA/Ledger/Types.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Types.hs
@@ -251,8 +251,7 @@ data Timestamp = Timestamp
     deriving (Eq,Ord,Show)
 
 data LedgerConfiguration = LedgerConfiguration
-    { minTtl :: LL.Duration
-    , maxTtl :: LL.Duration
+    { maxDeduplicationTime :: LL.Duration
     }
     deriving (Eq,Ord,Show)
 

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -340,8 +340,7 @@ tGetLedgerConfiguration withSandbox = testCase "tGetLedgerConfiguration" $ run w
     xs <- getLedgerConfiguration lid
     Just (Right config) <- liftIO $ timeout 1 (takeStream xs)
     let expected = LedgerConfiguration {
-            minTtl = Duration {durationSeconds = 2, durationNanos = 0},
-            maxTtl = Duration {durationSeconds = 30, durationNanos = 0}}
+            maxDeduplicationTime = Duration {durationSeconds = 86400, durationNanos = 0}}
     liftIO $ assertEqual "config" expected config
 
 tUploadDarFileBad :: SandboxTest

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/admin/config_management_service.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/admin/config_management_service.proto
@@ -73,17 +73,23 @@ message SetTimeModelResponse {
 }
 
 message TimeModel {
-  // The expected minimum latency of a transaction.
-  // Required.
-  google.protobuf.Duration min_transaction_latency = 1;
+  reserved 1; // was min_transaction_latency
+  reserved 2; // was max_clock_skew
+  reserved 3; // was max_ttl
 
-  // The maximum allowed clock skew between the ledger and clients.
+  // The expected average latency of a transaction, i.e., the average time
+  // from submitting the transaction to a [[WriteService]] and the transaction
+  // being assigned a record time.
   // Required.
-  google.protobuf.Duration max_clock_skew = 2;
+  google.protobuf.Duration avg_transaction_latency = 4;
 
-  // The maximum allowed time to live for a transaction.
-  // Must be greater than the derived minimum time to live.
+  // The minimimum skew between ledger time and record time: lt_TX >= rt_TX - minSkew
   // Required.
-  google.protobuf.Duration max_ttl = 3;
+  google.protobuf.Duration min_skew = 5;
+
+  // The maximum skew between ledger time and record time: lt_TX <= rt_TX + maxSkew
+  // Required.
+  google.protobuf.Duration max_skew = 6;
+
 }
 

--- a/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/ledger_configuration_service.proto
+++ b/ledger-api/grpc-definitions/com/digitalasset/ledger/api/v1/ledger_configuration_service.proto
@@ -43,9 +43,11 @@ message GetLedgerConfigurationResponse {
 // LedgerConfiguration contains parameters of the ledger instance that may be useful to clients.
 message LedgerConfiguration {
 
-  // Minimum difference between ledger effective time and maximum record time in submitted commands.
-  google.protobuf.Duration min_ttl = 1;
+  reserved 1; // was min_ttl
+  reserved 2; // was max_ttl
 
-  // Maximum difference between ledger effective time and maximum record time in submitted commands.
-  google.protobuf.Duration max_ttl = 2;
+  // The maximum value for the ``deduplication_time`` parameter of command submissions
+  // (as described in ``commands.proto``). This defines the maximum time window during which
+  // commands can be deduplicated.
+  google.protobuf.Duration max_deduplication_time = 3;
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagement.scala
@@ -19,9 +19,9 @@ final class ConfigManagement(session: LedgerSession) extends LedgerTestSuite(ses
 
     case Participants(Participant(ledger)) =>
       val newTimeModel = TimeModel(
-        minTransactionLatency = Some(Duration(0, 1)),
-        maxClockSkew = Some(Duration(60, 0)),
-        maxTtl = Some(Duration(120, 0)),
+        avgTransactionLatency = Some(Duration(0, 1)),
+        minSkew = Some(Duration(60, 0)),
+        maxSkew = Some(Duration(120, 0)),
       )
       for {
         // Get the current time model

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationService.scala
@@ -49,7 +49,7 @@ class LedgerConfigurationService(session: LedgerSession) extends LedgerTestSuite
   }
 
   test(
-    "CSLSuccessIfMaxDedplicationTimeExceeded",
+    "CSLSuccessIfMaxDeduplicationTimeExceeded",
     "Submission returns OK if deduplication time is too high",
     allocate(SingleParty),
   ) {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationService.scala
@@ -15,8 +15,9 @@ class LedgerConfigurationService(session: LedgerSession) extends LedgerTestSuite
       for {
         config <- ledger.configuration()
       } yield {
-        assert(config.minTtl.isDefined, "The minTTL field of the configuration is empty")
-        assert(config.maxTtl.isDefined, "The maxTTL field of the configuration is empty")
+        assert(
+          config.maxDeduplicationTime.isDefined,
+          "The maxDeduplicationTime field of the configuration is empty")
       }
   }
 
@@ -31,20 +32,39 @@ class LedgerConfigurationService(session: LedgerSession) extends LedgerTestSuite
   }
 
   test(
-    "CSLSuccessIfLetRight",
-    "Submission returns OK if LET is within the accepted interval",
+    "CSLSuccessIfMaxDedplicationTimeRight",
+    "Submission returns OK if deduplication time is within the accepted interval",
     allocate(SingleParty),
   ) {
     case Participants(Participant(ledger, party)) =>
-      // The maximum accepted clock skew depends on the ledger and is not exposed through the LedgerConfigurationService,
-      // and there might be an actual clock skew between the devices running the test and the ledger.
-      // This test therefore does not attempt to simulate any clock skew
-      // but simply checks whether basic command submission with an unmodified LET works.
+      // Submission using the maximum allowed deduplication time
       val request = ledger.submitRequest(party, Dummy(party).create.command)
       for {
-        _ <- ledger.submit(request)
+        config <- ledger.configuration()
+        maxDedupTime = config.maxDeduplicationTime.get
+        _ <- ledger.submit(request.update(_.commands.deduplicationTime := maxDedupTime))
       } yield {
         // No assertions to make, since the command went through as expected
+      }
+  }
+
+  test(
+    "CSLSuccessIfMaxDedplicationTimeExceeded",
+    "Submission returns OK if deduplication time is too high",
+    allocate(SingleParty),
+  ) {
+    case Participants(Participant(ledger, party)) =>
+      val request = ledger.submitRequest(party, Dummy(party).create.command)
+      for {
+        config <- ledger.configuration()
+        maxDedupTime = config.maxDeduplicationTime.get
+        failure <- ledger
+          .submit(
+            request.update(_.commands.deduplicationTime := maxDedupTime.update(
+              _.seconds := maxDedupTime.seconds + 1)))
+          .failed
+      } yield {
+        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "")
       }
   }
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
@@ -88,7 +88,7 @@ package object v2 {
       recordTime: Instant,
       workflowId: WorkflowId)
 
-  final case class LedgerConfiguration(minTTL: Duration, maxTTL: Duration)
+  final case class LedgerConfiguration(maxDeduplicationTime: Duration)
 
   /** Meta-data of a DAML-LF package
     *

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -512,9 +512,6 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)(
                   Duration.ofSeconds(123),
                   Duration.ofSeconds(123),
                   Duration.ofSeconds(123),
-                  Duration.ofSeconds(123),
-                  Duration.ofSeconds(123),
-                  Duration.ofSeconds(123),
                 ).get,
               ),
             )

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -162,8 +162,6 @@ object KVTest {
       )
     }
 
-  val minMRTDelta: Duration = theDefaultConfig.timeModel.minTtl
-
   def runCommand(
       submitter: Party,
       submissionSeed: Option[crypto.Hash],
@@ -236,6 +234,8 @@ object KVTest {
       )
       result <- submit(subm)
     } yield result
+
+  val minMRTDelta: Duration = Duration.ofSeconds(1)
 
   def submitConfig(
       configModify: Configuration => Configuration,

--- a/ledger/participant-state/protobuf/com/daml/ledger/participant/state/ledger_configuration.proto
+++ b/ledger/participant-state/protobuf/com/daml/ledger/participant/state/ledger_configuration.proto
@@ -39,15 +39,9 @@ message LedgerConfiguration {
 }
 
 message LedgerTimeModel {
-  // The expected minimum latency of a transaction.
-  google.protobuf.Duration min_transaction_latency = 1;
-
-  // The maximum allowed clock skew between the ledger and clients.
-  google.protobuf.Duration max_clock_skew = 2;
-
-  // The maximum allowed time to live for a transaction.
-  // Must be greater than the derived minimum time to live.
-  google.protobuf.Duration max_ttl = 3;
+  reserved 1; // was min_transaction_latency
+  reserved 2; // was max_clock_skew
+  reserved 3; // was max_ttl
 
   // The expected average latency of a transaction, i.e., the average time
   // from submitting the transaction to a WriteService and the transaction

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Configuration.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Configuration.scala
@@ -60,9 +60,6 @@ object Configuration {
 
     def decodeTimeModel(tm: protobuf.LedgerTimeModel): Either[String, TimeModel] =
       TimeModel(
-        maxClockSkew = parseDuration(tm.getMaxClockSkew),
-        minTransactionLatency = parseDuration(tm.getMinTransactionLatency),
-        maxTtl = parseDuration(tm.getMaxTtl),
         avgTransactionLatency = parseDuration(tm.getAvgTransactionLatency),
         minSkew = parseDuration(tm.getMinSkew),
         maxSkew = parseDuration(tm.getMaxSkew),
@@ -91,9 +88,6 @@ object Configuration {
 
     def decodeTimeModel(tm: protobuf.LedgerTimeModel): Either[String, TimeModel] =
       TimeModel(
-        maxClockSkew = parseDuration(tm.getMaxClockSkew),
-        minTransactionLatency = parseDuration(tm.getMinTransactionLatency),
-        maxTtl = parseDuration(tm.getMaxTtl),
         avgTransactionLatency = parseDuration(tm.getAvgTransactionLatency),
         minSkew = parseDuration(tm.getMinSkew),
         maxSkew = parseDuration(tm.getMaxSkew),
@@ -107,9 +101,6 @@ object Configuration {
       .setGeneration(config.generation)
       .setTimeModel(
         protobuf.LedgerTimeModel.newBuilder
-          .setMaxClockSkew(buildDuration(tm.maxClockSkew))
-          .setMinTransactionLatency(buildDuration(tm.minTransactionLatency))
-          .setMaxTtl(buildDuration(tm.maxTtl))
           .setAvgTransactionLatency(buildDuration(tm.avgTransactionLatency))
           .setMinSkew(buildDuration(tm.minSkew))
           .setMaxSkew(buildDuration(tm.maxSkew))

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TimeModel.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TimeModel.scala
@@ -8,12 +8,6 @@ import scala.util.Try
 
 /**
   * The ledger time model and associated validations. Some values are given by constructor args; others are derived.
-  *
-  * @param minTransactionLatency The expected minimum latency of a transaction.
-  * @param maxClockSkew          The maximum allowed clock skew between the ledger and clients.
-  * @param maxTtl                The maximum allowed time to live for a transaction.
-  *                              Must be greater than the derived minimum time to live.
-  *
   * @param avgTransactionLatency The expected average latency of a transaction, i.e., the average time
   *                              from submitting the transaction to a [[WriteService]] and the transaction
   *                              being assigned a record time.
@@ -23,44 +17,10 @@ import scala.util.Try
   * @throws IllegalArgumentException if the parameters aren't valid
   */
 case class TimeModel private (
-    minTransactionLatency: Duration,
-    maxClockSkew: Duration,
-    maxTtl: Duration,
     avgTransactionLatency: Duration,
     minSkew: Duration,
     maxSkew: Duration,
 ) {
-
-  /**
-    * The minimum time to live for a transaction. Equal to the minimum transaction latency plus the maximum clock skew.
-    */
-  val minTtl: Duration = minTransactionLatency.plus(maxClockSkew)
-
-  /**
-    * The maximum window after the current time when transaction ledger effective times will be accepted.
-    * Currently equal to the max clock skew.
-    * <p/>
-    * The corresponding past acceptance window is given by the command's TTL, and thus bounded inclusive by [[maxTtl]].
-    */
-  val futureAcceptanceWindow: Duration = maxClockSkew
-
-  // TODO(RA) Old ledger time model, remove.
-  def checkTtl(givenLedgerEffectiveTime: Instant, givenMaximumRecordTime: Instant): Boolean = {
-    val givenTtl = Duration.between(givenLedgerEffectiveTime, givenMaximumRecordTime)
-    !givenTtl.minus(minTtl).isNegative && !maxTtl.minus(givenTtl).isNegative
-  }
-
-  // TODO(RA) Old ledger time model, remove.
-  def checkLet(
-      currentTime: Instant,
-      givenLedgerEffectiveTime: Instant,
-      givenMaximumRecordTime: Instant): Boolean = {
-    // Note that, contrary to the documented spec, the record time of a transaction is when it's sequenced.
-    // It turns out this isn't a problem for the participant or the sandbox,
-    // and MRT seems to be going away in Sirius anyway, so I've left it as is.
-    val lowerBound = givenLedgerEffectiveTime.minus(futureAcceptanceWindow)
-    !currentTime.isBefore(lowerBound) && !currentTime.isAfter(givenMaximumRecordTime)
-  }
 
   /**
     * Verifies whether the given ledger time and record time are valid under the ledger time model.
@@ -88,34 +48,16 @@ object TimeModel {
     */
   val reasonableDefault: TimeModel =
     TimeModel(
-      minTransactionLatency = Duration.ofSeconds(1L),
-      maxClockSkew = Duration.ofSeconds(1L),
-      maxTtl = Duration.ofSeconds(30L),
       avgTransactionLatency = Duration.ofSeconds(0L),
       minSkew = Duration.ofSeconds(30L),
       maxSkew = Duration.ofSeconds(30L),
     ).get
 
-  def apply(
-      minTransactionLatency: Duration,
-      maxClockSkew: Duration,
-      maxTtl: Duration,
-      avgTransactionLatency: Duration,
-      minSkew: Duration,
-      maxSkew: Duration): Try[TimeModel] = Try {
-    require(!minTransactionLatency.isNegative, "Negative min transaction latency")
-    require(!maxTtl.isNegative, "Negative max TTL")
-    require(!maxClockSkew.isNegative, "Negative max clock skew")
-    require(!maxTtl.minus(maxClockSkew).isNegative, "Max TTL must be greater than max clock skew")
-    require(!avgTransactionLatency.isNegative, "Negative average transaction latency")
-    require(!minSkew.isNegative, "Negative min skew")
-    require(!maxSkew.isNegative, "Negative max skew")
-    new TimeModel(
-      minTransactionLatency,
-      maxClockSkew,
-      maxTtl,
-      avgTransactionLatency,
-      minSkew,
-      maxSkew)
-  }
+  def apply(avgTransactionLatency: Duration, minSkew: Duration, maxSkew: Duration): Try[TimeModel] =
+    Try {
+      require(!avgTransactionLatency.isNegative, "Negative average transaction latency")
+      require(!minSkew.isNegative, "Negative min skew")
+      require(!maxSkew.isNegative, "Negative max skew")
+      new TimeModel(avgTransactionLatency, minSkew, maxSkew)
+    }
 }

--- a/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/TimeModelTest.scala
+++ b/ledger/participant-state/src/test/suite/scala/com/daml/ledger/participant/state/TimeModelTest.scala
@@ -13,91 +13,12 @@ class TimeModelTest extends WordSpec with Matchers {
   private val epsilon = Duration.ofMillis(10L)
   private val timeModel =
     TimeModel(
-      minTransactionLatency = Duration.ofSeconds(1L),
-      maxClockSkew = Duration.ofSeconds(1L),
-      maxTtl = Duration.ofSeconds(30L),
       avgTransactionLatency = Duration.ofSeconds(0L),
       minSkew = Duration.ofSeconds(30L),
       maxSkew = Duration.ofSeconds(30L),
     ).get
 
-  private val referenceMrt = referenceTime.plus(timeModel.maxTtl)
-
-  private def acceptLet(let: Instant): Boolean =
-    timeModel.checkLet(referenceTime, let, let.plus(timeModel.maxTtl))
-
-  private def acceptMrt(mrt: Instant): Boolean =
-    timeModel.checkLet(referenceTime, mrt.minus(timeModel.maxTtl), mrt)
-
-  private def acceptTtl(mrt: Instant): Boolean = timeModel.checkTtl(referenceTime, mrt)
-
-  "Ledger effective time model checker" when {
-    "calculating derived values" should {
-      "calculate minTtl correctly" in {
-        timeModel.minTtl shouldEqual timeModel.minTransactionLatency.plus(timeModel.maxClockSkew)
-      }
-    }
-
-    "checking if time is within accepted boundaries" should {
-      "succeed if the time equals the current time" in {
-        acceptLet(referenceTime) shouldEqual true
-      }
-
-      "succeed if the time is higher than the current time and is within tolerance limit" in {
-        acceptLet(referenceTime.plus(timeModel.futureAcceptanceWindow).minus(epsilon)) shouldEqual true
-      }
-
-      "succeed if the time is equal to the high boundary" in {
-        acceptLet(referenceTime.plus(timeModel.futureAcceptanceWindow)) shouldEqual true
-      }
-
-      "fail if the time is higher than the high boundary" in {
-        acceptLet(referenceTime.plus(timeModel.futureAcceptanceWindow).plus(epsilon)) shouldEqual false
-      }
-
-      "fail if the MRT is less than the low boundary" in {
-        acceptMrt(referenceMrt.minus(timeModel.maxTtl).minus(epsilon)) shouldEqual false
-      }
-
-      "succeed if the MRT is equal to the low boundary" in {
-        acceptMrt(referenceMrt.minus(timeModel.maxTtl)) shouldEqual true
-      }
-
-      "succeed if the MRT is greater than than the low boundary" in {
-        acceptMrt(referenceMrt.minus(timeModel.maxTtl).plus(epsilon)) shouldEqual true
-      }
-    }
-  }
-
-  "TTL time model" when {
-    "checking if TTL is within accepted boundaries" should {
-      "fail if the TTL is less than than the low boundary" in {
-        acceptTtl(referenceTime.plus(timeModel.minTtl).minus(epsilon)) shouldEqual false
-      }
-
-      "succeed if the TTL is equal to the low boundary" in {
-        acceptTtl(referenceTime.plus(timeModel.minTtl)) shouldEqual true
-      }
-
-      "succeed if the TTL is greater than the low boundary" in {
-        acceptTtl(referenceTime.plus(timeModel.minTtl).plus(epsilon)) shouldEqual true
-      }
-
-      "succeed if the TTL is less than the high boundary" in {
-        acceptTtl(referenceTime.plus(timeModel.maxTtl).minus(epsilon)) shouldEqual true
-      }
-
-      "succeed if the TTL is equal to the high boundary" in {
-        acceptTtl(referenceTime.plus(timeModel.maxTtl)) shouldEqual true
-      }
-
-      "fail if the TTL is greater than than the high boundary" in {
-        acceptTtl(referenceTime.plus(timeModel.maxTtl).plus(epsilon)) shouldEqual false
-      }
-    }
-  }
-
-  "New ledger time model" when {
+  "Ledger time model" when {
     "checking ledger time" should {
       "succeed if the ledger time equals the record time" in {
         timeModel.checkTime(referenceTime, referenceTime).isRight shouldEqual true

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -79,7 +79,7 @@ final class StandaloneApiServer(
       indexService <- JdbcIndex
         .owner(
           ServerRole.ApiServer,
-          initialConditions.config.timeModel,
+          initialConditions.config,
           domain.LedgerId(initialConditions.ledgerId),
           participantId,
           config.jdbcUrl,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiLedgerConfigurationService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiLedgerConfigurationService.scala
@@ -35,11 +35,9 @@ final class ApiLedgerConfigurationService private (configurationService: IndexCo
       .map(
         configuration =>
           GetLedgerConfigurationResponse(
-            Some(
-              LedgerConfiguration(
-                Some(toProto(configuration.minTTL)),
-                Some(toProto(configuration.maxTTL))
-              ))))
+            Some(LedgerConfiguration(
+              Some(toProto(configuration.maxDeduplicationTime)),
+            ))))
       .via(logger.logErrorsOnStream)
 
   override def bindService(): ServerServiceDefinition =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -62,9 +62,9 @@ final class ApiConfigManagementService private (
       configurationGeneration = config.generation,
       timeModel = Some(
         TimeModel(
-          minTransactionLatency = Some(DurationConversion.toProto(tm.minTransactionLatency)),
-          maxClockSkew = Some(DurationConversion.toProto(tm.maxClockSkew)),
-          maxTtl = Some(DurationConversion.toProto(tm.maxTtl))
+          avgTransactionLatency = Some(DurationConversion.toProto(tm.avgTransactionLatency)),
+          minSkew = Some(DurationConversion.toProto(tm.minSkew)),
+          maxSkew = Some(DurationConversion.toProto(tm.maxSkew))
         ))
     )
   }
@@ -109,9 +109,7 @@ final class ApiConfigManagementService private (
       result <- submissionResult match {
         case SubmissionResult.Acknowledged =>
           // Ledger acknowledged. Start polling to wait for the result to land in the index.
-          val maxTtl = Duration.fromNanos(currentConfig.timeModel.maxTtl.toNanos)
-          val timeToLive = if (params.timeToLive < maxTtl) params.timeToLive else maxTtl
-          pollUntilPersisted(request.submissionId, pollOffset, timeToLive).flatMap {
+          pollUntilPersisted(request.submissionId, pollOffset, params.timeToLive).flatMap {
             case accept: domain.ConfigurationEntry.Accepted =>
               Future.successful(SetTimeModelResponse(accept.configuration.generation))
             case rejected: domain.ConfigurationEntry.Rejected =>
@@ -141,18 +139,15 @@ final class ApiConfigManagementService private (
     import validation.FieldValidations._
     for {
       pTimeModel <- requirePresence(request.newTimeModel, "new_time_model")
-      pMinTransactionLatency <- requirePresence(
-        pTimeModel.minTransactionLatency,
-        "min_transaction_latency")
-      pMaxClockSkew <- requirePresence(pTimeModel.maxClockSkew, "max_clock_skew")
-      pMaxTtl <- requirePresence(pTimeModel.maxTtl, "max_ttl")
+      pAvgTransactionLatency <- requirePresence(
+        pTimeModel.avgTransactionLatency,
+        "avg_transaction_latency")
+      pMinSkew <- requirePresence(pTimeModel.minSkew, "min_skew")
+      pMaxSkew <- requirePresence(pTimeModel.maxSkew, "max_skew")
       newTimeModel <- v1.TimeModel(
-        minTransactionLatency = DurationConversion.fromProto(pMinTransactionLatency),
-        maxClockSkew = DurationConversion.fromProto(pMaxClockSkew),
-        maxTtl = DurationConversion.fromProto(pMaxTtl),
-        avgTransactionLatency = java.time.Duration.ZERO,
-        minSkew = java.time.Duration.ZERO,
-        maxSkew = java.time.Duration.ZERO,
+        avgTransactionLatency = DurationConversion.fromProto(pAvgTransactionLatency),
+        minSkew = DurationConversion.fromProto(pMinSkew),
+        maxSkew = DurationConversion.fromProto(pMaxSkew),
       ) match {
         case Failure(err) => Left(ErrorFactories.invalidArgument(err.toString))
         case Success(ok) => Right(ok)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
@@ -9,7 +9,7 @@ import akka.stream.scaladsl.Source
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.index.v2.IndexService
-import com.daml.ledger.participant.state.v1.{ParticipantId, TimeModel}
+import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId}
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.logging.LoggingContext
 import com.digitalasset.platform.configuration.ServerRole
@@ -18,7 +18,7 @@ import com.digitalasset.resources.ResourceOwner
 object JdbcIndex {
   def owner(
       serverRole: ServerRole,
-      timeModel: TimeModel,
+      initialConfig: Configuration,
       ledgerId: LedgerId,
       participantId: ParticipantId,
       jdbcUrl: String,
@@ -30,7 +30,7 @@ object JdbcIndex {
         new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId) {
           override def getLedgerConfiguration(): Source[v2.LedgerConfiguration, NotUsed] =
             // FIXME(JM): The indexer should on start set the default configuration.
-            Source.single(v2.LedgerConfiguration(timeModel.minTtl, timeModel.maxTtl))
+            Source.single(v2.LedgerConfiguration(initialConfig.maxDeduplicationTime))
         }
       }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -199,13 +199,6 @@ object Cli {
         .text("Whether to load all the packages in the .dar files provided eagerly, rather than when needed as the commands come.")
         .action((_, config) => config.copy(eagerPackageLoading = true))
 
-      opt[Long]("max-ttl-seconds")
-        .optional()
-        .validate(v => Either.cond(v > 0, (), "Max TTL must be a positive number"))
-        .text("The maximum TTL allowed for commands in seconds")
-        .action((maxTtl, config) =>
-          config.copy(timeModel = config.timeModel.copy(maxTtl = Duration.ofSeconds(maxTtl))))
-
       opt[String]("auth-jwt-hs256-unsafe")
         .optional()
         .hidden()

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/configuration/LedgerConfigurationServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/configuration/LedgerConfigurationServiceIT.scala
@@ -24,15 +24,14 @@ sealed trait LedgerConfigurationServiceITBase extends WordSpec with Matchers {
   "LedgerConfigurationService" when {
     "asked for ledger configuration" should {
       "return expected configuration" in {
-        val LedgerConfiguration(Some(minTtl), Some(maxTtl)) =
+        val LedgerConfiguration(Some(maxDeduplicationTime)) =
           LedgerConfigurationServiceGrpc
             .blockingStub(channel)
             .getLedgerConfiguration(GetLedgerConfigurationRequest(ledgerId().unwrap))
             .next()
             .getLedgerConfiguration
 
-        minTtl shouldEqual toProto(config.timeModel.minTtl)
-        maxTtl shouldEqual toProto(config.timeModel.maxTtl)
+        maxDeduplicationTime shouldEqual toProto(config.submissionConfig.maxDeduplicationTime)
       }
     }
   }


### PR DESCRIPTION
This PR removes parameters related to the old ledger time model from:

- the time model (`TimeModel`)
- the ledger configuration (`Configuration`)
- the config management service
- the ledger configuration service

Fixes #4716.
Contributes to #4194.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
