### PR TITLE
Add an --output-file option to DAML Script

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
@@ -20,6 +20,7 @@ case class RunnerConfig(
     timeProviderType: TimeProviderType,
     commandTtl: Duration,
     inputFile: Option[File],
+    outputFile: Option[File],
     accessTokenFile: Option[Path],
     tlsConfig: Option[TlsConfiguration],
     jsonApi: Boolean,
@@ -82,6 +83,12 @@ object RunnerConfig {
         c.copy(inputFile = Some(t))
       }
       .text("Path to a file containing the input value for the script in JSON format.")
+
+    opt[File]("output-file")
+      .action { (t, c) =>
+        c.copy(outputFile = Some(t))
+      }
+      .text("Path to a file where the result of the script will be written to in JSON format.")
 
     opt[String]("access-token-file")
       .action { (f, c) =>
@@ -159,6 +166,7 @@ object RunnerConfig {
         timeProviderType = null,
         commandTtl = Duration.ofSeconds(30L),
         inputFile = None,
+        outputFile = None,
         accessTokenFile = None,
         tlsConfig = None,
         jsonApi = false,

--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -191,6 +191,11 @@ We can then initialize our ledger passing in the json file via ``--input-file``.
 
 If you open Navigator, you can now see the contracts that have been created.
 
+While we will not use it here, there is also an ``--output-file``
+option that you can use to write the result of a script to a file
+using the DAML-LF JSON encoding. This is particularly useful if you need to consume
+the result from another program.
+
 .. _script-ledger-initialization:
 
 Using DAML Script for Ledger Initialization


### PR DESCRIPTION
This PR adds an --output-file option to DAML Script that writes the
result of a DAML Script to a file and complements the --input-file option.

changelog_begin

- [DAML Script] ``daml script`` now has a `--output-file`` option that
  can be used to specify a file the result of the script should be
  written to. Similar to ``--input-file`` the result will be output in
  the DAML-LF JSON encoding.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
