### PR TITLE
Avoid using setBinaryStream to not confuse H2

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
@@ -3,7 +3,6 @@
 
 package com.daml.platform.store
 
-import java.io.InputStream
 import java.sql.PreparedStatement
 import java.time.Instant
 import java.util.Date
@@ -152,14 +151,14 @@ object Conversions {
 
   implicit def offsetToStatement: ToStatement[Offset] = new ToStatement[Offset] {
     override def set(s: PreparedStatement, index: Int, v: Offset): Unit =
-      s.setBinaryStream(index, v.toInputStream)
+      s.setBytes(index, v.toByteArray)
   }
 
   def offset(name: String): RowParser[Offset] =
-    SqlParser.get[InputStream](name).map(Offset.fromInputStream)
+    SqlParser.get[Array[Byte]](name).map(Offset.fromByteArray)
 
-  implicit def columnToOffset(implicit c: Column[InputStream]): Column[Offset] =
-    Column.nonNull((value: Any, meta) => c(value, meta).toEither.map(Offset.fromInputStream))
+  implicit def columnToOffset(implicit c: Column[Array[Byte]]): Column[Offset] =
+    Column.nonNull((value: Any, meta) => c(value, meta).toEither.map(Offset.fromByteArray))
 
   // Instant
 


### PR DESCRIPTION
There have been reports of sporadic occurrences of
`java.lang.RuntimeException: Lob not found: 49/-2`
when running the participant server with H2.

It seems like using `setBinaryStream` triggers H2 to go through the BLOB
machinery. Since this issue is not easily reproducible, it seems like an
altogether better solution to switch to using `setBytes`. Offsets aren't
that large anyway, so going directly for byte array should be fine.
Better than a broken query anway.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
