### PR TITLE
damlc: Drop support for DAML-LF 1.5 and 1.6

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -44,10 +44,10 @@ versionDev :: Version
 versionDev = V1 PointDev
 
 supportedOutputVersions :: [Version]
-supportedOutputVersions = [version1_6, version1_7, version1_8, versionDev]
+supportedOutputVersions = [version1_7, version1_8, versionDev]
 
 supportedInputVersions :: [Version]
-supportedInputVersions = version1_5 : supportedOutputVersions
+supportedInputVersions = supportedOutputVersions
 
 
 data Feature = Feature


### PR DESCRIPTION
The sandbox has already dropped support for everything before
DAML-LF 1.7, hence there's no point in being able to produce or consume
them with the compiler.

This PR only drops support for DARs in DAML-LF 1.5 or 1.6 and support
for accepting DAML-LF 1.6 as the `--target`.

The code paths through the compiler which were only used for these
DAML-LF versions will be dropped in a followup PR.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5293)
<!-- Reviewable:end -->
