### PR TITLE
temp machines for cocreature

### DIFF
--- a/infra/TEMP_moritz_vsts_agent_linux.tf
+++ b/infra/TEMP_moritz_vsts_agent_linux.tf
@@ -1,0 +1,64 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+data "template_file" "temp-moritz-startup" {
+  template = "${file("${path.module}/TEMP_moritz_vsts_agent_linux_startup.sh")}"
+}
+
+resource "google_compute_region_instance_group_manager" "temp-moritz-linux" {
+  provider           = "google-beta"
+  name               = "temp-moritz-linux"
+  base_instance_name = "temp-moritz-linux"
+  region             = "${local.region}"
+  target_size        = 1
+
+  version {
+    name              = "temp-moritz-linux"
+    instance_template = "${google_compute_instance_template.temp-moritz-linux.self_link}"
+  }
+
+  update_policy {
+    type            = "PROACTIVE"
+    minimal_action  = "REPLACE"
+    max_surge_fixed = 3
+    min_ready_sec   = 60
+  }
+}
+
+resource "google_compute_instance_template" "temp-moritz-linux" {
+  name_prefix  = "temp-moritz-linux-"
+  machine_type = "n1-standard-8"
+  labels       = "${local.labels}"
+
+  disk {
+    disk_size_gb = 200
+    disk_type    = "pd-ssd"
+    source_image = "ubuntu-os-cloud/ubuntu-1604-lts"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  metadata {
+    startup-script = "${data.template_file.temp-moritz-startup.rendered}"
+  }
+
+  network_interface {
+    network = "default"
+
+    // Ephemeral IP to get access to the Internet
+    access_config {}
+  }
+
+  service_account {
+    email  = "log-writer@da-dev-gcp-daml-language.iam.gserviceaccount.com"
+    scopes = ["cloud-platform"]
+  }
+
+  scheduling {
+    automatic_restart   = false
+    on_host_maintenance = "TERMINATE"
+    preemptible         = false
+  }
+}

--- a/infra/TEMP_moritz_vsts_agent_linux_startup.sh
+++ b/infra/TEMP_moritz_vsts_agent_linux_startup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Agent startup script
+set -euo pipefail
+
+## Hardening
+
+# Commit harakiri on failure
+trap "shutdown -h now" EXIT
+
+# replace the default nameserver to not use the metadata server
+echo "nameserver 8.8.8.8" > /etc/resolv.conf
+
+# delete self
+rm -vf "$0"
+
+## Install system dependencies
+apt-get update -q
+apt-get install -qy \
+  curl sudo \
+  bzip2 rsync \
+  jq liblttng-ust0 libcurl3 libkrb5-3 libicu55 zlib1g \
+  git \
+  netcat \
+  apt-transport-https \
+  software-properties-common
+
+curl -sSL https://dl.google.com/cloudagents/install-logging-agent.sh | bash
+
+#install docker
+DOCKER_VERSION="5:18.09.5~3-0~ubuntu-$(lsb_release -cs)"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+apt-key fingerprint 0EBFCD88
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get update
+apt-get install -qy docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io
+
+#Start docker daemon
+systemctl enable docker
+
+## Install the VSTS agent
+groupadd --gid 3000 vsts
+useradd \
+  --create-home \
+  --gid 3000 \
+  --shell /bin/bash \
+  --uid 3000 \
+  vsts
+#add docker group to user
+usermod -aG docker vsts
+
+## Install Nix
+
+# This needs to run inside of a user with sudo access
+echo "vsts ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/nix_installation
+su --command "sh <(curl https://nixos.org/nix/install) --daemon" --login vsts
+rm /etc/sudoers.d/nix_installation
+
+# Note: the "hydra.da-int.net" string is now part of the name of the key for
+# legacy reasons; it bears no relation to the DNS hostname of the current
+# cache.
+cat <<NIX_CONF > /etc/nix/nix.conf
+binary-cache-public-keys = hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
+binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
+build-users-group = nixbld
+cores = 1
+max-jobs = 0
+sandbox = relaxed
+NIX_CONF
+
+systemctl restart nix-daemon

--- a/infra/TEMP_moritz_vsts_windows.tf
+++ b/infra/TEMP_moritz_vsts_windows.tf
@@ -1,0 +1,140 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+resource "google_compute_region_instance_group_manager" "temp-moritz-windows" {
+  provider = "google-beta"
+  name     = "temp-moritz-windows"
+
+  # keep the name short. windows hostnames are limited to 12(?) chars.
+  # -5 for the random postfix:
+  base_instance_name = "moritz-win"
+
+  region      = "${local.region}"
+  target_size = 1
+
+  version {
+    name              = "temp-moritz-windows"
+    instance_template = "${google_compute_instance_template.temp-moritz-windows.self_link}"
+  }
+
+  update_policy {
+    type           = "PROACTIVE"
+    minimal_action = "REPLACE"
+
+    # minimum is the number of availability zones (3)
+    max_surge_fixed = 3
+
+    # calculated with: serial console last timestamp after boot - VM start
+    # 09:54:28 - 09:45:55 = 513 seconds
+    min_ready_sec = 520
+  }
+}
+
+resource "google_compute_instance_template" "temp-moritz-windows" {
+  name_prefix  = "temp-moritz-windows-"
+  machine_type = "n1-standard-8"
+  labels       = "${local.labels}"
+
+  disk {
+    disk_size_gb = 200
+    disk_type    = "pd-ssd"
+
+    # find the image name with `gcloud compute images list`
+    source_image = "windows-cloud/windows-2016"
+  }
+
+  # Drive D:\ for the agent work folder
+  disk {
+    disk_size_gb = 200
+    disk_type    = "pd-ssd"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  metadata {
+    // Prepare the machine
+    sysprep-specialize-script-ps1 = <<SYSPREP_SPECIALIZE
+Set-StrictMode -Version latest
+$ErrorActionPreference = 'Stop'
+
+# Disable Windows Defender to speed up disk access
+Set-MpPreference -DisableRealtimeMonitoring $true
+
+# Enable long paths
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name LongPathsEnabled -Type DWord -Value 1
+
+# Disable UAC
+New-ItemProperty -Path HKLM:Software\Microsoft\Windows\CurrentVersion\policies\system -Name EnableLUA -PropertyType DWord -Value 0 -Force
+
+# Redirect logs to SumoLogic
+
+cd $env:UserProfile;
+Invoke-WebRequest https://dl.google.com/cloudagents/windows/StackdriverLogging-v1-9.exe -OutFile StackdriverLogging-v1-9.exe;
+.\StackdriverLogging-v1-9.exe /S /D="C:\Stackdriver\Logging\"
+
+# Install chocolatey
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+iex (New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')
+
+# Install git, bash
+& choco install git --no-progress --yes 2>&1 | %{ "$_" }
+& choco install windows-sdk-10.1 --no-progress --yes 2>&1 | %{ "$_" }
+
+# Add tools to the PATH
+$OldPath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
+$NewPath = "$OldPath;C:\Program Files\Git\bin;C:\Program Files (x86)\Windows Kits\10\App Certification Kit"
+Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $NewPath
+
+echo "== Prepare the D:\ drive"
+
+$partition = @"
+select disk 1
+clean
+convert gpt
+create partition primary
+format fs=ntfs quick
+assign letter="D"
+"@
+$partition | Set-Content C:\diskpart.txt
+& diskpart /s C:\diskpart.txt 2>&1 | %{ "$_" }
+
+# Create a temporary and random password for the VSTS user, forget about it once this script has finished running
+$Username = "VssAdministrator"
+$Account = "$env:COMPUTERNAME\$Username"
+Add-Type -AssemblyName System.Web
+$Password = [System.Web.Security.Membership]::GeneratePassword(24, 0)
+
+echo "== Creating the VSTS user"
+
+#New-LocalUser $Username -Password $SecurePassword -FullName $Username
+net user $Username $Password /add /y
+# net localgroup administrators $Username /add
+Add-LocalGroupMember -Group "Administrators" -Member $Username
+
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+net stop winrm
+sc.exe config winrm start=auto
+net start winrm
+
+echo OK
+SYSPREP_SPECIALIZE
+
+  }
+
+  network_interface {
+    network = "default"
+
+    // Ephemeral IP to get access to the Internet
+    access_config {}
+  }
+
+  scheduling {
+    automatic_restart   = false
+    on_host_maintenance = "TERMINATE"
+    preemptible         = false
+  }
+}


### PR DESCRIPTION
CI has been behaving weirdly for the past three days, with build times on Linux and Windows regularly taking over 40 minutes, macOS builds occasionally running for almost three hours, and generally a lot of OOM exceptions (mostly on Windows, but a bit on the other two too).

We currently have no idea what changed, and have been having trouble reproducing locally. As far as I'm aware, there has been no change to the CI infrastructure itself, so we suspect we broke something in our code somehow.

@cocreature has requested access to Linux and Windows machines with similar specs and set-up as the CI ones, but without credentials. This PR attempts to provide that.

Once the machines are up I will manually add accounts for @cocreature.

CHANGELOG_BEGIN
CHANGELOG_END