### PR TITLE
Fix leak of scenario contexts

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Service/Daml.hs
@@ -61,13 +61,13 @@ instance NFData VirtualResource
 data DamlEnv = DamlEnv
   { envScenarioService :: Maybe SS.Handle
   , envOpenVirtualResources :: Var (HashSet VirtualResource)
-  , envScenarioContexts :: Var (HashMap NormalizedFilePath SS.ContextId)
+  , envScenarioContexts :: MVar (HashMap NormalizedFilePath SS.ContextId)
   -- ^ This is a map from the file for which the context was created to
   -- the context id. We use this to track which scenario contexts
   -- are active so that we can GC inactive scenarios.
   -- This should eventually go away and we should track scenario contexts
   -- in the same way that we track diagnostics.
-  , envPreviousScenarioContexts :: Var [SS.ContextId]
+  , envPreviousScenarioContexts :: MVar [SS.ContextId]
   -- ^ The scenario contexts we used as GC roots in the last iteration.
   -- This is used to avoid unnecessary GC calls.
   , envDamlLfVersion :: LF.Version
@@ -80,8 +80,8 @@ instance IsIdeGlobal DamlEnv
 mkDamlEnv :: Options -> Maybe SS.Handle -> IO DamlEnv
 mkDamlEnv opts scenarioService = do
     openVRsVar <- newVar HashSet.empty
-    scenarioContextsVar <- newVar HashMap.empty
-    previousScenarioContextsVar <- newVar []
+    scenarioContextsVar <- newMVar HashMap.empty
+    previousScenarioContextsVar <- newMVar []
     pure DamlEnv
         { envScenarioService = scenarioService
         , envOpenVirtualResources = openVRsVar

--- a/compiler/damlc/tests/daml-test-files/TextMap.daml
+++ b/compiler/damlc/tests/daml-test-files/TextMap.daml
@@ -2,12 +2,6 @@
 -- All rights reserved.
 -- @SINCE-LF 1.3
 
--- @INFO Use /=
--- @INFO Use /=
--- @INFO Use /=
--- @INFO Use /=
-
-
 module TextMap where
 
 import DA.TextMap as TM
@@ -51,11 +45,11 @@ testNull = scenario do
 
 testEq = scenario do
   (TM.empty : TextMap Int) === (TM.empty : TextMap Int)
-  assert (not (TM.empty == TM.fromList [("1", 1)]))
+  assert (TM.empty /= TM.fromList [("1", 1)])
   TM.fromList [("1", 1), ("2", 2), ("3", 3)] === TM.fromList [("1", 1), ("2", 2), ("3", 3)]
-  assert (not (TM.fromList [("1", 1), ("2", 2), ("3", 3)] == TM.fromList [("1", 2), ("2", 2)]))
-  assert (not (TM.fromList [("1", 1), ("2", 2), ("3", 3)] == TM.fromList [("1", 2), ("2", 2), ("3", 4)]))
-  assert (not (TM.fromList [("1", 1), ("2", 2), ("3", 3)] == TM.fromList [("1", 2), ("2", 2), ("4", 3)]))
+  assert (TM.fromList [("1", 1), ("2", 2), ("3", 3)] /= TM.fromList [("1", 2), ("2", 2)])
+  assert (TM.fromList [("1", 1), ("2", 2), ("3", 3)] /= TM.fromList [("1", 2), ("2", 2), ("3", 4)])
+  assert (TM.fromList [("1", 1), ("2", 2), ("3", 3)] /= TM.fromList [("1", 2), ("2", 2), ("4", 3)])
 
 testInsert = scenario do
   [("1", True), ("2", False), ("3", True), ("4", False), ("5", False)]


### PR DESCRIPTION
The details are in a comment since I want to preserve them. Please
review carefully, I don’t trust my async exception foo.

This is only an issue in the integration tests I believe since we
change files of interest all the time. As long as you stay stable at
some point for some amount of time, we will GC properly either way.

In my tests, this reduces memory usage of the scenario service in the
integration tests from 3 to 2 GiB. There is sadly
anther leak somewhere (contexts are properly GCd now, I verified that
we never have more than 3 contexts in the server). I’ll do some more
investigation but memory grows linearly to the 2GiB while it should
stay pretty much constant.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
