### PR TITLE
Replace file globs in ts package BUILD files

### DIFF
--- a/docs/source/app-dev/app-arch.rst
+++ b/docs/source/app-dev/app-arch.rst
@@ -61,10 +61,6 @@ JSON <json-api>` endpoints. In addition, we provide support libraries for :ref:`
 <java-bindings>` and :ref:`Scala <scala-bindings>` and you can also interact with the :ref:`gRPC API
 <grpc>` directly.
 
-.. TODO (drsk) add and point to javascript bindings.
-.. If you choose a different Javascript based frontend framework, the packages ``@daml/ledger``,
-.. ``@daml/types`` and the generated ``@daml2js`` package provide you with the necessary interface code
-.. to connect and issue commands against your ledger.
 
 We provide two libraries to build your React frontend for a DAML application.
 
@@ -81,18 +77,20 @@ your project, e.g. ``yarn add @daml/react``. Please explore the ``create-daml-ap
 to see the usage of these libraries.
 
 To make your life easy when interacting with the ledger, the DAML assistant can generate
-corresponding typescript data definitions for the data types declared in the deployed DAR.
+corresponding JavaScript data definitions for the data types declared in the deployed DAR.
 
 .. code-block:: bash
 
   daml codegen js .daml/dist/<your-project-name.dar> -o daml.js
 
-This command will generate a typescript library for each DALF in you DAR.
+This command will generate a JavaScript library for each DALF in you DAR.
 In ``create-daml-app``, ``ui/package.json`` refers to these libraries via the
 ``"create-daml-app": "file:../daml.js/create-daml-app-0.1.0"`` entry in
 the ``dependencies`` field.
 
-.. TODO (drsk) this process is changing right now, make sure it is documented up to date here.
+If you choose a different JavaScript based frontend framework, the packages ``@daml/ledger``,
+``@daml/types`` and the generated ``daml.js`` libraries provide you with the necessary code to
+connect and issue commands against your ledger.
 
 Authentication
 ~~~~~~~~~~~~~~

--- a/language-support/ts/daml-ledger/BUILD.bazel
+++ b/language-support/ts/daml-ledger/BUILD.bazel
@@ -10,12 +10,11 @@ load("//language-support/ts:typedoc.bzl", "ts_docs")
 load("@build_environment//:configuration.bzl", "sdk_version")
 load("//language-support/ts:jest.bzl", "jest_test")
 
+sources = ["index.test.ts", "index.ts"]
+
 da_ts_library(
     name = "daml-ledger",
-    srcs = [
-        "index.test.ts",
-        "index.ts",
-    ],
+    srcs = sources,
     module_name = "@daml/ledger",
     visibility = ["//visibility:public"],
     deps = [
@@ -44,13 +43,7 @@ ts_docs("daml-ledger")
 
 eslint_test(
     name = "lint",
-    srcs = glob(
-        ["**/*.ts"],
-        exclude = [
-            "lib/**/*",
-            "node_modules/**/*",
-        ],
-    ),
+    srcs = sources,
 )
 
 pkg_npm(

--- a/language-support/ts/daml-ledger/BUILD.bazel
+++ b/language-support/ts/daml-ledger/BUILD.bazel
@@ -10,7 +10,10 @@ load("//language-support/ts:typedoc.bzl", "ts_docs")
 load("@build_environment//:configuration.bzl", "sdk_version")
 load("//language-support/ts:jest.bzl", "jest_test")
 
-sources = ["index.test.ts", "index.ts"]
+sources = [
+    "index.test.ts",
+    "index.ts",
+]
 
 da_ts_library(
     name = "daml-ledger",

--- a/language-support/ts/daml-ledger/tsconfig.json
+++ b/language-support/ts/daml-ledger/tsconfig.json
@@ -1,4 +1,3 @@
-
 {
   "compilerOptions": {
     "target": "es5",
@@ -15,6 +14,5 @@
     "esModuleInterop": true,
     "declaration": true,
     "sourceMap": true
-    },
-  "files": ["index.ts", "index.test.ts"]
+    }
 }

--- a/language-support/ts/daml-react/BUILD.bazel
+++ b/language-support/ts/daml-react/BUILD.bazel
@@ -10,7 +10,13 @@ load("//language-support/ts:jest.bzl", "jest_test")
 load("//language-support/ts:typedoc.bzl", "ts_docs")
 load("@build_environment//:configuration.bzl", "sdk_version")
 
-sources = ["index.ts", "index.test.ts", "context.ts", "hooks.ts", "DamlLedger.ts" ]
+sources = [
+    "index.ts",
+    "index.test.ts",
+    "context.ts",
+    "hooks.ts",
+    "DamlLedger.ts",
+]
 
 da_ts_library(
     name = "daml-react",

--- a/language-support/ts/daml-react/BUILD.bazel
+++ b/language-support/ts/daml-react/BUILD.bazel
@@ -10,11 +10,11 @@ load("//language-support/ts:jest.bzl", "jest_test")
 load("//language-support/ts:typedoc.bzl", "ts_docs")
 load("@build_environment//:configuration.bzl", "sdk_version")
 
+sources = ["index.ts", "index.test.ts", "context.ts", "hooks.ts", "DamlLedger.ts" ]
+
 da_ts_library(
     name = "daml-react",
-    srcs = glob([
-        "**/*.ts",
-    ]),
+    srcs = sources,
     module_name = "@daml/react",
     visibility = ["//visibility:public"],
     deps = [
@@ -38,9 +38,7 @@ ts_docs("daml-react")
 
 eslint_test(
     name = "lint",
-    srcs = glob([
-        "**/*.ts",
-    ]),
+    srcs = sources,
 )
 
 pkg_npm(

--- a/language-support/ts/daml-types/BUILD.bazel
+++ b/language-support/ts/daml-types/BUILD.bazel
@@ -11,7 +11,10 @@ load("//language-support/ts:jest.bzl", "jest_test")
 load("//language-support/ts:typedoc.bzl", "ts_docs")
 load("@build_environment//:configuration.bzl", "sdk_version")
 
-sources = ["index.ts", "index.test.ts"]
+sources = [
+    "index.ts",
+    "index.test.ts",
+]
 
 da_ts_library(
     name = "daml-types",

--- a/language-support/ts/daml-types/BUILD.bazel
+++ b/language-support/ts/daml-types/BUILD.bazel
@@ -11,14 +11,17 @@ load("//language-support/ts:jest.bzl", "jest_test")
 load("//language-support/ts:typedoc.bzl", "ts_docs")
 load("@build_environment//:configuration.bzl", "sdk_version")
 
+sources = ["index.ts", "index.test.ts"]
+
 da_ts_library(
     name = "daml-types",
-    srcs = ["index.ts"],
+    srcs = sources,
     module_name = "@daml/types",
     tsconfig = ":tsconfig.json",
     visibility = ["//visibility:public"],
     deps = [
         "@language_support_ts_deps//@mojotech/json-type-validation",
+        "@language_support_ts_deps//@types/jest",
     ],
 ) if not is_windows else None
 
@@ -35,10 +38,7 @@ ts_docs("daml-types")
 
 eslint_test(
     name = "lint",
-    srcs = glob(
-        ["**/*.ts"],
-        exclude = ["lib/**/*"],
-    ),
+    srcs = sources,
     data = ["tsconfig.json"],
     tsconfig = "tsconfig.eslint.json",
 )
@@ -60,7 +60,7 @@ pkg_npm(
 
 jest_test(
     name = "test",
-    srcs = glob(["**/*.ts"]),
+    srcs = sources,
     deps = [
         "@language_support_ts_deps//@mojotech/json-type-validation",
     ],

--- a/language-support/ts/daml-types/package.json
+++ b/language-support/ts/daml-types/package.json
@@ -3,11 +3,16 @@
   "name": "@daml/types",
   "version": "0.0.0-SDKVERSION",
   "description": "Primitive types of the DAML language and their serialization.",
-  "keywords": ["daml", "API", "types", "serialization"],
+  "keywords": [
+    "daml",
+    "API",
+    "types",
+    "serialization"
+  ],
   "homepage": "https://daml.com",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/digital-asset/daml.git",
+    "type": "git",
+    "url": "https://github.com/digital-asset/daml.git",
     "directory": "language-support/ts/daml-types"
   },
   "main": "index.js",
@@ -19,13 +24,15 @@
   "scripts": {
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "test": "true",
+    "test": "jest",
     "lint": "eslint --ext .ts --ignore-pattern lib/ --max-warnings 0 ./"
   },
   "devDependencies": {
+    "@types/jest": "^25.1.5",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",
     "eslint": "^6.8.0",
+    "jest": "^25.2.7",
     "typescript": "~3.8.3"
   }
 }

--- a/language-support/ts/daml-types/tsconfig.json
+++ b/language-support/ts/daml-types/tsconfig.json
@@ -15,5 +15,5 @@
     "declaration": true,
     "sourceMap": true
   },
-  "files": ["index.ts"]
+  "files": ["index.ts", "index.test.ts"]
 }

--- a/language-support/ts/daml-types/tsconfig.json
+++ b/language-support/ts/daml-types/tsconfig.json
@@ -14,6 +14,5 @@
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true
-  },
-  "files": ["index.ts", "index.test.ts"]
+  }
 }


### PR DESCRIPTION
This replaces the globs in the BUILD files of the typescript packages. Sadly, filegroups don't work here so we use a toplevel list of source files.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
