### PR TITLE
Signal live streaming with 'live' event

### DIFF
--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -101,7 +101,6 @@ sh_test(
             "ts/**/lib/**",
         ],
     ),
-    flaky = True,
     tags = [
         "exclusive",  # Due to the use of hardcoded ports in 'build-and-lint.sh'.
     ],

--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -4,7 +4,7 @@
 load("//rules_daml:daml.bzl", "daml_compile")
 load("//bazel_tools:haskell.bzl", "da_haskell_library", "da_haskell_test")
 load("@build_environment//:configuration.bzl", "sdk_version")
-load("@os_info//:os_info.bzl", "is_windows")
+load("@os_info//:os_info.bzl", "is_linux", "is_windows")
 
 # This rule builds a dar from the daml sources under the 'daml'
 # directory. It is referenced from the 'build-and-lint-test' target that
@@ -107,7 +107,7 @@ sh_test(
     deps = [
         "@bazel_tools//tools/bash/runfiles",
     ],
-) if not is_windows else None
+) if is_linux else None
 
 da_haskell_library(
     name = "daml2ts-test-helpers",

--- a/language-support/ts/daml-ledger/index.test.ts
+++ b/language-support/ts/daml-ledger/index.test.ts
@@ -167,8 +167,7 @@ describe("streamQuery", () => {
     const stream = ledger.streamQuery(Foo);
     stream.on("change", state => mockChange(state));
     mockInstance.serverSend({ events: [] });
-    expect(mockChange).toHaveBeenCalledTimes(1);
-    expect(mockChange).toHaveBeenLastCalledWith([]);
+    expect(mockChange).toHaveBeenCalledTimes(0);
   });
 
   test("receive one event", () => {
@@ -209,8 +208,7 @@ describe("streamFetchByKey", () => {
     const stream = ledger.streamFetchByKey(Foo, 'badKey');
     stream.on("change", state => mockChange(state));
     mockInstance.serverSend({ events: [] });
-    expect(mockChange).toHaveBeenCalledTimes(1);
-    expect(mockChange).toHaveBeenCalledWith(null);
+    expect(mockChange).toHaveBeenCalledTimes(0);
   });
 
   test("receive one event", () => {

--- a/language-support/ts/daml-ledger/index.test.ts
+++ b/language-support/ts/daml-ledger/index.test.ts
@@ -5,7 +5,7 @@ import { Template, Choice, ContractId } from "@daml/types";
 import Ledger, {CreateEvent} from "./index";
 import { Event } from "./index";
 import * as jtv from "@mojotech/json-type-validation";
-import { EventEmitter } from 'events';
+import type { EventEmitter } from 'events';
 import mockConsole from "jest-mock-console";
 
 const mockLive = jest.fn();

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -502,8 +502,10 @@ class Ledger {
       const json: unknown = JSON.parse(event.data.toString());
       if (isRecordWith('events', json)) {
         const events = jtv.Result.withException(jtv.array(decodeEvent(template)).run(json.events));
-        state = change(state, events);
-        emitter.emit('change', state, events);
+        if (events.length > 0) {
+          state = change(state, events);
+          emitter.emit('change', state, events);
+        }
         if (isRecordWith('offset', json) && !isLive) {
           isLive = true;
           emitter.emit('live', state);

--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -154,12 +154,12 @@ export function useStreamQuery<T extends object, K, I extends string>(template: 
     const query = queryFactory ? queryFactory() : undefined;
     console.debug(`mount useStreamQuery(${template.templateId}, ...)`, query);
     const stream = state.ledger.streamQuery(template, query);
+    stream.on('live', () => setResult(result => ({...result, loading: false})));
     stream.on('change', contracts => setResult(result => ({...result, contracts})));
     stream.on('close', closeEvent => {
       console.error('useStreamQuery: web socket closed', closeEvent);
       setResult(result => ({...result, loading: true}));
     });
-    setResult(result => ({...result, loading: false}));
     return (): void => {
       console.debug(`unmount useStreamQuery(${template.templateId}, ...)`, query);
       stream.close();

--- a/language-support/ts/daml-react/index.test.ts
+++ b/language-support/ts/daml-react/index.test.ts
@@ -287,6 +287,44 @@ describe('useFetchByKey', () => {
 });
 
 describe('useStreamQuery', () => {
+  test('live event changes loading status', () => {
+    // setup
+    const query = 'foo-query';
+    const [stream, emitter] = mockStream();
+    mockStreamQuery.mockReturnValueOnce(stream);
+    const hookResult = renderDamlHook(() => useStreamQuery(Foo, () => ({query}), [query]));
+    expect(mockStreamQuery).toHaveBeenCalledTimes(1);
+    expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query});
+
+    // no events have been emitted.
+    expect(hookResult.result.current).toEqual({contracts: [], loading:true});
+
+    // live event
+    act(() =>
+      void emitter.emit('live', [])
+    );
+    expect(hookResult.result.current).toEqual({contracts: [], loading: false});
+  });
+
+  test('live event changes loading status', () => {
+    // setup
+    const query = 'foo-query';
+    const [stream, emitter] = mockStream();
+    mockStreamQuery.mockReturnValueOnce(stream);
+    const hookResult = renderDamlHook(() => useStreamQuery(Foo, () => ({query}), [query]));
+    expect(mockStreamQuery).toHaveBeenCalledTimes(1);
+    expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query});
+
+    // no events have been emitted.
+    expect(hookResult.result.current).toEqual({contracts: [], loading:true});
+
+    // live event
+    act(() =>
+      void emitter.emit('live', [])
+    );
+    expect(hookResult.result.current).toEqual({contracts: [], loading: false});
+  });
+
   test('empty stream', () => {
     // setup
     const query = 'foo-query';
@@ -295,7 +333,11 @@ describe('useStreamQuery', () => {
     const hookResult = renderDamlHook(() => useStreamQuery(Foo, () => ({query}), [query]));
     expect(mockStreamQuery).toHaveBeenCalledTimes(1);
     expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query});
-    expect(hookResult.result.current).toEqual({contracts: [], loading: false});
+
+    // live event
+    act(() =>
+      void emitter.emit('live', [])
+    );
 
     // no events have been emitted.
     expect(hookResult.result.current).toEqual({contracts: [], loading:false});
@@ -307,6 +349,7 @@ describe('useStreamQuery', () => {
     expect(hookResult.result.current).toEqual({contracts: [], loading: false});
   });
 
+
   test('new events', () => {
     // setup
     const query = 'foo-query';
@@ -316,6 +359,12 @@ describe('useStreamQuery', () => {
     expect(mockStreamQuery).toHaveBeenCalledTimes(1);
     expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query: query});
     expect(hookResult.result.current.contracts).toEqual([]);
+
+    // live event
+    act(() =>
+      void emitter.emit('live', [])
+    );
+
     expect(hookResult.result.current.loading).toBe(false);
 
     // one new event
@@ -341,6 +390,12 @@ describe('useStreamQuery', () => {
     })
     expect(mockStreamQuery).toHaveBeenCalledTimes(1);
     expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query: query1});
+
+    // live event
+    act(() =>
+      void emitter.emit('live', [])
+    );
+
     expect(result.current.queryResult).toEqual({contracts: [], loading: false});
 
     // new events
@@ -351,6 +406,9 @@ describe('useStreamQuery', () => {
     mockStreamQuery.mockClear();
     mockStreamQuery.mockReturnValueOnce(stream);
     act(() => result.current.setQuery(query2));
+    // live event
+    act(() => void emitter.emit('live', null));
+    // change event
     act(() => void emitter.emit('change', ['bar']));
     expect(mockStreamQuery).toHaveBeenCalledTimes(1);
     expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query: query2});

--- a/language-support/ts/packages/yarn.lock
+++ b/language-support/ts/packages/yarn.lock
@@ -2431,11 +2431,6 @@ jest-watcher@^24.9.0:
     jest-util "^24.9.0"
     string-length "^2.0.0"
 
-jest-websocket-mock@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/jest-websocket-mock/-/jest-websocket-mock-2.0.2.tgz#8dfa268fd56bba6e0b759756cd1d3bafd40cdb42"
-  integrity sha512-SFTUI8O/LDGqROOMnfAzbrrX5gQ8GDhRqkzVrt8Y67evnFKccRPFI3ymS05tKcMONvVfxumat4pX/LRjM/CjVg==
-
 jest-worker@^24.6.0, jest-worker@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
@@ -2782,13 +2777,6 @@ mkdirp@0.x, mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
-
-mock-socket@^9.0.3:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.0.3.tgz#4bc6d2aea33191e4fed5ec71f039e2bbeb95e414"
-  integrity sha512-SxIiD2yE/By79p3cNAAXyLQWTvEFNEzcAO7PH+DzRqKSFaplAPFjiQLmw8ofmpCsZf+Rhfn2/xCJagpdGmYdTw==
-  dependencies:
-    url-parse "^1.4.4"
 
 ms@2.0.0:
   version "2.0.0"
@@ -3208,11 +3196,6 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-querystringify@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
-  integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
-
 react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
@@ -3357,11 +3340,6 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -4070,14 +4048,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-url-parse@^1.4.4:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
-  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This adds a new 'live' event to our streams that signals that the WebSocket
streams are now live updating. It is emitted as soon as a `{events: [], offset:
n}` message is received from the WebSocket.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
