### PR TITLE
fix cocreature's temp machine

### DIFF
--- a/infra/TEMP_moritz_vsts_agent_linux_startup.sh
+++ b/infra/TEMP_moritz_vsts_agent_linux_startup.sh
@@ -71,3 +71,5 @@ sandbox = relaxed
 NIX_CONF
 
 systemctl restart nix-daemon
+
+trap - EXIT


### PR DESCRIPTION
Our Linux startup script never finishes, as it ends with `exec`'ing to the Azure agent. Since I've removed that part, the EXIT handler, supposed to only kick in when an issue prevents the script from finishing, triggers on normal exit, and the machine shuts down. Making it hard to use.

CHANGELOG_BEGIN
CHANGELOG_END