### PR TITLE
DLint: Fix hint for nubBy

### DIFF
--- a/compiler/damlc/daml-ide-core/dlint.yaml
+++ b/compiler/damlc/daml-ide-core/dlint.yaml
@@ -193,7 +193,7 @@
     - warn: {lhs: intersectBy (==), rhs: intersect}
     - warn: {lhs: maximumBy compare, rhs: maximum}
     - warn: {lhs: minimumBy compare, rhs: minimum}
-    - warn: {lhs: nubBy (==), rhs: nub}
+    - warn: {lhs: dedupBy compare, rhs: dedup}
     - warn: {lhs: sortBy compare, rhs: sort}
     - warn: {lhs: unionBy (==), rhs: union}
 

--- a/compiler/damlc/tests/daml-test-files/List.daml
+++ b/compiler/damlc/tests/daml-test-files/List.daml
@@ -11,6 +11,7 @@
 -- @INFO Use isNone
 -- @INFO Use isNone
 -- @INFO Use isNone
+-- @INFO Use dedup
 
 module List where
 


### PR DESCRIPTION
We don't have `nubBy` and `nub` but rather `dedupBy` and `dedup` in
DAML. Let's fix the hints accordingly.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5627)
<!-- Reviewable:end -->
