### PR TITLE
Make DAML Triggers and DAML Script default to wall-clock-time

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Run.hs
@@ -728,9 +728,9 @@ runStart
                     , darPath
                     , "--script-name"
                     , initScript
-                    , if any (`elem` ["-w", "--wall-clock-time"]) sandboxOpts
-                        then "--wall-clock-time"
-                        else "--static-time"
+                    , if any (`elem` ["-s", "--static-time"]) sandboxOpts
+                        then "--static-time"
+                        else "--wall-clock-time"
                     , "--ledger-host"
                     , "localhost"
                     , "--ledger-port"

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -182,7 +182,6 @@ packagingTests = testGroup "packaging"
                        waitForConnectionOnPort (threadDelay 100000) p
                        callCommand $ unwords
                            [ "daml script"
-                           ,"--wall-clock-time"
                            , "--dar script.dar --script-name Main:test"
                            , "--input-file input.json --output-file output.json"
                            , "--ledger-host localhost --ledger-port " <> show p

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
@@ -145,8 +145,6 @@ object RunnerConfig {
         failure("Cannot specify both --ledger-host and --participant-config")
       } else if (c.ledgerHost.isEmpty && c.participantConfig.isEmpty) {
         failure("Must specify either --ledger-host or --participant-config")
-      } else if (c.timeProviderType == null) {
-        failure("Must specify either --wall-clock-time or --static-time")
       } else if (c.jsonApi && c.accessTokenFile.isEmpty) {
         failure("The json-api requires an access token")
       } else {
@@ -163,7 +161,7 @@ object RunnerConfig {
         ledgerHost = None,
         ledgerPort = None,
         participantConfig = None,
-        timeProviderType = null,
+        timeProviderType = TimeProviderType.WallClock,
         commandTtl = Duration.ofSeconds(30L),
         inputFile = None,
         outputFile = None,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -52,7 +52,7 @@ object RunnerMain {
 
         val applicationId = ApplicationId("Script Runner")
         val timeProvider: TimeProvider =
-          config.timeProviderType match {
+          config.timeProviderType.getOrElse(RunnerConfig.DefaultTimeProviderType) match {
             case TimeProviderType.Static => TimeProvider.Constant(Instant.EPOCH)
             case TimeProviderType.WallClock => TimeProvider.UTC
             case _ =>

--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -176,7 +176,7 @@ To run our script, we first build it with ``daml build`` and then run
 it by pointing to the DAR, the name of our script, the host and
 port our ledger is running on and the time mode of the ledger.
 
-``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:test --ledger-host localhost --ledger-port 6865 --wall-clock-time``
+``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:test --ledger-host localhost --ledger-port 6865``
 
 Up to now, we have worked with parties that we have allocated in the
 test. We can also pass in the path to a file containing
@@ -187,7 +187,7 @@ the input in the :doc:`/json-api/lf-value-specification`.
 
 We can then initialize our ledger passing in the json file via ``--input-file``.
 
-``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:initialize --ledger-host localhost --ledger-port 6865 --input-file ledger-parties.json --wall-clock-time``
+``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:initialize --ledger-host localhost --ledger-port 6865 --input-file ledger-parties.json``
 
 If you open Navigator, you can now see the contracts that have been created.
 

--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -240,7 +240,7 @@ Now we are ready to run the trigger using ``daml trigger``:
 
 .. code-block:: sh
 
-    daml trigger --dar .daml/dist/copy-trigger-0.0.1.dar --trigger-name CopyTrigger:copyTrigger --ledger-host localhost --ledger-port 6865 --ledger-party Alice --wall-clock-time
+    daml trigger --dar .daml/dist/copy-trigger-0.0.1.dar --trigger-name CopyTrigger:copyTrigger --ledger-host localhost --ledger-port 6865 --ledger-party Alice
 
 The first argument specifies the ``.dar`` file that we have just
 built. The second argument specifies the identifier of the trigger

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -134,8 +134,6 @@ object RunnerConfig {
           failure("Missing option --ledger-port")
         } else if (c.ledgerParty == null) {
           failure("Missing option --ledger-party")
-        } else if (c.timeProviderType == null) {
-          failure("Must specify either --wall-clock-time or --static-time")
         } else {
           success
         }
@@ -151,7 +149,7 @@ object RunnerConfig {
         ledgerHost = null,
         ledgerPort = 0,
         ledgerParty = null,
-        timeProviderType = null,
+        timeProviderType = TimeProviderType.WallClock,
         commandTtl = Duration.ofSeconds(30L),
         accessTokenFile = None,
         tlsConfig = None,

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -93,7 +93,7 @@ object RunnerMain {
             dar,
             triggerId,
             client,
-            config.timeProviderType,
+            config.timeProviderType.getOrElse(RunnerConfig.DefaultTimeProviderType),
             applicationId,
             config.ledgerParty)
         } yield ()


### PR DESCRIPTION
Now that sandbox defaults to wall-clock-time there is no reason why we
should not default in DAML triggers and DAML Script.

changelog_begin

- [DAML Triggers] ``daml trigger`` now defaults to wall clock time if
  neither ``--wall-clock-time`` or ``--static-time`` is passed.

- [DAML Script] ``daml script`` now defaults to wall clock time if
  neither ``--wall-clock-time`` or ``--static-time`` is passed.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
