### PR TITLE
Error and disconnect when multiple requests coming over the same WebSocket connection

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1069,6 +1069,8 @@ JavaScript/Node.js example demonstrating how to establish Streaming API connecti
       console.log(data);
     });
 
+Please note that Streaming API does not allow multiple requests over the same WebSocket connection. The server returns an error and disconnects if second request received over the same WebSocket connection.
+
 Error and Warning Reporting
 ===========================
 
@@ -1090,6 +1092,11 @@ Examples:
 
     {
       "errors":["JsonReaderError. Cannot read JSON: <{\"templateIds\":[]}>. Cause: spray.json.DeserializationException: search requires at least one item in 'templateIds'"],
+      "status":400
+    }
+
+    {
+      "errors":["Multiple requests over the same WebSocket connection are not allowed."],
       "status":400
     }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -345,17 +345,7 @@ class WebSocketService(
   ): Flow[Message, Message, NotUsed] = {
     val Q = implicitly[StreamQueryReader[A]]
     Flow[Message]
-      .mapAsync(1) {
-        case msg: TextMessage =>
-          msg.toStrict(config.maxDuration).map { m =>
-            SprayJson.parse(m.text).liftErr(InvalidUserInput)
-          }
-        case bm: BinaryMessage =>
-          // ignore binary messages but drain content to avoid the stream being clogged
-          discard { bm.dataStream.runWith(Sink.ignore) }
-          Future successful -\/(InvalidUserInput(
-            "Invalid request. Expected a single TextMessage with JSON payload, got BinaryMessage"))
-      }
+      .mapAsync(1)(parseJson)
       .via(withOptPrefix(ejv => ejv.toOption flatMap readStartingOffset))
       .map {
         case (oeso, ejv) =>
@@ -367,23 +357,40 @@ class WebSocketService(
       }
       .via(allowOnlyFirstInput(
         InvalidUserInput("Multiple requests over the same WebSocket connection are not allowed.")))
-      .flatMapMerge(
-        2,
-        x =>
-          x.flatMap {
-              case (offPrefix, qq: Q.Query[q]) =>
-                implicit val SQ: StreamQuery[q] = qq.alg
-                getTransactionSourceForParty[q](jwt, jwtPayload, offPrefix, qq.q: q)
-            }
-            .fold(e => Source.single(-\/(e)), s => s.map(\/-(_))): Source[Error \/ Message, NotUsed]
-      )
+      .flatMapMerge(2, x => sourceFromQuery(Q)(x)(jwt, jwtPayload))
       .takeWhile(_.isRight, inclusive = true) // stop after emitting 1st error
       .map(_.fold(e => wsErrorMessage(e), identity): Message)
   }
 
+  private def parseJson(x: Message): Future[InvalidUserInput \/ JsValue] = x match {
+    case msg: TextMessage =>
+      msg.toStrict(config.maxDuration).map { m =>
+        SprayJson.parse(m.text).liftErr(InvalidUserInput)
+      }
+    case bm: BinaryMessage =>
+      // ignore binary messages but drain content to avoid the stream being clogged
+      discard { bm.dataStream.runWith(Sink.ignore) }
+      Future successful -\/(
+        InvalidUserInput(
+          "Invalid request. Expected a single TextMessage with JSON payload, got BinaryMessage"))
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
+  private def sourceFromQuery[A](Q: StreamQueryReader[A])(
+      x: Error \/ (Option[domain.StartingOffset], Q.Query[_]))(
+      jwt: Jwt,
+      jwtPayload: JwtPayload
+  ): Source[Error \/ Message, NotUsed] =
+    x.flatMap {
+        case (offPrefix, qq: Q.Query[q]) =>
+          implicit val SQ: StreamQuery[q] = qq.alg
+          getTransactionSourceForParty[q](jwt, jwtPayload.party, offPrefix, qq.q: q)
+      }
+      .fold(e => Source.single(-\/(e)), s => s.map(\/-(_)))
+
   private def getTransactionSourceForParty[A: StreamQuery](
       jwt: Jwt,
-      jwtPayload: JwtPayload,
+      party: domain.Party,
       offPrefix: Option[domain.StartingOffset],
       request: A): Error \/ Source[Message, NotUsed] = {
     val Q = implicitly[StreamQuery[A]]
@@ -392,7 +399,7 @@ class WebSocketService(
 
     if (resolved.nonEmpty) {
       val source = contractsService
-        .insertDeleteStepSource(jwt, jwtPayload.party, resolved.toList, offPrefix, Terminates.Never)
+        .insertDeleteStepSource(jwt, party, resolved.toList, offPrefix, Terminates.Never)
         .via(convertFilterContracts(fn))
         .filter(_.nonEmpty)
         .via(removePhantomArchives(remove = Q.removePhantomArchives(request)))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/FlowUtil.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/FlowUtil.scala
@@ -11,7 +11,6 @@ object FlowUtil {
   def allowOnlyFirstInput[E, A](error: => E): Flow[E \/ A, E \/ A, NotUsed] =
     Flow[E \/ A]
       .scan(Option.empty[E \/ A]) { (s0, x) =>
-        println(s"-------- $s0, $x")
         s0 match {
           case Some(_) =>
             Some(-\/(error))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/FlowUtil.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/FlowUtil.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.http.util

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/FlowUtil.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/FlowUtil.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.http.util
+
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
+import scalaz.{-\/, \/}
+
+object FlowUtil {
+  def allowOnlyFirstInput[E, A](error: => E): Flow[E \/ A, E \/ A, NotUsed] =
+    Flow[E \/ A]
+      .scan(Option.empty[E \/ A]) { (s0, x) =>
+        println(s"-------- $s0, $x")
+        s0 match {
+          case Some(_) =>
+            Some(-\/(error))
+          case None =>
+            Some(x)
+        }
+      }
+      .collect {
+        case Some(x) => x
+      }
+}

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
@@ -82,7 +82,8 @@ class WebsocketServiceIntegrationTest
         )._1 flatMap (x => x.response.status shouldBe StatusCodes.Unauthorized)
     }
 
-    s"two ${scenario.id} requests over the same WebSocket connection are NOT allowed" ignore withHttpService {
+/*
+    s"two ${scenario.id} requests over the same WebSocket connection are NOT allowed" in withHttpService {
       (uri, _, _) =>
         val input = scenario.input.mapConcat(x => List(x, x))
         val webSocketFlow =
@@ -101,6 +102,7 @@ class WebsocketServiceIntegrationTest
             }
           }
     }
+ */
   }
 
   private val collectResultsAsTextMessageSkipOffsetTicks: Sink[Message, Future[Seq[String]]] =

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
@@ -41,27 +41,28 @@ class WebsocketServiceIntegrationTest
 
   private val headersWithAuth = List(Authorization(OAuth2BearerToken(jwt.value)))
 
-  private val baseQueryFlow: Flow[Message, Message, NotUsed] =
-    Flow.fromSinkAndSource(Sink.foreach(println), Source.single(TextMessage.Strict("{}")))
+  private val baseQueryInput: Source[Message, NotUsed] =
+    Source.single(TextMessage.Strict("{}"))
 
   private val fetchRequest =
     """[{"templateId": "Account:Account", "key": ["Alice", "abc123"]}]"""
 
-  private val baseFetchFlow: Flow[Message, Message, NotUsed] =
-    Flow.fromSinkAndSource(Sink.foreach(println), Source.single(TextMessage.Strict(fetchRequest)))
+  private val baseFetchInput: Source[Message, NotUsed] =
+    Source.single(TextMessage.Strict(fetchRequest))
 
   private val validSubprotocol = Option(s"""$tokenPrefix${jwt.value},$wsProtocol""")
 
   List(
-    SimpleScenario("query", Uri.Path("/v1/stream/query"), baseQueryFlow),
-    SimpleScenario("fetch", Uri.Path("/v1/stream/fetch"), baseFetchFlow)
+    SimpleScenario("query", Uri.Path("/v1/stream/query"), baseQueryInput),
+    SimpleScenario("fetch", Uri.Path("/v1/stream/fetch"), baseFetchInput)
   ).foreach { scenario =>
     s"${scenario.id} request with valid protocol token should allow client subscribe to stream" in withHttpService {
       (uri, _, _) =>
         wsConnectRequest(
           uri.copy(scheme = "ws").withPath(scenario.path),
           validSubprotocol,
-          scenario.flow)._1 flatMap (x => x.response.status shouldBe StatusCodes.SwitchingProtocols)
+          scenario.input)._1 flatMap (x =>
+          x.response.status shouldBe StatusCodes.SwitchingProtocols)
     }
 
     s"${scenario.id} request with invalid protocol token should be denied" in withHttpService {
@@ -69,8 +70,7 @@ class WebsocketServiceIntegrationTest
         wsConnectRequest(
           uri.copy(scheme = "ws").withPath(scenario.path),
           Option("foo"),
-          scenario.flow
-        )._1 flatMap (x => x.response.status shouldBe StatusCodes.Unauthorized)
+          scenario.input)._1 flatMap (x => x.response.status shouldBe StatusCodes.Unauthorized)
     }
 
     s"${scenario.id} request without protocol token should be denied" in withHttpService {
@@ -78,15 +78,37 @@ class WebsocketServiceIntegrationTest
         wsConnectRequest(
           uri.copy(scheme = "ws").withPath(scenario.path),
           None,
-          scenario.flow
+          scenario.input
         )._1 flatMap (x => x.response.status shouldBe StatusCodes.Unauthorized)
     }
+
+//    s"two ${scenario.id} requests over the same WebSocket connection are NOT allowed" ignore withHttpService {
+//      (uri, _, _) =>
+//        val inputFlow = scenario.flow.mapConcat(x => List(x, x))
+//        val webSocketFlow =
+//          Http().webSocketClientFlow(
+//            WebSocketRequest(
+//              uri = uri.copy(scheme = "ws").withPath(scenario.path),
+//              subprotocol = validSubprotocol))
+
+//        wsConnectRequest(uri.copy(scheme = "ws").withPath(scenario.path), validSubprotocol, flow)._1 flatMap {
+//          x =>
+//            x.response.status shouldBe StatusCodes.BadRequest
+//            flow.toMat(collectResultsAsTextMessageSkipOffsetTicks)(Keep.right).flatMap { msgs =>
+//              inside(msgs) {
+//                case Seq(errorMsg) =>
+//                  val error = decodeErrorResponse(errorMsg)
+//                  error.status shouldBe StatusCodes.BadRequest
+//              }
+//            }
+//        }
+//    }
   }
 
-  private val collectResultsAsTextMessageSkipHeartbeats: Sink[Message, Future[Seq[String]]] =
+  private val collectResultsAsTextMessageSkipOffsetTicks: Sink[Message, Future[Seq[String]]] =
     Flow[Message]
       .collect { case m: TextMessage => m.getStrictText }
-      .filterNot(isHeartbeat)
+      .filterNot(isOffsetTick)
       .toMat(Sink.seq)(Keep.right)
 
   private val collectResultsAsTextMessage: Sink[Message, Future[Seq[String]]] =
@@ -213,7 +235,7 @@ class WebsocketServiceIntegrationTest
   "query endpoint should send error msg when receiving malformed message" in withHttpService {
     (uri, _, _) =>
       val clientMsg = singleClientQueryStream(uri, "{}")
-        .runWith(collectResultsAsTextMessageSkipHeartbeats)
+        .runWith(collectResultsAsTextMessageSkipOffsetTicks)
 
       val result = Await.result(clientMsg, 10.seconds)
 
@@ -226,7 +248,7 @@ class WebsocketServiceIntegrationTest
   "fetch endpoint should send error msg when receiving malformed message" in withHttpService {
     (uri, _, _) =>
       val clientMsg = singleClientFetchStream(uri, """[abcdefg!]""")
-        .runWith(collectResultsAsTextMessageSkipHeartbeats)
+        .runWith(collectResultsAsTextMessageSkipOffsetTicks)
 
       val result = Await.result(clientMsg, 10.seconds)
 
@@ -451,7 +473,7 @@ class WebsocketServiceIntegrationTest
   "fetch should should return an error if empty list of (templateId, key) pairs is passed" in withHttpService {
     (uri, _, _) =>
       singleClientFetchStream(uri, "[]")
-        .runWith(collectResultsAsTextMessageSkipHeartbeats)
+        .runWith(collectResultsAsTextMessageSkipOffsetTicks)
         .map { clientMsgs =>
           inside(clientMsgs) {
             case Seq(errorMsg) =>
@@ -507,8 +529,11 @@ class WebsocketServiceIntegrationTest
   private def wsConnectRequest[M](
       uri: Uri,
       subprotocol: Option[String],
-      flow: Flow[Message, Message, M]) =
-    Http().singleWebSocketRequest(WebSocketRequest(uri = uri, subprotocol = subprotocol), flow)
+      input: Source[Message, NotUsed]) =
+    Http().singleWebSocketRequest(
+      request = WebSocketRequest(uri = uri, subprotocol = subprotocol),
+      clientFlow = dummyFlow(input)
+    )
 
   private val parseResp: Flow[Message, JsValue, NotUsed] = {
     import spray.json._
@@ -548,7 +573,7 @@ class WebsocketServiceIntegrationTest
         }
     }
 
-  private def isHeartbeat(str: String): Boolean =
+  private def isOffsetTick(str: String): Boolean =
     SprayJson
       .decode[EventsBlock](str)
       .map { b =>
@@ -574,6 +599,10 @@ object WebsocketServiceIntegrationTest {
   import spray.json._
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
+  def dummyFlow[A](source: Source[A, NotUsed]): Flow[A, A, NotUsed] =
+    Flow.fromSinkAndSource(Sink.foreach(println), source)
+
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
   private def foldWhile[S, A, T](zero: S)(f: (S, A) => (S \/ T)): Sink[A, Future[Option[T]]] =
     Flow[A]
       .scan(-\/(zero): S \/ T)((st, a) =>
@@ -586,10 +615,7 @@ object WebsocketServiceIntegrationTest {
 
   private val contractIdAtOffsetKey = "contractIdAtOffset"
 
-  private case class SimpleScenario(
-      id: String,
-      path: Uri.Path,
-      flow: Flow[Message, Message, NotUsed])
+  private case class SimpleScenario(id: String, path: Uri.Path, input: Source[Message, NotUsed])
 
   private sealed abstract class StreamState extends Product with Serializable
   private case object NothingYet extends StreamState

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
@@ -42,7 +42,7 @@ class WebsocketServiceIntegrationTest
   private val headersWithAuth = List(Authorization(OAuth2BearerToken(jwt.value)))
 
   private val baseQueryInput: Source[Message, NotUsed] =
-    Source.single(TextMessage.Strict("{}"))
+    Source.single(TextMessage.Strict("""{"templateIds": ["Account:Account"]}"""))
 
   private val fetchRequest =
     """[{"templateId": "Account:Account", "key": ["Alice", "abc123"]}]"""
@@ -82,7 +82,6 @@ class WebsocketServiceIntegrationTest
         )._1 flatMap (x => x.response.status shouldBe StatusCodes.Unauthorized)
     }
 
-/*
     s"two ${scenario.id} requests over the same WebSocket connection are NOT allowed" in withHttpService {
       (uri, _, _) =>
         val input = scenario.input.mapConcat(x => List(x, x))
@@ -98,11 +97,13 @@ class WebsocketServiceIntegrationTest
             inside(msgs) {
               case Seq(errorMsg) =>
                 val error = decodeErrorResponse(errorMsg)
-                error.status shouldBe StatusCodes.BadRequest
+                error shouldBe domain.ErrorResponse(
+                  List("Multiple requests over the same WebSocket connection are not allowed."),
+                  StatusCodes.BadRequest
+                )
             }
           }
     }
- */
   }
 
   private val collectResultsAsTextMessageSkipOffsetTicks: Sink[Message, Future[Seq[String]]] =

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
@@ -24,7 +24,7 @@ class FlowUtilTest
   implicit val asys: ActorSystem = ActorSystem(this.getClass.getSimpleName)
   implicit val materializer: Materializer = Materializer(asys)
 
-  "allowOnlyFirstInput" should "pass 1st inbound message all other replaced with error" in forAll {
+  "allowOnlyFirstInput" should "pass 1st message through and replace all others with errors" in forAll {
     xs: Vector[Int] =>
       val error = "Error"
       val errorNum = Math.max(xs.size - 1, 0)

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.digitalasset.http.util

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 The DAML Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.http.util
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import scalaz.{-\/, \/, \/-}
+
+import scala.concurrent.Future
+
+class FlowUtilTest
+    extends FlatSpec
+    with ScalaFutures
+    with Matchers
+    with GeneratorDrivenPropertyChecks {
+  import FlowUtil._
+
+  implicit val asys: ActorSystem = ActorSystem(this.getClass.getSimpleName)
+  implicit val materializer: Materializer = Materializer(asys)
+
+  "allowOnlyFirstInput" should "pass 1st inbound message all other replaced with error" in forAll {
+    xs: Vector[Int] =>
+      val error = "Error"
+      val errorNum = Math.max(xs.size - 1, 0)
+      val expected: Vector[String \/ Int] =
+        xs.take(1).map(\/-(_)) ++ Vector.fill(errorNum)(-\/(error))
+      val input: Source[String \/ Int, NotUsed] =
+        Source.fromIterator(() => xs.toIterator).map(\/-(_))
+
+      val actualF: Future[Vector[String \/ Int]] =
+        input
+          .via(allowOnlyFirstInput[String, Int](error))
+          .runFold(Vector.empty[String \/ Int])(_ :+ _)
+
+      whenReady(actualF) { actual =>
+        actual shouldBe expected
+      }
+  }
+}


### PR DESCRIPTION
Related to: #4521

This PR addresses:
> 4. We should send an error message for each request that gets sent after the first request.

with minor "change"... we also **drop** the connection after emitting the error.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
