### PR TITLE
kvutils | ledger-on-(memory|sql): Read metrics.

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -24,6 +24,7 @@ da_scala_library(
         "//language-support/scala/bindings",
         "//ledger/ledger-api-common",
         "//ledger/ledger-api-health",
+        "//ledger/metrics",
         "//ledger/participant-state",
         "//ledger/participant-state/kvutils",
         "//libs-scala/resources",

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -87,7 +87,7 @@ final class InMemoryLedgerReaderWriter private (
       }
   }
 
-  private class InMemoryLedgerStateOperations(
+  private final class InMemoryLedgerStateOperations(
       log: InMemoryState.MutableLog,
       state: InMemoryState.MutableState,
   ) extends BatchingLedgerStateOperations[Index] {
@@ -127,7 +127,7 @@ object InMemoryLedgerReaderWriter {
 
   private val sequentialLogEntryId = new SequentialLogEntryId(NamespaceLogEntries)
 
-  class SingleParticipantOwner(
+  final class SingleParticipantOwner(
       initialLedgerId: Option[LedgerId],
       participantId: ParticipantId,
       timeProvider: TimeProvider = DefaultTimeProvider,
@@ -156,7 +156,7 @@ object InMemoryLedgerReaderWriter {
 
   // passing the `dispatcher` and `state` from the outside allows us to share
   // the backing data for the LedgerReaderWriter and therefore setup multiple participants
-  class Owner(
+  final class Owner(
       initialLedgerId: Option[LedgerId],
       participantId: ParticipantId,
       metricRegistry: MetricRegistry,

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -72,9 +72,8 @@ final class InMemoryLedgerReaderWriter private (
             Timed.value(
               Metrics.readLog,
               state
-                .readLog(_.view.zipWithIndex.slice(startExclusive + 1, endInclusive + 1).map {
-                  case (entry, index) => index -> entry
-                })
+                .readLog(
+                  _.view.zipWithIndex.map(_.swap).slice(startExclusive + 1, endInclusive + 1))
                 .iterator)
           }))
       )

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -93,6 +93,7 @@ da_scala_library(
         "//ledger/ledger-api-common",
         "//ledger/ledger-api-domain",
         "//ledger/ledger-api-health",
+        "//ledger/metrics",
         "//ledger/participant-state",
         "//ledger/participant-state/kvutils",
         "//libs-scala/contextualized-logging",

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.on.sql
 
 import java.sql.Connection
 
+import com.codahale.metrics.{MetricRegistry, Timer}
 import com.daml.ledger.on.sql.queries.{
   H2Queries,
   PostgresqlQueries,
@@ -13,6 +14,7 @@ import com.daml.ledger.on.sql.queries.{
   SqliteQueries
 }
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.metrics.{MetricName, Timed}
 import com.daml.resources.ProgramResource.StartupException
 import com.daml.resources.ResourceOwner
 import com.zaxxer.hikari.HikariDataSource
@@ -20,7 +22,6 @@ import javax.sql.DataSource
 import org.flywaydb.core.Flyway
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -28,63 +29,46 @@ final class Database(
     queries: Connection => Queries,
     readerConnectionPool: DataSource,
     writerConnectionPool: DataSource,
+    metricRegistry: MetricRegistry,
 ) {
-  private val logger = ContextualizedLogger.get(this.getClass)
-
-  def inReadTransaction[T](message: String)(
+  def inReadTransaction[T](name: String)(
       body: ReadQueries => Future[T],
-  )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): Future[T] = {
-    inTransaction(message, readerConnectionPool)(connection => body(queries(connection)))
-  }
+  )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): Future[T] =
+    inTransaction(name, readerConnectionPool)(connection => body(queries(connection)))
 
-  def inWriteTransaction[T](message: String)(
+  def inWriteTransaction[T](name: String)(
       body: Queries => Future[T],
-  )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): Future[T] = {
-    inTransaction(message, writerConnectionPool)(connection => body(queries(connection)))
-  }
+  )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): Future[T] =
+    inTransaction(name, writerConnectionPool)(connection => body(queries(connection)))
 
-  private def inTransaction[T](message: String, connectionPool: DataSource)(
+  private def inTransaction[T](name: String, connectionPool: DataSource)(
       body: Connection => Future[T],
   )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): Future[T] = {
-    val connection =
-      time(s"$message: acquiring connection")(connectionPool.getConnection())
-    timeFuture(message) {
-      body(connection)
-        .andThen {
-          case Success(_) => connection.commit()
-          case Failure(_) => connection.rollback()
-        }
-        .andThen {
-          case _ => connection.close()
-        }
-    }
+    val connection = Timed.value(Metrics.acquireConnection(name), connectionPool.getConnection())
+    Timed.future(
+      Metrics.run(name), {
+        body(connection)
+          .andThen {
+            case Success(_) => connection.commit()
+            case Failure(_) => connection.rollback()
+          }
+          .andThen {
+            case _ => connection.close()
+          }
+      }
+    )
   }
 
-  private def time[T](message: String)(body: => T)(implicit logCtx: LoggingContext): T = {
-    val startTime = timeStart(message)
-    val result = body
-    timeEnd(message, startTime)
-    result
+  private object Metrics {
+    private val prefix = MetricName.DAML :+ "ledger" :+ "database" :+ "transactions"
+
+    def acquireConnection(name: String): Timer =
+      metricRegistry.timer(prefix :+ name :+ "acquire_connection")
+
+    def run(name: String): Timer =
+      metricRegistry.timer(prefix :+ name :+ "run")
   }
 
-  private def timeFuture[T](message: String)(
-      body: => Future[T],
-  )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): Future[T] = {
-    val startTime = timeStart(message)
-    body.andThen {
-      case _ => timeEnd(message, startTime)
-    }
-  }
-
-  private def timeStart(message: String)(implicit logCtx: LoggingContext): Long = {
-    logger.trace(s"$message: starting")
-    System.nanoTime()
-  }
-
-  private def timeEnd(message: String, startTime: Long)(implicit logCtx: LoggingContext): Unit = {
-    val endTime = System.nanoTime()
-    logger.trace(s"$message: finished in ${Duration.fromNanos(endTime - startTime).toMillis}ms")
-  }
 }
 
 object Database {
@@ -101,7 +85,7 @@ object Database {
   // entries missing.
   private val MaximumWriterConnectionPoolSize: Int = 1
 
-  def owner(jdbcUrl: String)(
+  def owner(jdbcUrl: String, metricRegistry: MetricRegistry)(
       implicit logCtx: LoggingContext,
   ): ResourceOwner[UninitializedDatabase] =
     (jdbcUrl match {
@@ -110,17 +94,17 @@ object Database {
           "Unnamed in-memory H2 databases are not supported. Please name the database using the format \"jdbc:h2:mem:NAME\".",
         )
       case url if url.startsWith("jdbc:h2:mem:") =>
-        SingleConnectionDatabase.owner(RDBMS.H2, jdbcUrl)
+        SingleConnectionDatabase.owner(RDBMS.H2, jdbcUrl, metricRegistry)
       case url if url.startsWith("jdbc:h2:") =>
-        MultipleConnectionDatabase.owner(RDBMS.H2, jdbcUrl)
+        MultipleConnectionDatabase.owner(RDBMS.H2, jdbcUrl, metricRegistry)
       case url if url.startsWith("jdbc:postgresql:") =>
-        MultipleConnectionDatabase.owner(RDBMS.PostgreSQL, jdbcUrl)
+        MultipleConnectionDatabase.owner(RDBMS.PostgreSQL, jdbcUrl, metricRegistry)
       case url if url.startsWith("jdbc:sqlite::memory:") =>
         throw new InvalidDatabaseException(
           "Unnamed in-memory SQLite databases are not supported. Please name the database using the format \"jdbc:sqlite:file:NAME?mode=memory&cache=shared\".",
         )
       case url if url.startsWith("jdbc:sqlite:") =>
-        SingleConnectionDatabase.owner(RDBMS.SQLite, jdbcUrl)
+        SingleConnectionDatabase.owner(RDBMS.SQLite, jdbcUrl, metricRegistry)
       case _ =>
         throw new InvalidDatabaseException(s"Unknown database: $jdbcUrl")
     }).map { database =>
@@ -132,6 +116,7 @@ object Database {
     def owner(
         system: RDBMS,
         jdbcUrl: String,
+        metricRegistry: MetricRegistry,
     ): ResourceOwner[UninitializedDatabase] =
       for {
         readerConnectionPool <- ResourceOwner.forCloseable(() =>
@@ -145,6 +130,7 @@ object Database {
           readerConnectionPool,
           writerConnectionPool,
           adminConnectionPool,
+          metricRegistry,
         )
   }
 
@@ -152,6 +138,7 @@ object Database {
     def owner(
         system: RDBMS,
         jdbcUrl: String,
+        metricRegistry: MetricRegistry,
     ): ResourceOwner[UninitializedDatabase] =
       for {
         readerWriterConnectionPool <- ResourceOwner.forCloseable(() =>
@@ -163,6 +150,7 @@ object Database {
           readerWriterConnectionPool,
           readerWriterConnectionPool,
           adminConnectionPool,
+          metricRegistry,
         )
   }
 
@@ -210,6 +198,7 @@ object Database {
       readerConnectionPool: DataSource,
       writerConnectionPool: DataSource,
       adminConnectionPool: DataSource,
+      metricRegistry: MetricRegistry,
   ) {
     private val flyway: Flyway =
       Flyway
@@ -225,7 +214,7 @@ object Database {
 
     def migrate(): Database = {
       flyway.migrate()
-      new Database(system.queries, readerConnectionPool, writerConnectionPool)
+      new Database(system.queries, readerConnectionPool, writerConnectionPool, metricRegistry)
     }
 
     def clear(): this.type = {

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.on.sql.queries
+
+import com.codahale.metrics.{MetricRegistry, Timer}
+import com.daml.ledger.on.sql.Index
+import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
+import com.daml.ledger.participant.state.v1.LedgerId
+import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.metrics.{MetricName, Timed}
+
+import scala.collection.immutable
+import scala.util.Try
+
+final class TimedQueries(delegate: Queries, metricRegistry: MetricRegistry) extends Queries {
+
+  override def selectLatestLogEntryId(): Try[Option[Index]] =
+    Timed.value(Metrics.selectLatestLogEntryId, delegate.selectLatestLogEntryId())
+
+  override def selectFromLog(start: Index, end: Index): Try[immutable.Seq[(Index, LedgerRecord)]] =
+    Timed.value(Metrics.selectFromLog, delegate.selectFromLog(start, end))
+
+  override def selectStateValuesByKeys(keys: Seq[Key]): Try[immutable.Seq[Option[Value]]] =
+    Timed.value(Metrics.selectStateValuesByKeys, delegate.selectStateValuesByKeys(keys))
+
+  override def updateOrRetrieveLedgerId(providedLedgerId: LedgerId): Try[LedgerId] =
+    Timed.value(
+      Metrics.updateOrRetrieveLedgerId,
+      delegate.updateOrRetrieveLedgerId(providedLedgerId))
+
+  override def insertRecordIntoLog(key: Key, value: Value): Try[Index] =
+    Timed.value(Metrics.insertRecordIntoLog, delegate.insertRecordIntoLog(key, value))
+
+  override def updateState(stateUpdates: Seq[(Key, Value)]): Try[Unit] =
+    Timed.value(Metrics.updateState, delegate.updateState(stateUpdates))
+
+  private object Metrics {
+    private val prefix = MetricName.DAML :+ "ledger" :+ "database" :+ "queries"
+
+    val selectLatestLogEntryId: Timer =
+      metricRegistry.timer(prefix :+ "select_latest_log_entry_id")
+    val selectFromLog: Timer =
+      metricRegistry.timer(prefix :+ "select_from_log")
+    val selectStateValuesByKeys: Timer =
+      metricRegistry.timer(prefix :+ "select_state_values_by_keys")
+    val updateOrRetrieveLedgerId: Timer =
+      metricRegistry.timer(prefix :+ "update_or_retrieve_ledger_id")
+    val insertRecordIntoLog: Timer =
+      metricRegistry.timer(prefix :+ "insert_record_into_log")
+    val updateState: Timer =
+      metricRegistry.timer(prefix :+ "update_state")
+  }
+
+}

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/DatabaseSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/DatabaseSpec.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.on.sql
 
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.on.sql.Database.InvalidDatabaseException
 import com.daml.logging.LoggingContext.newLoggingContext
 import org.scalatest.{AsyncWordSpec, Matchers}
@@ -12,14 +13,14 @@ class DatabaseSpec extends AsyncWordSpec with Matchers {
     "not accept unnamed H2 database URLs" in {
       newLoggingContext { implicit logCtx =>
         an[InvalidDatabaseException] should be thrownBy
-          Database.owner("jdbc:h2:mem:")
+          Database.owner("jdbc:h2:mem:", new MetricRegistry)
       }
     }
 
     "not accept unnamed SQLite database URLs" in {
       newLoggingContext { implicit logCtx =>
         an[InvalidDatabaseException] should be thrownBy
-          Database.owner("jdbc:sqlite::memory:")
+          Database.owner("jdbc:sqlite::memory:", new MetricRegistry)
       }
     }
   }

--- a/ledger/metrics/collection/dashboards/ledger-submissions.json
+++ b/ledger/metrics/collection/dashboards/ledger-submissions.json
@@ -253,7 +253,7 @@
                 "y": 8
             },
             "hiddenSeries": false,
-            "id": 6,
+            "id": 12,
             "legend": {
                 "avg": false,
                 "current": false,
@@ -281,39 +281,14 @@
                 {
                     "refCount": 0,
                     "refId": "A",
-                    "target": "jvm.thread_states.count"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "B",
-                    "target": "jvm.thread_states.new.count"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "C",
-                    "target": "jvm.thread_states.runnable.count"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "D",
-                    "target": "jvm.thread_states.waiting.count"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "E",
-                    "target": "jvm.thread_states.timed_waiting.count"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "F",
-                    "target": "jvm.thread_states.blocked.count"
+                    "target": "daml.kvutils.reader.*.mean"
                 }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "JVM thread states",
+            "title": "Events processing time",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -329,7 +304,7 @@
             },
             "yaxes": [
                 {
-                    "format": "short",
+                    "format": "ms",
                     "label": null,
                     "logBase": 1,
                     "max": null,
@@ -363,6 +338,269 @@
                 "w": 12,
                 "x": 12,
                 "y": 8
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "refCount": 0,
+                    "refId": "A",
+                    "target": "daml.ledger.*.*.mean"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Ledger operations",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "refId": "A",
+                    "target": "daml.ledger.database.transactions.*.*.mean"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DAML-on-SQL database transactions",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "refId": "A",
+                    "target": "daml.ledger.database.queries.*.mean"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DAML-on-SQL database queries",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 24
             },
             "hiddenSeries": false,
             "id": 8,
@@ -479,5 +717,5 @@
     "variables": {
         "list": []
     },
-    "version": 2
+    "version": 4
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Timed.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Timed.scala
@@ -14,6 +14,9 @@ import scala.concurrent.Future
 
 object Timed {
 
+  def value[T](timer: Timer, value: => T): T =
+    timer.time(() => value)
+
   def completionStage[T](timer: Timer, future: => CompletionStage[T]): CompletionStage[T] = {
     val ctx = timer.time()
     future.whenComplete { (_, _) =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
@@ -33,7 +33,7 @@ class KeyValueParticipantState(
 )(implicit materializer: Materializer)
     extends ReadService
     with WriteService {
-  private val readerAdapter = new KeyValueParticipantStateReader(reader)
+  private val readerAdapter = new KeyValueParticipantStateReader(reader, metricRegistry)
   private val writerAdapter = new KeyValueParticipantStateWriter(writer, metricRegistry)
 
   override def getLedgerInitialConditions(): Source[LedgerInitialConditions, NotUsed] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -271,7 +271,7 @@ class SubmissionValidator[LogResult] private[validator] (
           if (acquisitionWasRecorded.compareAndSet(false, true)) {
             successfulAcquisitionTimer.stop()
           }
-          body(operations)
+          body(new TimedLedgerStateOperations(operations, metricRegistry))
             .transform(result => Success((result, Metrics.releaseTransactionLock.time())))
         }
         .transform {
@@ -288,19 +288,19 @@ class SubmissionValidator[LogResult] private[validator] (
   }
 
   private object Metrics {
-    private val prefix = kvutils.MetricPrefix :+ "submission" :+ "validator"
+    private val Prefix = kvutils.MetricPrefix :+ "submission" :+ "validator"
 
-    val openEnvelope: Timer = metricRegistry.timer(prefix :+ "open_envelope")
-    val acquireTransactionLock: Timer = metricRegistry.timer(prefix :+ "acquire_transaction_lock")
+    val openEnvelope: Timer = metricRegistry.timer(Prefix :+ "open_envelope")
+    val acquireTransactionLock: Timer = metricRegistry.timer(Prefix :+ "acquire_transaction_lock")
     val failedToAcquireTransaction: Timer =
-      metricRegistry.timer(prefix :+ "failed_to_acquire_transaction")
-    val releaseTransactionLock: Timer = metricRegistry.timer(prefix :+ "release_transaction_lock")
-    val validateSubmission: Timer = metricRegistry.timer(prefix :+ "validate_submission")
-    val processSubmission: Timer = metricRegistry.timer(prefix :+ "process_submission")
-    val commitSubmission: Timer = metricRegistry.timer(prefix :+ "commit_submission")
-    val transformSubmission: Timer = metricRegistry.timer(prefix :+ "transform_submission")
+      metricRegistry.timer(Prefix :+ "failed_to_acquire_transaction")
+    val releaseTransactionLock: Timer = metricRegistry.timer(Prefix :+ "release_transaction_lock")
+    val validateSubmission: Timer = metricRegistry.timer(Prefix :+ "validate_submission")
+    val processSubmission: Timer = metricRegistry.timer(Prefix :+ "process_submission")
+    val commitSubmission: Timer = metricRegistry.timer(Prefix :+ "commit_submission")
+    val transformSubmission: Timer = metricRegistry.timer(Prefix :+ "transform_submission")
 
-    private val stateValueCachePrefix: MetricName = prefix :+ "state_value_cache"
+    private val stateValueCachePrefix: MetricName = Prefix :+ "state_value_cache"
     metricRegistry.gauge(stateValueCachePrefix :+ "size", () => () => stateValueCache.size)
     metricRegistry.gauge(stateValueCachePrefix :+ "weight", () => () => stateValueCache.weight)
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
@@ -3,18 +3,15 @@
 
 package com.daml.ledger.participant.state.kvutils.api
 
-import java.time.ZoneOffset.UTC
-import java.time.{Instant, ZonedDateTime}
-
 import akka.NotUsed
 import akka.stream.scaladsl.{Sink, Source}
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateReaderSpec._
 import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, KVOffset}
 import com.daml.ledger.participant.state.v1.{Offset, Update}
-import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.google.protobuf.ByteString
-import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar._
 import org.scalatest.{AsyncWordSpec, Matchers}
@@ -28,7 +25,6 @@ class KeyValueParticipantStateReaderSpec
 
   import KVOffset.{fromLong => toOffset}
 
-  private val start: Instant = Instant.from(ZonedDateTime.of(2020, 1, 1, 12, 0, 0, 0, UTC))
   "participant state reader" should {
     "stream offsets from the start" in {
       val reader = readerStreamingFrom(
@@ -37,7 +33,7 @@ class KeyValueParticipantStateReaderSpec
         LedgerRecord(toOffset(2), aLogEntryId(2), aWrappedLogEntry),
         LedgerRecord(toOffset(3), aLogEntryId(3), aWrappedLogEntry),
       )
-      val instance = new KeyValueParticipantStateReader(reader)
+      val instance = new KeyValueParticipantStateReader(reader, new MetricRegistry)
       val stream = instance.stateUpdates(None)
 
       offsetsFrom(stream).map { actual =>
@@ -58,7 +54,7 @@ class KeyValueParticipantStateReaderSpec
         LedgerRecord(toOffset(7), aLogEntryId(7), aWrappedLogEntry),
         LedgerRecord(toOffset(8), aLogEntryId(8), aWrappedLogEntry),
       )
-      val instance = new KeyValueParticipantStateReader(reader)
+      val instance = new KeyValueParticipantStateReader(reader, new MetricRegistry)
       val stream = instance.stateUpdates(Some(toOffset(4)))
 
       offsetsFrom(stream).map { actual =>
@@ -76,7 +72,7 @@ class KeyValueParticipantStateReaderSpec
       val reader = readerStreamingFrom(
         offset = Some(toOffset(1)),
         LedgerRecord(toOffset(2), aLogEntryId(2), aWrappedLogEntry))
-      val instance = new KeyValueParticipantStateReader(reader)
+      val instance = new KeyValueParticipantStateReader(reader, new MetricRegistry)
       val stream = instance.stateUpdates(Some(toOffset(1)))
 
       offsetsFrom(stream).map { actual =>
@@ -91,7 +87,7 @@ class KeyValueParticipantStateReaderSpec
         LedgerRecord(toOffset(1), aLogEntryId(1), aWrappedLogEntry),
         LedgerRecord(toOffset(2), aLogEntryId(2), aWrappedLogEntry)
       )
-      val instance = new KeyValueParticipantStateReader(reader)
+      val instance = new KeyValueParticipantStateReader(reader, new MetricRegistry)
       val stream = instance.stateUpdates(None)
 
       offsetsFrom(stream).map { actual =>
@@ -108,7 +104,9 @@ class KeyValueParticipantStateReaderSpec
       )
 
       def getInstance(offset: Option[Offset], items: LedgerRecord*) =
-        new KeyValueParticipantStateReader(readerStreamingFrom(offset = offset, items: _*))
+        new KeyValueParticipantStateReader(
+          readerStreamingFrom(offset = offset, items: _*),
+          new MetricRegistry)
 
       val instances = records.tails.flatMap {
         case first :: rest =>
@@ -135,7 +133,7 @@ class KeyValueParticipantStateReaderSpec
       val reader = readerStreamingFrom(
         offset = None,
         LedgerRecord(toOffset(0), aLogEntryId(0), anInvalidEnvelope))
-      val instance = new KeyValueParticipantStateReader(reader)
+      val instance = new KeyValueParticipantStateReader(reader, new MetricRegistry)
 
       offsetsFrom(instance.stateUpdates(None)).failed.map { _ =>
         succeed
@@ -153,7 +151,7 @@ class KeyValueParticipantStateReaderSpec
       val reader = readerStreamingFrom(
         offset = None,
         LedgerRecord(toOffset(0), aLogEntryId(0), anInvalidEnvelopeMessage))
-      val instance = new KeyValueParticipantStateReader(reader)
+      val instance = new KeyValueParticipantStateReader(reader, new MetricRegistry)
 
       offsetsFrom(instance.stateUpdates(None)).failed.map { _ =>
         succeed
@@ -185,13 +183,6 @@ object KeyValueParticipantStateReaderSpec {
     val reader = mock[LedgerReader]
     val stream = Source.fromIterator(() => items.iterator)
     when(reader.events(offset)).thenReturn(stream)
-    reader
-  }
-
-  private def readerStreamingFromAnyOffset(items: LedgerRecord*): LedgerReader = {
-    val reader = mock[LedgerReader]
-    val stream = Source.fromIterator(() => items.iterator)
-    when(reader.events(any[Option[Offset]]())).thenReturn(stream)
     reader
   }
 


### PR DESCRIPTION
This adds metrics on the read side in a number of places:

- for all _kvutils_ "ledger state operations" (appending to the log, reading state, and writing state),
- event streaming post-processing in _kvutils_,
- in _ledger-on-memory_ and _ledger-on-sql_, reading from the log in order to push data to the indexer, and
- in _ledger-on-sql_, connection acquisition, transaction and query timing.

I've added graphs to our stock Grafana setup to show these. They look something like this:

![read metrics in Grafana](https://user-images.githubusercontent.com/60356447/79430155-ceec4980-7fc8-11ea-9fc9-1ee7a186eea1.png)

### Changelog

- **[Ledger Integration Kit]** Report timing metrics for ledger state operations.
- **[Sandbox]** Record ledger database timing metrics under "daml.ledger".

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
