### PR TITLE
extend visual for exerciseByKey

### DIFF
--- a/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
+++ b/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
@@ -173,7 +173,11 @@ startFromExpr seen world e = case e of
         Set.singleton (AExercise tpl (LF.ChoiceName "Archive"))
     -- NOTE(RJR): Look for calls to the `exercise` method from a `Choice`
     -- instance and produce the corresponding edge in the graph.
+    --(LF.ETmApp (LF.ETyApp (LF.ETyApp (LF.ETyApp (EInternalTemplateVal "exercise") (LF.TCon tpl)) (LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])))) _ret), _dict)
     EInternalTemplateVal "exercise" `LF.ETyApp` LF.TCon tpl `LF.ETyApp` LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])) `LF.ETyApp` _ret `LF.ETmApp` _dict ->
+        Set.singleton (AExercise tpl (LF.ChoiceName chc))
+    --(LF.ETmApp (LF.ETyApp (LF.ETyApp (LF.ETyApp (LF.ETyApp (EInternalTemplateVal "exerciseByKey") (LF.TCon tpl)) _) (LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])))) _ret) _dict)
+    EInternalTemplateVal "exerciseByKey" `LF.TyApp` LF.TCon tpl `LF.ETyApp` _ `LF.ETyApp` LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])) `LF.ETyApp` _ret `LF.ETmApp` _dict ->
         Set.singleton (AExercise tpl (LF.ChoiceName chc))
     expr -> Set.unions $ map (startFromExpr seen world) $ children expr
 

--- a/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
+++ b/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
@@ -173,11 +173,9 @@ startFromExpr seen world e = case e of
         Set.singleton (AExercise tpl (LF.ChoiceName "Archive"))
     -- NOTE(RJR): Look for calls to the `exercise` method from a `Choice`
     -- instance and produce the corresponding edge in the graph.
-    --(LF.ETmApp (LF.ETyApp (LF.ETyApp (LF.ETyApp (EInternalTemplateVal "exercise") (LF.TCon tpl)) (LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])))) _ret), _dict)
     EInternalTemplateVal "exercise" `LF.ETyApp` LF.TCon tpl `LF.ETyApp` LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])) `LF.ETyApp` _ret `LF.ETmApp` _dict ->
         Set.singleton (AExercise tpl (LF.ChoiceName chc))
-    --(LF.ETmApp (LF.ETyApp (LF.ETyApp (LF.ETyApp (LF.ETyApp (EInternalTemplateVal "exerciseByKey") (LF.TCon tpl)) _) (LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])))) _ret) _dict)
-    EInternalTemplateVal "exerciseByKey" `LF.TyApp` LF.TCon tpl `LF.ETyApp` _ `LF.ETyApp` LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])) `LF.ETyApp` _ret `LF.ETmApp` _dict ->
+    EInternalTemplateVal "exerciseByKey" `LF.ETyApp` LF.TCon tpl `LF.ETyApp` _ `LF.ETyApp` LF.TCon (LF.Qualified _ _ (LF.TypeConName [chc])) `LF.ETyApp` _ret `LF.ETmApp` _dict ->
         Set.singleton (AExercise tpl (LF.ChoiceName chc))
     expr -> Set.unions $ map (startFromExpr seen world) $ children expr
 

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -1253,6 +1253,57 @@ visualDamlTests = Tasty.testGroup "Visual Tests"
                   ExpectedChoiceDetails {expectedConsuming = True
                                         , expectedName = "Delete"})
                 ])
+        -- test case taken from #5726
+        , testCase' "ExerciseByKey should add an edge" $ do
+            exerciseByKeyTest <- makeModule "F"
+                [ "template Ping"
+                , "  with"
+                , "    party : Party"
+                , "  where"
+                , "    signatory party"
+                , "    key party: Party"
+                , "    maintainer key"
+                , ""
+                , "    controller party can"
+                , "      nonconsuming ArchivePong : ()"
+                , "        with"
+                , "          pong : ContractId Pong"
+                , "        do"
+                , "          exercise pong Archive"
+                , ""
+                , "template Pong"
+                , "  with"
+                , "    party : Party"
+                , "  where"
+                , "    signatory party"
+                , ""
+                , "    controller party can"
+                , "      nonconsuming ArchivePing : ()"
+                , "        with"
+                , "          pingParty : Party"
+                , "        do"
+                , "          exerciseByKey @Ping pingParty Archive"
+                ]
+            setFilesOfInterest [exerciseByKeyTest]
+            expectNoErrors
+            expectedGraph exerciseByKeyTest (ExpectedGraph
+                [ ExpectedSubGraph { expectedNodes = ["Create", "ArchivePong", "Archive"]
+                                   , expectedTplFields = ["party"]
+                                   , expectedTemplate = "Ping"
+                                    }
+                , ExpectedSubGraph { expectedNodes = ["Create", "Archive", "ArchivePing"]
+                                   , expectedTplFields = ["party"]
+                                   , expectedTemplate = "Pong"}
+                ]
+                [ (ExpectedChoiceDetails {expectedConsuming = False
+                                         , expectedName = "ArchivePong"},
+                   ExpectedChoiceDetails {expectedConsuming = True
+                                         , expectedName = "Archive"})
+                , (ExpectedChoiceDetails {expectedConsuming = False
+                                         , expectedName = "ArchivePing"},
+                   ExpectedChoiceDetails {expectedConsuming = True
+                                         , expectedName = "Archive"})
+                ])
         , testCase' "Create on other template should be edge" $ do
             createTest <- makeModule "F"
                 [ "template TT"


### PR DESCRIPTION
Fair warning: I have no idea what I'm doing here. Please review carefully.

This commit extends the `daml damlc visual` command to draw a line for exerciseByKey choices. This fixes #5726.

I have not been able to find any existing test for the visualizer. If non exist, I think we should at least turn #5726 into a test case, checking that the expected dot file gets generated. I suggest doing that as a separate PR though.

If there is already a suite of tests, please point me to it and I'll happily add one for this.

CHANGELOG_BEGIN
[Visualization] Fix a bug where `exerciseByKey` was not properly recognized. See #5726.
CHANGELOG_END