### PR TITLE
Stop publishing to Bintray

### DIFF
--- a/docs/configs/html/conf.py
+++ b/docs/configs/html/conf.py
@@ -34,6 +34,7 @@ sys.path.insert(0, os.path.abspath('../static'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.extlinks'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -165,6 +166,13 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
+extlinks = {
+    'github-asset': ('https://github.com/digital-asset/daml/releases/download/v{}/%s-{}.zip'.format(version, version), None),
+    # For some reason extlinks insists that you can use %s only once.
+    # We need it twice in the URL so we need one URL per Maven artifact.
+    # Using it zero times also doesn’t work so you still have to supply an argument.
+    'ledger-api-test-tool-maven': ('https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/{}/%s-{}.jar'.format(version, version), None)
+}
 
 # Import the DAML lexer
 def setup(sphinx):

--- a/docs/configs/pdf/conf.py
+++ b/docs/configs/pdf/conf.py
@@ -36,7 +36,8 @@ sys.path.extend(map(os.path.abspath, glob.glob('packages/*')))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-  'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.extlinks'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -325,6 +326,15 @@ texinfo_documents = [
      author, 'DigitalAssetSDK', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+
+extlinks = {
+    'github-asset': ('https://github.com/https://github.com/digital-asset/daml/releases/download/v{}/%s-{}.zip'.format(version, version), None),
+    # For some reason extlinks insists that you can use %s only once.
+    # We need it twice in the URL so we need one URL per Maven artifact.
+    # Using it zero times also doesn’t work so you still have to supply an argument.
+    'ledger-api-test-tool-maven': ('https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/{}/%s-{}.jar'.format(version, version), None)
+}
 
 # Import the DAML lexer
 def setup(sphinx):

--- a/docs/source/app-dev/grpc/index.rst
+++ b/docs/source/app-dev/grpc/index.rst
@@ -19,7 +19,7 @@ If you're not familiar with gRPC and protobuf, we strongly recommend following t
 Getting started
 ***************
 
-You can either get the protobufs `from Bintray here <https://bintray.com/digitalassetsdk/DigitalAssetSDK/sdk-components#files/com%2Fdigitalasset%2Fledger-api-protos>`__, or from the ``daml`` repository `here <https://github.com/digital-asset/daml/tree/master/ledger-api/grpc-definitions>`__.
+You can get the protobufs from a :github-asset:`GitHub release<protobufs>`, or from the ``daml`` repository `here <https://github.com/digital-asset/daml/tree/master/ledger-api/grpc-definitions>`__.
 
 Protobuf reference documentation
 ********************************

--- a/docs/source/daml-integration-kit/index.rst
+++ b/docs/source/daml-integration-kit/index.rst
@@ -372,9 +372,8 @@ there are consistency or conformance problem with your implementation.
 
 Assuming that your Ledger API endpoint is accessible at ``localhost:6865``, you can use the tool in the following manner:
 
-#. Obtain the tool:
-
-   ``curl -L 'https://bintray.com/api/v1/content/digitalassetsdk/DigitalAssetSDK/com/daml/ledger/testtool/ledger-api-test-tool_2.12/$latest/ledger-api-test-tool_2.12-$latest.jar?bt_package=sdk-components' -o ledger-api-test-tool.jar``
+#. Download the Ledger API Test Tool from :ledger-api-test-tool-maven:`Maven <ledger-api-test-tool>`
+   and save it as ``ledger-api-test-tool.jar`` in your current directory.
 
 #. Obtain the DAML archives required to run the tests:
 

--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -20,13 +20,8 @@ Ledger Model </concepts/ledger-model/index>`.
 Downloading the tool
 ====================
 
-Run the following command to fetch the tool:
-
-.. code-block:: shell
-
-     curl -L 'https://bintray.com/api/v1/content/digitalassetsdk/DigitalAssetSDK/com/daml/ledger/testtool/ledger-api-test-tool/$latest/ledger-api-test-tool-$latest.jar?bt_package=sdk-components' -o ledger-api-test-tool.jar
-
-This will create a file ``ledger-api-test-tool.jar`` in your current directory.
+Download the Ledger API Test Tool from :ledger-api-test-tool-maven:`Maven <ledger-api-test-tool>`
+and save it as ``ledger-api-test-tool.jar`` in your current directory.
 
 Extracting ``.dar`` files required to run the tests
 ======================================================

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -80,7 +80,7 @@ latest commit on master.
    lead of the Language, Runtime or Product team.
 
 1. Once the CI checks have passed for the corresponding master build, the release
-   should be available on Bintray, Maven Central and GitHub, and have a Git tag.
+   should be available on Maven Central and GitHub, and have a Git tag.
    The release should be visible on GitHub with _prerelease_ status, meaning it's
    not yet ready for users to consume. The release notes should not be defined yet
    and will be adjusted later on. Maven central has a delay of around 20 minutes

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -6,71 +6,15 @@
 - target: //daml-lf/archive:daml_lf_1.6_archive_java_proto
   type: jar-lib
   javadoc-jar: daml_lf_1.6_archive_java_proto_javadoc.jar
-- target: //daml-lf/archive:daml_lf_1.6_archive_proto_tarball
-  type: targz
-  location:
-    groupId: com.daml
-    artifactId: daml-lf-1.6-archive-proto
-  # This is a tarball instead of a jar.
-  mavenUpload: false
-- target: //daml-lf/archive:daml_lf_1.6_archive_proto_zip
-  type: zip
-  location:
-    groupId: com.daml
-    artifactId: daml-lf-1.6-archive-proto
-  # This is a zip archive instead of a jar.
-  mavenUpload: false
 - target: //daml-lf/archive:daml_lf_1.7_archive_java_proto
   type: jar-lib
   javadoc-jar: daml_lf_1.7_archive_java_proto_javadoc.jar
-- target: //daml-lf/archive:daml_lf_1.7_archive_proto_tarball
-  type: targz
-  location:
-    groupId: com.daml
-    artifactId: daml-lf-1.7-archive-proto
-  # This is a tarball instead of a jar.
-  mavenUpload: false
-- target: //daml-lf/archive:daml_lf_1.7_archive_proto_zip
-  type: zip
-  location:
-    groupId: com.daml
-    artifactId: daml-lf-1.7-archive-proto
-  # This is a zip archive instead of a jar.
-  mavenUpload: false
 - target: //daml-lf/archive:daml_lf_1.8_archive_java_proto
   type: jar-lib
   javadoc-jar: daml_lf_1.8_archive_java_proto_javadoc.jar
-- target: //daml-lf/archive:daml_lf_1.8_archive_proto_tarball
-  type: targz
-  location:
-    groupId: com.daml
-    artifactId: daml-lf-1.8-archive-proto
-  # This is a tarball instead of a jar.
-  mavenUpload: false
-- target: //daml-lf/archive:daml_lf_1.8_archive_proto_zip
-  type: zip
-  location:
-    groupId: com.daml
-    artifactId: daml-lf-1.8-archive-proto
-  # This is a zip archive instead of a jar.
-  mavenUpload: false
 - target: //daml-lf/archive:daml_lf_dev_archive_java_proto
   type: jar-lib
   javadoc-jar: daml_lf_dev_archive_java_proto_javadoc.jar
-- target: //daml-lf/archive:daml_lf_dev_archive_proto_tarball
-  type: targz
-  location:
-    groupId: com.daml
-    artifactId: daml-lf-dev-archive-proto
-  # This is a tarball instead of a jar.
-  mavenUpload: false
-- target: //daml-lf/archive:daml_lf_dev_archive_proto_zip
-  type: zip
-  location:
-    groupId: com.daml
-    artifactId: daml-lf-dev-archive-proto
-  # This is a zip archive instead of a jar.
-  mavenUpload: false
 - target: //daml-lf/archive:daml_lf_archive_reader
   type: jar-scala
 - target: //daml-lf/data:data
@@ -85,10 +29,6 @@
   type: jar-scala
 - target: //daml-lf/language:language
   type: jar-scala
-- target: //daml-lf/repl:repl
-  type: jar
-  # This is an internal tool not something we want to make public
-  mavenUpload: false
 - target: //daml-lf/scenario-interpreter:scenario-interpreter
   type: jar-scala
 - target: //daml-lf/transaction:blindinginfo_java_proto
@@ -103,10 +43,6 @@
   type: jar-scala
 - target: //daml-lf/validation:validation
   type: jar-scala
-- target: //extractor:extractor-binary
-  type: jar-deploy
-  # This is a fat jar.
-  mavenUpload: false
 - target: //language-support/codegen-common:codegen-common
   type: jar-scala
 - target: //language-support/codegen-main:shaded_binary
@@ -125,10 +61,6 @@
   type: jar-scala
 - target: //language-support/scala/codegen:codegen
   type: jar-scala
-- target: //language-support/scala/codegen:codegen-main
-  type: jar
-  # This is a fat jar.
-  mavenUpload: false
 - target: //ledger-api/grpc-definitions:ledger-api-protos-tarball
   type: targz
   location:
@@ -180,21 +112,10 @@
   type: jar-scala
 - target: //ledger/sandbox:sandbox
   type: jar-scala
-- target: //ledger/sandbox:sandbox-tarball
-  type: targz
-  location:
-    groupId: com.daml
-    artifactId: sandbox
-  # This is a tarball of the fat jar.
-  mavenUpload: false
 - target: //ledger-service/db-backend:db-backend
   type: jar-scala
 - target: //ledger-service/http-json:http-json
   type: jar-scala
-- target: //ledger-service/http-json:http-json-binary
-  type: jar-deploy
-  # This is a fat jar.
-  mavenUpload: false
 - target: //ledger-service/lf-value-json:lf-value-json
   type: jar-scala
 - target: //ledger-service/jwt:jwt
@@ -217,10 +138,6 @@
   type: jar-scala
 - target: //libs-scala/timer-utils:timer-utils
   type: jar-scala
-- target: //navigator/backend:navigator-binary
-  type: jar-deploy
-  # This is a fat jar.
-  mavenUpload: false
 - target: //triggers/runner:trigger-runner-lib
   type: jar-scala
 - target: //libs-scala/build-info:build-info

--- a/release/src/Options.hs
+++ b/release/src/Options.hs
@@ -23,6 +23,6 @@ data Options = Options
 
 optsParser :: Parser Options
 optsParser = Options
-  <$> (PerformUpload <$> switch (long "upload" <> help "upload java/scala artifacts to bintray and Maven Central and typescript artifacts to the npm registry."))
+  <$> (PerformUpload <$> switch (long "upload" <> help "upload java/scala artifacts to Maven Central and typescript artifacts to the npm registry."))
   <*> option str (long "release-dir" <> help "specify full path to release directory")
   <*> switch (long "install-head-jars" <> help "install jars to ~/.m2")

--- a/release/src/Types.hs
+++ b/release/src/Types.hs
@@ -11,7 +11,6 @@ module Types (
     GroupId,
     MavenAllowUnsecureTls(..),
     MavenCoords(..),
-    MavenUpload(..),
     MavenUploadConfig(..),
     MonadCI,
     OS(..),
@@ -59,9 +58,6 @@ data MavenCoords = MavenCoords
 
 groupIdString :: GroupId -> String
 groupIdString gid = List.intercalate "." (map T.unpack gid)
-
-newtype MavenUpload = MavenUpload { getMavenUpload :: Bool }
-    deriving (Eq, Show, FromJSON)
 
 -- execution
 type MonadCI m = (MonadIO m, MonadMask m, MonadLogger m,


### PR DESCRIPTION
This PR removes the code for publishing to Bintray and updates the
documentation to point to github releases or Maven central.

I had to slightly change the docs formatting since trying to use
markup in code blocks results in a horrible layout and I don’t want to
fix that atm.

I’ve removed all artifacts that were only published to Bintray.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
