### PR TITLE
Integrate new flat transactions reader with Ledger API

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -51,7 +51,7 @@ object Config {
 
   val DefaultMaxInboundMessageSize: Int = 4 * 1024 * 1024
 
-  val DefaultEventsPageSize = 10000
+  val DefaultEventsPageSize = 1000
 
   def default[Extra](extra: Extra): Config[Extra] =
     Config(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -17,7 +17,7 @@ import com.digitalasset.resources.ProgramResource.SuppressedStartupException
 import com.digitalasset.resources.ResourceOwner
 import scopt.OptionParser
 
-case class Config[Extra](
+final case class Config[Extra](
     ledgerId: Option[String],
     archiveFiles: Seq[Path],
     tlsConfig: Option[TlsConfiguration],
@@ -25,6 +25,7 @@ case class Config[Extra](
     seeding: Seeding,
     metricsReporter: Option[MetricsReporter],
     metricsReportingInterval: Duration,
+    eventsPageSize: Int,
     extra: Extra,
 ) {
   def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): Config[Extra] =
@@ -50,6 +51,8 @@ object Config {
 
   val DefaultMaxInboundMessageSize: Int = 4 * 1024 * 1024
 
+  val DefaultEventsPageSize = 10000
+
   def default[Extra](extra: Extra): Config[Extra] =
     Config(
       ledgerId = None,
@@ -59,6 +62,7 @@ object Config {
       seeding = Seeding.Strong,
       metricsReporter = None,
       metricsReportingInterval = Duration.ofSeconds(10),
+      eventsPageSize = DefaultEventsPageSize,
       extra = extra,
     )
 
@@ -132,6 +136,12 @@ object Config {
         .unbounded()
         .text("DAR files to load. Scenarios are ignored. The server starts with an empty ledger by default.")
         .action((file, config) => config.copy(archiveFiles = config.archiveFiles :+ file.toPath))
+
+      opt[Int]("events-page-size")
+        .optional()
+        .text(
+          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${Config.DefaultEventsPageSize}.")
+        .action((eventsPageSize, config) => config.copy(eventsPageSize = eventsPageSize))
 
       private val seedingMap =
         Map[String, Seeding]("testing-weak" -> Seeding.Weak, "strong" -> Seeding.Strong)

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -29,9 +29,10 @@ import scala.compat.java8.FutureConverters.CompletionStageOps
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class Runner[T <: ReadWriteService, Extra](
+final class Runner[T <: ReadWriteService, Extra](
     name: String,
-    factory: LedgerFactory[ReadWriteService, Extra]) {
+    factory: LedgerFactory[ReadWriteService, Extra],
+) {
   def owner(args: Seq[String]): ResourceOwner[Unit] =
     Config
       .owner(name, factory.extraConfigParser, factory.defaultExtraConfig, args)
@@ -80,6 +81,7 @@ class Runner[T <: ReadWriteService, Extra](
                 submissionConfig = factory.submissionConfig(config),
                 readService = readService,
                 writeService = writeService,
+                eventsPageSize = config.eventsPageSize,
                 transformIndexService =
                   service => new TimedIndexService(service, metricRegistry, IndexServicePrefix),
                 authService = factory.authService(config),

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -73,6 +73,7 @@ final class Runner[T <: ReadWriteService, Extra](
                 readService = readService,
                 config = factory.indexerConfig(participantConfig, config),
                 metrics = metricRegistry,
+                eventsPageSize = config.eventsPageSize,
               ).acquire()
               _ <- new StandaloneApiServer(
                 config = factory.apiServerConfig(participantConfig, config),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -50,6 +50,7 @@ final class StandaloneApiServer(
     readService: ReadService,
     writeService: WriteService,
     authService: AuthService,
+    eventsPageSize: Int,
     transformIndexService: IndexService => IndexService = identity,
     metrics: MetricRegistry,
     timeServiceBackend: Option[TimeServiceBackend] = None,
@@ -84,6 +85,7 @@ final class StandaloneApiServer(
           participantId,
           config.jdbcUrl,
           metrics,
+          eventsPageSize,
         )
         .map(transformIndexService)
       healthChecks = new HealthChecks(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
@@ -23,9 +23,10 @@ object JdbcIndex {
       participantId: ParticipantId,
       jdbcUrl: String,
       metrics: MetricRegistry,
+      eventsPageSize: Int,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[IndexService] =
     ReadOnlySqlLedger
-      .owner(serverRole, jdbcUrl, ledgerId, metrics)
+      .owner(serverRole, jdbcUrl, ledgerId, metrics, eventsPageSize)
       .map { ledger =>
         new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId) {
           override def getLedgerConfiguration(): Source[v2.LedgerConfiguration, NotUsed] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/MeteredReadOnlyLedger.scala
@@ -10,7 +10,7 @@ import akka.stream.scaladsl.Source
 import com.codahale.metrics.{MetricRegistry, Timer}
 import com.daml.ledger.participant.state.index.v2.{CommandDeduplicationResult, PackageDetails}
 import com.daml.ledger.participant.state.v1.{Configuration, Offset}
-import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
+import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
@@ -22,7 +22,8 @@ import com.digitalasset.ledger.api.health.HealthStatus
 import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.digitalasset.ledger.api.v1.transaction_service.{
   GetFlatTransactionResponse,
-  GetTransactionResponse
+  GetTransactionResponse,
+  GetTransactionsResponse
 }
 import com.digitalasset.platform.metrics.timedFuture
 import com.digitalasset.platform.store.entries.{
@@ -77,6 +78,14 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: MetricRegistry)
       startExclusive: Option[Offset],
       endOpt: Option[Offset]): Source[(Offset, LedgerEntry), NotUsed] =
     ledger.ledgerEntries(startExclusive, endOpt)
+
+  override def flatTransactions(
+      startExclusive: Option[Offset],
+      endInclusive: Option[Offset],
+      filter: Map[Party, Set[Identifier]],
+      verbose: Boolean,
+  ): Source[(Offset, GetTransactionsResponse), NotUsed] =
+    ledger.flatTransactions(startExclusive, endInclusive, filter, verbose)
 
   override def ledgerEnd: Offset = ledger.ledgerEnd
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -33,9 +33,10 @@ object ReadOnlySqlLedger {
       jdbcUrl: String,
       ledgerId: LedgerId,
       metrics: MetricRegistry,
+      eventsPageSize: Int,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[ReadOnlyLedger] =
     for {
-      ledgerReadDao <- JdbcLedgerDao.readOwner(serverRole, jdbcUrl, metrics)
+      ledgerReadDao <- JdbcLedgerDao.readOwner(serverRole, jdbcUrl, metrics, eventsPageSize)
       factory = new Factory(ledgerReadDao)
       ledger <- ResourceOwner.forFutureCloseable(() => factory.createReadOnlySqlLedger(ledgerId))
     } yield ledger

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -37,6 +37,7 @@ final class JdbcIndexerFactory(
     jdbcUrl: String,
     readService: ReadService,
     metrics: MetricRegistry,
+    eventsPageSize: Int,
 )(implicit materializer: Materializer, logCtx: LoggingContext) {
 
   private val logger = ContextualizedLogger.get(this.getClass)
@@ -59,7 +60,7 @@ final class JdbcIndexerFactory(
       implicit executionContext: ExecutionContext
   ): ResourceOwner[JdbcIndexer] =
     for {
-      ledgerDao <- JdbcLedgerDao.writeOwner(serverRole, jdbcUrl, metrics)
+      ledgerDao <- JdbcLedgerDao.writeOwner(serverRole, jdbcUrl, metrics, eventsPageSize)
       initialLedgerEnd <- ResourceOwner.forFuture(() => initializeLedger(ledgerDao))
     } yield new JdbcIndexer(initialLedgerEnd, participantId, ledgerDao, metrics)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -16,6 +16,7 @@ final class StandaloneIndexerServer(
     readService: ReadService,
     config: IndexerConfig,
     metrics: MetricRegistry,
+    eventsPageSize: Int,
 )(implicit materializer: Materializer, logCtx: LoggingContext)
     extends ResourceOwner[Unit] {
 
@@ -28,6 +29,7 @@ final class StandaloneIndexerServer(
       config.jdbcUrl,
       readService,
       metrics,
+      eventsPageSize,
     )
     val indexer = new RecoveringIndexer(materializer.system.scheduler, config.restartDelay)
     config.startupMode match {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -246,6 +246,7 @@ final class SandboxServer(
           config.commandConfig.maxCommandsInFlight * 2, // we can get commands directly as well on the submission service
           packageStore,
           metrics,
+          config.eventsPageSize,
         )
 
       case None =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -219,6 +219,12 @@ object Cli {
         .text("Enables JWT-based authorization, where the JWT is signed by RSA256 with a public key loaded from the given JWKS URL")
         .action((url, config) => config.copy(authService = Some(AuthServiceJWT(JwksVerifier(url)))))
 
+      opt[Int]("events-page-size")
+        .optional()
+        .text(
+          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${SandboxConfig.DefaultEventsPageSize}.")
+        .action((eventsPageSize, config) => config.copy(eventsPageSize = eventsPageSize))
+
       private val seedingMap = Map[String, Option[Seeding]](
         "no" -> None,
         "testing-static" -> Some(Seeding.Static),

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -46,12 +46,15 @@ final case class SandboxConfig(
     seeding: Option[Seeding],
     metricsReporter: Option[MetricsReporter],
     metricsReportingInterval: Duration,
+    eventsPageSize: Int,
 )
 
 object SandboxConfig {
   val DefaultPort: Port = Port(6865)
 
   val DefaultMaxInboundMessageSize: Int = 4 * 1024 * 1024
+
+  val DefaultEventsPageSize: Int = 10000
 
   lazy val nextDefault: SandboxConfig =
     SandboxConfig(
@@ -77,6 +80,7 @@ object SandboxConfig {
       seeding = Some(Seeding.Strong),
       metricsReporter = None,
       metricsReportingInterval = Duration.ofSeconds(10),
+      eventsPageSize = DefaultEventsPageSize,
     )
 
   lazy val default: SandboxConfig =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -54,7 +54,7 @@ object SandboxConfig {
 
   val DefaultMaxInboundMessageSize: Int = 4 * 1024 * 1024
 
-  val DefaultEventsPageSize: Int = 10000
+  val DefaultEventsPageSize: Int = 1000
 
   lazy val nextDefault: SandboxConfig =
     SandboxConfig(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -64,21 +64,23 @@ object SandboxIndexAndWriteService {
       queueDepth: Int,
       templateStore: InMemoryPackageStore,
       metrics: MetricRegistry,
+      eventsPageSize: Int,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[IndexAndWriteService] =
     SqlLedger
       .owner(
-        ServerRole.Sandbox,
-        jdbcUrl,
-        ledgerId,
-        participantId,
-        timeProvider,
-        acs,
-        templateStore,
-        ledgerEntries,
-        initialConfig,
-        queueDepth,
-        startMode,
-        metrics,
+        serverRole = ServerRole.Sandbox,
+        jdbcUrl = jdbcUrl,
+        ledgerId = ledgerId,
+        participantId = participantId,
+        timeProvider = timeProvider,
+        acs = acs,
+        packages = templateStore,
+        initialLedgerEntries = ledgerEntries,
+        initialConfig = initialConfig,
+        queueDepth = queueDepth,
+        startMode = startMode,
+        metrics = metrics,
+        eventsPageSize = eventsPageSize,
       )
       .flatMap(ledger =>
         owner(MeteredLedger(ledger, metrics), participantId, initialConfig, timeProvider))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -62,10 +62,11 @@ object SqlLedger {
       queueDepth: Int,
       startMode: SqlStartMode = SqlStartMode.ContinueIfExists,
       metrics: MetricRegistry,
+      eventsPageSize: Int,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[Ledger] =
     for {
       _ <- ResourceOwner.forFuture(() => new FlywayMigrations(jdbcUrl).migrate()(DEC))
-      ledgerDao <- JdbcLedgerDao.writeOwner(serverRole, jdbcUrl, metrics)
+      ledgerDao <- JdbcLedgerDao.writeOwner(serverRole, jdbcUrl, metrics, eventsPageSize)
       ledger <- ResourceOwner.forFutureCloseable(
         () =>
           new SqlLedgerFactory(ledgerDao).createSqlLedger(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -177,6 +177,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     allowExistingSchema = true,
                   ),
                   metrics = metrics,
+                  eventsPageSize = config.eventsPageSize,
                 )
                 authService = config.authService.getOrElse(AuthServiceWildcard)
                 promise = Promise[Unit]
@@ -213,6 +214,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   readService = readService,
                   writeService = writeService,
                   authService = authService,
+                  eventsPageSize = config.eventsPageSize,
                   transformIndexService = new TimedIndexService(_, metrics, IndexServicePrefix),
                   metrics = metrics,
                   timeServiceBackend = timeServiceBackend,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.index.v2.CommandDeduplicationResult
 import com.daml.ledger.participant.state.v1.{Configuration, Offset}
 import com.digitalasset.daml.lf.archive.Decode
-import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
+import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node
 import com.digitalasset.daml.lf.value.Value
@@ -25,7 +25,8 @@ import com.digitalasset.ledger.api.health.HealthStatus
 import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.digitalasset.ledger.api.v1.transaction_service.{
   GetFlatTransactionResponse,
-  GetTransactionResponse
+  GetTransactionResponse,
+  GetTransactionsResponse
 }
 import com.digitalasset.platform.akkastreams.dispatcher.Dispatcher
 import com.digitalasset.platform.akkastreams.dispatcher.SubSource.RangeSource
@@ -41,7 +42,10 @@ import scalaz.syntax.tag.ToTagOps
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Offset, ledgerDao: LedgerReadDao)
+abstract class BaseLedger(
+    val ledgerId: LedgerId,
+    headAtInitialization: Offset,
+    ledgerDao: LedgerReadDao)
     extends ReadOnlyLedger {
 
   implicit private val DEC: ExecutionContext = DirectExecutionContext
@@ -66,6 +70,18 @@ class BaseLedger(val ledgerId: LedgerId, headAtInitialization: Offset, ledgerDao
       endInclusive
     )
   }
+
+  override def flatTransactions(
+      startExclusive: Option[Offset],
+      endInclusive: Option[Offset],
+      filter: Map[Party, Set[Identifier]],
+      verbose: Boolean,
+  ): Source[(Offset, GetTransactionsResponse), NotUsed] =
+    dispatcher.startingAt(
+      startExclusive.getOrElse(Offset.begin),
+      RangeSource(ledgerDao.transactionsReader.getFlatTransactions(_, _, filter, verbose)),
+      endInclusive
+    )
 
   override def ledgerEnd: Offset = dispatcher.getHead()
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ReadOnlyLedger.scala
@@ -10,7 +10,7 @@ import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.index.v2.{CommandDeduplicationResult, PackageDetails}
 import com.daml.ledger.participant.state.v1.{Configuration, Offset}
 import com.digitalasset.daml.lf.data.Ref
-import com.digitalasset.daml.lf.data.Ref.{PackageId, Party}
+import com.digitalasset.daml.lf.data.Ref.{Identifier, PackageId, Party}
 import com.digitalasset.daml.lf.language.Ast
 import com.digitalasset.daml.lf.transaction.Node.GlobalKey
 import com.digitalasset.daml.lf.value.Value
@@ -22,7 +22,8 @@ import com.digitalasset.ledger.api.health.ReportsHealth
 import com.digitalasset.ledger.api.v1.command_completion_service.CompletionStreamResponse
 import com.digitalasset.ledger.api.v1.transaction_service.{
   GetFlatTransactionResponse,
-  GetTransactionResponse
+  GetTransactionResponse,
+  GetTransactionsResponse
 }
 import com.digitalasset.platform.store.entries.{
   ConfigurationEntry,
@@ -41,6 +42,13 @@ trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
   def ledgerEntries(
       startExclusive: Option[Offset],
       endInclusive: Option[Offset]): Source[(Offset, LedgerEntry), NotUsed]
+
+  def flatTransactions(
+      startExclusive: Option[Offset],
+      endInclusive: Option[Offset],
+      filter: Map[Party, Set[Identifier]],
+      verbose: Boolean,
+  ): Source[(Offset, GetTransactionsResponse), NotUsed]
 
   def ledgerEnd: Offset
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableFlatEvents.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableFlatEvents.scala
@@ -130,7 +130,7 @@ private[events] trait EventsTableFlatEvents { this: EventsTable =>
         pageSize: Int,
         rowOffset: Long,
     ): SimpleSql[Row] =
-      SQL"select #$selectColumns, case when submitter in ($parties) then command_id else '' end as command_id from #$flatEventsTable where event_offset > $startExclusive and event_offset <= $endInclusive and event_witness in ($parties) group by (#$groupByColumns) order by (event_offset, transaction_id, node_index) limit $pageSize offset $rowOffset"
+      SQL"select #$selectColumns, case when submitter in ($parties) then command_id else '' end as command_id from #$flatEventsTable where event_offset > $startExclusive and event_offset <= $endInclusive and event_witness in ($parties) group by (#$groupByColumns) order by (#$orderByColumns) limit $pageSize offset $rowOffset"
 
     def sameTemplates(
         startExclusive: Offset,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsReader.scala
@@ -6,7 +6,6 @@ package com.digitalasset.platform.store.dao.events
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.v1.{Offset, TransactionId}
-import com.digitalasset.daml.lf.data.Ref.Identifier
 import com.digitalasset.ledger.api.v1.transaction_service.{
   GetFlatTransactionResponse,
   GetTransactionResponse,
@@ -18,94 +17,79 @@ import com.digitalasset.platform.store.SimpleSqlAsVectorOf.SimpleSqlAsVectorOf
 
 import scala.concurrent.{ExecutionContext, Future}
 
-private[dao] object TransactionsReader {
+/**
+  * @param dispatcher Executes the queries prepared by this object
+  * @param executionContext Runs transformations on data fetched from the database
+  * @param pageSize The number of events to fetch at a time the database when serving streaming calls
+  * @see [[PaginatingAsyncStream]]
+  */
+private[dao] final class TransactionsReader(
+    dispatcher: DbDispatcher,
+    executionContext: ExecutionContext,
+    pageSize: Int,
+) {
 
   private def offsetFor(response: GetTransactionsResponse): Offset =
     ApiOffset.assertFromString(response.transactions.head.offset)
 
-  def apply(dispatcher: DbDispatcher, executionContext: ExecutionContext): TransactionsReader =
-    new TransactionsReader {
-
-      override def getFlatTransactions(
-          startExclusive: Offset,
-          endInclusive: Offset,
-          filter: FilterRelation,
-          pageSize: Int,
-          verbose: Boolean,
-      ): Source[(Offset, GetTransactionsResponse), NotUsed] = {
-        val events =
-          PaginatingAsyncStream(pageSize) { offset =>
-            val query =
-              EventsTable.preparePagedGetFlatTransactions(
-                startExclusive = startExclusive,
-                endInclusive = endInclusive,
-                filter = filter,
-                pageSize = pageSize,
-                rowOffset = offset,
-              )
-            dispatcher.executeSql("get_flat_transactions") { implicit connection =>
-              query.asVectorOf(EventsTable.flatEventParser(verbose = verbose))
-            }
-          }
-
-        groupContiguous(events)(by = _.transactionId)
-          .flatMapConcat { events =>
-            val response = EventsTable.Entry.toGetTransactionsResponse(events)
-            Source(response.map(r => offsetFor(r) -> r))
-          }
-      }
-
-      override def lookupFlatTransactionById(
-          transactionId: TransactionId,
-          requestingParties: Set[Party],
-      ): Future[Option[GetFlatTransactionResponse]] = {
-        val query = EventsTable.prepareLookupFlatTransactionById(transactionId, requestingParties)
-        dispatcher
-          .executeSql(
-            description = "lookup_flat_transaction_by_id",
-            extraLog = Some(s"tx: $transactionId, parties = ${requestingParties.mkString(", ")}"),
-          ) { implicit connection =>
-            query.as(EventsTable.flatEventParser(verbose = true).*)
-          }
-          .map(EventsTable.Entry.toGetFlatTransactionResponse)(executionContext)
-      }
-
-      override def lookupTransactionTreeById(
-          transactionId: TransactionId,
-          requestingParties: Set[Party],
-      ): Future[Option[GetTransactionResponse]] = {
-        val query = EventsTable.prepareLookupTransactionTreeById(transactionId, requestingParties)
-        dispatcher
-          .executeSql(
-            description = "lookup_transaction_tree_by_id",
-            extraLog = Some(s"tx: $transactionId, parties = ${requestingParties.mkString(", ")}"),
-          ) { implicit connection =>
-            query.as(EventsTable.treeEventParser(verbose = true).*)
-          }
-          .map(EventsTable.Entry.toTransactionTree)(executionContext)
-      }
-
-    }
-}
-
-private[dao] trait TransactionsReader {
-
   def getFlatTransactions(
       startExclusive: Offset,
       endInclusive: Offset,
-      filter: Map[Party, Set[Identifier]],
-      pageSize: Int,
+      filter: FilterRelation,
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionsResponse), NotUsed]
+  ): Source[(Offset, GetTransactionsResponse), NotUsed] = {
+    val events =
+      PaginatingAsyncStream(pageSize) { offset =>
+        val query =
+          EventsTable
+            .preparePagedGetFlatTransactions(
+              startExclusive = startExclusive,
+              endInclusive = endInclusive,
+              filter = filter,
+              pageSize = pageSize,
+              rowOffset = offset,
+            )
+            .withFetchSize(Some(pageSize))
+        dispatcher.executeSql("get_flat_transactions") { implicit connection =>
+          query.asVectorOf(EventsTable.flatEventParser(verbose = verbose))
+        }
+      }
+
+    groupContiguous(events)(by = _.transactionId)
+      .flatMapConcat { events =>
+        val response = EventsTable.Entry.toGetTransactionsResponse(events)
+        Source(response.map(r => offsetFor(r) -> r))
+      }
+  }
 
   def lookupFlatTransactionById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetFlatTransactionResponse]]
+  ): Future[Option[GetFlatTransactionResponse]] = {
+    val query = EventsTable.prepareLookupFlatTransactionById(transactionId, requestingParties)
+    dispatcher
+      .executeSql(
+        description = "lookup_flat_transaction_by_id",
+        extraLog = Some(s"tx: $transactionId, parties = ${requestingParties.mkString(", ")}"),
+      ) { implicit connection =>
+        query.as(EventsTable.flatEventParser(verbose = true).*)
+      }
+      .map(EventsTable.Entry.toGetFlatTransactionResponse)(executionContext)
+  }
 
   def lookupTransactionTreeById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetTransactionResponse]]
+  ): Future[Option[GetTransactionResponse]] = {
+    val query = EventsTable.prepareLookupTransactionTreeById(transactionId, requestingParties)
+    dispatcher
+      .executeSql(
+        description = "lookup_transaction_tree_by_id",
+        extraLog = Some(s"tx: $transactionId, parties = ${requestingParties.mkString(", ")}"),
+      ) { implicit connection =>
+        query.as(EventsTable.treeEventParser(verbose = true).*)
+      }
+      .map(EventsTable.Entry.toTransactionTree)(executionContext)
+  }
 
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
@@ -53,6 +53,7 @@ object LedgerResource {
       initialConfig: Configuration,
       metrics: MetricRegistry,
       packages: InMemoryPackageStore = InMemoryPackageStore.empty,
+      eventsPageSize: Int,
   )(
       implicit executionContext: ExecutionContext,
       materializer: Materializer,
@@ -62,18 +63,19 @@ object LedgerResource {
       for {
         postgres <- PostgresResource.owner()
         ledger <- SqlLedger.owner(
-          ServerRole.Testing(testClass),
-          postgres.jdbcUrl,
-          LedgerIdMode.Static(ledgerId),
-          participantId,
-          timeProvider,
-          InMemoryActiveLedgerState.empty,
-          packages,
-          ImmArray.empty,
-          initialConfig,
-          128,
-          SqlStartMode.AlwaysReset,
-          metrics
+          serverRole = ServerRole.Testing(testClass),
+          jdbcUrl = postgres.jdbcUrl,
+          ledgerId = LedgerIdMode.Static(ledgerId),
+          participantId = participantId,
+          timeProvider = timeProvider,
+          acs = InMemoryActiveLedgerState.empty,
+          packages = packages,
+          initialLedgerEntries = ImmArray.empty,
+          initialConfig = initialConfig,
+          queueDepth = 128,
+          startMode = SqlStartMode.AlwaysReset,
+          metrics = metrics,
+          eventsPageSize = eventsPageSize,
         )
       } yield ledger
     )

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
@@ -53,7 +53,6 @@ object LedgerResource {
       initialConfig: Configuration,
       metrics: MetricRegistry,
       packages: InMemoryPackageStore = InMemoryPackageStore.empty,
-      eventsPageSize: Int,
   )(
       implicit executionContext: ExecutionContext,
       materializer: Materializer,
@@ -75,7 +74,7 @@ object LedgerResource {
           queueDepth = 128,
           startMode = SqlStartMode.AlwaysReset,
           metrics = metrics,
-          eventsPageSize = eventsPageSize,
+          eventsPageSize = 100,
         )
       } yield ledger
     )

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -33,7 +33,7 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll { this: Su
       for {
         _ <- Resource.fromFuture(new FlywayMigrations(jdbcUrl).migrate())
         dao <- JdbcLedgerDao
-          .writeOwner(ServerRole.Testing(getClass), jdbcUrl, new MetricRegistry)
+          .writeOwner(ServerRole.Testing(getClass), jdbcUrl, new MetricRegistry, 100)
           .acquire()
         _ <- Resource.fromFuture(dao.initializeLedger(LedgerId("test-ledger"), Offset.begin))
       } yield dao

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -135,37 +135,10 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             startExclusive = from,
             endInclusive = to,
             filter = Map(alice -> Set.empty, bob -> Set.empty, charlie -> Set.empty),
-            pageSize = 100,
             verbose = true,
           ))
     } yield {
       comparable(result) should contain theSameElementsInOrderAs comparable(lookups)
-    }
-  }
-
-  it should "return the same result regardless of the page size" in {
-    for {
-      (from, to, _) <- storeTestFixture()
-      result1 <- transactionsOf(
-        ledgerDao.transactionsReader
-          .getFlatTransactions(
-            startExclusive = from,
-            endInclusive = to,
-            filter = Map(alice -> Set.empty, bob -> Set.empty, charlie -> Set.empty),
-            pageSize = 100,
-            verbose = true,
-          ))
-      result2 <- transactionsOf(
-        ledgerDao.transactionsReader
-          .getFlatTransactions(
-            startExclusive = from,
-            endInclusive = to,
-            filter = Map(alice -> Set.empty, bob -> Set.empty, charlie -> Set.empty),
-            pageSize = 1,
-            verbose = true,
-          ))
-    } yield {
-      result1 should contain theSameElementsInOrderAs result2
     }
   }
 
@@ -183,7 +156,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             startExclusive = from,
             endInclusive = to,
             filter = Map(alice -> Set.empty),
-            pageSize = 100,
             verbose = true,
           ))
       resultForBob <- transactionsOf(
@@ -192,7 +164,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             startExclusive = from,
             endInclusive = to,
             filter = Map(bob -> Set.empty),
-            pageSize = 100,
             verbose = true,
           ))
       resultForCharlie <- transactionsOf(
@@ -201,7 +172,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             startExclusive = from,
             endInclusive = to,
             filter = Map(charlie -> Set.empty),
-            pageSize = 100,
             verbose = true,
           ))
     } yield {
@@ -230,7 +200,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             startExclusive = from,
             endInclusive = to,
             filter = Map(alice -> Set(Identifier.assertFromString("pkg:mod:Template3"))),
-            pageSize = 100,
             verbose = true,
           ))
     } yield {
@@ -271,7 +240,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
                 Identifier.assertFromString("pkg:mod:Template3"),
               )
             ),
-            pageSize = 100,
             verbose = true,
           ))
     } yield {
@@ -322,7 +290,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
                 Identifier.assertFromString("pkg:mod:Template3"),
               )
             ),
-            pageSize = 100,
             verbose = true,
           ))
     } yield {
@@ -371,7 +338,6 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
               ),
               bob -> Set.empty
             ),
-            pageSize = 100,
             verbose = true,
           ))
     } yield {

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -67,7 +67,8 @@ class ImplicitPartyAdditionIT
             participantId,
             timeProvider,
             ledgerConfig,
-            metrics)
+            metrics,
+          )
         }
     }
   }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -68,7 +68,8 @@ class TransactionTimeModelComplianceIT
             participantId,
             timeProvider,
             ledgerConfig,
-            metrics)
+            metrics,
+          )
         }
     }
   }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -211,9 +211,10 @@ class SqlLedgerSpec
             .fold(sys.error, identity),
           initialLedgerEntries = ImmArray.empty,
           initialConfig = Configuration(0, TimeModel.reasonableDefault, Duration.ofDays(1)),
-          queueDepth,
+          queueDepth = queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
-          metrics,
+          metrics = metrics,
+          eventsPageSize = 100,
         )
         .acquire()(system.dispatcher)
     }


### PR DESCRIPTION
- fixes outstanding issue with package id ignored when filtering
- adds --events-page-size CLI option to set the fetch size when streaming transactions

changelog_begin
[Sandbox] The --events-page-size option allows to tweak the fetch size when streaming
transactions.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
