### PR TITLE
fix permissions on periodic-killer

### DIFF
--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -21,6 +21,7 @@ resource "google_project_iam_custom_role" "periodic-killer" {
   permissions = [
     "compute.instances.delete",
     "compute.instances.list",
+    "compute.zoneOperations.get",
     "compute.zones.list",
   ]
 }


### PR DESCRIPTION
Even though the command succeeds as far as deleting the machine goes, it does log an error. That is probably why we recently had only one machine deleted per night.

Something must have changed on the Google side recently to make this additional permission required.

CHANGELOG_BEGIN
CHANGELOG_END