### PR TITLE
better Windows machine names

### DIFF
--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -61,7 +61,7 @@ resource "google_compute_instance_template" "vsts-agent-windows" {
 
   metadata {
     // Prepare the machine
-    sysprep-specialize-script-ps1 = <<SYSPREP_SPECIALIZE
+    windows-startup-script-ps1 = <<SYSPREP_SPECIALIZE
 Set-StrictMode -Version latest
 $ErrorActionPreference = 'Stop'
 
@@ -128,7 +128,8 @@ net start winrm
 
 echo "== Installing the VSTS agent"
 
-choco install azure-pipelines-agent --no-progress --yes --params "'/Token:${local.vsts_token} /Pool:${local.vsts_pool} /Url:https://dev.azure.com/${local.vsts_account}/ /LogonAccount:$Account /LogonPassword:$Password /Work:D:\a'"
+$MachineName = Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object CSName | ForEach{ $_.CSName }
+choco install azure-pipelines-agent --no-progress --yes --params "'/Token:${local.vsts_token} /Pool:${local.vsts_pool} /Url:https://dev.azure.com/${local.vsts_account}/ /LogonAccount:$Account /LogonPassword:$Password /Work:D:\a /AgentName:$MachineName'"
 echo OK
 SYSPREP_SPECIALIZE
 


### PR DESCRIPTION
This is a small QoL improvement, mostly targeted at myself: have Windows agents register with Azure using the name they display on the GCP console, so I don't need to find a build and look at the "Agent Diagnostics" step to figure out the corresponding between Azure and GCP.

CHANGELOG_BEGIN
CHANGELOG_END