### PR TITLE
@daml/react: Fix name of loading flag in README

### DIFF
--- a/language-support/ts/daml-react/README.md
+++ b/language-support/ts/daml-react/README.md
@@ -66,7 +66,7 @@ const [choiceReturnValue, events] = await ledger.exercise(ContractChoice, contra
 template and specified field values of the contracts of that template.
 
 ```typescript
-const {contracts, isLoading} = useQuery(ContractTemplate, () => {field: value}, [dependency1,
+const {contracts, loading} = useQuery(ContractTemplate, () => {field: value}, [dependency1,
 dependency2, ...]);
 ```
 
@@ -84,7 +84,7 @@ const onClick = reload;
 `useStreamQuery` has the same signature as `useQuery`, but it constantly refreshes the results.
 
 ```typescript
-const {contracts, isLoading} = useStreamQuery(ContractTemplate, () => {field: value}, [dependency1,
+const {contracts, loading} = useStreamQuery(ContractTemplate, () => {field: value}, [dependency1,
 dependency2, ...]);
 ```
 
@@ -93,7 +93,7 @@ dependency2, ...]);
 `useFetchByKey` returns the unique contract of a given template and a given contract key.
 
 ```typescript
-const {contract, isLoading} = useFetchByKey(ContractTemplate, () => key, [dependency1, dependency2, ...]);
+const {contract, loading} = useFetchByKey(ContractTemplate, () => key, [dependency1, dependency2, ...]);
 ```
 
 `useStreamFetchByKey`
@@ -102,7 +102,7 @@ const {contract, isLoading} = useFetchByKey(ContractTemplate, () => key, [depend
 the result.
 
 ```typescript
-const {contract, isLoading} = useStreamFetchByKey(ContractTemplate, () => key, [dependency1, dependency2, ...]);
+const {contract, loading} = useStreamFetchByKey(ContractTemplate, () => key, [dependency1, dependency2, ...]);
 ```
 
 


### PR DESCRIPTION
The actual name of the flag is `loading`. For some reason the README
claims it's `isLoading`. This PR fixes the README.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5370)
<!-- Reviewable:end -->
