### PR TITLE
Split standard library docs up one page per module.

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -187,15 +187,6 @@ da_haskell_library(
 # Generating DAML stdlib docs.
 
 filegroup(
-    name = "daml-base-files",  # DAML files to be included in DAML base docs.
-    srcs = [
-        "//compiler/damlc/daml-prim-src",
-        "//compiler/damlc/daml-stdlib-src",
-    ],
-    visibility = ["__pkg__"],
-)
-
-filegroup(
     name = "daml-base-hoogle-template",
     srcs = ["base-hoogle-template.txt"],
     visibility = ["__pkg__"],
@@ -204,6 +195,12 @@ filegroup(
 filegroup(
     name = "daml-base-rst-template",
     srcs = ["base-rst-template.rst"],
+    visibility = ["__pkg__"],
+)
+
+filegroup(
+    name = "daml-base-rst-index-template",
+    srcs = ["base-rst-index-template.rst"],
     visibility = ["__pkg__"],
 )
 
@@ -278,59 +275,21 @@ genrule(
     srcs = [
         ":daml-prim.json",
         ":daml-stdlib.json",
+        ":daml-base-rst-index-template",
         ":daml-base-rst-template",
     ],
-    outs = ["daml-base.rst"],
+    outs = ["daml-base-rst.tar.gz"],
     cmd = """
         $(location //compiler/damlc) -- docs \
-            --combine \
-            --output=$(OUTS) \
+            --output=daml-base-rst \
             --input-format=json \
             --format=Rst \
             --exclude-instances=HasField \
             --drop-orphan-instances \
             --template=$(location :daml-base-rst-template) \
+            --index-template=$(location :daml-base-rst-index-template) \
             $(location :daml-stdlib.json) $(location :daml-prim.json)
-    """,
-    tools = ["//compiler/damlc"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "daml-base-md-docs",
-    srcs = [
-        ":daml-prim.json",
-        ":daml-stdlib.json",
-        ":daml-base-md-template",
-    ],
-    outs = ["daml-base.md"],
-    cmd = """
-        $(location //compiler/damlc) -- docs \
-            --combine \
-            --output=$(OUTS) \
-            --input-format=json \
-            --format=Markdown \
-            --template=$(location :daml-base-md-template) \
-            $(location :daml-stdlib.json) $(location :daml-prim.json)
-    """,
-    tools = ["//compiler/damlc"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "daml-base-html-docs",
-    srcs = [
-        ":daml-prim.json",
-        ":daml-stdlib.json",
-    ],
-    outs = ["daml-base-html.tar.gz"],
-    cmd = """
-        $(location //compiler/damlc) -- docs \
-            --output=daml-base-html \
-            --input-format=json \
-            --format=Html \
-            $(location :daml-stdlib.json) $(location :daml-prim.json)
-        tar c daml-base-html \
+        tar c daml-base-rst \
             --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
             | gzip -n > $(OUTS)
     """,

--- a/compiler/damlc/base-hoogle-template.txt
+++ b/compiler/damlc/base-hoogle-template.txt
@@ -5,6 +5,6 @@
 -- All rights reserved. Any unauthorized use, duplication or distribution is strictly prohibited.
 
 -- | DAML standard library.
-@url https://docs.daml.com/daml/reference/base.html
+@url https://docs.daml.com/daml/stdlib/index.html
 @package base
 @version 1.2.0

--- a/compiler/damlc/base-rst-index-template.rst
+++ b/compiler/damlc/base-rst-index-template.rst
@@ -1,0 +1,20 @@
+.. Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. _stdlib-reference-base:
+
+The standard library
+====================
+
+The DAML standard library is a collection of DAML modules that are bundled with the DAML SDK, and can be used to implement concrete DAML applications.
+
+The :ref:`Prelude <module-prelude-6842>` module is imported automatically in every DAML module. Other modules must be imported manually, just like your own project's modules. For example:
+
+.. code-block:: daml
+
+   import DA.Optional
+   import DA.Time
+
+Here is a complete list of modules in the standard library:
+
+{{{body}}}

--- a/compiler/damlc/base-rst-index-template.rst
+++ b/compiler/damlc/base-rst-index-template.rst
@@ -6,7 +6,7 @@
 The standard library
 ====================
 
-The DAML standard library is a collection of DAML modules that are bundled with the DAML SDK, and can be used to implement concrete DAML applications.
+The DAML standard library is a collection of DAML modules that are bundled with the DAML SDK, and can be used to implement DAML applications.
 
 The :ref:`Prelude <module-prelude-6842>` module is imported automatically in every DAML module. Other modules must be imported manually, just like your own project's modules. For example:
 

--- a/compiler/damlc/base-rst-template.rst
+++ b/compiler/damlc/base-rst-template.rst
@@ -1,22 +1,4 @@
 .. Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-.. _stdlib-reference-base:
-
-The standard library
-====================
-
-The DAML standard library is a collection of DAML modules that can be used to implement concrete applications.
-
-Usage
-*****
-
-The standard library is included in the DAML compiler so it can
-be used straight out of the box. You can import modules from the standard library just like your own, for example:
-
-.. code-block:: daml
-
-   import DA.Optional
-   import DA.Time
-
 {{{body}}}

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Driver.hs
@@ -43,6 +43,7 @@ data DamldocOptions = DamldocOptions
     , do_outputPath :: FilePath
     , do_outputFormat :: OutputFormat
     , do_docTemplate :: Maybe FilePath
+    , do_docIndexTemplate :: Maybe FilePath
     , do_transformOptions :: TransformOptions
     , do_inputFiles :: [NormalizedFilePath]
     , do_docTitle :: Maybe T.Text
@@ -90,6 +91,7 @@ inputDocData DamldocOptions{..} = do
 renderDocData :: DamldocOptions -> [ModuleDoc] -> IO ()
 renderDocData DamldocOptions{..} docData = do
     templateM <- mapM T.readFileUtf8 do_docTemplate
+    indexTemplateM <- mapM T.readFileUtf8 do_docIndexTemplate
 
     let prefix = fromMaybe "" templateM
         write file contents = do
@@ -111,5 +113,6 @@ renderDocData DamldocOptions{..} docData = do
                         , ro_format = format
                         , ro_title = do_docTitle
                         , ro_template = templateM
+                        , ro_indexTemplate = indexTemplateM
                         }
                 renderDocs renderOptions docData

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Hoogle.hs
@@ -23,7 +23,9 @@ hooglify (Just md) =
 
 urlTag :: Maybe Anchor -> T.Text
 urlTag Nothing = ""
-urlTag (Just (Anchor t)) = "@url https://docs.daml.com/daml/reference/base.html#" <> t
+urlTag (Just (Anchor t)) = "@url https://docs.daml.com/daml/stdlib/index.html#" <> t
+    -- ^ TODO(sofia): This needs a map of anchors to final module names / filenames.
+    -- Or maybe there is a sphinx setting/plugin to create anchor-based redirects for us...
 
 renderSimpleHoogle :: ModuleDoc -> T.Text
 renderSimpleHoogle ModuleDoc{..}

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Markdown.hs
@@ -6,6 +6,7 @@ module DA.Daml.Doc.Render.Markdown
   ( renderMd
   ) where
 
+import DA.Daml.Doc.Anchor
 import DA.Daml.Doc.Types
 import DA.Daml.Doc.Render.Util (adjust, escapeText)
 import DA.Daml.Doc.Render.Monoid
@@ -24,6 +25,12 @@ renderMd env = \case
     RenderParagraph text -> [renderMdText env text]
     RenderDocs docText -> T.lines . unDocText $ docText
     RenderAnchor anchor -> [anchorTag anchor]
+    RenderIndex moduleNames ->
+        [ "* " <> renderMdLink env
+                (Reference Nothing (moduleAnchor moduleName))
+                (unModulename moduleName)
+        | moduleName <- moduleNames
+        ]
 
 renderMdWithAnchor :: RenderEnv -> Anchor -> RenderOut -> [T.Text]
 renderMdWithAnchor env anchor = \case
@@ -47,17 +54,20 @@ renderMdText env = \case
     RenderConcat ts -> mconcatMap (renderMdText env) ts
     RenderPlain text -> escapeMd text
     RenderStrong text -> T.concat ["**", escapeMd text, "**"]
-    RenderLink ref text ->
-        case lookupReference env ref of
-            Nothing -> escapeMd text
-            Just anchorLoc -> T.concat
-                [ "["
-                , escapeMd text
-                , "]("
-                , anchorHyperlink anchorLoc (referenceAnchor ref)
-                , ")"]
+    RenderLink ref text -> renderMdLink env ref text
     RenderDocsInline docText ->
         T.unwords . T.lines . unDocText $ docText
+
+renderMdLink :: RenderEnv -> Reference -> T.Text -> T.Text
+renderMdLink env ref text =
+    case lookupReference env ref of
+        Nothing -> escapeMd text
+        Just anchorLoc -> T.concat
+            [ "["
+            , escapeMd text
+            , "]("
+            , anchorHyperlink anchorLoc (referenceAnchor ref)
+            , ")"]
 
 anchorTag :: Anchor -> T.Text
 anchorTag (Anchor anchor) = T.concat ["<a name=\"", anchor, "\"></a>"]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -117,7 +117,9 @@ packageURI (Packagename "daml-stdlib") = Just damlBaseURI
 packageURI _ = Nothing
 
 damlBaseURI :: URI.URI
-damlBaseURI = fromJust $ URI.parseURI "https://docs.daml.com/daml/reference/base.html"
+damlBaseURI = fromJust $ URI.parseURI "https://docs.daml.com/daml/stdlib/index.html"
+    -- TODO (sofia): Make this configurable, and don't include index.html,
+    -- need a way to supply (or recreate) anchor list.
 
 type RenderFormatter = RenderEnv -> RenderOut -> [T.Text]
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -40,7 +40,10 @@ renderRst env = \case
         ] ++
         [ T.concat
             [ "   "
+            , unModulename moduleName
+            , " <"
             , T.pack (moduleNameToFileName moduleName)
+            , ">"
             ]
         | moduleName <- moduleNames
         ]

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Rst.hs
@@ -24,14 +24,32 @@ import CMarkGFM
 renderRst :: RenderEnv -> RenderOut -> [T.Text]
 renderRst env = \case
     RenderSpaced chunks -> spaced (map (renderRst env) chunks)
-    RenderModuleHeader title -> header "-" title
-    RenderSectionHeader title -> header "^" title
+    RenderModuleHeader title -> header (pick "=" "-") title
+    RenderSectionHeader title -> header (pick "-" "^") title
     RenderBlock block -> indent (renderRst env block)
     RenderList items -> spaced (map (bullet . renderRst env) items)
     RenderRecordFields fields -> renderRstFields env fields
     RenderParagraph text -> [renderRstText env text]
     RenderDocs docText -> docTextToRst docText
     RenderAnchor anchor -> [".. _" <> unAnchor anchor <> ":"]
+    RenderIndex moduleNames ->
+        [ ".. toctree::"
+        , "   :maxdepth: 3"
+        , "   :titlesonly:"
+        , "   "
+        ] ++
+        [ T.concat
+            [ "   "
+            , T.pack (moduleNameToFileName moduleName)
+            ]
+        | moduleName <- moduleNames
+        ]
+  where
+    pick :: t -> t -> t
+    pick a b =
+        if re_separateModules env
+            then a
+            else b
 
 renderRstText :: RenderEnv -> RenderText -> T.Text
 renderRstText env = \case
@@ -46,11 +64,18 @@ renderRstText env = \case
                     [ "`", escapeLinkText text
                     , " <", anchorHyperlink anchorLoc (referenceAnchor ref)
                     , ">`_"]
-            Just _ ->
+            Just SameFile ->
                 T.concat
                     [ "`", escapeLinkText text
                     , " <", unAnchor (referenceAnchor ref)
                     , "_>`_" ]
+            Just (SameFolder _) ->
+                T.concat
+                    [ ":ref:`", escapeLinkText text
+                    , " <", unAnchor (referenceAnchor ref)
+                    , ">`" ]
+                    -- We use :ref: to get automatic cross-referencing
+                    -- across all pages. This is a Sphinx extension.
     RenderDocsInline docText ->
         T.unwords (docTextToRst docText)
 

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Types.hs
@@ -23,4 +23,5 @@ data RenderOptions = RenderOptions
     , ro_format :: RenderFormat -- ^ renderer output format
     , ro_title :: Maybe T.Text -- ^ title of rendered documentation
     , ro_template :: Maybe T.Text -- ^ renderer template
+    , ro_indexTemplate :: Maybe T.Text -- ^ renderer template for index
     }

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Annotations.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Transform/Annotations.hs
@@ -6,6 +6,7 @@ module DA.Daml.Doc.Transform.Annotations
     ) where
 
 import DA.Daml.Doc.Types
+import DA.Daml.Doc.Anchor
 
 import qualified Data.Text as T
 import Data.List.Extra
@@ -20,7 +21,7 @@ applyAnnotations = applyMove . applyHide
 applyMove :: [ModuleDoc] -> [ModuleDoc]
 applyMove
     = map (foldr1 combineModules)
-    . groupSortOn (modulePriorityKey . md_name)
+    . groupSortOn md_name
     . map renameModule
   where
     -- | Rename module according to its MOVE annotation, if present.
@@ -30,6 +31,8 @@ applyMove
     renameModule md@ModuleDoc{..}
         | Just new <- isMove md_descr = md
             { md_name = new
+            , md_anchor = Just (moduleAnchor new)
+                -- ^ Update the module anchor
             , md_descr = Nothing
                 -- ^ Drop the renamed module's description.
             }
@@ -50,11 +53,6 @@ applyMove
         , md_classes = md_classes m1 ++ md_classes m2
         , md_instances = md_instances m1 ++ md_instances m2
         }
-
-    -- | We sort by name, but we also bring the Prelude module
-    -- to the front so it always comes before other modules.
-    modulePriorityKey :: Modulename -> (Int,Modulename)
-    modulePriorityKey m = (if m == "Prelude" then 0 else 1, m)
 
 -- | Apply the HIDE annotation, which removes the current subtree from
 -- the docs. This can be applied to an entire module, or to a specific

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -9,6 +9,7 @@ module DA.Daml.Doc.Types(
 
 import Data.Aeson
 import Data.Text (Text)
+import qualified Data.Text as T
 import Data.Hashable
 import GHC.Generics
 import Data.String
@@ -27,7 +28,19 @@ newtype Typename = Typename { unTypename :: Text }
 
 -- | Module name, starting with uppercase, may have dots.
 newtype Modulename = Modulename { unModulename :: Text }
-    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, IsString)
+    deriving newtype (Eq, Show, ToJSON, FromJSON, IsString)
+
+-- | Ord instance for Modulename. We want to always sort "Prelude" in front of
+-- other modules, then "DA.*" modules, and then any remaining modules.
+instance Ord Modulename where
+    compare a b = compare (moduleKey a, unModulename a) (moduleKey b, unModulename b)
+        where
+            moduleKey :: Modulename -> Int
+            moduleKey = \case
+                Modulename "Prelude" -> 0
+                Modulename m
+                    | "DA." `T.isPrefixOf` m -> 1
+                    | otherwise -> 2
 
 -- | Name of daml package, e.g. "daml-prim", "daml-stdlib"
 newtype Packagename = Packagename { unPackagename :: Text }

--- a/compiler/damlc/daml-prim-src/Control/Exception/Base.daml
+++ b/compiler/damlc/daml-prim-src/Control/Exception/Base.daml
@@ -3,6 +3,7 @@
 
 {-# LANGUAGE NoImplicitPrelude #-}
 
+-- | HIDE
 module Control.Exception.Base
   ( recSelError
   , recConError

--- a/compiler/damlc/daml-prim-src/DA/Internal/Erased.daml
+++ b/compiler/damlc/daml-prim-src/DA/Internal/Erased.daml
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE NoImplicitPrelude #-}
+-- | HIDE
 module DA.Internal.Erased
   ( Erased
   ) where

--- a/compiler/damlc/daml-prim-src/DA/Internal/PromotedText.daml
+++ b/compiler/damlc/daml-prim-src/DA/Internal/PromotedText.daml
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE NoImplicitPrelude #-}
+-- | HIDE
 module DA.Internal.PromotedText
   ( PromotedText
   ) where

--- a/compiler/damlc/daml-prim-src/DA/Types.daml
+++ b/compiler/damlc/daml-prim-src/DA/Types.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 
--- | A module containing all the standard types from the base libraries,
+-- | MOVE Prelude A module containing all the standard types from the base libraries,
 --   so they have nice names when used from Java or similar.
 module DA.Types
   ( Either (..)

--- a/compiler/damlc/daml-prim-src/Data/String.daml
+++ b/compiler/damlc/daml-prim-src/Data/String.daml
@@ -3,6 +3,7 @@
 
 {-# LANGUAGE NoImplicitPrelude #-}
 
+-- | HIDE
 module Data.String(fromString) where
 
 import GHC.Types

--- a/compiler/damlc/daml-prim-src/LibraryModules.daml
+++ b/compiler/damlc/daml-prim-src/LibraryModules.daml
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 
--- Remove this module when DEL-6311 is done.
+-- | HIDE Remove this module when DEL-6311 is done.
 module LibraryModules where
 
 import DA.Internal.Erased

--- a/compiler/damlc/daml-stdlib-src/DA/Generics.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Generics.daml
@@ -23,7 +23,7 @@
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE DamlSyntax                 #-}
 
-
+-- | HIDE Partial implementation of DeriveGeneric. Unstable, use at great risk.
 module DA.Generics (
 
   -- * Generic representation types

--- a/compiler/damlc/daml-stdlib-src/DA/Generics.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Generics.daml
@@ -23,7 +23,7 @@
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE DamlSyntax                 #-}
 
--- | HIDE Partial implementation of DeriveGeneric. Unstable, use at great risk.
+-- | HIDE Partial implementation of DeriveGeneric. Note that this is not supported in cross-SDK dependencies.
 module DA.Generics (
 
   -- * Generic representation types

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Any.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Any.daml
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE NoImplicitPrelude #-}
 
--- | MOVE Wrappers around Any and TypeRep.
+-- | MOVE Prelude Wrappers around Any and TypeRep.
 module DA.Internal.Any where
 
 -- This module should only define stable types.

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Compatible.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Compatible.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PatternSynonyms #-}
 
--- | Our Prelude, extending WiredIn with things that don't need special treatment.
+-- | HIDE Our Prelude, extending WiredIn with things that don't need special treatment.
 
 module DA.Internal.Compatible where
 

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 
--- | Automatically imported qualified in every module.
+-- | HIDE Automatically imported qualified in every module.
 module DA.Internal.Desugar (
     module DA.Internal.Template,
     module DA.Internal.Template.Functions,

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -232,11 +232,11 @@ data Pair (f1 : Symbol) (f2 : Symbol) a1 a2 = Pair Opaque
 unpackPair : forall f1 f2 a1 a2. Pair f1 f2 a1 a2 -> (a1, a2)
 unpackPair = magic @"unpackPair"
 
--- | Existential type that can wrap an arbitrary type.
+-- | HIDE Existential type that can wrap an arbitrary type.
 -- We do not expose this directly and instead only expose AnyTemplate and AnyChoice.
 data Any = Any Opaque
 
--- | Value-level representation of a type.
+-- | HIDE Value-level representation of a type.
 -- We do not expose this directly and instead only expose TemplateTypeRep.
 data TypeRep = TypeRep Opaque
 

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/RebindableSyntax.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/RebindableSyntax.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 
--- | Automatically imported unqualified in every module.
+-- | HIDE Automatically imported unqualified in every module.
 module DA.Internal.RebindableSyntax
   -- things GHC generates unqualified through RebindableSyntax
   (fromString

--- a/compiler/damlc/daml-stdlib-src/DA/Maybe/Total.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Maybe/Total.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+-- | HIDE Hidden because deprecated.
 module DA.Maybe.Total
   ( module DA.Maybe
   , module DA.Maybe.Total

--- a/compiler/damlc/daml-stdlib-src/LibraryModules.daml
+++ b/compiler/damlc/daml-stdlib-src/LibraryModules.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
-
+-- | HIDE
 module LibraryModules where
 
 import DA.Action

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -32,6 +32,7 @@ documentation numProcessors = Damldoc
     <*> optOutputPath
     <*> optOutputFormat
     <*> optTemplate
+    <*> optIndexTemplate
     <*> optOmitEmpty
     <*> optDataOnly
     <*> optNoAnnot
@@ -73,6 +74,13 @@ documentation numProcessors = Damldoc
             <> help "Path to mustache template. The variables 'title' and 'body' in the template are substituted with the doc title and body respectively. (Exception: for hoogle and json output, the template file is a prefix to the body, no replacement occurs.)" -- TODO: make template behavior uniform accross formats
             <> long "template"
             <> short 't'
+
+    optIndexTemplate :: Parser (Maybe FilePath)
+    optIndexTemplate =
+        optional . option str
+            $ metavar "FILE"
+            <> help "Path to mustache template for index, when rendering to a folder. The variable 'body' in the template is substituted with a module index."
+            <> long "index-template"
 
     argMainFiles :: Parser [FilePath]
     argMainFiles = some $ argument str $ metavar "FILE..."
@@ -190,6 +198,7 @@ data CmdArgs = Damldoc
     , cOutputPath :: FilePath
     , cOutputFormat :: OutputFormat
     , cTemplate :: Maybe FilePath
+    , cIndexTemplate :: Maybe FilePath
     , cOmitEmpty :: Bool
     , cDataOnly  :: Bool
     , cNoAnnot   :: Bool
@@ -217,6 +226,7 @@ exec Damldoc{..} = do
         , do_inputFormat = cInputFormat
         , do_inputFiles = map toNormalizedFilePath' cMainFiles
         , do_docTemplate = cTemplate
+        , do_docIndexTemplate = cIndexTemplate
         , do_transformOptions = transformOptions
         , do_docTitle = T.pack . unitIdString <$> optUnitId cOptions
         , do_combine = cCombine

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
@@ -13,4 +13,4 @@ not present in the class itself.
 > 
 > <a name="function-constrainedclassmethod-bar-13431"></a>[bar](#function-constrainedclassmethod-bar-13431)
 > 
-> > : [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) t =\> t -\> t
+> > : [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) t =\> t -\> t

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
@@ -21,4 +21,4 @@ Typeclasses
   .. _function-constrainedclassmethod-bar-13431:
   
   `bar <function-constrainedclassmethod-bar-13431_>`_
-    \: `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t \=\> t \-\> t
+    \: `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ t \=\> t \-\> t

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
@@ -4,38 +4,38 @@
 
 <a name="type-constrainttuples-eq2-31733"></a>**type** [Eq2](#type-constrainttuples-eq2-31733) a b
 
-> = ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b)
+> = ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b)
 
 <a name="type-constrainttuples-eq3-75180"></a>**type** [Eq3](#type-constrainttuples-eq3-75180) a b c
 
-> = ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) c)
+> = ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) c)
 
 <a name="type-constrainttuples-eq4-2935"></a>**type** [Eq4](#type-constrainttuples-eq4-2935) a b c d
 
-> = ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) d)
+> = ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) d)
 
 ## Functions
 
 <a name="function-constrainttuples-eq2-12289"></a>[eq2](#function-constrainttuples-eq2-12289)
 
-> : [Eq2](#type-constrainttuples-eq2-31733) a b =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+> : [Eq2](#type-constrainttuples-eq2-31733) a b =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq2tick-62955"></a>[eq2'](#function-constrainttuples-eq2tick-62955)
 
-> : ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b) =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+> : ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b) =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq3-55736"></a>[eq3](#function-constrainttuples-eq3-55736)
 
-> : [Eq3](#type-constrainttuples-eq3-75180) a b c =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+> : [Eq3](#type-constrainttuples-eq3-75180) a b c =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq3tick-75648"></a>[eq3'](#function-constrainttuples-eq3tick-75648)
 
-> : ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) c) =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+> : ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) c) =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq4-56779"></a>[eq4](#function-constrainttuples-eq4-56779)
 
-> : [Eq4](#type-constrainttuples-eq4-2935) a b c d =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+> : [Eq4](#type-constrainttuples-eq4-2935) a b c d =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq4tick-50089"></a>[eq4'](#function-constrainttuples-eq4tick-50089)
 
-> : ([Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) d) =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654)
+> : ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) d) =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
@@ -9,17 +9,17 @@ Data Types
 .. _type-constrainttuples-eq2-31733:
 
 **type** `Eq2 <type-constrainttuples-eq2-31733_>`_ a b
-  \= (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b)
+  \= (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b)
 
 .. _type-constrainttuples-eq3-75180:
 
 **type** `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c
-  \= (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ c)
+  \= (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ c)
 
 .. _type-constrainttuples-eq4-2935:
 
 **type** `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d
-  \= (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ d)
+  \= (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ d)
 
 Functions
 ^^^^^^^^^
@@ -27,29 +27,29 @@ Functions
 .. _function-constrainttuples-eq2-12289:
 
 `eq2 <function-constrainttuples-eq2-12289_>`_
-  \: `Eq2 <type-constrainttuples-eq2-31733_>`_ a b \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: `Eq2 <type-constrainttuples-eq2-31733_>`_ a b \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq2tick-62955:
 
 `eq2' <function-constrainttuples-eq2tick-62955_>`_
-  \: (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b) \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b) \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq3-55736:
 
 `eq3 <function-constrainttuples-eq3-55736_>`_
-  \: `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq3tick-75648:
 
 `eq3' <function-constrainttuples-eq3tick-75648_>`_
-  \: (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ c) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ c) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq4-56779:
 
 `eq4 <function-constrainttuples-eq4-56779_>`_
-  \: `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq4tick-50089:
 
 `eq4' <function-constrainttuples-eq4tick-50089_>`_
-  \: (`Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ d) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ d) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
@@ -18,7 +18,7 @@
 > 
 > > : (a -\> b -\> b) -\> b -\> t a -\> b
 
-<a name="class-defaultmethods-traversablex-59027"></a>**class** ([Functor](https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448) t, [FoldableX](#class-defaultmethods-foldablex-48748) t) =\> [TraversableX](#class-defaultmethods-traversablex-59027) t **where**
+<a name="class-defaultmethods-traversablex-59027"></a>**class** ([Functor](https://docs.daml.com/daml/stdlib/index.html#class-ghc-base-functor-73448) t, [FoldableX](#class-defaultmethods-foldablex-48748) t) =\> [TraversableX](#class-defaultmethods-traversablex-59027) t **where**
 
 > <a name="function-defaultmethods-traversex-21140"></a>[traverseX](#function-defaultmethods-traversex-21140)
 > 
@@ -34,7 +34,7 @@
 > 
 > > : a -\> a
 > 
-> **instance** [Id](#class-defaultmethods-id-77721) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> **instance** [Id](#class-defaultmethods-id-77721) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 <a name="class-defaultmethods-myshow-63359"></a>**class** [MyShow](#class-defaultmethods-myshow-63359) t **where**
 
@@ -42,12 +42,12 @@
 > 
 > <a name="function-defaultmethods-myshow-41356"></a>[myShow](#function-defaultmethods-myshow-41356)
 > 
-> > : t -\> [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703)
+> > : t -\> [Text](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703)
 > > 
 > > Doc for method.
 > 
 > **default** myShow
 > 
-> > : [Show](https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447) t =\> t -\> [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703)
+> > : [Show](https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447) t =\> t -\> [Text](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703)
 > > 
 > > Doc for default.

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
@@ -31,7 +31,7 @@ Typeclasses
 
 .. _class-defaultmethods-traversablex-59027:
 
-**class** (`Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ t, `FoldableX <class-defaultmethods-foldablex-48748_>`_ t) \=\> `TraversableX <class-defaultmethods-traversablex-59027_>`_ t **where**
+**class** (`Functor <https://docs.daml.com/daml/stdlib/index.html#class-ghc-base-functor-73448>`_ t, `FoldableX <class-defaultmethods-foldablex-48748_>`_ t) \=\> `TraversableX <class-defaultmethods-traversablex-59027_>`_ t **where**
 
   .. _function-defaultmethods-traversex-21140:
   
@@ -52,7 +52,7 @@ Typeclasses
   `id <function-defaultmethods-id-57162_>`_
     \: a \-\> a
   
-  **instance** `Id <class-defaultmethods-id-77721_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** `Id <class-defaultmethods-id-77721_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 .. _class-defaultmethods-myshow-63359:
 
@@ -63,12 +63,12 @@ Typeclasses
   .. _function-defaultmethods-myshow-41356:
   
   `myShow <function-defaultmethods-myshow-41356_>`_
-    \: t \-\> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+    \: t \-\> `Text <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703>`_
     
     Doc for method\.
   
   **default** myShow
   
-    \: `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t \=\> t \-\> `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+    \: `Show <https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447>`_ t \=\> t \-\> `Text <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703>`_
     
     Doc for default\.

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
@@ -22,10 +22,10 @@
 > <a name="constr-deriving-disjunction-94592"></a>[Disjunction](#constr-deriving-disjunction-94592) \[[Formula](#type-deriving-formula-84903) t\]
 > 
 > 
-> **instance** [Functor](https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448) [Formula](#type-deriving-formula-84903)
+> **instance** [Functor](https://docs.daml.com/daml/stdlib/index.html#class-ghc-base-functor-73448) [Formula](#type-deriving-formula-84903)
 > 
-> **instance** [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) t =\> [Eq](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216) ([Formula](#type-deriving-formula-84903) t)
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) t =\> [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) ([Formula](#type-deriving-formula-84903) t)
 > 
-> **instance** [Ord](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960) t =\> [Ord](https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960) ([Formula](#type-deriving-formula-84903) t)
+> **instance** [Ord](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-ord-70960) t =\> [Ord](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-ord-70960) ([Formula](#type-deriving-formula-84903) t)
 > 
-> **instance** [Show](https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447) t =\> [Show](https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447) ([Formula](#type-deriving-formula-84903) t)
+> **instance** [Show](https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447) t =\> [Show](https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447) ([Formula](#type-deriving-formula-84903) t)

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
@@ -40,10 +40,10 @@ Data Types
   `Disjunction <constr-deriving-disjunction-94592_>`_ \[`Formula <type-deriving-formula-84903_>`_ t\]
   
   
-  **instance** `Functor <https://docs.daml.com/daml/reference/base.html#class-ghc-base-functor-73448>`_ `Formula <type-deriving-formula-84903_>`_
+  **instance** `Functor <https://docs.daml.com/daml/stdlib/index.html#class-ghc-base-functor-73448>`_ `Formula <type-deriving-formula-84903_>`_
   
-  **instance** `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ t \=\> `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ t \=\> `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ t \=\> `Ord <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-ord-70960>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Ord <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-ord-70960>`_ t \=\> `Ord <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-ord-70960>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ t \=\> `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Show <https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447>`_ t \=\> `Show <https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447>`_ (`Formula <type-deriving-formula-84903_>`_ t)

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -90,11 +90,11 @@
 
 <a name="type-exportlist-data1-25282"></a>**data** [Data1](#type-exportlist-data1-25282)
 
-> **instance** HasField "field1" [Data1](#type-exportlist-data1-25282) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> **instance** HasField "field1" [Data1](#type-exportlist-data1-25282) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data2-68729"></a>**data** [Data2](#type-exportlist-data2-68729)
 
-> **instance** HasField "field2" [Data2](#type-exportlist-data2-68729) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> **instance** HasField "field2" [Data2](#type-exportlist-data2-68729) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data3-43604"></a>**data** [Data3](#type-exportlist-data3-43604)
 
@@ -102,37 +102,37 @@
 > 
 > > (no fields)
 > 
-> **instance** HasField "field3" [Data3](#type-exportlist-data3-43604) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> **instance** HasField "field3" [Data3](#type-exportlist-data3-43604) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data4-87051"></a>**data** [Data4](#type-exportlist-data4-87051)
 
-> **instance** HasField "field4" [Data4](#type-exportlist-data4-87051) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> **instance** HasField "field4" [Data4](#type-exportlist-data4-87051) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data5-40974"></a>**data** [Data5](#type-exportlist-data5-40974)
 
 > <a name="constr-exportlist-constr5-35310"></a>[Constr5](#constr-exportlist-constr5-35310)
 > 
-> > | Field                                                                          | Type                                                                           | Description |
-> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
-> > | field5                                                                         | [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) |  |
+> > | Field                                                                        | Type                                                                         | Description |
+> > | :--------------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :---------- |
+> > | field5                                                                       | [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) |  |
 > 
-> **instance** HasField "field5" [Data5](#type-exportlist-data5-40974) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> **instance** HasField "field5" [Data5](#type-exportlist-data5-40974) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data6-26325"></a>**data** [Data6](#type-exportlist-data6-26325)
 
 > <a name="constr-exportlist-constr6-63065"></a>[Constr6](#constr-exportlist-constr6-63065)
 > 
-> > | Field                                                                          | Type                                                                           | Description |
-> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
-> > | field6                                                                         | [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) |  |
+> > | Field                                                                        | Type                                                                         | Description |
+> > | :--------------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :---------- |
+> > | field6                                                                       | [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) |  |
 > 
 > <a name="constr-exportlist-constr6tick-67971"></a>[Constr6'](#constr-exportlist-constr6tick-67971)
 > 
 > 
-> **instance** HasField "field6" [Data6](#type-exportlist-data6-26325) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> **instance** HasField "field6" [Data6](#type-exportlist-data6-26325) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 ## Functions
 
 <a name="function-exportlist-function1-77714"></a>[function1](#function-exportlist-function1-77714)
 
-> : [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> : [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -145,13 +145,13 @@ Data Types
 
 **data** `Data1 <type-exportlist-data1-25282_>`_
 
-  **instance** HasField \"field1\" `Data1 <type-exportlist-data1-25282_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field1\" `Data1 <type-exportlist-data1-25282_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data2-68729:
 
 **data** `Data2 <type-exportlist-data2-68729_>`_
 
-  **instance** HasField \"field2\" `Data2 <type-exportlist-data2-68729_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field2\" `Data2 <type-exportlist-data2-68729_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data3-43604:
 
@@ -162,13 +162,13 @@ Data Types
   `Constr3 <constr-exportlist-constr3-90820_>`_
   
   
-  **instance** HasField \"field3\" `Data3 <type-exportlist-data3-43604_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field3\" `Data3 <type-exportlist-data3-43604_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data4-87051:
 
 **data** `Data4 <type-exportlist-data4-87051_>`_
 
-  **instance** HasField \"field4\" `Data4 <type-exportlist-data4-87051_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field4\" `Data4 <type-exportlist-data4-87051_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data5-40974:
 
@@ -186,10 +186,10 @@ Data Types
          - Type
          - Description
        * - field5
-         - `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+         - `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
          - 
   
-  **instance** HasField \"field5\" `Data5 <type-exportlist-data5-40974_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field5\" `Data5 <type-exportlist-data5-40974_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data6-26325:
 
@@ -207,7 +207,7 @@ Data Types
          - Type
          - Description
        * - field6
-         - `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+         - `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
          - 
   
   .. _constr-exportlist-constr6tick-67971:
@@ -215,7 +215,7 @@ Data Types
   `Constr6' <constr-exportlist-constr6tick-67971_>`_
   
   
-  **instance** HasField \"field6\" `Data6 <type-exportlist-data6-26325_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"field6\" `Data6 <type-exportlist-data6-26325_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 Functions
 ^^^^^^^^^
@@ -223,4 +223,4 @@ Functions
 .. _function-exportlist-function1-77714:
 
 `function1 <function-exportlist-function1-77714_>`_
-  \: `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  \: `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
@@ -4,13 +4,13 @@
 
 <a name="type-iou12-iou-45923"></a>**template** [Iou](#type-iou12-iou-45923)
 
-> | Field                                                                                  | Type                                                                                   | Description |
-> | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- | :---------- |
-> | issuer                                                                                 | Party                                                                                  |  |
-> | owner                                                                                  | Party                                                                                  |  |
-> | currency                                                                               | [Text](https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703)       | only 3-letter symbols are allowed |
-> | amount                                                                                 | [Decimal](https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602) | must be positive |
-> | regulators                                                                             | \[Party\]                                                                              | `regulators` may observe any use of the `Iou` |
+> | Field                                                                                | Type                                                                                 | Description |
+> | :----------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :---------- |
+> | issuer                                                                               | Party                                                                                |  |
+> | owner                                                                                | Party                                                                                |  |
+> | currency                                                                             | [Text](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703)       | only 3-letter symbols are allowed |
+> | amount                                                                               | [Decimal](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-decimal-54602) | must be positive |
+> | regulators                                                                           | \[Party\]                                                                            | `regulators` may observe any use of the `Iou` |
 > 
 > * **Choice Archive**
 >   
@@ -33,9 +33,9 @@
 >   splits into two `Iou`s with
 >   smaller amounts
 >   
->   | Field                                                                                  | Type                                                                                   | Description |
->   | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- | :---------- |
->   | splitAmount                                                                            | [Decimal](https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602) | must be between zero and original amount |
+>   | Field                                                                                | Type                                                                                 | Description |
+>   | :----------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :---------- |
+>   | splitAmount                                                                          | [Decimal](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-decimal-54602) | must be between zero and original amount |
 > 
 > * **Choice Transfer**
 >   

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
@@ -24,10 +24,10 @@ Templates
        - Party
        - 
      * - currency
-       - `Text <https://docs.daml.com/daml/reference/base.html#type-ghc-types-text-57703>`_
+       - `Text <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703>`_
        - only 3\-letter symbols are allowed
      * - amount
-       - `Decimal <https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602>`_
+       - `Decimal <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-decimal-54602>`_
        - must be positive
      * - regulators
        - \[Party\]
@@ -67,7 +67,7 @@ Templates
          - Type
          - Description
        * - splitAmount
-         - `Decimal <https://docs.daml.com/daml/reference/base.html#type-ghc-types-decimal-54602>`_
+         - `Decimal <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-decimal-54602>`_
          - must be between zero and original amount
   
   + **Choice Transfer**

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
@@ -6,21 +6,21 @@
 
 > <a name="constr-newtype-nat-99832"></a>[Nat](#constr-newtype-nat-99832)
 > 
-> > | Field                                                                          | Type                                                                           | Description |
-> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
-> > | unNat                                                                          | [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) |  |
+> > | Field                                                                        | Type                                                                         | Description |
+> > | :--------------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :---------- |
+> > | unNat                                                                        | [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) |  |
 > 
-> **instance** HasField "unNat" [Nat](#type-newtype-nat-61947) [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> **instance** HasField "unNat" [Nat](#type-newtype-nat-61947) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 ## Functions
 
 <a name="function-newtype-mknat-8513"></a>[mkNat](#function-newtype-mknat-8513)
 
-> : [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
+> : [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
 
 <a name="function-newtype-unsafemknat-96593"></a>[unsafeMkNat](#function-newtype-unsafemknat-96593)
 
-> : [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
+> : [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
 
 <a name="function-newtype-zero0-10450"></a>[zero0](#function-newtype-zero0-10450)
 
@@ -32,12 +32,12 @@
 
 <a name="function-newtype-unnat1-26452"></a>[unNat1](#function-newtype-unnat1-26452)
 
-> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 <a name="function-newtype-unnat2-96339"></a>[unNat2](#function-newtype-unnat2-96339)
 
-> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
 
 <a name="function-newtype-unnat3-97654"></a>[unNat3](#function-newtype-unnat3-97654)
 
-> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728)
+> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -22,10 +22,10 @@ Data Types
          - Type
          - Description
        * - unNat
-         - `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+         - `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
          - 
   
-  **instance** HasField \"unNat\" `Nat <type-newtype-nat-61947_>`_ `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  **instance** HasField \"unNat\" `Nat <type-newtype-nat-61947_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 Functions
 ^^^^^^^^^
@@ -33,12 +33,12 @@ Functions
 .. _function-newtype-mknat-8513:
 
 `mkNat <function-newtype-mknat-8513_>`_
-  \: `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
+  \: `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-unsafemknat-96593:
 
 `unsafeMkNat <function-newtype-unsafemknat-96593_>`_
-  \: `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
+  \: `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-zero0-10450:
 
@@ -53,14 +53,14 @@ Functions
 .. _function-newtype-unnat1-26452:
 
 `unNat1 <function-newtype-unnat1-26452_>`_
-  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat2-96339:
 
 `unNat2 <function-newtype-unnat2-96339_>`_
-  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat3-97654:
 
 `unNat3 <function-newtype-unnat3-97654_>`_
-  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/reference/base.html#type-ghc-types-int-68728>`_
+  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_

--- a/compiler/damlc/tests/daml-test-files/SingleConEnum.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/SingleConEnum.EXPECTED.rst
@@ -15,9 +15,9 @@ Data Types
   `Red <constr-singleconenum-red-70275_>`_
   
   
-  **instance** `Eq <https://docs.daml.com/daml/reference/base.html#class-ghc-classes-eq-21216>`_ `Color <type-singleconenum-color-33374_>`_
+  **instance** `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ `Color <type-singleconenum-color-33374_>`_
   
-  **instance** `Show <https://docs.daml.com/daml/reference/base.html#class-ghc-show-show-56447>`_ `Color <type-singleconenum-color-33374_>`_
+  **instance** `Show <https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447>`_ `Color <type-singleconenum-color-33374_>`_
 
 Functions
 ^^^^^^^^^
@@ -30,4 +30,4 @@ Functions
 .. _function-singleconenum-isred-76570:
 
 `isRed <function-singleconenum-isred-76570_>`_
-  \: `Color <type-singleconenum-color-33374_>`_ \-\> `Bool <https://docs.daml.com/daml/reference/base.html#type-ghc-types-bool-8654>`_
+  \: `Color <type-singleconenum-color-33374_>`_ \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -273,7 +273,10 @@ genrule(
         cp -rL docs/source source
 
         # Copy in Stdlib
-        cp -rL $(location //compiler/damlc:daml-base-rst-docs) source/daml/reference/base.rst
+        mkdir -p source/daml/reference/base
+        tar xf $(location //compiler/damlc:daml-base-rst-docs) \
+            --strip-components 1 \
+            -C source/daml/reference/base/
 
         # Copy in daml-trigger documentation
         cp -rL $(location //triggers/daml:daml-trigger-rst-docs) source/triggers/trigger-docs.rst

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -273,10 +273,10 @@ genrule(
         cp -rL docs/source source
 
         # Copy in Stdlib
-        mkdir -p source/daml/reference/base
+        mkdir -p source/daml/stdlib
         tar xf $(location //compiler/damlc:daml-base-rst-docs) \
             --strip-components 1 \
-            -C source/daml/reference/base/
+            -C source/daml/stdlib
 
         # Copy in daml-trigger documentation
         cp -rL $(location //triggers/daml:daml-trigger-rst-docs) source/triggers/trigger-docs.rst

--- a/docs/redirects.map
+++ b/docs/redirects.map
@@ -8,7 +8,8 @@ daml.html -> /daml/reference/index.html
 daml/reference/template-reference.html -> /daml/reference/index.html
 daml/anti-patterns.html
 daml/models-versus-application.html
-daml/stdlib/base.html -> daml/reference/base.html
+daml/stdlib/base.html -> daml/stdlib/index.html
+daml/reference/base.html -> daml/stdlib/index.html
 concepts.html -> /concepts/ledger-model/index.html
 getting-started.html -> /getting-started/index.html
 packages/da-docs-example-upgrade/index.html -> /examples/upgrade/index.html
@@ -80,8 +81,8 @@ packages/daml-licenses/licensing/scenario-service-licenses.html -> /
 packages/daml-licenses/licensing/ledger-bindings-licenses.html -> /
 packages/daml-studio/index.html -> /daml/daml-studio.html
 packages/sandbox-doc/index.html -> /tools/sandbox.html
-packages/daml-stdlib-doc/index.html -> /daml/reference/base.html
-packages/daml-stdlib-doc/base.html -> /daml/reference/base.html
+packages/daml-stdlib-doc/index.html -> /daml/stdlib/index.html
+packages/daml-stdlib-doc/base.html -> /daml/stdlib/index.html
 packages/bindings-java-tutorial/index.html -> /app-dev/bindings-java/index.html
 packages/bindings-java-tutorial/static/constant-values.html -> /app-dev/bindings-java/javadocs/constant-values.html
 packages/bindings-java-tutorial/static/overview-tree.html -> /app-dev/bindings-java/javadocs/overview-tree.html

--- a/docs/scripts/live-preview.sh
+++ b/docs/scripts/live-preview.sh
@@ -14,7 +14,7 @@ cleanup()
   echo "Caught Signal ... cleaning up."
   rm -rf $BUILD_DIR
   cd $SCRIPT_DIR
-  rm -f ../source/daml/reference/base.rst
+  rm -rf ../source/daml/stdlib
   rm -f ../source/app-dev/grpc/proto-docs.rst
   rm -f ../source/LICENSE
   rm -f ../source/NOTICES
@@ -59,8 +59,9 @@ do
         cp -L ../../bazel-bin/ledger-api/grpc-definitions/proto-docs.rst ../source/app-dev/grpc/
 
         #StdLib
-        bazel build //compiler/damlc:daml-base-rst-docs
-        cp -L ../../bazel-bin/compiler/damlc/daml-base.rst ../source/daml/reference/base.rst
+        bazel build //compiler/damlc:daml-base-rst.tar.gz
+        tar xf ../../bazel-bin/compiler/damlc/daml-base-rst.tar.gz \
+            --strip-components 1 -C ../source/daml/stdlib
     fi
 done
 

--- a/docs/source/app-dev/bindings-java/quickstart.rst
+++ b/docs/source/app-dev/bindings-java/quickstart.rst
@@ -325,7 +325,7 @@ A more interesting choice is ``IouTrade_Accept``. To look at it, open ``IouTrade
   :language: daml
   :lines: 25-46
 
-This choice uses the ``===`` operator from the :doc:`DAML Standard Library </daml/reference/base/index>` to check pre-conditions. The standard library is imported using ``import DA.Assert`` at the top of the module.
+This choice uses the ``===`` operator from the :doc:`DAML Standard Library </daml/stdlib/index>` to check pre-conditions. The standard library is imported using ``import DA.Assert`` at the top of the module.
 
 Then, it *composes* the ``Iou_Transfer`` and ``IouTransfer_Accept`` choices to build one big transaction. In this transaction, ``buyer`` and ``seller`` exchange their Ious atomically, without disclosing the entire transaction to all parties involved.
 

--- a/docs/source/app-dev/bindings-java/quickstart.rst
+++ b/docs/source/app-dev/bindings-java/quickstart.rst
@@ -325,7 +325,7 @@ A more interesting choice is ``IouTrade_Accept``. To look at it, open ``IouTrade
   :language: daml
   :lines: 25-46
 
-This choice uses the ``===`` operator from the :doc:`DAML Standard Library </daml/reference/base>` to check pre-conditions. The standard library is imported using ``import DA.Assert`` at the top of the module.
+This choice uses the ``===`` operator from the :doc:`DAML Standard Library </daml/reference/base/index>` to check pre-conditions. The standard library is imported using ``import DA.Assert`` at the top of the module.
 
 Then, it *composes* the ``Iou_Transfer`` and ``IouTransfer_Accept`` choices to build one big transaction. In this transaction, ``buyer`` and ``seller`` exchange their Ious atomically, without disclosing the entire transaction to all parties involved.
 

--- a/docs/source/app-dev/daml-lf-translation.rst
+++ b/docs/source/app-dev/daml-lf-translation.rst
@@ -44,12 +44,12 @@ Most built-in types have the same name in DAML-LF as in DAML. These are the exac
    * - ``ContractId``
      - ``ContractId``
 
-Be aware that only the DAML primitive types exported by the :ref:`Prelude <stdlib-reference-base>` module map to the DAML-LF primitive types above. That means that, if you define your own type named ``Party``, it will not translate to the DAML-LF primitive ``Party``.
+Be aware that only the DAML primitive types exported by the :ref:`Prelude <module-prelude-6842>` module map to the DAML-LF primitive types above. That means that, if you define your own type named ``Party``, it will not translate to the DAML-LF primitive ``Party``.
 
 Tuple types
 ***********
 
-DAML tuple type constructors take types ``T1, T2, …, TN`` to the type ``(T1, T2, …, TN)``. These are exposed in the DAML surface language through the :ref:`Prelude <stdlib-reference-base>` module.
+DAML tuple type constructors take types ``T1, T2, …, TN`` to the type ``(T1, T2, …, TN)``. These are exposed in the DAML surface language through the :ref:`Prelude <module-prelude-6842>` module.
 
 The equivalent DAML-LF type constructors are ``daml-prim:DA.Types:TupleN``, for each particular N (where 2 <= N <= 20). This qualified name refers to the package name (``ghc-prim``) and the module name (``GHC.Tuple``).
 

--- a/docs/source/concepts/glossary.rst
+++ b/docs/source/concepts/glossary.rst
@@ -169,7 +169,7 @@ Standard library
 
 The **DAML standard library** is a set of `DAML` functions, classes and more that make developing with DAML easier.
 
-For documentation, see :doc:`/daml/reference/base/index`.
+For documentation, see :doc:`/daml/stdlib/index`.
 
 Agreement
 =========

--- a/docs/source/concepts/glossary.rst
+++ b/docs/source/concepts/glossary.rst
@@ -70,7 +70,7 @@ A `choice <#choice>`__ marked **postconsuming** will not be `archived <#active-c
 Nonconsuming choice
 --------------------
 
-A **nonconsuming choice** does NOT `archive <#active-contract-archived-contract>`__ the `contract <#contract-contract-instance>`__ it is on when `exercised <#exercise>`__. This means the choice can be exercised more than once on the same `contract instance <#contract-contract-instance>`__. 
+A **nonconsuming choice** does NOT `archive <#active-contract-archived-contract>`__ the `contract <#contract-contract-instance>`__ it is on when `exercised <#exercise>`__. This means the choice can be exercised more than once on the same `contract instance <#contract-contract-instance>`__.
 
 Disjunction choice, flexible controllers
 ----------------------------------------
@@ -115,7 +115,7 @@ Controllers must be at least an `observer`_, otherwise they can't see the contra
 Stakeholder
 -----------
 
-**Stakeholder** is not a term used within the DAML language, but the concept refers to the `signatories <#signatory>`__ and `observers <#observer>`__ collectively. That is, it means all of the `parties <#party>`__ that are interested in a `contract instance <#contract-contract-instance>`__. 
+**Stakeholder** is not a term used within the DAML language, but the concept refers to the `signatories <#signatory>`__ and `observers <#observer>`__ collectively. That is, it means all of the `parties <#party>`__ that are interested in a `contract instance <#contract-contract-instance>`__.
 
 Maintainer
 ----------
@@ -169,14 +169,14 @@ Standard library
 
 The **DAML standard library** is a set of `DAML` functions, classes and more that make developing with DAML easier.
 
-For documentation, see :doc:`/daml/reference/base`. 
+For documentation, see :doc:`/daml/reference/base/index`.
 
 Agreement
 =========
 
 An **agreement** is part of a `contract <#contract-contract-instance>`__. It is text that explains what the contract represents.
 
-It can be used to clarify the legal intent of a contract, but this text isn't evaluated programmatically. 
+It can be used to clarify the legal intent of a contract, but this text isn't evaluated programmatically.
 
 See :doc:`/daml/reference/templates`.
 
@@ -458,4 +458,3 @@ A **trust domain** encompasses a part of the system (in particular, a DAML ledge
 
 .. Conformance
 .. ===========
-

--- a/docs/source/daml/reference/data-types.rst
+++ b/docs/source/daml/reference/data-types.rst
@@ -277,7 +277,7 @@ An example is the built-in data type ``Bool``. This is defined by ``data Bool = 
 Please note that all types which you intend to use as template or choice arguments need to derive at least from `(Eq, Show)`.
 
 A very useful sum type is ``data Optional a = None | Some a deriving (Eq,Show)``. It is part of
-the :doc:`DAML standard library </daml/reference/base>`.
+the :doc:`DAML standard library </daml/reference/base/index>`.
 
 ``Optional`` captures the concept of a box, which can be empty or contain a value of type ``a``.
 

--- a/docs/source/daml/reference/data-types.rst
+++ b/docs/source/daml/reference/data-types.rst
@@ -277,7 +277,7 @@ An example is the built-in data type ``Bool``. This is defined by ``data Bool = 
 Please note that all types which you intend to use as template or choice arguments need to derive at least from `(Eq, Show)`.
 
 A very useful sum type is ``data Optional a = None | Some a deriving (Eq,Show)``. It is part of
-the :doc:`DAML standard library </daml/reference/base/index>`.
+the :doc:`DAML standard library </daml/stdlib/index>`.
 
 ``Optional`` captures the concept of a box, which can be empty or contain a value of type ``a``.
 

--- a/docs/source/daml/reference/functions.rst
+++ b/docs/source/daml/reference/functions.rst
@@ -82,6 +82,6 @@ A function is *parametrically polymorphic* if it behaves uniformly for all types
 
 where ``a``, ``b``, and ``c`` are any data types. Both ``compose ((+) 4) ((*) 2) 3 == 10`` and ``compose not ((&&) True) False`` evaluate to ``True``. Note that ``((+) 4)`` has type ``Int -> Int``, whereas ``not`` has type ``Bool -> Bool``.
 
-You can find many other generic functions including this one in the :doc:`DAML standard library </daml/reference/base>`.
+You can find many other generic functions including this one in the :doc:`DAML standard library </daml/reference/base/index>`.
 
 .. note:: DAML currently does not support generic functions for a specific set of types, such as ``Int`` and ``Decimal`` numbers. For example, ``sum (x: a) (y: a) = x + y`` is undefined when ``a`` equals the type ``Party``. *Bounded polymorphism* might be added to DAML in a later version.

--- a/docs/source/daml/reference/functions.rst
+++ b/docs/source/daml/reference/functions.rst
@@ -82,6 +82,6 @@ A function is *parametrically polymorphic* if it behaves uniformly for all types
 
 where ``a``, ``b``, and ``c`` are any data types. Both ``compose ((+) 4) ((*) 2) 3 == 10`` and ``compose not ((&&) True) False`` evaluate to ``True``. Note that ``((+) 4)`` has type ``Int -> Int``, whereas ``not`` has type ``Bool -> Bool``.
 
-You can find many other generic functions including this one in the :doc:`DAML standard library </daml/reference/base/index>`.
+You can find many other generic functions including this one in the :doc:`DAML standard library </daml/stdlib/index>`.
 
 .. note:: DAML currently does not support generic functions for a specific set of types, such as ``Int`` and ``Decimal`` numbers. For example, ``sum (x: a) (y: a) = x + y`` is undefined when ``a`` equals the type ``Party``. *Bounded polymorphism* might be added to DAML in a later version.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,7 +29,7 @@ DAML SDK documentation
 
    daml/intro/0_Intro.rst
    daml/reference/index
-   daml/reference/base/index
+   daml/stdlib/index
    daml/daml-studio
    daml/testing-scenarios
    daml/troubleshooting

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,7 +29,7 @@ DAML SDK documentation
 
    daml/intro/0_Intro.rst
    daml/reference/index
-   daml/reference/base
+   daml/reference/base/index
    daml/daml-studio
    daml/testing-scenarios
    daml/troubleshooting


### PR DESCRIPTION
Fixes #3172 

This PR updates our standard library docs to put each module on its own page. Users can easily navigate the docs by using the table of contents on the left, or the standard library page.

Here's a preview:

![image](https://user-images.githubusercontent.com/63245722/79769636-4a7d2c00-8324-11ea-8fe0-ee3d357d2067.png)

Summary of changes:

* Redid & pruned some bazel rules to get multiple outputs.
* Adjusted the daml-doc RST renderer output to support cross-reference links.
* Added a module index that just lists all the modules. This is also used to generate the navigation (automatically) in RST docs.
* Added an `--index-template` option to daml-docs, so you can have a separate template for the module index and individual modules. This was used to make the "standard library" page.
* Small annotation changes in the standard library to hide modules that should be hidden, and move other modules to the correct place.

TODO before merging:

*  [ ] Fix hoogle database URLs.

This change also highlights how a lot of our standard library documentation could be improved. Most modules don't yet have any description. Also, it might be better to put data types before typeclasses in each module doc. I will leave further documentation changes to a separate PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
