### PR TITLE
sandbox: Move server parameters into the `Config` objects.

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -10,8 +10,8 @@ import java.time.Duration
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.digitalasset.ledger.api.tls.TlsConfiguration
-import com.digitalasset.platform.configuration.MetricsReporter
 import com.digitalasset.platform.configuration.Readers._
+import com.digitalasset.platform.configuration.{IndexConfiguration, MetricsReporter}
 import com.digitalasset.ports.Port
 import com.digitalasset.resources.ProgramResource.SuppressedStartupException
 import com.digitalasset.resources.ResourceOwner
@@ -51,8 +51,6 @@ object Config {
 
   val DefaultMaxInboundMessageSize: Int = 4 * 1024 * 1024
 
-  val DefaultEventsPageSize = 1000
-
   def default[Extra](extra: Extra): Config[Extra] =
     Config(
       ledgerId = None,
@@ -62,7 +60,7 @@ object Config {
       seeding = Seeding.Strong,
       metricsReporter = None,
       metricsReportingInterval = Duration.ofSeconds(10),
-      eventsPageSize = DefaultEventsPageSize,
+      eventsPageSize = IndexConfiguration.DefaultEventsPageSize,
       extra = extra,
     )
 
@@ -140,7 +138,7 @@ object Config {
       opt[Int]("events-page-size")
         .optional()
         .text(
-          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${Config.DefaultEventsPageSize}.")
+          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${IndexConfiguration.DefaultEventsPageSize}.")
         .action((eventsPageSize, config) => config.copy(eventsPageSize = eventsPageSize))
 
       private val seedingMap =

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -51,6 +51,7 @@ trait ConfigProvider[ExtraConfig] {
       maxInboundMessageSize = Config.DefaultMaxInboundMessageSize,
       eventsPageSize = config.eventsPageSize,
       portFile = participantConfig.portFile,
+      seeding = config.seeding,
     )
 
   def commandConfig(config: Config[ExtraConfig]): CommandConfiguration =

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -34,6 +34,7 @@ trait ConfigProvider[ExtraConfig] {
       participantConfig.participantId,
       jdbcUrl = participantConfig.serverJdbcUrl,
       startupMode = IndexerStartupMode.MigrateAndStart,
+      eventsPageSize = config.eventsPageSize,
       allowExistingSchema = participantConfig.allowExistingSchemaForIndex,
     )
 
@@ -48,6 +49,7 @@ trait ConfigProvider[ExtraConfig] {
       jdbcUrl = participantConfig.serverJdbcUrl,
       tlsConfig = config.tlsConfig,
       maxInboundMessageSize = Config.DefaultMaxInboundMessageSize,
+      eventsPageSize = config.eventsPageSize,
       portFile = participantConfig.portFile,
     )
 

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -73,7 +73,6 @@ final class Runner[T <: ReadWriteService, Extra](
                 readService = readService,
                 config = factory.indexerConfig(participantConfig, config),
                 metrics = metricRegistry,
-                eventsPageSize = config.eventsPageSize,
               ).acquire()
               _ <- new StandaloneApiServer(
                 config = factory.apiServerConfig(participantConfig, config),
@@ -82,10 +81,9 @@ final class Runner[T <: ReadWriteService, Extra](
                 submissionConfig = factory.submissionConfig(config),
                 readService = readService,
                 writeService = writeService,
-                eventsPageSize = config.eventsPageSize,
+                authService = factory.authService(config),
                 transformIndexService =
                   service => new TimedIndexService(service, metricRegistry, IndexServicePrefix),
-                authService = factory.authService(config),
                 metrics = metricRegistry,
                 timeServiceBackend = factory.timeServiceBackend(config),
                 seeding = Some(config.seeding),

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -86,7 +86,6 @@ final class Runner[T <: ReadWriteService, Extra](
                   service => new TimedIndexService(service, metricRegistry, IndexServicePrefix),
                 metrics = metricRegistry,
                 timeServiceBackend = factory.timeServiceBackend(config),
-                seeding = Some(config.seeding),
               ).acquire()
             } yield ()
           })

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -200,10 +200,10 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
     val jdbcUrl =
       s"jdbc:h2:mem:${getClass.getSimpleName.toLowerCase}-$testId;db_close_delay=-1;db_close_on_exit=false"
     JdbcLedgerDao.writeOwner(
-      ServerRole.Testing(getClass),
-      jdbcUrl,
+      serverRole = ServerRole.Testing(getClass),
+      jdbcUrl = jdbcUrl,
       eventsPageSize = 100,
-      new MetricRegistry,
+      metrics = new MetricRegistry,
     )
   }
 }

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -199,7 +199,12 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
   private def index(implicit logCtx: LoggingContext): ResourceOwner[LedgerDao] = {
     val jdbcUrl =
       s"jdbc:h2:mem:${getClass.getSimpleName.toLowerCase}-$testId;db_close_delay=-1;db_close_on_exit=false"
-    JdbcLedgerDao.writeOwner(ServerRole.Testing(getClass), jdbcUrl, new MetricRegistry, 100)
+    JdbcLedgerDao.writeOwner(
+      ServerRole.Testing(getClass),
+      jdbcUrl,
+      eventsPageSize = 100,
+      new MetricRegistry,
+    )
   }
 }
 

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -192,7 +192,6 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
           restartDelay = restartDelay,
         ),
         metrics = new MetricRegistry,
-        eventsPageSize = 100,
       )(materializer, logCtx)
     } yield participantState
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
@@ -7,6 +7,7 @@ import java.io.File
 import java.nio.file.Path
 
 import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.digitalasset.ledger.api.tls.TlsConfiguration
 import com.digitalasset.platform.configuration.IndexConfiguration
 import com.digitalasset.ports.Port
@@ -21,4 +22,5 @@ case class ApiServerConfig(
     maxInboundMessageSize: Int,
     eventsPageSize: Int = IndexConfiguration.DefaultEventsPageSize,
     portFile: Option[Path],
+    seeding: Seeding,
 )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
@@ -8,6 +8,7 @@ import java.nio.file.Path
 
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.digitalasset.ledger.api.tls.TlsConfiguration
+import com.digitalasset.platform.configuration.IndexConfiguration
 import com.digitalasset.ports.Port
 
 case class ApiServerConfig(
@@ -18,5 +19,6 @@ case class ApiServerConfig(
     jdbcUrl: String,
     tlsConfig: Option[TlsConfiguration],
     maxInboundMessageSize: Int,
+    eventsPageSize: Int = IndexConfiguration.DefaultEventsPageSize,
     portFile: Option[Path],
 )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -50,7 +50,6 @@ final class StandaloneApiServer(
     readService: ReadService,
     writeService: WriteService,
     authService: AuthService,
-    eventsPageSize: Int,
     transformIndexService: IndexService => IndexService = identity,
     metrics: MetricRegistry,
     timeServiceBackend: Option[TimeServiceBackend] = None,
@@ -84,8 +83,8 @@ final class StandaloneApiServer(
           domain.LedgerId(initialConditions.ledgerId),
           participantId,
           config.jdbcUrl,
+          config.eventsPageSize,
           metrics,
-          eventsPageSize,
         )
         .map(transformIndexService)
       healthChecks = new HealthChecks(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -12,7 +12,6 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.index.v2.IndexService
-import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.daml.ledger.participant.state.v1.{ParticipantId, ReadService, SeedService, WriteService}
 import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.buildinfo.BuildInfo
@@ -53,7 +52,6 @@ final class StandaloneApiServer(
     transformIndexService: IndexService => IndexService = identity,
     metrics: MetricRegistry,
     timeServiceBackend: Option[TimeServiceBackend] = None,
-    seeding: Option[Seeding],
     otherServices: immutable.Seq[BindableService] = immutable.Seq.empty,
     otherInterceptors: List[ServerInterceptor] = List.empty,
     engine: Engine = sharedEngine // allows sharing DAML engine with DAML-on-X participant
@@ -109,7 +107,7 @@ final class StandaloneApiServer(
               optTimeServiceBackend = timeServiceBackend,
               metrics = metrics,
               healthChecks = healthChecks,
-              seedService = seeding.map(SeedService(_)),
+              seedService = Some(SeedService(config.seeding)),
             )(mat, esf, logCtx)
             .map(_.withServices(otherServices))
         },

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/configuration/IndexConfiguration.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/configuration/IndexConfiguration.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.digitalasset.platform.configuration
+
+object IndexConfiguration {
+
+  val DefaultEventsPageSize: Int = 1000
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
@@ -26,7 +26,7 @@ object JdbcIndex {
       metrics: MetricRegistry,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[IndexService] =
     ReadOnlySqlLedger
-      .owner(serverRole, jdbcUrl, ledgerId, metrics, eventsPageSize)
+      .owner(serverRole, jdbcUrl, ledgerId, eventsPageSize, metrics)
       .map { ledger =>
         new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId) {
           override def getLedgerConfiguration(): Source[v2.LedgerConfiguration, NotUsed] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
@@ -22,8 +22,8 @@ object JdbcIndex {
       ledgerId: LedgerId,
       participantId: ParticipantId,
       jdbcUrl: String,
-      metrics: MetricRegistry,
       eventsPageSize: Int,
+      metrics: MetricRegistry,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[IndexService] =
     ReadOnlySqlLedger
       .owner(serverRole, jdbcUrl, ledgerId, metrics, eventsPageSize)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -32,11 +32,11 @@ object ReadOnlySqlLedger {
       serverRole: ServerRole,
       jdbcUrl: String,
       ledgerId: LedgerId,
-      metrics: MetricRegistry,
       eventsPageSize: Int,
+      metrics: MetricRegistry,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[ReadOnlyLedger] =
     for {
-      ledgerReadDao <- JdbcLedgerDao.readOwner(serverRole, jdbcUrl, metrics, eventsPageSize)
+      ledgerReadDao <- JdbcLedgerDao.readOwner(serverRole, jdbcUrl, eventsPageSize, metrics)
       factory = new Factory(ledgerReadDao)
       ledger <- ResourceOwner.forFutureCloseable(() => factory.createReadOnlySqlLedger(ledgerId))
     } yield ledger

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/IndexerConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/IndexerConfig.scala
@@ -4,6 +4,7 @@
 package com.digitalasset.platform.indexer
 
 import com.daml.ledger.participant.state.v1.ParticipantId
+import com.digitalasset.platform.configuration.IndexConfiguration
 import com.digitalasset.platform.indexer.IndexerConfig._
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -13,9 +14,12 @@ case class IndexerConfig(
     jdbcUrl: String,
     startupMode: IndexerStartupMode,
     restartDelay: FiniteDuration = DefaultRestartDelay,
+    eventsPageSize: Int = IndexConfiguration.DefaultEventsPageSize,
     allowExistingSchema: Boolean = false,
 )
 
 object IndexerConfig {
+
   val DefaultRestartDelay: FiniteDuration = 10.seconds
+
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -34,11 +34,9 @@ import scala.util.control.NonFatal
 
 final class JdbcIndexerFactory(
     serverRole: ServerRole,
-    participantId: ParticipantId,
-    jdbcUrl: String,
+    config: IndexerConfig,
     readService: ReadService,
     metrics: MetricRegistry,
-    eventsPageSize: Int,
 )(implicit materializer: Materializer, logCtx: LoggingContext) {
 
   private val logger = ContextualizedLogger.get(this.getClass)
@@ -46,14 +44,14 @@ final class JdbcIndexerFactory(
   def validateSchema()(
       implicit executionContext: ExecutionContext
   ): Future[ResourceOwner[JdbcIndexer]] =
-    new FlywayMigrations(jdbcUrl)
+    new FlywayMigrations(config.jdbcUrl)
       .validate()
       .map(_ => initialized())
 
   def migrateSchema(allowExistingSchema: Boolean)(
       implicit executionContext: ExecutionContext
   ): Future[ResourceOwner[JdbcIndexer]] =
-    new FlywayMigrations(jdbcUrl)
+    new FlywayMigrations(config.jdbcUrl)
       .migrate(allowExistingSchema)
       .map(_ => initialized())
 
@@ -61,9 +59,14 @@ final class JdbcIndexerFactory(
       implicit executionContext: ExecutionContext
   ): ResourceOwner[JdbcIndexer] =
     for {
-      ledgerDao <- JdbcLedgerDao.writeOwner(serverRole, jdbcUrl, metrics, eventsPageSize)
+      ledgerDao <- JdbcLedgerDao.writeOwner(
+        serverRole,
+        config.jdbcUrl,
+        metrics,
+        config.eventsPageSize,
+      )
       initialLedgerEnd <- ResourceOwner.forFuture(() => initializeLedger(ledgerDao))
-    } yield new JdbcIndexer(initialLedgerEnd, participantId, ledgerDao, metrics)
+    } yield new JdbcIndexer(initialLedgerEnd, config.participantId, ledgerDao, metrics)
 
   private def initializeLedger(dao: LedgerDao)(
       implicit executionContext: ExecutionContext,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -62,8 +62,8 @@ final class JdbcIndexerFactory(
       ledgerDao <- JdbcLedgerDao.writeOwner(
         serverRole,
         config.jdbcUrl,
-        metrics,
         config.eventsPageSize,
+        metrics,
       )
       initialLedgerEnd <- ResourceOwner.forFuture(() => initializeLedger(ledgerDao))
     } yield new JdbcIndexer(initialLedgerEnd, config.participantId, ledgerDao, metrics)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -24,11 +24,9 @@ final class StandaloneIndexerServer(
   override def acquire()(implicit executionContext: ExecutionContext): Resource[Unit] = {
     val indexerFactory = new JdbcIndexerFactory(
       ServerRole.Indexer,
-      config.participantId,
-      config.jdbcUrl,
+      config,
       readService,
       metrics,
-      config.eventsPageSize,
     )
     val indexer = new RecoveringIndexer(materializer.system.scheduler, config.restartDelay)
     config.startupMode match {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -16,7 +16,6 @@ final class StandaloneIndexerServer(
     readService: ReadService,
     config: IndexerConfig,
     metrics: MetricRegistry,
-    eventsPageSize: Int,
 )(implicit materializer: Materializer, logCtx: LoggingContext)
     extends ResourceOwner[Unit] {
 
@@ -29,7 +28,7 @@ final class StandaloneIndexerServer(
       config.jdbcUrl,
       readService,
       metrics,
-      eventsPageSize,
+      config.eventsPageSize,
     )
     val indexer = new RecoveringIndexer(materializer.system.scheduler, config.restartDelay)
     config.startupMode match {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -239,8 +239,8 @@ final class SandboxServer(
           startMode,
           config.commandConfig.maxCommandsInFlight * 2, // we can get commands directly as well on the submission service
           packageStore,
-          metrics,
           config.eventsPageSize,
+          metrics,
         )
 
       case None =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -61,8 +61,8 @@ object SandboxIndexAndWriteService {
       startMode: SqlStartMode,
       queueDepth: Int,
       templateStore: InMemoryPackageStore,
-      metrics: MetricRegistry,
       eventsPageSize: Int,
+      metrics: MetricRegistry,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[IndexAndWriteService] =
     SqlLedger
       .owner(
@@ -77,8 +77,8 @@ object SandboxIndexAndWriteService {
         initialConfig = initialConfig,
         queueDepth = queueDepth,
         startMode = startMode,
-        metrics = metrics,
         eventsPageSize = eventsPageSize,
+        metrics = metrics,
       )
       .flatMap(ledger =>
         owner(MeteredLedger(ledger, metrics), participantId, initialConfig, timeProvider))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -57,12 +57,12 @@ object SqlLedger {
       initialConfig: Configuration,
       queueDepth: Int,
       startMode: SqlStartMode = SqlStartMode.ContinueIfExists,
-      metrics: MetricRegistry,
       eventsPageSize: Int,
+      metrics: MetricRegistry,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[Ledger] =
     for {
       _ <- ResourceOwner.forFuture(() => new FlywayMigrations(jdbcUrl).migrate()(DEC))
-      ledgerDao <- JdbcLedgerDao.writeOwner(serverRole, jdbcUrl, metrics, eventsPageSize)
+      ledgerDao <- JdbcLedgerDao.writeOwner(serverRole, jdbcUrl, eventsPageSize, metrics)
       ledger <- ResourceOwner.forFutureCloseable(
         () =>
           new SqlLedgerFactory(ledgerDao).createSqlLedger(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -157,10 +157,10 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     ParticipantId,
                     jdbcUrl = indexJdbcUrl,
                     startupMode = IndexerStartupMode.MigrateAndStart,
+                    eventsPageSize = config.eventsPageSize,
                     allowExistingSchema = true,
                   ),
                   metrics = metrics,
-                  eventsPageSize = config.eventsPageSize,
                 )
                 authService = config.authService.getOrElse(AuthServiceWildcard)
                 promise = Promise[Unit]
@@ -189,6 +189,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     jdbcUrl = indexJdbcUrl,
                     tlsConfig = config.tlsConfig,
                     maxInboundMessageSize = config.maxInboundMessageSize,
+                    eventsPageSize = config.eventsPageSize,
                     portFile = config.portFile,
                   ),
                   commandConfig = config.commandConfig,
@@ -197,7 +198,6 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   readService = readService,
                   writeService = writeService,
                   authService = authService,
-                  eventsPageSize = config.eventsPageSize,
                   transformIndexService = new TimedIndexService(_, metrics, IndexServicePrefix),
                   metrics = metrics,
                   timeServiceBackend = timeServiceBackend,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -191,6 +191,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     maxInboundMessageSize = config.maxInboundMessageSize,
                     eventsPageSize = config.eventsPageSize,
                     portFile = config.portFile,
+                    seeding = seeding,
                   ),
                   commandConfig = config.commandConfig,
                   partyConfig = config.partyConfig,
@@ -201,7 +202,6 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   transformIndexService = new TimedIndexService(_, metrics, IndexServicePrefix),
                   metrics = metrics,
                   timeServiceBackend = timeServiceBackend,
-                  seeding = Some(seeding),
                   otherServices = List(resetService),
                   otherInterceptors = List(resetService),
                 )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -1626,24 +1626,24 @@ object JdbcLedgerDao {
   def readOwner(
       serverRole: ServerRole,
       jdbcUrl: String,
-      metrics: MetricRegistry,
       eventsPageSize: Int,
+      metrics: MetricRegistry,
   )(implicit logCtx: LoggingContext): ResourceOwner[LedgerReadDao] = {
     val maxConnections = DefaultNumberOfShortLivedConnections
-    owner(serverRole, jdbcUrl, maxConnections, metrics, eventsPageSize)
+    owner(serverRole, jdbcUrl, maxConnections, eventsPageSize, metrics)
       .map(new MeteredLedgerReadDao(_, metrics))
   }
 
   def writeOwner(
       serverRole: ServerRole,
       jdbcUrl: String,
-      metrics: MetricRegistry,
       eventsPageSize: Int,
+      metrics: MetricRegistry,
   )(implicit logCtx: LoggingContext): ResourceOwner[LedgerDao] = {
     val dbType = DbType.jdbcType(jdbcUrl)
     val maxConnections =
       if (dbType.supportsParallelWrites) DefaultNumberOfShortLivedConnections else 1
-    owner(serverRole, jdbcUrl, maxConnections, metrics, eventsPageSize)
+    owner(serverRole, jdbcUrl, maxConnections, eventsPageSize, metrics)
       .map(new MeteredLedgerDao(_, metrics))
   }
 
@@ -1651,8 +1651,8 @@ object JdbcLedgerDao {
       serverRole: ServerRole,
       jdbcUrl: String,
       maxConnections: Int,
-      metrics: MetricRegistry,
       eventsPageSize: Int,
+      metrics: MetricRegistry,
   )(implicit logCtx: LoggingContext): ResourceOwner[LedgerDao] =
     for {
       dbDispatcher <- DbDispatcher.owner(serverRole, jdbcUrl, maxConnections, metrics)

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
@@ -73,8 +73,8 @@ object LedgerResource {
           initialConfig = initialConfig,
           queueDepth = 128,
           startMode = SqlStartMode.AlwaysReset,
-          metrics = metrics,
           eventsPageSize = 100,
+          metrics = metrics,
         )
       } yield ledger
     )

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -33,7 +33,12 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll { this: Su
       for {
         _ <- Resource.fromFuture(new FlywayMigrations(jdbcUrl).migrate())
         dao <- JdbcLedgerDao
-          .writeOwner(ServerRole.Testing(getClass), jdbcUrl, new MetricRegistry, 100)
+          .writeOwner(
+            ServerRole.Testing(getClass),
+            jdbcUrl,
+            eventsPageSize = 100,
+            new MetricRegistry,
+          )
           .acquire()
         _ <- Resource.fromFuture(dao.initializeLedger(LedgerId("test-ledger"), Offset.begin))
       } yield dao

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -34,10 +34,10 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll { this: Su
         _ <- Resource.fromFuture(new FlywayMigrations(jdbcUrl).migrate())
         dao <- JdbcLedgerDao
           .writeOwner(
-            ServerRole.Testing(getClass),
-            jdbcUrl,
+            serverRole = ServerRole.Testing(getClass),
+            jdbcUrl = jdbcUrl,
             eventsPageSize = 100,
-            new MetricRegistry,
+            metrics = new MetricRegistry,
           )
           .acquire()
         _ <- Resource.fromFuture(dao.initializeLedger(LedgerId("test-ledger"), Offset.begin))

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -213,8 +213,8 @@ class SqlLedgerSpec
           initialConfig = Configuration(0, TimeModel.reasonableDefault, Duration.ofDays(1)),
           queueDepth = queueDepth,
           startMode = SqlStartMode.ContinueIfExists,
-          metrics = metrics,
           eventsPageSize = 100,
+          metrics = metrics,
         )
         .acquire()(system.dispatcher)
     }


### PR DESCRIPTION
Specifically:

- `eventsPageSize` is moved from a parameter of `StandaloneApiServer` and `StandaloneIndexerServer` to `ApiServerConfig` and `IndexerConfig` respectively, and
- `seeding` is moved from a parameter of `StandaloneApiServer` to `ApiServerConfig`.

I altered `JdbcIndexerFactory` so it just accepts `IndexerConfig`, as it seems to need half of it.

I also reordered parameters where possible to keep `MetricRegistry` last. I feel that this might be better as an implicit parameter at some point, but we'll probably need to wrap it.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
