### PR TITLE
Show hidden navigator server CLI option

### DIFF
--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
@@ -142,15 +142,17 @@ object Arguments {
           ))
 
       opt[Int]("ledger-api-inbound-message-size-max")
-        .hidden()
         .text(
           s"Maximum message size in bytes from the ledger API. Default is ${Arguments.default.ledgerInboundMessageSizeMax}.")
         .valueName("<bytes>")
         .validate(x => Either.cond(x > 0, (), "Buffer size must be positive"))
-        .action((x, arguments) =>
-          arguments.copy(
-            ledgerInboundMessageSizeMax = x
-        ))
+        .action(
+          (ledgerInboundMessageSizeMax, arguments) => {
+            arguments.copy(
+              ledgerInboundMessageSizeMax = ledgerInboundMessageSizeMax,
+            )
+          }
+        )
 
       cmd("server")
         .text("serve data from platform")


### PR DESCRIPTION
Specifically, the option to adjust the gRPC maximum inbound message size.

changelog_begin
[Navigator] The CLI help message now shows how to adjust the gRPC
maximum inbound message size.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
