### PR TITLE
replace Windows agents

### DIFF
--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -129,7 +129,7 @@ net start winrm
 echo "== Installing the VSTS agent"
 
 $MachineName = Get-CimInstance -ClassName Win32_OperatingSystem | Select-Object CSName | ForEach{ $_.CSName }
-choco install azure-pipelines-agent --no-progress --yes --params "'/Token:${local.vsts_token} /Pool:${local.vsts_pool} /Url:https://dev.azure.com/${local.vsts_account}/ /LogonAccount:$Account /LogonPassword:$Password /Work:D:\a /AgentName:$MachineName'"
+choco install azure-pipelines-agent --no-progress --yes --params "'/Token:${local.vsts_token} /Pool:${local.vsts_pool} /Url:https://dev.azure.com/${local.vsts_account}/ /LogonAccount:$Account /LogonPassword:$Password /Work:D:\a /AgentName:$MachineName /Replace'"
 echo OK
 SYSPREP_SPECIALIZE
 


### PR DESCRIPTION
It looks like the change in Windows agent names has caused an issue: because Windows agents are not always properly cleaned up on shutdown, i.e. they do not always have time to tell Azure they are going away, and because GCP likes to reuse the same names for machines in a group, we've been seeing errors like:

```
ERROR: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Pool 11 already contains an agent with name VSTS-WIN-3QCX.
```

recently. Today, only 2 out of our 6 agents have managed to register with Azure. This PR should fix that.

ChaNGELOG_BEGIN
CHANGELOG_END