### PR TITLE
Fix link in README's of generated ts docs

### DIFF
--- a/language-support/ts/typedoc.bzl
+++ b/language-support/ts/typedoc.bzl
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@os_info//:os_info.bzl", "is_windows")
+load("@build_environment//:configuration.bzl", "sdk_version")
 
 def ts_docs(pkg_name):
     "Macro for Typescript documentation generation with typedoc"
@@ -15,6 +16,7 @@ def ts_docs(pkg_name):
           # NOTE: we need the --ignoreCompilerErrors flag because we get errors when tsc is trying to
           # resolve the imported packages.
           $(location @language_support_ts_deps//typedoc/bin:typedoc) --out docs --ignoreCompilerErrors --readme README.md --stripInternal $(SRCS)
+          sed -i -e 's/0.0.0-SDKVERSION/{sdk_version}/' docs/**/*.html
           tar -hc docs \
                --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
                | gzip -n > $@


### PR DESCRIPTION
This fixes a link in the generated documentation for the TypeScript libraries.
Note that the README on the npm registry and the README on docs.daml.com for
these libraries are the same. Hence the link on docs.daml.com will point to
itself.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
