### PR TITLE
Implement replacement for post-commit validation

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/PostCommitValidation.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/PostCommitValidation.scala
@@ -1,0 +1,230 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+import java.sql.Connection
+import java.time.Instant
+
+import com.daml.ledger.api.domain.RejectionReason
+
+/**
+  * Performs post-commit validation on transactions for Sandbox Classic.
+  * This is intended exclusively as a temporary replacement for
+  * [[com.daml.platform.store.ActiveLedgerState]] and [[com.daml.platform.store.ActiveLedgerStateManager]]
+  * so that the old post-commit validation backed by the old participant schema can be
+  * dropped and the DAML-on-X-backed implementation of the Sandbox can skip it entirely.
+  *
+  * Post-commit validation is relevant for two reasons:
+  * - keys can be referenced by two concurrent interpretations, potentially leading to
+  *   either create nodes with duplicate active keys or lookup-by-key nodes referring to
+  *   inactive keys
+  * - the transaction's ledger effective time is determined after interpretation,
+  *   meaning that causal monotonicity cannot be verified while interpreting a command
+  */
+sealed trait PostCommitValidation {
+
+  def validate(
+      transaction: Transaction,
+      transactionLedgerEffectiveTime: Instant,
+      divulged: Set[ContractId],
+      submitter: Party,
+  )(implicit connection: Connection): Set[RejectionReason]
+
+}
+
+object PostCommitValidation {
+
+  /**
+    * Accept unconditionally a transaction.
+    *
+    * Designed to be used by a ledger integration that
+    * already performs post-commit validation.
+    */
+  object Skip extends PostCommitValidation {
+    override def validate(
+        transaction: Transaction,
+        transactionLedgerEffectiveTime: Instant,
+        divulged: Set[ContractId],
+        submitter: Party,
+    )(implicit connection: Connection): Set[RejectionReason] =
+      Set.empty
+  }
+
+  final class BackedBy(data: PostCommitValidationData) extends PostCommitValidation {
+
+    def validate(
+        transaction: Transaction,
+        transactionLedgerEffectiveTime: Instant,
+        divulged: Set[ContractId],
+        submitter: Party,
+    )(implicit connection: Connection): Set[RejectionReason] = {
+
+      val causalMonotonicityRejection =
+        validateCausalMonotonicity(transaction, transactionLedgerEffectiveTime, divulged)
+
+      val invalidKeyUsageRejection =
+        validateKeyUsages(transaction, submitter)
+
+      causalMonotonicityRejection.union(invalidKeyUsageRejection)
+    }
+
+    /**
+      * Do all exercise, fetch and lookup-by-key nodes
+      * 1. exist, and
+      * 2. refer exclusively to contracts with a ledger effective time smaller than or equal to the transaction's?
+      */
+    private def validateCausalMonotonicity(
+        transaction: Transaction,
+        transactionLedgerEffectiveTime: Instant,
+        divulged: Set[ContractId],
+    )(implicit connection: Connection): Set[RejectionReason] = {
+
+      // Collect all the identifiers of contracts that have not been divulged in the current transaction
+      val maximumLedgerEffectiveTime =
+        data.lookupMaximumLedgerTime(
+          transaction.fold(Set.empty[ContractId]) {
+            case (ids, (_, e: Exercise)) if !divulged(e.targetCoid) => ids + e.targetCoid
+            case (ids, (_, f: Fetch)) if !divulged(f.coid) => ids + f.coid
+            case (ids, (_, l: LookupByKey)) => l.result.filterNot(divulged).fold(ids)(ids + _)
+            case (ids, _) => ids
+          }
+        )
+
+      // Query the committed contracts store for the maximum ledger effective time of the
+      // collected contracts and returns an error if that is strictly greater than the
+      // ledger effective time of the current transaction.
+      maximumLedgerEffectiveTime
+        .map(
+          _.filter(_.isAfter(transactionLedgerEffectiveTime)).fold(Set.empty[RejectionReason])(
+            contractLedgerEffectiveTime => {
+              Set(
+                CausalMonotonicityViolation(
+                  contractLedgerEffectiveTime = contractLedgerEffectiveTime,
+                  transactionLedgerEffectiveTime = transactionLedgerEffectiveTime,
+                )
+              )
+            }
+          )
+        )
+        .getOrElse(Set(UnknownContract))
+    }
+
+    private def validateKeyUsages(transaction: Transaction, submitter: Party)(
+        implicit connection: Connection): Set[RejectionReason] = {
+      transaction
+        .fold(State.empty(data, submitter)) {
+          case (state, (_, node)) => validateKeyUsages(node, state)
+        }
+        .errors
+    }
+
+    private def validateKeyUsages(
+        node: Node,
+        state: State,
+    )(implicit connection: Connection): State = {
+
+      node match {
+        case c: Create =>
+          state.validateCreate(c.key.map(convert(c.coinst.template, _)), c.coid)
+        case l: LookupByKey =>
+          state.validateLookupByKey(convert(l.templateId, l.key), l.result)
+        case e: Exercise if e.consuming =>
+          state.removeKeyIfDefined(e.key.map(convert(e.templateId, _)))
+        case _ =>
+          // fetch and non-consuming exercise nodes don't need to validate
+          // anything with regards to contract keys and do not alter the
+          // state in a way which is relevant for the validation of
+          // subsequent nodes
+          state
+      }
+    }
+  }
+
+  /**
+    * Represents the state of an ongoing validation.
+    * It must be carried over as the transaction is
+    * validated one node at a time in pre-order
+    * traversal for this to make sense.
+    *
+    * @param errors Accumulates errors retrieved so far while validating
+    * @param contracts All contracts created as part of the current transaction
+    * @param removed Ensures indexed transactions are not referred to if they are removed in the current transaction
+    * @param submitter The submitter of the current transaction
+    */
+  private final case class State(
+      errors: Set[RejectionReason],
+      private val contracts: Map[Hash, ContractId],
+      private val removed: Set[Hash],
+      private val submitter: Party,
+      private val data: PostCommitValidationData,
+  ) {
+
+    def validateCreate(maybeKey: Option[Key], id: ContractId)(
+        implicit connection: Connection): State =
+      maybeKey.fold(this) { key =>
+        lookup(key).fold(add(key, id))(_ => error(DuplicateKey))
+      }
+
+    // `causalMonotonicity` already reports unknown contracts, no need to check it here
+    def removeKeyIfDefined(maybeKey: Option[Key])(implicit connection: Connection): State =
+      maybeKey.fold(this)(remove)
+
+    def validateLookupByKey(key: Key, expectation: Option[ContractId])(
+        implicit connection: Connection): State = {
+      val result = lookup(key)
+      if (result == expectation) this
+      else copy(errors = errors + MismatchingLookup(expectation, result))
+    }
+
+    private def add(key: Key, id: ContractId): State =
+      copy(
+        contracts = contracts.updated(key.hash, id),
+        removed = removed - key.hash,
+      )
+
+    private def remove(key: Key): State =
+      copy(
+        contracts = contracts - key.hash,
+        removed = removed + key.hash,
+      )
+
+    private def error(reason: RejectionReason): State =
+      copy(errors = errors + reason)
+
+    private def lookup(key: Key)(implicit connection: Connection): Option[ContractId] =
+      contracts.get(key.hash).orElse {
+        if (removed(key.hash)) None
+        else data.lookupContractKey(submitter, key)
+      }
+
+  }
+
+  private object State {
+    def empty(data: PostCommitValidationData, submitter: Party): State =
+      State(Set.empty, Map.empty, Set.empty, submitter, data)
+  }
+
+  private val DuplicateKey: RejectionReason =
+    RejectionReason.Disputed("DuplicateKey: contract key is not unique")
+
+  private def MismatchingLookup(
+      expectation: Option[ContractId],
+      result: Option[ContractId],
+  ): RejectionReason =
+    RejectionReason.Disputed(
+      s"Contract key lookup with different results: expected [$expectation], actual [$result]"
+    )
+
+  private val UnknownContract: RejectionReason =
+    RejectionReason.Inconsistent(s"Could not lookup contract")
+
+  private def CausalMonotonicityViolation(
+      contractLedgerEffectiveTime: Instant,
+      transactionLedgerEffectiveTime: Instant,
+  ): RejectionReason =
+    RejectionReason.InvalidLedgerTime(
+      s"Encountered contract with LET [$contractLedgerEffectiveTime] greater than the LET of the transaction [$transactionLedgerEffectiveTime]"
+    )
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/PostCommitValidation.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/PostCommitValidation.scala
@@ -148,7 +148,7 @@ object PostCommitValidation {
     *
     * @param errors Accumulates errors retrieved so far while validating
     * @param contracts All contracts created as part of the current transaction
-    * @param removed Ensures indexed transactions are not referred to if they are removed in the current transaction
+    * @param removed Ensures indexed contracts are not referred to by key if they are removed in the current transaction
     * @param submitter The submitter of the current transaction
     */
   private final case class State(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationData.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationData.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+import java.sql.Connection
+import java.time.Instant
+
+import scala.util.Try
+
+private[events] trait PostCommitValidationData {
+
+  def lookupContractKey(submitter: Party, key: Key)(
+      implicit connection: Connection): Option[ContractId]
+
+  def lookupMaximumLedgerTime(ids: Set[ContractId])(
+      implicit connection: Connection): Try[Option[Instant]]
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
@@ -12,6 +12,7 @@ package object events {
 
   import com.daml.lf.value.{Value => lfval}
   private[events] type ContractId = lfval.AbsoluteContractId
+  private[events] val ContractId = com.daml.lf.value.Value.AbsoluteContractId
   private[events] type Value = lfval.VersionedValue[ContractId]
   private[events] type Contract = lfval.ContractInst[Value]
   private[events] val Contract = lfval.ContractInst
@@ -29,6 +30,7 @@ package object events {
 
   import com.daml.lf.{data => lfdata}
   private[events] type Party = lfdata.Ref.Party
+  private[events] val Party = lfdata.Ref.Party
   private[events] type Identifier = lfdata.Ref.Identifier
   private[events] val Identifier = lfdata.Ref.Identifier
   private[events] type LedgerString = lfdata.Ref.LedgerString

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
@@ -39,6 +39,9 @@ package object events {
   private[events] type FilterRelation = lfdata.Relation.Relation[Party, lfdata.Ref.Identifier]
   private[events] val Relation = lfdata.Relation.Relation
 
+  import com.daml.lf.crypto
+  private[events] type Hash = crypto.Hash
+
   /**
     * Groups together items of type [[A]] that share an attribute [[K]] over a
     * contiguous stretch of the input [[Source]]. Well suited to perform group-by
@@ -76,5 +79,8 @@ package object events {
       case n if n > 1 => multi(set)
     }
   }
+
+  private[events] def convert(template: Identifier, key: lftx.Node.KeyWithMaintainers[Value]): Key =
+    Key.assertBuild(template, key.key.value)
 
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/events/TransactionBuilder.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/events/TransactionBuilder.scala
@@ -1,0 +1,164 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+import com.daml.lf.data.ImmArray
+import com.daml.lf.data.Ref.{ChoiceName, Name}
+
+import scala.collection.immutable.HashMap
+import scala.util.control.NonFatal
+
+final class TransactionBuilder {
+
+  import TransactionBuilder._
+
+  private val ids = Iterator.from(1).map(NodeId(_))
+  private var nodes = HashMap.newBuilder[NodeId, Node]
+  private val roots = ImmArray.newBuilder[NodeId]
+
+  def add(node: Node): NodeId = ids.synchronized {
+    val nodeId = ids.next()
+    nodes += (nodeId -> node)
+    roots += nodeId
+    nodeId
+  }
+
+  def add(node: Node, parent: NodeId): NodeId = ids.synchronized {
+    lazy val nodeId = ids.next() // lazy to avoid getting the next id if the method later throws
+    nodes = nodes.mapResult { ns =>
+      val exercise = try {
+        ns(parent).asInstanceOf[Exercise]
+      } catch {
+        case NonFatal(e) =>
+          throw new IllegalArgumentException(
+            s"Node ${parent.index} either does not exist or is not an exercise",
+            e)
+      }
+      ns.updated(parent, exercise.copy(children = exercise.children.slowSnoc(nodeId)))
+    }
+    nodeId
+  }
+
+  def build(): Transaction = ids.synchronized {
+    Transaction(nodes.result(), roots.result())
+  }
+
+}
+
+object TransactionBuilder {
+
+  private val ValueVersions = com.daml.lf.value.ValueVersions
+  private val LfValue = com.daml.lf.value.Value
+  private val Value = com.daml.lf.value.Value.VersionedValue
+
+  private val NodeId = com.daml.lf.transaction.Transaction.NodeId
+  private val Transaction = com.daml.lf.transaction.GenTransaction
+  private val Create = com.daml.lf.transaction.Node.NodeCreate
+  private val Exercise = com.daml.lf.transaction.Node.NodeExercises
+  private val Fetch = com.daml.lf.transaction.Node.NodeFetch
+  private val LookupByKey = com.daml.lf.transaction.Node.NodeLookupByKey
+  private type LeafOnlyNode = com.daml.lf.transaction.Node.LeafOnlyNode.WithTxValue[ContractId]
+  private type KeyWithMaintainers = com.daml.lf.transaction.Node.KeyWithMaintainers[Value]
+  private val KeyWithMaintainers = com.daml.lf.transaction.Node.KeyWithMaintainers
+
+  private val LatestLfValueVersion = ValueVersions.acceptedVersions.last
+
+  def record(fields: (String, String)*): Value =
+    Value(
+      LatestLfValueVersion,
+      LfValue.ValueRecord(
+        tycon = None,
+        fields = ImmArray(
+          fields.map {
+            case (name, value) =>
+              (Some(Name.assertFromString(name)), LfValue.ValueText(value))
+          },
+        )
+      )
+    )
+
+  def tuple(values: String*): Value =
+    record(values.zipWithIndex.map { case (v, i) => s"_$i" -> v }: _*)
+
+  def keyWithMaintainers(maintainers: Seq[String], value: String): KeyWithMaintainers =
+    KeyWithMaintainers(
+      key = tuple(maintainers :+ value: _*),
+      maintainers = maintainers.map(Party.assertFromString).toSet,
+    )
+
+  def create(
+      id: String,
+      template: String,
+      argument: Value,
+      signatories: Seq[String],
+      observers: Seq[String],
+      key: Option[String],
+  ): Create =
+    Create(
+      coid = ContractId.assertFromString(id),
+      coinst = Contract(
+        template = Identifier.assertFromString(template),
+        arg = argument,
+        agreementText = "",
+      ),
+      optLocation = None,
+      signatories = signatories.map(Party.assertFromString).toSet,
+      stakeholders = signatories.union(observers).map(Party.assertFromString).toSet,
+      key = key.map(keyWithMaintainers(maintainers = signatories, _)),
+    )
+
+  def exercise(
+      contract: Create,
+      choice: String,
+      consuming: Boolean,
+      actingParties: Set[String],
+      argument: Value,
+  ): Exercise =
+    Exercise(
+      targetCoid = contract.coid,
+      templateId = contract.coinst.template,
+      choiceId = ChoiceName.assertFromString(choice),
+      optLocation = None,
+      consuming = consuming,
+      actingParties = actingParties.map(Party.assertFromString),
+      chosenValue = argument,
+      stakeholders = contract.stakeholders,
+      signatories = contract.signatories,
+      children = ImmArray.empty,
+      exerciseResult = None,
+      key = contract.key,
+    )
+
+  def fetch(
+      contract: Create,
+      actingParties: Set[String],
+  ): Fetch =
+    Fetch(
+      coid = contract.coid,
+      templateId = contract.coinst.template,
+      optLocation = None,
+      actingParties = Some(actingParties.map(Party.assertFromString)),
+      signatories = contract.signatories,
+      stakeholders = contract.stakeholders,
+      key = contract.key,
+    )
+
+  def lookupByKey(contract: Create, found: Boolean): LookupByKey =
+    LookupByKey(
+      templateId = contract.coinst.template,
+      optLocation = None,
+      key = contract.key.get,
+      result = if (found) Some(contract.coid) else None
+    )
+
+  def just(node: Node, nodes: Node*): Transaction = {
+    val builder = new TransactionBuilder
+    val _ = builder.add(node)
+    for (node <- nodes) {
+      val _ = builder.add(node)
+    }
+    builder.build()
+  }
+
+}

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/events/TransactionBuilder.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/events/TransactionBuilder.scala
@@ -130,15 +130,12 @@ object TransactionBuilder {
       key = contract.key,
     )
 
-  def fetch(
-      contract: Create,
-      actingParties: Set[String],
-  ): Fetch =
+  def fetch(contract: Create): Fetch =
     Fetch(
       coid = contract.coid,
       templateId = contract.coinst.template,
       optLocation = None,
-      actingParties = Some(actingParties.map(Party.assertFromString)),
+      actingParties = Some(contract.signatories.map(Party.assertFromString)),
       signatories = contract.signatories,
       stakeholders = contract.stakeholders,
       key = contract.key,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationSpec.scala
@@ -1,0 +1,260 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+import java.sql.Connection
+import java.time.Instant
+import java.util.UUID
+
+import com.daml.platform.store.dao.events.TransactionBuilder._
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.util.{Failure, Success, Try}
+
+final class PostCommitValidationSpec extends WordSpec with Matchers {
+
+  import PostCommitValidation._
+  import PostCommitValidationSpec._
+
+  "PostCommitValidation" when {
+
+    "run without prior history" should {
+
+      val emptyLedger = new PostCommitValidation.BackedBy(noCommittedContract)
+
+      "accept a create that doesn't create a duplicate key" in {
+
+        val createWithKey = genTestCreate()
+
+        val validation =
+          emptyLedger.validate(
+            transaction = just(createWithKey),
+            transactionLedgerEffectiveTime = Instant.now(),
+            divulged = Set.empty,
+            submitter = Party.assertFromString("Alice"),
+          )
+
+        validation shouldBe Set.empty
+
+      }
+
+      "accept a create without a key" in {
+
+        val createWithoutKey = genTestCreate().copy(key = None)
+
+        val validation =
+          emptyLedger.validate(
+            transaction = just(createWithoutKey),
+            transactionLedgerEffectiveTime = Instant.now(),
+            divulged = Set.empty,
+            submitter = Party.assertFromString("Alice"),
+          )
+
+        validation shouldBe Set.empty
+
+      }
+
+      "accept an exercise of a contract created within the transaction" in {
+
+        val createContract = genTestCreate()
+        val exerciseContract = genTestExercise(createContract)
+
+        val validation =
+          emptyLedger.validate(
+            transaction = just(createContract, exerciseContract),
+            transactionLedgerEffectiveTime = Instant.now(),
+            divulged = Set.empty,
+            submitter = Party.assertFromString("Alice"),
+          )
+
+        validation shouldBe Set.empty
+
+      }
+
+      "accept an exercise of a contract divulged in the current transaction" in {
+
+        val divulgedContract = genTestCreate()
+        val exerciseContract = genTestExercise(divulgedContract)
+
+        val validation =
+          emptyLedger.validate(
+            transaction = just(exerciseContract),
+            transactionLedgerEffectiveTime = Instant.now(),
+            divulged = Set(divulgedContract.coid),
+            submitter = Party.assertFromString("Alice"),
+          )
+
+        validation shouldBe Set.empty
+
+      }
+
+      "reject an exercise of a contract not created in this transaction" in {
+
+        val missingCreate = genTestCreate()
+        val exerciseContract = genTestExercise(missingCreate)
+
+        val validation =
+          emptyLedger.validate(
+            transaction = just(exerciseContract),
+            transactionLedgerEffectiveTime = Instant.now(),
+            divulged = Set.empty,
+            submitter = Party.assertFromString("Alice"),
+          )
+
+        validation should contain theSameElementsAs Seq(UnknownContract)
+
+      }
+
+      "accept a successful lookup of a contract created in this transaction" in {
+
+        val createContract = genTestCreate()
+
+        val validation =
+          emptyLedger.validate(
+            transaction = just(createContract, lookupByKey(createContract, found = true)),
+            transactionLedgerEffectiveTime = Instant.now(),
+            divulged = Set.empty,
+            submitter = Party.assertFromString("Alice"),
+          )
+
+        validation shouldBe Set.empty
+
+      }
+
+      "reject a successful lookup of a missing contract" in {
+
+        val missingCreate = genTestCreate()
+
+        val validation =
+          emptyLedger.validate(
+            transaction = just(lookupByKey(missingCreate, found = true)),
+            transactionLedgerEffectiveTime = Instant.now(),
+            divulged = Set.empty,
+            submitter = Party.assertFromString("Alice"),
+          )
+
+        validation should contain allElementsOf Seq(
+          MismatchingLookup(
+            expectation = Some(missingCreate.coid),
+            result = None,
+          )
+        )
+
+      }
+
+      "accept a failed lookup of a missing contract" in {
+
+        val missingContract = genTestCreate()
+
+        val validation =
+          emptyLedger.validate(
+            transaction = just(lookupByKey(missingContract, found = false)),
+            transactionLedgerEffectiveTime = Instant.now(),
+            divulged = Set.empty,
+            submitter = Party.assertFromString("Alice"),
+          )
+
+        validation shouldBe Set.empty
+
+      }
+
+    }
+
+  }
+
+}
+
+object PostCommitValidationSpec {
+
+  private def genTestCreate(): Create =
+    create(
+      id = s"#${UUID.randomUUID}",
+      template = "foo:bar:baz",
+      argument = record("field" -> "value"),
+      signatories = Seq("Alice"),
+      observers = Seq.empty,
+      key = Some("key"),
+    )
+
+  private def genTestExercise(create: Create): Exercise =
+    exercise(
+      contract = create,
+      choice = "SomeChoice",
+      consuming = true,
+      actingParties = Set("Alice"),
+      argument = record("field" -> "value"),
+    )
+
+  private final case class ContractFixture private (
+      id: ContractId,
+      ledgerEffectiveTime: Option[Instant],
+      witnesses: Set[Party],
+      key: Option[Key],
+  )
+
+  // May whoever is in charge of supernatural stuff have mercy of my sould
+  private implicit val connection: Connection = null
+
+  private final case class Fixture private (contracts: Set[ContractFixture])
+      extends PostCommitValidationData {
+
+    override def lookupContractKey(submitter: Party, key: Key)(
+        implicit connection: Connection = null): Option[ContractId] =
+      contracts.find(c => c.key.contains(key) && c.witnesses.contains(submitter)).map(_.id)
+
+    override def lookupMaximumLedgerTime(ids: Set[ContractId])(
+        implicit connection: Connection = null): Try[Option[Instant]] = {
+      val lookup = contracts.collect {
+        case c if ids.contains(c.id) => c.ledgerEffectiveTime
+      }
+      if (lookup.isEmpty) Failure(notFound(ids))
+      else Success(lookup.fold[Option[Instant]](None)(pickTheGreater))
+    }
+  }
+
+  private def pickTheGreater(l: Option[Instant], r: Option[Instant]): Option[Instant] =
+    l.fold(r)(left => r.fold(l)(right => if (left.isAfter(right)) l else r))
+
+  private def notFound(contractIds: Set[ContractId]): Throwable =
+    new IllegalArgumentException(
+      s"One or more of the following contract identifiers has been found: ${contractIds.map(_.coid).mkString(", ")}"
+    )
+
+  private val noCommittedContract = Fixture(Set.empty)
+
+  private def contract(
+      id: String,
+      ledgerEffectiveTime: Instant,
+      witness: String,
+      witnesses: String*): ContractFixture =
+    ContractFixture(
+      ContractId.assertFromString(s"#$id"),
+      Some(ledgerEffectiveTime),
+      (Set(witness) ++ witnesses.toSet).map(_.asInstanceOf[Party]),
+      None,
+    )
+
+  private def contract(
+      id: String,
+      ledgerEffectiveTime: Instant,
+      key: Key,
+      witness: String,
+      witnesses: String*,
+  ): ContractFixture =
+    ContractFixture(
+      ContractId.assertFromString(s"#$id"),
+      Some(ledgerEffectiveTime),
+      (Set(witness) ++ witnesses.toSet).map(_.asInstanceOf[Party]),
+      Some(key),
+    )
+
+  private def divulgedContract(id: String, witness: String, witnesses: String*): ContractFixture =
+    ContractFixture(
+      ContractId.assertFromString(s"#$id"),
+      None,
+      (Set(witness) ++ witnesses.toSet).map(_.asInstanceOf[Party]),
+      None,
+    )
+
+}


### PR DESCRIPTION
PostCommitValidation is meant as a replacement for ActiveLedgerState and
ActiveLedgerStateManager for JdbcLedgerDao so that the old table can eventually
be retired and post-commit validation can happen on the new participant schema.

This commit simply introduces the implementation and tests it in isolation.

Integration with the existing system will come in a separate contribution.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
