### PR TITLE
daml-lf: Tiny performance improvements.

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
@@ -3,32 +3,29 @@
 
 package com.daml.lf.data
 
-import scala.annotation.tailrec
-import BackStack.{BQ, BQAppend, BQEmpty, BQSnoc}
+import com.daml.lf.data.BackStack.{BQ, BQAppend, BQEmpty, BQSnoc}
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 /** A stack which allows to snoc, append, and pop in constant time, and generate an ImmArray in linear time.
   */
-final class BackStack[+A] private (fq: BQ[A], len: Int) {
+final class BackStack[+A] private (fq: BQ[A], val length: Int) {
 
   /** O(1) */
-  def length: Int = len
-
-  /** O(1) */
-  def :+[B >: A](x: B): BackStack[B] = new BackStack(BQSnoc(fq, x), len + 1)
+  def :+[B >: A](x: B): BackStack[B] = new BackStack(BQSnoc(fq, x), length + 1)
 
   /** O(1) */
   def :++[B >: A](xs: ImmArray[B]): BackStack[B] =
     if (xs.length > 0) {
-      new BackStack(BQAppend(fq, xs), len + xs.length)
+      new BackStack(BQAppend(fq, xs), length + xs.length)
     } else {
       this
     }
 
   /** O(n) */
   def toImmArray: ImmArray[A] = {
-    val array = new mutable.ArraySeq[A](len)
+    val array = new mutable.ArraySeq[A](length)
 
     @tailrec
     def go(cursor: Int, fq: BQ[A]): Unit = fq match {
@@ -42,7 +39,8 @@ final class BackStack[+A] private (fq: BQ[A], len: Int) {
         }
         go(cursor - last.length, init)
     }
-    go(len - 1, fq)
+
+    go(length - 1, fq)
 
     ImmArray.unsafeFromArraySeq(array)
   }
@@ -61,15 +59,15 @@ final class BackStack[+A] private (fq: BQ[A], len: Int) {
 
   /** O(1) */
   def pop: Option[(BackStack[A], A)] = {
-    if (len > 0) {
+    if (length > 0) {
       fq match {
-        case BQEmpty => throw new RuntimeException(s"BackQueue has length $len but BQEmpty.")
-        case BQSnoc(init, last) => Some((new BackStack(init, len - 1), last))
+        case BQEmpty => throw new RuntimeException(s"BackQueue has length $length but BQEmpty.")
+        case BQSnoc(init, last) => Some((new BackStack(init, length - 1), last))
         case BQAppend(init, last) =>
           if (last.length > 1) {
-            Some((new BackStack(BQAppend(init, last.init), len - 1), last.last))
+            Some((new BackStack(BQAppend(init, last.init), length - 1), last.last))
           } else if (last.length > 0) {
-            Some((new BackStack(init, len - 1), last.last))
+            Some((new BackStack(init, length - 1), last.last))
           } else {
             throw new RuntimeException(s"BackQueue had BQPrepend with non-empty last: $last")
           }
@@ -85,10 +83,10 @@ final class BackStack[+A] private (fq: BQ[A], len: Int) {
   }
 
   /** O(1) */
-  def isEmpty: Boolean = len == 0
+  def isEmpty: Boolean = length == 0
 
   /** O(1) */
-  def nonEmpty: Boolean = len > 0
+  def nonEmpty: Boolean = length > 0
 
   /** O(1)
     *

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/BackStack.scala
@@ -3,7 +3,7 @@
 
 package com.daml.lf.data
 
-import com.daml.lf.data.BackStack.{BQ, BQAppend, BQEmpty, BQSnoc}
+import BackStack.{BQ, BQAppend, BQEmpty, BQSnoc}
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
@@ -3,7 +3,7 @@
 
 package com.daml.lf.data
 
-import com.daml.lf.data.FrontStack.{FQ, FQCons, FQEmpty, FQPrepend}
+import FrontStack.{FQ, FQCons, FQEmpty, FQPrepend}
 import scalaz.syntax.applicative._
 import scalaz.syntax.traverse._
 import scalaz.{Applicative, Equal, Traverse}

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
@@ -16,16 +16,14 @@ import scala.language.higherKinds
 /** A stack which allows to cons, prepend, and pop in constant time, and generate an ImmArray in linear time.
   * Very useful when needing to traverse stuff in topological order or similar situations.
   */
-final class FrontStack[+A] private (fq: FQ[A], len: Int) {
-
-  /** O(1) */
-  def length: Int = len
+final class FrontStack[+A] private (fq: FQ[A], val length: Int) {
 
   /** O(n) */
   @throws[IndexOutOfBoundsException]
   def slowApply(ix: Int): A = {
     if (ix < 0) throw new IndexOutOfBoundsException(ix.toString)
     val i = iterator
+
     @tailrec def lp(ix: Int): A =
       if (!i.hasNext) throw new IndexOutOfBoundsException(ix.toString)
       else {
@@ -36,19 +34,19 @@ final class FrontStack[+A] private (fq: FQ[A], len: Int) {
   }
 
   /** O(1) */
-  def +:[B >: A](x: B): FrontStack[B] = new FrontStack(FQCons(x, fq), len + 1)
+  def +:[B >: A](x: B): FrontStack[B] = new FrontStack(FQCons(x, fq), length + 1)
 
   /** O(1) */
   def ++:[B >: A](xs: ImmArray[B]): FrontStack[B] =
     if (xs.length > 0) {
-      new FrontStack(FQPrepend(xs, fq), len + xs.length)
+      new FrontStack(FQPrepend(xs, fq), length + xs.length)
     } else {
       this
     }
 
   /** O(n) */
   def toImmArray: ImmArray[A] = {
-    val array = new mutable.ArraySeq[A](len)
+    val array = new mutable.ArraySeq[A](length)
 
     @tailrec
     def go(cursor: Int, fq: FQ[A]): Unit = fq match {
@@ -69,15 +67,15 @@ final class FrontStack[+A] private (fq: FQ[A], len: Int) {
 
   /** O(1) */
   def pop: Option[(A, FrontStack[A])] = {
-    if (len > 0) {
+    if (length > 0) {
       fq match {
-        case FQEmpty => throw new RuntimeException(s"FrontStack has length $len but FQEmpty.")
-        case FQCons(head, tail) => Some((head, new FrontStack(tail, len - 1)))
+        case FQEmpty => throw new RuntimeException(s"FrontStack has length $length but FQEmpty.")
+        case FQCons(head, tail) => Some((head, new FrontStack(tail, length - 1)))
         case FQPrepend(head, tail) =>
           if (head.length > 1) {
-            Some((head.head, new FrontStack(FQPrepend(head.tail, tail), len - 1)))
+            Some((head.head, new FrontStack(FQPrepend(head.tail, tail), length - 1)))
           } else if (head.length > 0) {
-            Some((head.head, new FrontStack(tail, len - 1)))
+            Some((head.head, new FrontStack(tail, length - 1)))
           } else {
             throw new RuntimeException(s"FrontStack had FQPrepend with non-empty head: $head")
           }
@@ -93,10 +91,10 @@ final class FrontStack[+A] private (fq: FQ[A], len: Int) {
   }
 
   /** O(1) */
-  def isEmpty: Boolean = len == 0
+  def isEmpty: Boolean = length == 0
 
   /** O(1) */
-  def nonEmpty: Boolean = len > 0
+  def nonEmpty: Boolean = length > 0
 
   /** O(1) */
   def iterator: Iterator[A] = {
@@ -151,13 +149,13 @@ object FrontStack {
   def empty[A]: FrontStack[A] = emptySingleton
 
   def apply[A](xs: ImmArray[A]): FrontStack[A] =
-    new FrontStack(FQPrepend(xs, FQEmpty), len = xs.length)
+    new FrontStack(FQPrepend(xs, FQEmpty), length = xs.length)
 
   def apply[T](element: T): FrontStack[T] =
-    new FrontStack(FQCons(element, FQEmpty), len = 1)
+    new FrontStack(FQCons(element, FQEmpty), length = 1)
 
   def apply[T](a: T, b: T): FrontStack[T] =
-    new FrontStack(FQCons(a, FQCons(b, FQEmpty)), len = 2)
+    new FrontStack(FQCons(a, FQCons(b, FQEmpty)), length = 2)
 
   // Slow; only use this in tests.
   def apply[T](a: T, b: T, c: T, elements: T*): FrontStack[T] =

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
@@ -31,13 +31,16 @@ import scala.reflect.ClassTag
   */
 final class ImmArray[+A] private (
     private val start: Int,
-    private val len: Int,
-    array: mutable.ArraySeq[A]) {
+    val length: Int,
+    array: mutable.ArraySeq[A]
+) {
+  self =>
+
   def iterator: Iterator[A] = {
     var cursor = start
 
     new Iterator[A] {
-      override def hasNext: Boolean = cursor < start + len
+      override def hasNext: Boolean = cursor < start + self.length
 
       override def next(): A = {
         val x = array(cursor)
@@ -48,7 +51,7 @@ final class ImmArray[+A] private (
   }
 
   def reverseIterator: Iterator[A] = {
-    var cursor = start + len - 1
+    var cursor = start + self.length - 1
 
     new Iterator[A] {
       override def hasNext: Boolean = cursor >= start
@@ -63,7 +66,7 @@ final class ImmArray[+A] private (
 
   /** O(1), crashes on out of bounds */
   def apply(idx: Int): A =
-    if (idx >= len) {
+    if (idx >= length) {
       throw new IndexOutOfBoundsException("index out of bounds in ImmArray apply")
     } else {
       uncheckedGet(idx)
@@ -71,42 +74,39 @@ final class ImmArray[+A] private (
 
   private def uncheckedGet(idx: Int): A = array(start + idx)
 
-  /** O(1) */
-  def length: Int = len
-
   /** O(n) */
   def copyToArray[B >: A](dst: Array[B], dstStart: Int, dstLen: Int): Unit = {
-    for (i <- 0 until Math.max(len, dstLen)) {
+    for (i <- 0 until Math.max(length, dstLen)) {
       dst(dstStart + i) = uncheckedGet(i)
     }
   }
 
   /** O(n) */
   def copyToArray[B >: A](xs: Array[B]): Unit = {
-    copyToArray(xs, 0, len)
+    copyToArray(xs, 0, length)
   }
 
   /** O(1), crashes on empty list */
   def head: A = this(0)
 
   /** O(1), crashes on empty list */
-  def last: A = this(this.length - 1)
+  def last: A = this(length - 1)
 
   /** O(1), crashes on empty list */
   def tail: ImmArray[A] = {
-    if (len < 1) {
+    if (length < 1) {
       throw new RuntimeException("tail on empty ImmArray")
     } else {
-      new ImmArray(start + 1, len - 1, array)
+      new ImmArray(start + 1, length - 1, array)
     }
   }
 
   /** O(1), crashes on empty list */
   def init: ImmArray[A] = {
-    if (len < 1) {
+    if (length < 1) {
       throw new RuntimeException("init on empty ImmArray")
     } else {
-      new ImmArray(start, len - 1, array)
+      new ImmArray(start, length - 1, array)
     }
   }
 
@@ -123,9 +123,9 @@ final class ImmArray[+A] private (
     * use `relaxedSlice`.
     */
   def strictSlice(from: Int, until: Int): ImmArray[A] = {
-    if (from < 0 || from >= len || until < 0 || until > len) {
+    if (from < 0 || from >= length || until < 0 || until > length) {
       throw new IndexOutOfBoundsException(
-        s"strictSlice arguments out of bounds for ImmArray. length: $len, from: $from, until: $until")
+        s"strictSlice arguments out of bounds for ImmArray. length: $length, from: $from, until: $until")
     }
 
     relaxedSlice(from, until)
@@ -135,8 +135,8 @@ final class ImmArray[+A] private (
     * as Seq's slice.
     */
   def relaxedSlice(from0: Int, until0: Int): ImmArray[A] = {
-    val from = Math.max(Math.min(from0, len), 0)
-    val until = Math.max(Math.min(until0, len), 0)
+    val from = Math.max(Math.min(from0, length), 0)
+    val until = Math.max(Math.min(until0, length), 0)
 
     val newLen = until - from
     if (newLen <= 0) {
@@ -148,7 +148,7 @@ final class ImmArray[+A] private (
 
   /** O(n) */
   def map[B](f: A => B): ImmArray[B] = {
-    val newArray: mutable.ArraySeq[B] = new mutable.ArraySeq(len)
+    val newArray: mutable.ArraySeq[B] = new mutable.ArraySeq(length)
     for (i <- indices) {
       newArray(i) = f(uncheckedGet(i))
     }
@@ -157,9 +157,9 @@ final class ImmArray[+A] private (
 
   /** O(n) */
   def reverse: ImmArray[A] = {
-    val newArray: mutable.ArraySeq[A] = new mutable.ArraySeq(len)
+    val newArray: mutable.ArraySeq[A] = new mutable.ArraySeq(length)
     for (i <- indices) {
-      newArray(i) = array(start + len - (i + 1))
+      newArray(i) = array(start + length - (i + 1))
     }
     ImmArray.unsafeFromArraySeq[A](newArray)
   }
@@ -170,12 +170,12 @@ final class ImmArray[+A] private (
     * since to append ImmArray we must copy both of them.
     */
   def slowAppend[B >: A](other: ImmArray[B]): ImmArray[B] = {
-    val newArray: mutable.ArraySeq[B] = new mutable.ArraySeq(len + other.len)
+    val newArray: mutable.ArraySeq[B] = new mutable.ArraySeq(length + other.length)
     for (i <- indices) {
       newArray(i) = uncheckedGet(i)
     }
     for (i <- other.indices) {
-      newArray(len + i) = other.uncheckedGet(i)
+      newArray(length + i) = other.uncheckedGet(i)
     }
     ImmArray.unsafeFromArraySeq(newArray)
   }
@@ -186,7 +186,7 @@ final class ImmArray[+A] private (
     * since to cons an ImmArray we must copy it.
     */
   def slowCons[B >: A](el: B): ImmArray[B] = {
-    val newArray: mutable.ArraySeq[B] = new mutable.ArraySeq(len + 1)
+    val newArray: mutable.ArraySeq[B] = new mutable.ArraySeq(length + 1)
     newArray(0) = el
     for (i <- indices) {
       newArray(i + 1) = uncheckedGet(i)
@@ -200,17 +200,17 @@ final class ImmArray[+A] private (
     * since to snoc an ImmArray we must copy it.
     */
   def slowSnoc[B >: A](el: B): ImmArray[B] = {
-    val newArray: mutable.ArraySeq[B] = new mutable.ArraySeq(len + 1)
+    val newArray: mutable.ArraySeq[B] = new mutable.ArraySeq(length + 1)
     for (i <- indices) {
       newArray(i) = uncheckedGet(i)
     }
-    newArray(len) = el
+    newArray(length) = el
     ImmArray.unsafeFromArraySeq(newArray)
   }
 
   /** O(min(n, m)) */
   def zip[B](that: ImmArray[B]): ImmArray[(A, B)] = {
-    val newLen = Math.min(len, that.len)
+    val newLen = Math.min(length, that.length)
     val newArray: mutable.ArraySeq[(A, B)] = new mutable.ArraySeq(newLen)
     for (i <- 0 until newLen) {
       newArray(i) = (uncheckedGet(i), that.uncheckedGet(i))
@@ -219,17 +219,17 @@ final class ImmArray[+A] private (
   }
 
   /** O(1) */
-  def isEmpty: Boolean = len == 0
+  def isEmpty: Boolean = length == 0
 
   /** O(1) */
-  def nonEmpty: Boolean = len != 0
+  def nonEmpty: Boolean = length != 0
 
   /** O(n) */
   def toList: List[A] = toSeq.toList
 
   /** O(n) */
   def toArray[B >: A: ClassTag]: Array[B] = {
-    val arr: Array[B] = new Array(len)
+    val arr: Array[B] = new Array(length)
     for (i <- indices) {
       arr(i) = uncheckedGet(i)
     }
@@ -258,7 +258,7 @@ final class ImmArray[+A] private (
   def collect[B](f: PartialFunction[A, B]): ImmArray[B] = {
     val builder = ImmArray.newBuilder[B]
     var i = 0
-    while (i < len) {
+    while (i < length) {
       val a = uncheckedGet(i)
       if (f.isDefinedAt(a)) builder += f(a)
       i += 1
@@ -304,7 +304,7 @@ final class ImmArray[+A] private (
   def find(f: A => Boolean): Option[A] = {
     @tailrec
     def go(i: Int): Option[A] =
-      if (i < len) {
+      if (i < length) {
         val e = uncheckedGet(i)
         if (f(e)) Some(e)
         else go(i + 1)
@@ -319,14 +319,14 @@ final class ImmArray[+A] private (
     } getOrElse -1
 
   /** O(1) */
-  def indices: Range = 0 until len
+  def indices: Range = 0 until length
 
   /** O(1) */
   def canEqual(that: Any) = that.isInstanceOf[ImmArray[_]]
 
   /** O(n) */
   override def equals(that: Any): Boolean = that match {
-    case thatArr: ImmArray[_] if len == thatArr.len =>
+    case thatArr: ImmArray[_] if length == thatArr.length =>
       indices forall { i =>
         uncheckedGet(i) == thatArr.uncheckedGet(i)
       }
@@ -335,7 +335,7 @@ final class ImmArray[+A] private (
 
   /** O(n) */
   private def equalz[B >: A](thatArr: ImmArray[B])(implicit B: Equal[B]): Boolean =
-    (len == thatArr.len) && {
+    (length == thatArr.length) && {
       indices forall { i =>
         B.equal(uncheckedGet(i), thatArr.uncheckedGet(i))
       }
@@ -425,8 +425,11 @@ object ImmArray {
     // TODO make this faster by implementing as many methods as possible.
     override def iterator: Iterator[A] = array.iterator
     override def reverseIterator: Iterator[A] = array.reverseIterator
+
     override def apply(idx: Int): A = array(idx)
-    override def length: Int = array.len
+
+    override def length: Int = array.length
+
     override def head: A = array.head
     override def tail: ImmArraySeq[A] = new ImmArraySeq(array.tail)
     override def last: A = array.last

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/FrontStackSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/FrontStackSpec.scala
@@ -3,9 +3,8 @@
 
 package com.daml.lf.data
 
-import org.scalatest.{Matchers, WordSpec}
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, TableDrivenPropertyChecks}
-
+import org.scalatest.{Matchers, WordSpec}
 import scalaz.scalacheck.ScalazProperties
 import scalaz.std.anyVal._
 
@@ -15,7 +14,35 @@ class FrontStackSpec
     with GeneratorDrivenPropertyChecks
     with TableDrivenPropertyChecks
     with WordSpecCheckLaws {
+
   import DataArbitrary._
+
+  "apply" when {
+    "1 element is provided" should {
+      "behave the same as prepend" in forAll { x: Int =>
+        FrontStack(x) should ===(x +: FrontStack.empty)
+      }
+    }
+
+    "2 elements are provided" should {
+      "behave the same as prepend" in forAll { (x: Int, y: Int) =>
+        FrontStack(x, y) should ===(x +: y +: FrontStack.empty)
+      }
+    }
+
+    "more than 2 elements are provided" should {
+      "behave the same as prepend" in forAll { (x: Int, y: Int, z: Int, rest: Seq[Int]) =>
+        FrontStack(x, y, z, rest: _*) should ===(
+          ImmArray(Seq(x, y, z) ++ rest) ++: FrontStack.empty)
+      }
+    }
+
+    "a sequence of elements is provided" should {
+      "behave the same as prepend" in forAll { xs: Seq[Int] =>
+        FrontStack(xs) should ===(ImmArray(xs) ++: FrontStack.empty)
+      }
+    }
+  }
 
   "++:" should {
     "yield equal results to +:" in forAll { (ia: ImmArray[Int], fs: FrontStack[Int]) =>
@@ -37,8 +64,8 @@ class FrontStackSpec
 
   "slowApply" should {
     "throw when out of bounds" in forAll { fs: FrontStack[Int] =>
-      an[IndexOutOfBoundsException] should be thrownBy (fs.slowApply(-1))
-      an[IndexOutOfBoundsException] should be thrownBy (fs.slowApply(fs.length))
+      an[IndexOutOfBoundsException] should be thrownBy fs.slowApply(-1)
+      an[IndexOutOfBoundsException] should be thrownBy fs.slowApply(fs.length)
     }
 
     "preserve Seq's apply" in forAll { fs: FrontStack[Int] =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -4,21 +4,20 @@
 package com.daml.lf
 package speedy
 
-import com.daml.lf.data.{ImmArray, Ref, Time}
+import java.util
+
 import com.daml.lf.data.Ref._
+import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
-import com.daml.lf.value.{Value => V}
-
-import scala.collection.JavaConverters._
-import java.util
-
 import com.daml.lf.value.Value.AbsoluteContractId
+import com.daml.lf.value.{Value => V}
 import org.slf4j.LoggerFactory
 
+import scala.collection.JavaConverters._
 import scala.util.control.NoStackTrace
 
 object Speedy {
@@ -448,8 +447,12 @@ object Speedy {
     def execute(v: SValue, machine: Machine) = {
       v match {
         case SPAP(prim, args, arity) =>
-          val args2 = args.clone.asInstanceOf[util.ArrayList[SValue]]
-          val missing = arity - args2.size
+          val missing = arity - args.size
+          val newArgsLimit = Math.min(missing, newArgs.length)
+
+          // Keep some space free, because both `KFun` and `KPushTo` will add to the list.
+          val functionArgs = new util.ArrayList[SValue](args.size + newArgsLimit)
+          functionArgs.addAll(args)
 
           // Stash away over-applied arguments, if any.
           val othersLength = newArgs.length - missing
@@ -459,14 +462,13 @@ object Speedy {
             machine.kont.add(KArg(others))
           }
 
-          machine.kont.add(KFun(prim, args2, arity))
+          machine.kont.add(KFun(prim, functionArgs, arity))
 
-          // start evaluating the arguments
-          val newArgsLimit = Math.min(missing, newArgs.length)
+          // Start evaluating the arguments.
           var i = 1
           while (i < newArgsLimit) {
             val arg = newArgs(newArgsLimit - i)
-            machine.kont.add(KPushTo(args2, arg))
+            machine.kont.add(KPushTo(functionArgs, arg))
             i = i + 1
           }
           machine.ctrl = CtrlExpr(newArgs(0))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -451,8 +451,8 @@ object Speedy {
           val newArgsLimit = Math.min(missing, newArgs.length)
 
           // Keep some space free, because both `KFun` and `KPushTo` will add to the list.
-          val functionArgs = new util.ArrayList[SValue](args.size + newArgsLimit)
-          functionArgs.addAll(args)
+          val extendedArgs = new util.ArrayList[SValue](args.size + newArgsLimit)
+          extendedArgs.addAll(args)
 
           // Stash away over-applied arguments, if any.
           val othersLength = newArgs.length - missing
@@ -462,13 +462,13 @@ object Speedy {
             machine.kont.add(KArg(others))
           }
 
-          machine.kont.add(KFun(prim, functionArgs, arity))
+          machine.kont.add(KFun(prim, extendedArgs, arity))
 
           // Start evaluating the arguments.
           var i = 1
           while (i < newArgsLimit) {
             val arg = newArgs(newArgsLimit - i)
-            machine.kont.add(KPushTo(functionArgs, arg))
+            machine.kont.add(KPushTo(extendedArgs, arg))
             i = i + 1
           }
           machine.ctrl = CtrlExpr(newArgs(0))


### PR DESCRIPTION
Couple of things I noticed when going through the profiling logs.

First of all, I created a special-case `FrontStack.apply` to speed up equality checks. `areEqual` constructs a one-element `FrontStack`, which should be cheap, but turns out to be expensive because it constructs builders along the way. This provides overloads for `apply` that construct the FrontStack directly, rather than jumping through hoops.

This also changes the behavior of `FrontStack#equals` to check the length first, which makes the tests work but might also help performance.

Secondly, I modified Speedy to allocate arrays with enough space to push a function and arguments. We spend a fair amount of time in `ArrayList#add`; this lessens that by making sure than when we clone the `args` array for function application, we leave some room for adding the arguments.

Lastly, I merged `length` and `len` in `FrontStack`, `BackStack`, and `ImmArray`. There was no need to have both.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
