### PR TITLE
Getting Started guide: Remove useless yarn build

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -69,14 +69,13 @@ In order to connect the UI code to this DAML, we need to run a code generation s
 
     daml codegen js .daml/dist/create-daml-app-0.1.0.dar -o daml.js
 
-Now, changing to the ``ui`` folder, use Yarn to install the project dependencies and build the app::
+Now, changing to the ``ui`` folder, use Yarn to install the project dependencies::
 
     cd ui
     yarn install
-    yarn build
 
-These steps may take a couple of minutes each (it's worth it!).
-You should see ``Compiled successfully.`` in the output if everything worked as expected.
+This step may take a couple of moments (it's worth it!).
+You should see ``success Saved lockfile.`` in the output if everything worked as expected.
 
 .. TODO: Give instructions for possible failures.
 


### PR DESCRIPTION
The call to `yarn build` in the Getting Started guide is completely
useless for everything that follows (it would only be necessary if you
want to deploy the app) and quite time consuming. Let's just remove it!

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5482)
<!-- Reviewable:end -->
