### PR TITLE
DAML-LF: deprecate all DAML-LF versions < 1.6

### DIFF
--- a/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/digitalasset/daml_lf_dev/daml_lf_1.proto
@@ -15,7 +15,7 @@
 //   and light.
 
 
-// Minor version history (to be officialized in the spec):
+// Minor version history:
 // * 0 (somewhen in December 2018): initial version
 // * 1 -- 2019-01-10: Add Optional type
 //     -- 2019-01-27: Add <, <=, =>, > for Party

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -66,6 +66,11 @@ and operate on the same major version of the serialization format in
 a backward compatible way. This document describes DAML-LF major version
 1, including all its minor versions.
 
+Starting from DAML SDK 1.0 release, DAML-LF versions older than 1.6 are
+deprecated. An engine compliant with the present specification must handle
+all versions newer than or equal to DAML-LF 1.6, no requirement is made on
+handling older version.
+
 Each DAML-LF program is accompanied by the version identifier of the
 language it was serialized in. This number enables the DAML-LF engine
 to interpret previous versions of the language in a backward
@@ -93,8 +98,8 @@ features involved in the change.  One can refer also to the
 and backward compatibility.
 
 
-Version 1.0
-...........
+Version 1.0 (deprecated)
+........................
 
 * Introduction date:
 
@@ -104,8 +109,8 @@ Version 1.0
 
     Initial version
 
-Version: 1.1
-............
+Version: 1.1 (deprecated)
+.........................
 
 * Introduction date:
 
@@ -136,8 +141,8 @@ Version: 1.1
     refer to section `Function type vs arrow type`.
 
 
-Version: 1.2
-............
+Version: 1.2 (deprecated)
+.........................
 
 * Introduction date:
 
@@ -156,8 +161,8 @@ Version: 1.2
     in the surface language
 
 
-Version: 1.3
-............
+Version: 1.3 (deprecated)
+.........................
 
 * Introduction date:
 
@@ -169,8 +174,8 @@ Version: 1.3
 
   + **Add** support for built-in ``'Map'`` type.
 
-Version: 1.4
-............
+Version: 1.4 (deprecated)
+.........................
 
 * Introduction date:
 
@@ -180,8 +185,8 @@ Version: 1.4
 
   + **Add** support for complex contract keys.
 
-Version: 1.5
-............
+Version: 1.5 (deprecated)
+.........................
 
 * Introduction date:
 
@@ -218,7 +223,6 @@ Version: 1.6
 
 Version: 1.7
 ............
-
 
 * Introduction date:
 
@@ -570,7 +574,7 @@ can produce V0 or V1 contract identifiers.  When configured to produce
 V0 contract identifiers, a DAML-LF compliant engine must refuse to
 load any DAML-LF >= 1.dev archives.  On the contrary, when configured
 to produce V1 contract ids, a DAML-LF compliant engine must accept to
-load any DAML-LF version.
+load any non-deprecated DAML-LF version.
 
 Also note that package identifiers are typically `cryptographic hash
 <Package hash_>`_ of the content of the package itself.


### PR DESCRIPTION
We update the spec to officially deprecate DAML-LF < 1.6

This advance the state of #5220

CHANGELOG_BEGIN
* [DAML-LF] *Breaking* deprecating all DAML-LF versions < 1.6
   - older versions will be maintained and supported for Sandbox classic.
   - no data continuity would be guaranteed any-more for other ledgers using DAML-LF < 1.6
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
