### PR TITLE
damlc: Fail integration tests with outdated UNTIL-LF annotation

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -169,7 +169,9 @@ testCase :: TestArguments -> LF.Version -> IO IdeState -> FilePath -> (TODO -> I
 testCase args version getService outdir registerTODO (name, file) = singleTest name . TestCase $ \log -> do
   service <- getService
   anns <- readFileAnns file
-  if any (ignoreVersion version) anns
+  if any (`notElem` supportedOutputVersions) [v | UntilLF v <- anns] then
+    pure (testFailed "Unsupported DAML-LF version in UNTIL-LF annotation")
+  else if any (ignoreVersion version) anns
     then pure $ Result
       { resultOutcome = Success
       , resultDescription = ""


### PR DESCRIPTION
Until #5294, we had some test cases for `damlc` flying around there
were never run because they had an upper bound on an unsupported
DAML-LF version. This PR makes sure we'll clean up such test cases in
the future.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5298)
<!-- Reviewable:end -->
