### PR TITLE
Avoid instantiating new implicit conversions for every query

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
@@ -7,16 +7,7 @@ import java.sql.PreparedStatement
 import java.time.Instant
 import java.util.Date
 
-import anorm.ParameterMetaData.ByteArrayParameterMetaData
-import anorm.{
-  Column,
-  MetaDataItem,
-  ParameterMetaData,
-  RowParser,
-  SqlMappingError,
-  SqlParser,
-  ToStatement
-}
+import anorm._
 import com.daml.ledger.participant.state.v1.Offset
 import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref
@@ -24,140 +15,126 @@ import com.daml.lf.value.Value
 
 object Conversions {
 
-  private def stringColumnToX[X](f: String => Either[String, X])(c: Column[String]): Column[X] =
+  private def stringColumnToX[X](f: String => Either[String, X]): Column[X] =
     Column.nonNull((value: Any, meta) =>
-      c(value, meta).toEither.flatMap(x => f(x).left.map(SqlMappingError)))
+      Column.columnToString(value, meta).toEither.flatMap(x => f(x).left.map(SqlMappingError)))
 
-  private def subStringToStatement[T <: String](c: ToStatement[String]): ToStatement[T] =
-    (s: PreparedStatement, index: Int, v: T) => c.set(s, index, v)
-
-  private def subStringMetaParameter[T <: String](
-      strParamMetaData: ParameterMetaData[String]): ParameterMetaData[T] =
-    new ParameterMetaData[T] {
-      def sqlType: String = strParamMetaData.sqlType
-      def jdbcType: Int = strParamMetaData.jdbcType
-    }
-
-  // Parties
-
-  implicit def columnToParty(implicit c: Column[String]): Column[Ref.Party] =
-    stringColumnToX(Ref.Party.fromString)(c)
-
-  implicit def partyToStatement(implicit strToStm: ToStatement[String]): ToStatement[Ref.Party] =
-    subStringToStatement(strToStm)
-
-  implicit def partyMetaParameter(
-      implicit strParamMetaData: ParameterMetaData[String],
-  ): ParameterMetaData[Ref.Party] =
-    subStringMetaParameter(strParamMetaData)
-
-  def party(columnName: String)(implicit c: Column[String]): RowParser[Ref.Party] =
-    SqlParser.get[Ref.Party](columnName)(columnToParty(c))
-
-  // PackageIds
-
-  implicit def columnToPackageId(implicit c: Column[String]): Column[Ref.PackageId] =
-    stringColumnToX(Ref.PackageId.fromString)(c)
-
-  implicit def packageIdToStatement(
-      implicit strToStm: ToStatement[String]): ToStatement[Ref.PackageId] =
-    subStringToStatement(strToStm)
-
-  def packageId(columnName: String)(implicit c: Column[String]): RowParser[Ref.PackageId] =
-    SqlParser.get[Ref.PackageId](columnName)(columnToPackageId(c))
-
-  // LedgerStrings
-
-  implicit def columnToLedgerString(implicit c: Column[String]): Column[Ref.LedgerString] =
-    stringColumnToX(Ref.LedgerString.fromString)(c)
-
-  implicit def ledgerStringToStatement(
-      implicit strToStm: ToStatement[String]): ToStatement[Ref.LedgerString] =
-    subStringToStatement(strToStm)
-
-  implicit def columnToParticipantId(implicit c: Column[String]): Column[Ref.ParticipantId] =
-    stringColumnToX(Ref.ParticipantId.fromString)(c)
-
-  implicit def participantToStatement(
-      implicit strToStm: ToStatement[String]): ToStatement[Ref.ParticipantId] =
-    subStringToStatement(strToStm)
-
-  implicit def columnToContractId(implicit c: Column[String]): Column[Value.AbsoluteContractId] =
-    stringColumnToX(Value.AbsoluteContractId.fromString)(c)
-
-  implicit def contractIdToStatement(
-      implicit strToStm: ToStatement[String]
-  ): ToStatement[Value.AbsoluteContractId] =
-    (s: PreparedStatement, index: Int, v: Value.AbsoluteContractId) =>
-      strToStm.set(s, index, v.coid)
-
-  def emptyStringToNullColumn(implicit c: Column[String]): Column[String] = new Column[String] {
-    override def apply(value: Any, meta: MetaDataItem) = value match {
-      case "" => c(null, meta)
-      case x => c(x, meta)
-    }
+  private final class SubStringToStatement[S <: String] extends ToStatement[S] {
+    override def set(s: PreparedStatement, i: Int, v: S): Unit =
+      ToStatement.stringToStatement.set(s, i, v)
   }
 
-  def ledgerString(columnName: String)(implicit c: Column[String]): RowParser[Ref.LedgerString] =
-    SqlParser.get[Ref.LedgerString](columnName)(columnToLedgerString(c))
+  private final class ToStringToStatement[A] extends ToStatement[A] {
+    override def set(s: PreparedStatement, i: Int, v: A): Unit =
+      ToStatement.stringToStatement.set(s, i, v.toString)
+  }
 
-  implicit def ledgerStringMetaParameter(
-      implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[Ref.LedgerString] =
-    subStringMetaParameter(strParamMetaData)
+  private final class SubStringMetaParameter[S <: String] extends ParameterMetaData[S] {
+    override val sqlType: String = ParameterMetaData.StringParameterMetaData.sqlType
+    override val jdbcType: Int = ParameterMetaData.StringParameterMetaData.jdbcType
+  }
 
-  def participantId(columnName: String)(implicit c: Column[String]): RowParser[Ref.ParticipantId] =
-    SqlParser.get[Ref.ParticipantId](columnName)(columnToParticipantId(c))
+  // Party
 
-  implicit def participantIdMetaParameter(
-      implicit strParamMetaData: ParameterMetaData[String]): ParameterMetaData[Ref.ParticipantId] =
-    subStringMetaParameter(strParamMetaData)
+  implicit val columnToParty: Column[Ref.Party] =
+    stringColumnToX(Ref.Party.fromString)
 
-  def contractId(columnName: String)(
-      implicit c: Column[String]): RowParser[Value.AbsoluteContractId] =
-    SqlParser.get[Value.AbsoluteContractId](columnName)(columnToContractId(c))
+  implicit val partyToStatement: ToStatement[Ref.Party] =
+    new SubStringToStatement[Ref.Party]
 
-  implicit def contractIdStringMetaParameter(implicit strParamMetaData: ParameterMetaData[String])
-    : ParameterMetaData[Ref.ContractIdString] =
-    subStringMetaParameter(strParamMetaData)
+  implicit val partyMetaParameter: ParameterMetaData[Ref.Party] =
+    new SubStringMetaParameter[Ref.Party]
 
-  // ChoiceNames
+  def party(columnName: String): RowParser[Ref.Party] =
+    SqlParser.get[Ref.Party](columnName)(columnToParty)
 
-  implicit def columnToChoiceName(implicit c: Column[String]): Column[Ref.ChoiceName] =
-    stringColumnToX(Ref.ChoiceName.fromString)(c)
+  // PackageId
 
-  implicit def choiceNameToStatement(
-      implicit strToStm: ToStatement[String],
-  ): ToStatement[Ref.ChoiceName] =
-    subStringToStatement(strToStm)
+  implicit val columnToPackageId: Column[Ref.PackageId] =
+    stringColumnToX(Ref.PackageId.fromString)
 
-  implicit def choiceNameMetaParameter(
-      implicit strParamMetaData: ParameterMetaData[String],
-  ): ParameterMetaData[Ref.ChoiceName] =
-    subStringMetaParameter(strParamMetaData)
+  implicit val packageIdToStatement: ToStatement[Ref.PackageId] =
+    new SubStringToStatement[Ref.PackageId]
 
-  // QualifiedNames
+  def packageId(columnName: String): RowParser[Ref.PackageId] =
+    SqlParser.get[Ref.PackageId](columnName)(columnToPackageId)
 
-  implicit def qualifiedNameToStatement(
-      implicit strToStm: ToStatement[String],
-  ): ToStatement[Ref.QualifiedName] =
-    (s: PreparedStatement, index: Int, v: Ref.QualifiedName) => strToStm.set(s, index, v.toString)
+  // LedgerString
 
-  // Identifiers
+  implicit val columnToLedgerString: Column[Ref.LedgerString] =
+    stringColumnToX(Ref.LedgerString.fromString)
 
-  implicit def identifierToStatement(
-      implicit strToStm: ToStatement[String],
-  ): ToStatement[Ref.Identifier] =
-    (s: PreparedStatement, index: Int, v: Ref.Identifier) => strToStm.set(s, index, v.toString)
+  implicit val ledgerStringToStatement: ToStatement[Ref.LedgerString] =
+    new SubStringToStatement[Ref.LedgerString]
 
-  implicit def columnToIdentifier(implicit c: Column[String]): Column[Ref.Identifier] =
-    stringColumnToX(Ref.Identifier.fromString)(c)
+  def ledgerString(columnName: String): RowParser[Ref.LedgerString] =
+    SqlParser.get[Ref.LedgerString](columnName)(columnToLedgerString)
 
-  def identifier(columnName: String)(implicit c: Column[String]): RowParser[Ref.Identifier] =
-    SqlParser.get[Ref.Identifier](columnName)(columnToIdentifier(c))
+  implicit val ledgerStringMetaParameter: ParameterMetaData[Ref.LedgerString] =
+    new SubStringMetaParameter[Ref.LedgerString]
 
-  // Offsets
+  // ParticipantId
 
-  implicit val offsetToStatement: ToStatement[Offset] = new ToStatement[Offset] {
+  implicit val columnToParticipantId: Column[Ref.ParticipantId] =
+    stringColumnToX(Ref.ParticipantId.fromString)
+
+  implicit val participantToStatement: ToStatement[Ref.ParticipantId] =
+    new SubStringToStatement[Ref.ParticipantId]
+
+  implicit val participantIdMetaParameter: ParameterMetaData[Ref.ParticipantId] =
+    new SubStringMetaParameter[Ref.ParticipantId]
+
+  def participantId(columnName: String): RowParser[Ref.ParticipantId] =
+    SqlParser.get[Ref.ParticipantId](columnName)(columnToParticipantId)
+
+  // AbsoluteContractId
+
+  implicit val columnToContractId: Column[Value.AbsoluteContractId] =
+    stringColumnToX(Value.AbsoluteContractId.fromString)
+
+  implicit object ContractIdToStatement extends ToStatement[Value.AbsoluteContractId] {
+    override def set(s: PreparedStatement, index: Int, v: Value.AbsoluteContractId): Unit =
+      ToStatement.stringToStatement.set(s, index, v.coid)
+  }
+
+  def contractId(columnName: String): RowParser[Value.AbsoluteContractId] =
+    SqlParser.get[Value.AbsoluteContractId](columnName)(columnToContractId)
+
+  // ContractIdString
+
+  implicit val contractIdStringMetaParameter: ParameterMetaData[Ref.ContractIdString] =
+    new SubStringMetaParameter[Ref.ContractIdString]
+
+  // ChoiceName
+
+  implicit val columnToChoiceName: Column[Ref.ChoiceName] =
+    stringColumnToX(Ref.ChoiceName.fromString)
+
+  implicit val choiceNameToStatement: ToStatement[Ref.ChoiceName] =
+    new SubStringToStatement[Ref.ChoiceName]
+
+  implicit val choiceNameMetaParameter: ParameterMetaData[Ref.ChoiceName] =
+    new SubStringMetaParameter[Ref.ChoiceName]
+
+  // QualifiedName
+
+  implicit val qualifiedNameToStatement: ToStatement[Ref.QualifiedName] =
+    new ToStringToStatement[Ref.QualifiedName]
+
+  // Identifier
+
+  implicit val IdentifierToStatement: ToStatement[Ref.Identifier] =
+    new ToStringToStatement[Ref.Identifier]
+
+  implicit val columnToIdentifier: Column[Ref.Identifier] =
+    stringColumnToX(Ref.Identifier.fromString)
+
+  def identifier(columnName: String): RowParser[Ref.Identifier] =
+    SqlParser.get[Ref.Identifier](columnName)(columnToIdentifier)
+
+  // Offset
+
+  implicit object OffsetToStatement extends ToStatement[Offset] {
     override def set(s: PreparedStatement, index: Int, v: Offset): Unit =
       s.setBytes(index, v.toByteArray)
   }
@@ -165,15 +142,16 @@ object Conversions {
   def offset(name: String): RowParser[Offset] =
     SqlParser.get[Array[Byte]](name).map(Offset.fromByteArray)
 
-  implicit def columnToOffset(implicit c: Column[Array[Byte]]): Column[Offset] =
-    Column.nonNull((value: Any, meta) => c(value, meta).toEither.map(Offset.fromByteArray))
+  implicit val columnToOffset: Column[Offset] =
+    Column.nonNull((value: Any, meta) =>
+      Column.columnToByteArray(value, meta).toEither.map(Offset.fromByteArray))
 
   // Instant
 
   def instant(name: String): RowParser[Instant] =
     SqlParser.get[Date](name).map(_.toInstant)
 
-  // Hashes
+  // Hash
 
   implicit val hashToStatement: ToStatement[Hash] =
     (s: PreparedStatement, i: Int, v: Hash) => s.setBytes(i, v.bytes.toByteArray)
@@ -182,10 +160,9 @@ object Conversions {
     Column.nonNull((value: Any, meta) =>
       Column.columnToByteArray(value, meta).toEither.map(Hash.assertFromByteArray))
 
-  implicit val hashMetaParameter: ParameterMetaData[Hash] =
-    new ParameterMetaData[Hash] {
-      override final val sqlType: String = ByteArrayParameterMetaData.sqlType
-      override final val jdbcType: Int = ByteArrayParameterMetaData.jdbcType
-    }
+  implicit object HashMetaParameter extends ParameterMetaData[Hash] {
+    override val sqlType: String = ParameterMetaData.ByteArrayParameterMetaData.sqlType
+    override val jdbcType: Int = ParameterMetaData.ByteArrayParameterMetaData.jdbcType
+  }
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
@@ -153,8 +153,10 @@ object Conversions {
 
   // Hash
 
-  implicit val hashToStatement: ToStatement[Hash] =
-    (s: PreparedStatement, i: Int, v: Hash) => s.setBytes(i, v.bytes.toByteArray)
+  implicit object HashToStatement extends ToStatement[Hash] {
+    override def set(s: PreparedStatement, i: Int, v: Hash): Unit =
+      s.setBytes(i, v.bytes.toByteArray)
+  }
 
   implicit val columnToHash: Column[Hash] =
     Column.nonNull((value: Any, meta) =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Conversions.scala
@@ -19,7 +19,7 @@ object Conversions {
     Column.nonNull((value: Any, meta) =>
       Column.columnToString(value, meta).toEither.flatMap(x => f(x).left.map(SqlMappingError)))
 
-  private final class SubStringToStatement[S <: String] extends ToStatement[S] {
+  private final class SubTypeOfStringToStatement[S <: String] extends ToStatement[S] {
     override def set(s: PreparedStatement, i: Int, v: S): Unit =
       ToStatement.stringToStatement.set(s, i, v)
   }
@@ -29,7 +29,7 @@ object Conversions {
       ToStatement.stringToStatement.set(s, i, v.toString)
   }
 
-  private final class SubStringMetaParameter[S <: String] extends ParameterMetaData[S] {
+  private final class SubTypeOfStringMetaParameter[S <: String] extends ParameterMetaData[S] {
     override val sqlType: String = ParameterMetaData.StringParameterMetaData.sqlType
     override val jdbcType: Int = ParameterMetaData.StringParameterMetaData.jdbcType
   }
@@ -40,10 +40,10 @@ object Conversions {
     stringColumnToX(Ref.Party.fromString)
 
   implicit val partyToStatement: ToStatement[Ref.Party] =
-    new SubStringToStatement[Ref.Party]
+    new SubTypeOfStringToStatement[Ref.Party]
 
   implicit val partyMetaParameter: ParameterMetaData[Ref.Party] =
-    new SubStringMetaParameter[Ref.Party]
+    new SubTypeOfStringMetaParameter[Ref.Party]
 
   def party(columnName: String): RowParser[Ref.Party] =
     SqlParser.get[Ref.Party](columnName)(columnToParty)
@@ -54,7 +54,7 @@ object Conversions {
     stringColumnToX(Ref.PackageId.fromString)
 
   implicit val packageIdToStatement: ToStatement[Ref.PackageId] =
-    new SubStringToStatement[Ref.PackageId]
+    new SubTypeOfStringToStatement[Ref.PackageId]
 
   def packageId(columnName: String): RowParser[Ref.PackageId] =
     SqlParser.get[Ref.PackageId](columnName)(columnToPackageId)
@@ -65,13 +65,13 @@ object Conversions {
     stringColumnToX(Ref.LedgerString.fromString)
 
   implicit val ledgerStringToStatement: ToStatement[Ref.LedgerString] =
-    new SubStringToStatement[Ref.LedgerString]
+    new SubTypeOfStringToStatement[Ref.LedgerString]
 
   def ledgerString(columnName: String): RowParser[Ref.LedgerString] =
     SqlParser.get[Ref.LedgerString](columnName)(columnToLedgerString)
 
   implicit val ledgerStringMetaParameter: ParameterMetaData[Ref.LedgerString] =
-    new SubStringMetaParameter[Ref.LedgerString]
+    new SubTypeOfStringMetaParameter[Ref.LedgerString]
 
   // ParticipantId
 
@@ -79,10 +79,10 @@ object Conversions {
     stringColumnToX(Ref.ParticipantId.fromString)
 
   implicit val participantToStatement: ToStatement[Ref.ParticipantId] =
-    new SubStringToStatement[Ref.ParticipantId]
+    new SubTypeOfStringToStatement[Ref.ParticipantId]
 
   implicit val participantIdMetaParameter: ParameterMetaData[Ref.ParticipantId] =
-    new SubStringMetaParameter[Ref.ParticipantId]
+    new SubTypeOfStringMetaParameter[Ref.ParticipantId]
 
   def participantId(columnName: String): RowParser[Ref.ParticipantId] =
     SqlParser.get[Ref.ParticipantId](columnName)(columnToParticipantId)
@@ -103,7 +103,7 @@ object Conversions {
   // ContractIdString
 
   implicit val contractIdStringMetaParameter: ParameterMetaData[Ref.ContractIdString] =
-    new SubStringMetaParameter[Ref.ContractIdString]
+    new SubTypeOfStringMetaParameter[Ref.ContractIdString]
 
   // ChoiceName
 
@@ -111,10 +111,10 @@ object Conversions {
     stringColumnToX(Ref.ChoiceName.fromString)
 
   implicit val choiceNameToStatement: ToStatement[Ref.ChoiceName] =
-    new SubStringToStatement[Ref.ChoiceName]
+    new SubTypeOfStringToStatement[Ref.ChoiceName]
 
   implicit val choiceNameMetaParameter: ParameterMetaData[Ref.ChoiceName] =
-    new SubStringMetaParameter[Ref.ChoiceName]
+    new SubTypeOfStringMetaParameter[Ref.ChoiceName]
 
   // QualifiedName
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -216,7 +216,7 @@ private class JdbcLedgerDao(
       str("typ") ~
       str("submission_id") ~
       str("participant_id") ~
-      str("rejection_reason")(emptyStringToNullColumn).? ~
+      str("rejection_reason").map(s => if (s.isEmpty) null else s).? ~
       byteArray("configuration"))
       .map(flatten)
       .map {
@@ -1059,7 +1059,9 @@ private class JdbcLedgerDao(
       ledgerString("command_id").? ~
       ledgerString("application_id").? ~
       party("submitter").? ~
-      ledgerString("workflow_id")(emptyStringToNullColumn).? ~
+      ledgerString("workflow_id")
+        .map(s => if (s.isEmpty) null.asInstanceOf[Ref.LedgerString] else s)
+        .? ~
       date("effective_at").? ~
       date("recorded_at").? ~
       binaryStream("transaction").? ~


### PR DESCRIPTION
Right now new conversion objects are instantiated every time they are used. This can be avoided by using always the same instances of underlying implicits instead of getting them as parameters.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
