### PR TITLE
create-daml-app-test: Run sandbox and JSON API server separately and wait on port files

### DIFF
--- a/docs/source/getting-started/testing.rst
+++ b/docs/source/getting-started/testing.rst
@@ -43,11 +43,11 @@ You can scroll down to the important ones with the following descriptions (the f
 
 Before this, we need to set up the environment in which the tests run.
 At the top of the file we have some global state that we use throughout.
-Specifically, we have child processes for the ``daml start`` and ``yarn start`` commands, which run for the duration of our tests.
+Specifically, we have child processes for the ``daml sandbox``, ``daml json-api`` and ``yarn start`` commands, which run for the duration of our tests.
 We also have a single Puppeteer browser that we share among tests, opening new browser pages for each one.
 
 The ``beforeAll()`` section is a function run once before any of the tests run.
-We use it to spawn the ``daml start`` and ``yarn start`` processes and launch the browser.
+We use it to spawn the sandbox, JSON API and ``yarn start`` processes and launch the browser.
 On the other hand the ``afterAll()`` section is used to shut down these processes and close the browser.
 This step is important to prevent child processes persisting in the background after our program has finished.
 

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -223,7 +223,7 @@ test('log in as a new user, log out and log back in', async () => {
   expect(usersFinal[0].payload.username).toEqual(partyName);
 
   await page.close();
-}, 10_000);
+}, 20_000);
 // LOGIN_TEST_END
 
 // This tests following users in a few different ways:


### PR DESCRIPTION
Addresses https://github.com/digital-asset/daml/pull/5540#discussion_r410114169.

This at least stops hardcoding the sandbox port, though the HTTP port is still set at 7575. This is trickier to remove because it appears in the proxy setting and as argument to the test script in the `ui/package.json`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
