### PR TITLE
create-daml-app test: Move back to daml start

### DIFF
--- a/docs/source/getting-started/testing.rst
+++ b/docs/source/getting-started/testing.rst
@@ -43,11 +43,11 @@ You can scroll down to the important ones with the following descriptions (the f
 
 Before this, we need to set up the environment in which the tests run.
 At the top of the file we have some global state that we use throughout.
-Specifically, we have child processes for the ``daml sandbox``, ``daml json-api`` and ``yarn start`` commands, which run for the duration of our tests.
+Specifically, we have child processes for the ``daml start`` and ``yarn start`` commands, which run for the duration of our tests.
 We also have a single Puppeteer browser that we share among tests, opening new browser pages for each one.
 
 The ``beforeAll()`` section is a function run once before any of the tests run.
-We use it to spawn the sandbox, JSON API and ``yarn start`` processes and launch the browser.
+We use it to spawn the ``daml start`` and ``yarn start`` processes and launch the browser.
 On the other hand the ``afterAll()`` section is used to shut down these processes and close the browser.
 This step is important to prevent child processes persisting in the background after our program has finished.
 

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -12,9 +12,6 @@ import { computeCredentials } from './Credentials';
 
 const JSON_API_PORT_FILE_NAME = 'json-api.port';
 
-// We hardcode the JSON API port as it also appears in test and proxy settings
-// in ui/package.json.
-const JSON_API_PORT = 7575;
 const UI_PORT = 3000;
 
 // `daml start` process
@@ -23,8 +20,7 @@ let startProc: ChildProcess | undefined = undefined;
 // `yarn start` process
 let uiProc: ChildProcess | undefined = undefined;
 
-// Headless Chrome browser
-// (see https://developers.google.com/web/updates/2017/04/headless-chrome)
+// Chrome browser that we run in headless mode
 let browser: Browser | undefined = undefined;
 
 // Function to generate unique party names for us.
@@ -68,15 +64,12 @@ beforeAll(async () => {
   const startOpts: SpawnOptions = { cwd: '..', stdio: 'inherit' };
 
   // Arguments for `daml start` (besides those in the `daml.yaml`).
-  // `--sandbox-port=0` instructs the sandbox to find an available port which is
-  // then used as the `--ledger-port` for the JSON API.
   // The JSON API `--port-file` gives us a file we can check to know that both
   // the sandbox and JSON API server are up and running.
-  // The JSON API port is hardcoded for now.
+  // We use the default ports for the sandbox and JSON API as done in the
+  // Getting Started Guide.
   const startArgs = [
     'start',
-    '--sandbox-port=0',
-    `--json-api-port=${JSON_API_PORT}`,
     `--json-api-option=--port-file=${JSON_API_PORT_FILE_NAME}`
   ];
 


### PR DESCRIPTION
Previously we changed to running the sandbox and JSON API separately to
have more control over port allocation. Now the same behaviour is
possible using `daml start`, which is preferable because it's what we
suggest users of the Getting Started Guide should use. This change
returns to using `daml start` in the end-to-end test. We use
`--sandbox-port=0` to get a dynamically allocated sandbox port which is
passed as the JSON API ledger port. We continue to hardcode the JSON API port.

Follow up from https://github.com/digital-asset/daml/pull/5615#issuecomment-616616361.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
