### PR TITLE
Only publish protobuf zip from Linux

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -77,7 +77,7 @@ steps:
       TARBALL=daml-sdk-${{parameters.release_tag}}-${{parameters.name}}.tar.gz
       cp bazel-bin/release/sdk-release-tarball.tar.gz $(Build.StagingDirectory)/$TARBALL
       echo "##vso[task.setvariable variable=tarball;isOutput=true]$TARBALL"
-      PROTOS_ZIP=protobufs-{{parameters.release_tag}}.tar.gz
+      PROTOS_ZIP=protobufs-${{parameters.release_tag}}.tar.gz
       cp bazel-bin/release/protobufs.zip $(Build.StagingDirectory)/$PROTOS_ZIP
       echo "##vso[task.setvariable variable=protos-zip;isOutput=true]$PROTOS_ZIP"
     name: publish
@@ -97,4 +97,5 @@ steps:
       artifactName: $(publish.protos-zip)
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'))
+                   eq(variables['Build.SourceBranchName'], 'master'),
+                   eq('${{parameters.name}}', 'linux'))


### PR DESCRIPTION
Last release attempt failed because when we tried to publish it from
macos it was already published from Linux.

Also includes a fix for the name of the zip.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
