### PR TITLE
Fix unstableSplitOn

### DIFF
--- a/compiler/damlc/tests/daml-test-files/UnstableText.daml
+++ b/compiler/damlc/tests/daml-test-files/UnstableText.daml
@@ -48,6 +48,7 @@ testUnstableSplitOn = scenario do
   T.unstableSplitOn " " " "               === [ "", "" ]
   T.unstableSplitOn " " "foo bar baz"     === [ "foo", "bar", "baz" ]
   T.unstableSplitOn " " "  foo bar baz  " === [ "", "", "foo", "bar", "baz", "", "" ]
+  T.unstableSplitOn " " "foo  bar" === [ "foo", "", "bar" ]
   T.unstableSplitOn "." "4"               === [ "4" ]
   T.unstableSplitOn "." "4."              === [ "4", "" ]
   T.unstableSplitOn "." "4.0"             === [ "4", "0" ]

--- a/compiler/damlc/tests/daml-test-files/UnstableText.daml
+++ b/compiler/damlc/tests/daml-test-files/UnstableText.daml
@@ -1,0 +1,58 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @SINCE-LF 1.dev
+module UnstableText where
+
+import DA.Text as T
+import DA.Assert
+
+testUnstableDrop : Scenario ()
+testUnstableDrop = do
+  T.unstableDrop 0 "abc" === "abc"
+  T.unstableDrop 1 "abc" === "bc"
+  T.unstableDrop 2 "abc" === "c"
+  T.unstableDrop 3 "abc" === ""
+  T.unstableDrop 4 "abc" === ""
+
+testUnstableTake : Scenario ()
+testUnstableTake = do
+  T.unstableTake 0 "abc" === ""
+  T.unstableTake 1 "abc" === "a"
+  T.unstableTake 2 "abc" === "ab"
+  T.unstableTake 3 "abc" === "abc"
+  T.unstableTake 4 "abc" === "abc"
+
+testBreakOn : Scenario ()
+testBreakOn = do
+  T.unstableBreakOn "|" "|"     === ("", "|")
+  T.unstableBreakOn "|" "|b"    === ("", "|b")
+  T.unstableBreakOn "|" "a|"    === ("a", "|")
+  T.unstableBreakOn "|" "a|b"   === ("a", "|b")
+  T.unstableBreakOn "|" "a|b|c" === ("a", "|b|c")
+  T.unstableBreakOn "|" "ab"    === ("ab", "")
+
+testUnstableStripInfix : Scenario ()
+testUnstableStripInfix = do
+  T.unstableStripInfix "|" "|"     === Some ("", "")
+  T.unstableStripInfix "|" "|b"    === Some ("", "b")
+  T.unstableStripInfix "|" "a|"    === Some ("a", "")
+  T.unstableStripInfix "|" "a|b"   === Some ("a", "b")
+  T.unstableStripInfix "|" "a|b|c" === Some ("a", "b|c")
+  T.unstableStripInfix "|" "ab"    === None
+
+testUnstableSplitOn = scenario do
+  T.unstableSplitOn "" ""                 === [ "" ]
+  T.unstableSplitOn "" " "                === [ " " ]
+  T.unstableSplitOn " " ""                === [ "" ]
+  T.unstableSplitOn " " " "               === [ "", "" ]
+  T.unstableSplitOn " " "foo bar baz"     === [ "foo", "bar", "baz" ]
+  T.unstableSplitOn " " "  foo bar baz  " === [ "", "", "foo", "bar", "baz", "", "" ]
+  T.unstableSplitOn "." "4"               === [ "4" ]
+  T.unstableSplitOn "." "4."              === [ "4", "" ]
+  T.unstableSplitOn "." "4.0"             === [ "4", "0" ]
+  T.unstableSplitOn "." "4.3.2.1."        === [ "4", "3", "2", "1", "" ]
+  T.unstableSplitOn "\\." "4"             === [ "4" ]
+  T.unstableSplitOn "\\." "4."            === [ "4." ]
+  T.unstableSplitOn "\\." "4.0"           === [ "4.0" ]
+  T.unstableSplitOn "\\." "4.3.2.1."      === [ "4.3.2.1." ]


### PR DESCRIPTION
unstableSplitOn is supposed to behave like splitOn but fast™ but it
didn’t live up to that promise for a few reasons:

1. Java’s split method by default drops empty strings at the
   end. Passing a second negative parameter avoids that.
2. Java’s split method does regex splitting so we need to quote the
   string.
3. Java’s split method splits on an empty pattern whereas we want to
   simply preserve the input.

I’ve added regression tests for this and for unstableDrop and a few
other functions while I was at it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
