### PR TITLE
Refactor createProjectPackageDb

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -119,6 +119,7 @@ da_haskell_library(
         "containers",
         "cryptonite",
         "directory",
+        "either",
         "extra",
         "file-embed",
         "filepath",

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -29,7 +29,6 @@ import Control.Exception
 import Control.Exception.Safe (handleIO)
 import Control.Concurrent.Extra
 import Control.Monad.Extra
-import Control.Monad.Trans.Maybe (runMaybeT)
 import qualified CmdLineParser as Cmd (warnMsg)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
@@ -506,9 +505,8 @@ calcUnitsFromDeps root deps = do
       bs <- BS.readFile (fromNormalizedFilePath root </> fp)
       pure (fp, bs)
   let mainDalfs = dalfsFromDars ++ dalfsFromFps
-  flip mapMaybeM mainDalfs $ \(file, dalf) -> runMaybeT $ do
+  forM mainDalfs $ \(file, dalf) -> do
     (pkgId, pkg) <-
-        liftIO $
         either (fail . DA.Pretty.renderPretty) pure $
         Archive.decodeArchive Archive.DecodeAsMain dalf
     let (name, mbVersion) = packageMetadataFromFile file pkg pkgId

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -10,10 +10,10 @@ module DA.Cli.Damlc.Packaging
 import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
 import Control.Lens (toListOf)
 import Control.Monad.Extra
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Maybe
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
+import Data.Either.Combinators
 import Data.Graph
 import Data.List.Extra
 import qualified Data.Map.Strict as MS
@@ -102,119 +102,40 @@ createProjectPackageDb projectRoot opts thisSdkVer deps dataDeps
     mbRes <- withDamlIdeState opts loggerH diagnosticsLogger $ \ide -> runActionSync ide $ runMaybeT $
         (,) <$> useNoFileE GenerateStablePackages
             <*> useE GeneratePackageMap projectRoot
-    (stablePkgs, dependencies) <- maybe (fail "Failed to generate package info") pure mbRes
+    (stablePkgs, dependenciesInPkgDb) <- maybe (fail "Failed to generate package info") pure mbRes
     let stablePkgIds :: Set LF.PackageId
         stablePkgIds = Set.fromList $ map LF.dalfPackageId $ MS.elems stablePkgs
-    -- This includes both SDK dependencies like daml-prim and daml-stdlib but also DARs specified
-    -- in the dependencies field.
-    let dependencyPkgIdMap :: MS.Map UnitId LF.PackageId
-        dependencyPkgIdMap = MS.map LF.dalfPackageId dependencies
-    let dependencyPkgIds = Set.fromList $ MS.elems dependencyPkgIdMap
+    let dependenciesInPkgDbIds =
+            Set.fromList $ map LF.dalfPackageId $ MS.elems dependenciesInPkgDb
 
     -- Now handle data imports.
-    let (fpDars, fpDalfs) = partition ((== ".dar") . takeExtension) dataDeps
-    dars <- mapM extractDar fpDars
-    -- These are the dalfs that are in a DAR that has been passed in via data-dependencies.
-    let dalfsFromDars =
-            [ ( ZipArchive.eRelativePath e
-              , BSL.toStrict $ ZipArchive.fromEntry e
-              )
-            | e <- concatMap edDalfs dars
-            ]
-    -- These are dalfs that have been passed in directly as DALFs via data-dependencies.
-    dalfsFromFps <-
-        forM fpDalfs $ \fp -> do
-            bs <- BS.readFile fp
-            pure (fp, bs)
-    let allDalfs = dalfsFromDars ++ dalfsFromFps
-    pkgs <- flip mapMaybeM allDalfs $ \(dalfPath, dalf) -> runMaybeT $ do
-        (pkgId, package) <-
-            liftIO $
-            either (fail . DA.Pretty.renderPretty) pure $
-            Archive.decodeArchive Archive.DecodeAsDependency dalf
-        -- daml-prim and daml-stdlib are somewhat special:
-        --
-        -- We always have daml-prim and daml-stdlib from the current SDK and we
-        -- cannot control their unit id since that would require recompiling them.
-        -- However, we might also have daml-prim and daml-stdlib in a different version
-        -- in a DAR we are depending on. Luckily, we can control the unit id there.
-        -- To avoid colliding unit ids which will confuse GHC (or rather hide
-        -- one of them), we instead include the package hash in the unit id.
-        --
-        -- In principle, we can run into the same issue if you combine "dependencies"
-        -- (which have precompiled interface files) and
-        -- "data-dependencies". However, there you can get away with changing the
-        -- package name and version to change the unit id which is not possible for
-        -- daml-prim.
-        --
-        -- If the version of daml-prim/daml-stdlib in a data-dependency is the same
-        -- as the one we are currently compiling against, we don’t need to apply this
-        -- hack.
-        let (name, mbVersion) = case LF.packageMetadataFromFile dalfPath package pkgId of
-              (LF.PackageName "daml-prim", Nothing) | pkgId `Set.notMember` dependencyPkgIds -> (LF.PackageName ("daml-prim-" <> LF.unPackageId pkgId), Nothing)
-              (LF.PackageName "daml-stdlib", _) | pkgId `Set.notMember` dependencyPkgIds -> (LF.PackageName ("daml-stdlib-" <> LF.unPackageId pkgId), Nothing)
-              (name, mbVersion) -> (name, mbVersion)
-        pure (pkgNameVersion name mbVersion, LF.DalfPackage pkgId (LF.ExternalPackage pkgId package) dalf)
+    dalfsFromDataDependencies <- getDalfsFromDataDependencies dependenciesInPkgDbIds dataDeps
 
-    -- All transitive packages from DARs specified in  `dependencies`. This is only used for unit-id collision checks
+    -- All transitive packages from DARs specified in  `dependencies`.
+    -- This is only used for unit-id collision checks
     -- and dependencies on newer LF versions.
-    transitiveDependencies <- fmap concat $ forM depsExtracted $ \ExtractedDar{..} -> forM edDalfs $ \zipEntry -> do
-       let bytes = BSL.toStrict $ ZipArchive.fromEntry zipEntry
-       (pkgId, pkg) <- liftIO $
-            either (fail . DA.Pretty.renderPretty) pure $
-            Archive.decodeArchive Archive.DecodeAsMain bytes
-       let (pkgName, mbPkgVer) = LF.packageMetadataFromFile (ZipArchive.eRelativePath zipEntry) pkg pkgId
-       pure (pkgId, (pkgNameVersion pkgName mbPkgVer, LF.packageLfVersion pkg))
+    dalfsFromDependencies <- getDalfsFromDependencies depsExtracted
 
-
-    -- We perform this check before checking for unit id collisions since it provides a more useful error message.
-    let newerLfDeps =
-          filter (\(_, ver) -> ver > optDamlLfVersion opts) $ concat
-            [ [ ((LF.dalfPackageId dalfPkg, unitId), (LF.packageLfVersion . LF.extPackagePkg . LF.dalfPackagePkg) dalfPkg)
-              | (unitId, dalfPkg) <- pkgs <> MS.toList dependencies
-              ]
-            , [ ((pkgId, unitId), version)
-              | (pkgId, (unitId, version)) <- transitiveDependencies
-              ]
-            ]
-    when (not $ null newerLfDeps) $
-        exitWithError $ "Targeted LF version " <> DA.Pretty.renderPretty (optDamlLfVersion opts) <> " but dependencies have newer LF versions: " ++
-          intercalate ", " [ T.unpack (LF.unPackageId pkgId) <> " (" <> unitIdString unitId <> "): " <> DA.Pretty.renderPretty ver | ((pkgId, unitId), ver) <- newerLfDeps ]
-
-    let unitIdConflicts = MS.filter ((>=2) . Set.size) .  MS.fromListWith Set.union $ concat
-            [ [ (unitId, Set.singleton (LF.dalfPackageId dalfPkg))
-              | (unitId, dalfPkg) <- pkgs ]
-            , [ (unitId, Set.singleton (LF.dalfPackageId dalfPkg))
-              | (unitId, dalfPkg) <- MS.toList dependencies ]
-            , [ (unitId, Set.singleton pkgId)
-              | (pkgId, (unitId, _)) <- transitiveDependencies
-              ]
-            ]
-    when (not $ MS.null unitIdConflicts) $ do
-        fail $ "Transitive dependencies with same unit id but conflicting package ids: "
-            ++ intercalate ", "
-                [ show k <> " [" <> intercalate "," (map (T.unpack . LF.unPackageId) (Set.toList v)) <> "]"
-                | (k,v) <- MS.toList unitIdConflicts ]
-
-    -- We only do this at this point to ensure that all checks for duplicate unit ids have come
-    -- before and don’t end up blowing up GHC.
-    exposedModules <- do
-        -- We need to avoid inference of package flags. Otherwise, we will
-        -- try to load package flags for data-dependencies that we have not generated
-        -- yet. We only look for the packages in the package db so the --package flags
-        -- do not matter and can be actively harmful since we might have picked up
-        -- some from the daml.yaml if they are explicitly specified.
-        opts <- pure opts
-            { optInferDependantPackages = InferDependantPackages False
-            , optPackageImports = []
+    let dependencyInfo = DependencyInfo
+            { dependenciesInPkgDb
+            , dalfsFromDependencies
+            , dalfsFromDataDependencies
             }
-        hscEnv <-
-            (maybe (exitWithError "Failed to list exposed modules") (pure . hscEnv) =<<) $
-            withDamlIdeState opts loggerH diagnosticsLogger $ \ide ->
-            runActionSync ide $ runMaybeT $ useE GhcSession projectRoot
-        pure $! getExposedModules $ hsc_dflags hscEnv
 
-    let (depGraph, vertexToNode) = buildLfPackageGraph pkgs stablePkgs dependencies
+    -- We perform this check before checking for unit id collisions
+    -- since it provides a more useful error message.
+    whenLeft
+        (checkForIncompatibleLfVersions (optDamlLfVersion opts) dependencyInfo)
+        exitWithError
+    whenLeft
+        (checkForUnitIdConflicts dependencyInfo)
+        exitWithError
+
+    -- We run the checks for duplicate unit ids before
+    -- to avoid blowing up GHC when setting up the GHC session.
+    exposedModules <- getExposedModules opts projectRoot
+
+    let (depGraph, vertexToNode) = buildLfPackageGraph dalfsFromDataDependencies stablePkgs dependenciesInPkgDb
     -- Iterate over the dependency graph in topological order.
     -- We do a topological sort on the transposed graph which ensures that
     -- the packages with no dependencies come first and we
@@ -223,7 +144,7 @@ createProjectPackageDb projectRoot opts thisSdkVer deps dataDeps
       let (pkgNode, pkgId) = vertexToNode vertex in
       -- stable packages are mapped to the current version of daml-prim/daml-stdlib
       -- so we don’t need to generate interface files for them.
-      unless (pkgId `Set.member` stablePkgIds || pkgId `Set.member` dependencyPkgIds) $ do
+      unless (pkgId `Set.member` stablePkgIds || pkgId `Set.member` dependenciesInPkgDbIds) $ do
         let unitIdStr = unitIdString $ unitId pkgNode
         let pkgIdStr = T.unpack $ LF.unPackageId pkgId
         let (pkgName, mbPkgVersion) = LF.splitUnitId (unitId pkgNode)
@@ -249,7 +170,7 @@ createProjectPackageDb projectRoot opts thisSdkVer deps dataDeps
             pkgName
             mbPkgVersion
             deps
-            dependencies
+            dependenciesInPkgDb
             exposedModules
   where
     dbPath = projectPackageDatabase </> lfVersionString (optDamlLfVersion opts)
@@ -260,14 +181,6 @@ createProjectPackageDb projectRoot opts thisSdkVer deps dataDeps
         -- reinitializing everything, we probably want to change this.
         removePathForcibly dbPath
         createDirectoryIfMissing True $ dbPath </> "package.conf.d"
-
--- Produce the list of exposed modules for each package.
-getExposedModules :: DynFlags -> MS.Map UnitId (UniqSet GHC.ModuleName)
-getExposedModules df =
-    MS.fromList $
-    map (\pkgConf -> (getUnitId pkgConf, mkUniqSet $ map fst $ GHC.exposedModules pkgConf)) $
-    GHC.listPackageConfigMap df
-    where getUnitId = GHC.DefiniteUnitId . GHC.DefUnitId . GHC.unitId
 
 toGhcModuleName :: LF.ModuleName -> GHC.ModuleName
 toGhcModuleName = GHC.mkModuleName . T.unpack . LF.moduleNameString
@@ -546,3 +459,156 @@ exitWithError msg = do
     hPutStrLn stderr msg
     hFlush stderr
     exitFailure
+
+data DependencyInfo = DependencyInfo
+  { dependenciesInPkgDb :: MS.Map UnitId LF.DalfPackage
+  -- ^ Dependencies picked up by the GeneratePackageMap rule.
+  -- The rule is run after installing DALFs from `dependencies` so
+  -- this includes dependencies in the builtin package db like daml-prim
+  -- as well as the main DALFs of DARs specified in `dependencies`.
+  , dalfsFromDependencies :: [(LF.PackageId, (UnitId, LF.Version))]
+  -- ^ All dalfs (not just main DALFs) in DARs listed in `dependencies`.
+  -- This does not include DALFs in the global package db like daml-prim.
+  -- Note that a DAR does not include interface files for dependencies
+  -- so to use a DAR as a `dependency` you also need to list the DARs of all
+  -- of its dependencies.
+  , dalfsFromDataDependencies :: [(UnitId, LF.DalfPackage)]
+  -- ^ All dalfs (not jus tmain DALFs) from DARs and DALFs listed in `data-dependencies`.
+  -- Note that for data-dependencies it is sufficient to list a DAR without
+  -- listing all of its dependencies.
+  }
+
+checkForIncompatibleLfVersions :: LF.Version -> DependencyInfo -> Either String ()
+checkForIncompatibleLfVersions lfTarget DependencyInfo{dalfsFromDependencies, dalfsFromDataDependencies}
+  | null incompatibleLfDeps = Right ()
+  | otherwise = Left $ concat
+        [ "Targeted LF version "
+        , DA.Pretty.renderPretty lfTarget
+        , " but dependencies have newer LF versions: "
+        , intercalate ", "
+              [ T.unpack (LF.unPackageId pkgId) <>
+                " (" <> unitIdString unitId <> "): " <> DA.Pretty.renderPretty ver
+              | ((pkgId, unitId), ver) <- incompatibleLfDeps
+              ]
+        ]
+  where
+    incompatibleLfDeps =
+        filter (\(_, ver) -> ver > lfTarget) $ concat
+            [ [ ((pkgId, unitId), version)
+              | (pkgId, (unitId, version)) <- dalfsFromDependencies
+              ]
+            , [ ( (LF.dalfPackageId dalfPkg, unitId)
+                , (LF.packageLfVersion . LF.extPackagePkg . LF.dalfPackagePkg) dalfPkg
+                )
+              | (unitId, dalfPkg) <- dalfsFromDataDependencies
+              ]
+            ]
+
+checkForUnitIdConflicts :: DependencyInfo -> Either String ()
+checkForUnitIdConflicts DependencyInfo{..}
+  | MS.null unitIdConflicts = Right ()
+  | otherwise = Left $ concat
+        [ "Transitive dependencies with same unit id but conflicting package ids: "
+        , intercalate ", "
+              [ show k <>
+                " [" <>
+                intercalate "," (map (T.unpack . LF.unPackageId) (Set.toList v)) <>
+                "]"
+              | (k,v) <- MS.toList unitIdConflicts
+              ]
+        ]
+  where
+    unitIdConflicts = MS.filter ((>=2) . Set.size) .  MS.fromListWith Set.union $ concat
+        [ [ (unitId, Set.singleton (LF.dalfPackageId dalfPkg))
+          | (unitId, dalfPkg) <- dalfsFromDataDependencies
+          ]
+        , [ (unitId, Set.singleton (LF.dalfPackageId dalfPkg))
+          | (unitId, dalfPkg) <- MS.toList dependenciesInPkgDb
+          ]
+        , [ (unitId, Set.singleton pkgId)
+          | (pkgId, (unitId, _)) <- dalfsFromDependencies
+          ]
+        ]
+
+getExposedModules :: Options -> NormalizedFilePath -> IO (MS.Map UnitId (UniqSet GHC.ModuleName))
+getExposedModules opts projectRoot = do
+    logger <- getLogger opts "list exposed modules"
+    -- We need to avoid inference of package flags. Otherwise, we will
+    -- try to load package flags for data-dependencies that we have not generated
+    -- yet. We only look for the packages in the package db so the --package flags
+    -- do not matter and can be actively harmful since we might have picked up
+    -- some from the daml.yaml if they are explicitly specified.
+    opts <- pure opts
+        { optInferDependantPackages = InferDependantPackages False
+        , optPackageImports = []
+        }
+    hscEnv <-
+        (maybe (exitWithError "Failed to list exposed modules") (pure . hscEnv) =<<) $
+        withDamlIdeState opts logger diagnosticsLogger $ \ide ->
+        runActionSync ide $ runMaybeT $ useE GhcSession projectRoot
+    pure $! exposedModulesFromDynFlags $ hsc_dflags hscEnv
+  where
+    exposedModulesFromDynFlags :: DynFlags -> MS.Map UnitId (UniqSet GHC.ModuleName)
+    exposedModulesFromDynFlags df =
+        MS.fromList $
+        map (\pkgConf -> (getUnitId pkgConf, mkUniqSet $ map fst $ GHC.exposedModules pkgConf)) $
+        GHC.listPackageConfigMap df
+    getUnitId = GHC.DefiniteUnitId . GHC.DefUnitId . GHC.unitId
+
+getDalfsFromDataDependencies :: Set LF.PackageId -> [FilePath] -> IO [(UnitId, LF.DalfPackage)]
+getDalfsFromDataDependencies dependenciesInPkgDb files = do
+    extractedDars <- mapM extractDar fpDars
+
+    -- These are the dalfs that are in a DAR that has been passed in via data-dependencies.
+    let dalfsFromDars =
+            [ ( ZipArchive.eRelativePath e
+              , BSL.toStrict $ ZipArchive.fromEntry e
+              )
+            | e <- concatMap edDalfs extractedDars
+            ]
+    -- These are dalfs that have been passed in directly as DALFs via data-dependencies.
+    dalfsFromFps <-
+        forM fpDalfs $ \fp -> do
+            bs <- BS.readFile fp
+            pure (fp, bs)
+    let allDalfs :: [(FilePath, BS.ByteString)] = dalfsFromDars ++ dalfsFromFps
+    forM allDalfs $ \(dalfPath, dalf) -> do
+        (pkgId, package) <-
+            either (fail . DA.Pretty.renderPretty) pure $
+            Archive.decodeArchive Archive.DecodeAsDependency dalf
+        -- daml-prim and daml-stdlib are somewhat special:
+        --
+        -- We always have daml-prim and daml-stdlib from the current SDK and we
+        -- cannot control their unit id since that would require recompiling them.
+        -- However, we might also have daml-prim and daml-stdlib in a different version
+        -- in a DAR we are depending on. Luckily, we can control the unit id there.
+        -- To avoid colliding unit ids which will confuse GHC (or rather hide
+        -- one of them), we instead include the package hash in the unit id.
+        --
+        -- In principle, we can run into the same issue if you combine "dependencies"
+        -- (which have precompiled interface files) and
+        -- "data-dependencies". However, there you can get away with changing the
+        -- package name and version to change the unit id which is not possible for
+        -- daml-prim.
+        --
+        -- If the version of daml-prim/daml-stdlib in a data-dependency is the same
+        -- as the one we are currently compiling against, we don’t need to apply this
+        -- hack.
+        let (name, mbVersion) = case LF.packageMetadataFromFile dalfPath package pkgId of
+              (LF.PackageName "daml-prim", Nothing) | pkgId `Set.notMember` dependenciesInPkgDb -> (LF.PackageName ("daml-prim-" <> LF.unPackageId pkgId), Nothing)
+              (LF.PackageName "daml-stdlib", _) | pkgId `Set.notMember` dependenciesInPkgDb -> (LF.PackageName ("daml-stdlib-" <> LF.unPackageId pkgId), Nothing)
+              (name, mbVersion) -> (name, mbVersion)
+        pure (pkgNameVersion name mbVersion, LF.DalfPackage pkgId (LF.ExternalPackage pkgId package) dalf)
+    where (fpDars, fpDalfs) = partition ((== ".dar") . takeExtension) files
+
+getDalfsFromDependencies :: [ExtractedDar] -> IO [(LF.PackageId, (UnitId, LF.Version))]
+getDalfsFromDependencies depsExtracted =
+    fmap concat $
+    forM depsExtracted $ \ExtractedDar{..} ->
+    forM edDalfs $ \zipEntry -> do
+       let bytes = BSL.toStrict $ ZipArchive.fromEntry zipEntry
+       (pkgId, pkg) <-
+            either (fail . DA.Pretty.renderPretty) pure $
+            Archive.decodeArchive Archive.DecodeAsMain bytes
+       let (pkgName, mbPkgVer) = LF.packageMetadataFromFile (ZipArchive.eRelativePath zipEntry) pkg pkgId
+       pure (pkgId, (pkgNameVersion pkgName mbPkgVer, LF.packageLfVersion pkg))


### PR DESCRIPTION
This is a first step in probably a series of PRs to cleanup the
packaging logic.

There is no change in functionality (or at least none that is
intended). The changes boil down to two things:

1. Add a `DependencyInfo` type that stores the various maps and has
   detailed comments what exactly is in each map and hopefully somewhat
   descriptive field names.
2. Move a lot of the logic in `createProjectPackageDb` into various
   helper functions.

There is definitely a lot more cleanup and refactoring that we can do
here but I’ll try to keep it in manageable chunks.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
