### PR TITLE
sandbox: Provide an option to disable implicit party allocation.

### DIFF
--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -483,4 +483,17 @@ server_conformance_test(
     ],
 )
 
+server_conformance_test(
+    name = "next-conformance-test-closed-world",
+    server_args = [
+        "--wall-clock-time",
+        "--implicit-party-allocation=false",
+    ],
+    servers = NEXT_SERVERS,
+    test_tool_args = [
+        "--verbose",
+        "--include=ClosedWorldIT",
+    ],
+)
+
 exports_files(["src/main/resources/logback.xml"])

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxMain.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxMain.scala
@@ -4,11 +4,16 @@
 package com.daml.platform.sandbox
 
 import com.daml.platform.sandbox.cli.Cli
+import com.daml.platform.sandbox.config.InvalidConfigException
 import com.daml.resources.ProgramResource
 
 object SandboxMain {
   def main(args: Array[String]): Unit = {
     val config = Cli.parse(args).getOrElse(sys.exit(1))
+    if (!config.implicitPartyAllocation) {
+      throw new InvalidConfigException(
+        "This version of Sandbox does not support disabling implicit party allocation.")
+    }
     config.logLevel.foreach(GlobalLogLevel.set)
     new ProgramResource(SandboxServer.owner(config)).run()
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -100,6 +100,11 @@ object Cli {
             "Two identifier formats are supported: Module.Name:Entity.Name (preferred) and Module.Name.Entity.Name (deprecated, will print a warning when used)." +
             "Also note that instructing the sandbox to load a scenario will have the side effect of loading _all_ the .dar files provided eagerly (see --eager-package-loading).")
 
+      opt[Boolean](name = "implicit-party-allocation")
+        .action((x, c) => c.copy(implicitPartyAllocation = x))
+        .text("When referring to a party that doesn't yet exist on the ledger, Sandbox will implicitly allocate that party."
+          + " You can optionally disable this behavior to bring Sandbox into line with other ledgers.")
+
       opt[String]("pem")
         .optional()
         .text("TLS: The pem file to be used as the private key.")

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -8,15 +8,14 @@ import java.nio.file.Path
 import java.time.Duration
 
 import ch.qos.logback.classic.Level
-import com.daml.ledger.participant.state.v1.SeedService.Seeding
-import com.daml.ledger.participant.state.v1.TimeModel
 import com.daml.ledger.api.auth.AuthService
 import com.daml.ledger.api.tls.TlsConfiguration
+import com.daml.ledger.participant.state.v1.SeedService.Seeding
+import com.daml.ledger.participant.state.v1.TimeModel
 import com.daml.platform.common.LedgerIdMode
 import com.daml.platform.configuration.{
   CommandConfiguration,
   MetricsReporter,
-  PartyConfiguration,
   SubmissionConfiguration
 }
 import com.daml.platform.services.time.TimeProviderType
@@ -33,10 +32,10 @@ final case class SandboxConfig(
     timeProviderType: Option[TimeProviderType],
     timeModel: TimeModel,
     commandConfig: CommandConfiguration, //TODO: this should go to the file config
-    partyConfig: PartyConfiguration,
     submissionConfig: SubmissionConfiguration,
     tlsConfig: Option[TlsConfiguration],
     scenario: Option[String],
+    implicitPartyAllocation: Boolean,
     ledgerIdMode: LedgerIdMode,
     maxInboundMessageSize: Int,
     jdbcUrl: Option[String],
@@ -67,12 +66,10 @@ object SandboxConfig {
       timeProviderType = None,
       timeModel = TimeModel.reasonableDefault,
       commandConfig = CommandConfiguration.default,
-      partyConfig = PartyConfiguration.default.copy(
-        implicitPartyAllocation = true,
-      ),
       submissionConfig = SubmissionConfiguration.default,
       tlsConfig = None,
       scenario = None,
+      implicitPartyAllocation = true,
       ledgerIdMode = LedgerIdMode.Dynamic,
       maxInboundMessageSize = DefaultMaxInboundMessageSize,
       jdbcUrl = None,
@@ -87,11 +84,6 @@ object SandboxConfig {
 
   lazy val default: SandboxConfig =
     nextDefault.copy(
-      partyConfig = nextDefault.partyConfig.copy(
-        // In Sandbox, parties are always allocated implicitly. Enabling this would result in an
-        // extra `writeService.allocateParty` call, which is unnecessary and bad for performance.
-        implicitPartyAllocation = false,
-      ),
       seeding = None,
     )
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -29,6 +29,7 @@ import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.MetricName
 import com.daml.platform.apiserver._
 import com.daml.platform.common.LedgerIdMode
+import com.daml.platform.configuration.PartyConfiguration
 import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode, StandaloneIndexerServer}
 import com.daml.platform.sandbox.banner.Banner
 import com.daml.platform.sandbox.config.{InvalidConfigException, SandboxConfig}
@@ -193,7 +194,9 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     seeding = Some(seeding),
                   ),
                   commandConfig = config.commandConfig,
-                  partyConfig = config.partyConfig,
+                  partyConfig = PartyConfiguration.default.copy(
+                    implicitPartyAllocation = config.implicitPartyAllocation,
+                  ),
                   submissionConfig = config.submissionConfig,
                   readService = readService,
                   writeService = writeService,


### PR DESCRIPTION
Resolves #5557.

### Changelog

- **[Sandbox]** You can now disable implicit party allocation by passing the flag, `--implicit-party-allocation=false`. This makes it easier to test as you would against another ledger which does not support this feature.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
