### PR TITLE
Use relative symlink in daml install on unix.

### DIFF
--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -171,6 +171,7 @@ activateDaml env@InstallEnv{..} targetPath = do
         damlBinarySourcePath = unwrapSdkPath targetPath </> "daml" </> damlSourceName
         damlBinaryTargetPath = installedAssistantPath damlPath
         damlBinaryTargetDir = takeDirectory damlBinaryTargetPath
+        damlBinaryRelativeSourcePath = ".." </> makeRelative (unwrapDamlPath damlPath) damlBinarySourcePath
 
     unlessM (doesFileExist damlBinarySourcePath) $
         throwIO $ assistantErrorBecause
@@ -189,7 +190,7 @@ activateDaml env@InstallEnv{..} targetPath = do
                      [ "@echo off"
                      , "\"" <> damlBinarySourcePath <> "\" %*"
                      ]
-            else createSymbolicLink damlBinarySourcePath damlBinaryTargetPath
+            else createSymbolicLink damlBinaryRelativeSourcePath damlBinaryTargetPath
 
     updatePath options (\s -> unlessQuiet env (output s)) damlBinaryTargetDir
     installBashCompletions options damlPath (\s -> unlessQuiet env (output s))

--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -363,7 +363,7 @@ testInstall = Tasty.testGroup "DA.Daml.Assistant.Install"
             createDirectoryIfMissing True "source"
             createDirectoryIfMissing True ("source" </> "daml")
             writeFileUTF8 ("source" </> sdkConfigName) "version: 0.0.0-test"
-            -- daml / daml.exe "binary" for --install-assistan=yes
+            -- daml / daml.exe "binary" for --install-assistant=yes
             writeFileUTF8 ("source" </> "daml" </> if isWindows then "daml.exe" else "daml") ""
 
             runConduitRes $

--- a/daml-assistant/test/DA/Daml/Assistant/Tests.hs
+++ b/daml-assistant/test/DA/Daml/Assistant/Tests.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-
 module DA.Daml.Assistant.Tests
     ( main
     ) where
@@ -352,7 +351,7 @@ testInstall = Tasty.testGroup "DA.Daml.Assistant.Install"
                     { iTargetM = Just (RawInstallTarget "source.tar.gz")
                     , iSnapshots = False
                     , iAssistant = InstallAssistant Yes
-                    , iActivate = ActivateInstall True
+                    , iActivate = ActivateInstall False
                     , iQuiet = QuietInstall True
                     , iForce = ForceInstall False
                     , iSetPath = SetPath False
@@ -364,7 +363,7 @@ testInstall = Tasty.testGroup "DA.Daml.Assistant.Install"
             createDirectoryIfMissing True "source"
             createDirectoryIfMissing True ("source" </> "daml")
             writeFileUTF8 ("source" </> sdkConfigName) "version: 0.0.0-test"
-            -- daml / daml.exe "binary" for --activate
+            -- daml / daml.exe "binary" for --install-assistan=yes
             writeFileUTF8 ("source" </> "daml" </> if isWindows then "daml.exe" else "daml") ""
 
             runConduitRes $
@@ -388,7 +387,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
                           { iTargetM = Just (RawInstallTarget "source.tar.gz")
                           , iSnapshots = False
                           , iAssistant = InstallAssistant Yes
-                          , iActivate = ActivateInstall True
+                          , iActivate = ActivateInstall False
                           , iQuiet = QuietInstall True
                           , iForce = ForceInstall False
                           , iSetPath = SetPath False
@@ -400,7 +399,7 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
                   createDirectoryIfMissing True "source"
                   createDirectoryIfMissing True ("source" </> "daml")
                   writeFileUTF8 ("source" </> sdkConfigName) "version: 0.0.0-test"
-                  writeFileUTF8 ("source" </> "daml" </> "daml") "" -- daml "binary" for --activate
+                  writeFileUTF8 ("source" </> "daml" </> "daml") "" -- daml "binary" for --install-assistant=yes
                   createSymbolicLink ("daml" </> "daml") ("source" </> "daml-link")
                       -- check if symbolic links are handled correctly
 
@@ -473,6 +472,42 @@ testInstallUnix = Tasty.testGroup "unix-specific tests"
             assertError "Extracting SDK release tarball."
                 "Invalid SDK release: symbolic link target escapes tarball."
                 (install options damlPath Nothing Nothing)
+
+    , Tasty.testCase "check that relative symlink is used in installation" $ do
+        withSystemTempDirectory "test-install" $ \ base -> do
+            let damlPath = DamlPath (base </> "daml")
+                options = InstallOptions
+                    { iTargetM = Just (RawInstallTarget "source.tar.gz")
+                    , iSnapshots = False
+                    , iAssistant = InstallAssistant Yes
+                    , iActivate = ActivateInstall False
+                    , iQuiet = QuietInstall True
+                    , iForce = ForceInstall False
+                    , iSetPath = SetPath False
+                    , iBashCompletions = BashCompletions No
+                    , iZshCompletions = ZshCompletions No
+                    }
+
+            setCurrentDirectory base
+            createDirectoryIfMissing True "source"
+            createDirectoryIfMissing True ("source" </> "daml")
+            writeFileUTF8 ("source" </> sdkConfigName) "version: 0.0.0-test"
+            -- daml / daml.exe "binary" for --install-assistant=yes
+            writeFileUTF8 ("source" </> "daml" </> "daml") "secret"
+
+            runConduitRes $
+                yield "source"
+                .| void Tar.tarFilePath
+                .| Zlib.gzip
+                .| sinkFile "source.tar.gz"
+
+            install options damlPath Nothing Nothing
+            renamePath "daml" "daml2"
+            x <- readFileUTF8 ("daml2" </> "bin" </> "daml")
+                -- ^ this will fail if the symlink created for
+                -- $DAML_HOME/bin/daml was absolute instead of
+                -- relative.
+            Tasty.assertEqual "Binary should be the same after moving." x "secret"
     ]
 
 testInstallWindows :: Tasty.TestTree


### PR DESCRIPTION
Fixes #5568. Adds a test (and updates the the daml install tests to use `--install-assistant` instead of the deprecated `--activate`).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
