### PR TITLE
tarball reproducibility

### DIFF
--- a/bazel_tools/packaging/package-app.sh
+++ b/bazel_tools/packaging/package-app.sh
@@ -173,5 +173,6 @@ elif [[ "$(uname -s)" == "Darwin" ]]; then
 else
     cp "$SRC" "$WORKDIR/$NAME/$NAME"
 fi
-cd $WORKDIR && tar czf $OUT $NAME
-
+cd $WORKDIR && tar c $NAME \
+    --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+    | gzip -n $OUT

--- a/bazel_tools/packaging/package-app.sh
+++ b/bazel_tools/packaging/package-app.sh
@@ -175,4 +175,4 @@ else
 fi
 cd $WORKDIR && tar c $NAME \
     --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
-    | gzip -n $OUT
+    | gzip -n > $OUT

--- a/compiler/daml-extension/BUILD.bazel
+++ b/compiler/daml-extension/BUILD.bazel
@@ -66,8 +66,9 @@ genrule(
             cp ../$$f $$dir/$$file
         done
         cd ..
-        tar czf node_modules.tar.gz node_modules
-        cp node_modules.tar.gz $@
+        tar c node_modules \
+          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+          | gzip -n > $@
     """,
 )
 

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -333,7 +333,9 @@ genrule(
             --input-format=json \
             --format=Html \
             $(location :daml-stdlib.json) $(location :daml-prim.json)
-        tar czf $(OUTS) daml-base-html
+        tar c daml-base-html \
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+            | gzip -n > $(OUTS)
     """,
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -63,7 +63,8 @@ genrule(
         $(location //ledger/ledger-api-auth-client:libledger-api-auth-client.jar) \
         $(location //ledger/ledger-api-auth-client:ledger-api-auth-client_pom.xml)
       $(location @mvn_dev_env//:mvn) -q -Dmaven.repo.local=$$MVN_DB -f "$$TMP_DIR/quickstart-java/pom.xml" dependency:resolve dependency:resolve-plugins
-      tar cf $(location integration-tests-mvn.tar) -C $$(dirname $$MVN_DB) $$(basename $$MVN_DB)
+      tar cf $(location integration-tests-mvn.tar) -C $$(dirname $$MVN_DB) $$(basename $$MVN_DB) \
+        --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name
     """.format(mvn = mvn_version),
 )
 

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -235,16 +235,15 @@ genrule(
             sass:da_theme/static/css
         ../$(location :grunt) build
 
-        tar \
+        tar c da_theme \
             --owner=1000 \
             --group=1000 \
-            --mtime=1337 \
+            --mtime=2000-01-01\ 00:00Z \
             --no-acls \
             --no-xattrs \
             --no-selinux \
             --sort=name \
-            -czf ../$(location da_theme.tar.gz) \
-            da_theme
+            | gzip -n > ../$(location da_theme.tar.gz)
     """,
     tools = [
         ":grunt",
@@ -282,7 +281,9 @@ genrule(
         cp -L $(location //:LICENSE) source/LICENSE
         cp -L $(location //:NOTICES) source/NOTICES
 
-        tar -zcf $(location source.tar.gz) source
+        tar c source \
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+            | gzip -n > $(location source.tar.gz)
     """,
 )
 
@@ -393,7 +394,9 @@ genrule(
         mkdir -p html/hoogle_db
         cp -rL ../$(location //compiler/damlc:daml-base-hoogle-docs) html/hoogle_db/base.txt
 
-        tar -zcf ../$(location html-only.tar.gz) html
+        tar c html \
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+            | gzip -n > ../$(location html-only.tar.gz)
         """.format(sdk = sdk_version),
     tools =
         ["@sphinx_nix//:bin/sphinx-build"] +
@@ -419,7 +422,9 @@ genrule(
                 sed -i -e "s,__URL__,$${to}," redirects/$$from
             fi
         done <docs/redirects.map
-        tar -zcf $(location redirects.tar.gz) redirects
+        tar c redirects \
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+            | gzip -n > $(location redirects.tar.gz)
     """,
 )
 
@@ -454,7 +459,9 @@ genrule(
         cp -L $(location :pdf-docs) html/_downloads
         # Remove Sphinx build products
         rm -rf .buildinfo .doctrees objects.inv
-        tar -zcf $(location html.tar.gz) html
+        tar c html \
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+            | gzip -n > $(location html.tar.gz)
     """.format(
         head = """<?xml version='1.0' encoding='UTF-8'?><urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd'>""",
         item = """<url><loc>%LOC%</loc><lastmod>%DATE%</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>""",
@@ -487,7 +494,9 @@ genrule(
         mkdir -p quickstart-java
         cp -rL docs/source/getting-started/quickstart/template-root/* quickstart-java/
         sed -i "s/__VERSION__/{mvn}/" quickstart-java/pom.xml
-        tar zcf $@ quickstart-java
+        tar c quickstart-java \
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+            | gzip -n > $@
     """.format(mvn = mvn_version),
     visibility = ["//visibility:public"],
 )

--- a/language-support/ts/typedoc.bzl
+++ b/language-support/ts/typedoc.bzl
@@ -15,7 +15,9 @@ def ts_docs(pkg_name):
           # NOTE: we need the --ignoreCompilerErrors flag because we get errors when tsc is trying to
           # resolve the imported packages.
           $(location @language_support_ts_deps//typedoc/bin:typedoc) --out docs --ignoreCompilerErrors --readme README.md --stripInternal $(SRCS)
-          tar -hczf $@ docs
+          tar -hc docs \
+               --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+               | gzip -n > $@
         """,
         visibility = ["//visibility:public"],
     ) if not is_windows else None

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -166,7 +166,9 @@ genrule(
         cp -L $(location :sandbox-binary_deploy.jar) sandbox-tarball/sandbox/sandbox-{mvn}.jar
         out=$$(realpath $@)
         cd sandbox-tarball
-        tar zcf $$out sandbox
+        tar c sandbox \
+          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+          | gzip -n > $$out
     """.format(mvn = mvn_version),
     visibility = ["//visibility:public"],
 )

--- a/navigator/frontend/BUILD.bazel
+++ b/navigator/frontend/BUILD.bazel
@@ -114,9 +114,11 @@ genrule(
       --env.bazel_out_dir="{WP_OUT_ESCAPED}"
 
     # Package result (.TGZ)
-    # To debug, change 'czf' to 'czfv'.
+    # To debug, change 'c' to 'cv'.
     echo "Packaging result from $$OUT to $(@D)/frontend.tgz"
-    tar czf "$(@D)/frontend.tgz" -C $$OUT .
+    tar c -C $$OUT . \
+        --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        | gzip -n > "$(@D)/frontend.tgz"
 
     # Package result (.JAR)
     echo "Packaging result from $$OUT to $(@D)/frontend.jar"

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -73,7 +73,9 @@ def sdk_tarball(name, version):
           cp -L $(location //triggers/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/trigger-logback.xml
           cp -L $(location //daml-script/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/script-logback.xml
 
-          tar c --format=ustar --sort=name --owner=root:0 --group=root:0 --mtime=0 $$OUT | gzip -n > $@
+          tar c --format=ustar $$OUT \
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+            | gzip -n > $@
         """.format(version = version),
         visibility = ["//visibility:public"],
     )

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -53,7 +53,9 @@ genrule(
         mkdir -p $$OUT/daml-patterns
         tar xf $(location //docs:daml-patterns) --strip-components=1 -C $$OUT/daml-patterns
 
-        tar zcf $(location :templates-tarball.tar.gz) templates-tarball
+        tar c templates-tarball \
+          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+          | gzip -n >$(location :templates-tarball.tar.gz)
     """,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
We had a couple `genrule` that only mangled filepaths of already existing files and bundled them into a tarball. These have been replaced by `pkg_tar`. `pkg_tar` is designed to produce reproducible outputs and it also avoids some unnecessary file copies. Most notably the `sdk-release-tarball` has been replaced by a `pkg_tar` rule.

The remaining invocations of `tar`/`gzip` (at least those that I found) where modified to be reproducible. I.e. fixed timestamp/fileattrs/fileorder.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
