### PR TITLE
reenable collect_build_data and notify_user

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -335,7 +335,7 @@ jobs:
           trigger_sha: '$(trigger_sha)'
 
   - job: collect_build_data
-    condition: succeededOrFailed()
+    condition: always()
     dependsOn:
       - Linux
       - macOS
@@ -485,7 +485,7 @@ jobs:
           PR_BRANCH: $(pr.branch)
 
   - job: notify_user
-    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    condition: eq(variables['Build.Reason'], 'PullRequest')
     dependsOn:
       - git_sha
       - collect_build_data


### PR DESCRIPTION
Looking at the behaviour of `succeededOrFailed`, it looks like it does not do what we want at all: both steps now only run on failures. My current hypothesis is that `write_ledger_dump` being skipped switches the state of the last job to something that is neither success nor failure.

It would be really nice if Azure had a way to detect cancellation. :(

CHANGELOG_BEGIN
CHANGELOG_END