### PR TITLE
Sync query error reporting improvements

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -222,9 +222,9 @@ If client's HTTP GET or POST request reaches an API endpoint, the corresponding 
 .. code-block:: none
 
     {
-        "status": <400 | 401 | 404 | 500>
-        ,"errors": <JSON array of strings> | ,"result": <JSON object>
-        [ ,"warnings": <JSON object> ]
+        "status": <400 | 401 | 404 | 500>,
+        "errors": <JSON array of strings>, | "result": <JSON object or array>,
+        ["warnings": <JSON object> ]
     }
 
 Where:
@@ -281,21 +281,43 @@ Failure, HTTP status: 400 | 401 | 404 | 500
 Examples
 ========
 
+**Result with JSON Object without Warnings:**
+
 .. code-block:: none
 
     {"status": 200, "result": {...}}
+
+**Result with JSON Array Warnings:**
 
 .. code-block:: none
 
     {"status": 200, "result": [...], "warnings": {"unknownTemplateIds": ["UnknownModule:UnknownEntity"]}}
 
-.. code-block:: json
-
-    {"status": 401, "errors": ["Authentication Required"]}
+**Bad Request Error:**
 
 .. code-block:: json
 
     {"status": 400, "errors": ["JSON parser error: Unexpected character 'f' at input index 27 (line 1, position 28)"]}
+
+**Bad Request Error with Warnings:**
+
+.. code-block:: json
+
+    {"status":400, "errors":["Cannot not resolve any template ID from request"], "warnings":{"unknownTemplateIds":["XXX:YYY","AAA:BBB"]}}
+
+**Authentication Error:**
+
+.. code-block:: json
+
+    {"status": 401, "errors": ["Authentication Required"]}
+
+**Not Found Error:**
+
+.. code-block:: json
+
+    {"status": 404, "errors": ["HttpMethod(POST), uri: http://localhost:7575/v1/query1"]}
+
+**Internal Server Error:**
 
 .. code-block:: json
 

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -287,7 +287,7 @@ Examples
 
     {"status": 200, "result": {...}}
 
-**Result with JSON Array Warnings:**
+**Result with JSON Array and Warnings:**
 
 .. code-block:: none
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.http
 
 import akka.NotUsed
+import akka.http.scaladsl.model.StatusCodes
 import akka.stream.scaladsl._
 import akka.stream.Materializer
 import com.digitalasset.daml.lf
@@ -155,9 +156,8 @@ class ContractsService(
       jwt: Jwt,
       party: domain.Party,
   ): SearchResult[Error \/ domain.ActiveContract[LfValue]] =
-    SearchResult(
-      Source(allTemplateIds()).flatMapConcat(x => searchInMemoryOneTpId(jwt, party, x, Map.empty)),
-      Set.empty,
+    domain.OkResponse(
+      Source(allTemplateIds()).flatMapConcat(x => searchInMemoryOneTpId(jwt, party, x, Map.empty))
     )
 
   def search(
@@ -176,13 +176,24 @@ class ContractsService(
 
     val (resolvedTemplateIds, unresolvedTemplateIds) = resolveTemplateIds(templateIds)
 
-    val source = daoAndFetch.cata(
-      x => searchDb(x._1, x._2)(jwt, party, resolvedTemplateIds, queryParams),
-      searchInMemory(jwt, party, resolvedTemplateIds, queryParams)
-        .map(_.flatMap(lfAcToJsAc)),
-    )
+    val warnings: Option[domain.UnknownTemplateIds] =
+      if (unresolvedTemplateIds.isEmpty) None
+      else Some(domain.UnknownTemplateIds(unresolvedTemplateIds.toList))
 
-    SearchResult(source, unresolvedTemplateIds)
+    if (resolvedTemplateIds.isEmpty) {
+      domain.ErrorResponse(
+        errors = List(ErrorMessages.cannotResolveAnyTemplateId),
+        warnings = warnings,
+        status = StatusCodes.BadRequest
+      )
+    } else {
+      val source = daoAndFetch.cata(
+        x => searchDb(x._1, x._2)(jwt, party, resolvedTemplateIds, queryParams),
+        searchInMemory(jwt, party, resolvedTemplateIds, queryParams)
+          .map(_.flatMap(lfAcToJsAc)),
+      )
+      domain.OkResponse(source, warnings)
+    }
   }
 
   // we store create arguments as JSON in DB, that is why it is `domain.ActiveContract[JsValue]` in the result
@@ -352,8 +363,5 @@ object ContractsService {
     }
   }
 
-  final case class SearchResult[A](
-      source: Source[A, NotUsed],
-      unresolvedTemplateIds: Set[domain.TemplateId.OptionalPkg],
-  )
+  type SearchResult[A] = domain.SyncResponse[Source[A, NotUsed]]
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -376,6 +376,7 @@ object Endpoints {
     } yield c
   }
 
+  // TODO(Leo) return error if all parties are unknown
   private def okResponse(
       parties: List[domain.PartyDetails],
       unknownParties: List[domain.Party]): domain.OkResponse[List[domain.PartyDetails]] = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ErrorMessages.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ErrorMessages.scala
@@ -9,6 +9,9 @@ object ErrorMessages {
   def cannotResolveTemplateId(t: domain.TemplateId[_]): String =
     s"Cannot resolve template ID, given: ${t.toString}"
 
+  def cannotResolveAnyTemplateId: String =
+    "Cannot not resolve any template ID from request"
+
   def cannotResolveTemplateId(a: domain.ContractLocator[_]): String =
     s"Cannot resolve templateId, given: $a"
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -457,7 +457,7 @@ class WebSocketService(
   }
 
   private[http] def wsErrorMessage(error: Error): TextMessage.Strict =
-    wsMessage(errorResponse(error).toJson)
+    wsMessage(SprayJson.encodeUnsafe(errorResponse(error)))
 
   private[http] def wsMessage(jsVal: JsValue): TextMessage.Strict =
     TextMessage(jsVal.compactPrint)
@@ -493,7 +493,6 @@ class WebSocketService(
     if (unresolved.isEmpty) Source.empty
     else {
       import spray.json._
-      Source.single(domain.WarningsWrapper(domain.UnknownTemplateIds(unresolved.toList)).toJson)
+      Source.single(domain.AsyncWarningsWrapper(domain.UnknownTemplateIds(unresolved.toList)).toJson)
     }
-
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -406,8 +406,7 @@ class WebSocketService(
     } else {
       reportUnresolvedTemplateIds(unresolved)
         .map(jsv => \/-(wsMessage(jsv)))
-        .concat(
-          Source.single(-\/(InvalidUserInput(s"Could not resolve any template ID from request."))))
+        .concat(Source.single(-\/(InvalidUserInput(ErrorMessages.cannotResolveAnyTemplateId))))
     }
   }
 
@@ -493,6 +492,7 @@ class WebSocketService(
     if (unresolved.isEmpty) Source.empty
     else {
       import spray.json._
-      Source.single(domain.AsyncWarningsWrapper(domain.UnknownTemplateIds(unresolved.toList)).toJson)
+      Source.single(
+        domain.AsyncWarningsWrapper(domain.UnknownTemplateIds(unresolved.toList)).toJson)
     }
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -554,32 +554,39 @@ object domain {
     }
   }
 
-  sealed abstract class ServiceResponse extends Product with Serializable
+  sealed abstract class SyncResponse[+R] extends Product with Serializable
 
-  final case class OkResponse[R, W](
+  final case class OkResponse[+R](
       result: R,
-      warnings: Option[W] = Option.empty[W],
+      warnings: Option[ServiceWarning] = None,
       status: StatusCode = StatusCodes.OK,
-  ) extends ServiceResponse
+  ) extends SyncResponse[R]
 
-  final case class ErrorResponse[E](errors: E, status: StatusCode) extends ServiceResponse
+  final case class ErrorResponse(
+      errors: List[String],
+      warnings: Option[ServiceWarning],
+      status: StatusCode,
+  ) extends SyncResponse[Nothing]
 
   object OkResponse {
-    implicit val covariant: Bitraverse[OkResponse] = new Bitraverse[OkResponse] {
-      override def bitraverseImpl[G[_]: Applicative, A, B, C, D](
-          fab: OkResponse[A, B],
-      )(f: A => G[C], g: B => G[D]): G[OkResponse[C, D]] = {
-        import scalaz.syntax.applicative._
-        ^(f(fab.result), fab.warnings.traverse(g))((c, d) => fab.copy(result = c, warnings = d))
-      }
+    implicit val covariant: Traverse[OkResponse] = new Traverse[OkResponse] {
+      override def traverseImpl[G[_]: Applicative, A, B](fa: OkResponse[A])(
+          f: A => G[B]): G[OkResponse[B]] =
+        f(fa.result).map(b => fa.copy(result = b))
     }
   }
 
-  object ErrorResponse {
-    implicit val traverseInstance: Traverse[ErrorResponse] = new Traverse[ErrorResponse] {
-      override def traverseImpl[G[_]: Applicative, A, B](fa: ErrorResponse[A])(
-          f: A => G[B],
-      ): G[ErrorResponse[B]] = f(fa.errors).map(b => fa.copy(errors = b))
+  object SyncResponse {
+    implicit val covariant: Traverse[SyncResponse] = new Traverse[SyncResponse] {
+      override def traverseImpl[G[_]: Applicative, A, B](fa: SyncResponse[A])(
+          f: A => G[B]): G[SyncResponse[B]] = {
+        import scalaz.syntax.functor._
+        val G = implicitly[Applicative[G]]
+        fa match {
+          case err: ErrorResponse => G.point[SyncResponse[B]](err)
+          case ok: OkResponse[A] => OkResponse.covariant.traverse(ok)(f).widen
+        }
+      }
     }
   }
 
@@ -590,5 +597,6 @@ object domain {
 
   final case class UnknownParties(unknownParties: List[domain.Party]) extends ServiceWarning
 
-  final case class WarningsWrapper(warnings: ServiceWarning)
+  // It wraps warnings in the streaming API.. TODO(Leo): define AsyncResponse ADT
+  final case class AsyncWarningsWrapper(warnings: ServiceWarning)
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -24,6 +24,7 @@ import scalaz.{
   Applicative,
   Bitraverse,
   NonEmptyList,
+  OneAnd,
   Semigroup,
   Show,
   Tag,
@@ -92,7 +93,7 @@ object domain {
   )
 
   case class GetActiveContractsRequest(
-      templateIds: Set[TemplateId.OptionalPkg],
+      templateIds: OneAnd[Set, TemplateId.OptionalPkg],
       query: Map[String, JsValue],
   )
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -360,7 +360,7 @@ object JsonProtocol extends DefaultJsonProtocol {
   implicit val ErrorResponseFormat: RootJsonFormat[domain.ErrorResponse] =
     jsonFormat3(domain.ErrorResponse)
 
-  implicit def SyncResponse[R: JsonFormat]: RootJsonFormat[domain.SyncResponse[R]] =
+  implicit def SyncResponseFormat[R: JsonFormat]: RootJsonFormat[domain.SyncResponse[R]] =
     new RootJsonFormat[domain.SyncResponse[R]] {
       private val resultKey = "result"
       private val errorsKey = "errors"

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/SprayJson.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/SprayJson.scala
@@ -52,10 +52,7 @@ object SprayJson {
       implicit ev1: JsonReader[F[JsValue]],
       ev2: Traverse[F],
       ev3: JsonReader[A]): JsonReaderError \/ F[A] =
-    for {
-      jsValue <- parse(str)
-      a <- decode1[F, A](jsValue)
-    } yield a
+    parse(str).flatMap(decode1[F, A])
 
   def decode1[F[_], A](a: JsValue)(
       implicit ev1: JsonReader[F[JsValue]],
@@ -65,6 +62,13 @@ object SprayJson {
       fj <- decode[F[JsValue]](a)
       fa <- fj.traverse(decode[A](_))
     } yield fa
+
+  def decode2[F[_, _], A, B](str: String)(
+      implicit ev1: JsonReader[F[JsValue, JsValue]],
+      ev2: Bitraverse[F],
+      ev3: JsonReader[A],
+      ev4: JsonReader[B]): JsonReaderError \/ F[A, B] =
+    parse(str).flatMap(decode2[F, A, B])
 
   def decode2[F[_, _], A, B](a: JsValue)(
       implicit ev1: JsonReader[F[JsValue, JsValue]],
@@ -79,6 +83,11 @@ object SprayJson {
   def encode[A: JsonWriter](a: A): JsonWriterError \/ JsValue = {
     import spray.json._
     \/.fromTryCatchNonFatal(a.toJson).leftMap(e => JsonWriterError(a, e.description))
+  }
+
+  def encodeUnsafe[A: JsonWriter](a: A): JsValue = {
+    import spray.json._
+    a.toJson
   }
 
   def encode1[F[_], A](fa: F[A])(

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -901,7 +901,7 @@ abstract class AbstractHttpServiceIntegrationTest
           assertStatus(output, StatusCodes.BadRequest)
           val errorMsg = expectedOneErrorMessage(output)
           errorMsg should include("Cannot read JSON: <[]>")
-          errorMsg should include("must be a list with at least 1 element")
+          errorMsg should include("must be a JSON array with at least 1 element")
       }: Future[Assertion]
   }
 

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -490,8 +490,9 @@ abstract class AbstractHttpServiceIntegrationTest
         encoder
       ).map { response =>
         inside(response) {
-          case domain.ErrorResponse(errors, warnings, StatusCodes.BadRequest) =>
-            errors.size shouldBe 1
+          case domain.ErrorResponse(errors, warnings, status) =>
+            status shouldBe StatusCodes.BadRequest
+            errors shouldBe List(ErrorMessages.cannotResolveAnyTemplateId)
             warnings shouldBe Some(domain.AsyncWarningsWrapper(domain.UnknownTemplateIds(
               List(domain.TemplateId(None, "AAA", "BBB"), domain.TemplateId(None, "XXX", "YYY")))))
         }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -490,8 +490,7 @@ abstract class AbstractHttpServiceIntegrationTest
         encoder
       ).map { response =>
         inside(response) {
-          case domain.ErrorResponse(errors, warnings, status) =>
-            status shouldBe StatusCodes.BadRequest
+          case domain.ErrorResponse(errors, warnings, StatusCodes.BadRequest) =>
             errors shouldBe List(ErrorMessages.cannotResolveAnyTemplateId)
             inside(warnings) {
               case Some(domain.UnknownTemplateIds(unknownTemplateIds)) =>

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/AbstractHttpServiceIntegrationTest.scala
@@ -493,8 +493,12 @@ abstract class AbstractHttpServiceIntegrationTest
           case domain.ErrorResponse(errors, warnings, status) =>
             status shouldBe StatusCodes.BadRequest
             errors shouldBe List(ErrorMessages.cannotResolveAnyTemplateId)
-            warnings shouldBe Some(domain.AsyncWarningsWrapper(domain.UnknownTemplateIds(
-              List(domain.TemplateId(None, "AAA", "BBB"), domain.TemplateId(None, "XXX", "YYY")))))
+            inside(warnings) {
+              case Some(domain.UnknownTemplateIds(unknownTemplateIds)) =>
+                unknownTemplateIds.toSet shouldBe Set(
+                  domain.TemplateId(None, "AAA", "BBB"),
+                  domain.TemplateId(None, "XXX", "YYY"))
+            }
         }
       }
   }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -167,6 +167,6 @@ object Generators {
   def genServiceWarning: Gen[domain.ServiceWarning] =
     Gen.oneOf(genUnknownTemplateIds, genUnknownParties)
 
-  def genWarningsWrapper: Gen[domain.WarningsWrapper] =
-    genServiceWarning.map(domain.WarningsWrapper)
+  def genWarningsWrapper: Gen[domain.AsyncWarningsWrapper] =
+    genServiceWarning.map(domain.AsyncWarningsWrapper)
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
@@ -33,7 +33,7 @@ class HttpServiceWithPostgresIntTest
   )
 
   "query persists all active contracts" in withHttpService { (uri, encoder, _) =>
-    searchWithQuery(
+    searchExpectOk(
       searchDataSet,
       jsObject("""{"templateIds": ["Iou:Iou"], "query": {"currency": "EUR"}}"""),
       uri,

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
@@ -99,6 +99,7 @@ class WebsocketServiceIntegrationTest
                 val error = decodeErrorResponse(errorMsg)
                 error shouldBe domain.ErrorResponse(
                   List("Multiple requests over the same WebSocket connection are not allowed."),
+                  None,
                   StatusCodes.BadRequest
                 )
             }
@@ -137,6 +138,7 @@ class WebsocketServiceIntegrationTest
                 val error = decodeErrorResponse(errorMsg)
                 error shouldBe domain.ErrorResponse(
                   List("Could not resolve any template ID from request."),
+                  None,
                   StatusCodes.BadRequest
                 )
             }
@@ -520,7 +522,7 @@ class WebsocketServiceIntegrationTest
               errorResponse.status shouldBe StatusCodes.BadRequest
               inside(errorResponse.errors) {
                 case List(error) =>
-                  error should include("must be a list with at least 1 element")
+                  error should include("must be a JSON array with at least 1 element")
               }
           }
         }: Future[Assertion]
@@ -626,16 +628,16 @@ class WebsocketServiceIntegrationTest
       }
       .valueOr(_ => false)
 
-  private def decodeErrorResponse(str: String): domain.ErrorResponse[List[String]] = {
+  private def decodeErrorResponse(str: String): domain.ErrorResponse = {
     import json.JsonProtocol._
-    inside(SprayJson.decode1[domain.ErrorResponse, List[String]](str)) {
+    inside(SprayJson.decode[domain.ErrorResponse](str)) {
       case \/-(e) => e
     }
   }
 
   private def decodeServiceWarning(str: String): domain.ServiceWarning = {
     import json.JsonProtocol._
-    inside(SprayJson.decode[domain.WarningsWrapper](str)) {
+    inside(SprayJson.decode[domain.AsyncWarningsWrapper](str)) {
       case \/-(w) => w.warnings
     }
   }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/WebsocketServiceIntegrationTest.scala
@@ -137,7 +137,7 @@ class WebsocketServiceIntegrationTest
                 }
                 val error = decodeErrorResponse(errorMsg)
                 error shouldBe domain.ErrorResponse(
-                  List("Could not resolve any template ID from request."),
+                  List(ErrorMessages.cannotResolveAnyTemplateId),
                   None,
                   StatusCodes.BadRequest
                 )

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/json/JsonProtocolTest.scala
@@ -3,6 +3,7 @@
 
 package com.digitalasset.http.json
 
+import akka.http.scaladsl.model.StatusCodes
 import com.digitalasset.http.Generators.{
   OptionalPackageIdGen,
   contractGen,
@@ -21,12 +22,14 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen.{identifier, listOf}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FreeSpec, Inside, Matchers, Succeeded}
+import scalaz.syntax.functor._
 import scalaz.syntax.std.option._
 import scalaz.syntax.tag._
 import scalaz.{\/, \/-}
 
 import scala.collection.breakOut
 
+@SuppressWarnings(Array("org.wartremover.warts.Any"))
 class JsonProtocolTest
     extends FreeSpec
     with Matchers
@@ -124,19 +127,18 @@ class JsonProtocolTest
       }
     }
     "roundtrips" in forAll(genWarningsWrapper) { x =>
-      x.toJson.convertTo[domain.WarningsWrapper] === x
+      x.toJson.convertTo[domain.AsyncWarningsWrapper] === x
     }
   }
 
   "domain.OkResponse" - {
-    import scalaz.syntax.bifunctor._
 
     "response with warnings" in forAll(listOf(genDomainTemplateIdO(OptionalPackageIdGen))) {
       templateIds: List[domain.TemplateId.OptionalPkg] =>
-        val response: domain.OkResponse[Int, domain.ServiceWarning] =
+        val response: domain.OkResponse[Int] =
           domain.OkResponse(result = 100, warnings = Some(domain.UnknownTemplateIds(templateIds)))
 
-        val responseJsVal: domain.OkResponse[JsValue, JsValue] = response.bimap(_.toJson, _.toJson)
+        val responseJsVal: domain.OkResponse[JsValue] = response.map(_.toJson)
 
         discard {
           responseJsVal.toJson shouldBe JsObject(
@@ -148,16 +150,31 @@ class JsonProtocolTest
     }
 
     "response without warnings" in forAll(identifier) { str =>
-      val response: domain.OkResponse[String, domain.ServiceWarning] =
+      val response: domain.OkResponse[String] =
         domain.OkResponse(result = str, warnings = None)
 
-      val responseJsVal: domain.OkResponse[JsValue, JsValue] = response.bimap(_.toJson, _.toJson)
+      val responseJsVal: domain.OkResponse[JsValue] = response.map(_.toJson)
 
       discard {
         responseJsVal.toJson shouldBe JsObject(
           "result" -> JsString(str),
           "status" -> JsNumber(200),
         )
+      }
+    }
+  }
+
+  "domain.SyncResponse" - {
+    "Ok response parsed" in {
+      import SprayJson.decode1
+
+      val str =
+        """{"warnings":{"unknownTemplateIds":["AAA:BBB"]},"result":[],"status":200}"""
+
+      inside(decode1[domain.SyncResponse, List[JsValue]](str)) {
+        case \/-(domain.OkResponse(List(), Some(warning), StatusCodes.OK)) =>
+          warning shouldBe domain.UnknownTemplateIds(
+            List(domain.TemplateId(Option.empty[String], "AAA", "BBB")))
       }
     }
   }


### PR DESCRIPTION
Related to: #4417

1. We are already rejecting search requests with empty templateIDs, this change documents this through the use of `OneAnd[Set, TemplateId.OptionalPkg]` in the domain class.

2. Plus another change to report error for the following search request:
```
{
  "templateIds": ["XXX:YYY","AAA:BBB"],
  "query": {"amount": 999.99}
}
```
this used to return OK, now it is a BadRequest  error with unknownTemplateIds warning (this matches the streaming API search behavior):
```
{
  "errors":["Cannot not resolve any template ID from request"],
  "warnings":{"unknownTemplateIds":["XXX:YYY","AAA:BBB"]},
  "status":400
}
```

### TODO:
- [x] Update docs, `errors` response has got an optional `warnings` element.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
