### PR TITLE
Report UnknownTemplateIds warning before sending an error

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1074,7 +1074,7 @@ Please note that Streaming API does not allow multiple requests over the same We
 Error and Warning Reporting
 ===========================
 
-Errors and warnings reported as part of the regular ``on-message`` flow.
+Errors and warnings reported as part of the regular ``on-message`` flow: ``ws.addEventListener("message", ...)``.
 
 Streaming API error messages formatted the same way as :ref:`synchronous API errors <error-format>`.
 

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1084,7 +1084,8 @@ Streaming API reports only one type of warnings -- unknown template IDs, which i
 
     {"warnings":{"unknownTemplateIds":<JSON Array of template ID strings>>}}
 
-Examples of Warnings and Errors:
+Error and Warning Examples:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: none
 

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1100,6 +1100,11 @@ Examples:
       "status":400
     }
 
+    {
+      "errors":["Could not resolve any template ID from request."],
+      "status":400
+    }
+
 Contracts Query Stream
 ======================
 

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1084,7 +1084,7 @@ Streaming API reports only one type of warnings -- unknown template IDs, which i
 
     {"warnings":{"unknownTemplateIds":<JSON Array of template ID strings>>}}
 
-Examples:
+Examples of Warnings and Errors:
 
 .. code-block:: none
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -358,14 +358,12 @@ class WebSocketService(
       .via(allowOnlyFirstInput(
         InvalidUserInput("Multiple requests over the same WebSocket connection are not allowed.")))
       .flatMapMerge(
-        2,
-        x =>
-          x.flatMap {
-              case (offPrefix, qq: Q.Query[q]) =>
-                implicit val SQ: StreamQuery[q] = qq.alg
-                getTransactionSourceForParty[q](jwt, jwtPayload.party, offPrefix, qq.q: q)
-            }
-            .fold(e => Source.single(-\/(e)), s => s.map(\/-(_))): Source[Error \/ Message, NotUsed]
+        2, // 2 streams max, the 2nd is to be able to send an error back
+        _.map {
+          case (offPrefix, qq: Q.Query[q]) =>
+            implicit val SQ: StreamQuery[q] = qq.alg
+            getTransactionSourceForParty[q](jwt, jwtPayload.party, offPrefix, qq.q: q)
+        }.fold(e => Source.single(-\/(e)), identity): Source[Error \/ Message, NotUsed]
       )
       .takeWhile(_.isRight, inclusive = true) // stop after emitting 1st error
       .map(_.fold(e => wsErrorMessage(e), identity): Message)
@@ -388,13 +386,13 @@ class WebSocketService(
       jwt: Jwt,
       party: domain.Party,
       offPrefix: Option[domain.StartingOffset],
-      request: A): Error \/ Source[Message, NotUsed] = {
+      request: A): Source[Error \/ Message, NotUsed] = {
     val Q = implicitly[StreamQuery[A]]
 
     val (resolved, unresolved, fn) = Q.predicate(request, resolveTemplateId, lookupType)
 
     if (resolved.nonEmpty) {
-      val source = contractsService
+      contractsService
         .insertDeleteStepSource(jwt, party, resolved.toList, offPrefix, Terminates.Never)
         .via(convertFilterContracts(fn))
         .filter(_.nonEmpty)
@@ -402,11 +400,12 @@ class WebSocketService(
         .map(_.mapPos(Q.renderCreatedMetadata).render)
         .via(renderEventsAndEmitHeartbeats) // wrong place, see https://github.com/digital-asset/daml/issues/4955
         .prepend(reportUnresolvedTemplateIds(unresolved))
-        .map(jsv => TextMessage(jsv.compactPrint))
-      \/-(source)
+        .map(jsv => \/-(wsMessage(jsv)))
     } else {
-      -\/(InvalidUserInput(
-        s"Cannot resolve any of the requested template IDs: ${unresolved: Set[domain.TemplateId.OptionalPkg]}"))
+      reportUnresolvedTemplateIds(unresolved)
+        .map(jsv => \/-(wsMessage(jsv)))
+        .concat(
+          Source.single(-\/(InvalidUserInput(s"Could not resolve any template ID from request."))))
     }
   }
 
@@ -455,9 +454,11 @@ class WebSocketService(
       .collect { case (_, Some(x)) => x }
   }
 
-  private[http] def wsErrorMessage(error: Error): TextMessage.Strict = {
-    TextMessage(errorResponse(error).toJson.compactPrint)
-  }
+  private[http] def wsErrorMessage(error: Error): TextMessage.Strict =
+    wsMessage(errorResponse(error).toJson)
+
+  private[http] def wsMessage(jsVal: JsValue): TextMessage.Strict =
+    TextMessage(jsVal.compactPrint)
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   private def convertFilterContracts[Pos](fn: domain.ActiveContract[LfV] => Option[Pos])
@@ -488,9 +489,9 @@ class WebSocketService(
   private def reportUnresolvedTemplateIds(
       unresolved: Set[domain.TemplateId.OptionalPkg]): Source[JsValue, NotUsed] =
     if (unresolved.isEmpty) Source.empty
-    else
-      Source.single {
-        import spray.json._
-        Map("warnings" -> domain.UnknownTemplateIds(unresolved.toList)).toJson
-      }
+    else {
+      import spray.json._
+      Source.single(domain.WarningsWrapper(domain.UnknownTemplateIds(unresolved.toList)).toJson)
+    }
+
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -363,7 +363,7 @@ class WebSocketService(
           case (offPrefix, qq: Q.Query[q]) =>
             implicit val SQ: StreamQuery[q] = qq.alg
             getTransactionSourceForParty[q](jwt, jwtPayload.party, offPrefix, qq.q: q)
-        }.fold(e => Source.single(-\/(e)), identity): Source[Error \/ Message, NotUsed]
+        }.valueOr(e => Source.single(-\/(e))): Source[Error \/ Message, NotUsed]
       )
       .takeWhile(_.isRight, inclusive = true) // stop after emitting 1st error
       .map(_.fold(e => wsErrorMessage(e), identity): Message)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -588,4 +588,6 @@ object domain {
       extends ServiceWarning
 
   final case class UnknownParties(unknownParties: List[domain.Party]) extends ServiceWarning
+
+  final case class WarningsWrapper(warnings: ServiceWarning)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -350,6 +350,9 @@ object JsonProtocol extends DefaultJsonProtocol {
       }
     }
 
+  implicit val WarningsWrapperFormat: RootJsonFormat[domain.WarningsWrapper] =
+    jsonFormat1(domain.WarningsWrapper)
+
   implicit val UnknownTemplateIdsFormat: RootJsonFormat[domain.UnknownTemplateIds] = jsonFormat1(
     domain.UnknownTemplateIds)
 

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -155,4 +155,18 @@ object Generators {
       a2 <- Gen.posNum[Int]
       a3 <- Gen.posNum[Int]
     } yield lav1.ledger_offset.LedgerOffset.Value.Absolute(s"${a1: String}-${a2: Int}-${a3: Int}")
+
+  def genUnknownTemplateIds: Gen[domain.UnknownTemplateIds] =
+    Gen
+      .listOf(genDomainTemplateIdO(OptionalPackageIdGen))
+      .map(domain.UnknownTemplateIds)
+
+  def genUnknownParties: Gen[domain.UnknownParties] =
+    Gen.listOf(partyGen).map(domain.UnknownParties)
+
+  def genServiceWarning: Gen[domain.ServiceWarning] =
+    Gen.oneOf(genUnknownTemplateIds, genUnknownParties)
+
+  def genWarningsWrapper: Gen[domain.WarningsWrapper] =
+    genServiceWarning.map(domain.WarningsWrapper)
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
@@ -106,6 +106,44 @@ class WebsocketServiceIntegrationTest
     }
   }
 
+  List(
+    SimpleScenario(
+      "query",
+      Uri.Path("/v1/stream/query"),
+      Source.single(TextMessage.Strict("""{"templateIds": ["AA:BB"]}"""))),
+    SimpleScenario(
+      "fetch",
+      Uri.Path("/v1/stream/fetch"),
+      Source.single(TextMessage.Strict("""[{"templateId": "AA:BB", "key": ["k", "v"]}]""")))
+  ).foreach { scenario =>
+    s"${scenario.id} report UnknownTemplateIds and error when cannot resolve any template ID" in withHttpService {
+      (uri, _, _) =>
+        val webSocketFlow =
+          Http().webSocketClientFlow(
+            WebSocketRequest(
+              uri = uri.copy(scheme = "ws").withPath(scenario.path),
+              subprotocol = validSubprotocol))
+        scenario.input
+          .via(webSocketFlow)
+          .runWith(collectResultsAsTextMessageSkipOffsetTicks)
+          .flatMap { msgs =>
+            inside(msgs) {
+              case Seq(warningMsg, errorMsg) =>
+                val warning = decodeServiceWarning(warningMsg)
+                inside(warning) {
+                  case domain.UnknownTemplateIds(ids) =>
+                    ids shouldBe List(domain.TemplateId(None, "AA", "BB"))
+                }
+                val error = decodeErrorResponse(errorMsg)
+                error shouldBe domain.ErrorResponse(
+                  List("Could not resolve any template ID from request."),
+                  StatusCodes.BadRequest
+                )
+            }
+          }
+    }
+  }
+
   private val collectResultsAsTextMessageSkipOffsetTicks: Sink[Message, Future[Seq[String]]] =
     Flow[Message]
       .collect { case m: TextMessage => m.getStrictText }
@@ -592,6 +630,13 @@ class WebsocketServiceIntegrationTest
     import json.JsonProtocol._
     inside(SprayJson.decode1[domain.ErrorResponse, List[String]](str)) {
       case \/-(e) => e
+    }
+  }
+
+  private def decodeServiceWarning(str: String): domain.ServiceWarning = {
+    import json.JsonProtocol._
+    inside(SprayJson.decode[domain.WarningsWrapper](str)) {
+      case \/-(w) => w.warnings
     }
   }
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -117,7 +117,7 @@ class JsonProtocolTest
   }
 
   "domain.WarningsWrapper" - {
-    "WarningsWrapper serialization" in forAll(genWarningsWrapper) { x =>
+    "serialization" in forAll(genWarningsWrapper) { x =>
       inside(x.toJson) {
         case JsObject(fields) if fields.contains("warnings") && fields.size == 1 =>
           Succeeded

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -9,17 +9,23 @@ import com.digitalasset.http.Generators.{
   contractLocatorGen,
   exerciseCmdGen,
   genDomainTemplateId,
-  genDomainTemplateIdO
+  genDomainTemplateIdO,
+  genServiceWarning,
+  genUnknownParties,
+  genUnknownTemplateIds,
+  genWarningsWrapper
 }
 import com.digitalasset.http.Statement.discard
 import com.digitalasset.http.domain
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen.{identifier, listOf}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{FreeSpec, Inside, Matchers}
+import org.scalatest.{FreeSpec, Inside, Matchers, Succeeded}
 import scalaz.syntax.std.option._
 import scalaz.syntax.tag._
 import scalaz.{\/, \/-}
+
+import scala.collection.breakOut
 
 class JsonProtocolTest
     extends FreeSpec
@@ -91,6 +97,34 @@ class JsonProtocolTest
     type Loc = domain.ContractLocator[JsValue]
     "roundtrips" in forAll(contractLocatorGen(arbitrary[Int] map (JsNumber(_)))) { locator: Loc =>
       locator.toJson.convertTo[Loc] should ===(locator)
+    }
+  }
+
+  "domain.ServiceWarning" - {
+    "UnknownTemplateIds serialization" in forAll(genUnknownTemplateIds) { x =>
+      val expectedTemplateIds: Vector[JsValue] = x.unknownTemplateIds.map(_.toJson)(breakOut)
+      val expected = JsObject("unknownTemplateIds" -> JsArray(expectedTemplateIds))
+      x.toJson.asJsObject shouldBe expected
+    }
+    "UnknownParties serialization" in forAll(genUnknownParties) { x =>
+      val expectedParties: Vector[JsValue] = x.unknownParties.map(_.toJson)(breakOut)
+      val expected = JsObject("unknownParties" -> JsArray(expectedParties))
+      x.toJson.asJsObject shouldBe expected
+    }
+    "roundtrips" in forAll(genServiceWarning) { x =>
+      x.toJson.convertTo[domain.ServiceWarning] === x
+    }
+  }
+
+  "domain.WarningsWrapper" - {
+    "WarningsWrapper serialization" in forAll(genWarningsWrapper) { x =>
+      inside(x.toJson) {
+        case JsObject(fields) if fields.contains("warnings") && fields.size == 1 =>
+          Succeeded
+      }
+    }
+    "roundtrips" in forAll(genWarningsWrapper) { x =>
+      x.toJson.convertTo[domain.WarningsWrapper] === x
     }
   }
 


### PR DESCRIPTION
if no template IDs resolved, send warning before the error, this is for
consistency with the case when at least one ID resolved (we continue
processing request in this case).

Related to: #4521

This PR addresses step 3 from above ticket/discussion:

> Would it make sense to send warnings for all template ids that cannot be resolved and send an error if the list of template ids that can be resolved is empty? Thus, a query containing only invalid template ids would first have a warning for each template id that it cannot be resolved and then an error that there are no template ids that can be resolved. Sending an empty list of template ids would not trigger the warning but only the error.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
