### PR TITLE
Dont deduplicate rejected transactions

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -92,8 +92,7 @@ private[kvutils] class ProcessTransactionSubmission(
     isVisible && isActive
   }
 
-  /** Deduplicate the submission. If the check passes we save the command deduplication
-    * state.
+  /** Reject duplicate commands
     */
   private def deduplicateCommand(
       recordTime: Timestamp,
@@ -103,15 +102,7 @@ private[kvutils] class ProcessTransactionSubmission(
     get(dedupKey).flatMap { dedupEntry =>
       val submissionTime = if (inStaticTimeMode) Instant.now() else recordTime.toInstant
       if (dedupEntry.forall(isAfterDeduplicationTime(submissionTime, _))) {
-        Commit.set(
-          dedupKey ->
-            DamlStateValue.newBuilder
-              .setCommandDedup(
-                DamlCommandDedupValue.newBuilder
-                  .setRecordTime(buildTimestamp(recordTime))
-                  .setDeduplicatedUntil(transactionEntry.submitterInfo.getDeduplicateUntil)
-                  .build)
-              .build)
+        pure(())
       } else {
         logger.trace(
           s"Transaction rejected, duplicate command, correlationId=${transactionEntry.commandId}")
@@ -332,6 +323,8 @@ private[kvutils] class ProcessTransactionSubmission(
 
     val cid2nid: Value.AbsoluteContractId => Value.NodeId = transactionEntry.abs.localContracts
 
+    val dedupKey = commandDedupKey(transactionEntry.submitterInfo)
+
     // Helper to read the _current_ contract state.
     // NOTE(JM): Important to fetch from the state that is currently being built up since
     // we mark some contracts as archived and may later change their disclosure and do not
@@ -342,6 +335,15 @@ private[kvutils] class ProcessTransactionSubmission(
       }
 
     sequence2(
+      // Set a deduplication entry
+      set(
+        dedupKey -> DamlStateValue.newBuilder
+          .setCommandDedup(
+            DamlCommandDedupValue.newBuilder
+              .setRecordTime(buildTimestamp(recordTime))
+              .setDeduplicatedUntil(transactionEntry.submitterInfo.getDeduplicateUntil)
+              .build)
+          .build),
       // Add contract state entries to mark contract activeness (checked by 'validateModelConformance')
       set(effects.createdContracts.map {
         case (key, createNode) =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committing/ProcessTransactionSubmission.scala
@@ -102,7 +102,7 @@ private[kvutils] class ProcessTransactionSubmission(
     get(dedupKey).flatMap { dedupEntry =>
       val submissionTime = if (inStaticTimeMode) Instant.now() else recordTime.toInstant
       if (dedupEntry.forall(isAfterDeduplicationTime(submissionTime, _))) {
-        pure(())
+        pass
       } else {
         logger.trace(
           s"Transaction rejected, duplicate command, correlationId=${transactionEntry.commandId}")

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -70,6 +70,7 @@ import org.slf4j.LoggerFactory
 import scalaz.syntax.tag.ToTagOps
 
 import scala.concurrent.Future
+import scala.util.Try
 
 sealed trait InMemoryEntry extends Product with Serializable
 final case class InMemoryLedgerEntry(entry: LedgerEntry) extends InMemoryEntry
@@ -260,14 +261,14 @@ class InMemoryLedger(
     })
 
   override def lookupMaximumLedgerTime(contractIds: Set[AbsoluteContractId]): Future[Instant] =
-    Future.successful(this.synchronized {
+    Future.fromTry(Try(this.synchronized {
       contractIds.foldLeft[Instant](Instant.EPOCH)((acc, id) => {
         val let = acs.activeContracts
           .getOrElse(id, sys.error(s"Contract $id not found while looking for maximum ledger time"))
           .let
         if (let.isAfter(acc)) let else acc
       })
-    })
+    }))
 
   override def publishTransaction(
       submitterInfo: SubmitterInfo,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -334,6 +334,7 @@ class InMemoryLedger(
 
   private def handleError(submitterInfo: SubmitterInfo, reason: RejectionReason): Unit = {
     logger.warn(s"Publishing error to ledger: ${reason.description}")
+    stopDeduplicatingCommand(CommandId(submitterInfo.commandId), submitterInfo.submitter)
     entries.publish(
       InMemoryLedgerEntry(
         LedgerEntry.Rejection(

--- a/ledger/test-common/src/main/daml/Test.daml
+++ b/ledger/test-common/src/main/daml/Test.daml
@@ -353,6 +353,15 @@ template TextKeyOperations
           mbCid2 <- lookupByKey @TextKey keyToLookup
           assertMsg "does not get contract after exercise" (mbCid2 == None)
 
+    controller tkoParty can
+      nonconsuming TKOFetchAndRecreate : ()
+        with
+          keyToFetch: (Party, Text)
+        do
+          (cid, contract) <- fetchByKey @TextKey keyToFetch
+          exercise cid TextKeyChoice
+          cid2 <- create TextKey with tkParty = contract.tkParty, tkKey = contract.tkKey, tkDisclosedTo = contract.tkDisclosedTo
+          return ()
 
 -- dummy contract to be divulged out-of-band
 template Divulgence1


### PR DESCRIPTION
This PR stops deduplicating commands by the submission service when a transaction was rejected.

Fixes #5338.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
