### PR TITLE
Change gpg keyserver used in the docs

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -56,7 +56,7 @@ To do that:
 2. Download the artifact (*Assets* section, after the release notes) for your platform as well as the corresponding signature file. For example, if you are on macOS and want to install release 0.13.27, you would download the files ``daml-sdk-0.13.27-macos.tar.gz`` and ``daml-sdk-0.13.27-macos.tar.gz.asc``. Note that for Windows you can choose between the tarball, which follows the same instructions as the Linux and macOS ones (but assumes you have a number of typical Unix tools installed), or the installer, which ends with ``.exe``. Regardless, the steps to verify the signature are the same.
 3. To verify the signature, you need to have ``gpg`` installed (see https://gnupg.org for more information on that) and the Digital Asset Security Public Key imported into your keychain. Once you have ``gpg`` installed, you can import the key by running::
 
-     gpg --keyserver pgp.key-server.io --search 4911A8DFE976ACDFA07130DBE8372C0C1C734C51
+     gpg --keyserver pool.sks-keyservers.net --search 4911A8DFE976ACDFA07130DBE8372C0C1C734C51
 
    This should come back with a key belonging to ``Digital Asset Holdings, LLC <security@digitalasset.com>``, created on 2019-05-16 and expiring on 2021-05-15. If any of those details are different, something is wrong. In that case please contact Digital Asset immediately.
 4. Once the key is imported, you can ask ``gpg`` to verify that the file you have downloaded has indeed been signed by that key. Continuing with our example of v0.13.27 on macOS, you should have both files in the current directory and run::


### PR DESCRIPTION
pgp.keyserver.io seems to have lost our key
somehow. pool.sks-keyservers.net is the pool that includes the MIT gpg
keyserver and others so hopefully it is somewhat reliable.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
