### PR TITLE
tweak periodic-killer

### DIFF
--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -27,7 +27,7 @@ resource "google_project_iam_custom_role" "periodic-killer" {
 
 resource "google_compute_instance" "periodic-killer" {
   name         = "periodic-killer"
-  machine_type = "f1-micro"
+  machine_type = "g1-small"
   zone         = "us-east4-a"
 
   boot_disk {
@@ -79,7 +79,7 @@ CRON
 chmod +x /root/periodic-kill.sh
 
 cat <<CRONTAB >> /etc/crontab
-0 4 * * * root /root/periodic-kill.sh >> /root/log
+0 4 * * * root /root/periodic-kill.sh >> /root/log 2>&1
 CRONTAB
 
 tail -f /root/log


### PR DESCRIPTION
1. Google says the instance is currently overutilized and suggests g1-small as a more appropriate size.
2. It occurred to me that the reason no error was logged might be that we lose them, so explicitly redirecting stderr too.

CHANGELOG_BEGIN
CHANGELOG_END