### PR TITLE
Small fix in formatting to be consistent with other parts

### DIFF
--- a/docs/source/concepts/ledger-model/ledger-integrity.rst
+++ b/docs/source/concepts/ledger-model/ledger-integrity.rst
@@ -76,7 +76,7 @@ Definition »contract consistency«
 
   #. either `act` is itself **Create c** or a **Create c** happens before `act`
   #. `act` does not happen before any **Create c** action
-  #. `act` does not happen after any exercise consuming `c`.
+  #. `act` does not happen after any **Exercise** action consuming `c`.
 
 
 The consistency condition rules out the double spend example.


### PR DESCRIPTION
Create and Exercise keywords are usually emboldened in the docs.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
