### PR TITLE
Implement timed command deduplication in kvutils

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -126,7 +126,7 @@ private[commands] class CommandTracker[Context](maxDeduplicationTime: () => JDur
       )
 
       setHandler(resultOut, new OutHandler {
-        override def onPull(): Unit = pull(commandResultIn)
+        override def onPull(): Unit = if (!hasBeenPulled(commandResultIn)) pull(commandResultIn)
       })
 
       setHandler(
@@ -147,7 +147,7 @@ private[commands] class CommandTracker[Context](maxDeduplicationTime: () => JDur
                 pushResultOrPullCommandResultIn(getOutputForCompletion(completion))
 
               case Right(CompletionStreamElement.CheckpointElement(checkpoint)) =>
-                pull(commandResultIn)
+                if (!hasBeenPulled(commandResultIn)) pull(commandResultIn)
                 checkpoint.offset.foreach(emit(offsetOut, _))
             }
 

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -154,6 +154,5 @@ conformance_test(
         "--crt $(rlocation $TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:client.crt))",
         "--cacrt $(rlocation $TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:ca.crt))",
         "--pem $(rlocation $TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:client.pem))",
-        "--exclude=CommandDeduplicationIT",
     ],
 )

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -115,7 +115,6 @@ conformance_test(
         "--verbose",
         "--all-tests",
         "--exclude=ConfigManagementServiceIT",
-        "--exclude=CommandDeduplicationIT",
     ],
 )
 
@@ -135,7 +134,6 @@ conformance_test(
         "--verbose",
         "--all-tests",
         "--exclude=ConfigManagementServiceIT",
-        "--exclude=CommandDeduplicationIT",
     ],
 )
 

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -40,10 +40,11 @@ final class InMemoryLedgerReaderWriter(
   private val committer = new ValidatingCommitter(
     () => timeProvider.getCurrentTime,
     SubmissionValidator
-      .create(
+      .createForTimeMode(
         new InMemoryLedgerStateAccess(state),
         allocateNextLogEntryId = () => sequentialLogEntryId.next(),
         metricRegistry = metricRegistry,
+        inStaticTimeMode = timeProvider != TimeProvider.UTC
       ),
     dispatcher.signalNewHead,
   )

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -234,7 +234,6 @@ da_scala_test_suite(
                 "--verbose",
                 "--all-tests",
                 "--exclude=ConfigManagementServiceIT",
-                "--exclude=CommandDeduplicationIT",
             ],
         ),
         conformance_test(

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -56,10 +56,11 @@ final class SqlLedgerReaderWriter(
   private val committer = new ValidatingCommitter[Index](
     () => timeProvider.getCurrentTime,
     SubmissionValidator
-      .create(
+      .createForTimeMode(
         SqlLedgerStateAccess,
         allocateNextLogEntryId = () => allocateSeededLogEntryId(),
         metricRegistry = metricRegistry,
+        inStaticTimeMode = timeProvider != TimeProvider.UTC
       ),
     latestSequenceNo => dispatcher.signalNewHead(latestSequenceNo),
   )

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -157,7 +157,6 @@ client_server_build(
     testonly = True,  # only test targets can depend on this.
     client = "//ledger/ledger-api-test-tool",
     client_args = [
-        "--exclude=LotsOfPartiesIT,TransactionScaleIT",
         "--timeout-scale-factor=20",
         "localhost:6865",
     ],

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -157,7 +157,7 @@ client_server_build(
     testonly = True,  # only test targets can depend on this.
     client = "//ledger/ledger-api-test-tool",
     client_args = [
-        "--exclude=LotsOfPartiesIT,TransactionScaleIT,CommandDeduplicationIT",
+        "--exclude=LotsOfPartiesIT,TransactionScaleIT",
         "--timeout-scale-factor=20",
         "localhost:6865",
     ],

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -350,11 +350,15 @@ message DamlCommandDedupKey {
   string submitter = 1;
   string application_id = 2;
   string command_id = 3;
+  google.protobuf.Timestamp submissionUntil = 4;
+
+
 }
 
 message DamlCommandDedupValue {
   // record time will be used in the future for pruning
   google.protobuf.Timestamp record_time = 1;
+  google.protobuf.Timestamp deduplication_time = 2;
 }
 
 message DamlSubmissionDedupKey {

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -348,17 +348,16 @@ message DamlStateValue {
 
 message DamlCommandDedupKey {
   string submitter = 1;
-  string application_id = 2;
+  reserved 2; // was application_id
   string command_id = 3;
-  google.protobuf.Timestamp submissionUntil = 4;
-
-
 }
 
 message DamlCommandDedupValue {
   // record time will be used in the future for pruning
   google.protobuf.Timestamp record_time = 1;
-  google.protobuf.Timestamp deduplication_time = 2;
+  // the time until when future commands with the same
+  // deduplication key will be rejected due to a duplicate submission
+  google.protobuf.Timestamp deduplicated_until = 2;
 }
 
 message DamlSubmissionDedupKey {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -131,6 +131,8 @@ private[state] object Conversions {
       .setSubmitter(subInfo.submitter)
       .setApplicationId(subInfo.applicationId)
       .setCommandId(subInfo.commandId)
+      .setDeduplicateUntil(
+        buildTimestamp(Time.Timestamp.assertFromInstant(subInfo.deduplicateUntil)))
       .build
 
   def parseSubmitterInfo(subInfo: DamlSubmitterInfo): SubmitterInfo =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -82,7 +82,6 @@ private[state] object Conversions {
     DamlStateKey.newBuilder
       .setCommandDedup(
         DamlCommandDedupKey.newBuilder
-          .setApplicationId(subInfo.getApplicationId)
           .setCommandId(subInfo.getCommandId)
           .setSubmitter(subInfo.getSubmitter)
           .build

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -10,6 +10,10 @@ package com.daml.ledger.participant.state.kvutils
   * [after 100.13.55]: *BACKWARDS INCOMPATIBLE*
   * - Remove use of relative contract ids. Introduces kvutils version 2.
   * - Introduce DamlSubmissionBatch.
+  * - Respect the deduplication time provided by submissions.
+  *   - Remove DamlCommandDedupKey#application_id.
+  *   - Add DamlCommanDedupValue#deduplicatedUntil.
+  *   - Introduces kvutils version 3.
   *
   * [after 100.13.52]: *BACKWARDS INCOMPATIBLE*
   * - Use hash for serializing contract keys instead of serializing the value, as
@@ -74,6 +78,8 @@ object Version {
     *      * Add submissionTime in DamlTransactionEntry and use it instead of ledgerTime to derive
     *        contract ids.
     *      * Add DamlSubmissionBatch message.
+    *   4: * Remove application_id from DamlCommandDedupKey. Only submitter and commandId are used for deduplication.
+    *      * Add deduplicatedUntil field to DamlCommandDedupValue to restrict the deduplication window.
     */
-  val version: Long = 3
+  val version: Long = 4
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils.committing
 
-import java.time.Instant
-
 import com.codahale.metrics.{Counter, MetricRegistry, Timer}
 import com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.participant.state.kvutils.Conversions._

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -309,9 +309,26 @@ object SubmissionValidator {
       checkForMissingInputs: Boolean = false,
       metricRegistry: MetricRegistry,
   )(implicit executionContext: ExecutionContext): SubmissionValidator[LogResult] = {
+    createForTimeMode(
+      ledgerStateAccess,
+      allocateNextLogEntryId,
+      checkForMissingInputs,
+      metricRegistry,
+      inStaticTimeMode = false,
+    )
+  }
+
+  // Internal method to enable proper command dedup in sandbox with static time mode
+  private[daml] def createForTimeMode[LogResult](
+      ledgerStateAccess: LedgerStateAccess[LogResult],
+      allocateNextLogEntryId: () => DamlLogEntryId = () => allocateRandomLogEntryId(),
+      checkForMissingInputs: Boolean = false,
+      metricRegistry: MetricRegistry,
+      inStaticTimeMode: Boolean,
+  )(implicit executionContext: ExecutionContext): SubmissionValidator[LogResult] = {
     new SubmissionValidator(
       ledgerStateAccess,
-      processSubmission(new KeyValueCommitting(metricRegistry)),
+      processSubmission(new KeyValueCommitting(metricRegistry, inStaticTimeMode)),
       allocateNextLogEntryId,
       checkForMissingInputs,
       metricRegistry,

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -432,7 +432,6 @@ server_conformance_test(
         "--all-tests",
         "--exclude=ConfigManagementServiceIT",
         "--exclude=ClosedWorldIT",
-        "--exclude=CommandDeduplicationIT",
     ],
 )
 
@@ -466,7 +465,6 @@ server_conformance_test(
         "--open-world",
         "--all-tests",
         "--exclude=ClosedWorldIT",
-        "--exclude=CommandDeduplicationIT",
         "--exclude=ConfigManagementServiceIT",
     ],
 )
@@ -482,7 +480,6 @@ server_conformance_test(
         "--open-world",
         "--all-tests",
         "--exclude=ClosedWorldIT",
-        "--exclude=CommandDeduplicationIT",
         "--exclude=ConfigManagementServiceIT",
     ],
 )


### PR DESCRIPTION
This adds a field deduplication_time to DamlCommandDedupValue for
deduplication timeout checking.

Fixes #4624.

CHANGELOG_BEGIN
[kvutils] KVUtils now respects the command deduplciation time instead of
deduplicating commands forever.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
