### PR TITLE
Support for large grpc messages in ledger-on-memory

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -78,6 +78,7 @@ da_scala_library(
         "//ledger/participant-state/kvutils/app",
         "//ledger/sandbox",
         "//libs-scala/contextualized-logging",
+        "//libs-scala/ports",
         "//libs-scala/resources",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/ExtraConfig.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/ExtraConfig.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.on.memory
+
+final case class ExtraConfig(
+    maxInboundMessageSize: Int
+)
+
+object ExtraConfig {
+  val defaultMaxInboundMessageSize: Int = 64 * 1024 * 1024
+  val default = ExtraConfig(defaultMaxInboundMessageSize)
+}

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/ExtraConfig.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/ExtraConfig.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.daml.ledger.on.memory
@@ -8,6 +8,6 @@ final case class ExtraConfig(
 )
 
 object ExtraConfig {
-  val defaultMaxInboundMessageSize: Int = 64 * 1024 * 1024
+  val defaultMaxInboundMessageSize: Int = 4 * 1024 * 1024
   val default = ExtraConfig(defaultMaxInboundMessageSize)
 }

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -5,11 +5,18 @@ package com.daml.ledger.on.memory
 
 import akka.stream.Materializer
 import com.daml.ledger.on.memory.InMemoryLedgerReaderWriter.Index
-import com.daml.ledger.participant.state.kvutils.app.LedgerFactory.KeyValueLedgerFactory
-import com.daml.ledger.participant.state.kvutils.app.{Config, ParticipantConfig, Runner}
+import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
+import com.daml.ledger.participant.state.kvutils.app.{
+  Config,
+  LedgerFactory,
+  ParticipantConfig,
+  Runner
+}
 import com.digitalasset.logging.LoggingContext
 import com.digitalasset.platform.akkastreams.dispatcher.Dispatcher
+import com.digitalasset.platform.apiserver.ApiServerConfig
 import com.digitalasset.resources.{ProgramResource, ResourceOwner}
+import scopt.OptionParser
 
 object Main {
   def main(args: Array[String]): Unit = {
@@ -24,9 +31,20 @@ object Main {
   }
 
   class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state: InMemoryState)
-      extends KeyValueLedgerFactory[InMemoryLedgerReaderWriter] {
+      extends LedgerFactory[KeyValueParticipantState, ExtraConfig] {
 
-    override def owner(config: Config[Unit], participantConfig: ParticipantConfig)(
+    override final def readWriteServiceOwner(
+        config: Config[ExtraConfig],
+        participantConfig: ParticipantConfig,
+    )(
+        implicit materializer: Materializer,
+        logCtx: LoggingContext,
+    ): ResourceOwner[KeyValueParticipantState] =
+      for {
+        readerWriter <- owner(config, participantConfig)
+      } yield new KeyValueParticipantState(readerWriter, readerWriter)
+
+    def owner(config: Config[ExtraConfig], participantConfig: ParticipantConfig)(
         implicit materializer: Materializer,
         logCtx: LoggingContext,
     ): ResourceOwner[InMemoryLedgerReaderWriter] =
@@ -37,5 +55,26 @@ object Main {
         dispatcher = dispatcher,
         state = state,
       )
+
+    override val defaultExtraConfig: ExtraConfig = ExtraConfig.default
+
+    override final def extraConfigParser(parser: OptionParser[Config[ExtraConfig]]): Unit = {
+      parser
+        .opt[Int]("maxInboundMessageSize")
+        .text(
+          s"Max inbound message size in bytes. Defaults to ${ExtraConfig.defaultMaxInboundMessageSize}.")
+        .action((maxInboundMessageSize, config) => {
+          val extra = config.extra
+          config.copy(extra = extra.copy(maxInboundMessageSize = maxInboundMessageSize))
+        })
+      ()
+    }
+
+    override def apiServerConfig(
+        participantConfig: ParticipantConfig,
+        config: Config[ExtraConfig]): ApiServerConfig =
+      super
+        .apiServerConfig(participantConfig, config)
+        .copy(maxInboundMessageSize = config.extra.maxInboundMessageSize)
   }
 }

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -42,7 +42,11 @@ object Main {
     ): ResourceOwner[KeyValueParticipantState] =
       for {
         readerWriter <- owner(config, participantConfig)
-      } yield new KeyValueParticipantState(readerWriter, readerWriter)
+      } yield
+        new KeyValueParticipantState(
+          readerWriter,
+          readerWriter,
+          metricRegistry(participantConfig, config))
 
     def owner(config: Config[ExtraConfig], participantConfig: ParticipantConfig)(
         implicit materializer: Materializer,


### PR DESCRIPTION
Add a command line parameter `maxInboundMessageSize` to the ledger-on-memory. It allows specifying maximum grpc message size that can be passed over the ledger api.
This is required for testing large models on with that ledger.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.