### PR TITLE
Fix yarn invocation in daml2ts on Windws

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -612,7 +612,10 @@ buildPackages sdkVersion optScope optOutputDir dependencies = do
 
     yarn :: [String] -> IO ()
     yarn args = do
-      (exitCode, _, err) <- readProcessWithExitCode "yarn" args ""
+      -- We need to use `shell` instead of `proc` since at least in some cases
+      -- `yarn` is called `yarn.cmd` which will not be picked up by `proc`.
+      -- We could hardcode `yarn.cmd` on Windows but that seems rather fragile.
+      (exitCode, _, err) <- readCreateProcessWithExitCode (shell $ unwords $ "yarn" : args) ""
       unless (exitCode == ExitSuccess) $ do
         putStrLn $ "Failure: \"yarn " <> unwords args <> "\" exited with " <> show exitCode
         putStrLn err


### PR DESCRIPTION
The details are in a source code comment but roughly it boils down to
`proc` vs `shell` looking things up in PATH differently.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
