### PR TITLE
Engine: support reinterpreting LookupByKey nodes

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/CommandPreprocessor.scala
@@ -166,6 +166,29 @@ private[engine] class CommandPreprocessor(compiledPackages: MutableCompiledPacka
     )
   }
 
+  private[engine] def preprocessLookupByKey(
+      templateId: ValueRef,
+      contractKey: Value[Nothing]
+  ): Result[(Type, SpeedyCommand)] = {
+    Result.needTemplate(
+      compiledPackages,
+      templateId,
+      template => {
+        template.key match {
+          case None =>
+            ResultError(
+              Error(s"Impossible to lookup by key, no key is defined for template $templateId"))
+          case Some(ck) =>
+            for {
+              key <- translateValue(ck.typ, contractKey)
+            } yield
+              TTyCon(templateId) -> SpeedyCommand
+                .LookupByKey(templateId, key)
+        }
+      }
+    )
+  }
+
   private[engine] def preprocessCommand(cmd: Command): Result[(Type, SpeedyCommand)] =
     cmd match {
       case CreateCommand(templateId, argument) =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -271,6 +271,12 @@ final class Engine {
         ResultDone(acoid)
     }
 
+  private[this] def asValueWithNoContractIds(v: Value[Value.ContractId]): Result[Value[Nothing]] =
+    v.ensureNoCid.fold(
+      coid => ResultError(ValidationError(s"engine: found a contract ID $coid in the given value")),
+      ResultDone(_)
+    )
+
   // Translate a GenNode into an expression re-interpretable by the interpreter
   private[this] def translateNode[Cid <: Value.ContractId](
       commandPreprocessor: CommandPreprocessor)(
@@ -308,8 +314,11 @@ final class Engine {
         asAbsoluteContractId(coid)
           .flatMap(acoid => commandPreprocessor.preprocessFetch(templateId, acoid))
 
-      case NodeLookupByKey(_, _, _, _) =>
-        sys.error("TODO lookup by key command translate")
+      case NodeLookupByKey(templateId, _, key, _) =>
+        for {
+          validatedKeyValue <- asValueWithNoContractIds(key.key.value)
+          res <- commandPreprocessor.preprocessLookupByKey(templateId, validatedKeyValue)
+        } yield res
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
@@ -46,4 +46,9 @@ object Command {
       choiceArgument: SValue,
   ) extends Command
 
+  final case class LookupByKey(
+      templateId: Identifier,
+      contractKey: SValue,
+  ) extends Command
+
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -514,32 +514,7 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
             //    let mbContractId = $lookupKey keyWithMaintainers
             //        _ = $insertLookup Foo keyWithMaintainers
             //    in mbContractId
-            val template = lookupTemplate(retrieveByKey.templateId)
-            withEnv { _ =>
-              val key = translate(retrieveByKey.key)
-              val templateKey = template.key.getOrElse(
-                throw CompileError(
-                  s"Expecting to find key for template ${retrieveByKey.templateId}, but couldn't",
-                ),
-              )
-              SELet(encodeKeyWithMaintainers(key, templateKey)) in {
-                env = env.incrPos // keyWithM
-                SEAbs(1) {
-                  env = env.incrPos // token
-                  SELet(
-                    SBULookupKey(retrieveByKey.templateId)(
-                      SEVar(2), // key with maintainers
-                      SEVar(1) // token
-                    ),
-                    SBUInsertLookupNode(retrieveByKey.templateId)(
-                      SEVar(3), // key with maintainers
-                      SEVar(1), // mb contract id
-                      SEVar(2) // token
-                    ),
-                  ) in SEVar(2) // mb contract id
-                }
-              }
-            }
+            compileLookupByKey(retrieveByKey.templateId, translate(retrieveByKey.key))
 
           case UpdateFetchByKey(retrieveByKey) =>
             // Translates 'fetchByKey Foo <key>' into:
@@ -1298,6 +1273,34 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
     }
   }
 
+  private def compileLookupByKey(templateId: Identifier, key: SExpr): SExpr = {
+    val template = lookupTemplate(templateId)
+    withEnv { _ =>
+      val templateKey = template.key.getOrElse(
+        throw CompileError(
+          s"Expecting to find key for template ${templateId}, but couldn't",
+        ),
+      )
+      SELet(encodeKeyWithMaintainers(key, templateKey)) in {
+        env = env.incrPos // keyWithM
+        SEAbs(1) {
+          env = env.incrPos // token
+          SELet(
+            SBULookupKey(templateId)(
+              SEVar(2), // key with maintainers
+              SEVar(1) // token
+            ),
+            SBUInsertLookupNode(templateId)(
+              SEVar(3), // key with maintainers
+              SEVar(1), // mb contract id
+              SEVar(2) // token
+            ),
+          ) in SEVar(2) // mb contract id
+        }
+      }
+    }
+  }
+
   private def translateCommand(cmd: Command): SExpr = cmd match {
     case Command.Create(templateId, argument) =>
       compileCreate(templateId, SEValue(argument))
@@ -1314,6 +1317,8 @@ final case class Compiler(packages: PackageId PartialFunction Package) {
         choice,
         choiceArg,
       )
+    case Command.LookupByKey(templateId, contractKey) =>
+      compileLookupByKey(templateId, SEValue(contractKey))
   }
 
   private val SEUpdatePureUnit = translate(EUpdate(UpdatePure(TUnit, EUnit)))

--- a/daml-lf/tests/BasicTests.daml
+++ b/daml-lf/tests/BasicTests.daml
@@ -340,6 +340,19 @@ template FetcherByKey
           (_, c) <- fetchByKey @WithKey (p, n)
           pure c
 
+template LookerUpByKey
+  with p: Party
+  where
+    signatory p
+
+    controller p can
+      nonconsuming Lookup : Maybe (ContractId WithKey)
+        with
+          n : Int
+        do
+          lookupByKey @WithKey (p, n)
+
+
 test_failedAuths = scenario do
   alice <- getParty "alice"
   bob <- getParty "bob"


### PR DESCRIPTION
Fixes #5264

CHANGELOG_BEGIN

- [Engine] Support reinterpreting LookupByKey nodes

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
