### PR TITLE
sandbox: Wait longer in tests to start the Sandbox.

### DIFF
--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixture.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/SandboxFixture.scala
@@ -11,6 +11,7 @@ import io.grpc.Channel
 import org.scalatest.Suite
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
 
 trait SandboxFixture extends AbstractSandboxFixture with SuiteResource[(SandboxServer, Channel)] {
   self: Suite =>
@@ -30,7 +31,9 @@ trait SandboxFixture extends AbstractSandboxFixture with SuiteResource[(SandboxS
             Some(info.jdbcUrl)))
         server <- SandboxServer.owner(config.copy(jdbcUrl = jdbcUrl))
         channel <- GrpcClientResource.owner(server.port)
-      } yield (server, channel)
+      } yield (server, channel),
+      acquisitionTimeout = 1.minute,
+      releaseTimeout = 1.minute,
     )
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/SandboxNextFixture.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/SandboxNextFixture.scala
@@ -14,6 +14,7 @@ import io.grpc.Channel
 import org.scalatest.Suite
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
 
 trait SandboxNextFixture extends AbstractSandboxFixture with SuiteResource[(Port, Channel)] {
   self: Suite =>
@@ -36,7 +37,9 @@ trait SandboxNextFixture extends AbstractSandboxFixture with SuiteResource[(Port
             Some(info.jdbcUrl)))
         port <- new Runner(config.copy(jdbcUrl = jdbcUrl))
         channel <- GrpcClientResource.owner(port)
-      } yield (port, channel)
+      } yield (port, channel),
+      acquisitionTimeout = 1.minute,
+      releaseTimeout = 1.minute,
     )
   }
 }


### PR DESCRIPTION
This can fail in CI, especially when we're running tests in parallel, and starting PostgreSQL as well.

I've increased the limit from 30 seconds to 1 minute.

This is hopefully not a permanent fix; I'm going to look into doing this without an `Await.result`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
