### PR TITLE
Used `daml codegen java` instead of calling the codegen from maven

### DIFF
--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -417,6 +417,7 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart"
           runConduitRes
             $ sourceFileBS mvnDbTarball
             .| Tar.Conduit.Extra.untar (Tar.Conduit.Extra.restoreFile throwError mvnDir)
+          callCommand "daml codegen java -o target/generated-sources/iou -d com.daml.quickstart.iou.TemplateDecoder .daml/dist/quickstart-0.0.1.dar=com.daml.quickstart.model"
           callCommand $ unwords ["mvn", mvnRepoFlag, "-q", "compile"]
     , testCase "mvn exec:java@run-quickstart" $
       withCurrentDirectory quickstartDir $

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -417,7 +417,7 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart"
           runConduitRes
             $ sourceFileBS mvnDbTarball
             .| Tar.Conduit.Extra.untar (Tar.Conduit.Extra.restoreFile throwError mvnDir)
-          callCommand "daml codegen java -o target/generated-sources/iou -d com.daml.quickstart.iou.TemplateDecoder .daml/dist/quickstart-0.0.1.dar=com.daml.quickstart.model"
+          callCommand "daml codegen java"
           callCommand $ unwords ["mvn", mvnRepoFlag, "-q", "compile"]
     , testCase "mvn exec:java@run-quickstart" $
       withCurrentDirectory quickstartDir $

--- a/docs/source/app-dev/bindings-java/codegen.rst
+++ b/docs/source/app-dev/bindings-java/codegen.rst
@@ -88,15 +88,7 @@ In the following example the logging is set to print most of the output with det
 Integrate with build tools
 --------------------------
 
-While we currently don’t provide direct integration with Maven, Groovy, SBT, etc., you can run the Java codegen as described in :ref:`daml-codegen-java-running` just like any other external process (for example the protobuf compiler). Alternatively you can integrate it as a runnable dependency in your ``pom.xml`` file for Maven.
-
-The following snippet is an excerpt from the ``pom.xml`` that is part of the :ref:`quickstart` guide.
-
-  .. literalinclude:: quickstart/template-root/pom.xml
-    :language: xml
-    :lines: 47-78,94-95
-    :dedent: 12
-
+While we currently don’t provide direct integration with Maven, Groovy, SBT, etc., you can run the Java codegen as described in :ref:`daml-codegen-java-running` just like any other external process (for example the protobuf compiler).
 
 .. _daml-codegen-java-compiling:
 

--- a/docs/source/app-dev/bindings-java/quickstart.rst
+++ b/docs/source/app-dev/bindings-java/quickstart.rst
@@ -478,7 +478,7 @@ To build automations and integrations around the ledger, the SDK has :doc:`langu
 
 To compile the Java integration for the quickstart application, we first need to run the Java codegen on the DAR we built before::
 
-    daml codegen java -o target/generated-sources/iou -d com.daml.quickstart.iou.TemplateDecoder .daml/dist/quickstart-0.0.1.dar=com.daml.quickstart.model
+    daml codegen java
 
 Once the code has been generated, we can now compile it using ``mvn compile``.
 

--- a/docs/source/app-dev/bindings-java/quickstart.rst
+++ b/docs/source/app-dev/bindings-java/quickstart.rst
@@ -475,7 +475,12 @@ A distributed ledger only forms the core of a full DAML application.
 
 To build automations and integrations around the ledger, the SDK has :doc:`language bindings </app-dev/bindings-java/index>` for the Ledger API in several programming languages.
 
-To compile the Java integration for the quickstart application, run ``mvn compile``.
+
+To compile the Java integration for the quickstart application, we first need to run the Java codegen on the DAR we built before::
+
+    daml codegen java -o target/generated-sources/iou -d com.daml.quickstart.iou.TemplateDecoder .daml/dist/quickstart-0.0.1.dar=com.daml.quickstart.model
+
+Once the code has been generated, we can now compile it using ``mvn compile``.
 
 Now start the Java integration with ``mvn exec:java@run-quickstart``. Note that
 this step requires that the sandbox started :ref:`earlier

--- a/docs/source/app-dev/bindings-java/quickstart/template-root/pom.xml
+++ b/docs/source/app-dev/bindings-java/quickstart/template-root/pom.xml
@@ -58,25 +58,6 @@
                 </dependencies>
                 <executions>
                     <execution>
-                        <id>daml-codegen-java</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>java</goal>
-                        </goals>
-                        <configuration>
-                            <includeProjectDependencies>false</includeProjectDependencies>
-                            <includePluginDependencies>true</includePluginDependencies>
-                            <mainClass>com.daml.lf.codegen.Main</mainClass>
-                            <arguments>
-                                <argument>-o</argument>
-                                <argument>${daml-codegen-java.output}</argument>
-                                <argument>-d</argument>
-                                <argument>com.daml.quickstart.iou.TemplateDecoder</argument>
-                                <argument>${project.basedir}/.daml/dist/quickstart-0.0.1.dar=com.daml.quickstart.model</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>run-quickstart</id>
                         <goals>
                             <goal>java</goal>

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -120,7 +120,7 @@ latest commit on master.
       1. `daml sandbox --wall-clock-time --port 6865 .daml/dist/quickstart-0.0.1.dar`
       1. `daml script --dar .daml/dist/quickstart-0.0.1.dar --script-name Setup:initialize --ledger-host localhost --ledger-port 6865 --wall-clock-time`
       1. `daml navigator server localhost 6865 --port 7500`
-      1. `daml codegen java -o target/generated-sources/iou -d com.daml.quickstart.iou.TemplateDecoder .daml/dist/quickstart-0.0.1.dar=com.daml.quickstart.model`
+      1. `daml codegen java`
       1. `mvn compile exec:java@run-quickstart`
 
       > Note: It takes some time for our artifacts to be available on Maven

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -120,6 +120,7 @@ latest commit on master.
       1. `daml sandbox --wall-clock-time --port 6865 .daml/dist/quickstart-0.0.1.dar`
       1. `daml script --dar .daml/dist/quickstart-0.0.1.dar --script-name Setup:initialize --ledger-host localhost --ledger-port 6865 --wall-clock-time`
       1. `daml navigator server localhost 6865 --port 7500`
+      1. `daml codegen java -o target/generated-sources/iou -d com.daml.quickstart.iou.TemplateDecoder .daml/dist/quickstart-0.0.1.dar=com.daml.quickstart.model`
       1. `mvn compile exec:java@run-quickstart`
 
       > Note: It takes some time for our artifacts to be available on Maven

--- a/templates/quickstart-java/daml.yaml.template
+++ b/templates/quickstart-java/daml.yaml.template
@@ -14,3 +14,8 @@ dependencies:
   - daml-script
 sandbox-options:
   - --wall-clock-time
+codegen:
+  java:
+    package-prefix: com.daml.quickstart.model
+    output-directory: target/generated-sources/iou
+    decoderClass: com.daml.quickstart.iou.TemplateDecoder


### PR DESCRIPTION
This should hopefully fix the issues with mismatched versions of
slf4j.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
