### PR TITLE
Jest vs Bazel: Something is broken

### DIFF
--- a/language-support/ts/jest_vs_bazel/.gitignore
+++ b/language-support/ts/jest_vs_bazel/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/language-support/ts/jest_vs_bazel/BUILD.bazel
+++ b/language-support/ts/jest_vs_bazel/BUILD.bazel
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+load("//language-support/ts:jest.bzl", "jest_test")
+
+jest_test(
+    name = "test",
+    srcs = ["index.test.js"],
+    jest_config = ":jest.config.js",
+    deps = [
+        "@language_support_ts_deps//jest-websocket-mock",
+        "@language_support_ts_deps//mock-socket",
+    ],
+)

--- a/language-support/ts/jest_vs_bazel/index.test.js
+++ b/language-support/ts/jest_vs_bazel/index.test.js
@@ -1,0 +1,9 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+const WS = require("jest-websocket-mock").default;
+const Server = require("mock-socket").Server;
+
+test("jest-websocket-mock", () => {
+  const ws = new WS("ws://localhost:1234");
+  expect(ws.server).toBeInstanceOf(Server);
+});

--- a/language-support/ts/jest_vs_bazel/jest.config.js
+++ b/language-support/ts/jest_vs_bazel/jest.config.js
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+module.exports = {
+  testEnvironment: "node",
+  testMatch: [
+    "**/__tests__/**/*.+(ts|tsx|js)",
+    "**/?(*.)+(spec|test).+(ts|tsx|js)"
+  ],
+  transform: {
+    "^.+\\.(js|jsx)$": "babel-jest",
+  },
+}

--- a/language-support/ts/jest_vs_bazel/package.json
+++ b/language-support/ts/jest_vs_bazel/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "jest_vs_bazel",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^24.9.0",
+    "jest-websocket-mock": "^2.0.2",
+    "mock-socket": "^9.0.3"
+  }
+}

--- a/language-support/ts/jest_vs_bazel/tsconfig.json
+++ b/language-support/ts/jest_vs_bazel/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "es2015"
+     ],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "outDir": "lib/",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "declaration": true,
+    "sourceMap": true,
+    "allowJs": true
+  },
+  "include": ["index.test.js"]
+}

--- a/language-support/ts/packages/package.json
+++ b/language-support/ts/packages/package.json
@@ -24,6 +24,8 @@
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
     "jest-mock-console": "^1.0.0",
+    "jest-websocket-mock": "^2.0.2",
+    "mock-socket": "^9.0.3",
     "ts-jest": "^24.3.0",
     "typedoc": "^0.16.11"
   }


### PR DESCRIPTION
Running the test in the new project via `yarn test` works just fine.
However, running the same tests via
```
bazel test //language-support/ts/jest_vs_bazel:test
```
doesn't work. The test fails because it thinks the `ws.server` object
is not an instance of class `Server`. This clearly contradicts the
implementation of the `WS` class at
https://github.com/romgain/jest-websocket-mock/blob/eb8324ff0d4fd1a09effd994cba142f240fb8f7a/src/websocket.ts#L48

My suspicion is that bazel somehow brings multiple versions of the
`Server` class from `mock-socket` into scope. If you drill into
`node_modules/mock-socket`, you'll see that `package.json` lists
`"main": "./dist/mock-socket"` and there are five files in `dist`:
- `mock-socket.amd.js`
- `mock-socket.cjs.js`
- `mock-socket.es.js`
- `mock-socket.es.mjs`
- `mock-socket.js`
The is also `src/index.js` which exports a `Server` class. So, there's
plenty of ooportunity for `bazel` to get confused.

Despite that, I wonder how `jest` gets it right on its own but `bazel`
manages to confuse `jest` to get it wrong under `bazel`'s guidance.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
