### PR TITLE
Add legacy proxy gRPC services.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
@@ -15,8 +15,9 @@ import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFact
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.ports.Port
 import com.daml.resources.{Resource, ResourceOwner}
+import com.google.protobuf.Message
 import io.grpc.netty.NettyServerBuilder
-import io.grpc.{Server, ServerInterceptor}
+import io.grpc._
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.channel.{EventLoopGroup, ServerChannel}
 import io.netty.handler.ssl.SslContext
@@ -137,7 +138,7 @@ final class LedgerApiServer(
         builder.channelType(channelType)
         builder.bossEventLoopGroup(bossEventLoopGroup)
         builder.workerEventLoopGroup(workerEventLoopGroup)
-        apiServices.services.foreach(builder.addService)
+        apiServices.services.foreach(addService(builder, _))
         val server = builder.build()
         try {
           server.start()
@@ -147,6 +148,37 @@ final class LedgerApiServer(
         }
         server
       })(server => Future(server.shutdown().awaitTermination()))
+    }
+
+    // This exposes the existing services under com.daml also under com.digitalasset.
+    // This is necessary to allow applications built with an earlier version of the SDK
+    // to still work.
+    // The "proxy" services will not show up on the reflection service, because of the way it
+    // processes service definitions via protobuf file descriptors.
+    private def addService(serverBuilder: NettyServerBuilder, service: BindableService): Unit = {
+      // First add the original com.daml service
+      serverBuilder.addService(service)
+
+      val damlDef = service.bindService()
+      val damlDesc = damlDef.getServiceDescriptor
+      // Only add "proxy" services if it actually contains com.daml in the service name.
+      // There are other services registered like the reflection service, that doesn't need the special treatment.
+      if (damlDesc.getName.contains("com.daml")) {
+        val digitalassetName = damlDesc.getName.replace("com.daml", "com.digitalasset")
+        val digitalassetDef = ServerServiceDefinition.builder(digitalassetName)
+        damlDef.getMethods.forEach { methodDef =>
+          val damlMethodDesc = methodDef.getMethodDescriptor
+          val digitalassetMethodName =
+            damlMethodDesc.getFullMethodName.replace("com.daml", "com.digitalasset")
+          val digitalassetMethodDesc =
+            damlMethodDesc.toBuilder.setFullMethodName(digitalassetMethodName).build()
+          val _ = digitalassetDef.addMethod(
+            digitalassetMethodDesc.asInstanceOf[MethodDescriptor[Message, Message]],
+            methodDef.getServerCallHandler.asInstanceOf[ServerCallHandler[Message, Message]]
+          )
+        }
+        val _ = serverBuilder.addService(digitalassetDef.build())
+      }
     }
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala
@@ -138,7 +138,10 @@ final class LedgerApiServer(
         builder.channelType(channelType)
         builder.bossEventLoopGroup(bossEventLoopGroup)
         builder.workerEventLoopGroup(workerEventLoopGroup)
-        apiServices.services.foreach(addService(builder, _))
+        apiServices.services.foreach { service =>
+          builder.addService(service)
+          toLegacyService(service).foreach(builder.addService)
+        }
         val server = builder.build()
         try {
           server.start()
@@ -155,21 +158,21 @@ final class LedgerApiServer(
     // to still work.
     // The "proxy" services will not show up on the reflection service, because of the way it
     // processes service definitions via protobuf file descriptors.
-    private def addService(serverBuilder: NettyServerBuilder, service: BindableService): Unit = {
-      // First add the original com.daml service
-      serverBuilder.addService(service)
+    private def toLegacyService(service: BindableService): Option[ServerServiceDefinition] = {
+      val `com.daml` = "com.daml"
+      val `com.digitalasset` = "com.digitalasset"
 
       val damlDef = service.bindService()
       val damlDesc = damlDef.getServiceDescriptor
       // Only add "proxy" services if it actually contains com.daml in the service name.
       // There are other services registered like the reflection service, that doesn't need the special treatment.
-      if (damlDesc.getName.contains("com.daml")) {
-        val digitalassetName = damlDesc.getName.replace("com.daml", "com.digitalasset")
+      if (damlDesc.getName.contains(`com.daml`)) {
+        val digitalassetName = damlDesc.getName.replace(`com.daml`, `com.digitalasset`)
         val digitalassetDef = ServerServiceDefinition.builder(digitalassetName)
         damlDef.getMethods.forEach { methodDef =>
           val damlMethodDesc = methodDef.getMethodDescriptor
           val digitalassetMethodName =
-            damlMethodDesc.getFullMethodName.replace("com.daml", "com.digitalasset")
+            damlMethodDesc.getFullMethodName.replace(`com.daml`, `com.digitalasset`)
           val digitalassetMethodDesc =
             damlMethodDesc.toBuilder.setFullMethodName(digitalassetMethodName).build()
           val _ = digitalassetDef.addMethod(
@@ -177,8 +180,8 @@ final class LedgerApiServer(
             methodDef.getServerCallHandler.asInstanceOf[ServerCallHandler[Message, Message]]
           )
         }
-        val _ = serverBuilder.addService(digitalassetDef.build())
-      }
+        Option(digitalassetDef.build())
+      } else None
     }
   }
 

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/LegacyServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/LegacyServiceIT.scala
@@ -1,0 +1,192 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.services
+
+import java.util.UUID
+
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.ledger.api.v1.active_contracts_service.{
+  ActiveContractsServiceGrpc,
+  GetActiveContractsRequest
+}
+import com.daml.ledger.api.v1.admin.config_management_service.{
+  ConfigManagementServiceGrpc,
+  GetTimeModelRequest
+}
+import com.daml.ledger.api.v1.admin.package_management_service.{
+  ListKnownPackagesRequest,
+  PackageManagementServiceGrpc
+}
+import com.daml.ledger.api.v1.admin.party_management_service.{
+  ListKnownPartiesRequest,
+  PartyManagementServiceGrpc
+}
+import com.daml.ledger.api.v1.command_completion_service.{
+  CommandCompletionServiceGrpc,
+  CompletionEndRequest
+}
+import com.daml.ledger.api.v1.command_service.{CommandServiceGrpc, SubmitAndWaitRequest}
+import com.daml.ledger.api.v1.command_submission_service.{
+  CommandSubmissionServiceGrpc,
+  SubmitRequest
+}
+import com.daml.ledger.api.v1.ledger_configuration_service.{
+  GetLedgerConfigurationRequest,
+  LedgerConfigurationServiceGrpc
+}
+import com.daml.ledger.api.v1.ledger_identity_service.{
+  GetLedgerIdentityRequest,
+  LedgerIdentityServiceGrpc
+}
+import com.daml.ledger.api.v1.package_service.{ListPackagesRequest, PackageServiceGrpc}
+import com.daml.ledger.api.v1.testing.reset_service.{ResetRequest, ResetServiceGrpc}
+import com.daml.ledger.api.v1.testing.time_service.{GetTimeRequest, TimeServiceGrpc}
+import com.daml.ledger.api.v1.transaction_service.{GetLedgerEndRequest, TransactionServiceGrpc}
+import io.grpc
+import io.grpc._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Assertion, AsyncWordSpec, Inside, Matchers}
+
+import scala.util.{Failure, Success, Try}
+
+class LegacyServiceIT
+    extends AsyncWordSpec
+    with Matchers
+    with Inside
+    with SandboxFixture
+    with ScalaFutures
+    with SuiteResourceManagementAroundAll {
+
+  val legacyCallInterceptor: ClientInterceptor = new ClientInterceptor {
+    override def interceptCall[ReqT, RespT](
+        method: grpc.MethodDescriptor[ReqT, RespT],
+        callOptions: CallOptions,
+        next: Channel): ClientCall[ReqT, RespT] = {
+      val legacyMethod = method
+        .toBuilder()
+        .setFullMethodName(method.getFullMethodName.replace("com.daml", "com.digitalasset"))
+        .build()
+      next.newCall(legacyMethod, callOptions)
+    }
+  }
+
+  private val randomLedgerId = UUID.randomUUID().toString
+
+  private def expectNotUnimplemented[A](block: => A): Assertion = {
+    inside(Try(block)) {
+      case Success(_) => succeed
+      case Failure(exc: StatusRuntimeException) =>
+        exc.getStatus.getCode should not be Status.Code.UNIMPLEMENTED
+      case Failure(otherwise) => fail(otherwise)
+    }
+  }
+
+  "Ledger API Server" should {
+    "offer com.digitalasset.ledger.api.v1.ActiveContractsService" in {
+      expectNotUnimplemented {
+        val acs =
+          ActiveContractsServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        acs.getActiveContracts(GetActiveContractsRequest(randomLedgerId)).toList
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.CommandCompletionService" in {
+      expectNotUnimplemented {
+        val completion =
+          CommandCompletionServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        completion.completionEnd(CompletionEndRequest(randomLedgerId))
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.CommandService" in {
+      expectNotUnimplemented {
+        val command =
+          CommandServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        command.submitAndWait(SubmitAndWaitRequest())
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.CommandSubmissionService" in {
+      expectNotUnimplemented {
+        val submission =
+          CommandSubmissionServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        submission.submit(SubmitRequest())
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.LedgerConfigurationService" in {
+      expectNotUnimplemented {
+        val configuration = LedgerConfigurationServiceGrpc
+          .blockingStub(channel)
+          .withInterceptors(legacyCallInterceptor)
+        configuration.getLedgerConfiguration(GetLedgerConfigurationRequest(randomLedgerId)).toList
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.LedgerIdentityService" in {
+      expectNotUnimplemented {
+        val identity =
+          LedgerIdentityServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        identity.getLedgerIdentity(GetLedgerIdentityRequest())
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.PackageServiceService" in {
+      expectNotUnimplemented {
+        val pkg = PackageServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        pkg.listPackages(ListPackagesRequest(randomLedgerId))
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.TransactionService" in {
+      expectNotUnimplemented {
+        val transaction =
+          TransactionServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        transaction.getLedgerEnd(GetLedgerEndRequest(randomLedgerId))
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.testing.ResetService" in {
+      expectNotUnimplemented {
+        val testingReset =
+          ResetServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        testingReset.reset(ResetRequest(randomLedgerId))
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.testing.TimeService" in {
+      expectNotUnimplemented {
+        val testingTime =
+          TimeServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        testingTime.getTime(GetTimeRequest(randomLedgerId)).toList
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.admin.ConfigManagementService" in {
+      expectNotUnimplemented {
+        val adminConfig =
+          ConfigManagementServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        adminConfig.getTimeModel(GetTimeModelRequest())
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.admin.PackageManagementService" in {
+      expectNotUnimplemented {
+        val adminPackage =
+          PackageManagementServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        adminPackage.listKnownPackages(ListKnownPackagesRequest())
+      }
+    }
+
+    "offer com.digitalasset.ledger.api.v1.admin.PartyManagementService" in {
+      expectNotUnimplemented {
+        val adminParty =
+          PartyManagementServiceGrpc.blockingStub(channel).withInterceptors(legacyCallInterceptor)
+        adminParty.listKnownParties(ListKnownPartiesRequest())
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
This exposes the Ledger API services as `com.digitalasset` as well, to ensure that
applications built with a previous release of the SDK continue to work
with the Ledger API.

Due to how the gRPC reflection service works, this doesn't expose the
com.digitalasset services on the reflection api, and thus `grpcurl` won't
work with the old services. These scripts need to be updated to refer to
the com.daml services.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
