### PR TITLE
correct commit title in Slack msg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,6 +100,8 @@ jobs:
           ./bazel-bin/release/release --release-dir "$(mktemp -d)"
         condition: and(succeeded(), ne(variables['is_release'], 'true'))
       - template: ci/tell-slack-failed.yml
+        parameters:
+          trigger_sha: '$(trigger_sha)'
       - template: ci/report-end.yml
 
   - job: macOS
@@ -138,6 +140,8 @@ jobs:
       - bash: mkdir -p $(bazel-repo-cache-path)
         displayName: ensure bazel repo cache exists
       - template: ci/tell-slack-failed.yml
+        parameters:
+          trigger_sha: '$(trigger_sha)'
       - template: ci/report-end.yml
 
   - job: Windows
@@ -165,6 +169,8 @@ jobs:
           release_tag: $(release_tag)
           is_release: variables.is_release
       - template: ci/tell-slack-failed.yml
+        parameters:
+          trigger_sha: '$(trigger_sha)'
       - template: ci/report-end.yml
 
   - job: check_for_release
@@ -213,6 +219,7 @@ jobs:
       protos-zip: $[ dependencies.Linux.outputs['publish.protos-zip'] ]
       release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
       release_tag: $[ dependencies.check_for_release.outputs['out.release_tag'] ]
+      trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
     steps:
       - template: ci/report-start.yml
       - checkout: self
@@ -283,6 +290,8 @@ jobs:
           isPrerelease: true
         condition: not(eq(variables['skip-github'], 'TRUE'))
       - template: ci/tell-slack-failed.yml
+        parameters:
+          trigger_sha: '$(trigger_sha)'
       - template: ci/report-end.yml
 
   - job: write_ledger_dump
@@ -294,6 +303,7 @@ jobs:
     variables:
       release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
       release_tag: $[ dependencies.check_for_release.outputs['out.release_tag'] ]
+      trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
     steps:
       - checkout: self
       - bash: |
@@ -321,6 +331,8 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
       - template: ci/tell-slack-failed.yml
+        parameters:
+          trigger_sha: '$(trigger_sha)'
 
   - job: collect_build_data
     condition: always()

--- a/ci/tell-slack-failed.yml
+++ b/ci/tell-slack-failed.yml
@@ -1,14 +1,22 @@
 # Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+parameters:
+  trigger_sha: ''
+
 steps:
   - bash: |
       set -euo pipefail
-      MESSAGE=$(git log --pretty=format:%s -n1)
+      COMMIT_TITLE=$(git log --pretty=format:%s -n1 ${{ parameters.trigger_sha }})
+      COMMI_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$COMMIT_TITLE>"
+      if [ -z "${{ parameters.trigger_sha }}" ]; then
+          WARNING="<!here> *FAILED* $(Agent.JobName): $COMMIT_LINK"
+      else
+          WARNING=":fire: :fire: :fire: :fire: :fire:\n<!here> *RELEASE FAILED* $(Agent.JobName): $COMMIT_LINK\n:fire: :fire: :fire: :fire: :fire:"
+      fi
       curl -XPOST \
            -i \
            -H 'Content-type: application/json' \
-           --data "{\"text\":\"<!here> *FAILED* $(Agent.JobName): <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
+           --data "{\"text\":\"$WARNING\n\"}" \
            $(Slack.team-daml)
     condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
-


### PR DESCRIPTION
Currently, on a release commit on master, if the commit fails, we get the message from the target PR, which is confusing. This should (hopefully; it's a bit hard to test as it would require setting up a release PR that succeeds but fails on master) get us the title of the release commit, which hopefully will be less confusing.

CHANGELOG_BEGIN
CHANGELOG_END