### PR TITLE
Mark build-and-lint-test flaky

### DIFF
--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -101,6 +101,7 @@ sh_test(
             "ts/**/lib/**",
         ],
     ),
+    flaky = True,
     tags = [
         "exclusive",  # Due to the use of hardcoded ports in 'build-and-lint.sh'.
     ],


### PR DESCRIPTION
Reluctantly marking `build-and-lint-test` "flaky" in light of the recent spate of as yet unexplained failures.