### PR TITLE
daml2ts: Don't reinvent assertInfixOf in tests

### DIFF
--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -175,5 +175,6 @@ da_haskell_test(
         "//compiler/daml-lf-ast",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
+        "//libs-haskell/test-utils",
     ],
 ) if not is_windows else None

--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2Ts.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2Ts.hs
@@ -21,6 +21,7 @@ import qualified Data.HashMap.Strict as HMS
 import Data.Aeson
 import Test.Tasty
 import Test.Tasty.HUnit
+import DA.Test.Util
 
 -- Referenced from the DAVL test. Lifted here for easy
 -- maintenance.
@@ -105,7 +106,7 @@ tests damlTypes yarn damlc daml2ts davl = testGroup "daml2ts tests"
         setupYarnEnvironment
         (exitCode, _, err) <- readProcessWithExitCode daml2ts ([groverDar, elmoDar] ++ ["-o", daml2tsDir]) ""
         assertBool "daml2ts is expected to fail but succeeded" (exitCode /= ExitSuccess)
-        assertIsInfixOf "A duplicate name for different packages error was expected." "Duplicate name 'grover-1.0' for different packages detected" err
+        assertInfixOf "Duplicate name 'grover-1.0' for different packages detected" err
 
   , testCaseSteps "Different name, same package test" $ \step -> withTempDir $ \here -> do
       let daml2tsDir = here </> "daml2ts"
@@ -136,7 +137,7 @@ tests damlTypes yarn damlc daml2ts davl = testGroup "daml2ts tests"
         setupYarnEnvironment
         (exitCode, _, err) <- readProcessWithExitCode daml2ts ([groverDar, superGroverDar] ++ ["-o", daml2tsDir]) ""
         assertBool "daml2ts is expected to fail but succeeded" (exitCode /= ExitSuccess)
-        assertIsInfixOf "A different names for same package error was expected." "Different names ('grover-1.0' and 'super-grover-1.0') for the same package detected" err
+        assertInfixOf "Different names ('grover-1.0' and 'super-grover-1.0') for the same package detected" err
 
   , testCaseSteps "Same package, same name test" $ \step -> withTempDir $ \here -> do
       let grover = here </> "grover"
@@ -292,7 +293,3 @@ tests damlTypes yarn damlc daml2ts davl = testGroup "daml2ts tests"
     assertFileLines file expectedContent = do
       actualContent <- T.lines <$> T.readFileUtf8 file
       assertEqual ("The content of file '" ++ file ++ "' does not match") expectedContent actualContent
-
-    assertIsInfixOf :: String -> String -> String -> IO ()
-    assertIsInfixOf msg x y =
-      assertBool (msg ++ "\nexpected infix: " ++ show x ++ "\nbut got: " ++ show y) (x `isInfixOf` y)


### PR DESCRIPTION
Instead use the version from `DA.Test.Util`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5245)
<!-- Reviewable:end -->
