### PR TITLE
Add canonical string representation for identifiers

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -13,7 +13,7 @@ object Ref {
 
   /* Encoding of byte array */
   type HexString = IdString.HexString
-  val HexString: HexStringModule[Ref.IdString.HexString] = IdString.HexString
+  val HexString: IdString.HexString.type = IdString.HexString
 
   type PackageName = IdString.PackageName
   val PackageName: IdString.PackageName.type = IdString.PackageName

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Ref.scala
@@ -13,7 +13,7 @@ object Ref {
 
   /* Encoding of byte array */
   type HexString = IdString.HexString
-  val HexString = IdString.HexString
+  val HexString: HexStringModule[Ref.IdString.HexString] = IdString.HexString
 
   type PackageName = IdString.PackageName
   val PackageName: IdString.PackageName.type = IdString.PackageName
@@ -71,6 +71,12 @@ object Ref {
     segments.result()
   }
 
+  private def splitInTwo(s: String, splitCh: Char): Option[(String, String)] = {
+    val splitIndex = s.indexOf(splitCh.toInt)
+    if (splitIndex < 0) None
+    else Some((s.substring(0, splitIndex), s.substring(splitIndex + 1)))
+  }
+
   final class DottedName private (val segments: ImmArray[Name])
       extends Equals
       with Ordered[DottedName] {
@@ -98,8 +104,6 @@ object Ref {
   }
 
   object DottedName {
-    type T = DottedName
-
     def fromString(s: String): Either[String, DottedName] =
       if (s.isEmpty)
         Left(s"Expected a non-empty string")
@@ -107,7 +111,7 @@ object Ref {
         fromSegments(split(s, '.').toSeq)
 
     @throws[IllegalArgumentException]
-    final def assertFromString(s: String): T =
+    final def assertFromString(s: String): DottedName =
       assertRight(fromString(s))
 
     def fromSegments(strings: Iterable[String]): Either[String, DottedName] = {
@@ -142,13 +146,11 @@ object Ref {
     }
   }
 
-  case class QualifiedName private (module: ModuleName, name: DottedName) {
+  final case class QualifiedName private (module: ModuleName, name: DottedName) {
     override def toString: String = module.toString + ":" + name.toString
     def qualifiedName: String = toString
   }
   object QualifiedName {
-    type T = QualifiedName
-
     def fromString(s: String): Either[String, QualifiedName] = {
       val segments = split(s, ':')
       if (segments.length != 2)
@@ -162,13 +164,31 @@ object Ref {
     }
 
     @throws[IllegalArgumentException]
-    final def assertFromString(s: String): T =
+    def assertFromString(s: String): QualifiedName =
       assertRight(fromString(s))
   }
 
   /* A fully-qualified identifier pointing to a definition in the
    * specified package. */
-  case class Identifier(packageId: PackageId, qualifiedName: QualifiedName)
+  final case class Identifier(packageId: PackageId, qualifiedName: QualifiedName) {
+    override def toString: String = packageId.toString + ":" + qualifiedName.toString
+  }
+  object Identifier {
+    def fromString(s: String): Either[String, Identifier] = {
+      splitInTwo(s, ':').fold[Either[String, Identifier]](
+        Left(s"Separator ':' between package identifier and qualified name not found in $s")) {
+        case (packageIdString, qualifiedNameString) =>
+          for {
+            packageId <- PackageId.fromString(packageIdString)
+            qualifiedName <- QualifiedName.fromString(qualifiedNameString)
+          } yield Identifier(packageId, qualifiedName)
+      }
+    }
+
+    @throws[IllegalArgumentException]
+    def assertFromString(s: String): Identifier =
+      assertRight(fromString(s))
+  }
 
   /* Choice name in a template. */
   type ChoiceName = Name

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/RefTest.scala
@@ -3,10 +3,17 @@
 
 package com.digitalasset.daml.lf.data
 
-import com.digitalasset.daml.lf.data.Ref.{DottedName, LedgerString, PackageId, Party, QualifiedName}
-import org.scalatest.{FreeSpec, Matchers}
+import com.digitalasset.daml.lf.data.Ref.{
+  DottedName,
+  Identifier,
+  LedgerString,
+  PackageId,
+  Party,
+  QualifiedName
+}
+import org.scalatest.{EitherValues, FreeSpec, Matchers}
 
-class RefTest extends FreeSpec with Matchers {
+class RefTest extends FreeSpec with Matchers with EitherValues {
   "DottedName" - {
     "rejects bad segments" - {
       "digit at the start" in {
@@ -68,6 +75,49 @@ class RefTest extends FreeSpec with Matchers {
     "rejects empty dotted names" in {
       QualifiedName.fromString(":bar") shouldBe 'left
       QualifiedName.fromString("bar:") shouldBe 'left
+    }
+
+    "accepts valid qualified names" in {
+      QualifiedName.fromString("foo:bar").right.value shouldBe QualifiedName(
+        module = DottedName.assertFromString("foo"),
+        name = DottedName.assertFromString("bar")
+      )
+      QualifiedName.fromString("foo.bar:baz").right.value shouldBe QualifiedName(
+        module = DottedName.assertFromString("foo.bar"),
+        name = DottedName.assertFromString("baz")
+      )
+      QualifiedName.fromString("foo:bar.baz").right.value shouldBe QualifiedName(
+        module = DottedName.assertFromString("foo"),
+        name = DottedName.assertFromString("bar.baz")
+      )
+      QualifiedName.fromString("foo.bar:baz.quux").right.value shouldBe QualifiedName(
+        module = DottedName.assertFromString("foo.bar"),
+        name = DottedName.assertFromString("baz.quux")
+      )
+    }
+  }
+
+  "Identifier" - {
+
+    val errorMessageBeginning =
+      "Separator ':' between package identifier and qualified name not found in "
+
+    "rejects strings without any colon" in {
+      Identifier.fromString("foo").left.value should startWith(errorMessageBeginning)
+    }
+
+    "rejects strings with empty segments but the error is caught further down the stack" in {
+      Identifier.fromString(":bar").left.value should not startWith errorMessageBeginning
+      Identifier.fromString("bar:").left.value should not startWith errorMessageBeginning
+      Identifier.fromString("::").left.value should not startWith errorMessageBeginning
+      Identifier.fromString("bar:baz").left.value should not startWith errorMessageBeginning
+    }
+
+    "accepts valid identifiers" in {
+      Identifier.fromString("foo:bar:baz").right.value shouldBe Identifier(
+        packageId = PackageId.assertFromString("foo"),
+        qualifiedName = QualifiedName.assertFromString("bar:baz"),
+      )
     }
   }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -506,31 +506,31 @@ class HashSpec extends WordSpec with Matchers {
           | da9ab333c3de358c2e5aead8a9ced5cbe5dda7fc454ade82180596120c5abdc6
           |ValueTextMap(SortedLookupList((a,ValueBool(false)),(c,ValueBool(false))))
           | 5ac45cbc29a66cd2f10dad87daf37dbb5fa905f5647586fc5f2eafca5d349bac
-          |ValueEnum(Some(Identifier(pkgId,Mod:Color)),Red)
+          |ValueEnum(Some(pkgId:Mod:Color),Red)
           | 048b20422b487b8eeba059a219589ad477e5f11eb769c7fea658b63f1bb1d405
-          |ValueEnum(Some(Identifier(pkgId,Mod:Color)),Green)
+          |ValueEnum(Some(pkgId:Mod:Color),Green)
           | ff89416f14a9369d7ef3f9a23057878320aa7b777c7233a79f2b0cab812a3e7a
-          |ValueEnum(Some(Identifier(pkgId,Mod:ColorBis)),Green)
+          |ValueEnum(Some(pkgId:Mod:ColorBis),Green)
           | ff89416f14a9369d7ef3f9a23057878320aa7b777c7233a79f2b0cab812a3e7a
-          |ValueRecord(Some(Identifier(pkgId,Mod:Unit)),ImmArray())
+          |ValueRecord(Some(pkgId:Mod:Unit),ImmArray())
           | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
-          |ValueRecord(Some(Identifier(pkgId,Mod:UnitBis)),ImmArray())
+          |ValueRecord(Some(pkgId:Mod:UnitBis),ImmArray())
           | 01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086
-          |ValueRecord(Some(Identifier(pkgId,Mod:Tuple)),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
+          |ValueRecord(Some(pkgId:Mod:Tuple),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
           | 8f5dff2ff3f971b847284fb225522005587449fad2746879a0280bbd036f1abc
-          |ValueRecord(Some(Identifier(pkgId,Mod:Tuple)),ImmArray((Some(_1),ValueBool(true)),(Some(_2),ValueBool(false))))
+          |ValueRecord(Some(pkgId:Mod:Tuple),ImmArray((Some(_1),ValueBool(true)),(Some(_2),ValueBool(false))))
           | 768c5b90ed7ae5b727381e331fac83d7defd397d040f46ba067c80ec2af3eb33
-          |ValueRecord(Some(Identifier(pkgId,Mod:Tuple)),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(true))))
+          |ValueRecord(Some(pkgId:Mod:Tuple),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(true))))
           | 4f6de867c24682cee05db95d48e1ea47cf5f8b6e74fe07582d3cd8cecaea84b7
-          |ValueRecord(Some(Identifier(pkgId,Mod:TupleBis)),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
+          |ValueRecord(Some(pkgId:Mod:TupleBis),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
           | 8f5dff2ff3f971b847284fb225522005587449fad2746879a0280bbd036f1abc
-          |ValueVariant(Some(Identifier(pkgId,Mod:Either)),Left,ValueBool(false))
+          |ValueVariant(Some(pkgId:Mod:Either),Left,ValueBool(false))
           | 41edeaec86ac919e3c184057b021753781bd2ac1d60b8d4329375f60df953097
-          |ValueVariant(Some(Identifier(pkgId,Mod:Either)),Left,ValueBool(true))
+          |ValueVariant(Some(pkgId:Mod:Either),Left,ValueBool(true))
           | 31d69356947365e8a3dd9706774182e86774af1aa6550055efc56a22bb594745
-          |ValueVariant(Some(Identifier(pkgId,Mod:Either)),Right,ValueBool(false))
+          |ValueVariant(Some(pkgId:Mod:Either),Right,ValueBool(false))
           | bd89c47c2379a69e8e0d46ff634c533449e8e7e532e84def4e2b2e168bc786e7
-          |ValueVariant(Some(Identifier(pkgId,Mod:EitherBis)),Left,ValueBool(false))
+          |ValueVariant(Some(pkgId:Mod:EitherBis),Left,ValueBool(false))
           | 41edeaec86ac919e3c184057b021753781bd2ac1d60b8d4329375f60df953097
           |""".stripMargin
 

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/store/serialization/KeyHasherSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/store/serialization/KeyHasherSpec.scala
@@ -567,31 +567,31 @@ class KeyHasherSpec extends WordSpec with Matchers {
           | 91e247b396cea58ab670b0767940d360cf1fd541b52444d5b1dcb4d74132d0f9
           |ValueTextMap(SortedLookupList((a,ValueBool(false)),(c,ValueBool(false))))
           | 10e757f68e9e602f8780440193064fec42a7e2f85bec983d416d171079b7240e
-          |ValueEnum(Some(Identifier(pkgId,Mod:Color)),Red)
+          |ValueEnum(Some(pkgId:Mod:Color),Red)
           | 3bf7245f74973e912a49c95a28e77d59594f73c78ede8683663d4bf9eca5c37c
-          |ValueEnum(Some(Identifier(pkgId,Mod:Color)),Green)
+          |ValueEnum(Some(pkgId:Mod:Color),Green)
           | 181bfc4e71007c1dc5406594346ae45a52c2a0bb377800b04e26ce09d8b66004
-          |ValueEnum(Some(Identifier(pkgId,Mod:ColorBis)),Green)
+          |ValueEnum(Some(pkgId:Mod:ColorBis),Green)
           | 181bfc4e71007c1dc5406594346ae45a52c2a0bb377800b04e26ce09d8b66004
-          |ValueRecord(Some(Identifier(pkgId,Mod:Unit)),ImmArray())
+          |ValueRecord(Some(pkgId:Mod:Unit),ImmArray())
           | df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119
-          |ValueRecord(Some(Identifier(pkgId,Mod:UnitBis)),ImmArray())
+          |ValueRecord(Some(pkgId:Mod:UnitBis),ImmArray())
           | df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119
-          |ValueRecord(Some(Identifier(pkgId,Mod:Tuple)),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
+          |ValueRecord(Some(pkgId:Mod:Tuple),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
           | e44728408fa247053c017f791d5d2fe87752119c5010006ffc4e098efbaea679
-          |ValueRecord(Some(Identifier(pkgId,Mod:Tuple)),ImmArray((Some(_1),ValueBool(true)),(Some(_2),ValueBool(false))))
+          |ValueRecord(Some(pkgId:Mod:Tuple),ImmArray((Some(_1),ValueBool(true)),(Some(_2),ValueBool(false))))
           | 06cb0843c56b268bd5fc5373f450e9ee50c49705f3d8d8e33356af5d54ab0315
-          |ValueRecord(Some(Identifier(pkgId,Mod:Tuple)),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(true))))
+          |ValueRecord(Some(pkgId:Mod:Tuple),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(true))))
           | 4f1366f56ad5b2ebd9738248a63d9d90bbb3b4b2eac3b74713c6bfd852477802
-          |ValueRecord(Some(Identifier(pkgId,Mod:TupleBis)),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
+          |ValueRecord(Some(pkgId:Mod:TupleBis),ImmArray((Some(_1),ValueBool(false)),(Some(_2),ValueBool(false))))
           | e44728408fa247053c017f791d5d2fe87752119c5010006ffc4e098efbaea679
-          |ValueVariant(Some(Identifier(pkgId,Mod:Either)),Left,ValueBool(false))
+          |ValueVariant(Some(pkgId:Mod:Either),Left,ValueBool(false))
           | 7ac33585fca214756dfe4b2c4de9283d7682f5a47ae8a78acf7abe266d5f41bc
-          |ValueVariant(Some(Identifier(pkgId,Mod:Either)),Left,ValueBool(true))
+          |ValueVariant(Some(pkgId:Mod:Either),Left,ValueBool(true))
           | bd43854d7f0bfe9fc246492fe783c5e1600a764195152cc240dc1750f7c5ce16
-          |ValueVariant(Some(Identifier(pkgId,Mod:Either)),Right,ValueBool(false))
+          |ValueVariant(Some(pkgId:Mod:Either),Right,ValueBool(false))
           | 635185b1cff7ebfdbde5045291955d39af1d3c392b30c53d36c06615e5479b24
-          |ValueVariant(Some(Identifier(pkgId,Mod:EitherBis)),Left,ValueBool(false))
+          |ValueVariant(Some(pkgId:Mod:EitherBis),Left,ValueBool(false))
           | 7ac33585fca214756dfe4b2c4de9283d7682f5a47ae8a78acf7abe266d5f41bc
           |""".stripMargin
 


### PR DESCRIPTION
An identifier is represented as a string as a package identifier and a qualified name separated by a colon.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- x ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
