### PR TITLE
Remove exposed-modules from `daml init` and quickstart-java template

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -448,7 +448,6 @@ runInit targetFolderM = do
         , ("scenario", Y.String "Main:mainScenario")
         , ("parties", Y.array [Y.String "Alice", Y.String "Bob"])
         , ("version", Y.String "1.0.0")
-        , ("exposed-modules", Y.array [Y.String "Main"])
         , ("dependencies", Y.array [Y.String "daml-prim", Y.String "daml-stdlib"])
         ]
 

--- a/templates/quickstart-java/daml.yaml.template
+++ b/templates/quickstart-java/daml.yaml.template
@@ -8,8 +8,6 @@ parties:
   - USD_Bank
   - EUR_Bank
 version: 0.0.1
-exposed-modules:
-  - Main
 dependencies:
   - daml-prim
   - daml-stdlib


### PR DESCRIPTION
This cause issues in combination with data-dependencies see #5330 and
we started warning if you don’t expose everything. This resulted in
quickstart-java producing a warning on every `daml build`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
