### PR TITLE
Haskell: Add assertFileExists to DA.Test.Util

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -79,7 +79,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
             , "  - daml-stdlib"
             ]
         buildProject projectA
-        assertBool "a-1.0.dar was not created." =<< doesFileExist aDar
+        assertFileExists aDar
         step "Creating project b..."
         createDirectoryIfMissing True (projectB </> "daml")
         writeFileUTF8 (projectB </> "daml" </> "B.daml") $ unlines
@@ -106,7 +106,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
             -- the last option checks that module aliases work and modules imported without aliases
             -- are still exposed.
         buildProject projectB
-        assertBool "b.dar was not created." =<< doesFileExist bDar
+        assertFileExists bDar
     , testCaseSteps "Dependency on a package with source: A.daml" $ \step -> withTempDir $ \tmpDir -> do
         let projectA = tmpDir </> "a"
         let projectB = tmpDir </> "b"
@@ -127,7 +127,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
             , "  - daml-stdlib"
             ]
         buildProject projectA
-        assertBool "a-1.0.dar was not created." =<< doesFileExist aDar
+        assertFileExists aDar
         step "Creating project b..."
         createDirectoryIfMissing True projectB
         writeFileUTF8 (projectB </> "B.daml") $ unlines
@@ -145,7 +145,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
             , "  - " <> aDar
             ]
         buildProject projectB
-        assertBool "b.dar was not created." =<< doesFileExist bDar
+        assertFileExists bDar
         darFiles <- Zip.filesInArchive . Zip.toArchive <$> BSL.readFile bDar
         assertBool "b.dar contains source file from package database" $
             not $ any ("A.daml" `isSuffixOf`) darFiles
@@ -171,7 +171,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
           ]
         buildProject projDir
         let dar = projDir </> ".daml" </> "dist" </> "proj-1.0.dar"
-        assertBool "proj.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
         darFiles <- Zip.filesInArchive . Zip.toArchive <$> BSL.readFile dar
         assertBool "A.daml is missing" (any (\f -> takeFileName f == "A.daml") darFiles)
 
@@ -201,7 +201,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
             (\ _ -> buildProject projDir)
 
         let dar = projDir </> ".daml" </> "dist" </> "proj-1.0.dar"
-        assertBool "proj.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
         archive <- Zip.toArchive <$> BSL.readFile dar
         Just entry <- pure $ Zip.findEntryByPath "META-INF/MANIFEST.MF" archive
         let lines = BSL.Char8.lines (Zip.fromEntry entry)
@@ -227,7 +227,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
           ]
         buildProject projDir
         let dar = projDir </> ".daml/dist/proj-0.1.0.dar"
-        assertBool "proj-0.1.0.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
         darFiles <- Zip.filesInArchive . Zip.toArchive <$> BSL.readFile dar
         forM_ ["A.daml", "A.hi", "A.hie", "B.daml", "B.hi", "B.hie"] $ checkDarFile darFiles "."
     , testCase "Root source file in subdir" $ withTempDir $ \projDir -> do
@@ -251,7 +251,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
           ]
         buildProject projDir
         let dar = projDir </> ".daml/dist/proj-0.1.0.dar"
-        assertBool "proj-0.1.0.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
         darFiles <- Zip.filesInArchive . Zip.toArchive <$> BSL.readFile dar
         checkDarFile darFiles "A" "B.daml"
         checkDarFile darFiles "A" "B.hi"
@@ -275,7 +275,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
           ]
         buildProject projDir
         let dar = projDir </> ".daml/dist/proj-0.1.0.dar"
-        assertBool "proj-0.1.0.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
         darFiles <- Zip.filesInArchive . Zip.toArchive <$> BSL.readFile dar
         let allDalfFilesHavePkgId = and $ do
               fp <- darFiles
@@ -1241,7 +1241,7 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
             ["--with-archive-choice" | withArchiveChoice ] <> ["simple-dalf-0.0.0.dalf"]
         withCurrentDirectory projDir $ callProcess damlc ["build", "--target=1.dev", "--generated-src"]
         let dar = projDir </> ".daml/dist/proj-0.1.0.dar"
-        assertBool "proj-0.1.0.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
         callProcessSilent damlc ["test", "--target=1.dev", "--project-root", projDir, "--generated-src"]
     | withArchiveChoice <- [False, True]
     ] <>

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -116,13 +116,13 @@ packagingTests = testGroup "packaging"
         callCommandSilent $ unwords ["daml", "new", projDir, "copy-trigger"]
         withCurrentDirectory projDir $ callCommandSilent "daml build"
         let dar = projDir </> ".daml" </> "dist" </> "copy-trigger-0.0.1.dar"
-        assertBool "copy-trigger-0.1.0.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
      , testCase "Build copy trigger with LF version 1.dev" $ withTempDir $ \tmpDir -> do
         let projDir = tmpDir </> "copy-trigger"
         callCommandSilent $ unwords ["daml", "new", projDir, "copy-trigger"]
         withCurrentDirectory projDir $ callCommandSilent "daml build --target 1.dev"
         let dar = projDir </> ".daml" </> "dist" </> "copy-trigger-0.0.1.dar"
-        assertBool "copy-trigger-0.1.0.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
      , testCase "Build trigger with extra dependency" $ withTempDir $ \tmpDir -> do
         let myDepDir = tmpDir </> "mydep"
         createDirectoryIfMissing True (myDepDir </> "daml")
@@ -161,19 +161,19 @@ packagingTests = testGroup "packaging"
             ]
         withCurrentDirectory myTriggerDir $ callCommandSilent "daml build -o mytrigger.dar"
         let dar = myTriggerDir </> "mytrigger.dar"
-        assertBool "mytrigger.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
      , testCase "Build DAML script example" $ withTempDir $ \tmpDir -> do
         let projDir = tmpDir </> "script-example"
         callCommandSilent $ unwords ["daml", "new", projDir, "script-example"]
         withCurrentDirectory projDir $ callCommandSilent "daml build"
         let dar = projDir </> ".daml/dist/script-example-0.0.1.dar"
-        assertBool "script-example-0.0.1.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
      , testCase "Build DAML script example with LF version 1.dev" $ withTempDir $ \tmpDir -> do
         let projDir = tmpDir </> "script-example"
         callCommandSilent $ unwords ["daml", "new", projDir, "script-example"]
         withCurrentDirectory projDir $ callCommandSilent "daml build --target 1.dev"
         let dar = projDir </> ".daml/dist/script-example-0.0.1.dar"
-        assertBool "script-example-0.0.1.dar was not created." =<< doesFileExist dar
+        assertFileExists dar
      , testCase "Package depending on daml-script and daml-trigger can use data-dependencies" $ withTempDir $ \tmpDir -> do
         callCommandSilent $ unwords ["daml", "new", tmpDir </> "data-dependency"]
         withCurrentDirectory (tmpDir </> "data-dependency") $ callCommandSilent "daml build -o data-dependency.dar"
@@ -554,8 +554,7 @@ createDamlAppTests = testGroup "create-daml-app" [gettingStartedGuideTest | not 
           callCommandSilent "daml build"
           setupYarnEnv tmpDir (Workspaces ["create-daml-app/daml.js"]) [DamlTypes]
           callCommandSilent "daml codegen js -o daml.js .daml/dist/create-daml-app-0.1.0.dar"
-        doesFileExist (cdaDir </> "ui" </> "build" </> "index.html") >>=
-          assertBool "ui/build/index.html does not yet exist" . not
+        assertFileDoesNotExist (cdaDir </> "ui" </> "build" </> "index.html")
         withCurrentDirectory (cdaDir </> "ui") $ do
           -- NOTE(MH): We set up the yarn env again to avoid having all the
           -- dependencies of the UI already in scope when `daml2js` runs
@@ -565,8 +564,7 @@ createDamlAppTests = testGroup "create-daml-app" [gettingStartedGuideTest | not 
           retry 3 (callCommandSilent "yarn install")
           callCommandSilent "yarn lint --max-warnings 0"
           callCommandSilent "yarn build"
-        doesFileExist (cdaDir </> "ui" </> "build" </> "index.html") >>=
-          assertBool "ui/build/index.html has been produced"
+        assertFileExists (cdaDir </> "ui" </> "build" </> "index.html")
 
 damlInstallerName :: String
 damlInstallerName

--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
@@ -278,11 +278,6 @@ tests yarn damlc daml2js davl = testGroup "daml2js tests"
       assertFileExists (proj </> "src" </> file <.> "ts")
       assertFileExists (proj </> "lib" </> file <.> "js")
       assertFileExists (proj </> "lib" </> file <.> "d.ts")
-        where
-          assertFileExists :: FilePath -> IO ()
-          assertFileExists file = doesFileExist file >>= assertBool (file ++ " was not created")
-    assertFileDoesNotExist :: FilePath -> IO ()
-    assertFileDoesNotExist file = doesFileExist file >>= assertBool (file ++ " should not exist") . not
 
     assertFileLines :: FilePath -> [T.Text] -> IO ()
     assertFileLines file expectedContent = do

--- a/libs-haskell/test-utils/BUILD.bazel
+++ b/libs-haskell/test-utils/BUILD.bazel
@@ -11,6 +11,7 @@ da_haskell_library(
     srcs = glob(["DA/Test/**/*.hs"]),
     hackage_deps = [
         "base",
+        "directory",
         "extra",
         "filepath",
         "network",

--- a/libs-haskell/test-utils/DA/Test/Util.hs
+++ b/libs-haskell/test-utils/DA/Test/Util.hs
@@ -11,12 +11,15 @@ module DA.Test.Util (
     withEnv,
     nullDevice,
     withDevNull,
+    assertFileExists,
+    assertFileDoesNotExist,
 ) where
 
 import Control.Monad
 import Control.Exception.Safe
 import Data.List.Extra (isInfixOf)
 import qualified Data.Text as T
+import System.Directory
 import System.IO.Extra
 import System.Info.Extra
 import System.Environment.Blank
@@ -75,3 +78,9 @@ withEnv vs m = bracket pushEnv popEnv (const m)
                     Nothing -> unsetEnv key
                     Just val -> setEnv key val True
                 pure (key, oldVal)
+
+assertFileExists :: FilePath -> IO ()
+assertFileExists file = doesFileExist file >>= assertBool (file ++ " was expected to exist, but does not exist")
+
+assertFileDoesNotExist :: FilePath -> IO ()
+assertFileDoesNotExist file = doesFileExist file >>= assertBool (file ++ " was expected to not exist, but does exist") . not


### PR DESCRIPTION
This PR adds a helper function `assertFileExists` that captures the
`doesFileExist ... >>= assertBool ...` pattern that is very common in
our Haskell test suites. It also adds the inverse
`assertFileDoesNotExist` function. Both functions are now used where
appropriate.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5520)
<!-- Reviewable:end -->
