### PR TITLE
Prefix Dropwizard JVM metrics in participant server

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Metrics.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Metrics.scala
@@ -13,4 +13,6 @@ private[app] object Metrics {
   val ReadServicePrefix: MetricName = ServicePrefix :+ "read"
   val WriteServicePrefix: MetricName = ServicePrefix :+ "write"
 
+  val JVMServicePrefix: MetricName = ServicePrefix :+ "jvm"
+
 }

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Metrics.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Metrics.scala
@@ -13,6 +13,6 @@ private[app] object Metrics {
   val ReadServicePrefix: MetricName = ServicePrefix :+ "read"
   val WriteServicePrefix: MetricName = ServicePrefix :+ "write"
 
-  val JVMServicePrefix: MetricName = ServicePrefix :+ "jvm"
+  val JvmServicePrefix: MetricName = ServicePrefix :+ "jvm"
 
 }

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Metrics.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Metrics.scala
@@ -13,6 +13,6 @@ private[app] object Metrics {
   val ReadServicePrefix: MetricName = ServicePrefix :+ "read"
   val WriteServicePrefix: MetricName = ServicePrefix :+ "write"
 
-  val JvmServicePrefix: MetricName = ServicePrefix :+ "jvm"
+  val JvmPrefix: MetricName = MetricName.DAML :+ "jvm"
 
 }

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.participant.state.kvutils.app.Metrics.{
   IndexServicePrefix,
   ReadServicePrefix,
   WriteServicePrefix,
-  JVMServicePrefix,
+  JvmServicePrefix,
 }
 import com.daml.ledger.participant.state.metrics.JvmMetricSet
 import com.daml.ledger.participant.state.v1.metrics.{TimedReadService, TimedWriteService}
@@ -57,7 +57,7 @@ final class Runner[T <: ReadWriteService, Extra](
           // initialize all configured participants
           _ <- Resource.sequence(config.participants.map { participantConfig =>
             val metricRegistry = factory.metricRegistry(participantConfig, config)
-            metricRegistry.registerAll(JVMServicePrefix, new JvmMetricSet)
+            metricRegistry.registerAll(JvmServicePrefix, new JvmMetricSet)
             for {
               _ <- config.metricsReporter.fold(Resource.unit)(
                 reporter =>

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.participant.state.kvutils.app.Metrics.{
   IndexServicePrefix,
   ReadServicePrefix,
   WriteServicePrefix,
-  JvmServicePrefix,
+  JvmPrefix,
 }
 import com.daml.ledger.participant.state.metrics.JvmMetricSet
 import com.daml.ledger.participant.state.v1.metrics.{TimedReadService, TimedWriteService}
@@ -57,7 +57,7 @@ final class Runner[T <: ReadWriteService, Extra](
           // initialize all configured participants
           _ <- Resource.sequence(config.participants.map { participantConfig =>
             val metricRegistry = factory.metricRegistry(participantConfig, config)
-            metricRegistry.registerAll(JvmServicePrefix, new JvmMetricSet)
+            metricRegistry.registerAll(JvmPrefix, new JvmMetricSet)
             for {
               _ <- config.metricsReporter.fold(Resource.unit)(
                 reporter =>

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -12,7 +12,8 @@ import akka.stream.Materializer
 import com.daml.ledger.participant.state.kvutils.app.Metrics.{
   IndexServicePrefix,
   ReadServicePrefix,
-  WriteServicePrefix
+  WriteServicePrefix,
+  JVMServicePrefix,
 }
 import com.daml.ledger.participant.state.metrics.JvmMetricSet
 import com.daml.ledger.participant.state.v1.metrics.{TimedReadService, TimedWriteService}
@@ -56,7 +57,7 @@ final class Runner[T <: ReadWriteService, Extra](
           // initialize all configured participants
           _ <- Resource.sequence(config.participants.map { participantConfig =>
             val metricRegistry = factory.metricRegistry(participantConfig, config)
-            metricRegistry.registerAll(new JvmMetricSet)
+            metricRegistry.registerAll(JVMServicePrefix, new JvmMetricSet)
             for {
               _ <- config.metricsReporter.fold(Resource.unit)(
                 reporter =>


### PR DESCRIPTION
CHANGELOG_BEGIN
Prefix JVM metrics in participant server with "daml.services" for easier aggregation
CHANGELOG_END

In some deployments metrics can be aggregated from several sources and distinguishing the source without a suitable prefix can be problematic. This PR adds a "daml.services" prefix to JVM metrics from the participant server.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
