### PR TITLE
Reenable isScoopEnabled

### DIFF
--- a/dev-env/windows/libexec/install.ps1
+++ b/dev-env/windows/libexec/install.ps1
@@ -15,10 +15,7 @@ function da_install {
     }
 
     da_enable_scoop
-    # $isScoopEnabled = da_is_scoop_installed
-    # Temporary because we upgraded scoop so we need to force a reinstall. After all
-    # machines have been refreshed we can remove this.
-    $isScoopEnabled = $false
+    $isScoopEnabled = da_is_scoop_installed
     da_reset_path
 
     if ($isScoopEnabled) {


### PR DESCRIPTION
Our CI machines have been reset so there is no need to keep this hack
around to force scoop to be upgraded.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
