### PR TITLE
Refactor mkConfFile

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Dar.hs
@@ -16,7 +16,6 @@ module DA.Daml.Compiler.Dar
     ) where
 
 import qualified "zip" Codec.Archive.Zip as Zip
-import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
 import Control.Applicative
 import Control.Exception (assert)
 import Control.Monad.Extra
@@ -26,7 +25,6 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Resource (ResourceT)
 import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.LF.Proto3.Archive (encodeArchiveAndHash)
-import DA.Daml.LF.Reader (readDalfManifest, packageName)
 import DA.Daml.Options (expandSdkPackages)
 import DA.Daml.Options.Types
 import DA.Daml.Package.Config
@@ -53,13 +51,13 @@ import Development.IDE.GHC.Util
 import Development.IDE.Types.Location
 import Development.IDE.Types.Options
 import qualified Development.IDE.Types.Logger as IdeLogger
-import SdkVersion
 import System.Directory.Extra
 import System.FilePath
 import System.IO
 
 import MkIface
 import Module
+import qualified Module as Ghc
 import HscTypes
 
 -- | Create a DAR file by running a ZipArchive action.
@@ -105,7 +103,7 @@ buildDar ::
     -> NormalizedFilePath
     -> FromDalf
     -> IO (Maybe (Zip.ZipArchive ()))
-buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
+buildDar service PackageConfigFields {..} ifDir dalfInput = do
     liftIO $
         IdeLogger.logDebug (ideLogger service) $
         "Creating dar: " <> T.pack pSrc
@@ -129,7 +127,7 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
 
                  MaybeT $ finalPackageCheck (toNormalizedFilePath' pSrc) pkg
 
-                 let pkgModuleNames = map T.unpack $ LF.packageModuleNames pkg
+                 let pkgModuleNames = map (Ghc.mkModuleName . T.unpack) $ LF.packageModuleNames pkg
                  let missingExposed =
                          S.fromList (fromMaybe [] pExposedModules) S.\\
                          S.fromList pkgModuleNames
@@ -137,7 +135,7 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
                      -- FIXME: Should be producing a proper diagnostic
                      error $
                      "The following modules are declared in exposed-modules but are not part of the DALF: " <>
-                     show (S.toList missingExposed)
+                     show (map Ghc.moduleNameString $ S.toList missingExposed)
                  let (dalf,pkgId) = encodeArchiveAndHash pkg
                  -- For now, we don’t include ifaces and hie files in incremental mode.
                  -- The main reason for this is that writeIfacesAndHie is not yet ported to incremental mode
@@ -156,10 +154,12 @@ buildDar service pkgConf@PackageConfigFields {..} ifDir dalfInput = do
                  liftIO $ whenJust (fmap (pkgModuleNames \\) pExposedModules) $ \hidden ->
                      when (notNull hidden) $
                      hPutStr stderr $ unlines
-                         [ "WARNING: The following modules are not part of exposed-modules: " <> show hidden
+                         [ "WARNING: The following modules are not part of exposed-modules: " <>
+                           show (map Ghc.moduleNameString hidden)
                          , "This can cause issues if those modules are referenced from a data-dependency."
                          ]
-                 confFile <- liftIO $ mkConfFile lfVersion pkgConf pkgModuleNames pkgId
+                 unstableDeps <- getUnstableDalfDependencies files
+                 let confFile = mkConfFile pName pVersion (Map.keys unstableDeps) pExposedModules pkgModuleNames pkgId
                  let dataFiles = [confFile]
                  srcRoot <- getSrcRoot pSrc
                  pure $
@@ -265,25 +265,20 @@ getDamlRootFiles srcRoot = do
         then liftIO $ damlFilesInDir srcRoot
         else pure [toNormalizedFilePath' srcRoot]
 
-mkConfFile ::
-       LF.Version -> PackageConfigFields -> [String] -> LF.PackageId -> IO (String, BS.ByteString)
-mkConfFile lfVersion PackageConfigFields {..} pkgModuleNames pkgId = do
-    deps <- mapM darUnitId =<< expandSdkPackages lfVersion pDependencies
-    pure (confName, confContent deps)
+mkConfFile
+    :: LF.PackageName
+    -> Maybe LF.PackageVersion
+    -> [UnitId]
+    -> Maybe [Ghc.ModuleName]
+    -> [Ghc.ModuleName]
+    -> LF.PackageId
+    -> (FilePath, BS.ByteString)
+mkConfFile pName pVersion pDependencies pExposedModules pkgModuleNames pkgId =
+    (confName, confContent)
   where
-    darUnitId "daml-stdlib" = pure damlStdlib
-    darUnitId "daml-prim" = pure $ stringToUnitId "daml-prim"
-    darUnitId f
-      -- This case is used by data-dependencies. DALF names are not affected by
-      -- -o so this should be fine.
-      | takeExtension f == ".dalf" = pure $ stringToUnitId $ dropExtension $ takeFileName f
-    darUnitId darPath = do
-        archive <- ZipArchive.toArchive . BSL.fromStrict  <$> BS.readFile darPath
-        manifest <- either (\err -> fail $ "Failed to read manifest of " <> darPath <> ": " <> err) pure $ readDalfManifest archive
-        maybe (fail $ "Missing 'Name' attribute in manifest of " <> darPath) (pure . stringToUnitId) (packageName manifest)
     confName = unitIdString (pkgNameVersion pName pVersion) ++ ".conf"
     key = fullPkgName pName pVersion pkgId
-    confContent deps =
+    confContent =
         BSC.toStrict $
         BSC.pack $
         unlines $
@@ -294,11 +289,11 @@ mkConfFile lfVersion PackageConfigFields {..} pkgModuleNames pkgId = do
             ++
             [ "exposed: True"
             , "exposed-modules: " ++
-              unwords (fromMaybe pkgModuleNames pExposedModules)
+              (unwords . map Ghc.moduleNameString . fromMaybe pkgModuleNames) pExposedModules
             , "import-dirs: ${pkgroot}" ++ "/" ++ key -- we really want '/' here
             , "library-dirs: ${pkgroot}" ++ "/" ++ key
             , "data-dir: ${pkgroot}" ++ "/" ++ key
-            , "depends: " ++ unwords (map unitIdString deps)
+            , "depends: " ++ unwords (map unitIdString pDependencies)
             ]
 
 sinkEntryDeterministic

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -339,22 +339,13 @@ generateAndInstallIfaceFiles dalf src opts workDir dbPath projectPackageDatabase
           $ "Failed to compile interface for data-dependency: "
           <> unitIdString (pkgNameVersion pkgName mbPkgVersion)
     -- write the conf file and refresh the package cache
-    (cfPath, cfBs) <-
-            mkConfFile
-                (LF.packageLfVersion dalf)
-                PackageConfigFields
-                    { pName = pkgName
-                    , pSrc = error "src field was used for creation of pkg conf file"
-                    , pExposedModules = Nothing
-                    , pVersion = mbPkgVersion
-                    -- TODO Appending ".dalf" makes no sense but is needed to make `mkConfFile` happy.
-                    -- We should refactor this to allow us to pass unit ids verbatim.
-                    , pDependencies = map (\(unitId, _) -> unitIdString unitId <.> "dalf") deps
-                    , pDataDependencies = []
-                    , pSdkVersion = error "sdk version field was used for creation of pkg conf file"
-                    }
-                (map T.unpack $ LF.packageModuleNames dalf)
-                pkgIdStr
+    let (cfPath, cfBs) = mkConfFile
+            pkgName
+            mbPkgVersion
+            (map fst deps)
+            Nothing
+            (map (GHC.mkModuleName . T.unpack) $ LF.packageModuleNames dalf)
+            pkgIdStr
     BS.writeFile (dbPath </> "package.conf.d" </> cfPath) cfBs
     recachePkgDb dbPath
 


### PR DESCRIPTION
mkConfFile was a bit of a mess before. Half of the arguments we passed
in via `PackageConfigFields` were unused as shown by the fact that we
set them to `error …` in various places where we did not have that
information. More importantly rather than passing in the unit ids
which need to end up in the GHC package config, we passed in file
names which required us to parse the DAR again and have a bunch of
hacks where file names with .dalf endings were not translated.

This PR changes this to only pass in the fields we need and pass in
dependencies directly as unit ids.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
