### PR TITLE
Sadbonx: Add migration that backfills the participant_events table

### DIFF
--- a/ledger/sandbox/src/main/resources/logback.xml
+++ b/ledger/sandbox/src/main/resources/logback.xml
@@ -32,6 +32,7 @@
     for the usual startup info logging (which port, dar files, etc...)
     -->
     <logger name="com.daml.platform.sandboxnext" level="INFO" />
+    <logger name="com.daml.platform.sandbox" level="INFO" />
     <logger name="com.daml.platform.apiserver.LedgerApiServer" level="INFO" />
 
     <root level="INFO">

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V25__Backfill_Participant_Events.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V25__Backfill_Participant_Events.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package db.migration.postgres
+
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.lf.data.Ref
+import com.daml.platform.events.EventIdFormatter
+import com.daml.platform.store.serialization.TransactionSerializer
+import db.migration.postgres.v25_backfill_participant_events.V25TransactionsWriter
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+
+class V25__Backfill_Participant_Events extends BaseJavaMigration {
+
+  val SELECT_TRANSACTIONS = "select * from ledger_entries where typ='transaction'"
+
+  override def migrate(context: Context): Unit = {
+    val conn = context.getConnection
+    val loadTransactions = conn.createStatement()
+    val rows = loadTransactions.executeQuery(SELECT_TRANSACTIONS)
+
+    def getNonEmptyString(name: String): Option[String] =
+      Option(rows.getString(name)).filter(s => !rows.wasNull() && s.nonEmpty)
+
+    while (rows.next()) {
+      val transactionId = Ref.LedgerString.assertFromString(rows.getString("transaction_id"))
+      val applicationId =
+        getNonEmptyString("application_id").map(Ref.LedgerString.assertFromString)
+      val commandId = getNonEmptyString("command_id").map(Ref.LedgerString.assertFromString)
+      val submitter = getNonEmptyString("submitter").map(Ref.Party.assertFromString)
+      val workflowId = getNonEmptyString("workflow_id").map(Ref.LedgerString.assertFromString)
+      val let = rows.getTimestamp("effective_at").toInstant
+      val offset = Offset.fromByteArray(rows.getBytes("ledger_offset"))
+
+      val transaction = TransactionSerializer
+        .deserializeTransaction(rows.getBinaryStream("transaction"))
+        .getOrElse(sys.error(s"failed to deserialize transaction $transactionId"))
+        .mapNodeId(evId => EventIdFormatter.split(evId).map(_.nodeId).get)
+
+      V25TransactionsWriter.apply(
+        applicationId,
+        workflowId,
+        transactionId,
+        commandId,
+        submitter,
+        transaction.roots.toSeq.toSet,
+        let,
+        offset,
+        transaction,
+      )(conn)
+    }
+    loadTransactions.close()
+  }
+
+}

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/V25EventsTableInsert.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/V25EventsTableInsert.scala
@@ -1,0 +1,295 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package db.migration.postgres.v25_backfill_participant_events
+
+import java.time.Instant
+
+import anorm.{BatchSql, NamedParameter}
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger._
+import com.daml.platform.events.EventIdFormatter.fromTransactionId
+import com.daml.platform.store.Conversions._
+import com.daml.platform.store.serialization.ValueSerializer.{serializeValue => serialize}
+
+// Copied here to make it safe against future refactoring
+// in production code
+private[v25_backfill_participant_events] object V25EventsTableInsert {
+
+  private def cantSerialize(attribute: String, forContract: ContractId): String =
+    s"Cannot serialize $attribute for ${forContract.coid}"
+
+  private def serializeCreateArgOrThrow(node: Create): Array[Byte] =
+    serialize(
+      value = node.coinst.arg,
+      errorContext = cantSerialize(attribute = "create argument", forContract = node.coid),
+    )
+
+  private def serializeNullableKeyOrThrow(node: Create): Option[Array[Byte]] =
+    node.key.map(
+      k =>
+        serialize(
+          value = k.key,
+          errorContext = cantSerialize(attribute = "key", forContract = node.coid),
+      ))
+
+  private def serializeExerciseArgOrThrow(node: Exercise): Array[Byte] =
+    serialize(
+      value = node.chosenValue,
+      errorContext = cantSerialize(attribute = "exercise argument", forContract = node.targetCoid),
+    )
+
+  private def serializeNullableExerciseResultOrThrow(node: Exercise): Option[Array[Byte]] =
+    node.exerciseResult.map(exerciseResult =>
+      serialize(
+        value = exerciseResult,
+        errorContext = cantSerialize(attribute = "exercise result", forContract = node.targetCoid),
+    ))
+
+  private def insertEvent(columnNameAndValues: (String, String)*): String = {
+    val (columns, values) = columnNameAndValues.unzip
+    s"insert into participant_events(${columns.mkString(", ")}) values (${values.mkString(", ")})"
+  }
+
+  private val insertCreate: String =
+    insertEvent(
+      "event_id" -> "{event_id}",
+      "event_offset" -> "{event_offset}",
+      "contract_id" -> "{contract_id}",
+      "transaction_id" -> "{transaction_id}",
+      "workflow_id" -> "{workflow_id}",
+      "ledger_effective_time" -> "{ledger_effective_time}",
+      "template_package_id" -> "{template_package_id}",
+      "template_name" -> "{template_name}",
+      "node_index" -> "{node_index}",
+      "is_root" -> "{is_root}",
+      "command_id" -> "{command_id}",
+      "application_id" -> "{application_id}",
+      "submitter" -> "{submitter}",
+      "create_argument" -> "{create_argument}",
+      "create_signatories" -> "{create_signatories}",
+      "create_observers" -> "{create_observers}",
+      "create_agreement_text" -> "{create_agreement_text}",
+      "create_consumed_at" -> "null",
+      "create_key_value" -> "{create_key_value}"
+    )
+
+  private def create(
+      applicationId: Option[ApplicationId],
+      workflowId: Option[WorkflowId],
+      commandId: Option[CommandId],
+      transactionId: TransactionId,
+      nodeId: NodeId,
+      submitter: Option[Party],
+      roots: Set[NodeId],
+      ledgerEffectiveTime: Instant,
+      offset: Offset,
+      create: Create,
+  ): Vector[NamedParameter] =
+    Vector[NamedParameter](
+      "event_id" -> fromTransactionId(transactionId, nodeId),
+      "event_offset" -> offset,
+      "contract_id" -> create.coid.coid,
+      "transaction_id" -> transactionId,
+      "workflow_id" -> workflowId,
+      "ledger_effective_time" -> ledgerEffectiveTime,
+      "template_package_id" -> create.coinst.template.packageId,
+      "template_name" -> create.coinst.template.qualifiedName,
+      "node_index" -> nodeId.index,
+      "is_root" -> roots(nodeId),
+      "command_id" -> commandId,
+      "application_id" -> applicationId,
+      "submitter" -> submitter,
+      "create_argument" -> serializeCreateArgOrThrow(create),
+      "create_signatories" -> create.signatories.toArray[String],
+      "create_observers" -> create.stakeholders.diff(create.signatories).toArray[String],
+      "create_agreement_text" -> Some(create.coinst.agreementText).filter(_.nonEmpty),
+      "create_key_value" -> serializeNullableKeyOrThrow(create),
+    )
+
+  private val insertExercise =
+    insertEvent(
+      "event_id" -> "{event_id}",
+      "event_offset" -> "{event_offset}",
+      "contract_id" -> "{contract_id}",
+      "transaction_id" -> "{transaction_id}",
+      "workflow_id" -> "{workflow_id}",
+      "ledger_effective_time" -> "{ledger_effective_time}",
+      "template_package_id" -> "{template_package_id}",
+      "template_name" -> "{template_name}",
+      "node_index" -> "{node_index}",
+      "is_root" -> "{is_root}",
+      "command_id" -> "{command_id}",
+      "application_id" -> "{application_id}",
+      "submitter" -> "{submitter}",
+      "exercise_consuming" -> "{exercise_consuming}",
+      "exercise_choice" -> "{exercise_choice}",
+      "exercise_argument" -> "{exercise_argument}",
+      "exercise_result" -> "{exercise_result}",
+      "exercise_actors" -> "{exercise_actors}",
+      "exercise_child_event_ids" -> "{exercise_child_event_ids}"
+    )
+
+  private def exercise(
+      applicationId: Option[ApplicationId],
+      workflowId: Option[WorkflowId],
+      commandId: Option[CommandId],
+      transactionId: TransactionId,
+      nodeId: NodeId,
+      submitter: Option[Party],
+      roots: Set[NodeId],
+      ledgerEffectiveTime: Instant,
+      offset: Offset,
+      exercise: Exercise,
+  ): Vector[NamedParameter] =
+    Vector[NamedParameter](
+      "event_id" -> fromTransactionId(transactionId, nodeId),
+      "event_offset" -> offset,
+      "contract_id" -> exercise.targetCoid.coid,
+      "transaction_id" -> transactionId,
+      "workflow_id" -> workflowId,
+      "ledger_effective_time" -> ledgerEffectiveTime,
+      "template_package_id" -> exercise.templateId.packageId,
+      "template_name" -> exercise.templateId.qualifiedName,
+      "node_index" -> nodeId.index,
+      "is_root" -> roots(nodeId),
+      "command_id" -> commandId,
+      "application_id" -> applicationId,
+      "submitter" -> submitter,
+      "exercise_consuming" -> exercise.consuming,
+      "exercise_choice" -> exercise.choiceId,
+      "exercise_argument" -> serializeExerciseArgOrThrow(exercise),
+      "exercise_result" -> serializeNullableExerciseResultOrThrow(exercise),
+      "exercise_actors" -> exercise.actingParties.toArray[String],
+      "exercise_child_event_ids" -> exercise.children
+        .map(fromTransactionId(transactionId, _))
+        .toArray[String],
+    )
+
+  private val updateArchived =
+    """update participant_events set create_consumed_at={consumed_at} where contract_id={contract_id} and create_argument is not null"""
+
+  private def archive(
+      contractId: ContractId,
+      consumedAt: Offset,
+  ): Vector[NamedParameter] =
+    Vector[NamedParameter](
+      "consumed_at" -> consumedAt,
+      "contract_id" -> contractId.coid,
+    )
+
+  sealed abstract case class PreparedBatches(
+      creates: Option[BatchSql],
+      exercises: Option[BatchSql],
+      archives: Option[BatchSql],
+  ) {
+    final def isEmpty: Boolean = creates.isEmpty && exercises.isEmpty && archives.isEmpty
+    final def foreach[U](f: BatchSql => U): Unit = {
+      creates.foreach(f)
+      exercises.foreach(f)
+      archives.foreach(f)
+    }
+  }
+
+  private case class AccumulatingBatches(
+      creates: Vector[Vector[NamedParameter]],
+      exercises: Vector[Vector[NamedParameter]],
+      archives: Vector[Vector[NamedParameter]],
+  ) {
+
+    def addCreate(create: Vector[NamedParameter]): AccumulatingBatches =
+      copy(creates = creates :+ create)
+
+    def addExercise(exercise: Vector[NamedParameter]): AccumulatingBatches =
+      copy(exercises = exercises :+ exercise)
+
+    def addArchive(archive: Vector[NamedParameter]): AccumulatingBatches =
+      copy(archives = archives :+ archive)
+
+    private def prepareNonEmpty(
+        query: String,
+        params: Vector[Vector[NamedParameter]],
+    ): Option[BatchSql] =
+      if (params.nonEmpty) Some(BatchSql(query, params.head, params.tail: _*)) else None
+
+    def prepare: PreparedBatches =
+      new PreparedBatches(
+        prepareNonEmpty(insertCreate, creates),
+        prepareNonEmpty(insertExercise, exercises),
+        prepareNonEmpty(updateArchived, archives),
+      ) {}
+
+  }
+
+  private object AccumulatingBatches {
+    val empty: AccumulatingBatches = AccumulatingBatches(
+      creates = Vector.empty,
+      exercises = Vector.empty,
+      archives = Vector.empty,
+    )
+  }
+
+  /**
+    * @throws RuntimeException If a value cannot be serialized into an array of bytes
+    */
+  @throws[RuntimeException]
+  def prepareBatchInsert(
+      applicationId: Option[ApplicationId],
+      workflowId: Option[WorkflowId],
+      transactionId: TransactionId,
+      commandId: Option[CommandId],
+      submitter: Option[Party],
+      roots: Set[NodeId],
+      ledgerEffectiveTime: Instant,
+      offset: Offset,
+      transaction: Transaction,
+  ): PreparedBatches =
+    transaction
+      .fold(AccumulatingBatches.empty) {
+        case (batches, (nodeId, node: Create)) =>
+          batches.addCreate(
+            create(
+              applicationId = applicationId,
+              workflowId = workflowId,
+              commandId = commandId,
+              transactionId = transactionId,
+              nodeId = nodeId,
+              submitter = submitter,
+              roots = roots,
+              ledgerEffectiveTime = ledgerEffectiveTime,
+              offset = offset,
+              create = node,
+            )
+          )
+        case (batches, (nodeId, node: Exercise)) =>
+          val batchWithExercises =
+            batches.addExercise(
+              exercise(
+                applicationId = applicationId,
+                workflowId = workflowId,
+                commandId = commandId,
+                transactionId = transactionId,
+                nodeId = nodeId,
+                submitter = submitter,
+                roots = roots,
+                ledgerEffectiveTime = ledgerEffectiveTime,
+                offset = offset,
+                exercise = node,
+              )
+            )
+          if (node.consuming) {
+            batchWithExercises.addArchive(
+              archive(
+                contractId = node.targetCoid,
+                consumedAt = offset,
+              )
+            )
+          } else {
+            batchWithExercises
+          }
+        case (batches, _) =>
+          batches // ignore any event which is neither a create nor an exercise
+      }
+      .prepare
+
+}

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/V25TransactionsWriter.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/V25TransactionsWriter.scala
@@ -1,0 +1,124 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package db.migration.postgres.v25_backfill_participant_events
+
+import java.sql.Connection
+import java.time.Instant
+
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger.{ApplicationId, CommandId, EventId, TransactionId, WorkflowId}
+import com.daml.lf.engine.Blinding
+import com.daml.lf.transaction.BlindingInfo
+import com.daml.platform.events.EventIdFormatter
+
+object V25TransactionsWriter extends V25TransactionsWriter {
+
+  private def computeDisclosureForFlatTransaction(
+      transactionId: TransactionId,
+      transaction: Transaction,
+  ): WitnessRelation[EventId] =
+    transaction.nodes.collect {
+      case (nodeId, c: Create) =>
+        EventIdFormatter.fromTransactionId(transactionId, nodeId) -> c.stakeholders
+      case (nodeId, e: Exercise) if e.consuming =>
+        EventIdFormatter.fromTransactionId(transactionId, nodeId) -> e.stakeholders
+    }
+
+  private def computeDisclosureForTransactionTree(
+      transactionId: TransactionId,
+      transaction: Transaction,
+      blinding: BlindingInfo,
+  ): WitnessRelation[EventId] = {
+    val disclosed =
+      transaction.nodes.collect {
+        case p @ (_, _: Create) => p
+        case p @ (_, _: Exercise) => p
+      }.keySet
+    blinding.disclosure.collect {
+      case (nodeId, party) if disclosed(nodeId) =>
+        EventIdFormatter.fromTransactionId(transactionId, nodeId) -> party
+    }
+  }
+
+  def apply(
+      applicationId: Option[ApplicationId],
+      workflowId: Option[WorkflowId],
+      transactionId: TransactionId,
+      commandId: Option[CommandId],
+      submitter: Option[Party],
+      roots: Set[NodeId],
+      ledgerEffectiveTime: Instant,
+      offset: Offset,
+      transaction: Transaction,
+  )(implicit connection: Connection): Unit = {
+
+    val eventBatches = V25EventsTableInsert.prepareBatchInsert(
+      applicationId = applicationId,
+      workflowId = workflowId,
+      transactionId = transactionId,
+      commandId = commandId,
+      submitter = submitter,
+      roots = roots,
+      ledgerEffectiveTime = ledgerEffectiveTime,
+      offset = offset,
+      transaction = transaction,
+    )
+
+    if (eventBatches.isEmpty) {
+
+      // Nothing to persist, avoid hitting the underlying storage
+      ()
+
+    } else {
+
+      val blinding = Blinding.blind(transaction)
+
+      val disclosureForFlatTransaction =
+        computeDisclosureForFlatTransaction(transactionId, transaction)
+
+      val disclosureForTransactionTree =
+        computeDisclosureForTransactionTree(transactionId, transaction, blinding)
+
+      // Remove witnesses for the flat transactions from the full disclosure
+      // This minimizes the data we save and allows us to use the union of the
+      // witnesses for flat transactions and its complement to filter parties
+      // for the transactions tree stream
+      val disclosureComplement =
+        Relation.diff(disclosureForTransactionTree, disclosureForFlatTransaction)
+
+      // Prepare batch inserts for flat transactions
+      val flatTransactionWitnessesBatch =
+        V25WitnessesTable.ForFlatTransactions.prepareBatchInsert(
+          witnesses = disclosureForFlatTransaction,
+        )
+
+      // Prepare batch inserts for all witnesses except those for flat transactions
+      val complementWitnessesBatch =
+        V25WitnessesTable.Complement.prepareBatchInsert(
+          witnesses = disclosureComplement,
+        )
+
+      eventBatches.foreach(_.execute())
+      flatTransactionWitnessesBatch.foreach(_.execute())
+      complementWitnessesBatch.foreach(_.execute())
+    }
+  }
+
+}
+
+trait V25TransactionsWriter {
+
+  def apply(
+      applicationId: Option[ApplicationId],
+      workflowId: Option[WorkflowId],
+      transactionId: TransactionId,
+      commandId: Option[CommandId],
+      submitter: Option[Party],
+      roots: Set[NodeId],
+      ledgerEffectiveTime: Instant,
+      offset: Offset,
+      transaction: Transaction,
+  )(implicit connection: Connection): Unit
+
+}

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/V25WitnessesTable.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/V25WitnessesTable.scala
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package db.migration.postgres.v25_backfill_participant_events
+
+import anorm.{BatchSql, NamedParameter}
+import com.daml.platform.store.Conversions._
+
+// Copied here to make it safe against future refactoring
+// in production code
+/**
+  * A table storing a flattened representation of a [[DisclosureRelation]],
+  * which says which [[NodeId]] is visible to which [[Party]].
+  */
+private[v25_backfill_participant_events] sealed abstract class V25WitnessesTable(
+    tableName: String,
+    idColumn: String,
+    witnessColumn: String,
+) {
+
+  private val insert =
+    s"insert into $tableName($idColumn, $witnessColumn) values ({$idColumn}, {$witnessColumn})"
+
+  final def prepareBatchInsert(witnesses: WitnessRelation[LedgerString]): Option[BatchSql] = {
+    val flattenedWitnesses = Relation.flatten(witnesses)
+    if (flattenedWitnesses.nonEmpty) {
+      val ws = flattenedWitnesses.map {
+        case (id, party) => Vector[NamedParameter](idColumn -> id, witnessColumn -> party)
+      }.toSeq
+      Some(BatchSql(insert, ws.head, ws.tail: _*))
+    } else {
+      None
+    }
+  }
+
+}
+
+private[v25_backfill_participant_events] object V25WitnessesTable {
+
+  private[v25_backfill_participant_events] sealed abstract class V25EventWitnessesTable(
+      tableName: String)
+      extends V25WitnessesTable(
+        tableName = tableName,
+        idColumn = "event_id",
+        witnessColumn = "event_witness",
+      )
+
+  /**
+    * Concrete [[WitnessesTable]] to store which party can see which
+    * event in a flat transaction.
+    */
+  private[v25_backfill_participant_events] object ForFlatTransactions
+      extends V25EventWitnessesTable(
+        tableName = "participant_event_flat_transaction_witnesses",
+      )
+
+  /**
+    * Concrete [[WitnessesTable]] to store which party can see which
+    * event in a transaction tree, diffed by the items that are going
+    * to be eventually stored in [[ForFlatTransactions]]
+    */
+  private[v25_backfill_participant_events] object Complement
+      extends V25EventWitnessesTable(
+        tableName = "participant_event_witnesses_complement",
+      )
+}

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package db.migration.postgres
+
+// Copied here to make it safe against future refactoring
+// in production code
+/**
+  * Type aliases used throughout the package
+  */
+package object v25_backfill_participant_events {
+
+  import com.daml.lf.value.{Value => lfval}
+  type ContractId = lfval.AbsoluteContractId
+
+  import com.daml.lf.{transaction => lftx}
+  type NodeId = lftx.Transaction.NodeId
+  type Transaction = lftx.GenTransaction.WithTxValue[NodeId, ContractId]
+  type Create = lftx.Node.NodeCreate.WithTxValue[ContractId]
+  type Exercise = lftx.Node.NodeExercises.WithTxValue[NodeId, ContractId]
+
+  import com.daml.lf.{data => lfdata}
+  type Party = lfdata.Ref.Party
+  type Identifier = lfdata.Ref.Identifier
+  type LedgerString = lfdata.Ref.LedgerString
+  type WitnessRelation[A] = lfdata.Relation.Relation[A, Party]
+  type DisclosureRelation = WitnessRelation[NodeId]
+  val Relation = lfdata.Relation.Relation
+}


### PR DESCRIPTION
We started serving the LedgerAPI from the new schema in #5104, #5305, #5346,
and #5397.

We must therefore also add a migration that moves the data from
`ledger_entries` to the new tables. Not having this migration means that existing
persistent ledgers will not see contracts/transactions created prior to the upgrade of sandbox.

To keep the migration relatively stable with respect to refactoring the
code, I copied a bunch of files to
`db.migration.postgres.v25_backfill_participant_events`.

As a bonus, I added a line to logback.xml so that we get the usual
sandbox output on startup.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
