### PR TITLE
Fix conversion from contract to node ids in the scenario service

### DIFF
--- a/compiler/damlc/tests/daml-test-files/TransientFailure.daml
+++ b/compiler/damlc/tests/daml-test-files/TransientFailure.daml
@@ -1,0 +1,35 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @ERROR exercise C on #1:1
+module TransientFailure where
+
+template T'
+  with
+    p: Party
+  where
+    signatory p
+    choice C : ()
+      controller p
+      do assert False
+
+template T
+  with
+    p: Party
+  where
+    signatory p
+    nonconsuming choice FailingTransient : ()
+      controller p
+      do cid <- create T' with p
+         exercise cid C
+
+testBio : Scenario ()
+testBio  = do
+  p <- getParty "p"
+  latestCid <- submit p do create T with p
+  -- This produces a failing transaction with a contract created
+  -- in the same transaction. In the past this resulted
+  -- in an exception in the scenario service when converting
+  -- between contract ids and node ids.
+  submit p do exercise latestCid FailingTransient
+  return ()

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -26,7 +26,7 @@ final class Conversions(
 
   // The ledger data will not contain information from the partial transaction at this point.
   // We need the mapping for converting error message so we manually add it here.
-  private val ptxCoidToNodeId = machine.ptx.nodes.toList
+  private val ptxCoidToNodeId = machine.ptx.nodes
     .collect({
       case (nodeId, node: N.NodeCreate.WithTxValue[V.ContractId]) =>
         node.coid match {

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -35,7 +35,7 @@ final class Conversions(
           case V.RelativeContractId(_) =>
             throw new IllegalArgumentException("unexpected relative contract id")
         }
-    })
+    }
 
   private val coidToNodeId = ledger.ledgerData.coidToNodeId ++ ptxCoidToNodeId
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -36,7 +36,6 @@ final class Conversions(
             throw new IllegalArgumentException("unexpected relative contract id")
         }
     })
-    .toMap
 
   private val coidToNodeId = ledger.ledgerData.coidToNodeId ++ ptxCoidToNodeId
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -31,7 +31,7 @@ final class Conversions(
       case (nodeId, node: N.NodeCreate.WithTxValue[V.ContractId]) =>
         node.coid match {
           case acoid: V.AbsoluteContractId =>
-            (node.coid.asInstanceOf[V.AbsoluteContractId], ledger.ptxNodeId(nodeId))
+            acoid -> ledger.ptxNodeId(nodeId)
           case V.RelativeContractId(_) =>
             throw new IllegalArgumentException("unexpected relative contract id")
         }

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -27,7 +27,7 @@ final class Conversions(
   // The ledger data will not contain information from the partial transaction at this point.
   // We need the mapping for converting error message so we manually add it here.
   private val ptxCoidToNodeId = machine.ptx.nodes
-    .collect({
+    .collect {
       case (nodeId, node: N.NodeCreate.WithTxValue[V.ContractId]) =>
         node.coid match {
           case acoid: V.AbsoluteContractId =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -389,6 +389,11 @@ object Ledger {
           }
       }
     }
+
+    // Given a ledger and the node index of a node in a partial transaction
+    // turn it into a node it that can be used in scenario error messages.
+    def ptxNodeId(nodeIdx: NodeId): ScenarioNodeId =
+      ScenarioNodeId(scenarioStepId.makeCommitPrefix, nodeIdx)
   }
 
   sealed trait CommitError


### PR DESCRIPTION
Previously we only included the mapping from the ledger. However, this
does not include any contracts which might have been created in a
partial transaction that failed. This caused a
`NoSuchElementException` when converting the error which is obviously
not what we want.

This PR extends the mapping to include any contracts created in the
current partial transaction.

changelog_begin

- [DAML Studio] Fix a bug where a failed transaction that included
  references to a transient contract returned a gRPC error instead of
  the expected error message.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
