### PR TITLE
sandbox: Re-enable "no seeding mode" for the StandaloneApiServer.

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -51,7 +51,7 @@ trait ConfigProvider[ExtraConfig] {
       maxInboundMessageSize = Config.DefaultMaxInboundMessageSize,
       eventsPageSize = config.eventsPageSize,
       portFile = participantConfig.portFile,
-      seeding = config.seeding,
+      seeding = Some(config.seeding),
     )
 
   def commandConfig(config: Config[ExtraConfig]): CommandConfiguration =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServerConfig.scala
@@ -16,11 +16,11 @@ case class ApiServerConfig(
     participantId: ParticipantId,
     archiveFiles: List[File],
     port: Port,
-    address: Option[String], // address for ledger-api server to bind to, defaulting to `localhost` for None
+    address: Option[String], // This defaults to "localhost" when set to `None`.
     jdbcUrl: String,
     tlsConfig: Option[TlsConfiguration],
     maxInboundMessageSize: Int,
     eventsPageSize: Int = IndexConfiguration.DefaultEventsPageSize,
     portFile: Option[Path],
-    seeding: Seeding,
+    seeding: Option[Seeding] // Third-party participants may need to set this to `None`.
 )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -107,7 +107,7 @@ final class StandaloneApiServer(
               optTimeServiceBackend = timeServiceBackend,
               metrics = metrics,
               healthChecks = healthChecks,
-              seedService = Some(SeedService(config.seeding)),
+              seedService = config.seeding.map(SeedService(_)),
             )(mat, esf, logCtx)
             .map(_.withServices(otherServices))
         },

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -190,7 +190,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     maxInboundMessageSize = config.maxInboundMessageSize,
                     eventsPageSize = config.eventsPageSize,
                     portFile = config.portFile,
-                    seeding = seeding,
+                    seeding = Some(seeding),
                   ),
                   commandConfig = config.commandConfig,
                   partyConfig = config.partyConfig,


### PR DESCRIPTION
Turns out not every participant can support seeding (yet).

Resolves #5077 (again).

### Changelog

- **[Ledger API Server]** Re-introduce an option to disable seeding. This does not affect Sandbox.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
