### PR TITLE
Create single-party specialized queries to access events

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableFlatEvents.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableFlatEvents.scala
@@ -125,13 +125,13 @@ private[events] trait EventsTableFlatEvents { this: EventsTable =>
       transactionId: TransactionId,
       requestingParty: Party,
   ): SimpleSql[Row] =
-    SQL"select #$selectColumns, array[$requestingParty] as event_witnesses, case when submitter = $requestingParty then command_id else '' end as command_id from #$flatEventsTable where transaction_id = $transactionId and event_witness = $requestingParty"
+    SQL"select #$selectColumns, array[$requestingParty] as event_witnesses, case when submitter = $requestingParty then command_id else '' end as command_id from #$flatEventsTable where transaction_id = $transactionId and event_witness = $requestingParty order by #$orderByColumns"
 
   private def multiPartyLookup(
       transactionId: TransactionId,
       requestingParties: Set[Party],
   ): SimpleSql[Row] =
-    SQL"select #$selectColumns, #$witnessesAggregation, case when submitter in ($requestingParties) then command_id else '' end as command_id from #$flatEventsTable where transaction_id = $transactionId and event_witness in ($requestingParties) group by (#$groupByColumns)"
+    SQL"select #$selectColumns, #$witnessesAggregation, case when submitter in ($requestingParties) then command_id else '' end as command_id from #$flatEventsTable where transaction_id = $transactionId and event_witness in ($requestingParties) group by (#$groupByColumns) order by #$orderByColumns"
 
   private val getFlatTransactionsQueries =
     new EventsTableFlatEventsRangeQueries.GetTransactions(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableFlatEvents.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableFlatEvents.scala
@@ -84,8 +84,10 @@ private[events] trait EventsTableFlatEvents { this: EventsTable =>
       "create_observers",
       "create_agreement_text",
       "create_key_value",
-      "array_agg(event_witness) as event_witnesses",
     ).mkString(", ")
+
+  private val witnessesAggregation =
+    "array_agg(event_witness) as event_witnesses"
 
   private val flatEventsTable =
     "participant_events natural join participant_event_flat_transaction_witnesses"
@@ -114,11 +116,27 @@ private[events] trait EventsTableFlatEvents { this: EventsTable =>
       transactionId: TransactionId,
       requestingParties: Set[Party],
   ): SimpleSql[Row] =
-    SQL"select #$selectColumns, case when submitter in ($requestingParties) then command_id else '' end as command_id from #$flatEventsTable where transaction_id = $transactionId and event_witness in ($requestingParties) group by (#$groupByColumns)"
+    route(requestingParties)(
+      single = singlePartyLookup(transactionId, _),
+      multi = multiPartyLookup(transactionId, _),
+    )
+
+  private def singlePartyLookup(
+      transactionId: TransactionId,
+      requestingParty: Party,
+  ): SimpleSql[Row] =
+    SQL"select #$selectColumns, array[$requestingParty] as event_witnesses, case when submitter = $requestingParty then command_id else '' end as command_id from #$flatEventsTable where transaction_id = $transactionId and event_witness = $requestingParty"
+
+  private def multiPartyLookup(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  ): SimpleSql[Row] =
+    SQL"select #$selectColumns, #$witnessesAggregation, case when submitter in ($requestingParties) then command_id else '' end as command_id from #$flatEventsTable where transaction_id = $transactionId and event_witness in ($requestingParties) group by (#$groupByColumns)"
 
   private val getFlatTransactionsQueries =
     new EventsTableFlatEventsRangeQueries.GetTransactions(
       selectColumns = selectColumns,
+      witnessesAggregation = witnessesAggregation,
       flatEventsTable = flatEventsTable,
       groupByColumns = groupByColumns,
       orderByColumns = orderByColumns,
@@ -136,6 +154,7 @@ private[events] trait EventsTableFlatEvents { this: EventsTable =>
   private val getActiveContractsQueries =
     new EventsTableFlatEventsRangeQueries.GetActiveContracts(
       selectColumns = selectColumns,
+      witnessesAggregation = witnessesAggregation,
       flatEventsTable = flatEventsTable,
       groupByColumns = groupByColumns,
       orderByColumns = orderByColumns,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableTreeEvents.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableTreeEvents.scala
@@ -97,8 +97,10 @@ private[events] trait EventsTableTreeEvents { this: EventsTable =>
     "exercise_result",
     "exercise_actors",
     "exercise_child_event_ids",
-    "array_agg(event_witness) as event_witnesses",
   ).mkString(", ")
+
+  private val witnessesAggregation =
+    "array_agg(event_witness) as event_witnesses"
 
   private val treeEventsTable =
     "participant_events natural join (select event_id, event_witness from participant_event_flat_transaction_witnesses union select event_id, event_witness from participant_event_witnesses_complement) as participant_event_witnesses"
@@ -135,7 +137,22 @@ private[events] trait EventsTableTreeEvents { this: EventsTable =>
       transactionId: TransactionId,
       requestingParties: Set[Party],
   ): SimpleSql[Row] =
-    SQL"select #$selectColumns, case when submitter in ($requestingParties) then command_id else '' end as command_id from #$treeEventsTable where transaction_id = $transactionId and event_witness in ($requestingParties) group by (#$groupByColumns) order by node_index asc"
+    route(requestingParties)(
+      single = singlePartyLookup(transactionId, _),
+      multi = multiPartyLookup(transactionId, _),
+    )
+
+  private def singlePartyLookup(
+      transactionId: TransactionId,
+      requestingParty: Party,
+  ): SimpleSql[Row] =
+    SQL"select #$selectColumns, array[$requestingParty] as event_witnesses, case when submitter = $requestingParty then command_id else '' end as command_id from #$treeEventsTable where transaction_id = $transactionId and event_witness = $requestingParty order by node_index asc"
+
+  private def multiPartyLookup(
+      transactionId: TransactionId,
+      requestingParties: Set[Party],
+  ): SimpleSql[Row] =
+    SQL"select #$selectColumns, #$witnessesAggregation, case when submitter in ($requestingParties) then command_id else '' end as command_id from #$treeEventsTable where transaction_id = $transactionId and event_witness in ($requestingParties) group by (#$groupByColumns) order by node_index asc"
 
   def preparePagedGetTransactionTrees(
       startExclusive: Offset,
@@ -144,6 +161,27 @@ private[events] trait EventsTableTreeEvents { this: EventsTable =>
       pageSize: Int,
       rowOffset: Long,
   ): SimpleSql[Row] =
-    SQL"select #$selectColumns, case when submitter in ($requestingParties) then command_id else '' end as command_id from #$treeEventsTable where event_offset > $startExclusive and event_offset <= $endInclusive and event_witness in ($requestingParties) group by (#$groupByColumns) order by (#$orderByColumns) limit $pageSize offset $rowOffset"
+    route(requestingParties)(
+      single = singlePartyTrees(startExclusive, endInclusive, _, pageSize, rowOffset),
+      multi = multiPartyTrees(startExclusive, endInclusive, _, pageSize, rowOffset),
+    )
+
+  private def singlePartyTrees(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      requestingParty: Party,
+      pageSize: Int,
+      rowOffset: Long,
+  ): SimpleSql[Row] =
+    SQL"select #$selectColumns, array[$requestingParty] as event_witnesses, case when submitter = $requestingParty then command_id else '' end as command_id from #$treeEventsTable where event_offset > $startExclusive and event_offset <= $endInclusive and event_witness = $requestingParty order by (#$orderByColumns) limit $pageSize offset $rowOffset"
+
+  private def multiPartyTrees(
+      startExclusive: Offset,
+      endInclusive: Offset,
+      requestingParties: Set[Party],
+      pageSize: Int,
+      rowOffset: Long,
+  ): SimpleSql[Row] =
+    SQL"select #$selectColumns, #$witnessesAggregation, case when submitter in ($requestingParties) then command_id else '' end as command_id from #$treeEventsTable where event_offset > $startExclusive and event_offset <= $endInclusive and event_witness in ($requestingParties) group by (#$groupByColumns) order by (#$orderByColumns) limit $pageSize offset $rowOffset"
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
@@ -63,4 +63,18 @@ package object events {
       .fold(Vector.empty[A])(_ :+ _)
       .mergeSubstreams
 
+  // Dispatches the call to either function based on the cardinality of the input
+  // This is mostly designed to route requests to queries specialized for single/multi-party subs
+  // Callers should ensure that the set is not empty, which in the usage this
+  // is designed for should be provided by the Ledger API validation layer
+  private[events] def route[A, B](
+      set: Set[A],
+  )(single: A => B, multi: Set[A] => B): B = {
+    assume(set.nonEmpty, "Empty set, unable to dispatch to single/multi implementation")
+    set.size match {
+      case 1 => single(set.toIterator.next)
+      case n if n > 1 => multi(set)
+    }
+  }
+
 }


### PR DESCRIPTION
Create alternative implementations of event table queries that are specialized for single-party requests: in this case `event_witnesses` requires no `group by` clause as any result will always result in the requesting party being the only witnesses.

Closes #5620

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
