### PR TITLE
sandbox: Moar command submission metrics.

### DIFF
--- a/ledger/metrics/collection/dashboards/ledger-submissions.json
+++ b/ledger/metrics/collection/dashboards/ledger-submissions.json
@@ -60,6 +60,12 @@
             "steppedLine": false,
             "targets": [
                 {
+                    "refCount": 0,
+                    "refId": "B",
+                    "target": "daml.commands.submissions.count"
+                },
+                {
+                    "refCount": 0,
                     "refId": "A",
                     "target": "daml.services.write.submit_transaction.count"
                 }
@@ -68,7 +74,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Submission count",
+            "title": "Command submission count",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -120,7 +126,7 @@
                 "y": 0
             },
             "hiddenSeries": false,
-            "id": 4,
+            "id": 8,
             "legend": {
                 "avg": false,
                 "current": false,
@@ -146,62 +152,26 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "hide": false,
                     "refCount": 0,
                     "refId": "A",
-                    "target": "daml.services.write.submit_transaction.mean"
+                    "target": "jvm.memory_usage.total.used"
                 },
                 {
                     "refCount": 0,
                     "refId": "B",
-                    "target": "daml.kvutils.committer.run_timer.mean"
+                    "target": "jvm.memory_usage.heap.used"
                 },
                 {
                     "refCount": 0,
                     "refId": "C",
-                    "target": "daml.kvutils.committer.transaction.run_timer.mean"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "D",
-                    "target": "daml.kvutils.submission.conversion.transaction_to_submission.mean"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "E",
-                    "target": "daml.kvutils.submission.validator.acquire_transaction_lock.mean"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "F",
-                    "target": "daml.kvutils.submission.validator.release_transaction_lock.mean"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "G",
-                    "target": "daml.kvutils.submission.validator.open_envelope.mean"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "H",
-                    "target": "daml.kvutils.submission.validator.validate_submission.mean"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "I",
-                    "target": "daml.kvutils.submission.validator.process_submission.mean"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "J",
-                    "target": "daml.kvutils.submission.validator.commit_submission.mean"
+                    "target": "jvm.memory_usage.non-heap.used"
                 }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Submission processing time",
+            "title": "JVM memory used",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -217,8 +187,8 @@
             },
             "yaxes": [
                 {
-                    "format": "ms",
-                    "label": "",
+                    "format": "decbytes",
+                    "label": null,
                     "logBase": 1,
                     "max": null,
                     "min": null,
@@ -230,7 +200,7 @@
                     "logBase": 1,
                     "max": null,
                     "min": null,
-                    "show": false
+                    "show": true
                 }
             ],
             "yaxis": {
@@ -253,7 +223,7 @@
                 "y": 8
             },
             "hiddenSeries": false,
-            "id": 12,
+            "id": 17,
             "legend": {
                 "avg": false,
                 "current": false,
@@ -281,14 +251,39 @@
                 {
                     "refCount": 0,
                     "refId": "A",
-                    "target": "daml.kvutils.reader.*.mean"
+                    "target": "daml.commands.submissions.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "B",
+                    "target": "daml.commands.execution.total.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "C",
+                    "target": "daml.commands.execution.get_lf_package.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "D",
+                    "target": "daml.commands.execution.lookup_active_contract.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "E",
+                    "target": "daml.commands.execution.lookup_contract_key.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "F",
+                    "target": "daml.services.write.submit_transaction.mean"
                 }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Events processing time",
+            "title": "Command submission (API server)",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -338,6 +333,226 @@
                 "w": 12,
                 "x": 12,
                 "y": 8
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "hide": false,
+                    "refCount": 0,
+                    "refId": "A",
+                    "target": "daml.services.write.submit_transaction.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "D",
+                    "target": "daml.kvutils.submission.conversion.transaction_to_submission.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "E",
+                    "target": "daml.kvutils.submission.validator.acquire_transaction_lock.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "F",
+                    "target": "daml.kvutils.submission.validator.release_transaction_lock.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "G",
+                    "target": "daml.kvutils.submission.validator.open_envelope.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "H",
+                    "target": "daml.kvutils.submission.validator.validate_submission.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "I",
+                    "target": "daml.kvutils.submission.validator.process_submission.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "B",
+                    "target": "daml.kvutils.committer.run_timer.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "C",
+                    "target": "daml.kvutils.committer.transaction.run_timer.mean"
+                },
+                {
+                    "refCount": 0,
+                    "refId": "J",
+                    "target": "daml.kvutils.submission.validator.commit_submission.mean"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Transaction submission (participant)",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 16
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "dataLinks": []
+            },
+            "percentage": false,
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "refCount": 0,
+                    "refId": "A",
+                    "target": "daml.kvutils.reader.*.mean"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Events processing time (participant)",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 16
             },
             "hiddenSeries": false,
             "id": 10,
@@ -428,7 +643,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 16
+                "y": 24
             },
             "hiddenSeries": false,
             "id": 14,
@@ -514,7 +729,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 16
+                "y": 24
             },
             "hiddenSeries": false,
             "id": 15,
@@ -587,103 +802,6 @@
                 "align": false,
                 "alignLevel": null
             }
-        },
-        {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": null,
-            "fill": 1,
-            "fillGradient": 0,
-            "gridPos": {
-                "h": 8,
-                "w": 12,
-                "x": 0,
-                "y": 24
-            },
-            "hiddenSeries": false,
-            "id": 8,
-            "legend": {
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "show": true,
-                "total": false,
-                "values": false
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "null",
-            "options": {
-                "dataLinks": []
-            },
-            "percentage": false,
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                    "refCount": 0,
-                    "refId": "A",
-                    "target": "jvm.memory_usage.total.used"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "B",
-                    "target": "jvm.memory_usage.heap.used"
-                },
-                {
-                    "refCount": 0,
-                    "refId": "C",
-                    "target": "jvm.memory_usage.non-heap.used"
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "JVM memory used",
-            "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                    "format": "decbytes",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                },
-                {
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                }
-            ],
-            "yaxis": {
-                "align": false,
-                "alignLevel": null
-            }
         }
     ],
     "refresh": "5s",
@@ -717,5 +835,5 @@
     "variables": {
         "list": []
     },
-    "version": 4
+    "version": 14
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/MetricsInterceptor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/MetricsInterceptor.scala
@@ -3,11 +3,10 @@
 
 package com.daml.platform.apiserver
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import com.codahale.metrics.{MetricRegistry, Timer}
 import com.daml.metrics.MetricName
-import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor}
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall
+import io.grpc.{Metadata, ServerCall, ServerCallHandler, ServerInterceptor, Status}
 
 import scala.collection.concurrent.TrieMap
 
@@ -44,38 +43,17 @@ final class MetricsInterceptor(metrics: MetricRegistry) extends ServerIntercepto
       fullMethodName,
       MetricsNaming.nameFor(fullMethodName))
     val timer = metrics.timer(metricName).time()
-    val listener = next.startCall(call, headers)
-    new TimedListener(listener, timer)
+    next.startCall(new TimedServerCall(call, timer), headers)
   }
 
-  class TimedListener[ReqT](listener: ServerCall.Listener[ReqT], timer: Timer.Context)
-      extends ServerCall.Listener[ReqT] {
-    private val timerStopped = new AtomicBoolean(false)
-
-    override def onReady(): Unit =
-      listener.onReady()
-
-    override def onMessage(message: ReqT): Unit =
-      listener.onMessage(message)
-
-    override def onHalfClose(): Unit =
-      listener.onHalfClose()
-
-    override def onCancel(): Unit = {
-      listener.onCancel()
-      stopTimer()
-    }
-
-    override def onComplete(): Unit = {
-      listener.onComplete()
-      stopTimer()
-    }
-
-    private def stopTimer(): Unit = {
-      if (timerStopped.compareAndSet(false, true)) {
-        timer.stop()
-        ()
-      }
+  private final class TimedServerCall[ReqT, RespT](
+      delegate: ServerCall[ReqT, RespT],
+      timer: Timer.Context,
+  ) extends SimpleForwardingServerCall[ReqT, RespT](delegate) {
+    override def close(status: Status, trailers: Metadata): Unit = {
+      delegate.close(status, trailers)
+      timer.stop()
+      ()
     }
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/package.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/package.scala
@@ -7,6 +7,6 @@ import com.daml.metrics.MetricName
 
 package object execution {
 
-  private[execution] val MetricPrefix = MetricName.DAML :+ "execution"
+  private[execution] val MetricPrefix = MetricName.DAML :+ "commands" :+ "execution"
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
@@ -12,7 +12,6 @@ import com.daml.api.util.TimeProvider
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.domain.{LedgerId, Commands => ApiCommands}
 import com.daml.ledger.api.messages.command.submission.SubmitRequest
-import com.daml.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc
 import com.daml.ledger.participant.state.index.v2.{
   CommandDeduplicationDuplicate,
   CommandDeduplicationNew,
@@ -35,9 +34,8 @@ import com.daml.lf.transaction.BlindingInfo
 import com.daml.lf.transaction.Transaction.Transaction
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
-import com.daml.metrics.Timed
+import com.daml.metrics.{MetricName, Timed}
 import com.daml.platform.api.grpc.GrpcApiService
-import com.daml.platform.apiserver.MetricsNaming
 import com.daml.platform.apiserver.execution.{CommandExecutionResult, CommandExecutor}
 import com.daml.platform.server.api.services.domain.CommandSubmissionService
 import com.daml.platform.server.api.services.grpc.GrpcCommandSubmissionService
@@ -126,19 +124,18 @@ final class ApiSubmissionService private (
   private val logger = ContextualizedLogger.get(this.getClass)
 
   private object Metrics {
-    private val servicePrefix =
-      MetricsNaming.nameForService(CommandSubmissionServiceGrpc.javaDescriptor.getFullName)
+    private val Prefix = MetricName.DAML :+ "commands"
 
     val submissionsTimer: Timer =
-      metrics.timer(servicePrefix :+ "submissions")
+      metrics.timer(Prefix :+ "submissions")
     val failedInterpretationsMeter: Meter =
-      metrics.meter(servicePrefix :+ "failed_command_interpretations")
+      metrics.meter(Prefix :+ "failed_command_interpretations")
     val deduplicatedCommandsMeter: Meter =
-      metrics.meter(servicePrefix :+ "deduplicated_commands")
+      metrics.meter(Prefix :+ "deduplicated_commands")
     val delayedSubmissionsMeter: Meter =
-      metrics.meter(servicePrefix :+ "delayed_submissions")
+      metrics.meter(Prefix :+ "delayed_submissions")
     val validSubmissionsMeter: Meter =
-      metrics.meter(servicePrefix :+ "valid_submissions")
+      metrics.meter(Prefix :+ "valid_submissions")
   }
 
   private def deduplicateAndRecordOnLedger(seed: Option[crypto.Hash], commands: ApiCommands)(


### PR DESCRIPTION
We were not capturing submission time when the submission comes through the Command Service, rather than the Command Submission Service. I added one at `daml.commands.submissions`, and then moved the others to match.

Originally I added it as `daml.lapi.command_submission_service.submissions`, but as this also applies to submissions that come through another service, this was quite confusing. The same is true for all the other metrics I moved; they're captured even if the Command Submission Service was not the originating endpoint.

I removed `daml.lapi.command_submission_service.submitted_transactions` because it's a duplicate of `daml.services.write.submit_transaction`. I did keep a meter around to replace it though.

The Grafana dashboard now looks like this (running ledger-on-memory):

![Grafana dashboard](https://user-images.githubusercontent.com/60356447/79465856-2821a080-7ffc-11ea-8538-8b7309ee6e2f.png)

### Changelog

- **[Ledger API Server]** A number of command submission metrics have moved, and we have added a couple.
  - `daml.commands.submissions` is a new timer that measures all submissions.
  - `daml.commands.valid_submissions` is a new meter that counts valid (unique, interpretable) submissions.
  - `daml.lapi.command_submission_service.failed_command_interpretations` has been moved to `daml.commands.failed_command_interpretations`.
  - `daml.lapi.command_submission_service.deduplicated_commands` has been moved to `daml.commands.deduplicated_commands`.
  - `daml.lapi.command_submission_service.delayed_submissions` has been moved to `daml.commands.delayed_submissions`.
  - `daml.lapi.command_submission_service.submitted_transactions` has been moved to `daml.services.write.submit_transaction`.
  - All `daml.execution.*` metrics have moved to `daml.commands.execution`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
