### PR TITLE
Move more trigger tests to scala-test

### DIFF
--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -4,7 +4,7 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
-    "da_scala_test_suite",
+    "da_scala_test",
 )
 load(
     "//bazel_tools/client_server:client_server_test.bzl",
@@ -54,10 +54,8 @@ EOF
 
 da_scala_binary(
     name = "test_client",
-    srcs = glob(
-        ["src/**/*.scala"],
-        exclude = ["src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TriggerIt.scala"],
-    ),
+    srcs =
+        ["src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala"],
     main_class = "com.digitalasset.daml.lf.engine.trigger.test.TestMain",
     resources = ["//triggers/runner:src/main/resources/logback.xml"],
     deps = [
@@ -108,16 +106,23 @@ client_server_test(
     server_files = ["$(rootpath :acs.dar)"],
 )
 
-da_scala_test_suite(
+da_scala_test(
     name = "trigger-integration-tests",
-    srcs = glob(
-        ["src/**/*.scala"],
-        exclude = ["src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/TestMain.scala"],
-    ),
-    data = [":acs.dar"],
+    srcs =
+        [
+            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala",
+            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala",
+            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala",
+            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala",
+            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala",
+            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala",
+        ],
+    data = [
+        ":acs.dar",
+        "//ledger/test-common/test-certificates",
+    ],
     resources = ["//triggers/runner:src/main/resources/logback.xml"],
     deps = [
-        ":test_client",
         "//bazel_tools/runfiles:scala_runfiles",
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
@@ -129,101 +134,17 @@ da_scala_test_suite(
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",
+        "//ledger/ledger-api-auth",
         "//ledger/ledger-api-common",
         "//ledger/ledger-api-domain",
         "//ledger/participant-state",
         "//ledger/sandbox",
         "//ledger/sandbox:sandbox-scala-tests-lib",
         "//ledger/test-common",
-        "//libs-scala/auth-utils",
-        "//libs-scala/direct-execution-context",
         "//libs-scala/ports",
         "//libs-scala/resources",
         "//triggers/runner:trigger-runner-lib",
-        "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
-    ],
-)
-
-client_server_test(
-    name = "test_wallclock_time_tls",
-    timeout = "long",
-    client = ":test_client",
-    client_args = [
-        "-w",
-        "--cacrt $(rlocation $TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:ca.crt))",
-    ],
-    client_files = [
-        "$(rootpath :acs.dar)",
-    ],
-    data = [
-        ":acs.dar",
-        "//ledger/test-common/test-certificates:ca.crt",
-        "//ledger/test-common/test-certificates:server.crt",
-        "//ledger/test-common/test-certificates:server.pem",
-    ],
-    server = "//ledger/sandbox:sandbox-binary",
-    server_args = [
-        "--wall-clock-time",
-        "--port=0",
-        "--crt $(rlocation $TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.crt))",
-        "--pem $(rlocation $TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.pem))",
-        "--client-auth=none",
-    ],
-    server_files = ["$(rootpath :acs.dar)"],
-)
-
-AUTH_TOKEN = "I_CAN_HAZ_AUTH"
-
-# This is a genrule so we can replace it by something nicer that actually generates the token
-# from some readable input so we can change it more easily.
-# For now, this corresponds to a token that has admin set to false
-# and actAs to Alice1, …, Alice100
-genrule(
-    name = "test-auth-token",
-    outs = ["test-auth-token.jwt"],
-    cmd = """
-      cat <<EOF > $(location test-auth-token.jwt)
-Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY3RBcyI6WyJBbGljZTEiLCJBbGljZTIiLCJBbGljZTMiLCJBbGljZTQiLCJBbGljZTUiLCJBbGljZTYiLCJBbGljZTciLCJBbGljZTgiLCJBbGljZTkiLCJBbGljZTEwIiwiQWxpY2UxMSIsIkFsaWNlMTIiLCJBbGljZTEzIiwiQWxpY2UxNCIsIkFsaWNlMTUiLCJBbGljZTE2IiwiQWxpY2UxNyIsIkFsaWNlMTgiLCJBbGljZTE5IiwiQWxpY2UyMCIsIkFsaWNlMjEiLCJBbGljZTIyIiwiQWxpY2UyMyIsIkFsaWNlMjQiLCJBbGljZTI1IiwiQWxpY2UyNiIsIkFsaWNlMjciLCJBbGljZTI4IiwiQWxpY2UyOSIsIkFsaWNlMzAiLCJBbGljZTMxIiwiQWxpY2UzMiIsIkFsaWNlMzMiLCJBbGljZTM0IiwiQWxpY2UzNSIsIkFsaWNlMzYiLCJBbGljZTM3IiwiQWxpY2UzOCIsIkFsaWNlMzkiLCJBbGljZTQwIiwiQWxpY2U0MSIsIkFsaWNlNDIiLCJBbGljZTQzIiwiQWxpY2U0NCIsIkFsaWNlNDUiLCJBbGljZTQ2IiwiQWxpY2U0NyIsIkFsaWNlNDgiLCJBbGljZTQ5IiwiQWxpY2U1MCIsIkFsaWNlNTEiLCJBbGljZTUyIiwiQWxpY2U1MyIsIkFsaWNlNTQiLCJBbGljZTU1IiwiQWxpY2U1NiIsIkFsaWNlNTciLCJBbGljZTU4IiwiQWxpY2U1OSIsIkFsaWNlNjAiLCJBbGljZTYxIiwiQWxpY2U2MiIsIkFsaWNlNjMiLCJBbGljZTY0IiwiQWxpY2U2NSIsIkFsaWNlNjYiLCJBbGljZTY3IiwiQWxpY2U2OCIsIkFsaWNlNjkiLCJBbGljZTcwIiwiQWxpY2U3MSIsIkFsaWNlNzIiLCJBbGljZTczIiwiQWxpY2U3NCIsIkFsaWNlNzUiLCJBbGljZTc2IiwiQWxpY2U3NyIsIkFsaWNlNzgiLCJBbGljZTc5IiwiQWxpY2U4MCIsIkFsaWNlODEiLCJBbGljZTgyIiwiQWxpY2U4MyIsIkFsaWNlODQiLCJBbGljZTg1IiwiQWxpY2U4NiIsIkFsaWNlODciLCJBbGljZTg4IiwiQWxpY2U4OSIsIkFsaWNlOTAiLCJBbGljZTkxIiwiQWxpY2U5MiIsIkFsaWNlOTMiLCJBbGljZTk0IiwiQWxpY2U5NSIsIkFsaWNlOTYiLCJBbGljZTk3IiwiQWxpY2U5OCIsIkFsaWNlOTkiLCJBbGljZTEwMCJdfQ.p78Bgrx0kX2tPwXoc2p5Uz22HifzfELjnmf7XwmCI4k
-EOF
-    """,
-)
-
-client_server_test(
-    name = "test_static_time_authenticated",
-    timeout = "long",
-    client = ":test_client",
-    client_args = ["--access-token-file"],
-    client_files = [
-        "$(rootpath :test-auth-token.jwt)",
-        "$(rootpath :acs.dar)",
-    ],
-    data = [
-        ":acs.dar",
-        ":test-auth-token.jwt",
-    ],
-    server = "//ledger/sandbox:sandbox-binary",
-    server_args = [
-        "--static-time",
-        "--port=0",
-        "--auth-jwt-hs256-unsafe={}".format(AUTH_TOKEN),
-    ],
-    server_files = ["$(rootpath :acs.dar)"],
-)
-
-sh_test(
-    name = "list-triggers",
-    srcs = ["list-triggers.sh"],
-    args = [
-        "$(location //triggers/runner:trigger-runner)",
-        "$(location :acs.dar)",
-    ],
-    data = [
-        ":acs.dar",
-        "//triggers/runner:trigger-runner",
-    ],
-    deps = [
-        "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -4,6 +4,7 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
+    "da_scala_library",
     "da_scala_test",
 )
 load(
@@ -106,22 +107,12 @@ client_server_test(
     server_files = ["$(rootpath :acs.dar)"],
 )
 
-da_scala_test(
-    name = "trigger-integration-tests",
-    srcs =
-        [
-            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala",
-            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala",
-            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala",
-            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala",
-            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala",
-            "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala",
-        ],
-    data = [
-        ":acs.dar",
-        "//ledger/test-common/test-certificates",
+da_scala_library(
+    name = "test-utils",
+    srcs = [
+        "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala",
+        "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala",
     ],
-    resources = ["//triggers/runner:src/main/resources/logback.xml"],
     deps = [
         "//bazel_tools/runfiles:scala_runfiles",
         "//daml-lf/archive:daml_lf_archive_reader",
@@ -130,6 +121,47 @@ da_scala_test(
         "//daml-lf/interpreter",
         "//daml-lf/language",
         "//daml-lf/transaction",
+        "//language-support/scala/bindings",
+        "//language-support/scala/bindings-akka",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger/ledger-api-common",
+        "//ledger/ledger-api-domain",
+        "//ledger/sandbox",
+        "//ledger/sandbox:sandbox-scala-tests-lib",
+        "//ledger/test-common",
+        "//libs-scala/ports",
+        "//libs-scala/resources",
+        "//triggers/runner:trigger-runner-lib",
+        "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:org_scalactic_scalactic_2_12",
+        "@maven//:org_scalatest_scalatest_2_12",
+        "@maven//:org_scalaz_scalaz_core_2_12",
+    ],
+)
+
+# For now turning this into a scala_test_suite has too much overhead and ends up making
+# things slower rather than faster. Once we have more tests, we might want to reconsider.
+da_scala_test(
+    name = "trigger-integration-tests",
+    srcs = [
+        "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala",
+        "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala",
+        "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala",
+        "src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala",
+    ],
+    data = [
+        ":acs.dar",
+        "//ledger/test-common/test-certificates",
+    ],
+    resources = ["//triggers/runner:src/main/resources/logback.xml"],
+    deps = [
+        ":test-utils",
+        "//bazel_tools/runfiles:scala_runfiles",
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/data",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
@@ -1,0 +1,160 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.engine.trigger.test
+
+import akka.stream.scaladsl.{Flow}
+import com.digitalasset.daml.lf.data.Ref._
+import com.digitalasset.daml.lf.speedy.SExpr
+import com.digitalasset.daml.lf.speedy.SExpr._
+import com.digitalasset.daml.lf.speedy.SValue._
+import com.digitalasset.daml.lf.value.Value.AbsoluteContractId
+import com.digitalasset.ledger.api.testing.utils.{SuiteResourceManagementAroundAll}
+import com.digitalasset.ledger.api.v1.commands._
+import com.digitalasset.ledger.api.v1.commands.CreateCommand
+import com.digitalasset.ledger.api.v1.{value => LedgerApi}
+import com.digitalasset.platform.services.time.TimeProviderType
+import org.scalatest._
+import scalaz.syntax.traverse._
+
+import com.digitalasset.daml.lf.engine.trigger.TriggerMsg
+
+abstract class AbstractFuncTests
+    extends AsyncWordSpec
+    with AbstractTriggerTest
+    with Matchers
+    with SuiteResourceManagementAroundAll
+    with TryValues {
+  self: Suite =>
+
+  this.getClass.getSimpleName can {
+    "AcsTests" should {
+      val assetId = LedgerApi.Identifier(packageId, "ACS", "Asset")
+      val assetMirrorId = LedgerApi.Identifier(packageId, "ACS", "AssetMirror")
+      def asset(party: String): CreateCommand =
+        CreateCommand(
+          templateId = Some(assetId),
+          createArguments = Some(
+            LedgerApi.Record(fields =
+              Seq(LedgerApi.RecordField("issuer", Some(LedgerApi.Value().withParty(party)))))))
+
+      final case class AssetResult(
+          successfulCompletions: Long,
+          failedCompletions: Long,
+          activeAssets: Set[String])
+
+      def toResult(expr: SExpr): AssetResult = {
+        val fields = expr.asInstanceOf[SEValue].v.asInstanceOf[SRecord].values
+        AssetResult(
+          successfulCompletions = fields.get(1).asInstanceOf[SInt64].value,
+          failedCompletions = fields.get(2).asInstanceOf[SInt64].value,
+          activeAssets = fields
+            .get(0)
+            .asInstanceOf[SList]
+            .list
+            .map(x =>
+              x.asInstanceOf[SContractId].value.asInstanceOf[AbsoluteContractId].coid.toString)
+            .toSet
+        )
+      }
+
+      "1 create" in {
+        for {
+          client <- ledgerClient()
+          party <- allocateParty(client)
+          runner = getRunner(client, QualifiedName.assertFromString("ACS:test"), party)
+          (acs, offset) <- runner.queryACS()
+          // Start the future here
+          finalStateF = runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(6))._2
+          // Execute commands
+          contractId <- create(client, party, asset(party))
+          // Wait for the trigger to terminate
+          result <- finalStateF.map(toResult)
+          acs <- queryACS(client, party)
+        } yield {
+          assert(result.activeAssets == Seq(contractId).toSet)
+          assert(result.successfulCompletions == 2)
+          assert(result.failedCompletions == 0)
+          assert(acs(assetMirrorId).size == 1)
+        }
+      }
+
+      "2 creates" in {
+        for {
+          client <- ledgerClient()
+          party <- allocateParty(client)
+          runner = getRunner(client, QualifiedName.assertFromString("ACS:test"), party)
+          (acs, offset) <- runner.queryACS()
+
+          finalStateF = runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(12))._2
+
+          contractId1 <- create(client, party, asset(party))
+          contractId2 <- create(client, party, asset(party))
+
+          result <- finalStateF.map(toResult)
+          acs <- queryACS(client, party)
+        } yield {
+          assert(result.activeAssets == Seq(contractId1, contractId2).toSet)
+          assert(result.successfulCompletions == 4)
+          assert(result.failedCompletions == 0)
+          assert(acs(assetMirrorId).size == 2)
+        }
+      }
+
+      "2 creates and 2 archives" in {
+        for {
+          client <- ledgerClient()
+          party <- allocateParty(client)
+          runner = getRunner(client, QualifiedName.assertFromString("ACS:test"), party)
+          (acs, offset) <- runner.queryACS()
+
+          finalStateF = runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(16))._2
+
+          contractId1 <- create(client, party, asset(party))
+          contractId2 <- create(client, party, asset(party))
+          _ <- archive(client, party, assetId, contractId1)
+          _ <- archive(client, party, assetId, contractId2)
+
+          result <- finalStateF.map(toResult)
+          acs <- queryACS(client, party)
+        } yield {
+          assert(result.activeAssets == Seq().toSet)
+          assert(result.successfulCompletions == 4)
+          assert(result.failedCompletions == 0)
+          assert(acs(assetMirrorId).size == 2)
+        }
+      }
+    }
+
+    "TimeTests" should {
+      "test" in {
+        for {
+          client <- ledgerClient()
+          party <- allocateParty(client)
+          runner = getRunner(client, QualifiedName.assertFromString("Time:test"), party)
+          (acs, offset) <- runner.queryACS()
+          finalState <- runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(4))._2
+        } yield {
+          finalState match {
+            case SEValue(SRecord(_, _, values)) if values.size == 2 =>
+              values.get(1) match {
+                case SList(items) if items.length == 2 =>
+                  val t0 = items.slowApply(0).asInstanceOf[STimestamp].value
+                  val t1 = items.slowApply(1).asInstanceOf[STimestamp].value
+                  config.timeProviderType match {
+                    case None => fail("No time provider type specified")
+                    case Some(TimeProviderType.WallClock) =>
+                      // Given the limited resolution it can happen that t0 == t1
+                      assert(t0 >= t1)
+                    case Some(TimeProviderType.Static) =>
+                      assert(t0 == t1)
+                  }
+                case v => fail(s"Expected list with 2 elements but got $v")
+              }
+            case _ => fail(s"Expected Tuple2 but got $finalState")
+          }
+        }
+      }
+    }
+  }
+}

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest
@@ -45,7 +45,7 @@ import scalaz.syntax.traverse._
 import com.digitalasset.daml.lf.engine.trigger.{Runner, Trigger, TriggerMsg}
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
-final class TriggerIt
+final class AbstractTriggerTest
     extends AsyncWordSpec
     with TestCommands
     with SandboxFixture

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -1,0 +1,131 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.engine.trigger.test
+
+import akka.stream.scaladsl.Sink
+import java.io.File
+import java.util.UUID
+
+import com.digitalasset.daml.bazeltools.BazelRunfiles._
+import com.digitalasset.daml.lf.PureCompiledPackages
+import com.digitalasset.daml.lf.archive.{DarReader, Decode}
+import com.digitalasset.daml.lf.data.Ref._
+import com.digitalasset.ledger.api.testing.utils.MockMessages
+import com.digitalasset.ledger.api.v1.command_service.SubmitAndWaitRequest
+import com.digitalasset.ledger.api.v1.commands._
+import com.digitalasset.ledger.api.v1.commands.{Command, CreateCommand, ExerciseCommand}
+import com.digitalasset.ledger.api.v1.event.CreatedEvent
+import com.digitalasset.ledger.api.refinements.ApiTypes.ApplicationId
+import com.digitalasset.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
+import com.digitalasset.ledger.api.v1.{value => LedgerApi}
+import com.digitalasset.ledger.client.LedgerClient
+import com.digitalasset.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement
+}
+import com.digitalasset.platform.sandbox.services.{SandboxFixture, TestCommands}
+import org.scalatest._
+import scala.concurrent.{ExecutionContext, Future}
+import scalaz.syntax.tag._
+import scalaz.syntax.traverse._
+
+import com.digitalasset.daml.lf.engine.trigger.{Runner, Trigger}
+
+trait AbstractTriggerTest extends SandboxFixture with TestCommands {
+  self: Suite =>
+
+  protected def ledgerClientConfiguration =
+    LedgerClientConfiguration(
+      applicationId = MockMessages.applicationId,
+      ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
+      commandClient = CommandClientConfiguration.default,
+      sslContext = None,
+      token = None
+    )
+
+  protected def ledgerClient()(implicit ec: ExecutionContext): Future[LedgerClient] =
+    LedgerClient.singleHost("localhost", serverPort.value, ledgerClientConfiguration)
+
+  override protected def darFile = new File(rlocation("triggers/tests/acs.dar"))
+
+  protected val dar = DarReader().readArchiveFromFile(darFile).get.map {
+    case (pkgId, archive) => Decode.readArchivePayload(pkgId, archive)
+  }
+  protected val compiledPackages = PureCompiledPackages(dar.all.toMap).right.get
+
+  protected def getRunner(client: LedgerClient, name: QualifiedName, party: String): Runner = {
+    val triggerId = Identifier(packageId, name)
+    val trigger = Trigger.fromIdentifier(compiledPackages, triggerId).right.get
+    new Runner(
+      compiledPackages,
+      trigger,
+      client,
+      config.timeProviderType.get,
+      ApplicationId(MockMessages.applicationId),
+      party)
+  }
+
+  protected def allocateParty(client: LedgerClient)(implicit ec: ExecutionContext): Future[String] =
+    client.partyManagementClient.allocateParty(None, None).map(_.party)
+
+  protected def create(client: LedgerClient, party: String, cmd: CreateCommand)(
+      implicit ec: ExecutionContext): Future[String] = {
+    val commands = Seq(Command().withCreate(cmd))
+    val request = SubmitAndWaitRequest(
+      Some(
+        Commands(
+          party = party,
+          commands = commands,
+          ledgerId = client.ledgerId.unwrap,
+          applicationId = MockMessages.applicationId,
+          commandId = UUID.randomUUID.toString
+        )))
+    for {
+      response <- client.commandServiceClient.submitAndWaitForTransaction(request)
+    } yield response.getTransaction.events.head.getCreated.contractId
+  }
+
+  protected def archive(
+      client: LedgerClient,
+      party: String,
+      templateId: LedgerApi.Identifier,
+      contractId: String)(implicit ec: ExecutionContext): Future[Unit] = {
+    val commands = Seq(
+      Command().withExercise(
+        ExerciseCommand(
+          templateId = Some(templateId),
+          contractId = contractId,
+          choice = "Archive",
+          choiceArgument = Some(LedgerApi.Value().withRecord(LedgerApi.Record())))))
+    val request = SubmitAndWaitRequest(
+      Some(
+        Commands(
+          party = party,
+          commands = commands,
+          ledgerId = client.ledgerId.unwrap,
+          applicationId = MockMessages.applicationId,
+          commandId = UUID.randomUUID.toString
+        )))
+    for {
+      response <- client.commandServiceClient.submitAndWaitForTransaction(request)
+    } yield ()
+  }
+
+  protected def queryACS(client: LedgerClient, party: String)(
+      implicit ec: ExecutionContext): Future[Map[LedgerApi.Identifier, Seq[LedgerApi.Record]]] = {
+    val filter = TransactionFilter(List((party, Filters.defaultInstance)).toMap)
+    val contractsF: Future[Seq[CreatedEvent]] = client.activeContractSetClient
+      .getActiveContracts(filter, verbose = true)
+      .runWith(Sink.seq)
+      .map(_.flatMap(x => x.activeContracts))
+    contractsF.map(
+      contracts =>
+        contracts
+          .map(created => (created.getTemplateId, created.getCreateArguments))
+          .groupBy(_._1)
+          .mapValues(cs => cs.map(_._2)))
+  }
+
+}

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsStaticTime.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.engine.trigger.test
+
+import com.digitalasset.platform.services.time.TimeProviderType
+
+final class FuncTestsStaticTime extends AbstractFuncTests {
+  override def config = super.config.copy(timeProviderType = Some(TimeProviderType.Static))
+}

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/FuncTestsWallClock.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.engine.trigger.test
+
+import com.digitalasset.platform.services.time.TimeProviderType
+
+final class FuncTestsWallClock extends AbstractFuncTests {
+  override def config = super.config.copy(timeProviderType = Some(TimeProviderType.WallClock))
+}

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.engine.trigger.test
+
+import akka.stream.scaladsl.{Flow}
+import com.digitalasset.daml.lf.data.Ref._
+import com.digitalasset.platform.sandbox.services.SandboxFixtureWithAuth
+import com.digitalasset.ledger.api.testing.utils.{SuiteResourceManagementAroundAll}
+import com.digitalasset.ledger.api.v1.commands._
+import com.digitalasset.ledger.api.v1.commands.CreateCommand
+import com.digitalasset.ledger.api.v1.{value => LedgerApi}
+import org.scalatest._
+
+import com.digitalasset.daml.lf.engine.trigger.TriggerMsg
+
+class Jwt
+    extends AsyncWordSpec
+    with AbstractTriggerTest
+    with SandboxFixtureWithAuth
+    with Matchers
+    with SuiteResourceManagementAroundAll
+    with TryValues {
+  self: Suite =>
+
+  override protected def ledgerClientConfiguration = super.ledgerClientConfiguration.copy(
+    token = Some(toHeader(readWriteToken(party)))
+  )
+
+  private val party = "AliceAuth"
+
+  "Jwt" can {
+    // We just need something simple to test the connection.
+    val assetId = LedgerApi.Identifier(packageId, "ACS", "Asset")
+    val assetMirrorId = LedgerApi.Identifier(packageId, "ACS", "AssetMirror")
+    def asset(party: String): CreateCommand =
+      CreateCommand(
+        templateId = Some(assetId),
+        createArguments = Some(LedgerApi.Record(
+          fields = Seq(LedgerApi.RecordField("issuer", Some(LedgerApi.Value().withParty(party)))))))
+    "1 create" in {
+      for {
+        client <- ledgerClient()
+        runner = getRunner(client, QualifiedName.assertFromString("ACS:test"), party)
+        (acs, offset) <- runner.queryACS()
+        // Start the future here
+        finalStateF = runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(6))._2
+        // Execute commands
+        contractId <- create(client, party, asset(party))
+        // Wait for the trigger to terminate
+        _ <- finalStateF
+        acs <- queryACS(client, party)
+      } yield {
+        assert(acs(assetId).size == 1)
+        assert(acs(assetMirrorId).size == 1)
+      }
+    }
+  }
+}

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.daml.lf.engine.trigger.test
+
+import akka.stream.scaladsl.{Flow}
+import com.digitalasset.daml.bazeltools.BazelRunfiles._
+import com.digitalasset.daml.lf.data.Ref._
+import com.digitalasset.ledger.api.testing.utils.{SuiteResourceManagementAroundAll}
+import com.digitalasset.ledger.api.tls.TlsConfiguration
+import com.digitalasset.ledger.api.v1.commands._
+import com.digitalasset.ledger.api.v1.commands.CreateCommand
+import com.digitalasset.ledger.api.v1.{value => LedgerApi}
+import java.io.File
+import org.scalatest._
+
+import com.digitalasset.daml.lf.engine.trigger.TriggerMsg
+
+class Tls
+    extends AsyncWordSpec
+    with AbstractTriggerTest
+    with Matchers
+    with SuiteResourceManagementAroundAll
+    with TryValues {
+  self: Suite =>
+
+  val List(serverCrt, serverPem, caCrt, clientCrt, clientPem) = {
+    List("server.crt", "server.pem", "ca.crt", "client.crt", "client.pem").map { src =>
+      Some(new File(rlocation("ledger/test-common/test-certificates/" + src)))
+    }
+  }
+
+  override protected def config =
+    super.config
+      .copy(tlsConfig = Some(TlsConfiguration(enabled = true, serverCrt, serverPem, caCrt)))
+
+  override protected def ledgerClientConfiguration =
+    super.ledgerClientConfiguration
+      .copy(sslContext = TlsConfiguration(enabled = true, clientCrt, clientPem, caCrt).client)
+
+  "TLS" can {
+    // We just need something simple to test the connection.
+    val assetId = LedgerApi.Identifier(packageId, "ACS", "Asset")
+    val assetMirrorId = LedgerApi.Identifier(packageId, "ACS", "AssetMirror")
+    def asset(party: String): CreateCommand =
+      CreateCommand(
+        templateId = Some(assetId),
+        createArguments = Some(LedgerApi.Record(
+          fields = Seq(LedgerApi.RecordField("issuer", Some(LedgerApi.Value().withParty(party)))))))
+    "1 create" in {
+      for {
+        client <- ledgerClient()
+        party <- allocateParty(client)
+        runner = getRunner(client, QualifiedName.assertFromString("ACS:test"), party)
+        (acs, offset) <- runner.queryACS()
+        // Start the future here
+        finalStateF = runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(6))._2
+        // Execute commands
+        contractId <- create(client, party, asset(party))
+        // Wait for the trigger to terminate
+        _ <- finalStateF
+        acs <- queryACS(client, party)
+      } yield {
+        assert(acs(assetId).size == 1)
+        assert(acs(assetMirrorId).size == 1)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR moves more tests of triggers over to the Scala test suite, in
particular:

- The existing tests there abstract over the time mode and are
  instantiated once for wallclock mode and once for static time mode.
- I’ve added tests for TLS and Auth.
- I’ve removed the TLS and Auth tests outside of scala-test since they
  are now redundant.
- I’ve added the time tests to the scala-tests stuff since with the
  new ledger time model, that’s necessary to actually trigger a
  failure if you get static time vs wallclock time wrong (MRT and LET
  no longer exist).

I haven’t yet moved all the func tests over, I’ll do that separately
and then we can kill the old tests completely.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
