### PR TITLE
Reset service improvements for sadbonx

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -47,6 +47,7 @@ da_scala_test(
     deps = [
         ":ledger-on-memory",
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//language-support/scala/bindings",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -21,6 +21,7 @@ da_scala_library(
     ],
     deps = [
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//language-support/scala/bindings",
         "//ledger/ledger-api-common",
         "//ledger/ledger-api-health",
@@ -72,6 +73,7 @@ da_scala_library(
     deps = [
         ":ledger-on-memory",
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//language-support/scala/bindings",
         "//ledger/ledger-api-auth",
         "//ledger/ledger-api-common",

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -21,6 +21,7 @@ import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.validator.LedgerStateOperations.{Key, MetricPrefix, Value}
 import com.daml.ledger.validator._
 import com.daml.lf.data.Ref
+import com.daml.lf.engine.Engine
 import com.daml.metrics.Timed
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.akkastreams.dispatcher.SubSource.RangeSource
@@ -37,6 +38,7 @@ final class InMemoryLedgerReaderWriter private (
     stateValueCache: Cache[Bytes, DamlStateValue],
     dispatcher: Dispatcher[Index],
     state: InMemoryState,
+    engine: Engine,
 )(implicit executionContext: ExecutionContext)
     extends LedgerWriter
     with LedgerReader {
@@ -45,6 +47,7 @@ final class InMemoryLedgerReaderWriter private (
     () => timeProvider.getCurrentTime,
     SubmissionValidator
       .createForTimeMode(
+        engine,
         InMemoryLedgerStateAccess,
         allocateNextLogEntryId = () => sequentialLogEntryId.next(),
         stateValueCache = stateValueCache,
@@ -127,6 +130,7 @@ object InMemoryLedgerReaderWriter {
       timeProvider: TimeProvider = DefaultTimeProvider,
       stateValueCache: Cache[Bytes, DamlStateValue] = Cache.none,
       metricRegistry: MetricRegistry,
+      engine: Engine,
   )(implicit materializer: Materializer)
       extends ResourceOwner[InMemoryLedgerReaderWriter] {
     override def acquire()(
@@ -143,6 +147,7 @@ object InMemoryLedgerReaderWriter {
           stateValueCache,
           dispatcher,
           state,
+          engine
         ).acquire()
       } yield readerWriter
     }
@@ -158,6 +163,7 @@ object InMemoryLedgerReaderWriter {
       stateValueCache: Cache[Bytes, DamlStateValue] = Cache.none,
       dispatcher: Dispatcher[Index],
       state: InMemoryState,
+      engine: Engine,
   ) extends ResourceOwner[InMemoryLedgerReaderWriter] {
     override def acquire()(
         implicit executionContext: ExecutionContext
@@ -173,6 +179,7 @@ object InMemoryLedgerReaderWriter {
           stateValueCache,
           dispatcher,
           state,
+          engine,
         ))
     }
   }

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -47,10 +47,10 @@ final class InMemoryLedgerReaderWriter private (
     () => timeProvider.getCurrentTime,
     SubmissionValidator
       .createForTimeMode(
-        engine,
         InMemoryLedgerStateAccess,
         allocateNextLogEntryId = () => sequentialLogEntryId.next(),
         stateValueCache = stateValueCache,
+        engine = engine,
         metricRegistry = metricRegistry,
         inStaticTimeMode = timeProvider != TimeProvider.UTC
       ),

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
@@ -8,6 +8,7 @@ import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpec
 import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase.ParticipantState
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
 import com.daml.ledger.participant.state.v1.{LedgerId, ParticipantId}
+import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.resources.ResourceOwner
 
@@ -26,5 +27,6 @@ class InMemoryLedgerReaderWriterIntegrationSpec
       ledgerId,
       participantId,
       metricRegistry = metricRegistry,
+      engine = Engine(),
     ).map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter, metricRegistry))
 }

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -193,6 +193,7 @@ da_scala_test_suite(
         ":ledger-on-sql",
         ":ledger-on-sql-test-lib",
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",
         "//ledger/ledger-api-common",

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -119,6 +119,7 @@ da_scala_library(
     deps = [
         ":ledger-on-sql",
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//language-support/scala/bindings",
         "//ledger/ledger-api-auth",
         "//ledger/ledger-api-health",
@@ -156,6 +157,7 @@ da_scala_library(
         ":ledger-on-sql",
         ":ledger-on-sql-app",
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//language-support/scala/bindings",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -88,6 +88,7 @@ da_scala_library(
     ],
     deps = [
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//daml-lf/transaction",
         "//language-support/scala/bindings",
         "//ledger/ledger-api-common",

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
@@ -7,7 +7,14 @@ import java.sql.Connection
 import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics.{MetricRegistry, Timer}
-import com.daml.ledger.on.sql.queries.{H2Queries, PostgresqlQueries, Queries, ReadQueries, SqliteQueries, TimedQueries}
+import com.daml.ledger.on.sql.queries.{
+  H2Queries,
+  PostgresqlQueries,
+  Queries,
+  ReadQueries,
+  SqliteQueries,
+  TimedQueries
+}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{MetricName, Timed}
 import com.daml.resources.ProgramResource.StartupException
@@ -214,7 +221,9 @@ object Database {
       new Database(system.queries, readerConnectionPool, writerConnectionPool, metricRegistry)
     }
 
-    def migrateAndReset()(implicit executionContext: ExecutionContext, loggerCtx: LoggingContext): Future[Database] = {
+    def migrateAndReset()(
+        implicit executionContext: ExecutionContext,
+        loggerCtx: LoggingContext): Future[Database] = {
 //      val db = new Database(system.queries, readerConnectionPool, writerConnectionPool, metricRegistry)
       val start = System.nanoTime()
       val db = migrate()
@@ -222,7 +231,9 @@ object Database {
       logger.error(s"######## ELAPSED KV MIGRATION: ${TimeUnit.NANOSECONDS.toMillis(elapsed)}")
       val before = System.nanoTime()
       val result = db
-        .inWriteTransaction("ledger_reset") { queries => Future.fromTry(queries.truncate()) }
+        .inWriteTransaction("ledger_reset") { queries =>
+          Future.fromTry(queries.truncate())
+        }
         .map(_ => db)
       result.foreach { _ =>
         val elapsed = System.nanoTime() - before

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
@@ -4,16 +4,10 @@
 package com.daml.ledger.on.sql
 
 import java.sql.Connection
+import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics.{MetricRegistry, Timer}
-import com.daml.ledger.on.sql.queries.{
-  H2Queries,
-  PostgresqlQueries,
-  Queries,
-  ReadQueries,
-  SqliteQueries,
-  TimedQueries
-}
+import com.daml.ledger.on.sql.queries.{H2Queries, PostgresqlQueries, Queries, ReadQueries, SqliteQueries, TimedQueries}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{MetricName, Timed}
 import com.daml.resources.ProgramResource.StartupException
@@ -218,6 +212,24 @@ object Database {
     def migrate(): Database = {
       flyway.migrate()
       new Database(system.queries, readerConnectionPool, writerConnectionPool, metricRegistry)
+    }
+
+    def migrateAndReset()(implicit executionContext: ExecutionContext, loggerCtx: LoggingContext): Future[Database] = {
+//      val db = new Database(system.queries, readerConnectionPool, writerConnectionPool, metricRegistry)
+      val start = System.nanoTime()
+      val db = migrate()
+      val elapsed = System.nanoTime() - start
+      logger.error(s"######## ELAPSED KV MIGRATION: ${TimeUnit.NANOSECONDS.toMillis(elapsed)}")
+      val before = System.nanoTime()
+      val result = db
+        .inWriteTransaction("ledger_reset") { queries => Future.fromTry(queries.truncate()) }
+        .map(_ => db)
+      result.foreach { _ =>
+        val elapsed = System.nanoTime() - before
+        logger.error(s"######### ELAPSED KV TRUNCATION: ${TimeUnit.NANOSECONDS.toMillis(elapsed)}")
+      }
+      result
+
     }
 
     def clear(): this.type = {

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.on.sql
 
 import java.sql.Connection
-import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics.{MetricRegistry, Timer}
 import com.daml.ledger.on.sql.queries.{
@@ -224,23 +223,11 @@ object Database {
     def migrateAndReset()(
         implicit executionContext: ExecutionContext,
         loggerCtx: LoggingContext): Future[Database] = {
-//      val db = new Database(system.queries, readerConnectionPool, writerConnectionPool, metricRegistry)
-      val start = System.nanoTime()
       val db = migrate()
-      val elapsed = System.nanoTime() - start
-      logger.error(s"######## ELAPSED KV MIGRATION: ${TimeUnit.NANOSECONDS.toMillis(elapsed)}")
-      val before = System.nanoTime()
-      val result = db
-        .inWriteTransaction("ledger_reset") { queries =>
+      db.inWriteTransaction("ledger_reset") { queries =>
           Future.fromTry(queries.truncate())
         }
         .map(_ => db)
-      result.foreach { _ =>
-        val elapsed = System.nanoTime() - before
-        logger.error(s"######### ELAPSED KV TRUNCATION: ${TimeUnit.NANOSECONDS.toMillis(elapsed)}")
-      }
-      result
-
     }
 
     def clear(): this.type = {

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -62,10 +62,10 @@ final class SqlLedgerReaderWriter(
     () => timeProvider.getCurrentTime,
     SubmissionValidator
       .createForTimeMode(
-        engine,
         SqlLedgerStateAccess,
         allocateNextLogEntryId = () => allocateSeededLogEntryId(),
         stateValueCache = stateValueCache,
+        engine = engine,
         metricRegistry = metricRegistry,
         inStaticTimeMode = timeProvider != TimeProvider.UTC,
       ),

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -22,6 +22,7 @@ import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.validator.LedgerStateOperations.{Key, MetricPrefix, Value}
 import com.daml.ledger.validator._
 import com.daml.lf.data.Ref
+import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Timed
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
@@ -36,6 +37,7 @@ import scala.util.{Failure, Success}
 final class SqlLedgerReaderWriter(
     override val ledgerId: LedgerId = Ref.LedgerString.assertFromString(UUID.randomUUID.toString),
     val participantId: ParticipantId,
+    engine: Engine,
     metricRegistry: MetricRegistry,
     timeProvider: TimeProvider,
     stateValueCache: Cache[Bytes, DamlStateValue],
@@ -60,6 +62,7 @@ final class SqlLedgerReaderWriter(
     () => timeProvider.getCurrentTime,
     SubmissionValidator
       .createForTimeMode(
+        engine,
         SqlLedgerStateAccess,
         allocateNextLogEntryId = () => allocateSeededLogEntryId(),
         stateValueCache = stateValueCache,
@@ -124,6 +127,7 @@ object SqlLedgerReaderWriter {
       initialLedgerId: Option[LedgerId],
       participantId: ParticipantId,
       metricRegistry: MetricRegistry,
+      engine: Engine,
       jdbcUrl: String,
       stateValueCache: Cache[Bytes, DamlStateValue] = Cache.none,
       timeProvider: TimeProvider = DefaultTimeProvider,
@@ -142,6 +146,7 @@ object SqlLedgerReaderWriter {
         new SqlLedgerReaderWriter(
           ledgerId,
           participantId,
+          engine,
           metricRegistry,
           timeProvider,
           stateValueCache,

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -140,7 +140,9 @@ object SqlLedgerReaderWriter {
     ): Resource[SqlLedgerReaderWriter] =
       for {
         uninitializedDatabase <- Database.owner(jdbcUrl, metricRegistry).acquire()
-        database <- Resource.fromFuture(if (resetOnStartup) uninitializedDatabase.migrateAndReset() else Future.successful(uninitializedDatabase.migrate()))
+        database <- Resource.fromFuture(
+          if (resetOnStartup) uninitializedDatabase.migrateAndReset()
+          else Future.successful(uninitializedDatabase.migrate()))
         ledgerId <- Resource.fromFuture(updateOrRetrieveLedgerId(initialLedgerId, database))
         dispatcher <- ResourceOwner.forFutureCloseable(() => newDispatcher(database)).acquire()
       } yield

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
@@ -38,6 +38,13 @@ final class H2Queries(override protected implicit val connection: Connection)
     SQL"CALL IDENTITY()"
       .as(long("IDENTITY()").single)
   }
+
+  override final def truncate(): Try[Unit] = Try {
+    SQL"truncate #$StateTable".executeUpdate()
+    SQL"truncate #$LogTable".executeUpdate()
+    SQL"truncate #$MetaTable".executeUpdate()
+    ()
+  }
 }
 
 object H2Queries {

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
@@ -31,6 +31,13 @@ final class PostgresqlQueries(override protected implicit val connection: Connec
 
   override protected val updateStateQuery: String =
     s"INSERT INTO $StateTable VALUES ({key}, {value}) ON CONFLICT(key) DO UPDATE SET value = {value}"
+
+  override final def truncate(): Try[Unit] = Try {
+    SQL"truncate #$StateTable".executeUpdate()
+    SQL"truncate #$LogTable".executeUpdate()
+    SQL"truncate #$MetaTable".executeUpdate()
+    ()
+  }
 }
 
 object PostgresqlQueries {

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
@@ -38,6 +38,13 @@ final class SqliteQueries(override protected implicit val connection: Connection
     SQL"SELECT LAST_INSERT_ROWID() AS row_id"
       .as(long("row_id").single)
   }
+
+  override final def truncate(): Try[Unit] = Try {
+    SQL"delete from #$StateTable".executeUpdate()
+    SQL"delete from #$LogTable".executeUpdate()
+    SQL"delete from #$MetaTable".executeUpdate()
+    ()
+  }
 }
 
 object SqliteQueries {

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
@@ -35,6 +35,10 @@ final class TimedQueries(delegate: Queries, metricRegistry: MetricRegistry) exte
   override def updateState(stateUpdates: Seq[(Key, Value)]): Try[Unit] =
     Timed.value(Metrics.updateState, delegate.updateState(stateUpdates))
 
+  override def truncate(): Try[Unit] = {
+    Timed.value(Metrics.truncate, delegate.truncate())
+  }
+
   private object Metrics {
     private val prefix = MetricName.DAML :+ "ledger" :+ "database" :+ "queries"
 
@@ -50,6 +54,8 @@ final class TimedQueries(delegate: Queries, metricRegistry: MetricRegistry) exte
       metricRegistry.timer(prefix :+ "insert_record_into_log")
     val updateState: Timer =
       metricRegistry.timer(prefix :+ "update_state")
+    val truncate: Timer =
+      metricRegistry.timer(prefix :+ "truncate")
   }
 
 }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
@@ -35,9 +35,7 @@ final class TimedQueries(delegate: Queries, metricRegistry: MetricRegistry) exte
   override def updateState(stateUpdates: Seq[(Key, Value)]): Try[Unit] =
     Timed.value(Metrics.updateState, delegate.updateState(stateUpdates))
 
-  override def truncate(): Try[Unit] = {
-    Timed.value(Metrics.truncate, delegate.truncate())
-  }
+  override def truncate(): Try[Unit] = Timed.value(Metrics.truncate, delegate.truncate())
 
   private object Metrics {
     private val prefix = MetricName.DAML :+ "ledger" :+ "database" :+ "queries"

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
@@ -15,4 +15,7 @@ trait WriteQueries {
   def insertRecordIntoLog(key: Key, value: Value): Try[Index]
 
   def updateState(stateUpdates: Seq[(Key, Value)]): Try[Unit]
+
+  def truncate(): Try[Unit]
+
 }

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralDirectory.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralDirectory.scala
@@ -13,6 +13,7 @@ import com.daml.ledger.participant.state.kvutils.app.{
   ReadWriteService,
   Runner
 }
+import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.resources.{ProgramResource, Resource, ResourceOwner}
 import scopt.OptionParser
@@ -37,16 +38,18 @@ object MainWithEphemeralDirectory {
 
     override def readWriteServiceOwner(
         config: Config[ExtraConfig],
-        participantConfig: ParticipantConfig
+        participantConfig: ParticipantConfig,
+        engine: Engine,
     )(
         implicit materializer: Materializer,
         logCtx: LoggingContext
     ): ResourceOwner[ReadWriteService] =
-      new Owner(config, participantConfig)
+      new Owner(config, participantConfig, engine)
 
     class Owner(
         config: Config[ExtraConfig],
-        participantConfig: ParticipantConfig
+        participantConfig: ParticipantConfig,
+        engine: Engine,
     )(implicit materializer: Materializer, logCtx: LoggingContext)
         extends ResourceOwner[ReadWriteService] {
       override def acquire()(
@@ -58,6 +61,7 @@ object MainWithEphemeralDirectory {
           .readWriteServiceOwner(
             config.copy(extra = config.extra.copy(jdbcUrl = jdbcUrl)),
             participantConfig,
+            engine,
           )
           .acquire()
       }

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
@@ -9,6 +9,7 @@ import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpec
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
 import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.daml.ledger.participant.state.v1.{LedgerId, ParticipantId, SeedService}
+import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.resources.ResourceOwner
 
@@ -28,8 +29,10 @@ abstract class SqlLedgerReaderWriterIntegrationSpecBase(implementationName: Stri
       ledgerId,
       participantId,
       metricRegistry,
+      engine = Engine(),
       jdbcUrl(testId),
+      resetOnStartup = false,
       // Using a weak random source to avoid slowdown during tests.
-      seedService = SeedService(Seeding.Weak),
+      seedService = SeedService(Seeding.Weak)
     ).map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter, metricRegistry))
 }

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -10,6 +10,7 @@ import com.codahale.metrics.{MetricRegistry, SharedMetricRegistries}
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
 import com.daml.ledger.participant.state.v1.{ReadService, WriteService}
 import com.daml.ledger.api.auth.{AuthService, AuthServiceWildcard}
+import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.platform.apiserver.{ApiServerConfig, TimeServiceBackend}
 import com.daml.platform.configuration.{
@@ -87,6 +88,7 @@ trait ReadServiceOwner[+RS <: ReadService, ExtraConfig] extends ConfigProvider[E
   def readServiceOwner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
+      engine: Engine,
   )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[RS]
 }
 
@@ -94,6 +96,7 @@ trait WriteServiceOwner[+WS <: WriteService, ExtraConfig] extends ConfigProvider
   def writeServiceOwner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
+      engine: Engine,
   )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[WS]
 }
 
@@ -104,18 +107,21 @@ trait LedgerFactory[+RWS <: ReadWriteService, ExtraConfig]
   override final def readServiceOwner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
+      engine: Engine,
   )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[RWS] =
-    readWriteServiceOwner(config, participantConfig)
+    readWriteServiceOwner(config, participantConfig, engine)
 
   override final def writeServiceOwner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
+      engine: Engine,
   )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[RWS] =
-    readWriteServiceOwner(config, participantConfig)
+    readWriteServiceOwner(config, participantConfig, engine)
 
   def readWriteServiceOwner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
+      engine: Engine,
   )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[RWS]
 }
 
@@ -128,12 +134,13 @@ object LedgerFactory {
     override final def readWriteServiceOwner(
         config: Config[Unit],
         participantConfig: ParticipantConfig,
+        engine: Engine,
     )(
         implicit materializer: Materializer,
         logCtx: LoggingContext,
     ): ResourceOwner[KeyValueParticipantState] =
       for {
-        readerWriter <- owner(config, participantConfig)
+        readerWriter <- owner(config, participantConfig, engine)
       } yield
         new KeyValueParticipantState(
           readerWriter,
@@ -144,6 +151,7 @@ object LedgerFactory {
     def owner(
         value: Config[Unit],
         config: ParticipantConfig,
+        engine: Engine,
     )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[KVL]
 
     override final def extraConfigParser(parser: OptionParser[Config[Unit]]): Unit =

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -18,6 +18,7 @@ import com.daml.ledger.participant.state.kvutils.app.Metrics.{
 import com.daml.ledger.participant.state.v1.metrics.{TimedReadService, TimedWriteService}
 import com.daml.ledger.participant.state.v1.{SubmissionId, WritePackagesService}
 import com.daml.lf.archive.DarReader
+import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.JvmMetricSet
 import com.daml.platform.apiserver.{StandaloneApiServer, TimedIndexService}
@@ -46,6 +47,10 @@ final class Runner[T <: ReadWriteService, Extra](
         "[^A-Za-z0-9_\\-]".r.replaceAllIn(name.toLowerCase, "-"))
       implicit val materializer: Materializer = Materializer(actorSystem)
 
+      // share engine between the kvutils committer backend and the ledger api server
+      // this avoids duplicate compilation of packages as well as keeping them in memory twice
+      val engine = Engine()
+
       newLoggingContext { implicit logCtx =>
         for {
           // Take ownership of the actor system and materializer so they're cleaned up properly.
@@ -64,7 +69,7 @@ final class Runner[T <: ReadWriteService, Extra](
                     .forCloseable(() => reporter.register(metricRegistry))
                     .map(_.start(config.metricsReportingInterval.getSeconds, TimeUnit.SECONDS))
                     .acquire())
-              ledger <- factory.readWriteServiceOwner(config, participantConfig).acquire()
+              ledger <- factory.readWriteServiceOwner(config, participantConfig, engine).acquire()
               readService = new TimedReadService(ledger, metricRegistry, ReadServicePrefix)
               writeService = new TimedWriteService(ledger, metricRegistry, WriteServicePrefix)
               _ <- Resource.fromFuture(
@@ -87,6 +92,7 @@ final class Runner[T <: ReadWriteService, Extra](
                   service => new TimedIndexService(service, metricRegistry, IndexServicePrefix),
                 metrics = metricRegistry,
                 timeServiceBackend = factory.timeServiceBackend(config),
+                engine = engine,
               ).acquire()
             } yield ()
           })

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -32,10 +32,10 @@ import scala.collection.JavaConverters._
 //
 // The primary constructor is private to the daml package, because we don't expect any ledger other
 // than sandbox to actually support static time.
-class KeyValueCommitting private[daml] (metricRegistry: MetricRegistry, inStaticTimeMode: Boolean) {
+class KeyValueCommitting private[daml] (engine: Engine, metricRegistry: MetricRegistry, inStaticTimeMode: Boolean) {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  def this(metricRegistry: MetricRegistry) = this(metricRegistry, false)
+  def this(engine: Engine, metricRegistry: MetricRegistry) = this(engine, metricRegistry, false)
 
   def packDamlStateKey(key: DamlStateKey): ByteString = key.toByteString
 
@@ -94,7 +94,6 @@ class KeyValueCommitting private[daml] (metricRegistry: MetricRegistry, inStatic
     */
   @throws(classOf[Err])
   def processSubmission(
-      engine: Engine,
       entryId: DamlLogEntryId,
       recordTime: Timestamp,
       defaultConfig: Configuration,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -32,7 +32,10 @@ import scala.collection.JavaConverters._
 //
 // The primary constructor is private to the daml package, because we don't expect any ledger other
 // than sandbox to actually support static time.
-class KeyValueCommitting private[daml] (engine: Engine, metricRegistry: MetricRegistry, inStaticTimeMode: Boolean) {
+class KeyValueCommitting private[daml] (
+    engine: Engine,
+    metricRegistry: MetricRegistry,
+    inStaticTimeMode: Boolean) {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   def this(engine: Engine, metricRegistry: MetricRegistry) = this(engine, metricRegistry, false)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -79,7 +79,6 @@ class KeyValueCommitting private[daml] (
     * existing entries in the key-value store. The concrete key for DAML state entry is obtained by applying
     * [[packDamlStateKey]] to [[DamlStateKey]].
     *
-    * @param engine: Engine instance to use for interpreting submission.
     * @param entryId: Log entry id to which this submission is committed.
     * @param recordTime: Record time at which this log entry is committed.
     * @param defaultConfig: The default configuration that is to be used if no configuration has been committed to state.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -313,19 +313,19 @@ object SubmissionValidator {
   type LogEntryAndState = (DamlLogEntry, StateMap)
 
   def create[LogResult](
-      engine: Engine,
       ledgerStateAccess: LedgerStateAccess[LogResult],
       allocateNextLogEntryId: () => DamlLogEntryId = () => allocateRandomLogEntryId(),
       checkForMissingInputs: Boolean = false,
       stateValueCache: Cache[Bytes, DamlStateValue] = Cache.none,
+      engine: Engine = Engine(),
       metricRegistry: MetricRegistry,
   )(implicit executionContext: ExecutionContext): SubmissionValidator[LogResult] = {
     createForTimeMode(
-      engine,
       ledgerStateAccess,
       allocateNextLogEntryId,
       checkForMissingInputs,
       stateValueCache,
+      engine,
       metricRegistry,
       inStaticTimeMode = false,
     )
@@ -333,11 +333,11 @@ object SubmissionValidator {
 
   // Internal method to enable proper command dedup in sandbox with static time mode
   private[daml] def createForTimeMode[LogResult](
-      engine: Engine,
       ledgerStateAccess: LedgerStateAccess[LogResult],
       allocateNextLogEntryId: () => DamlLogEntryId = () => allocateRandomLogEntryId(),
       checkForMissingInputs: Boolean = false,
       stateValueCache: Cache[Bytes, DamlStateValue] = Cache.none,
+      engine: Engine,
       metricRegistry: MetricRegistry,
       inStaticTimeMode: Boolean,
   )(implicit executionContext: ExecutionContext): SubmissionValidator[LogResult] =

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -32,7 +32,6 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with Inside {
       when(mockStateOperations.readState(any[Seq[Bytes]]()))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val instance = SubmissionValidator.create(
-        Engine(),
         new FakeStateAccess(mockStateOperations),
         metricRegistry = new MetricRegistry,
       )
@@ -49,7 +48,6 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with Inside {
       when(mockStateOperations.readState(any[Seq[Bytes]]()))
         .thenReturn(Future.successful(Seq(None)))
       val instance = SubmissionValidator.create(
-        Engine(),
         ledgerStateAccess = new FakeStateAccess(mockStateOperations),
         checkForMissingInputs = true,
         metricRegistry = new MetricRegistry,
@@ -64,7 +62,6 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with Inside {
     "return invalid submission for invalid envelope" in {
       val mockStateOperations = mock[LedgerStateOperations[Unit]]
       val instance = SubmissionValidator.create(
-        Engine(),
         new FakeStateAccess(mockStateOperations),
         metricRegistry = new MetricRegistry,
       )

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -15,6 +15,7 @@ import com.daml.ledger.validator.SubmissionValidator.{LogEntryAndState, RawKeyVa
 import com.daml.ledger.validator.SubmissionValidatorSpec._
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}
 import com.daml.lf.data.Time.Timestamp
+import com.daml.lf.engine.Engine
 import com.google.protobuf.{ByteString, Empty}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{times, verify, when}
@@ -31,6 +32,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with Inside {
       when(mockStateOperations.readState(any[Seq[Bytes]]()))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val instance = SubmissionValidator.create(
+        Engine(),
         new FakeStateAccess(mockStateOperations),
         metricRegistry = new MetricRegistry,
       )
@@ -47,6 +49,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with Inside {
       when(mockStateOperations.readState(any[Seq[Bytes]]()))
         .thenReturn(Future.successful(Seq(None)))
       val instance = SubmissionValidator.create(
+        Engine(),
         ledgerStateAccess = new FakeStateAccess(mockStateOperations),
         checkForMissingInputs = true,
         metricRegistry = new MetricRegistry,
@@ -61,6 +64,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with Inside {
     "return invalid submission for invalid envelope" in {
       val mockStateOperations = mock[LedgerStateOperations[Unit]]
       val instance = SubmissionValidator.create(
+        Engine(),
         new FakeStateAccess(mockStateOperations),
         metricRegistry = new MetricRegistry,
       )
@@ -124,7 +128,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with Inside {
       val instance = new SubmissionValidator(
         ledgerStateAccess = new FakeStateAccess(mockStateOperations),
         processSubmission = SubmissionValidator
-          .processSubmission(new KeyValueCommitting(new MetricRegistry)),
+          .processSubmission(new KeyValueCommitting(Engine(), new MetricRegistry)),
         allocateLogEntryId = mockLogEntryIdGenerator,
         checkForMissingInputs = false,
         stateValueCache = Cache.none,

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheck.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheck.scala
@@ -50,7 +50,7 @@ object IntegrityCheck extends App {
     timeModel = TimeModel.reasonableDefault,
     maxDeduplicationTime = Duration.ofDays(1),
   )
-  val keyValueCommitting = new KeyValueCommitting(metricRegistry)
+  val keyValueCommitting = new KeyValueCommitting(engine, metricRegistry)
   var state = Map.empty[Proto.DamlStateKey, Proto.DamlStateValue]
 
   var total_t_commit = 0L
@@ -80,7 +80,6 @@ object IntegrityCheck extends App {
     val (t_commit, (logEntry2, outputState)) = Helpers.time(
       () =>
         keyValueCommitting.processSubmission(
-          engine,
           entry.getEntryId,
           Conversions.parseTimestamp(logEntry.getRecordTime),
           defaultConfig,

--- a/ledger/recovering-indexer-integration-tests/BUILD.bazel
+++ b/ledger/recovering-indexer-integration-tests/BUILD.bazel
@@ -18,6 +18,7 @@ da_scala_test_suite(
     ],
     deps = [
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//language-support/scala/bindings",
         "//ledger/ledger-api-common",
         "//ledger/ledger-api-domain",

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -17,6 +17,7 @@ import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
 import com.daml.ledger.participant.state.v1._
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.LedgerString
+import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.platform.configuration.ServerRole
@@ -234,6 +235,7 @@ object RecoveringIndexerIntegrationSpec {
         ledgerId,
         participantId,
         metricRegistry = metricRegistry,
+        engine = Engine()
       ).map(readerWriter =>
         new KeyValueParticipantState(readerWriter, readerWriter, metricRegistry))
     }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -21,7 +21,6 @@ import com.daml.ledger.participant.state.index.v2.IndexService
 import com.daml.ledger.participant.state.v1.{ParticipantId, ReadService, SeedService, WriteService}
 import com.daml.lf.engine.Engine
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
-import com.daml.platform.apiserver.StandaloneApiServer._
 import com.daml.platform.configuration.{
   CommandConfiguration,
   LedgerConfiguration,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -56,7 +56,7 @@ final class StandaloneApiServer(
     timeServiceBackend: Option[TimeServiceBackend] = None,
     otherServices: immutable.Seq[BindableService] = immutable.Seq.empty,
     otherInterceptors: List[ServerInterceptor] = List.empty,
-    engine: Engine = sharedEngine // allows sharing DAML engine with DAML-on-X participant
+    engine: Engine
 )(implicit actorSystem: ActorSystem, materializer: Materializer, logCtx: LoggingContext)
     extends ResourceOwner[ApiServer] {
 
@@ -169,8 +169,4 @@ final class StandaloneApiServer(
     config.portFile.foreach { path =>
       Files.write(path, Seq(port.toString).asJava)
     }
-}
-
-object StandaloneApiServer {
-  private val sharedEngine: Engine = Engine()
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -66,9 +66,6 @@ final class StandaloneApiServer(
   val participantId: ParticipantId = config.participantId
 
   override def acquire()(implicit executionContext: ExecutionContext): Resource[ApiServer] = {
-    val packageStore = loadDamlPackages()
-    preloadPackages(packageStore)
-
     val owner = for {
       initialConditions <- ResourceOwner.forFuture(() =>
         readService.getLedgerInitialConditions().runWith(Sink.head))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/IndexerStartupMode.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/IndexerStartupMode.scala
@@ -11,6 +11,8 @@ object IndexerStartupMode {
 
   case object MigrateAndStart extends IndexerStartupMode
 
+  case object ResetAndStart extends IndexerStartupMode
+
   case object MigrateOnly extends IndexerStartupMode
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/JdbcIndexer.scala
@@ -55,7 +55,7 @@ final class JdbcIndexerFactory(
       .map(_ => initialized())
 
   def resetSchema()(
-    implicit executionContext: ExecutionContext
+      implicit executionContext: ExecutionContext
   ): Future[ResourceOwner[JdbcIndexer]] =
     Future.successful(for {
       ledgerDao <- JdbcLedgerDao.writeOwner(
@@ -66,9 +66,7 @@ final class JdbcIndexerFactory(
       )
       _ <- ResourceOwner.forFuture(() => ledgerDao.reset())
       initialLedgerEnd <- ResourceOwner.forFuture(() => initializeLedger(ledgerDao))
-    } yield new JdbcIndexer(initialLedgerEnd, config.participantId, ledgerDao, metrics)
-    )
-
+    } yield new JdbcIndexer(initialLedgerEnd, config.participantId, ledgerDao, metrics))
 
   private def initialized()(
       implicit executionContext: ExecutionContext

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala
@@ -39,6 +39,13 @@ final class StandaloneIndexerServer(
           .map { _ =>
             logger.debug("Waiting for the indexer to initialize the database.")
           }
+      case IndexerStartupMode.ResetAndStart =>
+        Resource
+          .fromFuture(indexerFactory.resetSchema())
+          .flatMap(startIndexer(indexer, _))
+          .map { _ =>
+            logger.debug("Waiting for the indexer to initialize the database.")
+          }
       case IndexerStartupMode.ValidateAndStart =>
         Resource
           .fromFuture(indexerFactory.validateSchema())

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -148,15 +148,19 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                 _ <- if (isReset) {
                   ResourceOwner.unit
                 } else {
-                  ResourceOwner.forFuture(() =>
-                    Future.sequence(config.damlPackages.map(uploadDar(_, writeService)))).map(_ => ())
+                  ResourceOwner
+                    .forFuture(() =>
+                      Future.sequence(config.damlPackages.map(uploadDar(_, writeService))))
+                    .map(_ => ())
                 }
                 _ <- new StandaloneIndexerServer(
                   readService = readService,
                   config = IndexerConfig(
                     ParticipantId,
                     jdbcUrl = indexJdbcUrl,
-                    startupMode = if (isReset) IndexerStartupMode.ResetAndStart else IndexerStartupMode.MigrateAndStart,
+                    startupMode =
+                      if (isReset) IndexerStartupMode.ResetAndStart
+                      else IndexerStartupMode.MigrateAndStart,
                     eventsPageSize = config.eventsPageSize,
                     allowExistingSchema = true,
                   ),

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/SandboxBackend.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/SandboxBackend.scala
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.daml.platform.sandbox
+import java.util.UUID
+
 import com.daml.platform.sandbox.services.DbInfo
 import com.daml.platform.store.DbType
 import com.daml.resources.ResourceOwner
 import com.daml.testing.postgresql.PostgresResource
+
+import scala.util.Success
 
 object SandboxBackend {
 
@@ -15,9 +19,10 @@ object SandboxBackend {
   }
 
   trait H2Database { this: AbstractSandboxFixture =>
-    private[this] lazy val jdbcUrl = s"jdbc:h2:mem:${getClass.getSimpleName};db_close_delay=-1"
+    private def randomDatabaseName = UUID.randomUUID().toString
+    private[this] def jdbcUrl = s"jdbc:h2:mem:$randomDatabaseName;db_close_delay=-1"
     override protected final def database: Option[ResourceOwner[DbInfo]] =
-      Some(ResourceOwner.successful(DbInfo(jdbcUrl, DbType.H2Database)))
+      Some(ResourceOwner.forTry(() => Success(DbInfo(jdbcUrl, DbType.H2Database))))
   }
 
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceITBase.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/reset/ResetServiceITBase.scala
@@ -60,7 +60,6 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 import scala.concurrent.Future
 import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
 
-@SuppressWarnings(Array("org.wartremover.warts.Any"))
 abstract class ResetServiceITBase
     extends AsyncWordSpec
     with AsyncTimeLimitedTests
@@ -229,7 +228,7 @@ abstract class ResetServiceITBase
           ledgerId <- fetchLedgerId()
           packagesBeforeReset <- eventually { (_, _) =>
             listPackages(ledgerId).map { packages =>
-              packages should not be empty
+              packages.size should be > 0
               packages
             }
           }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandboxnext/services/reset/ResetServiceInMemoryIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandboxnext/services/reset/ResetServiceInMemoryIT.scala
@@ -3,9 +3,13 @@
 
 package com.daml.platform.sandboxnext.services.reset
 
+import com.daml.platform.sandbox.SandboxBackend
 import com.daml.platform.sandbox.services.reset.ResetServiceITBase
 import com.daml.platform.sandboxnext.SandboxNextFixture
 
-final class ResetServiceInMemoryIT extends ResetServiceITBase with SandboxNextFixture {
+final class ResetServiceInMemoryIT
+    extends ResetServiceITBase
+    with SandboxNextFixture
+    with SandboxBackend.H2Database {
   override def spanScaleFactor: Double = super.spanScaleFactor * 2
 }


### PR DESCRIPTION
There are a few things that we can improve on:

1. Share an instance of `Engine` between API Server and KV Committer. This also makes it so that the KV Committer doesn't need to recompile packages after a reset.
1. Only load packages from disk on first startup, but not during resets. This is only necessary to preload the packages into `Engine` anyway, but since we conserve the `Engine` across resets, this doesn't need to be done.
1. Don't kill the schema (i.e. drop all tables) but only truncate. This means we don't need to run schema migrations during reset. This step needs to preserve the `packages` table, because we explicitly want to avoid having to load the packages again.


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
