### PR TITLE
enable patch releases, attempt 2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,7 @@ jobs:
     condition: and(succeeded(),
                    eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')))
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
     pool:
       vmImage: "Ubuntu-16.04"
     variables:
@@ -311,7 +311,7 @@ jobs:
       vmImage: "Ubuntu-16.04"
     condition: and(eq(dependencies.check_for_release.outputs['out.is_release'], 'true'),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')))
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
     variables:
       release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
       release_tag: $[ dependencies.check_for_release.outputs['out.release_tag'] ]

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -68,7 +68,7 @@ steps:
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')),
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')),
                    eq('${{parameters.name}}', 'linux'))
   - bash: |
       set -euo pipefail
@@ -83,7 +83,7 @@ steps:
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')))
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.tarball)
@@ -91,7 +91,7 @@ steps:
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')))
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.protos-zip)
@@ -99,5 +99,5 @@ steps:
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')),
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')),
                    eq('${{parameters.name}}', 'linux'))

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -52,12 +52,12 @@ steps:
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')))
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
   - task: PublishPipelineArtifact@0
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')))
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.installer)
       artifactName: $(publish.installer)
@@ -65,7 +65,7 @@ steps:
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')))
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.tarball)
       artifactName: $(publish.tarball)

--- a/ci/tell-slack-failed.yml
+++ b/ci/tell-slack-failed.yml
@@ -21,4 +21,4 @@ steps:
            $(Slack.team-daml)
     condition: and(failed(),
                    or(eq(variables['Build.SourceBranchName'], 'master'),
-                      startsWith(variables['Build.SourceBranchName'], 'release/')))
+                      startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))


### PR DESCRIPTION
It looks like Azure strips everything up to the last `/` when using `SourceBranchName`, which means that variable does not map to git's notion of a branch's name. According to the [documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml), using the full `SourceBranch` instead might work.

p.s. I have learned my lesson: I'll only update the master branch to match once I get this working.

CHANGELOG_BEGIN
CHANGELOG_END