### PR TITLE
report compat status every day

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -38,4 +38,19 @@ jobs:
     steps:
       - checkout: self
       - template: ../compatibility.yml
-      - template: ../tell-slack-failed.yml
+      - bash: |
+          set -euo pipefail
+          COMMIT_TITLE=$(git log --pretty=format:%s -n1)
+          COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$COMMIT_TITLE>"
+          if [ "$(Agent.JobStatus)" != "Succeeded" ]; then
+              MESSAGE=":fire: <!here> :fire: :fire:\n$(Agent.JobName) *FAILED*: $COMMIT_LINK\n:fire: :fire:"
+          else
+              MESSAGE="$(Agent.JobName) passed: $COMMIT_LINK"
+          fi
+          curl -XPOST \
+               -i \
+               -H 'Content-type: application/json' \
+               --data "{\"text\":\"$MESSAGE\n\"}" \
+               $(Slack.team-daml)
+        displayName: report
+        condition: always()


### PR DESCRIPTION
I believe the compatibility check is important enough, and should fail rarely enough, that it is worth reporting even on success. This will mean (once we support Windows) 3 messages a day, sent while presumably nobody is working, so the disruption should be minimal.

The issue with reporting only on failures is that, if we don't proactively check (which we do for the state of master for different reasons, but would likely not keep doing for a job that doesn't block PRs), we may get into a state where it is so broken that it doesn't even report.

CHANGELOG_BEGIN
CHANGELOG_END