### PR TITLE
Replace warning about new releases by something less scary

### DIFF
--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -99,9 +99,11 @@ versionChecks Env{..} =
         -- Project SDK version is outdated.
         when (not isHead && projectSdkVersionIsOld) $ do
             hPutStr stderr . unlines $
-                [ "WARNING: Using an outdated version of the DAML SDK in project."
-                , "To migrate to the latest DAML SDK, please set the sdk-version"
-                , "field in daml.yaml to " <> versionToString latestVersion
+                [ "DAML SDK " <> versionToString latestVersion <> " has been released!"
+                , "See https://github.com/digital-asset/daml/releases/tag/v"
+                  <> versionToString latestVersion <> " for details."
+                -- Carefully crafted wording to make sure it’s < 80 characters so
+                -- we do not get a line break.
                 , ""
                 ]
 


### PR DESCRIPTION
Previously we emitted 3 lines starting with a capslock `WARNING` which
seems to scare some people. Now we emit two lines without the
`WARNING` and point to the release notes since that seems better than
explaining to users how they upgrade without telling them what
changed.

It’s still two lines, I couldn’t come up with anything shorter that
seems reasonable. We might want to reduce the frequency at which this
is displayed as well but for now this should do.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
