### PR TITLE
Consistently avoid infix syntax in the GSG and reinstantiate dlint

### DIFF
--- a/docs/source/getting-started/code/daml-after/User.daml
+++ b/docs/source/getting-started/code/daml-after/User.daml
@@ -18,7 +18,7 @@ template User with
       controller username
       do
         assertMsg "You cannot follow yourself" (userToFollow /= username)
-        assertMsg "You cannot follow the same user twice" (userToFollow `notElem` following)
+        assertMsg "You cannot follow the same user twice" (notElem userToFollow following)
         archive self
         create this with following = userToFollow :: following
 

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -30,6 +30,16 @@ genrule(
             # use default .gitignore and .dlint.yaml if they don't exist in the template
             cp -n $$SRC/default-gitignore $$OUT/$$d/.gitignore
             cp -n $$SRC/default-dlint-yaml $$OUT/$$d/.dlint.yaml
+            # We avoid introducing infix syntax in the GSG so we disable
+            # the lint there.
+            if [ "$$d" = "create-daml-app" ]; then
+              cat >> $$OUT/$$d/.dlint.yaml <<EOF
+
+# This rule is enabled by default but we avoid
+# infix syntax here to keep things simple.
+- ignore: {name: Use infix }
+EOF
+            fi
         done
 
         ## special cases we should work to remove

--- a/templates/create-daml-app/daml/User.daml
+++ b/templates/create-daml-app/daml/User.daml
@@ -21,7 +21,7 @@ template User with
       controller username
       do
         assertMsg "You cannot follow yourself" (userToFollow /= username)
-        assertMsg "You cannot follow the same user twice" (userToFollow `notElem` following)
+        assertMsg "You cannot follow the same user twice" (notElem userToFollow following)
         archive self
         create this with following = userToFollow :: following
     -- FOLLOW_END


### PR DESCRIPTION
We avoided infix syntax here for `elem` but still used it for
`notElem` which doesn’t make much sense. Also we lost the config to
disable the lint when integrating the example in this repo. This
resulted in our own code producing a lint which is obviously a bad
idea.

side note: I think this lint does make sense once you
are familiar with the syntax and I feel slightly bad about disabling
more and more lints so for now I’m keeping it in the config.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
