### PR TITLE
Ledger: Add nodeSeeds and byKeyNodes to participant state transaction… 

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -232,6 +232,8 @@ object KeyValueConsumption {
         submissionTime = parseTimestamp(txEntry.getSubmissionTime),
         submissionSeed = parseOptHash(txEntry.getSubmissionSeed),
         optUsedPackages = None,
+        optNodeSeeds = None,
+        optByKeyNodes = None,
       ),
       transaction = transaction,
       transactionId = hexTxId,

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -723,6 +723,8 @@ object ParticipantStateIntegrationSpecBase {
         crypto.Hash.assertFromString(
           "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")),
       optUsedPackages = Some(Set.empty),
+      optNodeSeeds = None,
+      optByKeyNodes = None,
     )
 
   private def matchPackageUpload(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -228,7 +228,9 @@ object KVTest {
           workflowId = None,
           submissionTime = txMetaData.submissionTime,
           submissionSeed = submissionSeed,
-          optUsedPackages = Some(txMetaData.usedPackages)
+          optUsedPackages = Some(txMetaData.usedPackages),
+          optNodeSeeds = None,
+          optByKeyNodes = None,
         ),
         tx = tx
       )

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -118,7 +118,9 @@ object KeyValueParticipantStateWriterSpec {
     submissionSeed = Some(
       crypto.Hash.assertFromString(
         "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")),
-    optUsedPackages = Some(Set.empty)
+    optUsedPackages = Some(Set.empty),
+    optNodeSeeds = None,
+    optByKeyNodes = None
   )
 
   private def newRecordTime(): Timestamp =

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
@@ -4,7 +4,8 @@
 package com.daml.ledger.participant.state.v1
 
 import com.daml.lf.crypto
-import com.daml.lf.data.{Ref, Time}
+import com.daml.lf.data.{ImmArray, Ref, Time}
+import com.daml.lf.transaction.{Transaction => Tx}
 
 /** Meta-data of a transaction visible to all parties that can see a part of
   * the transaction.
@@ -19,6 +20,18 @@ import com.daml.lf.data.{Ref, Time}
   *   and to traffic-shape the work handled by DAML applications
   *   communicating over the ledger.
   *
+  * @param submissionTime: the transaction submission time
+  *
+  * @param submissionSeed: The seed used to derive the transaction contract IDs.
+  *
+  * @param optUsedPackages: the set of package IDs the transaction is depending on.
+  *   undefined is not known. Undefined is not known.
+  *
+  * @param optNodeSeeds: an association list that maps to each ID if create and exercise nodes
+  *   its respective seed. Undefined is not known.
+  *
+  * @param optByKeyNodes: the list of each ID of the fetch and exercise nodes that correspond
+  *   to a fetch-by-key, lookup-by-key, or exercise-by-key command. Undefined is not known.
   */
 final case class TransactionMeta(
     ledgerEffectiveTime: Time.Timestamp,
@@ -26,4 +39,6 @@ final case class TransactionMeta(
     submissionTime: Time.Timestamp,
     submissionSeed: Option[crypto.Hash],
     optUsedPackages: Option[Set[Ref.PackageId]],
+    optNodeSeeds: Option[ImmArray[(Tx.NodeId, crypto.Hash)]],
+    optByKeyNodes: Option[ImmArray[Tx.NodeId]]
 )

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
@@ -22,10 +22,10 @@ import com.daml.lf.transaction.{Transaction => Tx}
   *
   * @param submissionTime: the transaction submission time
   *
-  * @param submissionSeed: The seed used to derive the transaction contract IDs.
+  * @param submissionSeed: the seed used to derive the transaction contract IDs.
   *
   * @param optUsedPackages: the set of package IDs the transaction is depending on.
-  *   undefined is not known. Undefined is not known.
+  *   Undefined means 'not known'.
   *
   * @param optNodeSeeds: an association list that maps to each ID if create and exercise nodes
   *   its respective seed. Undefined is not known.

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -66,7 +66,9 @@ final class StoreBackedCommandExecutor(
               commands.workflowId.map(_.unwrap),
               meta.submissionTime,
               submissionSeed,
-              Some(meta.usedPackages)
+              Some(meta.usedPackages),
+              Some(meta.nodeSeeds),
+              Some(meta.byKeyNodes),
             ),
             transaction = updateTx,
             dependsOnLedgerTime = meta.dependsOnTime,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/ImplicitPartyAdditionIT.scala
@@ -206,6 +206,8 @@ object ImplicitPartyAdditionIT {
       submissionTime = let.addMicros(1000),
       submissionSeed = None,
       optUsedPackages = None,
+      optNodeSeeds = None,
+      optByKeyNodes = None
     )
 
     ledger.publishTransaction(submitterInfo, transactionMeta, transaction)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -92,6 +92,8 @@ class TransactionTimeModelComplianceIT
       submissionTime = Time.Timestamp.assertFromInstant(ledgerTime.plusNanos(3)),
       submissionSeed = submissionSeed,
       optUsedPackages = None,
+      optNodeSeeds = None,
+      optByKeyNodes = None
     )
 
     val offset = ledger.ledgerEnd


### PR DESCRIPTION
We add to the participant state transaction meta data the extra info 
- `nodeSeeds` (from #5570) that tracks the seeds of the nodes create and exercise as generated during the submission
- `byKeyNodes` (from #5599) that tracks the nodes that correspond to "byKey" command. 

together with #5570 this fixes #5500 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
