### PR TITLE
sandbox|kvutils: Use `MetricRegistry.name` to create metric names.

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Metrics.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Metrics.scala
@@ -3,10 +3,12 @@
 
 package com.daml.ledger.participant.state.kvutils.app
 
+import com.codahale.metrics.MetricRegistry
+
 private[app] object Metrics {
 
-  val IndexServicePrefix = "daml.services.index"
-  val ReadServicePrefix = "daml.services.read"
-  val WriteServicePrefix = "daml.services.write"
+  val IndexServicePrefix: String = MetricRegistry.name("daml", "services", "index")
+  val ReadServicePrefix: String = MetricRegistry.name("daml", "services", "read")
+  val WriteServicePrefix: String = MetricRegistry.name("daml", "services", "write")
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -321,28 +321,33 @@ class KeyValueCommitting(metricRegistry: MetricRegistry) {
   }
 
   private object Metrics {
-    private val prefix = "kvutils.committer"
+    private val prefix = MetricRegistry.name("kvutils", "committer")
 
     // Timer (and count) of how fast submissions have been processed.
-    val runTimer: metrics.Timer = metricRegistry.timer(s"$prefix.run_timer")
+    val runTimer: metrics.Timer =
+      metricRegistry.timer(MetricRegistry.name(prefix, "run_timer"))
 
     // Number of exceptions seen.
-    val exceptions: metrics.Counter = metricRegistry.counter(s"$prefix.exceptions")
+    val exceptions: metrics.Counter =
+      metricRegistry.counter(MetricRegistry.name(prefix, "exceptions"))
 
     // Counter to monitor how many at a time and when kvutils is processing a submission.
-    val processing: metrics.Counter = metricRegistry.counter(s"$prefix.processing")
+    val processing: metrics.Counter =
+      metricRegistry.counter(MetricRegistry.name(prefix, "processing"))
 
     val lastRecordTimeGauge = new VarGauge[String]("<none>")
-    metricRegistry.register(s"$prefix.last.record_time", lastRecordTimeGauge)
+    metricRegistry.register(MetricRegistry.name(prefix, "last", "record_time"), lastRecordTimeGauge)
 
     val lastEntryIdGauge = new VarGauge[String]("<none>")
-    metricRegistry.register(s"$prefix.last.entry_id", lastEntryIdGauge)
+    metricRegistry.register(MetricRegistry.name(prefix, "last", "entry_id"), lastEntryIdGauge)
 
     val lastParticipantIdGauge = new VarGauge[String]("<none>")
-    metricRegistry.register(s"$prefix.last.participant_id", lastParticipantIdGauge)
+    metricRegistry.register(
+      MetricRegistry.name(prefix, "last", "participant_id"),
+      lastParticipantIdGauge)
 
     val lastExceptionGauge = new VarGauge[String]("<none>")
-    metricRegistry.register(s"$prefix.last.exception", lastExceptionGauge)
+    metricRegistry.register(MetricRegistry.name(prefix, "last", "exception"), lastExceptionGauge)
   }
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -518,13 +518,16 @@ private[kvutils] class ProcessTransactionSubmission(
   }
 
   private object Metrics {
-    private val prefix = "kvutils.committer.transaction"
-    val runTimer: Timer = metricRegistry.timer(s"$prefix.run_timer")
-    val interpretTimer: Timer = metricRegistry.timer(s"$prefix.interpret_timer")
-    val accepts: Counter = metricRegistry.counter(s"$prefix.accepts")
+    private val prefix = MetricRegistry.name("kvutils", "committer", "transaction")
+    val runTimer: Timer = metricRegistry.timer(MetricRegistry.name(prefix, "run_timer"))
+    val interpretTimer: Timer = metricRegistry.timer(MetricRegistry.name(prefix, "interpret_timer"))
+    val accepts: Counter = metricRegistry.counter(MetricRegistry.name(prefix, "accepts"))
     val rejections: Map[Int, Counter] =
       DamlTransactionRejectionEntry.ReasonCase.values
-        .map(v => v.getNumber -> metricRegistry.counter(s"$prefix.rejections_${v.name}"))
+        .map(
+          v =>
+            v.getNumber -> metricRegistry.counter(
+              MetricRegistry.name(prefix, s"rejections_${v.name}")))
         .toMap
   }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/MetricsNaming.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/MetricsNaming.scala
@@ -5,7 +5,7 @@ package com.digitalasset.platform.apiserver
 
 import com.codahale.metrics.MetricRegistry
 
-object MetricsNaming {
+private[apiserver] object MetricsNaming {
 
   private[this] val capitalization = "[A-Z]+".r
   private[this] val startWordCapitalization = "^[A-Z]+".r
@@ -34,18 +34,24 @@ object MetricsNaming {
   }
 
   // Turns a camelCased string into a snake_cased one
-  private[apiserver] val camelCaseToSnakeCase: String => String =
+  val camelCaseToSnakeCase: String => String =
     snakifyWholeWord andThen snakifyStart andThen snakifyEnd andThen snakify
 
-  // assert(fullServiceName("org.example.SomeService/someMethod") == "daml.lapi.some_service.some_method")
-  private[apiserver] def nameFor(fullMethodName: String): String = {
+  // assert(nameForService("org.example.SomeService") == "daml.lapi.some_service")
+  def nameForService(fullServiceName: String): String = {
+    val serviceName = camelCaseToSnakeCase(fullServiceName.split('.').last)
+    MetricRegistry.name("daml", "lapi", serviceName)
+  }
+
+  // assert(nameFor("org.example.SomeService/someMethod") == "daml.lapi.some_service.some_method")
+  def nameFor(fullMethodName: String): String = {
     val serviceAndMethodName = fullMethodName.split('/')
     assert(
       serviceAndMethodName.length == 2,
       s"Expected service and method names separated by '/', got '$fullMethodName'")
-    val serviceName = camelCaseToSnakeCase(serviceAndMethodName(0).split('.').last)
+    val prefix = nameForService(serviceAndMethodName(0))
     val methodName = camelCaseToSnakeCase(serviceAndMethodName(1))
-    MetricRegistry.name("daml", "lapi", serviceName, methodName)
+    MetricRegistry.name(prefix, methodName)
   }
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -39,20 +39,34 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
     extends ReadOnlyLedger {
 
   private object Metrics {
-    val lookupContract: Timer = metrics.timer("daml.index.lookup_contract")
-    val lookupKey: Timer = metrics.timer("daml.index.lookup_key")
-    val lookupFlatTransactionById: Timer = metrics.timer("daml.index.lookup_flat_transaction_by_id")
-    val lookupTransactionTreeById: Timer = metrics.timer("daml.index.lookup_transaction_tree_by_id")
-    val lookupLedgerConfiguration: Timer = metrics.timer("daml.index.lookup_ledger_configuration")
-    val lookupMaximumLedgerTime: Timer = metrics.timer("daml.index.lookup_maximum_ledger_time")
-    val getParties: Timer = metrics.timer("daml.index.get_parties")
-    val listKnownParties: Timer = metrics.timer("daml.index.list_known_parties")
-    val listLfPackages: Timer = metrics.timer("daml.index.list_lf_packages")
-    val getLfArchive: Timer = metrics.timer("daml.index.get_lf_archive")
-    val getLfPackage: Timer = metrics.timer("daml.index.get_lf_package")
-    val deduplicateCommand: Timer = metrics.timer("daml.index.deduplicate_command")
+    private val prefix: String = MetricRegistry.name("daml", "index")
+
+    val lookupContract: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_contract"))
+    val lookupKey: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_key"))
+    val lookupFlatTransactionById: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_flat_transaction_by_id"))
+    val lookupTransactionTreeById: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_transaction_tree_by_id"))
+    val lookupLedgerConfiguration: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_ledger_configuration"))
+    val lookupMaximumLedgerTime: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_maximum_ledger_time"))
+    val getParties: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "get_parties"))
+    val listKnownParties: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "list_known_parties"))
+    val listLfPackages: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "list_lf_packages"))
+    val getLfArchive: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "get_lf_archive"))
+    val getLfPackage: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "get_lf_package"))
+    val deduplicateCommand: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "deduplicate_command"))
     val removeExpiredDeduplicationData: Timer =
-      metrics.timer("daml.index.remove_expired_deduplication_data")
+      metrics.timer(MetricRegistry.name(prefix, "remove_expired_deduplication_data"))
   }
 
   override def ledgerId: LedgerId = ledger.ledgerId

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -113,11 +113,16 @@ class JdbcIndexer private[indexer] (
   private var lastReceivedOffset: LedgerString = _
 
   object Metrics {
+    private val prefix: String = MetricRegistry.name("daml", "indexer")
 
-    val processedStateUpdatesName = "daml.indexer.processed_state_updates"
-    val lastReceivedRecordTimeName = "daml.indexer.last_received_record_time"
-    val lastReceivedOffsetName = "daml.indexer.last_received_offset"
-    val currentRecordTimeLagName = "daml.indexer.current_record_time_lag"
+    val processedStateUpdatesName: LedgerId =
+      MetricRegistry.name(prefix, "processed_state_updates")
+    val lastReceivedRecordTimeName: LedgerId =
+      MetricRegistry.name(prefix, "last_received_record_time")
+    val lastReceivedOffsetName: LedgerId =
+      MetricRegistry.name(prefix, "last_received_offset")
+    val currentRecordTimeLagName: LedgerId =
+      MetricRegistry.name(prefix, "current_record_time_lag")
 
     val stateUpdateProcessingTimer: Timer = metrics.timer(processedStateUpdatesName)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -295,11 +295,11 @@ final class SandboxServer(
               writeService = new TimedWriteService(
                 indexAndWriteService.writeService,
                 metrics,
-                "daml.sandbox.writeService"),
+                MetricRegistry.name("daml", "services", "write")),
               indexService = new TimedIndexService(
                 indexAndWriteService.indexService,
                 metrics,
-                "daml.sandbox.indexService"),
+                MetricRegistry.name("daml", "services", "index")),
               authorizer = authorizer,
               engine = SandboxServer.engine,
               timeProvider = timeProvider,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/MeteredLedger.scala
@@ -20,11 +20,18 @@ private class MeteredLedger(ledger: Ledger, metrics: MetricRegistry)
     with Ledger {
 
   private object Metrics {
-    val publishHeartbeat: Timer = metrics.timer("daml.index.publish_heartbeat")
-    val publishTransaction: Timer = metrics.timer("daml.index.publish_transaction")
-    val publishPartyAllocation: Timer = metrics.timer("daml.index.publish_party_allocation")
-    val uploadPackages: Timer = metrics.timer("daml.index.upload_packages")
-    val publishConfiguration: Timer = metrics.timer("daml.index.publish_configuration")
+    private val prefix: String = MetricRegistry.name("daml", "index")
+
+    val publishHeartbeat: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "publish_heartbeat"))
+    val publishTransaction: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "publish_transaction"))
+    val publishPartyAllocation: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "publish_party_allocation"))
+    val uploadPackages: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "upload_packages"))
+    val publishConfiguration: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "publish_configuration"))
   }
 
   override def publishHeartbeat(time: Instant): Future[Unit] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -10,6 +10,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.on.sql.Database.InvalidDatabaseException
 import com.daml.ledger.on.sql.SqlLedgerReaderWriter
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
@@ -268,9 +269,9 @@ object Runner {
   private val InMemoryIndexJdbcUrl =
     "jdbc:h2:mem:index;db_close_delay=-1;db_close_on_exit=false"
 
-  private val IndexServicePrefix = "daml.services.index"
-  private val ReadServicePrefix = "daml.services.read"
-  private val WriteServicePrefix = "daml.services.write"
+  private val IndexServicePrefix = MetricRegistry.name("daml", "services", "index")
+  private val ReadServicePrefix = MetricRegistry.name("daml", "services", "read")
+  private val WriteServicePrefix = MetricRegistry.name("daml", "services", "write")
 
   private val HeartbeatInterval: FiniteDuration = 1.second
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/DbDispatcher.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/DbDispatcher.scala
@@ -29,8 +29,16 @@ final class DbDispatcher private (
   private val executionContext = ExecutionContext.fromExecutor(executor)
 
   object Metrics {
-    val waitAllTimer: Timer = metrics.timer("daml.index.db.all.wait")
-    val execAllTimer: Timer = metrics.timer("daml.index.db.all.exec")
+    private val prefix: String = MetricRegistry.name("daml", "index", "db")
+
+    def waitTimer(description: String): Timer =
+      metrics.timer(MetricRegistry.name(prefix, description, "wait"))
+
+    def execTimer(description: String): Timer =
+      metrics.timer(MetricRegistry.name(prefix, description, "exec"))
+
+    val waitAllTimer: Timer = waitTimer("all")
+    val execAllTimer: Timer = execTimer("all")
   }
 
   override def currentHealth(): HealthStatus = connectionProvider.currentHealth()
@@ -44,8 +52,8 @@ final class DbDispatcher private (
       sql: Connection => T
   ): Future[T] = {
     lazy val extraLogMemoized = extraLog
-    val waitTimer = metrics.timer(s"daml.index.db.$description.wait")
-    val execTimer = metrics.timer(s"daml.index.db.$description.exec")
+    val waitTimer = Metrics.waitTimer(description)
+    val execTimer = Metrics.execTimer(description)
     val startWait = System.nanoTime()
     Future {
       val waitNanos = System.nanoTime() - startWait

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/MeteredLedgerDao.scala
@@ -35,22 +35,36 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: MetricRegistry)
     extends LedgerReadDao {
 
   private object Metrics {
-    val lookupLedgerId: Timer = metrics.timer("daml.index.db.lookup_ledger_id")
-    val lookupLedgerEnd: Timer = metrics.timer("daml.index.db.lookup_ledger_end")
-    val lookupLedgerEntry: Timer = metrics.timer("daml.index.db.lookup_ledger_entry")
-    val lookupTransaction: Timer = metrics.timer("daml.index.db.lookup_transaction")
+    private val prefix: String = MetricRegistry.name("daml", "index", "db")
+
+    val lookupLedgerId: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_ledger_id"))
+    val lookupLedgerEnd: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_ledger_end"))
+    val lookupLedgerEntry: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_ledger_entry"))
+    val lookupTransaction: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_transaction"))
     val lookupLedgerConfiguration: Timer =
-      metrics.timer("daml.index.db.lookup_ledger_configuration")
-    val lookupKey: Timer = metrics.timer("daml.index.db.lookup_key")
-    val lookupActiveContract: Timer = metrics.timer("daml.index.db.lookup_active_contract")
-    val lookupMaximumLedgerTime: Timer = metrics.timer("daml.index.db.lookup_maximum_ledger_time")
-    val getParties: Timer = metrics.timer("daml.index.db.get_parties")
-    val listKnownParties: Timer = metrics.timer("daml.index.db.list_known_parties")
-    val listLfPackages: Timer = metrics.timer("daml.index.db.list_lf_packages")
-    val getLfArchive: Timer = metrics.timer("daml.index.db.get_lf_archive")
-    val deduplicateCommand: Timer = metrics.timer("daml.index.db.deduplicate_command")
+      metrics.timer(MetricRegistry.name(prefix, "lookup_ledger_configuration"))
+    val lookupKey: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_key"))
+    val lookupActiveContract: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_active_contract"))
+    val lookupMaximumLedgerTime: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "lookup_maximum_ledger_time"))
+    val getParties: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "get_parties"))
+    val listKnownParties: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "list_known_parties"))
+    val listLfPackages: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "list_lf_packages"))
+    val getLfArchive: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "get_lf_archive"))
+    val deduplicateCommand: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "deduplicate_command"))
     val removeExpiredDeduplicationData: Timer =
-      metrics.timer("daml.index.db.remove_expired_deduplication_data")
+      metrics.timer(MetricRegistry.name(prefix, "remove_expired_deduplication_data"))
   }
 
   override def maxConcurrentConnections: Int = ledgerDao.maxConcurrentConnections
@@ -154,11 +168,18 @@ class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: MetricRegistry)
     with LedgerDao {
 
   private object Metrics {
-    val storePartyEntry: Timer = metrics.timer("daml.index.db.store_party_entry")
-    val storeInitialState: Timer = metrics.timer("daml.index.db.store_initial_state")
-    val storePackageEntry: Timer = metrics.timer("daml.index.db.store_package_entry")
-    val storeLedgerEntry: Timer = metrics.timer("daml.index.db.store_ledger_entry")
-    val storeConfigurationEntry: Timer = metrics.timer("daml.index.db.store_configuration_entry")
+    private val prefix: String = MetricRegistry.name("daml", "index", "db")
+
+    val storePartyEntry: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "store_party_entry"))
+    val storeInitialState: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "store_initial_state"))
+    val storePackageEntry: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "store_package_entry"))
+    val storeLedgerEntry: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "store_ledger_entry"))
+    val storeConfigurationEntry: Timer =
+      metrics.timer(MetricRegistry.name(prefix, "store_configuration_entry"))
   }
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/apiserver/MetricsNamingSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/apiserver/MetricsNamingSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 final class MetricsNamingSpec extends FlatSpec with Matchers {
 
-  behavior of "ApiMetricsNaming.camelCaseToSnakeCase"
+  behavior of "MetricsNaming.camelCaseToSnakeCase"
 
   import MetricsNaming.camelCaseToSnakeCase
 
@@ -49,11 +49,21 @@ final class MetricsNamingSpec extends FlatSpec with Matchers {
     camelCaseToSnakeCase("AJVMHeap") shouldBe "ajvm_heap"
   }
 
-  behavior of "ApiMetricsNaming.nameFor"
+  behavior of "MetricsNaming.nameForService"
+
+  import MetricsNaming.nameForService
+
+  behavior of "MetricsNaming.nameFor"
+
+  it should "produce the expected name for a selection of services" in {
+    nameForService(CommandServiceGrpc.javaDescriptor.getFullName) shouldBe "daml.lapi.command_service"
+    nameForService(CommandSubmissionServiceGrpc.javaDescriptor.getFullName) shouldBe "daml.lapi.command_submission_service"
+    nameForService(ActiveContractsServiceGrpc.javaDescriptor.getFullName) shouldBe "daml.lapi.active_contracts_service"
+  }
 
   import MetricsNaming.nameFor
 
-  it should "produce the expected name for a selection of services" in {
+  it should "produce the expected name for a selection of service methods" in {
     nameFor(CommandServiceGrpc.METHOD_SUBMIT_AND_WAIT.getFullMethodName) shouldBe "daml.lapi.command_service.submit_and_wait"
     nameFor(CommandSubmissionServiceGrpc.METHOD_SUBMIT.getFullMethodName) shouldBe "daml.lapi.command_submission_service.submit"
     nameFor(ActiveContractsServiceGrpc.METHOD_GET_ACTIVE_CONTRACTS.getFullMethodName) shouldBe "daml.lapi.active_contracts_service.get_active_contracts"


### PR DESCRIPTION
String interpolation is 4TL.

### Changelog

- **[Sandbox]** Move the service metrics from `daml.sandbox.indexService` and `daml.sandbox.writeService` to `daml.services.index` and `daml.services.write` respectively. This brings Sandbox in line with the Ledger Integration Kit.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
