### PR TITLE
Fix redirects

### DIFF
--- a/docs/redirects.map
+++ b/docs/redirects.map
@@ -808,4 +808,5 @@ tools.html -> /tools/assistant.html
 examples.html -> /examples/bond-trading/index.html
 search.html
 getting-started/installation.htm -> /getting-started/installation.html
-gsg -> /getting-started/installation.html
+gsg.html -> /getting-started/installation.html
+getting-started/quickstart.html -> /getting-started/index.html


### PR DESCRIPTION
/gsg doesn’t work since it creates a file called gsg which your
browser will try to download.

the old quickstart url appears in google searches so we need to
redirect it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
