### PR TITLE
Engine: ensure freshness of local cid discriminator

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Bytes.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Bytes.scala
@@ -22,6 +22,8 @@ final class Bytes private (protected val value: ByteString) extends AnyVal {
 
   def isEmpty: Boolean = value.isEmpty
 
+  def nonEmpty: Boolean = !value.isEmpty
+
   def toHexString: Ref.HexString = Ref.HexString.encode(this)
 
   def startsWith(prefix: Bytes): Boolean = value.startsWith(prefix.value)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -815,6 +815,13 @@ object SBuiltin {
         )
         .fold(err => throw DamlETransactionError(err), identity)
 
+      coid match {
+        case V.AbsoluteContractId.V1(discriminator, _)
+            if machine.ptx.globalContracts.isDefinedAt(discriminator) =>
+          crash(s"The local contract discriminator $discriminator is not fresh in the transaction")
+        case _ =>
+      }
+
       machine.ptx = newPtx
       machine.ctrl = CtrlValue(SContractId(coid))
       checkAborted(machine.ptx)
@@ -1006,9 +1013,14 @@ object SBuiltin {
       }
       val coinst =
         machine.ptx
-          .lookupLocalContract(coid)
+          .lookupCachedContract(coid)
           .getOrElse(
             coid match {
+              case V.AbsoluteContractId.V1(discriminator, _)
+                  if machine.ptx.localContracts.isDefinedAt(
+                    V.AbsoluteContractId.V1(discriminator)) =>
+                crash(
+                  s"The local contract discriminator $discriminator is not fresh in the transaction")
               case acoid: V.AbsoluteContractId =>
                 throw SpeedyHungry(
                   SResultNeedContract(
@@ -1025,6 +1037,7 @@ object SBuiltin {
                           machine.ctrl =
                             CtrlWronglyTypeContractId(acoid, templateId, coinst.template)
                         } else {
+                          machine.ptx = machine.ptx.cachedContract(coid, coinst)
                           machine.ctrl = translateValue(machine, coinst.arg.value)
                         }
                     },

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -125,7 +125,7 @@ object PartialTransaction {
   *              correct semantics, since otherwise lookups for keys for
   *              locally archived absolute contract ids will succeed wrongly.
   * @param localContracts A map that associates to each contract created the
-  *                      contract the node in which it was created.
+  *                      node in which it was created.
   * @param globalContracts A map that associates to each fetched AbsoluteContractId.V1
   *                       contract id its respective contract instance.
   *                       other format of contract ids are not cached.
@@ -243,7 +243,7 @@ case class PartialTransaction(
         copy(
           globalContracts = globalContracts.updated(
             discriminator,
-            globalContracts.getOrElse(discriminator, Map(suffix -> contract))))
+            globalContracts.getOrElse(discriminator, Map.empty) + (suffix -> contract))
       case _ =>
         this
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -243,7 +243,9 @@ case class PartialTransaction(
         copy(
           globalContracts = globalContracts.updated(
             discriminator,
-            globalContracts.getOrElse(discriminator, Map.empty) + (suffix -> contract))
+            globalContracts.getOrElse(discriminator, Map.empty).updated(suffix, contract)
+          )
+        )
       case _ =>
         this
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -5,7 +5,7 @@ package com.digitalasset.daml.lf
 package speedy
 
 import com.digitalasset.daml.lf.data.Ref.{ChoiceName, Location, Party, TypeConName}
-import com.digitalasset.daml.lf.data.{BackStack, ImmArray, Time}
+import com.digitalasset.daml.lf.data.{BackStack, Bytes, ImmArray, Time}
 import com.digitalasset.daml.lf.transaction.{GenTransaction, Node, Transaction => Tx}
 import com.digitalasset.daml.lf.value.Value
 
@@ -96,6 +96,7 @@ object PartialTransaction {
       aborted = None,
       keys = Map.empty,
       localContracts = Map.empty,
+      globalContracts = Map.empty,
     )
 
 }
@@ -123,6 +124,11 @@ object PartialTransaction {
   *              we archive. This is not an optimization and is required for
   *              correct semantics, since otherwise lookups for keys for
   *              locally archived absolute contract ids will succeed wrongly.
+  * @param localContracts A map that associates to each contract created the
+  *                      contract the node in which it was created.
+  * @param globalContracts A map that associates to each fetched AbsoluteContractId.V1
+  *                       contract id its respective contract instance.
+  *                       other format of contract ids are not cached.
   */
 case class PartialTransaction(
     submissionTime: Option[Time.Timestamp],
@@ -132,7 +138,8 @@ case class PartialTransaction(
     context: PartialTransaction.Context,
     aborted: Option[Tx.TransactionError],
     keys: Map[Node.GlobalKey, Option[Value.ContractId]],
-    localContracts: Map[Value.ContractId, Value.NodeId]
+    localContracts: Map[Value.ContractId, Value.NodeId],
+    globalContracts: Map[crypto.Hash, Map[Bytes, Tx.ContractInst[Value.ContractId]]],
 ) {
 
   import PartialTransaction._
@@ -194,13 +201,9 @@ case class PartialTransaction(
         Left(this)
     }
 
-  /** Lookup the contract associated to 'Value.RelativeContractId'.
-    * Return the contract instance and the node in which it was
-    * consumed if any.
-    */
-  def lookupLocalContract(
+  private def lookupLocalContract(
       lcoid: Value.ContractId,
-  ): Option[Value.ContractInst[Tx.Value[Value.ContractId]]] =
+  ): Option[Tx.ContractInst[Value.ContractId]] =
     for {
       nid <- localContracts.get(lcoid)
       node <- nodes.get(nid)
@@ -213,11 +216,43 @@ case class PartialTransaction(
       }
     } yield coinst
 
+  private def lookupGlobalContract(
+      gcoid: Value.ContractId
+  ): Option[Tx.ContractInst[Value.ContractId]] =
+    gcoid match {
+      case Value.AbsoluteContractId.V1(discriminator, suffix) =>
+        globalContracts.get(discriminator).flatMap(_.get(suffix))
+      case _ =>
+        None
+    }
+
+  def lookupCachedContract(
+      coid: Value.ContractId
+  ): Option[Tx.ContractInst[Value.ContractId]] =
+    lookupLocalContract(coid).orElse(lookupGlobalContract(coid))
+
+  /** Update the globalContract if coid is an `Value.AbsoluteContractId.V1`,
+    *  idempotent otherwise.
+    */
+  def cachedContract(
+      coid: Value.ContractId,
+      contract: Tx.ContractInst[Value.ContractId]
+  ): PartialTransaction =
+    coid match {
+      case Value.AbsoluteContractId.V1(discriminator, suffix) =>
+        copy(
+          globalContracts = globalContracts.updated(
+            discriminator,
+            globalContracts.getOrElse(discriminator, Map(suffix -> contract))))
+      case _ =>
+        this
+    }
+
   /** Extend the 'PartialTransaction' with a node for creating a
     * contract instance.
     */
   def insertCreate(
-      coinst: Value.ContractInst[Tx.Value[Value.ContractId]],
+      coinst: Tx.ContractInst[Value.ContractId],
       optLocation: Option[Location],
       signatories: Set[Party],
       stakeholders: Set[Party],

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -366,6 +366,8 @@ object Transaction {
 
   type Value[+Cid] = Value.VersionedValue[Cid]
 
+  type ContractInst[+Cid] = Value.ContractInst[Value[Cid]]
+
   /** Transaction nodes */
   type Node = GenNode.WithTxValue[NodeId, TContractId]
   type LeafNode = LeafOnlyNode.WithTxValue[TContractId]


### PR DESCRIPTION
Following @andreaslochbihler-da suggestion we check freshness of contract id discriminator when fetching or creating contract. 

Additionally, we cache in the engine the fetched contracts.
 
This advances the state of #3830.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
