### PR TITLE
Remove useless timeProvider in scala quickstart

### DIFF
--- a/language-support/scala/examples/iou-no-codegen/application/src/main/scala/com/digitalasset/quickstart/iou/ClientUtil.scala
+++ b/language-support/scala/examples/iou-no-codegen/application/src/main/scala/com/digitalasset/quickstart/iou/ClientUtil.scala
@@ -7,7 +7,6 @@ import java.util.UUID
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import akka.{Done, NotUsed}
-import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.ledger.api.refinements.ApiTypes.{ApplicationId, WorkflowId}
 import com.digitalasset.ledger.api.v1.command_submission_service.SubmitRequest
@@ -19,14 +18,12 @@ import com.digitalasset.ledger.client.LedgerClient
 import com.digitalasset.quickstart.iou.FutureUtil.toFuture
 import com.google.protobuf.empty.Empty
 
-import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 class ClientUtil(
     client: LedgerClient,
     applicationId: ApplicationId,
-    ttl: Duration,
-    timeProvider: TimeProvider) {
+) {
 
   import ClientUtil._
 
@@ -48,7 +45,7 @@ class ClientUtil(
       applicationId = ApplicationId.unwrap(applicationId),
       commandId = uniqueId,
       party = party,
-      commands = Seq(Command(cmd))
+      commands = Seq(Command(cmd)),
     )
 
     commandClient.submitSingleCommand(SubmitRequest(Some(commands), None))

--- a/language-support/scala/examples/iou-no-codegen/application/src/main/scala/com/digitalasset/quickstart/iou/IouMain.scala
+++ b/language-support/scala/examples/iou-no-codegen/application/src/main/scala/com/digitalasset/quickstart/iou/IouMain.scala
@@ -3,11 +3,8 @@
 
 package com.digitalasset.quickstart.iou
 
-import java.time.Instant
-
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.grpc.adapter.AkkaExecutionSequencerPool
 import com.digitalasset.ledger.api.refinements.ApiTypes.{ApplicationId, WorkflowId}
 import com.digitalasset.ledger.api.v1.ledger_offset.LedgerOffset
@@ -58,8 +55,6 @@ object IouMain extends App with StrictLogging {
 
   private val applicationId = ApplicationId("IOU Example")
 
-  private val timeProvider = TimeProvider.Constant(Instant.EPOCH)
-
   private val clientConfig = LedgerClientConfiguration(
     applicationId = ApplicationId.unwrap(applicationId),
     ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
@@ -71,7 +66,7 @@ object IouMain extends App with StrictLogging {
     LedgerClient.singleHost(ledgerHost, ledgerPort, clientConfig)(ec, aesf)
 
   private val clientUtilF: Future[ClientUtil] =
-    clientF.map(client => new ClientUtil(client, applicationId, 30.seconds, timeProvider))
+    clientF.map(client => new ClientUtil(client, applicationId))
 
   private val offset0F: Future[LedgerOffset] = clientUtilF.flatMap(_.ledgerEnd)
 


### PR DESCRIPTION
This PR removed the timeProvider and ttl values from the no-codegen quickstart. These were used to set the LET/MRT values, which have recently been removed.

This makes it consistent with the other scala quickstart.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
