### PR TITLE
kvutils: Prefix metrics with "daml.".

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -321,7 +321,7 @@ class KeyValueCommitting(metricRegistry: MetricRegistry) {
   }
 
   private object Metrics {
-    private val prefix = MetricRegistry.name("kvutils", "committer")
+    private val prefix = MetricRegistry.name("daml", "kvutils", "committer")
 
     // Timer (and count) of how fast submissions have been processed.
     val runTimer: metrics.Timer =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
@@ -149,7 +149,8 @@ class KeyValueSubmission(metricRegistry: MetricRegistry) {
   def unpackDamlSubmission(bytes: ByteString): DamlSubmission = DamlSubmission.parseFrom(bytes)
 
   object Metrics {
-    private val prefix = MetricRegistry.name("kvutils", "submission", "conversion")
+    private val prefix = MetricRegistry.name("daml", "kvutils", "submission", "conversion")
+
     val transactionOutputs: Timer =
       metricRegistry.timer(MetricRegistry.name(prefix, "transaction_outputs"))
     val transactionToSubmission: Timer =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -51,7 +51,7 @@ private[committer] trait Committer[Submission, PartialResult] {
   protected val metricRegistry: metrics.MetricRegistry
 
   protected def metricsName(metric: String): String =
-    metrics.MetricRegistry.name("kvutils", "committer", committerName, metric)
+    metrics.MetricRegistry.name("daml", "kvutils", "committer", committerName, metric)
 
   // These timers are lazy because they rely on `committerName`, which is defined in the subclass
   // and therefore not set at object initialization.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -518,7 +518,8 @@ private[kvutils] class ProcessTransactionSubmission(
   }
 
   private object Metrics {
-    private val prefix = MetricRegistry.name("kvutils", "committer", "transaction")
+    private val prefix = MetricRegistry.name("daml", "kvutils", "committer", "transaction")
+
     val runTimer: Timer = metricRegistry.timer(MetricRegistry.name(prefix, "run_timer"))
     val interpretTimer: Timer = metricRegistry.timer(MetricRegistry.name(prefix, "interpret_timer"))
     val accepts: Counter = metricRegistry.counter(MetricRegistry.name(prefix, "accepts"))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -228,8 +228,10 @@ class SubmissionValidator[LogResult](
     }
 
   object Metrics {
-    private val prefix = MetricRegistry.name("kvutils", "submission", "validator")
-    val openEnvelope: Timer = metricRegistry.timer(MetricRegistry.name(prefix, "open_envelope"))
+    private val prefix = MetricRegistry.name("daml", "kvutils", "submission", "validator")
+
+    val openEnvelope: Timer =
+      metricRegistry.timer(MetricRegistry.name(prefix, "open_envelope"))
     val validateSubmission: Timer =
       metricRegistry.timer(MetricRegistry.name(prefix, "validate_submission"))
     val processSubmission: Timer =

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsConfigSpec.scala
@@ -163,9 +163,9 @@ class KVUtilsConfigSpec extends WordSpec with Matchers {
         }, submissionId = Ref.LedgerString.assertFromString("submission-id-1"))
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
-        metricRegistry.counter("kvutils.committer.config.accepts").getCount should be >= 1L
-        metricRegistry.counter("kvutils.committer.config.rejections").getCount should be >= 1L
-        metricRegistry.timer("kvutils.committer.config.run_timer").getCount should be >= 1L
+        metricRegistry.counter("daml.kvutils.committer.config.accepts").getCount should be >= 1L
+        metricRegistry.counter("daml.kvutils.committer.config.rejections").getCount should be >= 1L
+        metricRegistry.timer("daml.kvutils.committer.config.run_timer").getCount should be >= 1L
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPackageSpec.scala
@@ -92,11 +92,15 @@ class KVUtilsPackageSpec extends WordSpec with Matchers with BazelRunfiles {
         _ <- submitArchives("simple-archive-submission-1", simpleArchive).map(_._2)
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
-        metricRegistry.counter("kvutils.committer.package_upload.accepts").getCount should be >= 1L
         metricRegistry
-          .counter("kvutils.committer.package_upload.rejections")
+          .counter("daml.kvutils.committer.package_upload.accepts")
           .getCount should be >= 1L
-        metricRegistry.timer("kvutils.committer.package_upload.run_timer").getCount should be >= 1L
+        metricRegistry
+          .counter("daml.kvutils.committer.package_upload.rejections")
+          .getCount should be >= 1L
+        metricRegistry
+          .timer("daml.kvutils.committer.package_upload.run_timer")
+          .getCount should be >= 1L
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsPartySpec.scala
@@ -84,13 +84,13 @@ class KVUtilsPartySpec extends WordSpec with Matchers {
       } yield {
         // Check that we're updating the metrics (assuming this test at least has been run)
         metricRegistry
-          .counter("kvutils.committer.party_allocation.accepts")
+          .counter("daml.kvutils.committer.party_allocation.accepts")
           .getCount should be >= 1L
         metricRegistry
-          .counter("kvutils.committer.party_allocation.rejections")
+          .counter("daml.kvutils.committer.party_allocation.rejections")
           .getCount should be >= 1L
         metricRegistry
-          .timer("kvutils.committer.party_allocation.run_timer")
+          .timer("daml.kvutils.committer.party_allocation.run_timer")
           .getCount should be >= 1L
       }
     }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -269,11 +269,15 @@ class KVUtilsTransactionSpec extends WordSpec with Matchers {
       } yield {
         val disputed = DamlTransactionRejectionEntry.ReasonCase.DISPUTED
         // Check that we're updating the metrics (assuming this test at least has been run)
-        metricRegistry.counter("kvutils.committer.transaction.accepts").getCount should be >= 1L
         metricRegistry
-          .counter(s"kvutils.committer.transaction.rejections_${disputed.name}")
+          .counter("daml.kvutils.committer.transaction.accepts")
           .getCount should be >= 1L
-        metricRegistry.timer("kvutils.committer.transaction.run_timer").getCount should be >= 1L
+        metricRegistry
+          .counter(s"daml.kvutils.committer.transaction.rejections_${disputed.name}")
+          .getCount should be >= 1L
+        metricRegistry
+          .timer("daml.kvutils.committer.transaction.run_timer")
+          .getCount should be >= 1L
       }
     }
 


### PR DESCRIPTION
Just to get them consistent with the others.

Part of #5146.

### Changelog

- **[Ledger Integration Kit]** Prefixed all metrics with "daml." for consistency.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
