### PR TITLE
fix check_standard_change_label

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,7 @@ jobs:
       - git_sha
     variables:
       fork_sha: $[ dependencies.git_sha.outputs['out.fork_point'] ]
+      branch_sha: $[ dependencies.git_sha.outputs['out.branch'] ]
     condition: eq(variables['Build.Reason'], 'PullRequest')
     pool:
       name: 'linux-pool'
@@ -53,7 +54,7 @@ jobs:
           set -euo pipefail
 
           has_changed_infra_folder () {
-              git diff $(fork_sha) --name-only | grep -q '^infra/'
+              git diff $(fork_sha) $(branch_sha) --name-only | grep -q '^infra/'
           }
 
           fail_if_missing_std_change_label () {


### PR DESCRIPTION
As currently written, the check will compare the current commit with the base commit the branch was forked from. The intention was to only list the changes from the current PR, and to make the check work for PRs against release branches (the previous version of the heck always compared to master, regardless of what branch the PR was targeting).

However, this does not work as expected because the "current commit" is not the tip of the PR, but the merge commit supplied by GitHub. Therefore, the diff here will include not only the changes in this PR, but also all the changes that happened on the target branch since forking. This is not an issue if the PR is properly rebased, but that's hard to control in a world where other people work too.

This PR corrects this by explicitly computing the diff between the fork point on the target branch and the tip of the PR, ignoring the currently-checked-out commit.

CHANGELOG_BEGIN
CHANGELOG_END