### PR TITLE
DAML-LF. fix parameter and self binder in choices.

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -552,7 +552,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         consuming = lfChoice.getConsuming,
         controllers = decodeExpr(lfChoice.getControllers, s"$tpl:$chName:controller"),
         selfBinder = selfBinder,
-        argBinder = Some(v) -> t,
+        argBinder = v -> t,
         returnType = decodeType(lfChoice.getRetType),
         update = decodeExpr(lfChoice.getUpdate, s"$tpl:$chName:choice")
       )

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -662,7 +662,7 @@ private[daml] class EncodeV1(val minor: LV.Minor) {
       setString(name, b.setNameStr, b.setNameInternedStr)
       b.setConsuming(choice.consuming)
       b.setControllers(choice.controllers)
-      b.setArgBinder(choice.argBinder._1.getOrElse("") -> choice.argBinder._2)
+      b.setArgBinder(choice.argBinder._1 -> choice.argBinder._2)
       b.setRetType(choice.returnType)
       b.setUpdate(choice.update)
       setString(choice.selfBinder, b.setSelfBinderStr, b.setSelfBinderInternedStr)

--- a/daml-lf/encoder/src/test/lf/Template_all_.lf
+++ b/daml-lf/encoder/src/test/lf/Template_all_.lf
@@ -12,10 +12,10 @@ module TemplateMod {
     observers (Nil @Party),
     agreement "Agreement",
     choices {
-      choice Sleep (u: Unit) : Unit
+      choice Sleep (u: Unit) (self) : ContractId TemplateMod:Person
         by Cons @Party [TemplateMod:Person {person} this] (Nil @Party)
-        to upure @Unit u,
-      choice @nonConsuming Nap (i : Int64): Int64
+        to upure @(ContractId TemplateMod:Person) self,
+      choice @nonConsuming Nap (i : Int64) (self): Int64
         by Cons @Party [TemplateMod:Person {person} this] (Nil @Party)
         to upure @Int64 i
     }

--- a/daml-lf/encoder/src/test/lf/Template_all_.lf
+++ b/daml-lf/encoder/src/test/lf/Template_all_.lf
@@ -12,10 +12,10 @@ module TemplateMod {
     observers (Nil @Party),
     agreement "Agreement",
     choices {
-      choice Sleep (u: Unit) (self) : ContractId TemplateMod:Person
+      choice Sleep (self) (u: Unit) : ContractId TemplateMod:Person
         by Cons @Party [TemplateMod:Person {person} this] (Nil @Party)
         to upure @(ContractId TemplateMod:Person) self,
-      choice @nonConsuming Nap (i : Int64) (self): Int64
+      choice @nonConsuming Nap (self) (i : Int64) : Int64
         by Cons @Party [TemplateMod:Person {person} this] (Nil @Party)
         to upure @Int64 i
     }

--- a/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
+++ b/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
@@ -48,8 +48,8 @@ class EncodeV1Spec extends WordSpec with Matchers with TableDrivenPropertyChecks
               observers Cons @Party [Mod:Person {person} this] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Sleep (u: Unit) (self) : Unit by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Unit (),
-                choice @nonConsuming Nap (i : Int64) (self): Int64 by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Int64 i
+                choice Sleep (self) (u: Unit) : Unit by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Unit (),
+                choice @nonConsuming Nap (self) (i : Int64): Int64 by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Int64 i
               },
               key @Party (Mod:Person {person} this) (\ (p: Party) -> Cons @Party [p] (Nil @Party))
             };

--- a/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
+++ b/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
@@ -48,8 +48,8 @@ class EncodeV1Spec extends WordSpec with Matchers with TableDrivenPropertyChecks
               observers Cons @Party [Mod:Person {person} this] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Sleep (u: Unit): Unit by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Unit (),
-                choice @nonConsuming Nap (i : Int64) : Int64 by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Int64 i
+                choice Sleep (u: Unit) (self) : Unit by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Unit (),
+                choice @nonConsuming Nap (i : Int64) (self): Int64 by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Int64 i
               },
               key @Party (Mod:Person {person} this) (\ (p: Party) -> Cons @Party [p] (Nil @Party))
             };

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -570,7 +570,7 @@ object Ast {
       consuming: Boolean, // Flag indicating whether exercising the choice consumes the contract.
       controllers: Expr, // Parties that can exercise the choice.
       selfBinder: ExprVarName, // Self ContractId binder.
-      argBinder: (Option[ExprVarName], Type), // Choice argument binder.
+      argBinder: (ExprVarName, Type), // Choice argument binder.
       returnType: Type, // Return type of the choice follow-up.
       update: Expr // The choice follow-up.
   )

--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/AstSpec.scala
@@ -159,7 +159,7 @@ class AstSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
       consuming = true,
       controllers = eParties,
       selfBinder = Name.assertFromString("self"),
-      argBinder = (None, TUnit),
+      argBinder = Name.assertFromString("arg") -> TUnit,
       returnType = TUnit,
       update = EUpdate(UpdatePure(typ, expr)),
     )

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -135,8 +135,8 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
     `(` ~> id <~ `)`
 
   private lazy val templateChoice: Parser[(ChoiceName, TemplateChoice)] =
-    Id("choice") ~> tags(templateChoiceTags) ~ id ~ choiceParam ~ selfBinder ~ `:` ~ typ ~ `by` ~ expr ~ `to` ~ expr ^^ {
-      case choiceTags ~ name ~ param ~ self ~ _ ~ retTyp ~ _ ~ controllers ~ _ ~ update =>
+    Id("choice") ~> tags(templateChoiceTags) ~ id ~ selfBinder ~ choiceParam ~ `:` ~ typ ~ `by` ~ expr ~ `to` ~ expr ^^ {
+      case choiceTags ~ name ~ self ~ param ~ _ ~ retTyp ~ _ ~ controllers ~ _ ~ update =>
         name -> TemplateChoice(
           name,
           !choiceTags(nonConsumingTag),

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -126,27 +126,27 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
             agreement ~
             choices ~
             key =>
-        TemplDef(
-          tycon,
-          Template(x, precon, signatories, agreement, choices.map(_(x)), observers, key))
+        TemplDef(tycon, Template(x, precon, signatories, agreement, choices, observers, key))
     }
 
-  private lazy val choiceParam: Parser[(Option[Name], Type)] =
-    `(` ~> id ~ `:` ~ typ <~ `)` ^^ { case name ~ _ ~ typ => Some(name) -> typ } |
-      success(None -> TUnit)
+  private lazy val choiceParam: Parser[(Name, Type)] =
+    `(` ~> id ~ `:` ~ typ <~ `)` ^^ { case name ~ _ ~ typ => name -> typ }
 
-  private lazy val templateChoice: Parser[ExprVarName => (ChoiceName, TemplateChoice)] =
-    Id("choice") ~> tags(templateChoiceTags) ~ id ~ choiceParam ~ `:` ~ typ ~ `by` ~ expr ~ `to` ~ expr ^^ {
-      case choiceTags ~ name ~ param ~ _ ~ retTyp ~ _ ~ controllers ~ _ ~ update =>
-        self =>
-          name -> TemplateChoice(
-            name,
-            !choiceTags(nonConsumingTag),
-            controllers,
-            self,
-            param,
-            retTyp,
-            update)
+  private lazy val selfBinder: Parser[Name] =
+    `(` ~> id <~ `)`
+
+  private lazy val templateChoice: Parser[(ChoiceName, TemplateChoice)] =
+    Id("choice") ~> tags(templateChoiceTags) ~ id ~ choiceParam ~ selfBinder ~ `:` ~ typ ~ `by` ~ expr ~ `to` ~ expr ^^ {
+      case choiceTags ~ name ~ param ~ self ~ _ ~ retTyp ~ _ ~ controllers ~ _ ~ update =>
+        name -> TemplateChoice(
+          name,
+          !choiceTags(nonConsumingTag),
+          controllers,
+          self,
+          param,
+          retTyp,
+          update,
+        )
     }
 
   private val serializableTag = "serializable"

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -7,7 +7,6 @@ package testing.parser
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Ref.{ChoiceName, DottedName, Name}
 import com.daml.lf.language.Ast._
-import com.daml.lf.language.Util._
 import com.daml.lf.testing.parser.Parsers._
 import com.daml.lf.testing.parser.Token._
 

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -8,6 +8,7 @@ import java.math.BigDecimal
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{ImmArray, Numeric, Time}
 import com.daml.lf.language.Ast._
+import com.daml.lf.language.Util._
 import com.daml.lf.testing.parser.Implicits._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Matchers, WordSpec}
@@ -458,8 +459,8 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
             observers Cons @Party ['Alice'] (Nil @Party),
             agreement "Agreement",
             choices {
-              choice Sleep : Unit by Cons @Party [person] (Nil @Party) to upure @Unit (),
-              choice @nonConsuming Nap (i : Int64) : Int64 by Cons @Party [person] (Nil @Party) to upure @Int64 i
+              choice Sleep (u:Unit) (self) : ContractId Mod:Person by Cons @Party [person] (Nil @Party) to upure @(ContractId Mod:Person) self,
+              choice @nonConsuming Nap (i : Int64) (self): Int64 by Cons @Party [person] (Nil @Party) to upure @Int64 i
             },
             key @Party (Mod:Person {name} this) (\ (p: Party) -> p)
           } ;
@@ -477,17 +478,17 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
               name = n"Sleep",
               consuming = true,
               controllers = e"Cons @Party [person] (Nil @Party)",
-              selfBinder = n"this",
-              argBinder = None -> TBuiltin(BTUnit),
-              returnType = t"Unit",
-              update = e"upure @Unit ()"
+              selfBinder = n"self",
+              argBinder = n"u" -> TUnit,
+              returnType = t"ContractId Mod:Person",
+              update = e"upure @(ContractId Mod:Person) self"
             ),
             n"Nap" -> TemplateChoice(
               name = n"Nap",
               consuming = false,
               controllers = e"Cons @Party [person] (Nil @Party)",
-              selfBinder = n"this",
-              argBinder = Some(n"i") -> TBuiltin(BTInt64),
+              selfBinder = n"self",
+              argBinder = n"i" -> TInt64,
               returnType = t"Int64",
               update = e"upure @Int64 i"
             )

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -459,8 +459,8 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
             observers Cons @Party ['Alice'] (Nil @Party),
             agreement "Agreement",
             choices {
-              choice Sleep (u:Unit) (self) : ContractId Mod:Person by Cons @Party [person] (Nil @Party) to upure @(ContractId Mod:Person) self,
-              choice @nonConsuming Nap (i : Int64) (self): Int64 by Cons @Party [person] (Nil @Party) to upure @Int64 i
+              choice Sleep (self) (u:Unit) : ContractId Mod:Person by Cons @Party [person] (Nil @Party) to upure @(ContractId Mod:Person) self,
+              choice @nonConsuming Nap (self) (i : Int64): Int64 by Cons @Party [person] (Nil @Party) to upure @Int64 i
             },
             key @Party (Mod:Person {name} this) (\ (p: Party) -> p)
           } ;

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -731,7 +731,7 @@ available for usage::
        |  'key' τ eₖ eₘ
 
   Template choice definition
-    ChDef ::= 'choice' ChKind Ch (y : τ) (z) : σ 'by' eₚ ↦ e
+    ChDef ::= 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ)  : σ 'by' eₚ ↦ e
                                                     -- ChDef
   Definitions
     Def
@@ -1201,7 +1201,7 @@ Then we define *well-formed expressions*. ::
       Γ  ⊢  'create' @Mod:T e  : 'Update' ('ContractId' Mod:T)
 
       'tpl' (x : T)
-          ↦ { …, 'choices' { …, 'choice' ChKind Ch (y : τ) (z) : σ 'by' … ↦ …, … } }
+          ↦ { …, 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' … ↦ …, … } }
         ∈ 〚Ξ〛Mod
       Γ  ⊢  e₁  :  'ContractId' Mod:T
       Γ  ⊢  e₂  :  'List' 'Party'
@@ -1210,7 +1210,7 @@ Then we define *well-formed expressions*. ::
       Γ  ⊢  'exercise' @Mod:T Ch e₁ e₂ e₃  : 'Update' σ
 
       'tpl' (x : T)
-          ↦ { …, 'choices' { …, 'choice' ChKind Ch (y : τ) (z) : σ 'by' … ↦ …, … } }
+          ↦ { …, 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' … ↦ …, … } }
         ∈ 〚Ξ〛Mod
       Γ  ⊢  e₁  :  'ContractId' Mod:T
       Γ  ⊢  e₂  :  τ
@@ -1397,11 +1397,11 @@ for the ``DefTemplate`` rule). ::
                           └───────────────────┘
     ⊢ₛ  τ
     ⊢ₛ  σ
+    y : 'ContractId' Mod:T · z : τ · x : Mod:T  ⊢  e  :  'Update' σ
     x : Mod:T  ⊢  eₚ  :  'List' 'Party'     x ≠ y                        [DAML-LF < 1.2]
-    y : τ · x : Mod:T  ⊢  eₚ  :  'List' 'Party'                          [DAML-LF ≥ 1.2]
-    z : 'ContractId' Mod:T · y : τ · x : Mod:T  ⊢  e  :  'Update' σ
+    z : τ · x : Mod:T  ⊢  eₚ  :  'List' 'Party'                          [DAML-LF ≥ 1.2]
   ——————————————————————————————————————————————————————————————— ChDef
-    x : Mod:T  ⊢  'choice' ChKind Ch (y : τ) (z) : σ 'by' eₚ ↦ e
+    x : Mod:T  ⊢  'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ e
 
             ┌────────────┐
   Valid key │ ⊢ₖ e  :  τ │
@@ -2254,12 +2254,12 @@ as described by the ledger model::
      Err "template precondition violated"  ‖ E_ ; (st, keys)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : τ) (z) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[y ↦ v₂, x ↦ vₜ] ‖ E₀  ⇓  Ok vₚ ‖ E₁
      v₁ =ₛ vₚ
-     eₐ[z ↦ cid, y ↦ v₂, x ↦ vₜ] ‖ E₁  ⇓  Ok uₐ ‖ E₂
+     eₐ[y ↦ cid, z ↦ v₂, x ↦ vₜ] ‖ E₁  ⇓  Ok uₐ ‖ E₂
      keys₁ = keys₀ - keys₀⁻¹(cid)
      st₁ = st₀[cid ↦ (Mod:T, vₜ, 'inactive')]
      uₐ ‖ E₂ ; (st₁, keys₁)  ⇓ᵤ  Ok (vₐ, trₐ) ‖ E₃ ; (st₂, keys₂)
@@ -2269,12 +2269,12 @@ as described by the ledger model::
      Ok (vₐ, 'exercise' v₁ (cid, Mod:T, vₜ) 'consuming' trₐ) ‖ E₃ ; (st₂, keys₂)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' 'non-consuming' Ch z (y : τ) (z) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' 'non-consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
-     eₚ[y ↦ v₂, x ↦ vₜ] ‖ E₀  ⇓  Ok vₚ ‖ E₁
+     eₚ[z ↦ v₂, x ↦ vₜ] ‖ E₀  ⇓  Ok vₚ ‖ E₁
      v₁ =ₛ vₚ
-     eₐ[z ↦ cid, y ↦ v₂, x ↦ vₜ] ‖ E₁  ⇓  Ok uₐ ‖ E₂
+     eₐ[y ↦ cid, z ↦ v₂, x ↦ vₜ] ‖ E₁  ⇓  Ok uₐ ‖ E₂
      uₐ ‖ E₂ ; (st₀; keys₀)  ⇓ᵤ  Ok (vₐ, trₐ) ‖ E₃ ; (st₁, keys₁)
    —————————————————————————————————————————————————————————————————————— EvUpdExercNonConsum
      'exercise' Mod:T.Ch cid v₁ v₂ ‖ E₀ ; (st₀, keys₀)
@@ -2282,7 +2282,7 @@ as described by the ledger model::
      Ok (vₐ, 'exercise' v₁ (cid, Mod:T, vₜ) 'non-consuming' trₐ) ‖ E₃ ; (st₁, keys₁)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : τ) (z) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (z : 'ContractId' Mod:T) (y : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'inactive')
    —————————————————————————————————————————————————————————————————————— EvUpdExercInactive
@@ -2291,7 +2291,7 @@ as described by the ledger model::
      Err "Exercise on inactive contract" ‖ E₀ ; (st₀; keys₀)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : τ) (z) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (z : 'ContractId' Mod:T) (y : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ] ‖ E₀  ⇓  Ok vₚ ‖ E₁
@@ -2302,10 +2302,10 @@ as described by the ledger model::
      Err "Exercise actors do not match"  ‖ E₁ ; (st; keys)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : τ) (z) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (z : 'ContractId' Mod:T) (y : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
-     eₚ[y ↦ v₂, x ↦ vₜ] ‖ E₀  ⇓  Ok vₚ ‖ E₁
+     eₚ[y ↦ cid, z ↦ v₂, x ↦ vₜ] ‖ E₀  ⇓  Ok vₚ ‖ E₁
      'exercise' Mod:T.Ch cid vₚ v₁ ‖ E₁ ; (st₀, keys₀)  ⇓ᵤ  ur ‖ E₂ ; (st₁, keys₁)
    —————————————————————————————————————————————————————————————————————— EvUpdExercWithoutActors
      'exercise_without_actors' Mod:T.Ch cid v₁ ‖ E₀ ; (st₀, keys₀)

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -731,7 +731,7 @@ available for usage::
        |  'key' τ eₖ eₘ
 
   Template choice definition
-    ChDef ::= 'choice' ChKind Ch (y : τ) (z: 'ContractId' Mod:T) : σ 'by' eₚ ↦ e
+    ChDef ::= 'choice' ChKind Ch (y : τ) (z) : σ 'by' eₚ ↦ e
                                                     -- ChDef
   Definitions
     Def
@@ -1201,7 +1201,7 @@ Then we define *well-formed expressions*. ::
       Γ  ⊢  'create' @Mod:T e  : 'Update' ('ContractId' Mod:T)
 
       'tpl' (x : T)
-          ↦ { …, 'choices' { …, 'choice' ChKind Ch (y : τ) (z : 'ContractId' Mod:T) : σ 'by' … ↦ …, … } }
+          ↦ { …, 'choices' { …, 'choice' ChKind Ch (y : τ) (z) : σ 'by' … ↦ …, … } }
         ∈ 〚Ξ〛Mod
       Γ  ⊢  e₁  :  'ContractId' Mod:T
       Γ  ⊢  e₂  :  'List' 'Party'
@@ -1210,7 +1210,7 @@ Then we define *well-formed expressions*. ::
       Γ  ⊢  'exercise' @Mod:T Ch e₁ e₂ e₃  : 'Update' σ
 
       'tpl' (x : T)
-          ↦ { …, 'choices' { …, 'choice' ChKind Ch (y : τ) (z : 'ContractId' Mod:T) : σ 'by' … ↦ …, … } }
+          ↦ { …, 'choices' { …, 'choice' ChKind Ch (y : τ) (z) : σ 'by' … ↦ …, … } }
         ∈ 〚Ξ〛Mod
       Γ  ⊢  e₁  :  'ContractId' Mod:T
       Γ  ⊢  e₂  :  τ
@@ -1401,7 +1401,7 @@ for the ``DefTemplate`` rule). ::
     y : τ · x : Mod:T  ⊢  eₚ  :  'List' 'Party'                          [DAML-LF ≥ 1.2]
     z : 'ContractId' Mod:T · y : τ · x : Mod:T  ⊢  e  :  'Update' σ
   ——————————————————————————————————————————————————————————————— ChDef
-    x : Mod:T  ⊢  'choice' ChKind Ch (y : τ) (z : 'ContractId' Mod:T) : σ 'by' eₚ ↦ e
+    x : Mod:T  ⊢  'choice' ChKind Ch (y : τ) (z) : σ 'by' eₚ ↦ e
 
             ┌────────────┐
   Valid key │ ⊢ₖ e  :  τ │
@@ -2282,7 +2282,7 @@ as described by the ledger model::
      Ok (vₐ, 'exercise' v₁ (cid, Mod:T, vₜ) 'non-consuming' trₐ) ‖ E₃ ; (st₁, keys₁)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : τ) (z) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'inactive')
    —————————————————————————————————————————————————————————————————————— EvUpdExercInactive
@@ -2291,7 +2291,7 @@ as described by the ledger model::
      Err "Exercise on inactive contract" ‖ E₀ ; (st₀; keys₀)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : τ) (z) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ] ‖ E₀  ⇓  Ok vₚ ‖ E₁

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -343,7 +343,8 @@ private[validation] object Typing {
           if (supportsFlexibleControllers) {
             introExprVar(param, paramType).checkExpr(controllers, TParties)
           } else {
-            param.filter(eVars.isDefinedAt).foreach(x => throw EIllegalShadowingExprVar(ctx, x))
+            if (eVars.isDefinedAt(param))
+              throw EIllegalShadowingExprVar(ctx, param)
             checkExpr(controllers, TParties)
           }
           introExprVar(selfBinder, TContractId(TTyCon(tplName)))

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/PartyLiteralsSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/PartyLiteralsSpec.scala
@@ -39,7 +39,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Unit) : Unit by party to
+                  choice Ch (i : Unit) (self) : Unit by party to
                     upure @Unit ()
                 }
             } ;
@@ -63,7 +63,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:R) : Unit by party to
+                  choice Ch (i : Mod:R) (self): Unit by party to
                     upure @Unit ()
                 }
             } ;
@@ -77,7 +77,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:R) : Unit by party to
+                  choice Ch (i : Mod:R) (self): Unit by party to
                     upure @Unit ()
                 }
             } ;
@@ -91,7 +91,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party ['Alice'] (Nil @Party),    // disallowed party literal 'Alice'
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:R) : Unit by 'Alice' to
+                  choice Ch (i : Mod:R) (self): Unit by 'Alice' to
                     upure @Unit ()
                 }
             } ;
@@ -105,7 +105,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                   observers Cons @Party [party] (Nil @Party),
                   agreement TO_TEXT_PARTY 'Alice',               // disallowed party literal 'Alice'
                   choices {
-                    choice Ch (i : Mod:R) : Unit by 'Alice' to
+                    choice Ch (i : Mod:R) (self): Unit by 'Alice' to
                       upure @Unit ()
                   }
               } ;
@@ -119,7 +119,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:R) : Party by party to
+                  choice Ch (i : Mod:R) (self): Party by party to
                      upure @Party 'Alice'                        // disallowed party literal 'Alice'
                 }
             } ;

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/PartyLiteralsSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/PartyLiteralsSpec.scala
@@ -39,7 +39,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Unit) (self) : Unit by party to
+                  choice Ch (self) (i : Unit) : Unit by party to
                     upure @Unit ()
                 }
             } ;
@@ -63,7 +63,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:R) (self): Unit by party to
+                  choice Ch (self) (i : Mod:R): Unit by party to
                     upure @Unit ()
                 }
             } ;
@@ -77,7 +77,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:R) (self): Unit by party to
+                  choice Ch (self) (i : Mod:R): Unit by party to
                     upure @Unit ()
                 }
             } ;
@@ -91,7 +91,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party ['Alice'] (Nil @Party),    // disallowed party literal 'Alice'
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:R) (self): Unit by 'Alice' to
+                  choice Ch (self) (i : Mod:R): Unit by 'Alice' to
                     upure @Unit ()
                 }
             } ;
@@ -105,7 +105,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                   observers Cons @Party [party] (Nil @Party),
                   agreement TO_TEXT_PARTY 'Alice',               // disallowed party literal 'Alice'
                   choices {
-                    choice Ch (i : Mod:R) (self): Unit by 'Alice' to
+                    choice Ch (self) (i : Mod:R): Unit by 'Alice' to
                       upure @Unit ()
                   }
               } ;
@@ -119,7 +119,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:R) (self): Party by party to
+                  choice Ch (self) (i : Mod:R): Party by party to
                      upure @Party 'Alice'                        // disallowed party literal 'Alice'
                 }
             } ;

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
@@ -158,7 +158,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
               observers Nil @Party,
               agreement "Agreement",
               choices {
-                choice Ch (i : Mod:SerializableType) (self) : Mod:SerializableType by $partiesAlice to upure @Mod:SerializableType (Mod:SerializableType {})
+                choice Ch (self) (i : Mod:SerializableType) : Mod:SerializableType by $partiesAlice to upure @Mod:SerializableType (Mod:SerializableType {})
               }
             } ;
           }
@@ -172,7 +172,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
                 observers Nil @Party,
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:SerializableType) (self) :
+                  choice Ch (self) (i : Mod:SerializableType) :
                     Mod:SerializableType by $partiesAlice
                       to upure @Mod:SerializableType (Mod:SerializableType {})
                 }
@@ -189,7 +189,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
                 observers Nil @Party,
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:UnserializableType) (self) :     // disallowed unserializable type
+                  choice Ch (self) (i : Mod:UnserializableType) :     // disallowed unserializable type
                    Unit by $partiesAlice to
                        upure @Unit ()
                 }
@@ -205,7 +205,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
                 observers Nil @Party,
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:SerializableType) (self) :
+                  choice Ch (self) (i : Mod:SerializableType) :
                     Mod:UnserializableType by $partiesAlice to       // disallowed unserializable type
                        upure @Mod:UnserializableType (Mod:UnserializableType {})
                 }
@@ -322,7 +322,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
             observers Cons @Party ['Alice'] (Nil @Party),
             agreement "Agreement",
             choices {
-              choice Ch (x: Int64) (self) : Decimal by 'Bob' to upure @Int64 (DECIMAL_TO_INT64 x)
+              choice Ch (self) (x: Int64) : Decimal by 'Bob' to upure @Int64 (DECIMAL_TO_INT64 x)
             }
           } ;
 

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
@@ -158,7 +158,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
               observers Nil @Party,
               agreement "Agreement",
               choices {
-                choice Ch (i : Mod:SerializableType) : Mod:SerializableType by $partiesAlice to upure @Mod:SerializableType (Mod:SerializableType {})
+                choice Ch (i : Mod:SerializableType) (self) : Mod:SerializableType by $partiesAlice to upure @Mod:SerializableType (Mod:SerializableType {})
               }
             } ;
           }
@@ -172,7 +172,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
                 observers Nil @Party,
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:SerializableType) :
+                  choice Ch (i : Mod:SerializableType) (self) :
                     Mod:SerializableType by $partiesAlice
                       to upure @Mod:SerializableType (Mod:SerializableType {})
                 }
@@ -189,7 +189,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
                 observers Nil @Party,
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:UnserializableType) :     // disallowed unserializable type
+                  choice Ch (i : Mod:UnserializableType) (self) :     // disallowed unserializable type
                    Unit by $partiesAlice to
                        upure @Unit ()
                 }
@@ -205,7 +205,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
                 observers Nil @Party,
                 agreement "Agreement",
                 choices {
-                  choice Ch (i : Mod:SerializableType) :
+                  choice Ch (i : Mod:SerializableType) (self) :
                     Mod:UnserializableType by $partiesAlice to       // disallowed unserializable type
                        upure @Mod:UnserializableType (Mod:UnserializableType {})
                 }
@@ -322,7 +322,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
             observers Cons @Party ['Alice'] (Nil @Party),
             agreement "Agreement",
             choices {
-              choice Ch (x: Int64) : Decimal by 'Bob' to upure @Int64 (DECIMAL_TO_INT64 x)
+              choice Ch (x: Int64) (self) : Decimal by 'Bob' to upure @Int64 (DECIMAL_TO_INT64 x)
             }
           } ;
 

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -471,7 +471,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               },
               key @NegativeTestCase:TBis
                   (NegativeTestCase:TBis { person = (NegativeTestCase:T {name} this), party = (NegativeTestCase:T {person} this) })
@@ -488,7 +488,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -502,7 +502,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers (),                                  // should be of type (List Party)
               agreement "Agreement",
               choices {
-                choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -516,7 +516,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement (),                                 // should be of type Text
               choices {
-                choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -530,7 +530,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (i : List) (self) : Unit   // the type of i (here List) should be of kind * (here it is * -> *)
+                choice Ch (self) (i : List) : Unit   // the type of i (here List) should be of kind * (here it is * -> *)
                   by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
@@ -545,7 +545,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (i : Unit) (self) : List   // the return type (here List) should be of kind * (here it is * -> *)
+                choice Ch (self) (i : Unit) : List   // the return type (here List) should be of kind * (here it is * -> *)
                    by Cons @Party ['Alice'] (Nil @Party) to upure @(List) (/\ (tau : *). Nil @tau)
               }
             } ;
@@ -561,7 +561,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase6:TBis
               // In the next line, should use only record construction and projection, and variable. Here use string literal.
@@ -581,7 +581,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase7:TBis
           // In the next line, the declared type do not match body
@@ -601,7 +601,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase8:TBis
           (PositiveTestCase8:TBis { person = (PositiveTestCase8:T {name} this), party = (PositiveTestCase8:T {person} this) })
@@ -620,7 +620,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase9:TBis
           (PositiveTestCase9:TBis { person = (PositiveTestCase9:T {name} this), party = (PositiveTestCase9:T {person} this) })
@@ -701,7 +701,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
                observers Cons @Party ['Alice'] (Nil @Party),
                agreement "Agreement",
                choices {
-                 choice Ch (record : Mod:T) (self) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
+                 choice Ch (self) (record : Mod:T) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
                }
              } ;
            }
@@ -745,7 +745,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
                observers Cons @Party ['Alice'] (Nil @Party),
                agreement "Agreement",
                choices {
-                 choice Ch (record : Mod:T) (self) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
+                 choice Ch (self) (record : Mod:T) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
                }
              } ;
            }
@@ -903,7 +903,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
            observers Cons @Party ['Alice'] (Nil @Party),
            agreement "Agreement",
            choices {
-             choice Ch (x: Int64) (self) : Decimal by 'Bob' to upure @INT64 (DECIMAL_TO_INT64 x)
+             choice Ch (self) (x: Int64) : Decimal by 'Bob' to upure @INT64 (DECIMAL_TO_INT64 x)
            },
            key @Party (Mod:Person {person} this) (\ (p: Party) -> Cons @Party ['Alice', p] (Nil @Party))
          } ;

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -471,7 +471,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               },
               key @NegativeTestCase:TBis
                   (NegativeTestCase:TBis { person = (NegativeTestCase:T {name} this), party = (NegativeTestCase:T {person} this) })
@@ -488,7 +488,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -502,7 +502,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers (),                                  // should be of type (List Party)
               agreement "Agreement",
               choices {
-                choice Ch (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -516,7 +516,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement (),                                 // should be of type Text
               choices {
-                choice Ch (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -530,7 +530,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (i : List) : Unit   // the type of i (here List) should be of kind * (here it is * -> *)
+                choice Ch (i : List) (self) : Unit   // the type of i (here List) should be of kind * (here it is * -> *)
                   by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
@@ -545,7 +545,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (i : Unit) : List   // the return type (here List) should be of kind * (here it is * -> *)
+                choice Ch (i : Unit) (self) : List   // the return type (here List) should be of kind * (here it is * -> *)
                    by Cons @Party ['Alice'] (Nil @Party) to upure @(List) (/\ (tau : *). Nil @tau)
               }
             } ;
@@ -561,7 +561,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase6:TBis
               // In the next line, should use only record construction and projection, and variable. Here use string literal.
@@ -581,7 +581,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase7:TBis
           // In the next line, the declared type do not match body
@@ -601,7 +601,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase8:TBis
           (PositiveTestCase8:TBis { person = (PositiveTestCase8:T {name} this), party = (PositiveTestCase8:T {person} this) })
@@ -620,7 +620,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (i : Unit) (self) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase9:TBis
           (PositiveTestCase9:TBis { person = (PositiveTestCase9:T {name} this), party = (PositiveTestCase9:T {person} this) })
@@ -701,7 +701,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
                observers Cons @Party ['Alice'] (Nil @Party),
                agreement "Agreement",
                choices {
-                 choice Ch (record : Mod:T) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
+                 choice Ch (record : Mod:T) (self) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
                }
              } ;
            }
@@ -745,7 +745,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
                observers Cons @Party ['Alice'] (Nil @Party),
                agreement "Agreement",
                choices {
-                 choice Ch (record : Mod:T) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
+                 choice Ch (record : Mod:T) (self) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
                }
              } ;
            }
@@ -903,7 +903,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
            observers Cons @Party ['Alice'] (Nil @Party),
            agreement "Agreement",
            choices {
-             choice Ch (x: Int64) : Decimal by 'Bob' to upure @INT64 (DECIMAL_TO_INT64 x)
+             choice Ch (x: Int64) (self) : Decimal by 'Bob' to upure @INT64 (DECIMAL_TO_INT64 x)
            },
            key @Party (Mod:Person {person} this) (\ (p: Party) -> Cons @Party ['Alice', p] (Nil @Party))
          } ;

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -36,7 +36,7 @@ object TestHelpers {
           observers Cons @Party [Simple:SimpleTemplate {observer} this] (Nil @Party),
           agreement "",
           choices {
-            choice Consume (x: Unit) : Unit by Cons @Party [Simple:SimpleTemplate {owner} this] (Nil @Party) to upure @Unit ()
+            choice Consume (x: Unit) (self) : Unit by Cons @Party [Simple:SimpleTemplate {owner} this] (Nil @Party) to upure @Unit ()
           },
           key @Party (Simple:SimpleTemplate {owner} this) (\ (p: Party) -> Cons @Party [p] (Nil @Party))
         } ;

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -36,7 +36,7 @@ object TestHelpers {
           observers Cons @Party [Simple:SimpleTemplate {observer} this] (Nil @Party),
           agreement "",
           choices {
-            choice Consume (x: Unit) (self) : Unit by Cons @Party [Simple:SimpleTemplate {owner} this] (Nil @Party) to upure @Unit ()
+            choice Consume (self) (x: Unit) : Unit by Cons @Party [Simple:SimpleTemplate {owner} this] (Nil @Party) to upure @Unit ()
           },
           key @Party (Simple:SimpleTemplate {owner} this) (\ (p: Party) -> Cons @Party [p] (Nil @Party))
         } ;


### PR DESCRIPTION
This PR fix self binder of choices in several places:
 - parser
 - spec

And remove optionality of choice parameter name. 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
