### PR TITLE
Docs: Remove refernce to ex-upgrade example

### DIFF
--- a/docs/source/examples/examples.rst
+++ b/docs/source/examples/examples.rst
@@ -10,6 +10,5 @@ We have plenty of example code, both of DAML and of applications around DAML, on
 - `Bond trading example <https://github.com/digital-asset/ex-bond-trading>`_: DAML code and automation using the Java bindings
 - `Collateral management example <https://github.com/digital-asset/ex-collateral>`_: DAML code
 - `Repurchase agreement example <https://github.com/digital-asset/ex-repo-market>`_: DAML code and automation using the Java bindings
-- `Upgrading DAML templates example <https://github.com/digital-asset/ex-upgrade>`_: DAML code
 - `Java bindings tutorial <https://github.com/digital-asset/ex-java-bindings>`_: Three examples using the Java bindings with a very simple DAML model
 - `Node.js tutorial <https://github.com/digital-asset/ex-tutorial-nodejs>`_: Step-by-step running through using the Node.js bindings


### PR DESCRIPTION
We have new documentation on how to manage model upgrades which
supersede the `ex-upgrade` example repository.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5650)
<!-- Reviewable:end -->
