### PR TITLE
Regression test for silent REPL server errors

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -167,6 +167,13 @@ functionalTests damlc scriptDar testDar getSandboxPort = testGroup "functional"
           , input "debug 1"
           , matchOutput "^.*: 1"
           ]
+    , testInteraction' "server error"
+          [ input "alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"alice_doubly_allocated\")"
+          , input "alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"alice_doubly_allocated\")"
+          , matchOutput "io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Invalid argument: Party already exists"
+          , input "debug 1"
+          , matchOutput "^.*: 1"
+          ]
     ]
   where
     testInteraction' testName steps = testCase testName $ do

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -164,6 +164,7 @@ functionalTests damlc scriptDar testDar getSandboxPort = testGroup "functional"
           , input "bob <- allocateParty \"Bob\""
           , input "submit alice (createCmd (T alice bob))"
           , matchOutput "^.*Submit failed.*requires authorizers.*but only.*were given.*$"
+          , matchOutput "^.*$"
           , input "debug 1"
           , matchOutput "^.*: 1"
           ]
@@ -227,6 +228,7 @@ testInteraction damlc scriptDar testDar steps ledgerPort mbTokenFile mbCaCrt = w
                 hPutStrLn hIn s
             MatchOutput regex regexStr -> do
                 line <- hGetLine hOut
+                putStrLn $ "match output " ++ regexStr ++ " ~= " ++ line
                 assertBool
                     (show line <> " did not match " <> show regexStr)
                     (matchTest regex line)

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -217,7 +217,7 @@ class ReplService(
       TimeProvider.UTC)
     runner.runWithClients(clients).onComplete {
       case Failure(e) =>
-        System.err.println(s"$e")
+        println(s"$e")
         respObs.onError(e)
       case Success(v) =>
         results = results ++ Seq(v)


### PR DESCRIPTION
Server errors such as `Party already exists` were silently ignored for a bit. This adds a regression test to make sure this is caught.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
