### PR TITLE
sandbox: Reset the time service when resetting in Static Time mode.

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -214,7 +214,7 @@ final class SandboxServer(
 
     val (acs, ledgerEntries, mbLedgerTime) = createInitialState(config, packageStore)
 
-    val timeProviderType = config.timeProviderType.getOrElse(TimeProviderType.WallClock)
+    val timeProviderType = config.timeProviderType.getOrElse(SandboxConfig.DefaultTimeProviderType)
     val (timeProvider, timeServiceBackendO: Option[TimeServiceBackend]) =
       (mbLedgerTime, timeProviderType) match {
         case (None, TimeProviderType.WallClock) => (TimeProvider.UTC, None)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -56,6 +56,8 @@ object SandboxConfig {
 
   val DefaultEventsPageSize: Int = 1000
 
+  val DefaultTimeProviderType: TimeProviderType = TimeProviderType.WallClock
+
   lazy val nextDefault: SandboxConfig =
     SandboxConfig(
       address = None,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -82,7 +82,8 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
         ("in-memory", InMemoryLedgerJdbcUrl, InMemoryIndexJdbcUrl, StartupMode.ResetAndStart)
     }
 
-  private val timeProviderType = config.timeProviderType.getOrElse(TimeProviderType.WallClock)
+  private val timeProviderType =
+    config.timeProviderType.getOrElse(SandboxConfig.DefaultTimeProviderType)
 
   private val seeding = config.seeding.getOrElse {
     throw new InvalidConfigException(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -103,13 +103,6 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
       implicit val actorSystem: ActorSystem = ActorSystem("sandbox")
       implicit val materializer: Materializer = Materializer(actorSystem)
 
-      val timeServiceBackend = timeProviderType match {
-        case TimeProviderType.Static =>
-          Some(TimeServiceBackend.simple(Instant.EPOCH))
-        case TimeProviderType.WallClock =>
-          None
-      }
-
       val owner = for {
         // Take ownership of the actor system and materializer so they're cleaned up properly.
         // This is necessary because we can't declare them as implicits within a `for` comprehension.
@@ -133,6 +126,12 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     // Resetting through Flyway removes all tables in the database schema.
                     // Therefore we don't need to "reset" the KV Ledger and Index separately.
                     ResourceOwner.forFuture(() => new FlywayMigrations(indexJdbcUrl).reset())
+                }
+                timeServiceBackend = timeProviderType match {
+                  case TimeProviderType.Static =>
+                    Some(TimeServiceBackend.simple(Instant.EPOCH))
+                  case TimeProviderType.WallClock =>
+                    None
                 }
                 readerWriter <- new SqlLedgerReaderWriter.Owner(
                   initialLedgerId = specifiedLedgerId,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceIT.scala
@@ -11,14 +11,16 @@ import scala.ref.WeakReference
 
 final class ResetServiceIT extends ResetServiceITBase with SandboxFixture {
   "ResetService" when {
-    "clear out all garbage" in {
-      val state = new WeakReference(Await.result(server.sandboxState, 5.seconds))
-      for {
-        lid <- fetchLedgerId()
-        _ <- reset(lid)
-      } yield {
-        System.gc()
-        state.get should be(None)
+    "state is reset" should {
+      "clear out all garbage" in {
+        val state = new WeakReference(Await.result(server.sandboxState, 5.seconds))
+        for {
+          lid <- fetchLedgerId()
+          _ <- reset(lid)
+        } yield {
+          System.gc()
+          state.get should be(None)
+        }
       }
     }
   }


### PR DESCRIPTION
The test, unfortunately, is `@Ignore`d due to flakiness in CI, so won't actually be run. However, I _hope_ we're going to remove that annotation eventually, and it allowed me to test-drive the fix on my machine, so it's still helpful.

Resolves #5508.

### Changelog

- **[Sandbox]** Fix a regression in the ResetService which did not reset the TimeService in static time mode.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
