### PR TITLE
fix tell-slack-failed CI "function"

### DIFF
--- a/ci/tell-slack-failed.yml
+++ b/ci/tell-slack-failed.yml
@@ -8,7 +8,7 @@ steps:
   - bash: |
       set -euo pipefail
       COMMIT_TITLE=$(git log --pretty=format:%s -n1 ${{ parameters.trigger_sha }})
-      COMMI_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$COMMIT_TITLE>"
+      COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$COMMIT_TITLE>"
       if [ -z "${{ parameters.trigger_sha }}" ]; then
           WARNING="<!here> *FAILED* $(Build.SourceBranchName)/$(Agent.JobName): $COMMIT_LINK"
       else


### PR DESCRIPTION
Backporting #5670 from master to this release branch.

Still :cry:, though.

CHANGELOG_BEGIN
CHANGELOG_END