### PR TITLE
drop v from release titles

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -317,7 +317,7 @@ jobs:
           tag: 'v$(release_tag)'
           assets: $(Build.StagingDirectory)/release/*
           assetUploadMode: 'replace'
-          title: 'v$(release_tag)'
+          title: '$(release_tag)'
           addChangeLog: false
           isPrerelease: true
         condition: not(eq(variables['skip-github'], 'TRUE'))


### PR DESCRIPTION
This is a minor, cosmetic change. Note that all our references to releases are based on tags, and do not depend on the release title. This is evidenced by the fairly random titles we used to have before the title was set by CI, see e.g. [0.13.53](https://github.com/digital-asset/daml/releases/tag/v0.13.53).

CHANGELOG_BEGIN
CHANGELOG_END