### PR TITLE
Backport "Remove duplicate ledger time field (#5698)"

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -65,7 +65,6 @@ final class CommandsValidator(ledgerId: LedgerId) {
         applicationId = appId,
         commandId = commandId,
         submitter = submitter,
-        ledgerEffectiveTime = ledgerEffectiveTime,
         submittedAt = currentUtcTime,
         deduplicateUntil = currentUtcTime.plus(deduplicationTime),
         commands = Commands(

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -77,7 +77,6 @@ class SubmitRequestValidatorTest
       applicationId = applicationId,
       commandId = commandId,
       submitter = DomainMocks.party,
-      ledgerEffectiveTime = ledgerTime,
       submittedAt = submittedAt,
       deduplicateUntil = deduplicateUntil,
       commands = LfCommands(
@@ -107,7 +106,6 @@ class SubmitRequestValidatorTest
 
   private[this] def withLedgerTime(commands: ApiCommands, let: Instant): ApiCommands =
     commands.copy(
-      ledgerEffectiveTime = let,
       commands = commands.commands.copy(
         ledgerEffectiveTime = Time.Timestamp.assertFromInstant(let),
       ),

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/domain.scala
@@ -271,7 +271,6 @@ object domain {
       applicationId: ApplicationId,
       commandId: CommandId,
       submitter: Ref.Party,
-      ledgerEffectiveTime: Instant,
       submittedAt: Instant,
       deduplicateUntil: Instant,
       commands: LfCommands)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.api.domain.{Commands => ApiCommands}
 import com.daml.ledger.participant.state.index.v2.{ContractStore, IndexPackagesService}
 import com.daml.ledger.participant.state.v1.{SubmitterInfo, TransactionMeta}
 import com.daml.lf.crypto
-import com.daml.lf.data.{Ref, Time}
+import com.daml.lf.data.Ref
 import com.daml.platform.metrics.timedFuture
 import com.daml.lf.engine.{
   Blinding,
@@ -62,7 +62,7 @@ final class StoreBackedCommandExecutor(
               commands.deduplicateUntil,
             ),
             transactionMeta = TransactionMeta(
-              Time.Timestamp.assertFromInstant(commands.ledgerEffectiveTime),
+              commands.commands.ledgerEffectiveTime,
               commands.workflowId.map(_.unwrap),
               meta.submissionTime,
               submissionSeed,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
@@ -166,7 +166,7 @@ final class ApiSubmissionService private (
       val commands = request.commands
 
       logger.trace(s"Received composite commands: $commands")
-      logger.debug(s"Received composite command let ${commands.ledgerEffectiveTime}.")
+      logger.debug(s"Received composite command let ${commands.commands.ledgerEffectiveTime}.")
       deduplicateAndRecordOnLedger(seedService.map(_.nextSeed()), commands)
         .andThen(logger.logErrorsOnCall[Unit])(DirectExecutionContext)
     }


### PR DESCRIPTION
The duplicated information was not always in sync.

Fixes #5662

CHANGELOG_BEGIN
- [Sandbox] Fix an issue where the sandbox would sometimes reject transactions
  with a "INVALID_ARGUMENT: Disputed" error if either of
  ``min_ledger_time_rel`` or ``min_ledger_time_abs`` was set in the
  submission request.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
