### PR TITLE
Fix DAML test file "expected" diagnostic range parsing

### DIFF
--- a/compiler/damlc/tests/daml-test-files/ActionFail.daml
+++ b/compiler/damlc/tests/daml-test-files/ActionFail.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Use catOptionals
+-- @INFO range=9:21-9:38; Use catOptionals
 
 module ActionFail where
 

--- a/compiler/damlc/tests/daml-test-files/AmbiguousDataType.daml
+++ b/compiler/damlc/tests/daml-test-files/AmbiguousDataType.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:1-9:17; Ambiguous data type declaration. Enums cannot have type arguments. Write data Foo x = Bar {} for a record or data Foo x = Bar () for a variant.
+-- @ERROR range=9:0-9:16; Ambiguous data type declaration. Enums cannot have type arguments. Write data Foo x = Bar {} for a record or data Foo x = Bar () for a variant.
 
 
 module AmbiguousDataType where

--- a/compiler/damlc/tests/daml-test-files/BadUTF8.daml
+++ b/compiler/damlc/tests/daml-test-files/BadUTF8.daml
@@ -1,4 +1,4 @@
--- @ERROR range=4:1-4:1; lexical error
+-- @ERROR range=4:0-4:0; lexical error
 
 
 £ -- pound symbol when saved as ASCII

--- a/compiler/damlc/tests/daml-test-files/ConstrainedRecursion.daml
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedRecursion.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2020 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 --
--- @INFO range=12:1-13:21; Use foldl
--- @INFO range=16:1-17:17; Use foldl
--- @INFO range=20:1-21:17; Use foldl
+-- @INFO range=12:0-13:20; Use foldl
+-- @INFO range=16:0-17:16; Use foldl
+-- @INFO range=20:0-21:16; Use foldl
 
 module ConstrainedRecursion where
 

--- a/compiler/damlc/tests/daml-test-files/ConstraintBad.daml
+++ b/compiler/damlc/tests/daml-test-files/ConstraintBad.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR Constructors with type constraints must give explicit field names
+-- @ERROR range=11:13-11:28; Constructors with type constraints must give explicit field names
 
 {-# LANGUAGE ExistentialQuantification #-}
 

--- a/compiler/damlc/tests/daml-test-files/Cyclic.daml
+++ b/compiler/damlc/tests/daml-test-files/Cyclic.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR Cyclic module dependency between Cyclic
+-- @ERROR range=8:7-8:13; Cyclic module dependency between Cyclic
 
 module Cyclic where
 

--- a/compiler/damlc/tests/daml-test-files/DesugarWarnings.daml
+++ b/compiler/damlc/tests/daml-test-files/DesugarWarnings.daml
@@ -4,9 +4,9 @@
 {-# OPTIONS_GHC -Wincomplete-patterns -Woverlapping-patterns #-}
 -- Check that warnings from desugarer, like incomplete/overlapping pattern
 -- match warnings, show up when we turn them on.
--- @WARN range=14:21-15:14; Pattern match(es) are non-exhaustive
--- @WARN range=18:1-19:21; Pattern match(es) are non-exhaustive
--- @WARN range=24:3-24:14; Pattern match is redundant
+-- @WARN range=14:20-15:13; Pattern match(es) are non-exhaustive
+-- @WARN range=18:0-19:20; Pattern match(es) are non-exhaustive
+-- @WARN range=24:2-24:13; Pattern match is redundant
 
 module DesugarWarnings where
 

--- a/compiler/damlc/tests/daml-test-files/EmptyWith.daml
+++ b/compiler/damlc/tests/daml-test-files/EmptyWith.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=18:12-19:1; Empty record update
+-- @ERROR range=18:11-19:0; Empty record update
 
 module EmptyWith where
 

--- a/compiler/damlc/tests/daml-test-files/EnumFromThenTo.daml
+++ b/compiler/damlc/tests/daml-test-files/EnumFromThenTo.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR enumFromThenTo: from == then
+-- @ERROR range=9:0-9:4; enumFromThenTo: from == then
 
 module EnumFromThenTo where
 

--- a/compiler/damlc/tests/daml-test-files/ErrorsWithColons.daml
+++ b/compiler/damlc/tests/daml-test-files/ErrorsWithColons.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=9:35-9:42; Use list literal
--- @ERROR range=9:35-9:42; In the expression: (1 :: [])
--- @ERROR range=11:13-11:14; In the expression: 1 : Text
+-- @INFO range=9:34-9:41; Use list literal
+-- @ERROR range=9:34-9:41; In the expression: (1 :: [])
+-- @ERROR range=11:12-11:13; In the expression: 1 : Text
 module ErrorsWithColons where
 
 badIf = if True then Some 1 else (1 :: [])

--- a/compiler/damlc/tests/daml-test-files/Existential.daml
+++ b/compiler/damlc/tests/daml-test-files/Existential.daml
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE ExistentialQuantification #-}
 
--- @ ERROR range=15:1-15:7; Pattern match with existential type.
+-- @ ERROR range=15:0-15:6; Pattern match with existential type.
 -- @ TODO Existential quantification
 
 

--- a/compiler/damlc/tests/daml-test-files/ExistentialSum.daml
+++ b/compiler/damlc/tests/daml-test-files/ExistentialSum.daml
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE ExistentialQuantification #-}
 
--- @ ERROR range=17:1-17:7; Pattern match with existential type.
+-- @ ERROR range=17:0-17:6; Pattern match with existential type.
 -- @ TODO Existential quantification
 
 

--- a/compiler/damlc/tests/daml-test-files/GenericTemplateError.daml
+++ b/compiler/damlc/tests/daml-test-files/GenericTemplateError.daml
@@ -1,6 +1,6 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
--- @ERROR range=11:24-11:34; Generic templates are no longer supported
+-- @ERROR range=11:23-11:33; Generic templates are no longer supported
 
 
 module GenericTemplateError where

--- a/compiler/damlc/tests/daml-test-files/GetPartyError.daml
+++ b/compiler/damlc/tests/daml-test-files/GetPartyError.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR Invalid party name: #party
+-- @ ERROR range=8:0-8:4; Invalid party name: #party
 
 module GetPartyError where
 

--- a/compiler/damlc/tests/daml-test-files/HelloWorld.daml
+++ b/compiler/damlc/tests/daml-test-files/HelloWorld.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR Hello World!
+-- @ ERROR range=9:0-9:4; Hello World!
 
 
 module HelloWorld where

--- a/compiler/damlc/tests/daml-test-files/Import.daml
+++ b/compiler/damlc/tests/daml-test-files/Import.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=13:5-13:10; Couldn't match expected type ‘Good.T’
+-- @ ERROR range=13:4-13:9; Couldn't match expected type ‘Good.T’
 
 module Import where
 

--- a/compiler/damlc/tests/daml-test-files/IntBoundsUpper.daml
+++ b/compiler/damlc/tests/daml-test-files/IntBoundsUpper.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- Test that overflowing integer literals are detected at compile time.
--- @ ERROR Int literal out of bounds
+-- @ ERROR range=10:0-10:6; Int literal out of bounds
 
 module IntBoundsUpper where
 

--- a/compiler/damlc/tests/daml-test-files/InternalImport.daml
+++ b/compiler/damlc/tests/daml-test-files/InternalImport.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:1-9:28; Import of internal module DA.Internal.Template is not allowed.
+-- @ERROR range=9:0-9:27; Import of internal module DA.Internal.Template is not allowed.
 
 
 module InternalImport where

--- a/compiler/damlc/tests/daml-test-files/Lazy.daml
+++ b/compiler/damlc/tests/daml-test-files/Lazy.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR Hello World!
+-- @ ERROR range=9:0-9:4; Hello World!
 
 
 module Lazy where

--- a/compiler/damlc/tests/daml-test-files/List.daml
+++ b/compiler/damlc/tests/daml-test-files/List.daml
@@ -1,17 +1,17 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Use null
--- @INFO Evaluate
--- @INFO Use sum
--- @INFO Use sum
--- @INFO Use sum
--- @INFO Use head
--- @INFO Use head
--- @INFO Use isNone
--- @INFO Use isNone
--- @INFO Use isNone
--- @INFO Use dedup
+-- @INFO range=36:16-36:29; Use section
+-- @INFO range=104:13-104:58; Use null
+-- @INFO range=118:16-118:31; Use dedup
+-- @INFO range=304:9-304:23; Evaluate
+-- @INFO range=319:37-319:47; Use sum
+-- @INFO range=320:42-320:52; Use sum
+-- @INFO range=321:28-321:38; Use sum
+-- @INFO range=324:2-324:22; Use head
+-- @INFO range=329:28-329:35; Use head
+-- @INFO range=336:11-336:33; Use isNone
+-- @INFO range=343:11-343:36; Use isNone
 
 module List where
 

--- a/compiler/damlc/tests/daml-test-files/Math.daml
+++ b/compiler/damlc/tests/daml-test-files/Math.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Use sqrt
--- @INFO Use sqrt
+-- @INFO range=47:21-47:31; Use sqrt
+-- @INFO range=57:14-57:24; Use sqrt
 
 
 module Math where

--- a/compiler/damlc/tests/daml-test-files/MaybeCompat.daml
+++ b/compiler/damlc/tests/daml-test-files/MaybeCompat.daml
@@ -1,11 +1,11 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @WARN range=14:12-14:17; Maybe
--- @WARN range=17:12-17:17; maybe
--- @WARN range=17:29-17:36; Nothing
--- @WARN range=18:12-18:20; fromSome
--- @WARN range=18:22-18:26; Just
+-- @WARN range=14:11-14:16; Maybe
+-- @WARN range=17:11-17:16; maybe
+-- @WARN range=17:28-17:35; Nothing
+-- @WARN range=18:11-18:19; fromSome
+-- @WARN range=18:21-18:25; Just
 
 module MaybeCompat where
 import DA.Maybe

--- a/compiler/damlc/tests/daml-test-files/MissingFields.daml
+++ b/compiler/damlc/tests/daml-test-files/MissingFields.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=10:10-10:22; does not have the required strict field(s): baz
+-- @ ERROR range=10:9-10:21; does not have the required strict field(s): baz
 
 module MissingFields where
 

--- a/compiler/damlc/tests/daml-test-files/ModuleName.daml
+++ b/compiler/damlc/tests/daml-test-files/ModuleName.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR Missing module name
+-- @ERROR range=1:0-100001:0; Missing module name
 
 
 

--- a/compiler/damlc/tests/daml-test-files/ModuleNameWarning.daml
+++ b/compiler/damlc/tests/daml-test-files/ModuleNameWarning.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR Module names should always match file names
+-- @ ERROR range=7:7-7:25; Module names should always match file names
 
 
 module ModuleNameMismatch where

--- a/compiler/damlc/tests/daml-test-files/MultipleFields.daml
+++ b/compiler/damlc/tests/daml-test-files/MultipleFields.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:12-9:23; Constructors with multiple fields must give explicit field names
+-- @ERROR range=9:11-9:22; Constructors with multiple fields must give explicit field names
 
 
 module MultipleFields where

--- a/compiler/damlc/tests/daml-test-files/NoCaseOfCase.daml
+++ b/compiler/damlc/tests/daml-test-files/NoCaseOfCase.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Use if
+-- @INFO range=22:13-22:51; Use if
 
 
 module NoCaseOfCase where

--- a/compiler/damlc/tests/daml-test-files/NoControllerAsVar.daml
+++ b/compiler/damlc/tests/daml-test-files/NoControllerAsVar.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR parse error on input ‘controller’
+-- @ ERROR range=15:0-15:10; parse error on input ‘controller’
 
 
 module NoControllerAsVar where

--- a/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB.daml
@@ -5,7 +5,7 @@
 -- `NumericScale` constraint.
 --
 -- @SINCE-LF 1.7
--- @ERROR No instance for (NumericScale 38)
+-- @ERROR range=16:11-16:18; No instance for (NumericScale 38)
 
 
 

--- a/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB2.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB2.daml
@@ -6,7 +6,7 @@
 -- conversion error even if we try to be clever.
 --
 -- @SINCE-LF 1.7
--- @ERROR type-level natural outside of supported range [0, 37]
+-- @ERROR range=17:0-17:8; type-level natural outside of supported range [0, 37]
 
 
 

--- a/compiler/damlc/tests/daml-test-files/NumericLitPoly.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitPoly.daml
@@ -6,7 +6,7 @@
 -- conversion error even if we try to be clever.
 --
 -- @SINCE-LF 1.7
--- @ERROR Polymorphic numeric literal. Specify a fixed scale by giving the type, e.g. (2.71828 : Numeric 10)
+-- @ERROR range=19:0-19:7; Polymorphic numeric literal. Specify a fixed scale by giving the type, e.g. (2.71828 : Numeric 10)
 
 
 

--- a/compiler/damlc/tests/daml-test-files/PartyCompare.daml
+++ b/compiler/damlc/tests/daml-test-files/PartyCompare.daml
@@ -1,12 +1,12 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Use >=
--- @INFO Use >=
--- @INFO Use >
--- @INFO Use <
--- @INFO Use <=
--- @INFO Use <=
+-- @INFO range=18:11-18:30; Use >=
+-- @INFO range=19:11-19:28; Use >=
+-- @INFO range=22:11-22:29; Use >
+-- @INFO range=25:11-25:29; Use <
+-- @INFO range=27:11-27:28; Use <=
+-- @INFO range=28:11-28:26; Use <=
 
 
 module PartyCompare where

--- a/compiler/damlc/tests/daml-test-files/PatError.daml
+++ b/compiler/damlc/tests/daml-test-files/PatError.daml
@@ -4,7 +4,7 @@
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 -- Make sure the error message is useful when the interpreter is face with
 -- an incomplete pattern match.
--- @ERROR PatError.daml:(11,7)-(12,14): Non-exhaustive patterns in case
+-- @ERROR range=14:0-14:4; Non-exhaustive patterns in case
 
 module PatError where
 

--- a/compiler/damlc/tests/daml-test-files/Phantom.daml
+++ b/compiler/damlc/tests/daml-test-files/Phantom.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Replace case with optional
+-- @INFO range=16:19-18:18; Replace case with optional
 
 
 module Phantom where

--- a/compiler/damlc/tests/daml-test-files/PolymorphicTest.daml
+++ b/compiler/damlc/tests/daml-test-files/PolymorphicTest.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR Aborted: boom
+-- @ERROR range=9:0-9:4; Aborted: boom
 
 module PolymorphicTest where
 

--- a/compiler/damlc/tests/daml-test-files/Precondition.daml
+++ b/compiler/damlc/tests/daml-test-files/Precondition.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR Template pre-condition violated
+-- @ERROR range=22:0-22:4; Template pre-condition violated
 
 module Precondition where
 

--- a/compiler/damlc/tests/daml-test-files/PreludeTest.daml
+++ b/compiler/damlc/tests/daml-test-files/PreludeTest.daml
@@ -1,39 +1,39 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Use uncurry
--- @INFO Redundant identity
--- @INFO Redundant identity
--- @INFO Redundant identity
--- @INFO Evaluate
--- @INFO Use elem
--- @INFO Use elem
--- @INFO Use elem
--- @INFO Redundant if
--- @INFO Redundant if
--- @INFO Use ||
--- @INFO Use ||
--- @INFO Use ||
--- @INFO Use &&
--- @INFO Use &&
--- @INFO Use &&
--- @INFO Use isNone
--- @INFO Use $>
--- @INFO Evaluate
--- @INFO Evaluate
--- @INFO Use ++
--- @INFO Redundant flip
--- @INFO Redundant flip
--- @INFO Evaluate
--- @INFO Take on a non-positive
--- @INFO Drop on a non-positive
--- @INFO Use zip
--- @INFO Use zip
--- @INFO Use zip3
--- @INFO Use zip3
--- @INFO Evaluate
--- @INFO Evaluate
--- @INFO Evaluate
+-- @INFO range=51:26-51:42; Use uncurry
+-- @INFO range=65:8-65:18; Redundant identity
+-- @INFO range=66:12-66:26; Redundant identity
+-- @INFO range=67:22-67:60; Redundant identity
+-- @INFO range=89:8-89:17; Evaluate
+-- @INFO range=93:12-93:21; Use elem
+-- @INFO range=94:12-94:21; Use elem
+-- @INFO range=95:10-95:19; Use elem
+-- @INFO range=99:22-99:59; Redundant if
+-- @INFO range=108:23-108:61; Redundant if
+-- @INFO range=111:12-111:36; Use ||
+-- @INFO range=113:11-113:34; Use ||
+-- @INFO range=114:11-114:26; Use ||
+-- @INFO range=117:12-117:37; Use &&
+-- @INFO range=119:12-119:36; Use &&
+-- @INFO range=120:11-120:27; Use &&
+-- @INFO range=155:11-155:35; Use isNone
+-- @INFO range=155:20-155:34; Use $>
+-- @INFO range=161:9-161:55; Evaluate
+-- @INFO range=162:9-162:58; Evaluate
+-- @INFO range=175:16-175:35; Use ++
+-- @INFO range=179:8-179:21; Redundant flip
+-- @INFO range=180:14-180:37; Redundant flip
+-- @INFO range=206:12-206:52; Evaluate
+-- @INFO range=218:9-218:28; Take on a non-positive
+-- @INFO range=224:9-224:28; Drop on a non-positive
+-- @INFO range=290:27-290:38; Use zip
+-- @INFO range=291:37-291:48; Use zip
+-- @INFO range=295:37-295:50; Use zip3
+-- @INFO range=296:52-296:65; Use zip3
+-- @INFO range=308:8-308:20; Evaluate
+-- @INFO range=311:10-311:22; Evaluate
+-- @INFO range=315:12-315:19; Evaluate
 
 
 module PreludeTest where

--- a/compiler/damlc/tests/daml-test-files/RationalLowerBoundError.daml
+++ b/compiler/damlc/tests/daml-test-files/RationalLowerBoundError.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- Test that rational negative literals bigger or equal -10^38 + 1 fail.
--- @ERROR Rational is out of bounds
+-- @ERROR range=13:0-13:1; Rational is out of bounds
 
 
 

--- a/compiler/damlc/tests/daml-test-files/RationalPrecisionUpperBoundError.daml
+++ b/compiler/damlc/tests/daml-test-files/RationalPrecisionUpperBoundError.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- Test that rational literals with precision higher then e^-10 fail.
--- @ERROR Rational is out of bounds
+-- @ERROR range=12:0-12:1; Rational is out of bounds
 
 
 

--- a/compiler/damlc/tests/daml-test-files/RationalUpperBoundError.daml
+++ b/compiler/damlc/tests/daml-test-files/RationalUpperBoundError.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- Test that rational positive literals fail when bigger than 10^38 -1 after multiplying with 10^10.
--- @ERROR Rational is out of bounds
+-- @ERROR range=13:0-13:1; Rational is out of bounds
 
 
 

--- a/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR Record type X has constructor Y with different name. Possible solution: Change the constructor name to X
+-- @ERROR range=10:0-10:13; Record type X has constructor Y with different name. Possible solution: Change the constructor name to X
 
--- @ERROR Record type A has constructor B with different name. Possible solution: Change the constructor name to A
+-- @ERROR range=12:0-12:26; Record type A has constructor B with different name. Possible solution: Change the constructor name to A
 
 module RecordConstructorCheck where
 

--- a/compiler/damlc/tests/daml-test-files/RecordUpdate.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordUpdate.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Evaluate
--- @INFO Use const
+-- @INFO range=43:17-43:41; Evaluate
+-- @INFO range=43:24-43:40; Use const
 
 
 

--- a/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden1.daml
+++ b/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden1.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR No instance for (DA.Internal.Record.HasField "microseconds" RelTime Int)
+-- @ ERROR range=11:9-11:24; No instance for (DA.Internal.Record.HasField "microseconds" RelTime Int)
 
 module RelTimeDetailsHidden1 where
 

--- a/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden2.daml
+++ b/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden2.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR Not in scope: data constructor ‘RelTime’
+-- @ ERROR range=11:5-11:12; Not in scope: data constructor ‘RelTime’
 
 module RelTimeDetailsHidden2 where
 

--- a/compiler/damlc/tests/daml-test-files/RightOfUse.daml
+++ b/compiler/damlc/tests/daml-test-files/RightOfUse.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR Scenario execution failed on commit at RightOfUse:56:5:
+-- @ERROR range=44:0-44:7; Scenario execution failed on commit at RightOfUse:56:5:
 
 
 module RightOfUse where

--- a/compiler/damlc/tests/daml-test-files/Set.daml
+++ b/compiler/damlc/tests/daml-test-files/Set.daml
@@ -1,10 +1,10 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Use infix
--- @INFO Use infix
--- @INFO Use infix
--- @INFO Use infix
+-- @INFO range=57:30-57:77; Use infix
+-- @INFO range=58:21-58:52; Use infix
+-- @INFO range=59:24-59:58; Use infix
+-- @INFO range=60:17-60:54; Use infix
 
 -- @SINCE-LF 1.3
 

--- a/compiler/damlc/tests/daml-test-files/ShortCircuit.daml
+++ b/compiler/damlc/tests/daml-test-files/ShortCircuit.daml
@@ -1,10 +1,10 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Redundant ==
--- @INFO Evaluate
--- @INFO Redundant ==
--- @INFO Evaluate
+-- @INFO range=15:11-15:41; Redundant ==
+-- @INFO range=15:12-15:32; Evaluate
+-- @INFO range=16:11-16:43; Redundant ==
+-- @INFO range=16:12-16:33; Evaluate
 
 
 module ShortCircuit where

--- a/compiler/damlc/tests/daml-test-files/Text.daml
+++ b/compiler/damlc/tests/daml-test-files/Text.daml
@@ -1,13 +1,13 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Evaluate
--- @INFO Evaluate
--- @INFO Use null
--- @INFO Use null
--- @INFO Use null
--- @INFO Use isNone
--- @INFO Use isNone
+-- @INFO range=41:9-41:17; Evaluate
+-- @INFO range=55:2-55:12; Evaluate
+-- @INFO range=61:13-61:46; Use null
+-- @INFO range=69:13-69:46; Use null
+-- @INFO range=70:13-70:46; Use null
+-- @INFO range=92:13-92:47; Use isNone
+-- @INFO range=97:13-97:47; Use isNone
 
 
 module Text where

--- a/compiler/damlc/tests/daml-test-files/Trace.daml
+++ b/compiler/damlc/tests/daml-test-files/Trace.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO Use <$>
+-- @INFO range=11:11-11:42; Use <$>
 
 
 module Trace where

--- a/compiler/damlc/tests/daml-test-files/TypeFamily.daml
+++ b/compiler/damlc/tests/daml-test-files/TypeFamily.daml
@@ -3,7 +3,7 @@
 
 {-# LANGUAGE TypeFamilies #-}
 
--- @ERROR range=11:1-11:16; Data definition, of type type family.
+-- @ERROR range=11:0-11:15; Data definition, of type type family.
 
 
 module TypeFamily where

--- a/compiler/damlc/tests/daml-test-files/Unicode.daml
+++ b/compiler/damlc/tests/daml-test-files/Unicode.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR ⛄ ¯\_(ツ)_/¯
+-- @ERROR range=9:0-9:4; ⛄ ¯\_(ツ)_/¯
 
 
 module Unicode where

--- a/compiler/damlc/tests/daml-test-files/Unserializable.daml
+++ b/compiler/damlc/tests/daml-test-files/Unserializable.daml
@@ -5,7 +5,7 @@
 -- We use the template typeclass and instances directly as otherwise the error
 -- is caught prior due to missing Eq and Show instances.
 
--- @ERROR expected serializable type
+-- @ERROR range=1:0-100001:0; expected serializable type
 
 module Unserializable where
 

--- a/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlcIntegration.hs
@@ -318,9 +318,40 @@ parseRange :: String -> Range
 parseRange s =
   case traverse readMaybe (wordsBy (`elem` (":-" :: String)) s) of
     Just [rowStart, colStart, rowEnd, colEnd] ->
-        Range
-            (Position (rowStart - 1) (colStart - 1))
-            (Position (rowEnd - 1) (colEnd - 1))
+      -- When specifying ranges:
+      --  * lines are 1-based
+      --  * columns are 0-based
+      --  * the column span is open, that is, the end column is "one
+      --    past the end" of the span.
+      --
+      -- Positions in these ranges are matched against LSP coordinates
+      -- which are 0-based in both line and column and also open. Error
+      -- messages are formatted by GHC and are 1-based in line, 0-based
+      -- in column and closed (so add one to column start, one to
+      -- column end to make them 1-based, then subtract one from column
+      -- end to convert to closed!)
+      --
+      -- 'showDiagnostics' reports ranges such that lines are 1-based,
+      -- columns are 0-based and open.
+      --
+      -- Example:
+      --   If @INFO 'range=8:13-8:47':
+      --   then the actual (LSP) range is
+      --      { _start = Position {_line = 7, _character = 13}
+      --      ,   _end = Position {_line = 7, _character = 47}}
+      --   and 'showDiagnostics' reports:
+      --     Hidden:   no
+      --     Range:    8:13-8:47
+      --     Source:   linter
+      --     Severity: DsInfo
+      --     Message:  RangeTest.daml:8:14-47: Some error message.
+      --
+      -- TL;DR: To mark a diagnostic as "expected" paste the range as it
+      -- appears in 'showDiagnostics' e.g. '@INFO range=8:13-8:47; Some
+      -- error message'.
+      Range
+        (Position (rowStart - 1) colStart)
+        (Position (rowEnd - 1) colEnd)
     _ -> error $ "Failed to parse range, got " ++ s
 
 mainProj :: TestArguments -> IdeState -> FilePath -> (String -> IO ()) -> NormalizedFilePath -> IO LF.Package


### PR DESCRIPTION
Fix range parsing (e.g.`-- @INFO range=36:16-36:29; Use section`) of DAML test files so that in order to mark a diagnostic as "expected" it is as simple as copy-pasting the range as it appears in the output of a call to`showDiagnostics`.

In more detail, ranges are now specified as 1-based in lines, 0-based in columns and open (in the sense that the end column of the diagnostic span is "one past the end").

All ranges in the test files are updated to the above convention and additionally, expected diagnostics that didn't have associated range information provided now do.