### PR TITLE
Build a zip containing all protobuf files

### DIFF
--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -20,18 +20,7 @@ load("//bazel_tools:pom_file.bzl", "pom_file")
 load("@os_info//:os_info.bzl", "is_windows")
 load("//bazel_tools:javadoc_library.bzl", "javadoc_library")
 load(":archive.bzl", "mangle_for_java")
-
-LF_MAJOR_VERSIONS = [
-    "0",
-    "1",
-]
-
-LF_VERSIONS = [
-    "1.6",
-    "1.7",
-    "1.8",
-    "dev",
-]
+load("//daml-lf/language:daml-lf.bzl", "LF_MAJOR_VERSIONS", "LF_VERSIONS")
 
 [
     [

--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -1,6 +1,19 @@
 # Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Stable and latest refers to the versions used by the compiler.
+# If we make a new LF release, we bump latest and once we make it the default
+# we bump stable.
 lf_stable_version = "1.8"
 lf_latest_version = "1.8"
 lf_dev_version = "1.dev"
+
+# All LF versions for which we have protobufs.
+LF_VERSIONS = [
+    "1.6",
+    "1.7",
+    "1.8",
+    "dev",
+]
+
+LF_MAJOR_VERSIONS = ["0", "1"]

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//bazel_tools:haskell.bzl", "da_haskell_binary")
-load("util.bzl", "sdk_tarball")
+load("util.bzl", "protos_zip", "sdk_tarball")
 load("@build_environment//:configuration.bzl", "sdk_version")
 
 da_haskell_binary(
@@ -55,6 +55,10 @@ da_haskell_binary(
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [],
+)
+
+protos_zip(
+    name = "protobufs",
 )
 
 sdk_tarball("sdk-release-tarball", sdk_version)

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -4,6 +4,7 @@
 load("//bazel_tools:haskell.bzl", "da_haskell_binary")
 load("util.bzl", "protos_zip", "sdk_tarball")
 load("@build_environment//:configuration.bzl", "sdk_version")
+load("@os_info//:os_info.bzl", "is_windows")
 
 da_haskell_binary(
     name = "release",
@@ -57,8 +58,9 @@ da_haskell_binary(
     deps = [],
 )
 
+# Disabled on Windows since directory outputs can cause issues.
 protos_zip(
     name = "protobufs",
-)
+) if not is_windows else None
 
 sdk_tarball("sdk-release-tarball", sdk_version)


### PR DESCRIPTION
This builds a fat zip that contains the DAML-LF protobuf files and
the Ledger API protobuf files for a given release.

I’ll tackle the Azure config for uploading this to github releases afterwards.

To ease reviewing this is how the resulting zip looks like:

```
Archive:  bazel-bin/release/protobufs.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
     3593  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/package_service.proto
     1355  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/ledger_identity_service.proto
     6262  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/event.proto
     2282  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/testing/reset_service.proto
     1908  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/testing/time_service.proto
      886  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/ledger_offset.proto
     1327  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/transaction_filter.proto
     2380  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/command_submission_service.proto
     6208  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/transaction_service.proto
     3800  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/transaction.proto
     1506  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/completion.proto
     1893  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/ledger_configuration_service.proto
     5109  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/admin/party_management_service.proto
     3562  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/admin/package_management_service.proto
     3559  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/admin/config_management_service.proto
     5542  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/commands.proto
     4286  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/command_completion_service.proto
     2989  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/active_contracts_service.proto
     3393  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/command_service.proto
     5868  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/value.proto
     1810  2010-01-01 00:00   protos-0.0.0/com/digitalasset/ledger/api/v1/trace_context.proto
      558  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_6/daml_lf_0.proto
     1766  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_6/daml_lf.proto
    27265  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_6/daml_lf_1.proto
      558  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_7/daml_lf_0.proto
     1766  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_7/daml_lf.proto
    35657  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_7/daml_lf_1.proto
      558  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_8/daml_lf_0.proto
     1766  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_8/daml_lf.proto
    37168  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_8/daml_lf_1.proto
      596  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_dev/daml_lf_0.proto
     1804  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_dev/daml_lf.proto
    39864  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_dev/daml_lf_1.proto
```

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
