### PR TITLE
Configure Bazel repository cache for build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,8 +7,15 @@ build --remote_upload_local_results=false
 # Enable the disk cache in addition to the http cache.
 build:linux --disk_cache=.bazel-cache/disk
 build:darwin --disk_cache=.bazel-cache/disk
+# `--repository_cache` must be repeated for all relevant actions.
+# TODO: use `common` starting from Bazel 2.2.0
+# See https://github.com/bazelbuild/bazel/issues/11232
+build:linux --repository_cache=.bazel-cache/repo
 fetch:linux --repository_cache=.bazel-cache/repo
+sync:linux --repository_cache=.bazel-cache/repo
+build:darwin --repository_cache=.bazel-cache/repo
 fetch:darwin --repository_cache=.bazel-cache/repo
+sync:darwin --repository_cache=.bazel-cache/repo
 
 # Improve remote cache hit rate by exluding environment variables from the
 # sandbox that are not whitelisted using --action_env.


### PR DESCRIPTION
`bazel build` doesn't recognize the flag if it is only configured for `fetch`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
