### PR TITLE
enable patch releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ trigger:
   branches:
     include:
       - master
+      - release/*
 
 # Enable PR triggers that target the master branch
 pr:
@@ -18,6 +19,7 @@ pr:
   branches:
     include:
       - master
+      - release/*
 
 jobs:
   - job: git_sha
@@ -38,6 +40,10 @@ jobs:
         name: out
 
   - job: check_standard_change_label
+    dependsOn:
+      - git_sha
+    variables:
+      fork_sha: $[ dependencies.git_sha.outputs['out.fork_point'] ]
     condition: eq(variables['Build.Reason'], 'PullRequest')
     pool:
       name: 'linux-pool'
@@ -47,7 +53,7 @@ jobs:
           set -euo pipefail
 
           has_changed_infra_folder () {
-              git diff origin/master --name-only | grep -q '^infra/'
+              git diff $(fork_sha) --name-only | grep -q '^infra/'
           }
 
           fail_if_missing_std_change_label () {
@@ -61,12 +67,16 @@ jobs:
           PR: $(System.PullRequest.PullRequestNumber)
 
   - job: check_changelog_entry
+    dependsOn:
+      - git_sha
+    variables:
+      fork_sha: $[ dependencies.git_sha.outputs['out.fork_point'] ]
     condition: eq(variables['Build.Reason'], 'PullRequest')
     pool:
       name: 'linux-pool'
     steps:
       - checkout: self
-      - bash: ci/check-changelog.sh
+      - bash: ci/check-changelog.sh $(fork_sha)
 
   - job: Linux
     dependsOn:
@@ -198,7 +208,8 @@ jobs:
     dependsOn: [ "check_for_release", "Linux", "macOS", "Windows" ]
     condition: and(succeeded(),
                    eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'))
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')))
     pool:
       vmImage: "Ubuntu-16.04"
     variables:
@@ -289,7 +300,8 @@ jobs:
     pool:
       vmImage: "Ubuntu-16.04"
     condition: and(eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'))
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')))
     variables:
       release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
       release_tag: $[ dependencies.check_for_release.outputs['out.release_tag'] ]

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -67,7 +67,8 @@ steps:
     name: publish_npm_mvn
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'),
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')),
                    eq('${{parameters.name}}', 'linux'))
   - bash: |
       set -euo pipefail
@@ -81,19 +82,22 @@ steps:
     name: publish
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'))
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')))
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.tarball)
       artifactName: $(publish.tarball)
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'))
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')))
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.protos-zip)
       artifactName: $(publish.protos-zip)
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'),
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')),
                    eq('${{parameters.name}}', 'linux'))

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -51,18 +51,21 @@ steps:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'))
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')))
   - task: PublishPipelineArtifact@0
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'))
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')))
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.installer)
       artifactName: $(publish.installer)
   - task: PublishPipelineArtifact@0
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(variables['Build.SourceBranchName'], 'master'))
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')))
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.tarball)
       artifactName: $(publish.tarball)

--- a/ci/check-changelog.sh
+++ b/ci/check-changelog.sh
@@ -16,7 +16,7 @@ contains_changelog () {
     [[ 2 == $(git show -s --format=%B $1 | awk "$awk_script") ]]
 }
 
-for sha in $(git rev-list origin/master..); do
+for sha in $(git rev-list ${1:-origin/master}..); do
     if contains_changelog $sha; then
         echo "Commit $sha contains a changelog entry."
         exit 0

--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -240,7 +240,7 @@ build_docs_folder path versions latest = do
 
 find_commit_for_version :: String -> IO String
 find_commit_for_version version = do
-    release_commits <- lines <$> shell "git log --format=%H origin/master -- LATEST"
+    release_commits <- lines <$> shell "git log --format=%H --branches='*' -- LATEST"
     ver_sha <- init <$> (shell $ "git rev-parse v" <> version)
     let expected = ver_sha <> " " <> version
     matching <- Maybe.catMaybes <$> Traversable.for release_commits (\sha -> do

--- a/ci/tell-slack-failed.yml
+++ b/ci/tell-slack-failed.yml
@@ -10,13 +10,15 @@ steps:
       COMMIT_TITLE=$(git log --pretty=format:%s -n1 ${{ parameters.trigger_sha }})
       COMMI_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$COMMIT_TITLE>"
       if [ -z "${{ parameters.trigger_sha }}" ]; then
-          WARNING="<!here> *FAILED* $(Agent.JobName): $COMMIT_LINK"
+          WARNING="<!here> *FAILED* $(Build.SourceBranchName)/$(Agent.JobName): $COMMIT_LINK"
       else
-          WARNING=":fire: :fire: :fire: :fire: :fire:\n<!here> *RELEASE FAILED* $(Agent.JobName): $COMMIT_LINK\n:fire: :fire: :fire: :fire: :fire:"
+          WARNING=":fire: :fire: :fire: :fire: :fire:\n<!here> *RELEASE FAILED* $(Build.SourceBranchName)/$(Agent.JobName): $COMMIT_LINK\n:fire: :fire: :fire: :fire: :fire:"
       fi
       curl -XPOST \
            -i \
            -H 'Content-type: application/json' \
            --data "{\"text\":\"$WARNING\n\"}" \
            $(Slack.team-daml)
-    condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))
+    condition: and(failed(),
+                   or(eq(variables['Build.SourceBranchName'], 'master'),
+                      startsWith(variables['Build.SourceBranchName'], 'release/')))


### PR DESCRIPTION
This commit aims at enabling future patch releases; it is the master-branch equivalent of #5569 (applied to the 1.0 release branch).

The only change between the two changelogs should be that this one also changes the docs cron so it can find the trigger commits for patch releases.

CHANGELOG_BEGIN
CHANGELOG_END