### PR TITLE
Improve error messages in daml repl on calls to `error`

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -184,7 +184,6 @@ functionalTests replClient serviceOut testDar options ideState = describe "repl 
           , input "bob <- allocateParty \"Bob\""
           , input "submit alice (createCmd (T alice bob))"
           , matchServiceOutput "^.*Submit failed.*requires authorizers.*but only.*were given.*$"
-          , matchServiceOutput "^.*$"
           , input "debug 1"
           , matchServiceOutput "^.*: 1"
           ]
@@ -215,6 +214,14 @@ functionalTests replClient serviceOut testDar options ideState = describe "repl 
           , input "import DA.Time"
           , input "debug (days 1)"
           , matchServiceOutput "^.*: RelTime {microseconds = 86400000000}$"
+          ]
+    , testInteraction' "error call"
+          [ input "error \"foobar\""
+          , matchServiceOutput "^Error: User abort: foobar$"
+          ]
+    , testInteraction' "abort call"
+          [ input "abort \"foobar\""
+          , matchServiceOutput "^Error: User abort: foobar$"
           ]
     ]
   where

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -14,7 +14,7 @@ import com.daml.lf.engine.script._
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.{Compiler, SValue, SExpr}
+import com.daml.lf.speedy.{Compiler, SValue, SExpr, SError}
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId}
 import com.daml.ledger.api.tls.TlsConfiguration
@@ -216,6 +216,10 @@ class ReplService(
       ApplicationId("daml repl"),
       TimeProvider.UTC)
     runner.runWithClients(clients).onComplete {
+      case Failure(e: SError.SError) =>
+        // The error here is already printed by the logger in stepToValue.
+        // No need to print anything here.
+        respObs.onError(e)
       case Failure(e) =>
         println(s"$e")
         respObs.onError(e)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -8,6 +8,7 @@ import io.grpc.StatusRuntimeException
 import java.util
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
 import scalaz.{\/-, -\/}
 import spray.json._
 
@@ -80,6 +81,11 @@ object Converter {
 
   private def toLedgerValue(v: SValue): Either[String, Value[AbsoluteContractId]] =
     v.toValue.ensureNoRelCid.left.map(rcoid => s"Unexpected contract id $rcoid")
+
+  def toFuture[T](s: Either[String, T]): Future[T] = s match {
+    case Left(err) => Future.failed(new ConverterException(err))
+    case Right(s) => Future.successful(s)
+  }
 
   def toAnyTemplate(v: SValue): Either[String, AnyTemplate] = {
     v match {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -296,220 +296,222 @@ class Runner(
 
     // Removing the early return only makes this harder to read.
     @SuppressWarnings(Array("org.wartremover.warts.Return"))
-    def stepToValue(): Future[Unit] = {
+    def stepToValue(): Either[RuntimeException, Unit] = {
       while (!machine.isFinal) {
         machine.step() match {
           case SResultContinue => ()
           case SResultError(err) => {
             logger.error(Pretty.prettyError(err, machine.ptx).render(80))
-            return Future.failed(err)
+            return Left(err)
           }
           case res => {
-            return Future.failed(new RuntimeException(s"Unexpected speedy result $res"))
+            return Left(new RuntimeException(s"Unexpected speedy result $res"))
           }
         }
       }
-      Future.unit
+      Right(())
     }
 
     def go(): Future[SValue] = {
-      stepToValue().flatMap(_ =>
-        machine.toSValue match {
-          case SVariant(_, "Free", _, v) => {
-            v match {
-              case SVariant(_, "Submit", _, v) => {
-                v match {
-                  case SRecord(_, _, vals) if vals.size == 3 => {
-                    for {
-                      freeAp <- vals.get(1) match {
-                        // Unwrap Commands newtype
-                        case SRecord(_, _, vals) if vals.size == 1 => Future.successful(vals.get(0))
-                        case v =>
-                          Future.failed(
-                            new ConverterException(s"Expected record with 1 field but got $v"))
-                      }
-                      party <- Converter.toFuture(
-                        Converter
-                          .toParty(vals.get(0)))
-                      commands <- Converter.toFuture(
-                        Converter
-                          .toCommands(extendedCompiledPackages, freeAp))
-                      client <- Converter.toFuture(
-                        clients
-                          .getPartyParticipant(Party(party.value)))
-                      submitRes <- client.submit(applicationId, party, commands)
-                      v <- submitRes match {
-                        case Right(results) => {
-                          for {
-                            filled <- Converter.toFuture(
-                              Converter
-                                .fillCommandResults(
-                                  extendedCompiledPackages,
-                                  lookupChoiceTy,
-                                  valueTranslator,
-                                  freeAp,
-                                  results))
-                            v <- {
-                              machine.ctrl = Speedy.CtrlExpr(filled)
-                              go()
-                            }
-                          } yield v
+      stepToValue()
+        .fold(Future.failed(_), Future.successful(_))
+        .flatMap(_ =>
+          machine.toSValue match {
+            case SVariant(_, "Free", _, v) => {
+              v match {
+                case SVariant(_, "Submit", _, v) => {
+                  v match {
+                    case SRecord(_, _, vals) if vals.size == 3 => {
+                      for {
+                        freeAp <- vals.get(1) match {
+                          // Unwrap Commands newtype
+                          case SRecord(_, _, vals) if vals.size == 1 =>
+                            Future.successful(vals.get(0))
+                          case v =>
+                            Future.failed(
+                              new ConverterException(s"Expected record with 1 field but got $v"))
                         }
-                        case Left(statusEx) => {
-                          for {
-                            res <- Converter.toFuture(
-                              Converter
-                                .fromStatusException(script.scriptIds, statusEx))
-                            v <- {
-                              machine.ctrl =
-                                Speedy.CtrlExpr(SEApp(SEValue(vals.get(2)), Array(SEValue(res))))
-                              go()
-                            }
-                          } yield v
-                        }
-                      }
-                    } yield v
-                  }
-                  case _ =>
-                    Future.failed(
-                      new ConverterException(s"Expected record with 2 fields but got $v"))
-                }
-              }
-              case SVariant(_, "Query", _, v) => {
-                v match {
-                  case SRecord(_, _, vals) if vals.size == 3 => {
-                    val continue = vals.get(2)
-                    for {
-                      party <- Converter.toFuture(
-                        Converter
-                          .toParty(vals.get(0)))
-                      tplId <- Converter.toFuture(
-                        Converter
-                          .typeRepToIdentifier(vals.get(1)))
-                      client <- Converter.toFuture(
-                        clients
-                          .getPartyParticipant(Party(party.value)))
-                      acs <- client.query(party, tplId)
-                      res <- Converter.toFuture(
-                        FrontStack(acs)
-                          .traverseU(Converter
-                            .fromCreated(valueTranslator, _)))
-                      v <- {
-                        machine.ctrl =
-                          Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SList(res)))))
-                        go()
-                      }
-                    } yield v
-                  }
-                  case _ =>
-                    Future.failed(
-                      new ConverterException(s"Expected record with 3 fields but got $v"))
-                }
-              }
-              case SVariant(_, "AllocParty", _, v) => {
-                v match {
-                  case SRecord(_, _, vals) if vals.size == 4 => {
-                    val continue = vals.get(3)
-                    for {
-                      displayName <- vals.get(0) match {
-                        case SText(value) => Future.successful(value)
-                        case v =>
-                          Future.failed(new ConverterException(s"Expected SText but got $v"))
-                      }
-                      partyIdHint <- vals.get(1) match {
-                        case SText(t) => Future.successful(t)
-                        case v =>
-                          Future.failed(new ConverterException(s"Expected SText but got $v"))
-                      }
-                      participantName <- vals.get(2) match {
-                        case SOptional(Some(SText(t))) => Future.successful(Some(Participant(t)))
-                        case SOptional(None) => Future.successful(None)
-                        case v =>
-                          Future.failed(
-                            new ConverterException(s"Expected SOptional(SText) but got $v"))
-                      }
-                      client <- clients.getParticipant(participantName) match {
-                        case Right(client) => Future.successful(client)
-                        case Left(err) => Future.failed(new RuntimeException(err))
-                      }
-                      party <- client.allocateParty(partyIdHint, displayName)
-                      v <- {
-                        participantName match {
-                          case None => {
-                            // If no participant is specified, we use default_participant so we don’t need to change anything.
+                        party <- Converter.toFuture(
+                          Converter
+                            .toParty(vals.get(0)))
+                        commands <- Converter.toFuture(
+                          Converter
+                            .toCommands(extendedCompiledPackages, freeAp))
+                        client <- Converter.toFuture(
+                          clients
+                            .getPartyParticipant(Party(party.value)))
+                        submitRes <- client.submit(applicationId, party, commands)
+                        v <- submitRes match {
+                          case Right(results) => {
+                            for {
+                              filled <- Converter.toFuture(
+                                Converter
+                                  .fillCommandResults(
+                                    extendedCompiledPackages,
+                                    lookupChoiceTy,
+                                    valueTranslator,
+                                    freeAp,
+                                    results))
+                              v <- {
+                                machine.ctrl = Speedy.CtrlExpr(filled)
+                                go()
+                              }
+                            } yield v
                           }
-                          case Some(participant) =>
-                            clients =
-                              clients.copy(
+                          case Left(statusEx) => {
+                            for {
+                              res <- Converter.toFuture(
+                                Converter
+                                  .fromStatusException(script.scriptIds, statusEx))
+                              v <- {
+                                machine.ctrl =
+                                  Speedy.CtrlExpr(SEApp(SEValue(vals.get(2)), Array(SEValue(res))))
+                                go()
+                              }
+                            } yield v
+                          }
+                        }
+                      } yield v
+                    }
+                    case _ =>
+                      Future.failed(
+                        new ConverterException(s"Expected record with 2 fields but got $v"))
+                  }
+                }
+                case SVariant(_, "Query", _, v) => {
+                  v match {
+                    case SRecord(_, _, vals) if vals.size == 3 => {
+                      val continue = vals.get(2)
+                      for {
+                        party <- Converter.toFuture(
+                          Converter
+                            .toParty(vals.get(0)))
+                        tplId <- Converter.toFuture(
+                          Converter
+                            .typeRepToIdentifier(vals.get(1)))
+                        client <- Converter.toFuture(
+                          clients
+                            .getPartyParticipant(Party(party.value)))
+                        acs <- client.query(party, tplId)
+                        res <- Converter.toFuture(
+                          FrontStack(acs)
+                            .traverseU(Converter
+                              .fromCreated(valueTranslator, _)))
+                        v <- {
+                          machine.ctrl =
+                            Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SList(res)))))
+                          go()
+                        }
+                      } yield v
+                    }
+                    case _ =>
+                      Future.failed(
+                        new ConverterException(s"Expected record with 3 fields but got $v"))
+                  }
+                }
+                case SVariant(_, "AllocParty", _, v) => {
+                  v match {
+                    case SRecord(_, _, vals) if vals.size == 4 => {
+                      val continue = vals.get(3)
+                      for {
+                        displayName <- vals.get(0) match {
+                          case SText(value) => Future.successful(value)
+                          case v =>
+                            Future.failed(new ConverterException(s"Expected SText but got $v"))
+                        }
+                        partyIdHint <- vals.get(1) match {
+                          case SText(t) => Future.successful(t)
+                          case v =>
+                            Future.failed(new ConverterException(s"Expected SText but got $v"))
+                        }
+                        participantName <- vals.get(2) match {
+                          case SOptional(Some(SText(t))) => Future.successful(Some(Participant(t)))
+                          case SOptional(None) => Future.successful(None)
+                          case v =>
+                            Future.failed(
+                              new ConverterException(s"Expected SOptional(SText) but got $v"))
+                        }
+                        client <- clients.getParticipant(participantName) match {
+                          case Right(client) => Future.successful(client)
+                          case Left(err) => Future.failed(new RuntimeException(err))
+                        }
+                        party <- client.allocateParty(partyIdHint, displayName)
+                        v <- {
+                          participantName match {
+                            case None => {
+                              // If no participant is specified, we use default_participant so we don’t need to change anything.
+                            }
+                            case Some(participant) =>
+                              clients = clients.copy(
                                 party_participants = clients.party_participants + (Party(
                                   party.value) -> participant))
-                        }
-                        machine.ctrl =
-                          Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(party))))
-                        go()
-                      }
-                    } yield v
-                  }
-                  case _ =>
-                    Future.failed(
-                      new ConverterException(s"Expected record with 2 fields but got $v"))
-                }
-              }
-              case SVariant(_, "GetTime", _, continue) => {
-                val t = Timestamp.assertFromInstant(timeProvider.getCurrentTime)
-                machine.ctrl =
-                  Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(STimestamp(t)))))
-                go()
-              }
-              case SVariant(_, "Sleep", _, v) => {
-                v match {
-                  case SRecord(_, _, vals) if vals.size == 2 => {
-                    val continue = vals.get(1)
-                    for {
-                      sleepMicros <- vals.get(0) match {
-                        case SRecord(_, _, vals) if vals.size == 1 =>
-                          vals.get(0) match {
-                            case SInt64(i) => Future.successful(i)
-                            case _ =>
-                              Future.failed(new ConverterException(s"Expected SInt64 but got $v"))
                           }
-                        case v =>
-                          Future.failed(new ConverterException(s"Expected RelTime but got $v"))
-                      }
-                      v <- {
-                        val sleepMillis = sleepMicros / 1000
-                        val sleepNanos = (sleepMicros % 1000) * 1000
-                        Thread.sleep(sleepMillis, sleepNanos.toInt)
-                        machine.ctrl =
-                          Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SUnit))))
-                        go()
-                      }
-                    } yield v
+                          machine.ctrl =
+                            Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(party))))
+                          go()
+                        }
+                      } yield v
+                    }
+                    case _ =>
+                      Future.failed(
+                        new ConverterException(s"Expected record with 2 fields but got $v"))
                   }
-                  case _ =>
-                    Future.failed(
-                      new ConverterException(s"Expected record with 2 fields but got $v"))
                 }
+                case SVariant(_, "GetTime", _, continue) => {
+                  val t = Timestamp.assertFromInstant(timeProvider.getCurrentTime)
+                  machine.ctrl =
+                    Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(STimestamp(t)))))
+                  go()
+                }
+                case SVariant(_, "Sleep", _, v) => {
+                  v match {
+                    case SRecord(_, _, vals) if vals.size == 2 => {
+                      val continue = vals.get(1)
+                      for {
+                        sleepMicros <- vals.get(0) match {
+                          case SRecord(_, _, vals) if vals.size == 1 =>
+                            vals.get(0) match {
+                              case SInt64(i) => Future.successful(i)
+                              case _ =>
+                                Future.failed(new ConverterException(s"Expected SInt64 but got $v"))
+                            }
+                          case v =>
+                            Future.failed(new ConverterException(s"Expected RelTime but got $v"))
+                        }
+                        v <- {
+                          val sleepMillis = sleepMicros / 1000
+                          val sleepNanos = (sleepMicros % 1000) * 1000
+                          Thread.sleep(sleepMillis, sleepNanos.toInt)
+                          machine.ctrl =
+                            Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SUnit))))
+                          go()
+                        }
+                      } yield v
+                    }
+                    case _ =>
+                      Future.failed(
+                        new ConverterException(s"Expected record with 2 fields but got $v"))
+                  }
+                }
+                case _ =>
+                  Future.failed(
+                    new ConverterException(s"Expected Submit, Query or AllocParty but got $v"))
               }
-              case _ =>
-                Future.failed(
-                  new ConverterException(s"Expected Submit, Query or AllocParty but got $v"))
             }
-          }
-          case SVariant(_, "Pure", _, v) =>
-            v match {
-              case SRecord(_, _, vals) if vals.size == 2 => {
-                // Unwrap the Tuple2 we get from the inlined StateT.
-                Future { vals.get(0) }
+            case SVariant(_, "Pure", _, v) =>
+              v match {
+                case SRecord(_, _, vals) if vals.size == 2 => {
+                  // Unwrap the Tuple2 we get from the inlined StateT.
+                  Future { vals.get(0) }
+                }
+                case _ => Future.failed(new ConverterException(s"Expected Tuple2 but got $v"))
               }
-              case _ => Future.failed(new ConverterException(s"Expected Tuple2 but got $v"))
-            }
-          case v => Future.failed(new ConverterException(s"Expected Free or Pure but got $v"))
-      })
+            case v => Future.failed(new ConverterException(s"Expected Free or Pure but got $v"))
+        })
     }
 
     for {
-      _ <- stepToValue()
+      _ <- stepToValue().fold(Future.failed(_), Future.successful(_))
       _ <- machine.toSValue match {
         // Unwrap Script newtype and apply to ()
         case SRecord(_, _, vals) if vals.size == 1 => {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -294,197 +294,240 @@ class Runner(
     var machine =
       Speedy.Machine.fromSExpr(script.expr, false, extendedCompiledPackages)
 
-    def stepToValue() = {
+    // Removing the early return only makes this harder to read.
+    @SuppressWarnings(Array("org.wartremover.warts.Return"))
+    def stepToValue(): Future[Unit] = {
       while (!machine.isFinal) {
         machine.step() match {
           case SResultContinue => ()
           case SResultError(err) => {
             logger.error(Pretty.prettyError(err, machine.ptx).render(80))
-            throw err
+            return Future.failed(err)
           }
           case res => {
-            throw new RuntimeException(s"Unexpected speedy result $res")
+            return Future.failed(new RuntimeException(s"Unexpected speedy result $res"))
           }
         }
       }
-    }
-
-    stepToValue()
-    machine.toSValue match {
-      // Unwrap Script newtype and apply to ()
-      case SRecord(_, _, vals) if vals.size == 1 => {
-        vals.get(0) match {
-          case SPAP(_, _, _) =>
-            machine.ctrl = Speedy.CtrlExpr(SEApp(SEValue(vals.get(0)), Array(SEValue(SUnit))))
-          case v =>
-            throw new ConverterException(
-              "Mismatch in structure of Script type. " +
-                "This probably means that you tried to run a script built against an " +
-                "SDK <= 0.13.55-snapshot.20200304.3329.6a1c75cf with a script runner from a newer SDK.")
-        }
-      }
-      case v => throw new ConverterException(s"Expected record with 1 field but got $v")
+      Future.unit
     }
 
     def go(): Future[SValue] = {
-      stepToValue()
-      machine.toSValue match {
-        case SVariant(_, "Free", _, v) => {
-          v match {
-            case SVariant(_, "Submit", _, v) => {
-              v match {
-                case SRecord(_, _, vals) if vals.size == 3 => {
-                  val freeAp = vals.get(1) match {
-                    // Unwrap Commands newtype
-                    case SRecord(_, _, vals) if vals.size == 1 => vals.get(0)
-                    case v =>
-                      throw new ConverterException(s"Expected record with 1 field but got $v")
-                  }
-                  val requestOrErr = for {
-                    party <- Converter.toParty(vals.get(0))
-                    commands <- Converter.toCommands(extendedCompiledPackages, freeAp)
-                    client <- clients.getPartyParticipant(Party(party.value))
-                  } yield (client, party, commands)
-                  val (client, party, commands) =
-                    requestOrErr.fold(s => throw new ConverterException(s), identity)
-                  val f = client.submit(applicationId, party, commands)
-                  f.flatMap({
-                    case Right(results) => {
-                      val filled =
-                        Converter.fillCommandResults(
-                          extendedCompiledPackages,
-                          lookupChoiceTy,
-                          valueTranslator,
-                          freeAp,
-                          results) match {
-                          case Left(s) => throw new ConverterException(s)
-                          case Right(r) => r
+      stepToValue().flatMap(_ =>
+        machine.toSValue match {
+          case SVariant(_, "Free", _, v) => {
+            v match {
+              case SVariant(_, "Submit", _, v) => {
+                v match {
+                  case SRecord(_, _, vals) if vals.size == 3 => {
+                    for {
+                      freeAp <- vals.get(1) match {
+                        // Unwrap Commands newtype
+                        case SRecord(_, _, vals) if vals.size == 1 => Future.successful(vals.get(0))
+                        case v =>
+                          Future.failed(
+                            new ConverterException(s"Expected record with 1 field but got $v"))
+                      }
+                      party <- Converter.toFuture(
+                        Converter
+                          .toParty(vals.get(0)))
+                      commands <- Converter.toFuture(
+                        Converter
+                          .toCommands(extendedCompiledPackages, freeAp))
+                      client <- Converter.toFuture(
+                        clients
+                          .getPartyParticipant(Party(party.value)))
+                      submitRes <- client.submit(applicationId, party, commands)
+                      v <- submitRes match {
+                        case Right(results) => {
+                          for {
+                            filled <- Converter.toFuture(
+                              Converter
+                                .fillCommandResults(
+                                  extendedCompiledPackages,
+                                  lookupChoiceTy,
+                                  valueTranslator,
+                                  freeAp,
+                                  results))
+                            v <- {
+                              machine.ctrl = Speedy.CtrlExpr(filled)
+                              go()
+                            }
+                          } yield v
                         }
-                      machine.ctrl = Speedy.CtrlExpr(filled)
-                      go()
-                    }
-                    case Left(statusEx) => {
-                      val res = Converter
-                        .fromStatusException(script.scriptIds, statusEx)
-                        .fold(s => throw new ConverterException(s), identity)
-                      machine.ctrl =
-                        Speedy.CtrlExpr(SEApp(SEValue(vals.get(2)), Array(SEValue(res))))
-                      go()
-                    }
-                  })
-                }
-                case _ => throw new RuntimeException(s"Expected record with 2 fields but got $v")
-              }
-            }
-            case SVariant(_, "Query", _, v) => {
-              v match {
-                case SRecord(_, _, vals) if vals.size == 3 => {
-                  val continue = vals.get(2)
-                  val filterOrErr = for {
-                    party <- Converter.toParty(vals.get(0))
-                    tplId <- Converter.typeRepToIdentifier(vals.get(1))
-                    client <- clients.getPartyParticipant(Party(party.value))
-                  } yield (client, party, tplId)
-                  val (client, party, tplId) =
-                    filterOrErr.fold(s => throw new ConverterException(s), identity)
-                  val acsF = client.query(party, tplId)
-                  acsF.flatMap(acs => {
-                    val res =
-                      FrontStack(acs)
-                        .traverseU(Converter
-                          .fromCreated(valueTranslator, _))
-                        .fold(s => throw new ConverterException(s), identity)
-                    machine.ctrl =
-                      Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SList(res)))))
-                    go()
-                  })
-                }
-                case _ => throw new RuntimeException(s"Expected record with 3 fields but got $v")
-              }
-            }
-            case SVariant(_, "AllocParty", _, v) => {
-              v match {
-                case SRecord(_, _, vals) if vals.size == 4 => {
-                  val displayName = vals.get(0) match {
-                    case SText(value) => value
-                    case v => throw new ConverterException(s"Expected SText but got $v")
-                  }
-                  val partyIdHint = vals.get(1) match {
-                    case SText(t) => t
-                    case v => throw new ConverterException(s"Expected SText but got $v")
-                  }
-                  val participantName = vals.get(2) match {
-                    case SOptional(Some(SText(t))) => Some(Participant(t))
-                    case SOptional(None) => None
-                    case v => throw new ConverterException(s"Expected SOptional(SText) but got $v")
-                  }
-                  val client = clients.getParticipant(participantName) match {
-                    case Left(err) => throw new RuntimeException(err)
-                    case Right(client) => client
-                  }
-                  val continue = vals.get(3)
-                  val f =
-                    client.allocateParty(partyIdHint, displayName)
-                  f.flatMap(party => {
-                    participantName match {
-                      case None => {
-                        // If no participant is specified, we use default_participant so we don’t need to change anything.
+                        case Left(statusEx) => {
+                          for {
+                            res <- Converter.toFuture(
+                              Converter
+                                .fromStatusException(script.scriptIds, statusEx))
+                            v <- {
+                              machine.ctrl =
+                                Speedy.CtrlExpr(SEApp(SEValue(vals.get(2)), Array(SEValue(res))))
+                              go()
+                            }
+                          } yield v
+                        }
                       }
-                      case Some(participant) =>
-                        clients =
-                          clients.copy(party_participants = clients.party_participants + (Party(
-                            party.value) -> participant))
-                    }
-                    machine.ctrl = Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(party))))
-                    go()
-                  })
-                }
-                case _ => throw new RuntimeException(s"Expected record with 2 fields but got $v")
-              }
-            }
-            case SVariant(_, "GetTime", _, continue) => {
-              val t = Timestamp.assertFromInstant(timeProvider.getCurrentTime)
-              machine.ctrl =
-                Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(STimestamp(t)))))
-              go()
-            }
-            case SVariant(_, "Sleep", _, v) => {
-              v match {
-                case SRecord(_, _, vals) if vals.size == 2 => {
-                  val continue = vals.get(1)
-                  val sleepMicros = vals.get(0) match {
-                    case SRecord(_, _, vals) if vals.size == 1 =>
-                      vals.get(0) match {
-                        case SInt64(i) => i
-                        case _ => throw new ConverterException(s"Expected SInt64 but got $v")
-                      }
-                    case v => throw new ConverterException(s"Expected RelTime but got $v")
+                    } yield v
                   }
-                  val sleepMillis = sleepMicros / 1000
-                  val sleepNanos = (sleepMicros % 1000) * 1000
-                  Thread.sleep(sleepMillis, sleepNanos.toInt)
-                  machine.ctrl = Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SUnit))))
-                  go()
+                  case _ =>
+                    Future.failed(
+                      new ConverterException(s"Expected record with 2 fields but got $v"))
                 }
-                case _ => throw new RuntimeException(s"Expected record with 2 fields but got $v")
               }
+              case SVariant(_, "Query", _, v) => {
+                v match {
+                  case SRecord(_, _, vals) if vals.size == 3 => {
+                    val continue = vals.get(2)
+                    for {
+                      party <- Converter.toFuture(
+                        Converter
+                          .toParty(vals.get(0)))
+                      tplId <- Converter.toFuture(
+                        Converter
+                          .typeRepToIdentifier(vals.get(1)))
+                      client <- Converter.toFuture(
+                        clients
+                          .getPartyParticipant(Party(party.value)))
+                      acs <- client.query(party, tplId)
+                      res <- Converter.toFuture(
+                        FrontStack(acs)
+                          .traverseU(Converter
+                            .fromCreated(valueTranslator, _)))
+                      v <- {
+                        machine.ctrl =
+                          Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SList(res)))))
+                        go()
+                      }
+                    } yield v
+                  }
+                  case _ =>
+                    Future.failed(
+                      new ConverterException(s"Expected record with 3 fields but got $v"))
+                }
+              }
+              case SVariant(_, "AllocParty", _, v) => {
+                v match {
+                  case SRecord(_, _, vals) if vals.size == 4 => {
+                    val continue = vals.get(3)
+                    for {
+                      displayName <- vals.get(0) match {
+                        case SText(value) => Future.successful(value)
+                        case v =>
+                          Future.failed(new ConverterException(s"Expected SText but got $v"))
+                      }
+                      partyIdHint <- vals.get(1) match {
+                        case SText(t) => Future.successful(t)
+                        case v =>
+                          Future.failed(new ConverterException(s"Expected SText but got $v"))
+                      }
+                      participantName <- vals.get(2) match {
+                        case SOptional(Some(SText(t))) => Future.successful(Some(Participant(t)))
+                        case SOptional(None) => Future.successful(None)
+                        case v =>
+                          Future.failed(
+                            new ConverterException(s"Expected SOptional(SText) but got $v"))
+                      }
+                      client <- clients.getParticipant(participantName) match {
+                        case Right(client) => Future.successful(client)
+                        case Left(err) => Future.failed(new RuntimeException(err))
+                      }
+                      party <- client.allocateParty(partyIdHint, displayName)
+                      v <- {
+                        participantName match {
+                          case None => {
+                            // If no participant is specified, we use default_participant so we don’t need to change anything.
+                          }
+                          case Some(participant) =>
+                            clients =
+                              clients.copy(
+                                party_participants = clients.party_participants + (Party(
+                                  party.value) -> participant))
+                        }
+                        machine.ctrl =
+                          Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(party))))
+                        go()
+                      }
+                    } yield v
+                  }
+                  case _ =>
+                    Future.failed(
+                      new ConverterException(s"Expected record with 2 fields but got $v"))
+                }
+              }
+              case SVariant(_, "GetTime", _, continue) => {
+                val t = Timestamp.assertFromInstant(timeProvider.getCurrentTime)
+                machine.ctrl =
+                  Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(STimestamp(t)))))
+                go()
+              }
+              case SVariant(_, "Sleep", _, v) => {
+                v match {
+                  case SRecord(_, _, vals) if vals.size == 2 => {
+                    val continue = vals.get(1)
+                    for {
+                      sleepMicros <- vals.get(0) match {
+                        case SRecord(_, _, vals) if vals.size == 1 =>
+                          vals.get(0) match {
+                            case SInt64(i) => Future.successful(i)
+                            case _ =>
+                              Future.failed(new ConverterException(s"Expected SInt64 but got $v"))
+                          }
+                        case v =>
+                          Future.failed(new ConverterException(s"Expected RelTime but got $v"))
+                      }
+                      v <- {
+                        val sleepMillis = sleepMicros / 1000
+                        val sleepNanos = (sleepMicros % 1000) * 1000
+                        Thread.sleep(sleepMillis, sleepNanos.toInt)
+                        machine.ctrl =
+                          Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SUnit))))
+                        go()
+                      }
+                    } yield v
+                  }
+                  case _ =>
+                    Future.failed(
+                      new ConverterException(s"Expected record with 2 fields but got $v"))
+                }
+              }
+              case _ =>
+                Future.failed(
+                  new ConverterException(s"Expected Submit, Query or AllocParty but got $v"))
             }
-            case _ =>
-              throw new RuntimeException(s"Expected Submit, Query or AllocParty but got $v")
           }
-        }
-        case SVariant(_, "Pure", _, v) =>
-          v match {
-            case SRecord(_, _, vals) if vals.size == 2 => {
-              // Unwrap the Tuple2 we get from the inlined StateT.
-              Future { vals.get(0) }
+          case SVariant(_, "Pure", _, v) =>
+            v match {
+              case SRecord(_, _, vals) if vals.size == 2 => {
+                // Unwrap the Tuple2 we get from the inlined StateT.
+                Future { vals.get(0) }
+              }
+              case _ => Future.failed(new ConverterException(s"Expected Tuple2 but got $v"))
             }
-            case _ => throw new RuntimeException(s"Expected Tuple2 but got $v")
-          }
-        case v => throw new RuntimeException(s"Expected Free or Pure but got $v")
-      }
+          case v => Future.failed(new ConverterException(s"Expected Free or Pure but got $v"))
+      })
     }
 
-    go()
+    for {
+      _ <- stepToValue()
+      _ <- machine.toSValue match {
+        // Unwrap Script newtype and apply to ()
+        case SRecord(_, _, vals) if vals.size == 1 => {
+          vals.get(0) match {
+            case SPAP(_, _, _) =>
+              machine.ctrl = Speedy.CtrlExpr(SEApp(SEValue(vals.get(0)), Array(SEValue(SUnit))))
+              Future.unit
+            case v =>
+              Future.failed(
+                new ConverterException(
+                  "Mismatch in structure of Script type. " +
+                    "This probably means that you tried to run a script built against an " +
+                    "SDK <= 0.13.55-snapshot.20200304.3329.6a1c75cf with a script runner from a newer SDK."))
+          }
+        }
+        case v => Future.failed(new ConverterException(s"Expected record with 1 field but got $v"))
+      }
+      v <- go()
+    } yield v
   }
 }


### PR DESCRIPTION
There were two issues with calls to `error`:

1. This one is harmless but somewhat annoying: When calling `error` we
   run into the log statement in `stepToValue` which prints out the
   error message in a fairly reasonable form (you can argue whether
   Error: User abort: is a super useful prefix but that’s a relatively
   minor issue). Afterwards we then call `println` on the failed
   future. However, that will just print the type of the exception
   which isn’t something we want to show to users. I’ve just disabled
   the println statement if the exception is `SError`.

2. This one is a bigger issue: `throw x` is not the same as
   `Future.failed(x)`. I only fully realized the difference fairly
   recently. The former fails before it produces a future. So `(throw
   x).onComplete(…)` will never execute the callback. The latter is
   just a failed future. It is rather confusing to have a function
   that returns a future but then throws an exception instead of a
   future and it confuses the grpc library which prints out a horrible
   exception. I’ve changed all calls to `throw` in `runWithClients` to
   instead use `Future.failed` and `flatMap` (in the form of
   for-comprehensions).
   There are still a few calls in `run` left which I’ll leave for a
   separate PR.

I think we need to factor out some helper functions here to make this
a bit more manageable (e.g. for the Converter.toFuture) stuff but I’ll
leave that for a separate PR. You probably want to view this with
whitespace diffs disabled.

changelog_begin

- [DAML Repl] DAML Repl now produces better error messages on calls to
  `error` and `abort`.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
