### PR TITLE
TypeScript libs: Enforce return type annotations

### DIFF
--- a/language-support/ts/daml-ledger/package.json
+++ b/language-support/ts/daml-ledger/package.json
@@ -47,7 +47,6 @@
     ],
     "rules": {
       "@typescript-eslint/no-floating-promises": "error",
-      "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-inferrable-types": "off"
     }
   },

--- a/language-support/ts/daml-react/package.json
+++ b/language-support/ts/daml-react/package.json
@@ -45,7 +45,6 @@
     ],
     "rules": {
       "@typescript-eslint/no-floating-promises": "error",
-      "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-inferrable-types": "off"
     }
   },

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -68,7 +68,7 @@ const registeredTemplates: {[key: string]: Template<object>} = {};
 /**
  * @internal
  */
-export const registerTemplate = <T extends object>(template: Template<T>) => {
+export const registerTemplate = <T extends object>(template: Template<T>): void => {
   const templateId = template.templateId;
   const oldTemplate = registeredTemplates[templateId];
   if (oldTemplate === undefined) {
@@ -211,7 +211,7 @@ export type List<T> = T[];
  * Companion object of the [[List]] type.
  */
 export const List = <T>(t: Serializable<T>): Serializable<T[]> => ({
-  decoder: () => jtv.array(t.decoder()),
+  decoder: (): jtv.Decoder<T[]> => jtv.array(t.decoder()),
 });
 
 /**
@@ -323,7 +323,7 @@ export type TextMap<T> = { [key: string]: T };
  * Companion object of the [[TextMap]] type.
  */
 export const TextMap = <T>(t: Serializable<T>): Serializable<TextMap<T>> => ({
-  decoder: () => jtv.dict(t.decoder()),
+  decoder: (): jtv.Decoder<TextMap<T>> => jtv.dict(t.decoder()),
 });
 
 // TODO(MH): `Map` type.

--- a/language-support/ts/daml-types/package.json
+++ b/language-support/ts/daml-types/package.json
@@ -38,7 +38,6 @@
     ],
     "rules": {
       "@typescript-eslint/no-floating-promises": "error",
-      "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-inferrable-types": "off",
       "@typescript-eslint/no-unnecessary-type-assertion": "off"
     }


### PR DESCRIPTION
For some reason the lint that catches missing return type annotations
was turned off. It's turned on now.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5287)
<!-- Reviewable:end -->
