### PR TITLE
Limit memory usage of scenario service in tests

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Scenario.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Scenario.hs
@@ -9,7 +9,7 @@ module DA.Daml.Compiler.Scenario (
   , EnableScenarioService(..)
   , withScenarioService
   , withScenarioService'
-  , SS.ScenarioServiceConfig
+  , SS.ScenarioServiceConfig(..)
   , SS.readScenarioServiceConfig
   , SS.defaultScenarioServiceConfig
   ) where

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -85,7 +85,9 @@ mainAll :: IO ()
 mainAll = mainWithVersions (delete versionDev supportedOutputVersions)
 
 mainWithVersions :: [Version] -> IO ()
-mainWithVersions versions = SS.withScenarioService Logger.makeNopHandle SS.defaultScenarioServiceConfig $ \scenarioService -> do
+mainWithVersions versions = do
+ let scenarioConf = SS.defaultScenarioServiceConfig { SS.cnfJvmOptions = ["-Xmx200M"] }
+ SS.withScenarioService Logger.makeNopHandle scenarioConf $ \scenarioService -> do
   hSetEncoding stdout utf8
   setEnv "TASTY_NUM_THREADS" "1" True
   todoRef <- newIORef DList.empty

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -28,12 +28,13 @@ import Development.IDE.Core.API.Testing
 import Development.IDE.Core.Service.Daml(VirtualResource(..))
 
 main :: IO ()
-main = SS.withScenarioService Logger.makeNopHandle SS.defaultScenarioServiceConfig $ \scenarioService -> do
+main = SS.withScenarioService Logger.makeNopHandle scenarioConfig $ \scenarioService -> do
   -- The scenario service is a shared resource so running tests in parallel doesn’t work properly.
   setEnv "TASTY_NUM_THREADS" "1" True
   -- The startup of the scenario service is fairly expensive so instead of launching a separate
   -- service for each test, we launch a single service that is shared across all tests.
   Tasty.deterministicMain (ideTests (Just scenarioService))
+  where scenarioConfig = SS.defaultScenarioServiceConfig { SS.cnfJvmOptions = ["-Xmx200M"] }
 
 ideTests :: Maybe SS.Handle -> Tasty.TestTree
 ideTests mbScenarioService =

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient.hs
@@ -3,7 +3,7 @@
 
 module DA.Daml.LF.ScenarioServiceClient
   ( Options(..)
-  , ScenarioServiceConfig
+  , ScenarioServiceConfig(..)
   , defaultScenarioServiceConfig
   , readScenarioServiceConfig
   , LowLevel.TimeoutSeconds
@@ -58,6 +58,7 @@ toLowLevelOpts Options{..} =
     where
         optRequestTimeout = fromMaybe 60 $ cnfGrpcTimeout optScenarioServiceConfig
         optGrpcMaxMessageSize = cnfGrpcMaxMessageSize optScenarioServiceConfig
+        optJvmOptions = cnfJvmOptions optScenarioServiceConfig
 
 data Handle = Handle
   { hLowLevelHandle :: LowLevel.Handle
@@ -94,12 +95,14 @@ withScenarioService hOptions f = do
 data ScenarioServiceConfig = ScenarioServiceConfig
     { cnfGrpcMaxMessageSize :: Maybe Int -- In bytes
     , cnfGrpcTimeout :: Maybe LowLevel.TimeoutSeconds
+    , cnfJvmOptions :: [String]
     } deriving Show
 
 defaultScenarioServiceConfig :: ScenarioServiceConfig
 defaultScenarioServiceConfig = ScenarioServiceConfig
     { cnfGrpcMaxMessageSize = Nothing
     , cnfGrpcTimeout = Nothing
+    , cnfJvmOptions = []
     }
 
 readScenarioServiceConfig :: IO ScenarioServiceConfig
@@ -115,6 +118,7 @@ parseScenarioServiceConfig :: ProjectConfig -> Either ConfigError ScenarioServic
 parseScenarioServiceConfig conf = do
     cnfGrpcMaxMessageSize <- queryProjectConfig ["scenario-service", "grpc-max-message-size"] conf
     cnfGrpcTimeout <- queryProjectConfig ["scenario-service", "grpc-timeout"] conf
+    cnfJvmOptions <- fromMaybe [] <$> queryProjectConfig ["scenario-service", "jvm-options"] conf
     pure ScenarioServiceConfig {..}
 
 data Context = Context

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -65,6 +65,7 @@ import qualified ScenarioService as SS
 
 data Options = Options
   { optServerJar :: FilePath
+  , optJvmOptions :: [String]
   , optRequestTimeout :: TimeoutSeconds
   , optGrpcMaxMessageSize :: Maybe Int
   , optLogInfo :: String -> IO ()
@@ -199,7 +200,7 @@ withScenarioService opts@Options{..} f = do
   unless serverJarExists $
       throwIO (ScenarioServiceException (optServerJar <> " does not exist."))
   validateJava opts
-  cp <- javaProc (["-jar" , optServerJar] <> maybeToList (show <$> optGrpcMaxMessageSize))
+  cp <- javaProc (optJvmOptions <> ["-jar" , optServerJar] <> maybeToList (show <$> optGrpcMaxMessageSize))
   exitExpected <- newIORef False
   let closeStdin hdl = do
           atomicWriteIORef exitExpected True

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -102,6 +102,7 @@ The existence of a ``daml.yaml`` file is what tells ``daml`` that this directory
     scenario-service:
       grpc-max-message-size: 134217728
       grpc-timeout: 60
+      jvm-options: []
     build-options: ["--ghc-option", "-Werror",
                     "--ghc-option", "-v"]
 
@@ -132,6 +133,8 @@ Here is what each field means:
   - ``grpc-timeout``: This option controls the timeout used for communicating
     with the scenario service. If unspecified this defaults to 60s. Unless you get
     errors, there should be no reason to modify this.
+  - ``jvm-options``: A list of options passed to the JVM when starting the scenario
+    service. This can be used to limit maximum heap size via ``-Xmx500M``.
 
 - ``build-options``: a list of tokens that will be appended to some invocations of ``damlc`` (currently `build` and `ide`). Note that there is no further shell parsing applied.
 - ``sandbox-options``: a list of options that will be passed to Sandbox in ``daml start``.

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -134,7 +134,7 @@ Here is what each field means:
     with the scenario service. If unspecified this defaults to 60s. Unless you get
     errors, there should be no reason to modify this.
   - ``jvm-options``: A list of options passed to the JVM when starting the scenario
-    service. This can be used to limit maximum heap size via ``-Xmx500M``.
+    service. This can be used to limit maximum heap size via the ``-Xmx`` flag.
 
 - ``build-options``: a list of tokens that will be appended to some invocations of ``damlc`` (currently `build` and `ide`). Note that there is no further shell parsing applied.
 - ``sandbox-options``: a list of options that will be passed to Sandbox in ``daml start``.


### PR DESCRIPTION
Previously the scenario service used over 2GB of memory during
//compiler/damlc/tests:integration-dev for absolutely no reason.

This PR adds an option to pass JVM options when starting the scenario
service and sets them to 200MB for the Shake tests and the damlc
integration tests which seems to be more than sufficient.

These option can also be set in `daml.yaml`. I did not change the
defaults since this is shipped to users where I’d rather have high
memory usage than a crashing scenario service and on certain large
DAML codebases we might actually use a fair bit.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
