### PR TITLE
kvutils: Add a timing metric for the commit.

### DIFF
--- a/ledger/metrics/collection/dashboards/ledger-submissions.json
+++ b/ledger/metrics/collection/dashboards/ledger-submissions.json
@@ -369,7 +369,7 @@
                     "hide": false,
                     "refCount": 0,
                     "refId": "A",
-                    "target": "daml.services.write.submit_transaction.mean"
+                    "target": "daml.kvutils.writer.commit.mean"
                 },
                 {
                     "refCount": 0,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantState.scala
@@ -9,10 +9,10 @@ import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.participant.state.v1._
-import com.daml.lf.data.Time
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.health.HealthStatus
+import com.daml.ledger.participant.state.v1._
+import com.daml.lf.data.Time
 
 /**
   * Implements read and write operations required for running a participant server.
@@ -33,8 +33,12 @@ class KeyValueParticipantState(
 )(implicit materializer: Materializer)
     extends ReadService
     with WriteService {
-  private val readerAdapter = new KeyValueParticipantStateReader(reader, metricRegistry)
-  private val writerAdapter = new KeyValueParticipantStateWriter(writer, metricRegistry)
+  private val readerAdapter =
+    new KeyValueParticipantStateReader(reader, metricRegistry)
+  private val writerAdapter =
+    new KeyValueParticipantStateWriter(
+      new TimedLedgerWriter(writer, metricRegistry),
+      metricRegistry)
 
   override def getLedgerInitialConditions(): Source[LedgerInitialConditions, NotUsed] =
     readerAdapter.getLedgerInitialConditions()

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
@@ -3,9 +3,9 @@
 
 package com.daml.ledger.participant.state.kvutils.api
 
+import com.daml.ledger.api.health.ReportsHealth
 import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.ledger.api.health.ReportsHealth
 
 import scala.concurrent.Future
 
@@ -18,17 +18,17 @@ import scala.concurrent.Future
 trait LedgerWriter extends ReportsHealth {
 
   /**
-    * Sends a submission to be committed to the ledger.
-    *
-    * @param correlationId correlation ID to be used for logging purposes
-    * @param envelope opaque submission; may be compressed
-    * @return  future for sending the submission; for possible results see
-    *          [[com.daml.ledger.participant.state.v1.SubmissionResult]]
-    */
-  def commit(correlationId: String, envelope: Bytes): Future[SubmissionResult]
-
-  /**
     * @return participant ID of the participant on which this LedgerWriter instance runs
     */
   def participantId: ParticipantId
+
+  /**
+    * Sends a submission to be committed to the ledger.
+    *
+    * @param correlationId correlation ID to be used for logging purposes
+    * @param envelope      opaque submission; may be compressed
+    * @return future for sending the submission; for possible results see
+    *         [[com.daml.ledger.participant.state.v1.SubmissionResult]]
+    */
+  def commit(correlationId: String, envelope: Bytes): Future[SubmissionResult]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/TimedLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/TimedLedgerWriter.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.api
+
+import com.codahale.metrics.{MetricRegistry, Timer}
+import com.daml.ledger.api.health.HealthStatus
+import com.daml.ledger.participant.state.kvutils
+import com.daml.ledger.participant.state.kvutils.Bytes
+import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
+import com.daml.metrics.Timed
+
+import scala.concurrent.Future
+
+class TimedLedgerWriter(delegate: LedgerWriter, metricRegistry: MetricRegistry)
+    extends LedgerWriter {
+
+  override def participantId: ParticipantId =
+    delegate.participantId
+
+  override def commit(correlationId: String, envelope: Bytes): Future[SubmissionResult] =
+    Timed.future(Metrics.commit, delegate.commit(correlationId, envelope))
+
+  override def currentHealth(): HealthStatus =
+    delegate.currentHealth()
+
+  private object Metrics {
+    private val Prefix = kvutils.MetricPrefix :+ "writer"
+
+    val commit: Timer = metricRegistry.timer(Prefix :+ "commit")
+  }
+
+}


### PR DESCRIPTION
On single-node participant/ledger combinations such as Sandbox, `daml.services.write.submit_transaction` covers this well. However, when the `WriteService` simply hands off to the ledger, all that metric tells us is that it was submitted. The new one is on the ledger side, and so measures it accurately.

### Changelog

- **[Ledger Integration Kit]** Added a timing metric for the commit at `daml.kvutils.writer.commit`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
