### PR TITLE
Make wall clock time the default time mode for sandbox

### DIFF
--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -125,7 +125,7 @@ In this section, you will run the quickstart application and get introduced to t
 
    .. _quickstart-sandbox:
 
-#. To run the :doc:`sandbox </tools/sandbox>` (a lightweight local version of the ledger), run ``daml sandbox --wall-clock-time .daml/dist/quickstart-0.0.1.dar``
+#. To run the :doc:`sandbox </tools/sandbox>` (a lightweight local version of the ledger), run ``daml sandbox .daml/dist/quickstart-0.0.1.dar``
 
    The output should look like this:
 
@@ -139,7 +139,7 @@ In this section, you will run the quickstart application and get introduced to t
       _\ \/ _ `/ _ \/ _  / _ \/ _ \\ \ /
       /___/\_,_/_//_/\_,_/_.__/\___/_\_\
 
-      Initialized sandbox version 100.13.10 with ledger-id = sandbox-5e12e502-817e-41f9-ad40-1c57b8845f9d, port = 6865, dar file = DamlPackageContainer(List(target/daml/iou.dar),false), time mode = Static, ledger = in-memory, daml-engine = {}
+      Initialized sandbox version 100.13.10 with ledger-id = sandbox-5e12e502-817e-41f9-ad40-1c57b8845f9d, port = 6865, dar file = DamlPackageContainer(List(target/daml/iou.dar),false), time mode = WallClock, ledger = in-memory, daml-engine = {}
 
    The sandbox is now running, and you can access its :doc:`ledger API </app-dev/ledger-api>` on port ``6865``.
 
@@ -171,7 +171,7 @@ Now everything is running, you can try out the quickstart application:
 
    .. figure:: quickstart/images/contracts.png
 
-   This is showing you what contracts are currently active on the sandbox ledger and visible to *Alice*. You can see that there is a single such contract, with Id ``#9:1``, created from a *template* called ``Iou:Iou@ffb...``.
+   This is showing you what contracts are currently active on the sandbox ledger and visible to *Alice*. You can see that there is a single such contract, in our case with Id ``#9:1``, created from a *template* called ``Iou:Iou@ffb...``.
 
    Your contract ID may vary. There's a lot going on in a DAML ledger, so things could have happened in a different order, or other internal ledger events might have occurred. The actual value doesn't matter. We'll refer to this contract as ``#9:1`` in the rest of this document, and you'll need to substitute your own value mentally.
 
@@ -374,11 +374,11 @@ In the transaction view, transaction ``#6`` is of particular interest, as it sho
       #6:1
       │   known to (since): 'Alice' (#6), 'Bob' (#6)
       └─> fetch #4:1 (Iou:Iou)
-      
+
       #6:2
       │   known to (since): 'Alice' (#6), 'Bob' (#6)
       └─> fetch #3:1 (Iou:Iou)
-      
+
       #6:3
       │   known to (since): 'Bob' (#6), 'USD_Bank' (#6), 'Alice' (#6)
       └─> 'Bob' exercises Iou_Transfer on #3:1 (Iou:Iou)
@@ -399,7 +399,7 @@ In the transaction view, transaction ``#6`` is of particular interest, as it sho
                      amount = 110.0;
                      observers = []);
                 newOwner = 'Alice'
-      
+
       #6:5
       │   known to (since): 'Bob' (#6), 'USD_Bank' (#6), 'Alice' (#6)
       └─> 'Alice' exercises IouTransfer_Accept on #6:4 (Iou:IouTransfer)
@@ -415,7 +415,7 @@ In the transaction view, transaction ``#6`` is of particular interest, as it sho
                 currency = "USD";
                 amount = 110.0;
                 observers = []
-      
+
       #6:7
       │   known to (since): 'Alice' (#6), 'EUR_Bank' (#6), 'Bob' (#6)
       └─> 'Alice' exercises Iou_Transfer on #4:1 (Iou:Iou)
@@ -436,7 +436,7 @@ In the transaction view, transaction ``#6`` is of particular interest, as it sho
                      amount = 100.0;
                      observers = ['Bob']);
                 newOwner = 'Bob'
-      
+
       #6:9
       │   known to (since): 'Alice' (#6), 'EUR_Bank' (#6), 'Bob' (#6)
       └─> 'Bob' exercises IouTransfer_Accept on #6:8 (Iou:IouTransfer)

--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -120,7 +120,7 @@ If you wanted to test out the tool, you can run it against :doc:`DAML Sandbox
    .. code-block:: console
 
      $ java -jar ledger-api-test-tool.jar --extract
-     $ daml sandbox --wall-clock-time *.dar
+     $ daml sandbox *.dar
      $ java -jar ledger-api-test-tool.jar localhost:6865
 
 This should always succeed, as the Sandbox is tested to correctly implement the

--- a/docs/source/tools/sandbox.rst
+++ b/docs/source/tools/sandbox.rst
@@ -6,13 +6,13 @@
 DAML Sandbox
 ############
 
-The DAML Sandbox, or Sandbox for short, is a simple ledger implementation that enables rapid application prototyping by simulating a DAML Ledger. 
+The DAML Sandbox, or Sandbox for short, is a simple ledger implementation that enables rapid application prototyping by simulating a DAML Ledger.
 
 You can start Sandbox together with :doc:`Navigator </tools/navigator/index>` using the ``daml start`` command in a DAML SDK project. This command will compile the DAML file and its dependencies as specified in the ``daml.yaml``. It will then launch Sandbox passing the just obtained DAR packages. Sandbox will also be given the name of the startup scenario specified in the project's ``daml.yaml``. Finally, it launches the navigator connecting it to the running Sandbox.
 
-It is possible to execute the Sandbox launching step in isolation by typing ``daml sandbox --wall-clock-time``.
+It is possible to execute the Sandbox launching step in isolation by typing ``daml sandbox``.
 
-Note: Sandbox is currently in the process of moving from Static Time mode to Wall Clock Time mode as the default. For this version only, you need to specify the time mode explicitly when launching Sandbox outside ``daml start``. (When you use ``daml start``, it provides this flag and any other flags in the ``sandbox-options:`` section of ``daml.yaml``.) From the next release, you can omit this flag.
+Note: Sandbox has switched to use Wall Clock Time mode by default. To use Static Time Mode you can provide the ``--static-time`` flag to the ``daml sandbox`` command or configure the time mode for ``daml start`` in ``sandbox-options:`` section of ``daml.yaml``. Please refer to :ref:`DAML configuration files <daml-yaml-configuration>` for more information.
 
 Sandbox can also be run manually as in this example:
 
@@ -32,7 +32,7 @@ Sandbox can also be run manually as in this example:
 Here, ``daml sandbox`` tells the SDK Assistant to run ``sandbox`` from the active SDK release and pass it any arguments that follow. The example passes the DAR file to load (``Main.dar``) and the optional ``--scenario`` flag tells Sandbox to run the ``Main:example`` scenario on startup. The scenario must be fully qualified; here ``Main`` is the module and ``example`` is the name of the scenario, separated by a ``:``. We also specify that the Sandbox should run in Static Time mode so that the scenario can control the time.
 
 .. note::
-  
+
   The scenario is used for testing and development only, and is not supported by production DAML Ledgers. It is therefore inadvisable to rely on scenarios for ledger initialization.
 
   ``submitMustFail`` is only supported by the test-ledger used by ``daml test`` and the IDE, not by the Sandbox.
@@ -84,10 +84,10 @@ By default, Sandbox uses an in-memory store, which means it loses its state when
 
 To set this up, you must:
 
-- create an initially empty Postgres database that the Sandbox application can access 
-- have a database user for Sandbox that has authority to execute DDL operations 
+- create an initially empty Postgres database that the Sandbox application can access
+- have a database user for Sandbox that has authority to execute DDL operations
 
-  This is because Sandbox manages its own database schema, applying migrations if necessary when upgrading versions. 
+  This is because Sandbox manages its own database schema, applying migrations if necessary when upgrading versions.
 
 To start Sandbox using persistence, pass an ``--sql-backend-jdbcurl <value>`` option, where ``<value>`` is a valid jdbc url containing the username, password and database name to connect to.
 
@@ -97,7 +97,7 @@ Due to possible conflicts between the ``&`` character and various terminal shell
 
 .. code-block:: none
 
-  $ daml sandbox Main.dar --wall-clock-time --sql-backend-jdbcurl "jdbc:postgresql://localhost/test?user=fred&password=secret"
+  $ daml sandbox Main.dar --sql-backend-jdbcurl "jdbc:postgresql://localhost/test?user=fred&password=secret"
 
 If you're not familiar with JDBC URLs, see the JDBC docs for more information: https://jdbc.postgresql.org/documentation/head/connect.html
 

--- a/docs/source/upgrade/index.rst
+++ b/docs/source/upgrade/index.rst
@@ -104,7 +104,7 @@ First we'll need a sandbox ledger to which we can deploy.
 
 .. code-block:: none
 
-   $ daml sandbox --port 6865 --wall-clock-time
+   $ daml sandbox --port 6865
 
 Now we'll setup the project for the original version of our coin. The project contains the DAML for just the ``Coin`` template, along with a ``CoinProposal`` template which will allow us to issue some coins in the example below.
 

--- a/language-support/scala/examples/quickstart-scala/README.md
+++ b/language-support/scala/examples/quickstart-scala/README.md
@@ -3,7 +3,7 @@
 This example demonstrates how to:
 - set up and configure Scala codegen (see `codegen` configuration in the `./daml.yaml`)
 - instantiate a contract and send a corresponding create command to the ledger
-- how to exercise a choice and send a corresponding exercise command  
+- how to exercise a choice and send a corresponding exercise command
 - subscribe to receive ledger events and decode them into generated Scala ADTs
 
 All instructions below assume that you have DAML SDK installed. If you have not installed it yet, please follow these instructions: https://docs.daml.com/getting-started/installation.html
@@ -49,7 +49,7 @@ codegen:
 ## Start Sandbox
 This examples requires a running sandbox. To start it, run the following command:
 ```
-$ daml sandbox --wall-clock-time ./.daml/dist/quickstart-0.0.1.dar
+$ daml sandbox ./.daml/dist/quickstart-0.0.1.dar
 ```
 where `./.daml/dist/quickstart-0.0.1.dar` is the DAR file created in the previous step.
 

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -395,7 +395,7 @@ server_conformance_test(
 server_conformance_test(
     name = "conformance-test-config-management",
     server_args = [
-        "--static-time",
+        "--wall-clock-time",
     ],
     servers = SERVERS,
     test_tool_args = [
@@ -408,7 +408,7 @@ server_conformance_test(
 server_conformance_test(
     name = "conformance-test-command-deduplication",
     server_args = [
-        "--static-time",
+        "--wall-clock-time",
     ],
     servers = SERVERS,
     test_tool_args = [
@@ -421,7 +421,7 @@ server_conformance_test(
 server_conformance_test(
     name = "conformance-test-contract-id-seeding",
     server_args = [
-        "--static-time",
+        "--wall-clock-time",
         "--contract-id-seeding=testing-weak",
     ],
     servers = SERVERS,

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -366,7 +366,7 @@ server_conformance_test(
     name = "conformance-test-lots-of-parties",
     flaky = True,
     server_args = [
-        "--static-time",
+        "--wall-clock-time",
     ],
     servers = SERVERS,
     test_tool_args = [

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -36,7 +36,7 @@ import com.digitalasset.platform.apiserver.{
 import com.digitalasset.platform.packages.InMemoryPackageStore
 import com.digitalasset.platform.sandbox.SandboxServer._
 import com.digitalasset.platform.sandbox.banner.Banner
-import com.digitalasset.platform.sandbox.config.{InvalidConfigException, SandboxConfig}
+import com.digitalasset.platform.sandbox.config.SandboxConfig
 import com.digitalasset.platform.sandbox.metrics.MetricsReporting
 import com.digitalasset.platform.sandbox.services.SandboxResetService
 import com.digitalasset.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryOrBump
@@ -223,7 +223,7 @@ final class SandboxServer(
 
     val (acs, ledgerEntries, mbLedgerTime) = createInitialState(config, packageStore)
 
-    val timeProviderType = config.timeProviderType.getOrElse(TimeProviderType.Static)
+    val timeProviderType = config.timeProviderType.getOrElse(TimeProviderType.WallClock)
     val (timeProvider, timeServiceBackendO: Option[TimeServiceBackend]) =
       (mbLedgerTime, timeProviderType) match {
         case (None, TimeProviderType.WallClock) => (TimeProvider.UTC, None)
@@ -349,13 +349,6 @@ final class SandboxServer(
 
   private def start(): Future[SandboxState] = {
     newLoggingContext(logging.participantId(participantId)) { implicit logCtx =>
-      if (config.timeProviderType.isEmpty) {
-        throw new InvalidConfigException(
-          "Sandbox used to default to Static Time mode. In the next release, Wall Clock Time mode"
-            + " will become the default. In this version, you will need to explicitly specify the"
-            + " `--static-time` flag to maintain the previous behavior, or `--wall-clock-time` if"
-            + " you would like to use the new defaults.")
-      }
       val packageStore = loadDamlPackages()
       val apiServerResource = buildAndStartApiServer(
         materializer,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -59,7 +59,7 @@ object SandboxConfig {
       port = DefaultPort,
       portFile = None,
       damlPackages = Nil,
-      timeProviderType = Some(TimeProviderType.WallClock),
+      timeProviderType = None,
       timeModel = TimeModel.reasonableDefault,
       commandConfig = CommandConfiguration.default,
       partyConfig = PartyConfiguration.default.copy(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -59,7 +59,7 @@ object SandboxConfig {
       port = DefaultPort,
       portFile = None,
       damlPackages = Nil,
-      timeProviderType = None,
+      timeProviderType = Some(TimeProviderType.WallClock),
       timeModel = TimeModel.reasonableDefault,
       commandConfig = CommandConfiguration.default,
       partyConfig = PartyConfiguration.default.copy(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -92,13 +92,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
         ("in-memory", InMemoryLedgerJdbcUrl, InMemoryIndexJdbcUrl, StartupMode.ResetAndStart)
     }
 
-  private val timeProviderType = config.timeProviderType.getOrElse {
-    throw new InvalidConfigException(
-      "Sandbox used to default to Static Time mode. In the next release, Wall Clock Time mode will"
-        + " become the default. In this version, you will need to explicitly specify the"
-        + " `--static-time` flag to maintain the previous behavior, or `--wall-clock-time` if you"
-        + " would like to use the new defaults.")
-  }
+  private val timeProviderType = config.timeProviderType.getOrElse(TimeProviderType.WallClock)
 
   private val seeding = config.seeding.getOrElse {
     throw new InvalidConfigException(


### PR DESCRIPTION
CHANGELOG_BEGIN
[Sandbox] Wall Clock Time mode (``--wall-clock-time``) is now the
default.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
