### PR TITLE
reduce test count for Ordering tests

### DIFF
--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -447,10 +447,10 @@ class OrderingSpec
     implicit val svalueOrd: Order[SValue] = Order fromScalaOrdering Ordering
     implicit val cidOrd: Order[Cid] = svalueOrd contramap SValue.SContractId
     val EmptyScope: Value.LookupVariantEnum = _ => None
-    "match SValue Ordering" in forAll(genAddend, minSuccessful(100)) { va =>
+    "match SValue Ordering" in forAll(genAddend, minSuccessful(20)) { va =>
       import va.{injarb, injshrink}
       implicit val valueOrd: Order[Value[Cid]] = Tag unsubst Value.orderInstance[Cid](EmptyScope)
-      forAll(minSuccessful(20)) { (a: va.Inj[Cid], b: va.Inj[Cid]) =>
+      forAll(minSuccessful(5)) { (a: va.Inj[Cid], b: va.Inj[Cid]) =>
         import va.injord
         val ta = va.inj(a)
         val tb = va.inj(b)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -150,13 +150,9 @@ class ValueSpec
       val EmptyScope: Value.LookupVariantEnum = _ => None
       implicit val ord: Order[T] = Tag unsubst Value.orderInstance(EmptyScope)
 
-      "obeys order laws" in forAll(genAddend, minSuccessful(100)) { va =>
+      "obeys order laws" in forAll(genAddend, minSuccessful(10)) { va =>
         implicit val arb: Arbitrary[T] = va.injarb[Cid] map (va.inj(_))
         checkLaws(SzP.order.laws[T])
-      }
-
-      "preserves base order" in forAll(genAddend, minSuccessful(100)) { va =>
-        checkOrderPreserved[Cid](va, EmptyScope)
       }
     }
 
@@ -194,7 +190,7 @@ class ValueSpec
           implicit val ord: Order[T] = Tag unsubst Value.orderInstance(scope)
           forEvery(Table("va", details.values.toSeq: _*)) { ea =>
             implicit val arb: Arbitrary[T] = ea.injarb[Cid] map (ea.inj(_))
-            forAll(minSuccessful(5)) { (a: T, b: T) =>
+            forAll(minSuccessful(20)) { (a: T, b: T) =>
               inside((a, b)) {
                 case (ValueEnum(_, ac), ValueEnum(_, bc)) =>
                   (a ?|? b) should ===((ea.values indexOf ac) ?|? (ea.values indexOf bc))

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -194,7 +194,7 @@ class ValueSpec
           implicit val ord: Order[T] = Tag unsubst Value.orderInstance(scope)
           forEvery(Table("va", details.values.toSeq: _*)) { ea =>
             implicit val arb: Arbitrary[T] = ea.injarb[Cid] map (ea.inj(_))
-            forAll(minSuccessful(20)) { (a: T, b: T) =>
+            forAll(minSuccessful(5)) { (a: T, b: T) =>
               inside((a, b)) {
                 case (ValueEnum(_, ac), ValueEnum(_, bc)) =>
                   (a ?|? b) should ===((ea.values indexOf ac) ?|? (ea.values indexOf bc))


### PR DESCRIPTION
Followup to #5526, to reduce outliers. A broader solution might be to revisit `genAddend`'s recursive cases; size reduction of values themselves is handled upstream.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
