### PR TITLE
Fix optPow and errPow

### DIFF
--- a/docs/source/daml/intro/daml/daml-intro-5/Restrictions.daml
+++ b/docs/source/daml/intro/daml/daml-intro-5/Restrictions.daml
@@ -4,6 +4,7 @@
 
 module Restrictions where
 
+import DA.Assert
 import DA.Date
 import DA.Text as T
 import DA.Time
@@ -284,18 +285,19 @@ nonPerformedAbort = scenario do
 
 -- OPTIONAL_POW_BEGIN
 optPow : Int -> Int -> Optional Int
-optPow x y 
- | y == 0 = Some 1
- | y > 0 = let Some z = optPow x (y - 1)
-           in Some (y * z)
+optPow base exponent
+ | exponent == 0 = Some 1
+ | exponent > 0 =
+   let Some result = optPow base (exponent - 1)
+   in Some (base * result)
  | otherwise = None
 -- OPTIONAL_POW_END
 
 -- ERROR_POW_BEGIN
 errPow : Int -> Int -> Int
-errPow x y 
- | y == 0 = 1
- | y > 0 = y * errPow x (y - 1)
+errPow base exponent
+ | exponent == 0 = 1
+ | exponent > 0 = base * errPow base (exponent - 1)
  | otherwise = error "Negative exponent not supported"
 -- ERROR_POW_END
 
@@ -308,3 +310,9 @@ nonPerformedError = scenario do
   return if causeError then failingComputation else successfulComputation
 -- NON_PERFORMED_ERROR_END
 -}
+
+test = scenario do
+  optPow 2 5 === Some 32
+  optPow 5 2 === Some 25
+  errPow 2 5 === 32
+  errPow 5 2 === 25


### PR DESCRIPTION
The last multiplication in both ended up being exponent * result
instead of base * result. I’ve renamed the variables since that makes
this trivial to spot and I’ve added a simple scenario that actually
tests this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
