### PR TITLE
Make new sandbox the default.

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -131,7 +131,7 @@ commandParser = subparser $ fold
         <*> (JsonApiOptions <$> many (strOption (long "json-api-option" <> metavar "JSON_API_OPTION" <> help "Pass option to HTTP JSON API")))
         <*> (ScriptOptions <$> many (strOption (long "script-option" <> metavar "SCRIPT_OPTION" <> help "Pass option to DAML script interpreter")))
         <*> stdinCloseOpt
-        <*> (SandboxClassic <$> switch (long "sandbox-classic" <> help "Run with old sandbox."))
+        <*> (SandboxClassic <$> switch (long "sandbox-classic" <> help "Run with sandbox-classic."))
 
     navigatorFlag =
         -- We do not use flagYesNoAuto here since that doesn’t allow us to differentiate

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -54,6 +54,7 @@ data Command
       , jsonApiOptions :: JsonApiOptions
       , scriptOptions :: ScriptOptions
       , shutdownStdinClose :: Bool
+      , sandboxClassic :: SandboxClassic
       }
     | Deploy { flags :: LedgerFlags }
     | LedgerListParties { flags :: LedgerFlags, json :: JsonFlag }
@@ -119,7 +120,7 @@ commandParser = subparser $ fold
         <$> optional (argument str (metavar "TARGET_PATH" <> help "Project folder to initialize."))
 
     startCmd = Start
-        <$> optional (SandboxPort <$> option auto (long "sandbox-port" <> metavar "PORT_NUM" <>     help "Port number for the sandbox"))
+        <$> optional (SandboxPort <$> option auto (long "sandbox-port" <> metavar "PORT_NUM" <> help "Port number for the sandbox"))
         <*> (OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser after navigator" idm)
         <*> optional navigatorFlag
         <*> jsonApiCfg
@@ -130,6 +131,7 @@ commandParser = subparser $ fold
         <*> (JsonApiOptions <$> many (strOption (long "json-api-option" <> metavar "JSON_API_OPTION" <> help "Pass option to HTTP JSON API")))
         <*> (ScriptOptions <$> many (strOption (long "script-option" <> metavar "SCRIPT_OPTION" <> help "Pass option to DAML script interpreter")))
         <*> stdinCloseOpt
+        <*> (SandboxClassic <$> flagYesNoAuto "sandbox-classic" False "Run with old sandbox." idm)
 
     navigatorFlag =
         -- We do not use flagYesNoAuto here since that doesn’t allow us to differentiate
@@ -336,6 +338,7 @@ runCommand = \case
             navigatorOptions
             jsonApiOptions
             scriptOptions
+            sandboxClassic
     Deploy {..} -> runDeploy flags
     LedgerListParties {..} -> runLedgerListParties flags json
     LedgerAllocateParties {..} -> runLedgerAllocateParties flags parties

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -131,7 +131,7 @@ commandParser = subparser $ fold
         <*> (JsonApiOptions <$> many (strOption (long "json-api-option" <> metavar "JSON_API_OPTION" <> help "Pass option to HTTP JSON API")))
         <*> (ScriptOptions <$> many (strOption (long "script-option" <> metavar "SCRIPT_OPTION" <> help "Pass option to DAML script interpreter")))
         <*> stdinCloseOpt
-        <*> (SandboxClassic <$> switch (long "sandbox-classic" <> help "Run with sandbox-classic."))
+        <*> (SandboxClassic <$> switch (long "sandbox-classic" <> help "Run with Sandbox Classic."))
 
     navigatorFlag =
         -- We do not use flagYesNoAuto here since that doesn’t allow us to differentiate

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -131,7 +131,7 @@ commandParser = subparser $ fold
         <*> (JsonApiOptions <$> many (strOption (long "json-api-option" <> metavar "JSON_API_OPTION" <> help "Pass option to HTTP JSON API")))
         <*> (ScriptOptions <$> many (strOption (long "script-option" <> metavar "SCRIPT_OPTION" <> help "Pass option to DAML script interpreter")))
         <*> stdinCloseOpt
-        <*> (SandboxClassic <$> flagYesNoAuto "sandbox-classic" False "Run with old sandbox." idm)
+        <*> (SandboxClassic <$> switch (long "sandbox-classic" <> help "Run with old sandbox."))
 
     navigatorFlag =
         -- We do not use flagYesNoAuto here since that doesn’t allow us to differentiate

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -44,6 +44,7 @@ module DA.Daml.Helper.Run
     , NavigatorOptions(..)
     , JsonApiOptions(..)
     , ScriptOptions(..)
+    , SandboxClassic(..)
     ) where
 
 import Control.Concurrent
@@ -741,10 +742,11 @@ navigatorPortNavigatorArgs (NavigatorPort p) = ["--port", show p]
 navigatorURL :: NavigatorPort -> String
 navigatorURL (NavigatorPort p) = "http://localhost:" <> show p
 
-withSandbox :: SandboxPort -> [String] -> (Process () () () -> IO a) -> IO a
-withSandbox (SandboxPort port) args a = withTempFile $ \portFile -> do
+withSandbox :: SandboxClassic -> SandboxPort -> [String] -> (Process () () () -> IO a) -> IO a
+withSandbox (SandboxClassic classic) (SandboxPort port) args a = withTempFile $ \portFile -> do
     logbackArg <- getLogbackArg (damlSdkJarFolder </> "sandbox-logback.xml")
-    withJar damlSdkJar [logbackArg] (["sandbox", "--port", show port, "--port-file", portFile] ++ args) $ \ph -> do
+    let sandbox = if classic then "sandbox-classic" else "sandbox"
+    withJar damlSdkJar [logbackArg] ([sandbox, "--port", show port, "--port-file", portFile] ++ args) $ \ph -> do
         putStrLn "Waiting for sandbox to start: "
         _port <- readPortFile maxRetries portFile
         a ph
@@ -807,6 +809,7 @@ newtype SandboxOptions = SandboxOptions [String]
 newtype NavigatorOptions = NavigatorOptions [String]
 newtype JsonApiOptions = JsonApiOptions [String]
 newtype ScriptOptions = ScriptOptions [String]
+newtype SandboxClassic = SandboxClassic { unSandboxClassic :: Bool }
 
 withOptsFromProjectConfig :: T.Text -> [String] -> ProjectConfig -> IO [String]
 withOptsFromProjectConfig fieldName cliOpts projectConfig = do
@@ -828,6 +831,7 @@ runStart
     -> NavigatorOptions
     -> JsonApiOptions
     -> ScriptOptions
+    -> SandboxClassic
     -> IO ()
 runStart
   sandboxPortM
@@ -840,6 +844,7 @@ runStart
   (NavigatorOptions navigatorOpts)
   (JsonApiOptions jsonApiOpts)
   (ScriptOptions scriptOpts)
+  sandboxClassic
   = withProjectRoot Nothing (ProjectCheck "daml start" True) $ \_ _ -> do
     let sandboxPort = fromMaybe defaultSandboxPort sandboxPortM
     projectConfig <- getProjectConfig
@@ -863,7 +868,7 @@ runStart
     scriptOpts <- withOptsFromProjectConfig "script-options" scriptOpts projectConfig
     doBuild
     let scenarioArgs = maybe [] (\scenario -> ["--scenario", scenario]) mbScenario
-    withSandbox sandboxPort (darPath : scenarioArgs ++ sandboxOpts) $ \sandboxPh -> do
+    withSandbox sandboxClassic sandboxPort (darPath : scenarioArgs ++ sandboxOpts) $ \sandboxPh -> do
         withNavigator' shouldStartNavigator sandboxPh sandboxPort navigatorPort navigatorOpts $ \navigatorPh -> do
             whenJust mbInitScript $ \initScript -> do
                 procScript <- toAssistantCommand $

--- a/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
+++ b/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
@@ -9,8 +9,8 @@ import com.digitalasset.daml.lf.engine.trigger.{RunnerMain => Trigger}
 import com.digitalasset.extractor.{Main => Extractor}
 import com.digitalasset.http.{Main => JsonApi}
 import com.digitalasset.navigator.{NavigatorBackend => Navigator}
-import com.digitalasset.platform.sandbox.{SandboxMain => Sandbox}
-import com.digitalasset.platform.sandboxnext.{Main => SandboxNext}
+import com.digitalasset.platform.sandbox.{SandboxMain => SandboxClassic}
+import com.digitalasset.platform.sandboxnext.{Main => Sandbox}
 
 object SdkMain {
   def main(args: Array[String]): Unit = {
@@ -25,7 +25,7 @@ object SdkMain {
       case "json-api" => JsonApi.main(rest)
       case "navigator" => Navigator.main(rest)
       case "sandbox" => Sandbox.main(rest)
-      case "sandbox-next" => SandboxNext.main(rest)
+      case "sandbox-classic" => SandboxClassic.main(rest)
       case _ => sys.exit(1)
     }
   }

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -337,11 +337,11 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart"
                   (\s -> connect s (addrAddress addr))
               -- waitForProcess' will block on Windows so we explicitly kill the process.
               terminateProcess ph
-    , testCase "Sandbox Next startup" $
+    , testCase "Sandbox Classic startup" $
       withCurrentDirectory quickstartDir $
       withDevNull $ \devNull -> do
           p :: Int <- fromIntegral <$> getFreePort
-          let sandboxProc = (shell $ unwords ["daml", "sandbox-next", "--wall-clock-time", "--port", show p, ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull, std_in = CreatePipe }
+          let sandboxProc = (shell $ unwords ["daml", "sandbox-classic", "--wall-clock-time", "--port", show p, ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull, std_in = CreatePipe }
           withCreateProcess sandboxProc  $
               \_ _ _ ph -> race_ (waitForProcess' sandboxProc ph) $ do
               waitForConnectionOnPort (threadDelay 100000) p
@@ -410,7 +410,7 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart"
       withDevNull $ \devNull1 ->
       withDevNull $ \devNull2 -> do
           sandboxPort :: Int <- fromIntegral <$> getFreePort
-          let sandboxProc = (shell $ unwords ["daml", "sandbox", "--", "--port", show sandboxPort, "--", "--static-time", "--scenario", "Main:setup", ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull1, std_in = CreatePipe }
+          let sandboxProc = (shell $ unwords ["daml", "sandbox-classic", "--", "--port", show sandboxPort, "--", "--static-time", "--scenario", "Main:setup", ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull1, std_in = CreatePipe }
           withCreateProcess sandboxProc $
               \_ _ _ ph -> race_ (waitForProcess' sandboxProc ph) $ do
               waitForConnectionOnPort (threadDelay 500000) sandboxPort

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -46,12 +46,12 @@ commands:
   completion: true
 - name: sandbox
   path: daml-helper/daml-helper
-  desc: "Launch the Sandbox"
+  desc: "Launch the new Sandbox"
   args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox"]
-- name: sandbox-next
+- name: sandbox-classic
   path: daml-helper/daml-helper
-  desc: "Launch the Sandbox's upcoming implementation (experimental, for testing purposes)"
-  args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox-next"]
+  desc: "Launch the old Sandbox"
+  args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox-classic"]
 - name: navigator
   path: daml-helper/daml-helper
   desc: "Launch the Navigator"

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -46,11 +46,11 @@ commands:
   completion: true
 - name: sandbox
   path: daml-helper/daml-helper
-  desc: "Launch the new Sandbox"
+  desc: "Launch sandbox"
   args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox"]
 - name: sandbox-classic
   path: daml-helper/daml-helper
-  desc: "Launch the old Sandbox"
+  desc: "Launch sandbox-classic (the sandbox implementation which was the default for SDK <= 0.13.55)"
   args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox-classic"]
 - name: navigator
   path: daml-helper/daml-helper

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -46,11 +46,11 @@ commands:
   completion: true
 - name: sandbox
   path: daml-helper/daml-helper
-  desc: "Launch sandbox"
+  desc: "Launch Sandbox"
   args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox"]
 - name: sandbox-classic
   path: daml-helper/daml-helper
-  desc: "Launch sandbox-classic (the sandbox implementation which was the default for SDK <= 0.13.55)"
+  desc: "Launch Sandbox Classic (the default Sandbox implementation for SDK <= 0.13.55)"
   args: ["run-jar", "--logback-config=daml-sdk/sandbox-logback.xml", "daml-sdk/daml-sdk.jar", "sandbox-classic"]
 - name: navigator
   path: daml-helper/daml-helper


### PR DESCRIPTION
The one thing that doesn't work with the new sandbox is the `"mvn exec:java@run-quickstart"` integration test, so I made it use `sandbox-classic`.

changelog_begin

- [DAML SDK] The new sandbox is now the default that runs with ``daml sandbox`` and ``daml start``. The command ``daml sandbox-next`` has been removed. The old sandbox can be invoked via ``daml sandbox-classic`` and ``daml start --sandbox-classic=yes``.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
