### PR TITLE
Change withEnv to not clear the whole env

### DIFF
--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -33,7 +33,9 @@ import qualified Data.Conduit.Tar as Tar
 -- unix specific
 import System.PosixCompat.Files (createSymbolicLink)
 
--- | Replace all environment variables for test action, then restore them.
+-- | Set the given environment variables, then restore them.
+-- Envirnoment variables not in the given list are unmodified.
+--
 -- Avoids System.Environment.setEnv because it treats empty strings as
 -- "delete environment variable", unlike main-tester's withEnv which
 -- consequently conflates (Just "") with Nothing.
@@ -41,11 +43,7 @@ withEnv :: [(String, Maybe String)] -> IO t -> IO t
 withEnv vs m = bracket pushEnv popEnv (const m)
     where
         pushEnv :: IO [(String, Maybe String)]
-        pushEnv = do
-            oldEnv <- getEnvironment
-            let ks  = map fst vs
-                vs' = [(key, Nothing)  | (key, _) <- oldEnv, key `notElem` ks] ++ vs
-            replaceEnv vs'
+        pushEnv = replaceEnv vs
 
         popEnv :: [(String, Maybe String)] -> IO ()
         popEnv vs' = void $ replaceEnv vs'


### PR DESCRIPTION
The way we use `withEnv` it is really intended to set a few
environment variables in an already existing environment instead of
clearing everything before. This PR changes it to do only that.

changelog_begin
changelog_end

closes #5280

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
