### PR TITLE
Make daml start work with --sandbox-port=0

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -4,6 +4,7 @@
 module DA.Daml.Helper.Main (main) where
 
 import Control.Exception
+import Control.Monad
 import Data.Foldable
 import Data.List.Extra
 import Options.Applicative.Extended
@@ -43,7 +44,7 @@ data Command
     | Init { targetFolderM :: Maybe FilePath }
     | ListTemplates
     | Start
-      { sandboxPortM :: Maybe SandboxPort
+      { sandboxPortM :: Maybe SandboxPortSpec
       , openBrowser :: OpenBrowser
       , startNavigator :: Maybe StartNavigator
       , jsonApiCfg :: JsonApiConfig
@@ -120,7 +121,7 @@ commandParser = subparser $ fold
         <$> optional (argument str (metavar "TARGET_PATH" <> help "Project folder to initialize."))
 
     startCmd = Start
-        <$> optional (SandboxPort <$> option auto (long "sandbox-port" <> metavar "PORT_NUM" <> help "Port number for the sandbox"))
+        <$> optional (option (maybeReader (toSandboxPortSpec <=< readMaybe)) (long "sandbox-port" <> metavar "PORT_NUM" <> help "Port number for the sandbox"))
         <*> (OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser after navigator" idm)
         <*> optional navigatorFlag
         <*> jsonApiCfg

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -34,6 +34,7 @@ import DA.Bazel.Runfiles
 import DA.Daml.Assistant.FreePort (getFreePort,socketHints)
 import DA.Daml.Assistant.IntegrationTestUtils
 import DA.Daml.Helper.Run (waitForHttpServer,waitForConnectionOnPort)
+import DA.PortFile
 import DA.Test.Daml2jsUtils
 import DA.Test.Process (callCommandSilent)
 import DA.Test.Util
@@ -320,6 +321,46 @@ packagingTests = testGroup "packaging"
               statusCode (responseStatus createResponse) @?= 200
               -- waitForProcess' will block on Windows so we explicitly kill the process.
               terminateProcess startPh
+    , testCase "daml start --sandbox-port=0" $ withTempDir $ \tmpDir -> do
+          writeFileUTF8 (tmpDir </> "daml.yaml") $ unlines
+              [ "sdk-version: " <> sdkVersion
+              , "name: sandbox-options"
+              , "version: \"1.0\""
+              , "source: ."
+              , "dependencies:"
+              , "  - daml-prim"
+              , "  - daml-stdlib"
+              , "start-navigator: false"
+              ]
+          let startProc = shell $ unwords
+                  [ "daml"
+                  , "start"
+                  , "--sandbox-port=0"
+                  , "--sandbox-option=--ledgerid=MyLedger"
+                  , "--json-api-port=0"
+                  , "--json-api-option=--port-file=jsonapi.port"
+                  ]
+          withCurrentDirectory tmpDir $
+              withCreateProcess startProc $ \_ _ _ _ph -> do
+              jsonApiPort <- readPortFile maxRetries "jsonapi.port"
+              let token = JWT.encodeSigned (JWT.HMACSecret "secret") mempty mempty
+                    { JWT.unregisteredClaims = JWT.ClaimsMap $
+                          Map.fromList [("https://daml.com/ledger-api", Aeson.Object $ HashMap.fromList [("actAs", Aeson.toJSON ["Alice" :: T.Text]), ("ledgerId", "MyLedger"), ("applicationId", "foobar")])]
+                    }
+              let headers =
+                    [ ("Authorization", "Bearer " <> T.encodeUtf8 token)
+                    ] :: RequestHeaders
+              initialRequest <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/parties/allocate"
+              let queryRequest = initialRequest
+                    { method = "POST"
+                    , requestHeaders = headers
+                    , requestBody = RequestBodyLBS $ Aeson.encode $ Aeson.object
+                        [ "identifierHint" Aeson..= ("Alice" :: String)
+                        ]
+                    }
+              manager <- newManager defaultManagerSettings
+              queryResponse <- httpLbs queryRequest manager
+              responseBody queryResponse @?= "{\"result\":{\"identifier\":\"Alice\",\"isLocal\":true},\"status\":200}"
     ]
 
 quickstartTests :: FilePath -> FilePath -> TestTree

--- a/libs-haskell/da-hs-base/src/DA/PortFile.hs
+++ b/libs-haskell/da-hs-base/src/DA/PortFile.hs
@@ -4,17 +4,21 @@
 module DA.PortFile (readPortFile, maxRetries, retryDelayMillis) where
 
 import Control.Concurrent
+import Control.Exception
+import Control.Monad
 import qualified Data.Text.IO as T
 import Safe (readMay)
 import System.Exit
 import System.IO
+import System.IO.Error
 
 readPortFile :: Int -> String -> IO Int
 readPortFile 0 _file = do
   T.hPutStrLn stderr "Port file was not written to in time."
   exitFailure
-readPortFile n file =
-  readMay <$> readFile file >>= \case
+readPortFile n file = do
+  fileContent <- catchJust (guard . isDoesNotExistError) (readFile file) (const $ pure "")
+  case readMay fileContent of
     Nothing -> do
       threadDelay (1000 * retryDelayMillis)
       readPortFile (n-1) file


### PR DESCRIPTION
Previously that resulted in us telling sandbox,navigator,… to connect
to port 0 which obviously does not work. I’ve changed the types a bit
to avoid accidentally passing on the cli argument to them.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
