### PR TITLE
Fix docs cron

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -240,7 +240,7 @@ build_docs_folder path versions latest = do
 
 find_commit_for_version :: String -> IO String
 find_commit_for_version version = do
-    release_commits <- lines <$> shell "git log --format=%H --branches='*' -- LATEST"
+    release_commits <- lines <$> shell "git log --format=%H --all -- LATEST"
     ver_sha <- init <$> (shell $ "git rev-parse v" <> version)
     let expected = ver_sha <> " " <> version
     matching <- Maybe.catMaybes <$> Traversable.for release_commits (\sha -> do


### PR DESCRIPTION
--branches='*' seems to only include local branches not branches in
the remote. It looks like --branches='*' --remotes='*' would work but
--all seems simpler. I struggled to find any docs on this but this
matched what I got when testing locally.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
