### PR TITLE
Removing unused domain.JwtPayload JSON formatter

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -97,8 +97,6 @@ object JsonProtocol extends DefaultJsonProtocol {
     }
   }
 
-  implicit val JwtPayloadFormat: RootJsonFormat[domain.JwtPayload] = jsonFormat3(domain.JwtPayload)
-
   implicit val InstantFormat: JsonFormat[java.time.Instant] = new JsonFormat[Instant] {
     override def write(obj: Instant): JsValue = JsNumber(obj.toEpochMilli)
 


### PR DESCRIPTION
we have been relying on `ledger.api.auth.AuthServiceJWTCodec` since the
refactoring happened

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
