### PR TITLE
Use real data for getLedgerConfiguration

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -79,7 +79,6 @@ final class StandaloneApiServer(
       indexService <- JdbcIndex
         .owner(
           ServerRole.ApiServer,
-          initialConditions.config,
           domain.LedgerId(initialConditions.ledgerId),
           participantId,
           config.jdbcUrl,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
@@ -3,13 +3,10 @@
 
 package com.digitalasset.platform.index
 
-import akka.NotUsed
 import akka.stream.Materializer
-import akka.stream.scaladsl.Source
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.index.v2.IndexService
-import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId}
+import com.daml.ledger.participant.state.v1.ParticipantId
 import com.digitalasset.ledger.api.domain.LedgerId
 import com.digitalasset.logging.LoggingContext
 import com.digitalasset.platform.configuration.ServerRole
@@ -18,7 +15,6 @@ import com.digitalasset.resources.ResourceOwner
 object JdbcIndex {
   def owner(
       serverRole: ServerRole,
-      initialConfig: Configuration,
       ledgerId: LedgerId,
       participantId: ParticipantId,
       jdbcUrl: String,
@@ -27,10 +23,6 @@ object JdbcIndex {
     ReadOnlySqlLedger
       .owner(serverRole, jdbcUrl, ledgerId, metrics)
       .map { ledger =>
-        new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId) {
-          override def getLedgerConfiguration(): Source[v2.LedgerConfiguration, NotUsed] =
-            // FIXME(JM): The indexer should on start set the default configuration.
-            Source.single(v2.LedgerConfiguration(initialConfig.maxDeduplicationTime))
-        }
+        new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId)
       }
 }


### PR DESCRIPTION
`getLedgerConfiguration()` used to return only the initial ledger config, as specified in the ledger API server config.

This PR changes the call to return real data, as specified by the ledger or `ReadService`.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
