### PR TITLE
fix daily-compat.yml

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -44,4 +44,7 @@ jobs:
 
           # FIXME: fill in the gaps.
           exit 0
-      - template: ci/tell-slack-failed.yml
+      # For whatever reason, templates are searched from the path of the
+      # current YML file. I could not find any reference to that in the
+      # documentation.
+      - template: ../tell-slack-failed.yml


### PR DESCRIPTION
For some reason the Azure Pipelines folks thought it was a good idea to
search for templates starting with the current YAML file's path. Other
steps (e.g. the bash script here) start from the root of the repo,
though.

CHANGELOG_BEGIN
CHANGELOG_END