### PR TITLE
TS libs: Fail linting on warnings

### DIFF
--- a/language-support/ts/daml-ledger/.eslintrc.json
+++ b/language-support/ts/daml-ledger/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-inferrable-types": "off"
+  }
+}

--- a/language-support/ts/daml-ledger/index.test.ts
+++ b/language-support/ts/daml-ledger/index.test.ts
@@ -41,23 +41,23 @@ jest.mock('isomorphic-ws', () => class {
     this.eventEmitter = new EventEmitter();
   }
 
-  addEventListener(event: string, handler: (...args: unknown[]) => void) {
+  addEventListener(event: string, handler: (...args: unknown[]) => void): void {
     this.eventEmitter.on(event, handler);
   }
 
-  send(message: string) {
+  send(message: string): void {
     mockSend(JSON.parse(message));
   }
 
-  serverOpen() {
+  serverOpen(): void {
     this.eventEmitter.emit('open');
   }
 
-  serverSend(message: Message) {
+  serverSend(message: Message): void {
     this.eventEmitter.emit('message', {data: JSON.stringify(message)});
   }
 
-  serverClose(event: {code: number; reason: string}) {
+  serverClose(event: {code: number; reason: string}): void {
     this.eventEmitter.emit('close', event);
   }
 });

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -531,10 +531,10 @@ class Ledger {
     });
     // TODO(MH): Make types stricter.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const on = (type: string, listener: any) => emitter.on(type, listener);
+    const on = (type: string, listener: any): void => void emitter.on(type, listener);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const off = (type: string, listener: any) => emitter.on(type, listener);
-    const close = () => {
+    const off = (type: string, listener: any): void => void emitter.on(type, listener);
+    const close = (): void => {
       emitter.removeAllListeners();
       ws.close();
     };
@@ -562,7 +562,7 @@ class Ledger {
     query?: Query<T>,
   ): Stream<T, K, I, readonly CreateEvent<T, K, I>[]> {
     const request = {templateIds: [template.templateId], query};
-    const change = (contracts: readonly CreateEvent<T, K, I>[], events: readonly Event<T, K, I>[]) => {
+    const change = (contracts: readonly CreateEvent<T, K, I>[], events: readonly Event<T, K, I>[]): CreateEvent<T, K, I>[] => {
       const archiveEvents: Set<ContractId<T>> = new Set();
       const createEvents: CreateEvent<T, K, I>[] = [];
       for (const event of events) {
@@ -593,7 +593,7 @@ class Ledger {
     key: K,
   ): Stream<T, K, I, CreateEvent<T, K, I> | null> {
     const request = [{templateId: template.templateId, key}];
-    const change = (contract: CreateEvent<T, K, I> | null, events: readonly Event<T, K, I>[]) => {
+    const change = (contract: CreateEvent<T, K, I> | null, events: readonly Event<T, K, I>[]): CreateEvent<T, K, I> | null => {
       // NOTE(MH, #4564): We're very lenient here. We should not see a create
       // event when `contract` is currently not null. We should also only see
       // archive events when `contract` is currently not null and the contract

--- a/language-support/ts/daml-ledger/package.json
+++ b/language-support/ts/daml-ledger/package.json
@@ -29,26 +29,7 @@
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
     "test": "jest",
-    "lint": "eslint --ext .ts ./ --max-warnings 0"
-  },
-  "eslintConfig": {
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "project": "./tsconfig.json"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "rules": {
-      "@typescript-eslint/no-floating-promises": "error",
-      "@typescript-eslint/no-inferrable-types": "off"
-    }
+    "lint": "eslint --ext .ts --ignore-pattern lib/ --max-warnings 0 ./"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",

--- a/language-support/ts/daml-react/.eslintrc.json
+++ b/language-support/ts/daml-react/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-inferrable-types": "off"
+  }
+}

--- a/language-support/ts/daml-react/DamlLedger.ts
+++ b/language-support/ts/daml-react/DamlLedger.ts
@@ -18,7 +18,7 @@ const DamlLedger: React.FC<Props> = ({token, httpBaseUrl, wsBaseUrl, party, chil
   const ledger = useMemo(() => new Ledger({token, httpBaseUrl, wsBaseUrl}), [token, httpBaseUrl, wsBaseUrl]);
   const state: DamlLedgerState = useMemo(() => ({
     reloadToken,
-    triggerReload: () => setReloadToken(x => x +1),
+    triggerReload: (): void => setReloadToken(x => x + 1),
     party,
     ledger,
   }), [party, ledger, reloadToken]);

--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Template } from "@daml/types";
+import { Template, Party } from "@daml/types";
 import Ledger, { CreateEvent, Query } from '@daml/ledger';
 import { useState, useContext, useEffect } from "react";
 import { DamlLedgerState, DamlLedgerContext } from './context'
@@ -28,7 +28,7 @@ const useDamlState = (): DamlLedgerState => {
 /**
  * React hook to get the party currently connected to the ledger.
  */
-export const useParty = () => {
+export const useParty = (): Party => {
   const state = useDamlState();
   return state.party;
 }
@@ -75,7 +75,7 @@ export function useQuery<T extends object, K, I extends string>(template: Templa
   useEffect(() => {
     setResult({contracts: [], loading: true});
     const query = queryFactory ? queryFactory() : undefined;
-    const load = async () => {
+    const load = async (): Promise<void> => {
       const contracts = await state.ledger.query(template, query);
       setResult({contracts, loading: false});
     };
@@ -119,7 +119,7 @@ export function useFetchByKey<T extends object, K, I extends string>(template: T
   useEffect(() => {
     const key = keyFactory();
     setResult({contract: null, loading: true});
-    const load = async () => {
+    const load = async (): Promise<void> => {
       const contract = await state.ledger.fetchByKey(template, key);
       setResult({contract, loading: false});
     };
@@ -160,7 +160,7 @@ export function useStreamQuery<T extends object, K, I extends string>(template: 
       setResult(result => ({...result, loading: true}));
     });
     setResult(result => ({...result, loading: false}));
-    return () => {
+    return (): void => {
       console.debug(`unmount useStreamQuery(${template.templateId}, ...)`, query);
       stream.close();
     };
@@ -196,7 +196,7 @@ export function useStreamFetchByKey<T extends object, K, I extends string>(templ
       setResult(result => ({...result, loading: true}));
     });
     setResult(result => ({...result, loading: false}));
-    return () => {
+    return (): void => {
       console.debug(`unmount useStreamFetchByKey(${template.templateId}, ...)`, key);
       stream.close();
     };
@@ -210,5 +210,5 @@ export function useStreamFetchByKey<T extends object, K, I extends string>(templ
  */
 export const useReload = (): () => void => {
   const state = useDamlState();
-  return () => state.triggerReload();
+  return (): void => state.triggerReload();
 }

--- a/language-support/ts/daml-react/index.test.ts
+++ b/language-support/ts/daml-react/index.test.ts
@@ -48,10 +48,10 @@ const mockStream = <T>(): [Stream <object, string, string, T>, EventEmitter] =>
   const stream =
     {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      on: (type: string, listener: (...args: any[]) => void) => emitter.on(type, listener),
+      on: (type: string, listener: (...args: any[]) => void): void => void emitter.on(type, listener),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      off: (type: string, listener: (...args: any[]) => void) => emitter.on(type, listener),
-      close: () => {
+      off: (type: string, listener: (...args: any[]) => void): void => void emitter.on(type, listener),
+      close: (): void => {
         emitter.removeAllListeners();
         console.log('mock stream closed');
       }

--- a/language-support/ts/daml-react/package.json
+++ b/language-support/ts/daml-react/package.json
@@ -27,26 +27,7 @@
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
     "test": "jest",
-    "lint": "eslint --ext .ts ./ --max-warnings 0"
-  },
-  "eslintConfig": {
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "project": "./tsconfig.json"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "rules": {
-      "@typescript-eslint/no-floating-promises": "error",
-      "@typescript-eslint/no-inferrable-types": "off"
-    }
+    "lint": "eslint --ext .ts --ignore-pattern lib/ --max-warnings 0 ./"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^3.2.1",

--- a/language-support/ts/daml-types/.eslintrc.json
+++ b/language-support/ts/daml-types/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.eslint.json"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/no-unnecessary-type-assertion": "off"
+  }
+}

--- a/language-support/ts/daml-types/package.json
+++ b/language-support/ts/daml-types/package.json
@@ -20,27 +20,7 @@
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
     "test": "true",
-    "lint": "eslint --ext .ts ./ --max-warnings 0"
-  },
-  "eslintConfig": {
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "project": "./tsconfig.eslint.json"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "rules": {
-      "@typescript-eslint/no-floating-promises": "error",
-      "@typescript-eslint/no-inferrable-types": "off",
-      "@typescript-eslint/no-unnecessary-type-assertion": "off"
-    }
+    "lint": "eslint --ext .ts --ignore-pattern lib/ --max-warnings 0 ./"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.16.0",

--- a/language-support/ts/eslint.bzl
+++ b/language-support/ts/eslint.bzl
@@ -4,14 +4,14 @@
 load("@language_support_ts_deps//eslint:index.bzl", _eslint_test = "eslint_test")
 load("@os_info//:os_info.bzl", "is_windows")
 
-def eslint_test(name, srcs, tsconfig = ":tsconfig.json", package_json = ":package.json", data = [], **kwargs):
+def eslint_test(name, srcs, tsconfig = ":tsconfig.json", eslintrc = ":.eslintrc.json", data = [], **kwargs):
     """Run eslint on the given typescript source.
 
     Args:
       name: The name of the generated test rule.
       srcs: The source files to lint.
       tsconfig: The tsconfig.json file.
-      package_json: The package.json file.
+      eslintrc: The .eslintrc.json file.
       data: Additional runtime dependencies.
     """
     eslint_deps = [
@@ -19,17 +19,18 @@ def eslint_test(name, srcs, tsconfig = ":tsconfig.json", package_json = ":packag
         "@language_support_ts_deps//tsutils",
     ] if not is_windows else []
     templated_args = [
-        "--ext",
-        "ts",
         "--config",
-        "$(rlocation $(location %s))" % package_json,
-        '--parser-options={"tsconfigRootDir":"$(dirname $(rlocation $(location %s)))"}' % tsconfig,
+        "$(rlocation $(location %s))" % eslintrc,
+        "--parser-options",
+        '{\"tsconfigRootDir":"$(dirname $(rlocation $(location %s)))"}' % tsconfig,
+        "--max-warnings",
+        "0",
     ]
     for src in srcs:
         templated_args.append("$(rlocation $(location %s))" % src)
     _eslint_test(
         name = name,
-        data = srcs + [tsconfig, package_json] + data + eslint_deps,
+        data = srcs + [tsconfig, eslintrc] + data + eslint_deps,
         templated_args = templated_args,
         **kwargs
     ) if not is_windows else None


### PR DESCRIPTION
Currently, we happily accept warnings of the linter as if nothing was
wrong. This PR makes the linter fail on warnings. It also moves the
linter configs into their own files to unclutter the `package.json`
files we ship to our users a bit.

And we fix all the warnings we now get from the linter.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5332)
<!-- Reviewable:end -->
