### PR TITLE
reenable collect_build_data

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -347,7 +347,7 @@ jobs:
           trigger_sha: '$(trigger_sha)'
 
   - job: collect_build_data
-    condition: succeededOrFailed()
+    condition: always()
     dependsOn:
       - Linux
       - macOS
@@ -497,7 +497,7 @@ jobs:
           PR_BRANCH: $(pr.branch)
 
   - job: notify_user
-    condition: and(succeededOrFailed(), eq(variables['Build.Reason'], 'PullRequest'))
+    condition: eq(variables['Build.Reason'], 'PullRequest')
     dependsOn:
       - git_sha
       - collect_build_data


### PR DESCRIPTION
backporting #5545 because otherwise failed builds can never be working
again (as collect_build_data only runs on failed builds and then fails
itself).

CHANGELOG_BEGIN
CHANGELOG_END