### PR TITLE
Fix ./fmt.sh check

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -8,6 +8,13 @@ load(
 load("@os_info//:os_info.bzl", "is_linux")
 load("//bazel_tools:testing.bzl", "sdk_platform_test")
 
+config_setting(
+    name = "ghci_data",
+    define_values = {
+        "ghci_data": "True",
+    },
+)
+
 sdk_versions = [
     "1.0.0",
     "1.0.1-snapshot.20200417.3908.1.722bac90",
@@ -17,22 +24,26 @@ sdk_versions = [
 platform_versions = [
     "1.0.0",
     "1.0.1-snapshot.20200417.3908.1.722bac90",
-    "1.1.0-snapshot.20200422.3991.0.6391ee9f"
+    "1.1.0-snapshot.20200422.3991.0.6391ee9f",
 ]
 
 [
     sh_binary(
         name = "sandbox-with-postgres-{}".format(version),
         srcs = ["@//bazel_tools:sandbox-with-postgres.sh"],
+        data = [
+            "@//bazel_tools/client_server:with-postgres",
+            "@daml-sdk-{}//:daml".format(version),
+        ],
         deps = ["@bazel_tools//tools/bash/runfiles"],
-        data = ["@//bazel_tools/client_server:with-postgres", "@daml-sdk-{}//:daml".format(version)],
-    ) for version in platform_versions
+    )
+    for version in platform_versions
 ]
 
 [
     sdk_platform_test(
-        sdk_version = sdk_version,
         platform_version = platform_version,
+        sdk_version = sdk_version,
     )
     for sdk_version in sdk_versions
     for platform_version in platform_versions

--- a/compatibility/WORKSPACE
+++ b/compatibility/WORKSPACE
@@ -7,20 +7,28 @@ local_repository(
     name = "daml",
     path = "..",
 )
+
 load("@daml//bazel_tools:os_info.bzl", "os_info")
+
 os_info(name = "os_info")
+
 load("@os_info//:os_info.bzl", "is_darwin", "is_linux", "is_windows")
+load("@daml//bazel_tools:build_environment.bzl", "build_environment")
+
+build_environment(name = "build_environment")
 
 load("//:deps.bzl", "daml_deps")
+
 daml_deps()
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
+
 rules_haskell_dependencies()
+
 load(
     "@rules_haskell//haskell:nixpkgs.bzl",
     "haskell_register_ghc_nixpkgs",
 )
-
 load(
     "@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl",
     "nixpkgs_cc_configure",
@@ -28,21 +36,25 @@ load(
     "nixpkgs_package",
     "nixpkgs_python_configure",
 )
+
 common_nix_file_deps = [
     "@daml//nix:bazel.nix",
     "@daml//nix:nixpkgs.nix",
     "@daml//nix:nixpkgs/default.nix",
     "@daml//nix:nixpkgs/default.src.json",
 ]
+
 nix_ghc_deps = common_nix_file_deps + [
     "@daml//nix:ghc.nix",
     "@daml//nix:with-packages-wrapper.nix",
     "@daml//nix:overrides/ghc-8.6.5.nix",
     "@daml//nix:overrides/ghc-8.6.3-binary.nix",
 ]
+
 dev_env_nix_repos = {
     "nixpkgs": "@nixpkgs",
 }
+
 nixpkgs_local_repository(
     name = "nixpkgs",
     nix_file = "@daml//nix:nixpkgs.nix",
@@ -51,6 +63,7 @@ nixpkgs_local_repository(
         "@daml//nix:nixpkgs/default.src.json",
     ],
 )
+
 nixpkgs_cc_configure(
     nix_file = "@daml//nix:bazel-cc-toolchain.nix",
     nix_file_deps = common_nix_file_deps + [
@@ -91,38 +104,47 @@ nixpkgs_python_configure(repository = "@nixpkgs")
 nixpkgs_package(
     name = "postgresql_nix",
     attribute_path = "postgresql_9_6",
-    fail_not_supported = False,
-    nix_file = "@daml//nix:bazel.nix",
-    nix_file_deps = common_nix_file_deps,
-    repositories = dev_env_nix_repos,
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "all",
     srcs = glob(["**"]),
 )
-"""
+""",
+    fail_not_supported = False,
+    nix_file = "@daml//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    repositories = dev_env_nix_repos,
+)
+
+nixpkgs_package(
+    name = "hlint_nix",
+    attribute_path = "hlint",
+    nix_file = "@daml//nix:bazel.nix",
+    nix_file_deps = nix_ghc_deps,
+    repositories = dev_env_nix_repos,
 )
 
 load("//:bazel-haskell-deps.bzl", "daml_haskell_deps")
+
 daml_haskell_deps()
 
 load("//bazel_tools:daml_sdk.bzl", "daml_sdk")
 
 daml_sdk(
-    version = "1.0.0",
     sdk_sha256 = "ee7e2f50394d44fb3490068de64d37f4f87534e802717bd7e07e8767df2e4e05",
     test_tool_sha256 = "cf66efafd9490e1256e825f377b208b8ae90151f56e411b596fbaaef91353e14",
+    version = "1.0.0",
 )
 
 daml_sdk(
-    version = "1.0.1-snapshot.20200417.3908.1.722bac90",
     sdk_sha256 = "aaf832ceda1a66a8469460d5a4b6c14f681ce692d4e9ef6010896febbaf4b6e1",
     test_tool_sha256 = "762cd4836a8359dca0fb3271ba2e1d0629138f7d8d914298324418a174c5d22a",
+    version = "1.0.1-snapshot.20200417.3908.1.722bac90",
 )
 
 daml_sdk(
-    version = "1.1.0-snapshot.20200422.3991.0.6391ee9f",
     sdk_sha256 = "d3bddaa903ebaebb6f714a3ac39598ba7fd71e8b80636c1275054ed7b883a0d9",
     test_tool_sha256 = "649ecf7a7e98caef7dac20082526444b33d85dfe79b4b9b66d069ad67aac74fa",
+    version = "1.1.0-snapshot.20200422.3991.0.6391ee9f",
 )

--- a/compatibility/bazel_tools/client_server/BUILD
+++ b/compatibility/bazel_tools/client_server/BUILD
@@ -1,36 +1,35 @@
-load(
-    "@rules_haskell//haskell:defs.bzl",
-    "haskell_binary",
-)
+load("@daml//bazel_tools:haskell.bzl", "da_haskell_binary")
 
-haskell_binary(
+da_haskell_binary(
     name = "runner",
     srcs = ["Main.hs"],
-    deps = [
-        "@stackage//:base",
-        "@stackage//:monad-loops",
-        "@stackage//:network",
-        "@stackage//:process",
-        "@stackage//:safe-exceptions",
-        "@stackage//:split",
+    hackage_deps = [
+        "base",
+        "monad-loops",
+        "network",
+        "process",
+        "safe-exceptions",
+        "split",
     ],
     visibility = ["//visibility:public"],
 )
 
-haskell_binary(
+da_haskell_binary(
     name = "with-postgres",
     srcs = ["WithPostgres.hs"],
     data = [
         "@postgresql_nix//:all",
     ],
-    deps = [
-        "@stackage//:base",
-        "@rules_haskell//tools/runfiles",
-        "@stackage//:directory",
-        "@stackage//:extra",
-        "@stackage//:filepath",
-        "@stackage//:process",
-        "@stackage//:text",
+    hackage_deps = [
+        "base",
+        "directory",
+        "extra",
+        "filepath",
+        "process",
+        "text",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@rules_haskell//tools/runfiles",
+    ],
 )

--- a/compatibility/bazel_tools/client_server/Main.hs
+++ b/compatibility/bazel_tools/client_server/Main.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE ScopedTypeVariables #-}
 module Main(main) where
 
 import System.Environment

--- a/compatibility/bazel_tools/client_server/WithPostgres.hs
+++ b/compatibility/bazel_tools/client_server/WithPostgres.hs
@@ -1,10 +1,8 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import qualified Bazel.Runfiles as Runfiles
 import Control.Exception
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -51,7 +49,6 @@ withPostgres f =
     let dataDir = tmpDir </> "data"
     let logFile = tmpDir </> "postgresql.log"
     createDirectory dataDir
-    runfiles <- Runfiles.create
     -- For reasons I don’t entirely understand, `locateRunfiles` does not
     -- work here. Hardcoding the paths to external/... matches what we do in
     -- com.daml.testing.postgresql.Tool.

--- a/compatibility/bazel_tools/daml_sdk.bzl
+++ b/compatibility/bazel_tools/daml_sdk.bzl
@@ -111,4 +111,5 @@ def daml_sdk(version, **kwargs):
     _daml_sdk(
         name = "daml-sdk-{}".format(version),
         version = version,
-        **kwargs)
+        **kwargs
+    )

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -14,11 +14,13 @@ def sdk_platform_test(sdk_version, platform_version):
     dar_files = "@daml-sdk-{sdk_version}//:dar-files".format(
         sdk_version = sdk_version,
     )
+
     # Platform components
     sandbox = "@daml-sdk-{platform_version}//:daml".format(
         platform_version = platform_version,
     )
     sandbox_args = ["sandbox"]
+
     # Test case
     name = "ledger-api-test-tool-{sdk_version}-platform-{platform_version}".format(
         sdk_version = sdk_version,

--- a/compatibility/deps.bzl
+++ b/compatibility/deps.bzl
@@ -28,8 +28,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-load("@daml//:deps.bzl", "rules_haskell_version", "rules_haskell_sha256", "rules_nixpkgs_version", "rules_nixpkgs_sha256")
+load("@daml//:deps.bzl", "buildifier_sha256", "buildifier_version", "rules_haskell_sha256", "rules_haskell_version", "rules_nixpkgs_sha256", "rules_nixpkgs_version")
 
 def daml_deps():
     if "rules_haskell" not in native.existing_rules():
@@ -46,4 +45,12 @@ def daml_deps():
             strip_prefix = "rules_nixpkgs-%s" % rules_nixpkgs_version,
             urls = ["https://github.com/tweag/rules_nixpkgs/archive/%s.tar.gz" % rules_nixpkgs_version],
             sha256 = rules_nixpkgs_sha256,
+        )
+
+    if "com_github_bazelbuild_buildtools" not in native.existing_rules():
+        http_archive(
+            name = "com_github_bazelbuild_buildtools",
+            sha256 = buildifier_sha256,
+            strip_prefix = "buildtools-{}".format(buildifier_version),
+            url = "https://github.com/bazelbuild/buildtools/archive/{}.tar.gz".format(buildifier_version),
         )

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -257,7 +257,10 @@ genrule(
         ":daml-base-rst-index-template",
         ":daml-base-rst-template",
     ],
-    outs = ["daml-base-rst.tar.gz", "daml-base-hoogle.txt"],
+    outs = [
+        "daml-base-rst.tar.gz",
+        "daml-base-hoogle.txt",
+    ],
     cmd = """
         $(location //compiler/damlc) -- docs \
             --output=daml-base-rst \

--- a/deps.bzl
+++ b/deps.bzl
@@ -35,6 +35,8 @@ rules_haskell_version = "cf6beb4e3748dce6dc401a95ab8cacb803c5d944"
 rules_haskell_sha256 = "cadb4ceb63994d86343fb407a9b5eaab363af428850d1698d6c6132690ccfb71"
 rules_nixpkgs_version = "c966bb8bd335f1e244c03efe6e7a1afa9784038e"
 rules_nixpkgs_sha256 = "ccafea4fc4d5fa2ddba2882f76728558bfe2c12657f7f56078ece43a31761148"
+buildifier_version = "0.26.0"
+buildifier_sha256 = "86592d703ecbe0c5cbb5139333a63268cf58d7efd2c459c8be8e69e77d135e29"
 
 # Recent davl.
 davl_version = "f2d7480d118f32626533d6a150a8ee7552cc0222"  # 2020-03-23, "Deploy upgrade to DAML SDK 0.13.56-snapshot.20200318",https://github.com/digital-asset/davl/pull/233/commits.
@@ -229,9 +231,9 @@ def daml_deps():
     if "com_github_bazelbuild_buildtools" not in native.existing_rules():
         http_archive(
             name = "com_github_bazelbuild_buildtools",
-            sha256 = "86592d703ecbe0c5cbb5139333a63268cf58d7efd2c459c8be8e69e77d135e29",
-            strip_prefix = "buildtools-0.26.0",
-            url = "https://github.com/bazelbuild/buildtools/archive/0.26.0.tar.gz",
+            sha256 = buildifier_sha256,
+            strip_prefix = "buildtools-{}".format(buildifier_version),
+            url = "https://github.com/bazelbuild/buildtools/archive/{}.tar.gz".format(buildifier_version),
         )
 
     native.bind(

--- a/fmt.sh
+++ b/fmt.sh
@@ -110,7 +110,7 @@ run dade-copyright-headers "$dade_copyright_arg" .
 # We do test hlint via Bazel rules but we run it separately
 # to get linting failures early.
 if [ "$hlint_diff" = "true" ]; then
-    changed_haskell_files="$(git diff --name-only origin/master | grep '.hs$' || [[ $? == 1 ]])"
+    changed_haskell_files="$(git diff --name-only origin/master | grep '\.hs$' || [[ $? == 1 ]])"
     if [ "" != "$changed_haskell_files" ]; then
         hlint -j4 $changed_haskell_files
     fi

--- a/fmt.sh
+++ b/fmt.sh
@@ -107,19 +107,15 @@ echo "\
 # Check for correct copyrights
 run dade-copyright-headers "$dade_copyright_arg" .
 
+# We do test hlint via Bazel rules but we run it separately
+# to get linting failures early.
 if [ "$hlint_diff" = "true" ]; then
     changed_haskell_files="$(git diff --name-only origin/master | grep '.hs$' || [[ $? == 1 ]])"
     if [ "" != "$changed_haskell_files" ]; then
         hlint -j4 $changed_haskell_files
     fi
 else
-    # We have a Bazel test that is meant to run HLint, but we're a little
-    # sceptical of it If we get this far, but hlint fails, that's a problem we
-    # should fix
-    if ! hlint --git -j4; then
-        echo "UNEXPECTED HLINT FAILURE: The Bazel rules should have spotted this, please raise a GitHub issue"
-        exit $?
-    fi
+    hlint --git -j4
 fi
 
 # check for scala code style


### PR DESCRIPTION
We accidentally introduced hlint lints when we added the compatibility
workspace. The hlint code in ./fmt.sh correctly detects that there is
a hint but then exits with 0 since it uses the exit code from `echo`
rather than the one from `hlint`. The info that we printed with
`echo` didn’t actually make any sense so I added a new comment as to
why we run hlint here. This requires some setup changes so that the
compatibility workspace gets the same Haskell flags since otherwise
using the same hlint rules obviously does not make sense.

Fixes #5701

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
