### PR TITLE
Drop verbose output from conformance tests

### DIFF
--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -354,7 +354,6 @@ server_conformance_test(
     ],
     servers = SERVERS,
     test_tool_args = [
-        "--verbose",
         "--open-world",
         "--all-tests",
         "--exclude=ConfigManagementServiceIT",
@@ -369,7 +368,6 @@ server_conformance_test(
     ],
     servers = SERVERS,
     test_tool_args = [
-        "--verbose",
         "--open-world",
         "--all-tests",
         "--exclude=ConfigManagementServiceIT",
@@ -384,7 +382,6 @@ server_conformance_test(
     ],
     servers = SERVERS,
     test_tool_args = [
-        "--verbose",
         "--open-world",
         "--include=ConfigManagementServiceIT",
     ],
@@ -397,7 +394,6 @@ server_conformance_test(
     ],
     servers = SERVERS,
     test_tool_args = [
-        "--verbose",
         "--open-world",
         "--include=CommandDeduplicationIT",
     ],
@@ -411,7 +407,6 @@ server_conformance_test(
     ],
     servers = SERVERS,
     test_tool_args = [
-        "--verbose",
         "--open-world",
         "--all-tests",
         "--exclude=ConfigManagementServiceIT",
@@ -445,7 +440,6 @@ server_conformance_test(
     ],
     servers = NEXT_SERVERS,
     test_tool_args = [
-        "--verbose",
         "--open-world",
         "--all-tests",
         "--exclude=ClosedWorldIT",
@@ -460,7 +454,6 @@ server_conformance_test(
     ],
     servers = NEXT_SERVERS,
     test_tool_args = [
-        "--verbose",
         "--open-world",
         "--all-tests",
         "--exclude=ClosedWorldIT",
@@ -475,7 +468,6 @@ server_conformance_test(
     ],
     servers = NEXT_SERVERS,
     test_tool_args = [
-        "--verbose",
         "--open-world",
         "--include=ConfigManagementServiceIT",
     ],


### PR DESCRIPTION
It rarely adds any useful information and mostly makes the output difficult to read.

It can be re-enabled on a need basis, of course.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
