### PR TITLE
Add an integration test for daml new ... create-daml-app

### DIFF
--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -68,6 +68,12 @@ genrule(
     """.format(mvn = mvn_version),
 )
 
+ts_libraries = [
+    "//language-support/ts/daml-types:npm_package",
+    "//language-support/ts/daml-ledger:npm_package",
+    "//language-support/ts/daml-react:npm_package",
+]
+
 da_haskell_test(
     name = "integration-tests",
     timeout = "long",
@@ -89,7 +95,7 @@ da_haskell_test(
         "//compiler/damlc/tests:generate-simple-dalf",
         "@mvn_dev_env//:mvn",
         "@tar_dev_env//:tar",
-    ] + ([] if is_windows else ["//language-support/ts/daml-types:npm_package"]),
+    ] + ([] if is_windows else ts_libraries),
     # I’m sure the mvn stuff will be flaky.
     flaky = True,
     hackage_deps = [

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -9,6 +9,8 @@ import Control.Exception
 import Control.Monad
 import Control.Monad.Fail (MonadFail)
 import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=), object)
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Conduit.Tar.Extra as Tar.Conduit.Extra
 import qualified Data.Conduit.Zlib as Zlib
 import Data.List.Extra
@@ -73,6 +75,7 @@ tests tmpDir damlTypesDir = withSdkResource $ \_ -> testGroup "Integration tests
     , cleanTests cleanDir
     , templateTests
     , codegenTests codegenDir damlTypesDir
+    , createDamlAppTests
     ]
     where quickstartDir = tmpDir </> "q-u-i-c-k-s-t-a-r-t"
           cleanDir = tmpDir </> "clean"
@@ -550,6 +553,38 @@ codegenTests codegenDir damlTypes = testGroup "daml codegen" (
                                   , "-o", outDir]
                         contents <- listDirectory outDir
                         assertBool "bindings were written" (not $ null contents)
+
+createDamlAppTests :: TestTree
+createDamlAppTests = testGroup "create-daml-app" [gettingStartedGuideTest | not isWindows]
+  where
+    gettingStartedGuideTest = testCase "Getting Started Guide" $
+      withTempDir $ \tmpDir -> do
+        let tsLibs = ["daml-types", "daml-ledger", "daml-react"]
+        forM_  tsLibs $ \tsLib -> do
+          srcDir <- locateRunfiles $ mainWorkspace </> "language-support" </> "ts" </> tsLib </> "npm_package"
+          copyDirectory srcDir (tmpDir </> tsLib)
+        BSL.writeFile (tmpDir </> "package.json") $ Aeson.encode $ object
+          [ "private" .= True
+          , "workspaces" .= ["create-daml-app/daml-ts", "create-daml-app/ui" :: String]
+          , "resolutions" .= object
+              [ pkgName .= ("file:" ++ tsLib)
+              | tsLib <- tsLibs, let pkgName = "@" <> T.replace "-" "/"  (T.pack tsLib)
+              ]
+          ]
+        withCurrentDirectory tmpDir $ do
+          callCommandSilent "daml new create-daml-app create-daml-app"
+        let cdaDir = tmpDir </> "create-daml-app"
+        withCurrentDirectory cdaDir $ do
+          callCommandSilent "daml build"
+          callCommandSilent "daml codegen ts -o daml-ts .daml/dist/create-daml-app-0.1.0.dar"
+        doesFileExist (cdaDir </> "ui" </> "build" </> "index.html") >>=
+          assertBool "ui/build/index.html does not yet exist" . not
+        withCurrentDirectory (cdaDir </> "ui") $ do
+          callCommandSilent "yarn install"
+          callCommandSilent "yarn lint --max-warnings 0"
+          callCommandSilent "yarn build"
+        doesFileExist (cdaDir </> "ui" </> "build" </> "index.html") >>=
+          assertBool "ui/build/index.html has been produced"
 
 damlInstallerName :: String
 damlInstallerName


### PR DESCRIPTION
The test calls `daml new ... create-daml-app`, builds the DAR, runs
the TypeScript codegen, lints and builds the React app.

We should also run the tests for the React app but since that's most
likely tricky, I'll leave that for a followup PR so that we can land
at least some sanity checks now.

There's also a bit of cleanup to do around setting up a yarn workspace
to bring our TypeScript libraries into scope. Other test already solve
a similar problem in a way that is not general enough for this test.
I'll unify the setup in a followup PR as well.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5389)
<!-- Reviewable:end -->
