### PR TITLE
DAML-LF: add function to derive maintainer contract key UUID

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -232,6 +232,7 @@ object Hash {
   private[crypto] object Purpose {
     val Testing = Purpose(1)
     val ContractKey = Purpose(2)
+    val MaintainerContractKeyUUID = Purpose(4)
     val PrivateKey = Purpose(3)
   }
 
@@ -355,4 +356,13 @@ object Hash {
       .addStringSet(parties)
       .build
 
+  // For Corda
+  def deriveMaintainerContractKeyUUID(
+      keyHash: Hash,
+      maintainer: Ref.Party,
+  ): Hash =
+    builder(Purpose.MaintainerContractKeyUUID, noCid2String)
+      .add(keyHash)
+      .add(maintainer)
+      .build
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -356,7 +356,7 @@ object Hash {
       .addStringSet(parties)
       .build
 
-  // For Corda
+  // For DAML-on-Corda to ensure the hashing is performed in a way that will work with upgrades.
   def deriveMaintainerContractKeyUUID(
       keyHash: Hash,
       maintainer: Ref.Party,

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -557,6 +557,32 @@ class HashSpec extends WordSpec with Matchers {
     }
   }
 
+  "Hash.derive" should {
+
+    val k1 =
+      Hash.assertFromString("01cf85cfeb36d628ca2e6f583fa2331be029b6b28e877e1008fb3f862306c086")
+    val k2 =
+      Hash.assertFromString("5a97286594af94c406d9354d35bf515a12e9d46b61f6dd6d4679e85395fde5f6")
+    val p1 = Ref.Party.assertFromString("alice")
+    val p2 = Ref.Party.assertFromString("bob")
+
+    "not produce collisions" in {
+      val set = for {
+        k <- Set(k1, k2)
+        p <- Set(p1, p2)
+      } yield Hash.deriveMaintainerContractKeyUUID(k, p)
+
+      set.size shouldBe 4
+    }
+
+    "be stable" in {
+      Hash.deriveMaintainerContractKeyUUID(k1, p1) shouldBe Hash.assertFromString(
+        "6ac76f1cb2b75305a6c910641ae39463321e09104d49d9aa32638d1d3286430c")
+      Hash.deriveMaintainerContractKeyUUID(k2, p2) shouldBe Hash.assertFromString(
+        "6874798ccf6ec1577955d61a6b6d96247f823515ef3afe8b1e086b3533a4fd56")
+    }
+  }
+
   private def defRef(module: String = "Module", name: String) =
     Ref.Identifier(
       packageId0,


### PR DESCRIPTION
Adding a hashing function for DAML-on-Corda.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
