### PR TITLE
Fix test for groupContiguous

### DIFF
--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/GroupContiguousSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/GroupContiguousSpec.scala
@@ -39,10 +39,10 @@ final class GroupContiguousSpec
     val pairs = List(0 -> "foo", 0 -> "bar", 1 -> "baz", 0 -> "quux")
     val grouped = groupContiguous(Source(pairs))(by = _._1)
     whenReady(grouped.runWith(Sink.seq[Vector[(Int, String)]])) {
-      _ should contain theSameElementsAs Vector(
-        Vector(0 -> "foo", 0 -> "bar"),
-        Vector(1 -> "baz"),
-        Vector(0 -> "quux"),
+      _.map(_.toSet) should contain theSameElementsAs Vector(
+        Set(0 -> "foo", 0 -> "bar"),
+        Set(1 -> "baz"),
+        Set(0 -> "quux"),
       )
     }
   }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/GroupContiguousSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/GroupContiguousSpec.scala
@@ -5,7 +5,6 @@ package com.digitalasset.platform.store.dao.events
 
 import akka.stream.scaladsl.{Sink, Source}
 import com.digitalasset.ledger.api.testing.utils.AkkaBeforeAndAfterAll
-import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{AsyncFlatSpec, Matchers}
@@ -18,7 +17,6 @@ final class GroupContiguousSpec
     with AkkaBeforeAndAfterAll {
 
   behavior of "groupContiguous"
-  import GroupContiguousSpec.contiguous
 
   it should "be equivalent to grouping on inputs with an ordered key" in forAll {
     pairs: List[(Int, String)] =>
@@ -29,12 +27,12 @@ final class GroupContiguousSpec
       }
   }
 
-  it should "be equivalent to grouping on inputs with a contiguous key" in forAll(contiguous) {
-    pairsWithContiguousKeys =>
-      val grouped = groupContiguous(Source(pairsWithContiguousKeys))(by = _._1)
-      whenReady(grouped.runWith(Sink.seq[Vector[(Int, String)]])) {
-        _ should contain theSameElementsAs pairsWithContiguousKeys.groupBy(_._1).values
-      }
+  it should "be equivalent to grouping on inputs with a contiguous key" in {
+    val pairsWithContiguousKeys = List(1 -> "baz", 0 -> "foo", 0 -> "bar", 0 -> "quux")
+    val grouped = groupContiguous(Source(pairsWithContiguousKeys))(by = _._1)
+    whenReady(grouped.runWith(Sink.seq[Vector[(Int, String)]])) {
+      _ should contain theSameElementsAs pairsWithContiguousKeys.groupBy(_._1).values
+    }
   }
 
   it should "behave as expected when grouping inputs without a contiguous key" in {
@@ -48,17 +46,5 @@ final class GroupContiguousSpec
       )
     }
   }
-
-}
-
-object GroupContiguousSpec {
-
-  private val contiguous =
-    for {
-      n <- Gen.oneOf(Gen.const(0), Gen.posNum[Int], Gen.negNum[Int])
-      l <- Gen.size
-      s <- Gen.asciiPrintableStr
-      ss <- Gen.listOfN(l, s)
-    } yield List.fill(l)(n).zip(ss)
 
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/GroupContiguousSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/GroupContiguousSpec.scala
@@ -31,7 +31,9 @@ final class GroupContiguousSpec
     val pairsWithContiguousKeys = List(1 -> "baz", 0 -> "foo", 0 -> "bar", 0 -> "quux")
     val grouped = groupContiguous(Source(pairsWithContiguousKeys))(by = _._1)
     whenReady(grouped.runWith(Sink.seq[Vector[(Int, String)]])) {
-       _.map(_.toSet should contain theSameElementsAs pairsWithContiguousKeys.groupBy(_._1).map.(_._2.toSet)
+      _.map(_.toSet) should contain theSameElementsAs pairsWithContiguousKeys
+        .groupBy(_._1)
+        .map(_._2.toSet)
     }
   }
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/GroupContiguousSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/GroupContiguousSpec.scala
@@ -31,7 +31,7 @@ final class GroupContiguousSpec
     val pairsWithContiguousKeys = List(1 -> "baz", 0 -> "foo", 0 -> "bar", 0 -> "quux")
     val grouped = groupContiguous(Source(pairsWithContiguousKeys))(by = _._1)
     whenReady(grouped.runWith(Sink.seq[Vector[(Int, String)]])) {
-      _ should contain theSameElementsAs pairsWithContiguousKeys.groupBy(_._1).values
+       _.map(_.toSet should contain theSameElementsAs pairsWithContiguousKeys.groupBy(_._1).map.(_._2.toSet)
     }
   }
 


### PR DESCRIPTION
Automatic generation of test values was prone to cause flakiness, removed in favor of a simpler test case.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
