### PR TITLE
testing-utils: Make `ManagedResource` idempotent.

### DIFF
--- a/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/ActorMaterializerResource.scala
+++ b/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/ActorMaterializerResource.scala
@@ -9,7 +9,7 @@ import akka.stream.Materializer
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class ActorMaterializerResource(actorSystemName: String = "")
+final class ActorMaterializerResource(actorSystemName: String = "")
     extends ManagedResource[Materializer] {
   override protected def construct(): Materializer = {
     implicit val system: ActorSystem =

--- a/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/GrpcServerResource.scala
+++ b/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/GrpcServerResource.scala
@@ -3,14 +3,15 @@
 
 package com.digitalasset.ledger.api.testing.utils
 
-import io.grpc._
 import java.net.SocketAddress
 import java.util.concurrent.TimeUnit
 
-class GrpcServerResource(
+import io.grpc._
+
+final class GrpcServerResource(
     services: () => Iterable[BindableService with AutoCloseable],
-    port: Option[SocketAddress])
-    extends ManagedResource[ServerWithChannelProvider] {
+    port: Option[SocketAddress],
+) extends ManagedResource[ServerWithChannelProvider] {
 
   @volatile private var boundServices: Iterable[BindableService with AutoCloseable] = Nil
 

--- a/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/ManagedResource.scala
+++ b/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/ManagedResource.scala
@@ -3,43 +3,34 @@
 
 package com.digitalasset.ledger.api.testing.utils
 
-import java.util.concurrent.atomic.AtomicReference
-
 import scala.reflect.ClassTag
 
 abstract class ManagedResource[Value: ClassTag] extends Resource[Value] {
-
-  private val resourceRef = new AtomicReference[Value]()
+  private var resource: Option[Value] = None
 
   protected def construct(): Value
 
   protected def destruct(resource: Value): Unit
 
-  final override def value: Value = {
-    val res = resourceRef.get()
-    if (res != null) res
-    else
+  final override def value: Value =
+    resource.getOrElse {
       throw new IllegalStateException(
-        s"Attempted to read non-initialized resource of class ${implicitly[ClassTag[Value]].runtimeClass.getName}")
-  }
+        s"Attempted to read non-initialized resource of ${implicitly[ClassTag[Value]].runtimeClass}")
+    }
 
-  final override def setup(): Unit = {
-    resourceRef.updateAndGet(
-      (resource: Value) =>
-        if (resource == null) construct()
-        else throw new IllegalStateException(s"Resource $resource is already set up"))
-    ()
-  }
-
-  final override def close(): Unit = {
-    resourceRef.updateAndGet { (resource: Value) =>
-      if (resource != null) {
-        destruct(resource)
-        null.asInstanceOf[Value]
-      } else {
-        resource
+  final override def setup(): Unit =
+    synchronized {
+      if (resource.isEmpty) {
+        resource = Some(construct())
       }
     }
-    ()
-  }
+
+  final override def close(): Unit =
+    synchronized {
+      if (resource.isDefined) {
+        destruct(resource.get)
+        resource = None
+        ()
+      }
+    }
 }

--- a/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/OwnedResource.scala
+++ b/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/OwnedResource.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext}
 import scala.reflect.ClassTag
 
-class OwnedResource[T: ClassTag](
+final class OwnedResource[T: ClassTag](
     owner: resources.ResourceOwner[T],
     acquisitionTimeout: FiniteDuration = 30.seconds,
     releaseTimeout: FiniteDuration = 30.seconds,


### PR DESCRIPTION
We saw a few issues in CI where `setup` might be called twice, which resulted in a test fail for no good reason. Rather than crashing, we can just do nothing the second time.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
