### PR TITLE
Reduce the default maximum heap size for all Scala processes.

### DIFF
--- a/BAZEL-JVM.md
+++ b/BAZEL-JVM.md
@@ -495,8 +495,8 @@ Strive to make library targets as small as possible. In a situation where
 multiple Scala sources have no interdependencies you can use the
 `da_scala_library_suite` macro to automatically generate one library target per
 Scala source file, and bundle them in one target. This rule takes the same
-attributes as `da_scala_library`, but enables `unused_dependency_checker_mode`
-by default.
+attributes as `da_scala_library` with the exception of
+`unused_dependency_checker_mode` which will always be disabled.
 
 #### Tests
 

--- a/BAZEL-JVM.md
+++ b/BAZEL-JVM.md
@@ -495,8 +495,8 @@ Strive to make library targets as small as possible. In a situation where
 multiple Scala sources have no interdependencies you can use the
 `da_scala_library_suite` macro to automatically generate one library target per
 Scala source file, and bundle them in one target. This rule takes the same
-attributes as `da_scala_library` with the exception of
-`unused_dependency_checker_mode` which will always be disabled.
+attributes as `da_scala_library`, but enables `unused_dependency_checker_mode`
+by default.
 
 If a Scala library defines macros then you must use the
 `da_scala_macro_library` rule instead of the above. Otherwise, you will encounter 

--- a/BAZEL-JVM.md
+++ b/BAZEL-JVM.md
@@ -498,17 +498,6 @@ Scala source file, and bundle them in one target. This rule takes the same
 attributes as `da_scala_library`, but enables `unused_dependency_checker_mode`
 by default.
 
-If a Scala library defines macros then you must use the
-`da_scala_macro_library` rule instead of the above. Otherwise, you will encounter 
-compiler errors of the following form (formatted for readability):
-
-```
-error: macro annotation could not be expanded (the most common reason
-for that is that you need to enable the macro paradise plugin; another
-possibility is that you try to use macro annotation in the same
-compilation run that defines it)
-```
-
 #### Tests
 
 Scala tests can be defined using the `da_scala_test` rule. It will generate an

--- a/BAZEL-JVM.md
+++ b/BAZEL-JVM.md
@@ -547,12 +547,21 @@ da_scala_test_suite(
     # Expected runtime and resource requirements.
     size = "small",
     ...
+
+    # You can adjust the heap size as follows:
+    initial_heap_size = "512m",
+    max_heap_size = "2g",
 )
 ```
 
 The `size` attribute is used to determine the default timeout and resource
 requirements. Refer to the [official documentation][bazel_test_size] for
 details about test size and other common test attributes.
+
+A couple of arguments have been added:
+
+  * `initial_heap_size` is translated to `-Xms`, and defaults to `512m`, and
+  * `max_heap_size` is translated to `-Xmx`, and defaults to `2g`.
 
 #### Executables
 
@@ -581,6 +590,10 @@ da_scala_binary(
     # A list of files that should be present in the runtime path at runtime.
     data = [ ... ],
     ...
+
+    # You can adjust the heap size as follows:
+    initial_heap_size = "512m",
+    max_heap_size = "2g",
 )
 ```
 

--- a/BAZEL.md
+++ b/BAZEL.md
@@ -807,12 +807,6 @@ da_scala_library(
 )
 ```
 
-### Scala Macro Libraries
-
-If a Scala library defines macros that should be used by other Scala targets
-later on, then it has to be defined using `da_scala_macro_library`. Macros may
-not be defined and used within the same target.
-
 ### Scala Executables
 
 Scala executables are defined using `da_scala_binary`. It takes most of the

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -121,6 +121,10 @@ lf_scalacopts = [
     "-Ywarn-unused",
 ]
 
+default_compile_arguments = {
+    "unused_dependency_checker_mode": "error",
+}
+
 def _wrap_rule(rule, name = "", scalacopts = [], plugins = [], generated_srcs = [], **kwargs):
     rule(
         name = name,
@@ -408,7 +412,7 @@ def _create_scaladoc_jar(**kwargs):
             tags = ["scaladoc"],
         )
 
-def da_scala_library(name, unused_dependency_checker_mode = "error", **kwargs):
+def da_scala_library(name, **kwargs):
     """
     Define a Scala library.
 
@@ -418,13 +422,15 @@ def da_scala_library(name, unused_dependency_checker_mode = "error", **kwargs):
 
     [rules_scala_library_docs]: https://github.com/bazelbuild/rules_scala/blob/master/docs/scala_library.md
     """
-    kwargs["unused_dependency_checker_mode"] = unused_dependency_checker_mode
-    _wrap_rule(scala_library, name, **kwargs)
-    _create_scala_source_jar(name = name, **kwargs)
-    _create_scaladoc_jar(name = name, **kwargs)
+    arguments = {}
+    arguments.update(default_compile_arguments)
+    arguments.update(kwargs)
+    _wrap_rule(scala_library, name, **arguments)
+    _create_scala_source_jar(name = name, **arguments)
+    _create_scaladoc_jar(name = name, **arguments)
 
-    if "tags" in kwargs:
-        for tag in kwargs["tags"]:
+    if "tags" in arguments:
+        for tag in arguments["tags"]:
             if tag.startswith("maven_coordinates="):
                 pom_file(
                     name = name + "_pom",
@@ -465,7 +471,7 @@ def da_scala_macro_library(**kwargs):
     _wrap_rule(scala_macro_library, **kwargs)
     _create_scala_source_jar(**kwargs)
 
-def da_scala_binary(name, unused_dependency_checker_mode = "error", **kwargs):
+def da_scala_binary(name, **kwargs):
     """
     Define a Scala executable.
 
@@ -475,11 +481,13 @@ def da_scala_binary(name, unused_dependency_checker_mode = "error", **kwargs):
 
     [rules_scala_docs]: https://github.com/bazelbuild/rules_scala#scala_binary
     """
-    kwargs["unused_dependency_checker_mode"] = unused_dependency_checker_mode
-    _wrap_rule(scala_binary, name, **kwargs)
+    arguments = {}
+    arguments.update(default_compile_arguments)
+    arguments.update(kwargs)
+    _wrap_rule(scala_binary, name, **arguments)
 
-    if "tags" in kwargs:
-        for tag in kwargs["tags"]:
+    if "tags" in arguments:
+        for tag in arguments["tags"]:
             if tag.startswith("maven_coordinates="):
                 pom_file(
                     name = name + "_pom",
@@ -499,7 +507,7 @@ def da_scala_binary(name, unused_dependency_checker_mode = "error", **kwargs):
                 )
                 break
 
-def da_scala_test(unused_dependency_checker_mode = "error", **kwargs):
+def da_scala_test(**kwargs):
     """
     Define a Scala executable that runs the unit tests in the given source files.
 
@@ -509,8 +517,10 @@ def da_scala_test(unused_dependency_checker_mode = "error", **kwargs):
 
     [rules_scala_docs]: https://github.com/bazelbuild/rules_scala#scala_test
     """
-    kwargs["unused_dependency_checker_mode"] = unused_dependency_checker_mode
-    _wrap_rule(scala_test, **kwargs)
+    arguments = {}
+    arguments.update(default_compile_arguments)
+    arguments.update(kwargs)
+    _wrap_rule(scala_test, **arguments)
 
 def da_scala_test_suite(**kwargs):
     """

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -125,6 +125,17 @@ default_compile_arguments = {
     "unused_dependency_checker_mode": "error",
 }
 
+default_initial_heap_size = "512m"
+default_max_heap_size = "2g"
+
+def _set_jvm_flags(arguments, initial_heap_size, max_heap_size):
+    result = {}
+    result.update(arguments)
+    result.update({
+        "jvm_flags": arguments.get("jvm_flags", []) + ["-Xms{}".format(initial_heap_size), "-Xmx{}".format(max_heap_size)],
+    })
+    return result
+
 def _wrap_rule(rule, name = "", scalacopts = [], plugins = [], generated_srcs = [], **kwargs):
     rule(
         name = name,
@@ -471,7 +482,7 @@ def da_scala_macro_library(**kwargs):
     _wrap_rule(scala_macro_library, **kwargs)
     _create_scala_source_jar(**kwargs)
 
-def da_scala_binary(name, **kwargs):
+def da_scala_binary(name, initial_heap_size = default_initial_heap_size, max_heap_size = default_max_heap_size, **kwargs):
     """
     Define a Scala executable.
 
@@ -484,6 +495,7 @@ def da_scala_binary(name, **kwargs):
     arguments = {}
     arguments.update(default_compile_arguments)
     arguments.update(kwargs)
+    arguments = _set_jvm_flags(arguments, initial_heap_size = initial_heap_size, max_heap_size = max_heap_size)
     _wrap_rule(scala_binary, name, **arguments)
 
     if "tags" in arguments:
@@ -507,7 +519,7 @@ def da_scala_binary(name, **kwargs):
                 )
                 break
 
-def da_scala_test(**kwargs):
+def da_scala_test(initial_heap_size = default_initial_heap_size, max_heap_size = default_max_heap_size, **kwargs):
     """
     Define a Scala executable that runs the unit tests in the given source files.
 
@@ -520,9 +532,10 @@ def da_scala_test(**kwargs):
     arguments = {}
     arguments.update(default_compile_arguments)
     arguments.update(kwargs)
+    arguments = _set_jvm_flags(arguments, initial_heap_size = initial_heap_size, max_heap_size = max_heap_size)
     _wrap_rule(scala_test, **arguments)
 
-def da_scala_test_suite(**kwargs):
+def da_scala_test_suite(initial_heap_size = default_initial_heap_size, max_heap_size = default_max_heap_size, **kwargs):
     """
     Define a Scala test executable for each source file and bundle them into one target.
 
@@ -532,7 +545,10 @@ def da_scala_test_suite(**kwargs):
 
     [rules_scala_docs]: https://github.com/bazelbuild/rules_scala#scala_test_suite
     """
-    _wrap_rule(scala_test_suite, use_short_names = is_windows, **kwargs)
+    arguments = {}
+    arguments.update(kwargs)
+    arguments = _set_jvm_flags(arguments, initial_heap_size = initial_heap_size, max_heap_size = max_heap_size)
+    _wrap_rule(scala_test_suite, use_short_names = is_windows, **arguments)
 
 # TODO make the jmh rule work with plugins -- probably
 # just a matter of passing the flag in

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -6,7 +6,6 @@ load(
     "scala_binary",
     "scala_library",
     "scala_library_suite",
-    "scala_macro_library",
     "scala_test",
     "scala_test_suite",
 )
@@ -495,19 +494,6 @@ def da_scala_library_suite(name, **kwargs):
             if tag.startswith("maven_coordinates="):
                 fail("Usage of maven_coordinates in da_scala_library_suite is NOT supported", "tags")
                 break
-
-def da_scala_macro_library(**kwargs):
-    """
-    Define a Scala library that contains macros.
-
-    Applies common Scala options defined in `bazel_tools/scala.bzl`.
-    And forwards to `scala_macro_library` from `rules_scala`.
-    Refer to the [`rules_scala` documentation][rules_scala_docs].
-
-    [rules_scala_docs]: https://github.com/bazelbuild/rules_scala#scala_library
-    """
-    _wrap_rule(scala_macro_library, **kwargs)
-    _create_scala_source_jar(**kwargs)
 
 def da_scala_binary(name, initial_heap_size = default_initial_heap_size, max_heap_size = default_max_heap_size, **kwargs):
     """

--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -50,11 +50,6 @@ da_scala_library(
         # Plugins have to be specified as JARs.
         "@maven//:org_spire_math_kind_projector_2_12",
     ],
-    # Bump stack size to avoid stack overflow in reflection.
-    scalac_jvm_flags = [
-        "-Xmx2G",
-        "-Xss2M",
-    ],
     visibility = [
         "//visibility:public",
     ],

--- a/language-support/scala/codegen/BUILD.bazel
+++ b/language-support/scala/codegen/BUILD.bazel
@@ -13,10 +13,6 @@ common_scalacopts = [
     "CONFIG",
 ]
 
-common_jvm_flags = [
-    "-Xmx2G",
-]
-
 da_scala_library(
     name = "codegen",
     srcs =
@@ -32,7 +28,6 @@ da_scala_library(
         # Plugins have to be specified as JARs.
         "@maven//:org_spire_math_kind_projector_2_12",
     ],
-    scalac_jvm_flags = common_jvm_flags,
     scalacopts = common_scalacopts,
     tags = ["maven_coordinates=com.daml:codegen-scala:__VERSION__"],
     visibility = [

--- a/language-support/scala/codegen/BUILD.bazel
+++ b/language-support/scala/codegen/BUILD.bazel
@@ -79,7 +79,6 @@ da_scala_test_suite(
     name = "tests",
     size = "small",
     srcs = glob(["src/test/scala/**/*.scala"]),
-    jvm_flags = common_jvm_flags,
     scalacopts = common_scalacopts,
     deps = [
         ":codegen",

--- a/navigator/backend/BUILD.bazel
+++ b/navigator/backend/BUILD.bazel
@@ -14,10 +14,6 @@ navigator_scalacopts = [
     "-Xsource:2.13",
 ]
 
-common_jvm_flags = [
-    "-Xmx2G",
-]
-
 # All frontend resource files.
 # These come in a manually created JAR file, this rule is just wrapping it in
 # a java_import, so that it is a valid target for the 'resources' property of


### PR DESCRIPTION
The JVM, as of version 8, on a 64-bit system, defaults to a quarter of your total memory as the maximum heap size. Most developers hover between 8 and 32 GB of RAM in their computer, and our CI has 32 GB available. This means that we might be allocating 8 GB of heap per Java process.

This PR decreases that to a maximum of 2 GB (overridable). For Sandbox, this is plenty, but it should mean more garbage collections are triggered, keeping it lean and allowing it to run in parallel with everything else going on.

I'm also decreasing `scalac`'s heap size, for the same reason. I've increased its stack size to 2 MB because the codegen sample app apparently needs it, and there's no harm in increasing it for everything AFAIK.

I also deleted `da_scala_macro_library`, because it's unused and I didn't want to have to figure out how this stuff applies there.

Hopefully this makes our Windows builds happier.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
