### PR TITLE
Retry if time lookup failed

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerTimeHelper.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerTimeHelper.scala
@@ -11,6 +11,7 @@ import com.digitalasset.daml.lf.data.Time
 import com.digitalasset.daml.lf.transaction.Transaction
 import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
 import com.digitalasset.ledger.api.domain.{Commands => ApiCommands}
+import com.digitalasset.logging.{ContextualizedLogger, LoggingContext}
 import com.digitalasset.platform.store.ErrorCause
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -21,6 +22,8 @@ final case class LedgerTimeHelper(
     maxRetries: Int,
 ) {
 
+  private val logger = ContextualizedLogger.get(this.getClass)
+
   /**
     * Executes a command, advancing the ledger time as necessary.
     *
@@ -30,14 +33,18 @@ final case class LedgerTimeHelper(
   def execute(
       commands: ApiCommands,
       submissionSeed: Option[crypto.Hash],
-  )(implicit ec: ExecutionContext): Future[Either[ErrorCause, CommandExecutionResult]] =
+  )(
+      implicit ec: ExecutionContext,
+      logCtx: LoggingContext): Future[Either[ErrorCause, CommandExecutionResult]] =
     loop(commands, submissionSeed, maxRetries)
 
   private[this] def loop(
       commands: ApiCommands,
       submissionSeed: Option[crypto.Hash],
       retriesLeft: Int,
-  )(implicit ec: ExecutionContext): Future[Either[ErrorCause, CommandExecutionResult]] = {
+  )(
+      implicit ec: ExecutionContext,
+      logCtx: LoggingContext): Future[Either[ErrorCause, CommandExecutionResult]] = {
     commandExecutor
       .execute(
         commands.submitter,
@@ -78,8 +85,14 @@ final case class LedgerTimeHelper(
               .recoverWith {
                 // An error while looking up the maximum ledger time for the used contracts
                 // most likely means that one of the contracts is already not active anymore,
-                // which can happen under contention. Retry without advancing time in this case.
-                case _ => loop(commands, submissionSeed, retriesLeft - 1)
+                // which can happen under contention.
+                // A retry would only be successful in case the archived contracts were referenced by key.
+                // Direct references to archived contracts will result in the same error.
+                case error =>
+                  logger.info(
+                    s"Lookup of maximum ledger time failed. This can happen if there is contention on contracts used by the transaction. Used contracts: ${usedContractIds
+                      .mkString(", ")}. Details: $error")
+                  Future.successful(Left(ErrorCause.LedgerTime(maxRetries - retriesLeft)))
               }
       }
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerTimeHelper.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerTimeHelper.scala
@@ -75,6 +75,12 @@ final case class LedgerTimeHelper(
                 else
                   Future.successful(Left(ErrorCause.LedgerTime(maxRetries)))
               })
+              .recoverWith {
+                // An error while looking up the maximum ledger time for the used contracts
+                // most likely means that one of the contracts is already not active anymore,
+                // which can happen under contention. Retry without advancing time in this case.
+                case _ => loop(commands, submissionSeed, retriesLeft - 1)
+              }
       }
   }
 


### PR DESCRIPTION
An error while looking up the maximum ledger time for the used contracts
likely means that one of the contracts is already not active anymore,
which can happen under contention.

Retry finding a suitable ledger time in this case instead of crashing.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
