### PR TITLE
kvutils: Don't report ledger metrics by default.

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -82,7 +82,10 @@ final class InMemoryLedgerReaderWriter private (
   object InMemoryLedgerStateAccess extends LedgerStateAccess[Index] {
     override def inTransaction[T](body: LedgerStateOperations[Index] => Future[T]): Future[T] =
       state.write { (log, state) =>
-        body(new InMemoryLedgerStateOperations(log, state))
+        body(
+          new TimedLedgerStateOperations(
+            new InMemoryLedgerStateOperations(log, state),
+            metricRegistry))
       }
   }
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -92,7 +92,7 @@ final class SqlLedgerReaderWriter(
   private object SqlLedgerStateAccess extends LedgerStateAccess[Index] {
     override def inTransaction[T](body: LedgerStateOperations[Index] => Future[T]): Future[T] =
       database.inWriteTransaction("commit") { queries =>
-        body(new SqlLedgerStateOperations(queries))
+        body(new TimedLedgerStateOperations(new SqlLedgerStateOperations(queries), metricRegistry))
       }
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -271,7 +271,7 @@ class SubmissionValidator[LogResult] private[validator] (
           if (acquisitionWasRecorded.compareAndSet(false, true)) {
             successfulAcquisitionTimer.stop()
           }
-          body(new TimedLedgerStateOperations(operations, metricRegistry))
+          body(operations)
             .transform(result => Success((result, Metrics.releaseTransactionLock.time())))
         }
         .transform {


### PR DESCRIPTION
Instead, opt-in explicitly in _ledger-on-memory_ and _ledger-on-sql_.

Wrapping the operations can confuse other users of `LedgerStateAccess`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
