### PR TITLE
Explore speedy execution steps.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -286,9 +286,8 @@ final class Engine {
       time: Time.Timestamp
   ): Result[(Tx.Transaction, Tx.Metadata)] = {
     while (!machine.isFinal) {
-      machine.step() match {
-        case SResultContinue =>
-          ()
+      machine.run() match {
+        case SResultFinalValue(_) => ()
 
         case SResultError(err) =>
           return ResultError(

--- a/daml-lf/interpreter/perf/BUILD.bazel
+++ b/daml-lf/interpreter/perf/BUILD.bazel
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+)
+
+da_scala_binary(
+    name = "explore",
+    srcs = glob(["src/main/**/*.scala"]),
+    main_class = "com.daml.lf.speedy.explore.Explore",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@maven//:ch_qos_logback_logback_classic",
+    ],
+    deps = [
+        "//daml-lf/data",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
+        "//daml-lf/transaction",
+    ],
+)

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+package explore
+
+import com.daml.lf.data._
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SResult._
+import com.daml.lf.speedy.SBuiltin._
+import com.daml.lf.speedy.Speedy._
+
+// Explore the execution of speedy machine on small examples.
+// Count & classify steps
+// Show lightweight trace with: --trace
+
+object Explore extends App {
+  PlaySpeedy.main(args.toList)
+}
+
+object PlaySpeedy {
+
+  def main(args0: List[String]) = {
+    val config: Config = parseArgs(args0)
+    val compiler: Compiler = Compiler(Map.empty)
+
+    val e: SExpr = compiler.unsafeCompile(examples(config.exampleName))
+    val m: Machine = makeMachine(e)
+    runMachine(config, m)
+  }
+
+  final case class Config(
+      exampleName: String,
+  )
+
+  def usage(): Unit = {
+    println("""
+     |usage: explore [EXAMPLE-NAME]
+    """.stripMargin)
+  }
+
+  def parseArgs(args0: List[String]): Config = {
+
+    var exampleName: String = "thrice-thrice"
+
+    def loop(args: List[String]): Unit = args match {
+      case Nil => {}
+      case "-h" :: _ => usage()
+      case "--help" :: _ => usage()
+      case name :: args =>
+        exampleName = name
+        loop(args)
+    }
+    loop(args0)
+    Config(exampleName)
+  }
+
+  private val txSeed = crypto.Hash.hashPrivateKey("SpeedyExplore")
+
+  def makeMachine(sexpr: SExpr): Machine = {
+    val compiledPackages: CompiledPackages = PureCompiledPackages(Map.empty).right.get
+    val compiler = Compiler(compiledPackages.packages)
+    Machine.fromSExpr(
+      sexpr,
+      compiledPackages,
+      Time.Timestamp.now(),
+      InitialSeeding(Some(txSeed)),
+      Set.empty,
+    )
+  }
+
+  def runMachine(config: Config, machine: Machine): Unit = {
+
+    println(s"example name: ${config.exampleName}")
+
+    machine.run() match {
+      case SResultFinalValue(value) => {
+        println(s"final-value: $value")
+      }
+      case res => throw new MachineProblem(s"Unexpected result from machine $res")
+    }
+  }
+
+  final case class MachineProblem(s: String) extends RuntimeException(s, null, false, false)
+
+  def examples: Map[String, SExpr] = {
+
+    def num(n: Long): SExpr = SEValue(SInt64(n))
+
+    // The trailing numeral is the number of args at the scala level
+
+    def decrement1(x: SExpr): SExpr = SEApp(SEBuiltin(SBSubInt64), Array(x, SEValue(SInt64(1))))
+    val decrement = SEAbs(1, decrement1(SEVar(1)))
+
+    def subtract2(x: SExpr, y: SExpr): SExpr = SEApp(SEBuiltin(SBSubInt64), Array(x, y))
+    val subtract = SEAbs(2, subtract2(SEVar(2), SEVar(1)))
+
+    def twice2(f: SExpr, x: SExpr): SExpr = SEApp(f, Array(SEApp(f, Array(x))))
+    val twice = SEAbs(2, twice2(SEVar(2), SEVar(1)))
+
+    def thrice2(f: SExpr, x: SExpr): SExpr = SEApp(f, Array(SEApp(f, Array(SEApp(f, Array(x))))))
+    val thrice = SEAbs(2, thrice2(SEVar(2), SEVar(1)))
+
+    Map(
+      "sub" -> subtract2(num(11), num(33)),
+      "sub/sub" -> subtract2(subtract2(num(1), num(3)), subtract2(num(5), num(10))),
+      "subF" -> SEApp(subtract, Array(num(88), num(55))),
+      "thrice" -> SEApp(thrice, Array(decrement, num(0))),
+      "thrice-thrice" -> SEApp(thrice, Array(thrice, decrement, num(0))),
+    )
+  }
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -1,0 +1,106 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import com.daml.lf.speedy.Speedy._
+import com.daml.lf.speedy.SExpr._
+
+object Classify { // classify the machine state w.r.t what step occurs next
+
+  case class Counts(
+      var steps: Int,
+      var returns: Int,
+      // expression classification (step)
+      var evalue: Int,
+      var evar: Int,
+      var eapp: Int,
+      var eclose: Int,
+      var ebuiltin: Int,
+      var eval: Int,
+      var elocation: Int,
+      var elet: Int,
+      var ecase: Int,
+      var ebuiltinrecursivedefinition: Int,
+      var ecatch: Int,
+      var eimportvalue: Int,
+      // kont classification (returnValue)
+      var kpop: Int,
+      var karg: Int,
+      var kfun: Int,
+      var kpushto: Int,
+      var kcacheval: Int,
+      var klocation: Int,
+      var kmatch: Int,
+      var kcatch: Int,
+  ) {
+    def pp: String = {
+      List(
+        ("Steps:", steps),
+        ("- evalue", evalue),
+        ("- evar", evar),
+        ("- eapp", eapp),
+        ("- eclose", eclose),
+        ("- ebuiltin", ebuiltin),
+        ("- eval", eval),
+        ("- elocation", elocation),
+        ("- elet", elet),
+        ("- ecase", ecase),
+        ("- ebuiltinrecursivedefinition", ebuiltinrecursivedefinition),
+        ("- ecatch", ecatch),
+        ("- eimportvalue", eimportvalue),
+        ("Returns:", returns),
+        ("- kpop", kpop),
+        ("- karg", karg),
+        ("- kfun", kfun),
+        ("- kpushto", kpushto),
+        ("- kcacheval", kcacheval),
+        ("- klocation", klocation),
+        ("- kmatch", kmatch),
+        ("- kcatch", kcatch),
+      ).map { case (tag, n) => s"$tag : $n" }.mkString("\n")
+    }
+  }
+
+  def newEmptyCounts(): Counts = {
+    Counts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+  }
+
+  def classifyStep(exp: SExpr, counts: Counts): Unit = {
+    counts.steps += 1
+    exp match {
+      case SEValue(_) => counts.evalue += 1
+      case SEVar(_) => counts.evar += 1
+      case SEApp(_, _) => counts.eapp += 1
+      case SEMakeClo(_, _, _) => counts.eclose += 1
+      case SEBuiltin(_) => counts.ebuiltin += 1
+      case SEVal(_, _) => counts.eval += 1
+      case SELocation(_, _) => counts.elocation += 1
+      case SELet(_, _) => counts.elet += 1
+      case SECase(_, _) => counts.ecase += 1
+      case SEBuiltinRecursiveDefinition(_) => counts.ebuiltinrecursivedefinition += 1
+      case SECatch(_, _, _) => counts.ecatch += 1
+      case SEWronglyTypeContractId(_, _, _) => ??? //not seen one yet
+      case SEImportValue(_) => ??? //not seen one yet
+      case SEAbs(_, _) => ??? //never expect these!
+    }
+  }
+
+  def classifyReturn(kont: Kont, counts: Counts): Unit = {
+    counts.returns += 1
+    kont match {
+      case KPop(_) => counts.kpop += 1
+      case KArg(_) => counts.karg += 1
+      case KFun(_, _, _) => counts.kfun += 1
+      case KPushTo(_, _) => counts.kpushto += 1
+      case KCacheVal(_, _) => counts.kcacheval += 1
+      case KLocation(_) => counts.klocation += 1
+      case KMatch(_) => counts.kmatch += 1
+      case KCatch(_, _, _) => counts.kcatch += 1
+    }
+  }
+
+  final case class ClassifyError(s: String) extends RuntimeException(s, null, false, false)
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -134,6 +134,11 @@ private[lf] final case class Compiler(packages: PackageId PartialFunction Packag
 
   @throws[PackageNotFound]
   @throws[CompilationError]
+  def unsafeCompile(sexpr: SExpr): SExpr =
+    validate(closureConvert(Map.empty, 0, sexpr))
+
+  @throws[PackageNotFound]
+  @throws[CompilationError]
   def unsafeCompileDefn(
       identifier: Identifier,
       defn: Definition,
@@ -995,6 +1000,12 @@ private[lf] final case class Compiler(packages: PackageId PartialFunction Packag
           closureConvert(remaps, bound, handler),
           closureConvert(remaps, bound, fin),
         )
+
+      case x: SEWronglyTypeContractId =>
+        throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
+
+      case x: SEImportValue =>
+        throw CompilationError(s"unexpected SEImportValue: $x")
     }
   }
 
@@ -1043,6 +1054,10 @@ private[lf] final case class Compiler(packages: PackageId PartialFunction Packag
           go(body)
           go(handler)
           go(fin)
+        case x: SEWronglyTypeContractId =>
+          throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
+        case x: SEImportValue =>
+          throw CompilationError(s"unexpected SEImportValue: $x")
       }
     go(expr)
     free
@@ -1119,6 +1134,10 @@ private[lf] final case class Compiler(packages: PackageId PartialFunction Packag
           go(fin)
         case SELocation(_, body) =>
           go(body)
+        case x: SEWronglyTypeContractId =>
+          throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
+        case x: SEImportValue =>
+          throw CompilationError(s"unexpected SEImportValue: $x")
       }
     go(expr)
     expr

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import java.util
+import scala.collection.JavaConverters._
+
+import com.daml.lf.speedy.Speedy._
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.SValue._
+
+object PrettyLightweight { // lightweight pretty printer for CEK machine states
+
+  def ppMachine(m: Machine): String = {
+    s"${ppEnv(m.env)} -- ${pp(m.ctrl)} -- ${ppKontStack(m.kontStack)}"
+  }
+
+  def ppEnv(env: Env): String = {
+    s"{${commas(env.asScala.map(pp))}}"
+  }
+
+  def ppKontStack(ks: util.ArrayList[Kont]): String = {
+    ks.asScala.reverse.map(ppKont).mkString(" -- ")
+  }
+
+  def ppKont(k: Kont): String = k match {
+    case KPop(n) => s"KPop($n)"
+    case KArg(es) => s"KArg(${commas(es.map(pp))})"
+    case KFun(prim, extendedArgs, arity) =>
+      s"KFun(${pp(prim)}/$arity,[${commas(extendedArgs.asScala.map(pp))}])"
+    case KPushTo(_, e) => s"KPushTo(_, ${pp(e)})"
+    case KCacheVal(_, _) => "KCacheVal"
+    case KLocation(_) => "KLocation"
+    case KMatch(_) => "KMatch"
+    case KCatch(_, _, _) => "KCatch" //never seen
+  }
+
+  def ppVarRef(n: Int): String = {
+    s"#$n"
+  }
+
+  def pp(e: SExpr): String = e match {
+    case SEValue(v) => pp(v)
+    case SEVar(n) => ppVarRef(n)
+
+    //case SEApp(func, args) => s"@(${pp(func)},${commas(args.map(pp))})"
+    case SEApp(_, _) => s"@(...)"
+
+    //case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(ppVarRef))}]lam/$arity->${pp(body)}"
+    case SEMakeClo(fvs, arity, _) => s"[${commas(fvs.map(ppVarRef))}]lam/$arity->..."
+
+    case SEBuiltin(b) => s"${b}"
+    case SEVal(_, _) => "<SEVal...>"
+    case SELocation(_, _) => "<SELocation...>"
+    case SELet(_, _) => "<SELet...>"
+    case SECase(_, _) => "<SECase...>"
+    case SEBuiltinRecursiveDefinition(_) => "<SEBuiltinRecursiveDefinition...>"
+    case SECatch(_, _, _) => ??? //not seen one yet
+    case SEWronglyTypeContractId(_, _, _) => ??? //not seen one yet
+    case SEImportValue(_) => ??? //not seen one yet
+    case SEAbs(_, _) => "<SEAbs...>" // will never get these on running machine
+  }
+
+  def pp(v: SValue): String = v match {
+    case SInt64(n) => s"$n"
+    case SPAP(prim, args, arity) =>
+      s"PAP[${args.size}/$arity](${pp(prim)}(${commas(args.asScala.map(pp))})))"
+    case SToken => "SToken"
+    case SText(s) => s"'$s'"
+    case SParty(_) => "<SParty>"
+    case SStruct(_, _) => "<SStruct...>"
+    case SUnit => "SUnit"
+    case SList(_) => "SList"
+    case _ => throw UnknownV(v)
+  }
+
+  def pp(prim: Prim): String = prim match {
+    case PBuiltin(b) => s"$b"
+    case PClosure(expr, fvs) =>
+      s"clo[${commas(fvs.map(pp))}]:${pp(expr)}"
+  }
+
+  def commas(xs: Seq[String]): String = xs.mkString(",")
+
+  final case class UnknownV(v: SValue) extends RuntimeException(v.toString)
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -13,15 +13,10 @@ import com.daml.lf.data.Numeric.Scale
 import com.daml.lf.language.Ast
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.Speedy.{
-  CtrlImportValue,
-  CtrlValue,
-  CtrlWronglyTypeContractId,
-  Machine,
-  SpeedyHungry
-}
+import com.daml.lf.speedy.Speedy.{Machine, SpeedyHungry}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SValue.{SValue => sv}
 import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.ValueVersions.asVersionedValue
@@ -114,7 +109,7 @@ object SBuiltin {
 
   sealed abstract class SBBinaryOpInt64(op: (Long, Long) => Long) extends SBuiltin(2) {
     final def execute(args: util.ArrayList[SValue], machine: Machine): Unit =
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         (args.get(0), args.get(1)) match {
           case (SInt64(a), SInt64(b)) => SInt64(op(a, b))
           case _ => crash(s"type mismatch add: $args")
@@ -166,7 +161,7 @@ object SBuiltin {
       val a = args.get(1).asInstanceOf[SNumeric].value
       val b = args.get(2).asInstanceOf[SNumeric].value
       assert(a.scale == scale && b.scale == scale)
-      machine.ctrl = CtrlValue(SNumeric(op(a, b)))
+      machine.returnValue(SNumeric(op(a, b)))
     }
   }
 
@@ -179,7 +174,7 @@ object SBuiltin {
       val a = args.get(3).asInstanceOf[SNumeric].value
       val b = args.get(4).asInstanceOf[SNumeric].value
       assert(a.scale == scaleA && b.scale == scaleB)
-      machine.ctrl = CtrlValue(SNumeric(op(scale, a, b)))
+      machine.returnValue(SNumeric(op(scale, a, b)))
     }
   }
 
@@ -193,7 +188,7 @@ object SBuiltin {
       val scale = args.get(0).asInstanceOf[STNat].n
       val prec = args.get(1).asInstanceOf[SInt64].value
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SNumeric(
           rightOrArithmeticError(s"Error while rounding (Numeric $scale)", Numeric.round(prec, x)),
         ),
@@ -206,7 +201,7 @@ object SBuiltin {
       val inputScale = args.get(0).asInstanceOf[STNat].n
       val outputScale = args.get(1).asInstanceOf[STNat].n
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SNumeric(
           rightOrArithmeticError(
             s"Error while casting (Numeric $inputScale) to (Numeric $outputScale)",
@@ -222,7 +217,7 @@ object SBuiltin {
       val inputScale = args.get(0).asInstanceOf[STNat].n
       val outputScale = args.get(1).asInstanceOf[STNat].n
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SNumeric(
           rightOrArithmeticError(
             s"Error while shifting (Numeric $inputScale) to (Numeric $outputScale)",
@@ -238,7 +233,7 @@ object SBuiltin {
   //
   final case object SBExplodeText extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case SText(t) =>
             SList(FrontStack(Utf8.explode(t).map(SText)))
@@ -251,7 +246,7 @@ object SBuiltin {
 
   final case object SBImplodeText extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case SList(xs) =>
             val ts = xs.map {
@@ -269,7 +264,7 @@ object SBuiltin {
 
   final case object SBAppendText extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         (args.get(0), args.get(1)) match {
           case (SText(head), SText(tail)) =>
             SText(head + tail)
@@ -282,7 +277,7 @@ object SBuiltin {
 
   final case object SBToText extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(litToText(args))
+      machine.returnValue(litToText(args))
     }
 
     def litToText(vs: util.ArrayList[SValue]): SValue = {
@@ -303,30 +298,30 @@ object SBuiltin {
   final case object SBToTextNumeric extends SBuiltin(2) {
     override def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val x = args.get(1).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(SText(Numeric.toUnscaledString(x)))
+      machine.returnValue(SText(Numeric.toUnscaledString(x)))
     }
   }
 
   final case object SBToQuotedTextParty extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val v = args.get(0).asInstanceOf[SParty]
-      machine.ctrl = CtrlValue(SText(s"'${v.value: String}'"))
+      machine.returnValue(SText(s"'${v.value: String}'"))
     }
   }
 
   final case object SBToTextCodePoints extends SBuiltin(1) {
     override def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val codePoints = args.get(0).asInstanceOf[SList].list.map(_.asInstanceOf[SInt64].value)
-      machine.ctrl = CtrlValue(SText(Utf8.pack(codePoints.toImmArray)))
+      machine.returnValue(SText(Utf8.pack(codePoints.toImmArray)))
     }
   }
 
   final case object SBFromTextParty extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val v = args.get(0).asInstanceOf[SText]
-      machine.ctrl = Party.fromString(v.value) match {
-        case Left(_) => CtrlValue.None
-        case Right(p) => CtrlValue(SOptional(Some(SParty(p))))
+      Party.fromString(v.value) match {
+        case Left(_) => machine.returnValue(sv.None)
+        case Right(p) => machine.returnValue(SOptional(Some(SParty(p))))
       }
     }
   }
@@ -336,15 +331,14 @@ object SBuiltin {
 
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val s = args.get(0).asInstanceOf[SText].value
-      machine.ctrl =
-        if (pattern.matcher(s).matches())
-          try {
-            CtrlValue(SOptional(Some(SInt64(java.lang.Long.parseLong(s)))))
-          } catch {
-            case _: NumberFormatException =>
-              CtrlValue.None
-          } else
-          CtrlValue.None
+      if (pattern.matcher(s).matches())
+        try {
+          machine.returnValue(SOptional(Some(SInt64(java.lang.Long.parseLong(s)))))
+        } catch {
+          case _: NumberFormatException =>
+            machine.returnValue(sv.None)
+        } else
+        machine.returnValue(sv.None)
     }
   }
 
@@ -359,7 +353,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val string = args.get(1).asInstanceOf[SText].value
-      machine.ctrl = string match {
+      string match {
         case validFormat(signPart, intPart, _, decPartOrNull) =>
           val decPart = Option(decPartOrNull).filterNot(_ == "0").getOrElse("")
           // First, we count the number of significant digits to avoid the conversion attempts that
@@ -371,14 +365,14 @@ object SBuiltin {
             // potentially very costly String to BigDecimal conversions. Take for example the String
             // "1." followed by millions of '0's
             val newString = s"$signPart$intPart.${Option(decPartOrNull).getOrElse("")}"
-            CtrlValue(
+            machine.returnValue(
               SOptional(Some(SNumeric(Numeric.assertFromBigDecimal(scale, BigDecimal(newString))))),
             )
           } else {
-            CtrlValue.None
+            machine.returnValue(sv.None)
           }
         case _ =>
-          CtrlValue.None
+          machine.returnValue(sv.None)
       }
     }
   }
@@ -387,13 +381,13 @@ object SBuiltin {
     override def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val string = args.get(0).asInstanceOf[SText].value
       val codePoints = Utf8.unpack(string)
-      machine.ctrl = CtrlValue(SList(FrontStack(codePoints.map(SInt64))))
+      machine.returnValue(SList(FrontStack(codePoints.map(SInt64))))
     }
   }
 
   final case object SBSHA256Text extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SText(t) => SText(Utf8.sha256(t))
         case _ =>
           throw SErrorCrash(s"type mismatch textSHA256: $args")
@@ -403,7 +397,7 @@ object SBuiltin {
 
   final case object SBTextMapInsert extends SBuiltin(3) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(2) match {
+      machine.returnValue(args.get(2) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -419,7 +413,7 @@ object SBuiltin {
 
   final case object SBTextMapLookup extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(1) match {
+      machine.returnValue(args.get(1) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -435,7 +429,7 @@ object SBuiltin {
 
   final case object SBTextMapDelete extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(1) match {
+      machine.returnValue(args.get(1) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -452,7 +446,7 @@ object SBuiltin {
   final case object SBTextMapToList extends SBuiltin(1) {
 
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case map: STextMap =>
           SValue.toList(map)
         case x =>
@@ -463,7 +457,7 @@ object SBuiltin {
 
   final case object SBTextMapSize extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case STextMap(map) =>
           SInt64(map.size.toLong)
         case x =>
@@ -474,7 +468,7 @@ object SBuiltin {
 
   final case object SBGenMapInsert extends SBuiltin(3) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(2) match {
+      machine.returnValue(args.get(2) match {
         case SGenMap(map) =>
           val key = args.get(0)
           SGenMap.comparable(key)
@@ -487,7 +481,7 @@ object SBuiltin {
 
   final case object SBGenMapLookup extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(1) match {
+      machine.returnValue(args.get(1) match {
         case SGenMap(value) =>
           val key = args.get(0)
           SGenMap.comparable(key)
@@ -500,7 +494,7 @@ object SBuiltin {
 
   final case object SBGenMapDelete extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(1) match {
+      machine.returnValue(args.get(1) match {
         case SGenMap(value) =>
           val key = args.get(0)
           SGenMap.comparable(key)
@@ -513,7 +507,7 @@ object SBuiltin {
 
   final case object SBGenMapKeys extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SGenMap(value) =>
           SList(ImmArray(value.keys) ++: FrontStack.empty)
         case x =>
@@ -524,7 +518,7 @@ object SBuiltin {
 
   final case object SBGenMapValues extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SGenMap(value) =>
           SList(ImmArray(value.values) ++: FrontStack.empty)
         case x =>
@@ -535,7 +529,7 @@ object SBuiltin {
 
   final case object SBGenMapSize extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SGenMap(value) =>
           SInt64(value.size.toLong)
         case x =>
@@ -552,7 +546,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val x = args.get(1).asInstanceOf[SInt64].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SNumeric(
           rightOrArithmeticError(
             s"overflow when converting $x to (Numeric $scale)",
@@ -566,7 +560,7 @@ object SBuiltin {
   final case object SBNumericToInt64 extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val x = args.get(1).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SInt64(
           rightOrArithmeticError(
             s"Int64 overflow when converting ${Numeric.toString(x)} to Int64",
@@ -579,7 +573,7 @@ object SBuiltin {
 
   final case object SBDateToUnixDays extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SDate(d) => SInt64(d.days.toLong)
         case _ =>
           throw SErrorCrash(s"type mismatch dateToUnixDays: $args")
@@ -589,7 +583,7 @@ object SBuiltin {
 
   final case object SBUnixDaysToDate extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case SInt64(days) =>
             SDate(
@@ -607,7 +601,7 @@ object SBuiltin {
 
   final case object SBTimestampToUnixMicroseconds extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case STimestamp(t) => SInt64(t.micros)
           case _ =>
@@ -619,7 +613,7 @@ object SBuiltin {
 
   final case object SBUnixMicrosecondsToTimestamp extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case SInt64(t) =>
             STimestamp(
@@ -640,13 +634,13 @@ object SBuiltin {
   //
   final case object SBEqual extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue.bool(svalue.Equality.areEqual(args.get(0), args.get(1)))
+      machine.returnValue(SBool(svalue.Equality.areEqual(args.get(0), args.get(1))))
     }
   }
 
   sealed abstract class SBCompare(pred: Int => Boolean) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue.bool(pred(svalue.Ordering.compare(args.get(0), args.get(1))))
+      machine.returnValue(SBool(pred(svalue.Ordering.compare(args.get(0), args.get(1)))))
     }
   }
 
@@ -658,7 +652,7 @@ object SBuiltin {
   /** $consMany[n] :: a -> ... -> List a -> List a */
   final case class SBConsMany(n: Int) extends SBuiltin(1 + n) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(n) match {
+      machine.returnValue(args.get(n) match {
         case SList(tail) =>
           SList(ImmArray(args.subList(0, n).asScala) ++: tail)
         case x =>
@@ -670,7 +664,7 @@ object SBuiltin {
   /** $some :: a -> Optional a */
   final case object SBSome extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SOptional(Some(args.get(0))))
+      machine.returnValue(SOptional(Some(args.get(0))))
     }
   }
 
@@ -679,14 +673,14 @@ object SBuiltin {
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SRecord(id, fields, args))
+      machine.returnValue(SRecord(id, fields, args))
     }
   }
 
   /** $rupd[R, field] :: R -> a -> R */
   final case class SBRecUpd(id: Identifier, field: Int) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SRecord(id2, fields, values) =>
           if (id != id2) {
             crash(s"type mismatch on record update: expected $id, got record of type $id2")
@@ -703,7 +697,7 @@ object SBuiltin {
   /** $rproj[R, field] :: R -> a */
   final case class SBRecProj(id: Identifier, field: Int) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SRecord(id @ _, _, values) => values.get(field)
         case v =>
           crash(s"RecProj on non-record: $v")
@@ -716,14 +710,14 @@ object SBuiltin {
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SStruct(fields, args))
+      machine.returnValue(SStruct(fields, args))
     }
   }
 
   /** $tproj[field] :: Struct -> a */
   final case class SBStructProj(field: Ast.FieldName) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SStruct(fields, values) =>
           values.get(fields.indexOf(field))
         case v =>
@@ -735,7 +729,7 @@ object SBuiltin {
   /** $tupd[field] :: Struct -> a -> Struct */
   final case class SBStructUpd(field: Ast.FieldName) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SStruct(fields, values) =>
           val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
           values2.set(fields.indexOf(field), args.get(1))
@@ -750,7 +744,7 @@ object SBuiltin {
   final case class SBVariantCon(id: Identifier, variant: Ast.VariantConName, constructorRank: Int)
       extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SVariant(id, variant, constructorRank, args.get(0)))
+      machine.returnValue(SVariant(id, variant, constructorRank, args.get(0)))
     }
   }
 
@@ -779,7 +773,7 @@ object SBuiltin {
         case v =>
           crash(s"PrecondCheck on non-boolean: $v")
       }
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SUnit)
     }
   }
 
@@ -821,7 +815,7 @@ object SBuiltin {
 
       machine.addLocalContract(coid, templateId, createArg)
       machine.ptx = newPtx
-      machine.ctrl = CtrlValue(SContractId(coid))
+      machine.returnValue(SContractId(coid))
       checkAborted(machine.ptx)
     }
   }
@@ -884,7 +878,7 @@ object SBuiltin {
         )
         .fold(err => throw DamlETransactionError(err), identity)
       checkAborted(machine.ptx)
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SUnit)
     }
   }
 
@@ -902,7 +896,7 @@ object SBuiltin {
           case Left(err) => crash(err)
           case Right(x) => x
         })
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SUnit)
       checkAborted(machine.ptx)
     }
   }
@@ -925,7 +919,7 @@ object SBuiltin {
           if (tmplId != templateId)
             crash(s"contract $coid ($templateId) not found from partial transaction")
           else
-            machine.ctrl = CtrlValue(contract)
+            machine.returnValue(contract)
         case None =>
           coid match {
             case acoid: V.AbsoluteContractId =>
@@ -940,9 +934,9 @@ object SBuiltin {
                     // set the control appropriately which will crash the machine
                     // correctly later.
                     if (coinst.template != templateId)
-                      machine.ctrl = CtrlWronglyTypeContractId(acoid, templateId, coinst.template)
+                      machine.ctrl = SEWronglyTypeContractId(acoid, templateId, coinst.template)
                     else
-                      machine.ctrl = CtrlImportValue(coinst.arg.value)
+                      machine.ctrl = SEImportValue(coinst.arg.value)
                   },
                 ),
               )
@@ -990,7 +984,7 @@ object SBuiltin {
         key,
         byKey,
       )
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SUnit)
       checkAborted(machine.ptx)
     }
   }
@@ -1008,7 +1002,10 @@ object SBuiltin {
       // check if we find it locally
       machine.ptx.keys.get(gkey) match {
         case Some(mbCoid) =>
-          machine.ctrl = CtrlValue(SOptional(mbCoid.map(SContractId)))
+          //machine.ctrl = CtrlValue(SOptional(mbCoid.map(SContractId)))
+          machine.returnValue(SOptional(mbCoid.map { coid =>
+            SContractId(coid)
+          }))
         case None =>
           // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
           // that.
@@ -1021,11 +1018,11 @@ object SBuiltin {
                   // We have to check that the discriminator of cid does not conflict with a local ones
                   // however we cannot raise an exception in case of failure here.
                   // We delegate to CtrlImportValue the task to check cid.
-                  machine.ctrl = CtrlImportValue(V.ValueOptional(Some(V.ValueContractId(cid))))
+                  machine.ctrl = SEImportValue(V.ValueOptional(Some(V.ValueContractId(cid))))
                   true
                 case SKeyLookupResult.NotFound =>
                   machine.ptx = machine.ptx.copy(keys = machine.ptx.keys + (gkey -> None))
-                  machine.ctrl = CtrlValue.None
+                  machine.returnValue(sv.None)
                   true
                 case SKeyLookupResult.NotVisible =>
                   machine.tryHandleException()
@@ -1063,7 +1060,7 @@ object SBuiltin {
         ),
         mbCoid,
       )
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(sv.Unit)
       checkAborted(machine.ptx)
     }
   }
@@ -1083,7 +1080,7 @@ object SBuiltin {
         case Some(None) =>
           crash(s"Could not find key $gkey")
         case Some(Some(coid)) =>
-          machine.ctrl = CtrlValue(SContractId(coid))
+          machine.returnValue(SContractId(coid))
         case None =>
           // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
           // that.
@@ -1096,7 +1093,7 @@ object SBuiltin {
                   // We have to check that the discriminator of cid does not conflict with a local ones
                   // however we cannot raise an exception in case of failure here.
                   // We delegate to CtrlImportValue the task to check cid.
-                  machine.ctrl = CtrlImportValue(V.ValueContractId(cid))
+                  machine.ctrl = SEImportValue(V.ValueContractId(cid))
                   true
                 case SKeyLookupResult.NotFound | SKeyLookupResult.NotVisible =>
                   machine.ptx = machine.ptx.copy(keys = machine.ptx.keys + (gkey -> None))
@@ -1114,7 +1111,7 @@ object SBuiltin {
       checkToken(args.get(0))
       // $ugettime :: Token -> Timestamp
       throw SpeedyHungry(
-        SResultNeedTime(timestamp => machine.ctrl = CtrlValue(STimestamp(timestamp))),
+        SResultNeedTime(timestamp => machine.returnValue(STimestamp(timestamp))),
       )
     }
   }
@@ -1127,7 +1124,7 @@ object SBuiltin {
       machine.globalDiscriminators = Set.empty
       machine.committers = extractParties(args.get(0))
       machine.commitLocation = optLocation
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(sv.Unit)
     }
   }
 
@@ -1153,19 +1150,19 @@ object SBuiltin {
           // update expression threw an exception. we're
           // now done.
           machine.clearCommit
-          machine.ctrl = CtrlValue.Unit
+          machine.returnValue(sv.Unit)
           throw SpeedyHungry(SResultScenarioInsertMustFail(committerOld, commitLocationOld))
 
         case SBool(false) =>
           ptxOld.finish match {
             case Left(_) =>
               machine.clearCommit
-              machine.ctrl = CtrlValue.Unit
+              machine.returnValue(sv.Unit)
             case Right(tx) =>
               // Transaction finished successfully. It might still
               // fail when committed, so tell the scenario runner to
               // do that.
-              machine.ctrl = CtrlValue.Unit
+              machine.returnValue(sv.Unit)
               throw SpeedyHungry(
                 SResultScenarioMustFail(tx, committerOld, _ => machine.clearCommit))
           }
@@ -1191,7 +1188,7 @@ object SBuiltin {
           committers = machine.committers,
           callback = newValue => {
             machine.clearCommit
-            machine.ctrl = CtrlValue(newValue)
+            machine.returnValue(newValue)
           },
         ),
       )
@@ -1210,7 +1207,7 @@ object SBuiltin {
       throw SpeedyHungry(
         SResultScenarioPassTime(
           relTime,
-          timestamp => machine.ctrl = CtrlValue(STimestamp(timestamp)),
+          timestamp => machine.returnValue(STimestamp(timestamp)),
         ),
       )
     }
@@ -1223,7 +1220,7 @@ object SBuiltin {
       args.get(0) match {
         case SText(name) =>
           throw SpeedyHungry(
-            SResultScenarioGetParty(name, party => machine.ctrl = CtrlValue(SParty(party))),
+            SResultScenarioGetParty(name, party => machine.returnValue(SParty(party))),
           )
         case v =>
           crash(s"invalid argument to GetParty: $v")
@@ -1237,7 +1234,7 @@ object SBuiltin {
       args.get(0) match {
         case SText(message) =>
           machine.traceLog.add(message, machine.lastLocation)
-          machine.ctrl = CtrlValue(args.get(1))
+          machine.returnValue(args.get(1))
         case v =>
           crash(s"invalid argument to trace: $v")
       }
@@ -1256,7 +1253,7 @@ object SBuiltin {
     */
   final case class SBToAny(ty: Ast.Type) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SAny(ty, args.get(0)))
+      machine.returnValue(SAny(ty, args.get(0)))
     }
   }
 
@@ -1266,7 +1263,7 @@ object SBuiltin {
     */
   final case class SBFromAny(expectedTy: Ast.Type) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SAny(actualTy, v) =>
           SOptional(if (actualTy == expectedTy) Some(v) else None)
         case v => crash(s"FromAny applied to non-Any: $v")
@@ -1281,7 +1278,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       args.get(0) match {
         case SText(t) =>
-          machine.ctrl = CtrlValue(SText(t.toUpperCase(util.Locale.ROOT)))
+          machine.returnValue(SText(t.toUpperCase(util.Locale.ROOT)))
         // TODO [FM]: replace with ASCII-specific function, or not
         case x =>
           throw SErrorCrash(s"type mismatch SBTextoUpper, expected Text got $x")
@@ -1294,7 +1291,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       args.get(0) match {
         case SText(t) =>
-          machine.ctrl = CtrlValue(SText(t.toLowerCase(util.Locale.ROOT)))
+          machine.returnValue(SText(t.toLowerCase(util.Locale.ROOT)))
         // TODO [FM]: replace with ASCII-specific function, or not
         case x =>
           throw SErrorCrash(s"type mismatch SBTextToLower, expected Text got $x")
@@ -1313,7 +1310,7 @@ object SBuiltin {
                 case SText(t) =>
                   val length = t.codePointCount(0, t.length).toLong
                   if (to <= 0 || from >= length || to <= from) {
-                    machine.ctrl = CtrlValue(SText(""))
+                    machine.returnValue(SText(""))
                   } else {
                     val rfrom = from.max(0).toInt
                     val rto = to.min(length).toInt
@@ -1324,7 +1321,7 @@ object SBuiltin {
                     // empty string below even though `to` was larger than length.
                     val ifrom = t.offsetByCodePoints(0, rfrom)
                     val ito = t.offsetByCodePoints(ifrom, rto - rfrom)
-                    machine.ctrl = CtrlValue(SText(t.slice(ifrom, ito)))
+                    machine.returnValue(SText(t.slice(ifrom, ito)))
                   }
                 case x =>
                   throw SErrorCrash(s"type mismatch SBTextSlice, expected Text got $x")
@@ -1347,10 +1344,10 @@ object SBuiltin {
             case SText(t) =>
               val n = t.indexOfSlice(slice) // n is -1 if slice is not found.
               if (n < 0) {
-                machine.ctrl = CtrlValue(SOptional(None))
+                machine.returnValue(SOptional(None))
               } else {
                 val rn = t.codePointCount(0, n).toLong // we want to return the number of codepoints!
-                machine.ctrl = CtrlValue(SOptional(Some(SInt64(rn))))
+                machine.returnValue(SOptional(Some(SInt64(rn))))
               }
             case x =>
               throw SErrorCrash(s"type mismatch SBTextSliceIndex, expected Text got $x")
@@ -1370,7 +1367,7 @@ object SBuiltin {
             case SText(t) =>
               val alphabetSet = alphabet.codePoints().iterator().asScala.toSet
               val result = t.codePoints().iterator().asScala.forall(alphabetSet.contains(_))
-              machine.ctrl = CtrlValue(SBool(result))
+              machine.returnValue(SBool(result))
             case x =>
               throw SErrorCrash(s"type mismatch SBTextContainsOnly, expected Text got $x")
           }
@@ -1388,10 +1385,10 @@ object SBuiltin {
           args.get(1) match {
             case SText(t) =>
               if (n < 0) {
-                machine.ctrl = CtrlValue(SText(""))
+                machine.returnValue(SText(""))
               } else {
                 val rn = n.min(Int.MaxValue.toLong).toInt
-                machine.ctrl = CtrlValue(SText(t * rn))
+                machine.returnValue(SText(t * rn))
               }
             case x =>
               throw SErrorCrash(s"type mismatch SBTextReplicate, expected Text got $x")
@@ -1419,7 +1416,7 @@ object SBuiltin {
                   // and we want to keep empty strings, so we use -1 as the second argument.
                   t.split(Pattern.quote(pattern), -1).map(SText).toSeq
                 }
-              machine.ctrl = CtrlValue(SList(FrontStack(seq)))
+              machine.returnValue(SList(FrontStack(seq)))
             case x =>
               throw SErrorCrash(s"type mismatch SBTextSplitOn, expected Text got $x")
           }
@@ -1445,7 +1442,7 @@ object SBuiltin {
                     )
                 }
               }
-              machine.ctrl = CtrlValue(SText(xs.iterator.mkString(sep)))
+              machine.returnValue(SText(xs.iterator.mkString(sep)))
             case x =>
               throw SErrorCrash(s"type mismatch SBTextIntercalate, expected List got $x")
           }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -9,8 +9,11 @@ package com.daml.lf.speedy
   * This reduces the number of binding forms by moving update and scenario
   * expressions into builtins.
   */
+import java.util
+
 import com.daml.lf.language.Ast._
 import com.daml.lf.data.Ref._
+import com.daml.lf.value.{Value => V}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SError._
@@ -24,8 +27,7 @@ import java.util.ArrayList
   * - all update and scenario operations converted to builtin functions.
   */
 sealed abstract class SExpr extends Product with Serializable {
-  def execute(machine: Machine): Ctrl
-
+  def execute(machine: Machine): Unit
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override def toString: String =
     productPrefix + productIterator.map(SExpr.prettyPrint).mkString("(", ",", ")")
@@ -39,8 +41,8 @@ object SExpr {
     * https://en.wikipedia.org/wiki/De_Bruijn_index
     */
   final case class SEVar(index: Int) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
-      CtrlValue(machine.getEnv(index))
+    def execute(machine: Machine): Unit = {
+      machine.returnValue(machine.getEnv(index))
     }
   }
 
@@ -51,27 +53,29 @@ object SExpr {
       ref: SDefinitionRef,
       var cached: Option[(SValue, List[Location])],
   ) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       machine.lookupVal(this)
     }
   }
 
   /** Reference to a builtin function */
   final case class SEBuiltin(b: SBuiltin) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       /* special case for nullary record constructors */
       b match {
         case SBRecCon(id, fields) if b.arity == 0 =>
-          CtrlValue(SRecord(id, fields, new ArrayList()))
+          machine.returnValue(SRecord(id, fields, new ArrayList()))
         case _ =>
-          Ctrl.fromPrim(PBuiltin(b), b.arity)
+          machine.returnValue(SPAP(PBuiltin(b), new util.ArrayList[SValue](), b.arity))
       }
     }
   }
 
   /** A pre-computed value, usually primitive literal, e.g. integer, text, boolean etc. */
   final case class SEValue(v: SValue) extends SExpr {
-    def execute(machine: Machine): Ctrl = CtrlValue(v)
+    def execute(machine: Machine): Unit = {
+      machine.returnValue(v)
+    }
   }
 
   object SEValue extends SValueContainer[SEValue]
@@ -80,9 +84,9 @@ object SExpr {
     * evaluates to a builtin or a closure.
     */
   final case class SEApp(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
-    def execute(machine: Machine): Ctrl = {
-      machine.kont.add(KArg(args))
-      CtrlExpr(fun)
+    def execute(machine: Machine): Unit = {
+      machine.pushKont(KArg(args))
+      machine.ctrl = fun
     }
   }
 
@@ -91,7 +95,7 @@ object SExpr {
     * can be written against this simplified expression type.
     */
   final case class SEAbs(arity: Int, body: SExpr) extends SExpr {
-    def execute(machine: Machine): Ctrl =
+    def execute(machine: Machine): Unit =
       crash("unexpected SEAbs, expected SEMakeClo")
   }
 
@@ -110,7 +114,7 @@ object SExpr {
       extends SExpr
       with SomeArrayEquals {
 
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       def convertToSValues(fv: Array[Int], getEnv: Int => SValue) = {
         val sValues = new Array[SValue](fv.length)
         var i = 0
@@ -122,15 +126,15 @@ object SExpr {
       }
 
       val sValues = convertToSValues(fv, machine.getEnv)
-      Ctrl.fromPrim(PClosure(body, sValues), arity)
+      machine.returnValue(SPAP(PClosure(body, sValues), new util.ArrayList[SValue](), arity))
     }
   }
 
   /** Pattern match. */
   final case class SECase(scrut: SExpr, alts: Array[SCaseAlt]) extends SExpr with SomeArrayEquals {
-    def execute(machine: Machine): Ctrl = {
-      machine.kont.add(KMatch(alts))
-      CtrlExpr(scrut)
+    def execute(machine: Machine): Unit = {
+      machine.pushKont(KMatch(alts))
+      machine.ctrl = scrut
     }
 
     override def toString: String = s"SECase($scrut, ${alts.mkString("[", ",", "]")})"
@@ -155,19 +159,19 @@ object SExpr {
     * with later expressions possibly referring to earlier.
     */
   final case class SELet(bounds: Array[SExpr], body: SExpr) extends SExpr with SomeArrayEquals {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       // Pop the block once we're done evaluating the body
-      machine.kont.add(KPop(bounds.size))
+      machine.pushKont(KPop(bounds.size))
 
       // Evaluate the body after we've evaluated the binders
-      machine.kont.add(KPushTo(machine.env, body))
+      machine.pushKont(KPushTo(machine.env, body))
 
       // Start evaluating the let binders
       for (i <- 1 until bounds.size) {
         val b = bounds(bounds.size - i)
-        machine.kont.add(KPushTo(machine.env, b))
+        machine.pushKont(KPushTo(machine.env, b))
       }
-      CtrlExpr(bounds.head)
+      machine.ctrl = bounds.head
     }
   }
 
@@ -193,9 +197,9 @@ object SExpr {
     * variable of the machine. When commit is begun the location is stored in 'commitLocation'.
     */
   final case class SELocation(loc: Location, expr: SExpr) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       machine.pushLocation(loc)
-      CtrlExpr(expr)
+      machine.ctrl = expr
     }
   }
 
@@ -207,9 +211,32 @@ object SExpr {
     * to access the value returned from 'body'.
     */
   final case class SECatch(body: SExpr, handler: SExpr, fin: SExpr) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
-      machine.kont.add(KCatch(handler, fin, machine.env.size))
-      CtrlExpr(body)
+    def execute(machine: Machine): Unit = {
+      machine.pushKont(KCatch(handler, fin, machine.env.size))
+      machine.ctrl = body
+    }
+  }
+
+  /** When we fetch a contract id from upstream we cannot crash in the upstream
+    * calls. Rather, we set the control to this expression and then crash when executing.
+    */
+  final case class SEWronglyTypeContractId(
+      acoid: V.AbsoluteContractId,
+      expected: TypeConName,
+      actual: TypeConName,
+  ) extends SExpr {
+    def execute(machine: Machine): Unit = {
+      throw DamlEWronglyTypedContract(acoid, expected, actual)
+    }
+  }
+
+  // This translates a well-typed LF value (typically coming from the ledger)
+  // to speedy value and set the control of with the result.
+  // All the contract IDs contained in the value are considered global.
+  // Raises an exception if missing a package.
+  final case class SEImportValue(value: V[V.ContractId]) extends SExpr {
+    def execute(machine: Machine): Unit = {
+      machine.translateValue(value)
     }
   }
 
@@ -263,7 +290,7 @@ object SExpr {
 
     import SEBuiltinRecursiveDefinition._
 
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       val body = ref match {
         case Reference.FoldL => foldLBody
         case Reference.FoldR => foldRBody

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -18,7 +18,9 @@ sealed abstract class SResult extends Product with Serializable
 
 object SResult {
   final case class SResultError(err: SError) extends SResult
-  final case object SResultContinue extends SResult
+
+  /** The speedy machine has completed evaluation to reach a final value.  */
+  final case class SResultFinalValue(v: SValue) extends SResult
 
   /** Update or scenario interpretation requires the current
     * ledger time. */

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -124,13 +124,13 @@ object SValue {
     override def toString: String = s"PClosure($expr, ${closure.mkString("[", ",", "]")})"
   }
 
-  /** A partially (or fully) applied primitive.
-    * This is constructed when an argument is applied. When it becomes fully
-    * applied (args.size == arity), the machine will apply the arguments to the primitive.
-    * If the primitive is a closure, the arguments are pushed to the environment and the
-    * closure body is entered.
+  /** A partially applied primitive.
+    * An SPAP is *never* fully applied. This is asserted on construction.
     */
   final case class SPAP(prim: Prim, args: util.ArrayList[SValue], arity: Int) extends SValue {
+    if (args.size >= arity) {
+      throw SErrorCrash(s"SPAP: unexpected args.size >= arity")
+    }
     override def toString: String = s"SPAP($prim, ${args.asScala.mkString("[", ",", "]")}, $arity)"
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -10,7 +10,7 @@ import com.daml.lf.data._
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SError.{DamlEArithmeticError, SError, SErrorCrash}
-import com.daml.lf.speedy.SResult.{SResultContinue, SResultError}
+import com.daml.lf.speedy.SResult.{SResultFinalValue, SResultError}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.testing.parser.Implicits._
 import org.scalactic.Equality
@@ -1459,8 +1459,8 @@ object SBuiltinTest {
     )
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {
-      while (!machine.isFinal) machine.step() match {
-        case SResultContinue => ()
+      while (!machine.isFinal) machine.run() match {
+        case SResultFinalValue(_) => ()
         case SResultError(err) => throw Goodbye(err)
         case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -12,7 +12,7 @@ import com.daml.lf.data.{FrontStack, Ref, Time}
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SError.SError
-import com.daml.lf.speedy.SResult.{SResultContinue, SResultError}
+import com.daml.lf.speedy.SResult.{SResultFinalValue, SResultError}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.validation.Validation
@@ -260,8 +260,8 @@ object SpeedyTest {
     )
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {
-      while (!machine.isFinal) machine.step() match {
-        case SResultContinue => ()
+      while (!machine.isFinal) machine.run() match {
+        case SResultFinalValue(_) => ()
         case SResultError(err) => throw Goodbye(err)
         case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -9,8 +9,10 @@ import java.util
 import com.daml.lf.crypto
 import com.daml.lf.data.{FrontStack, ImmArray, Numeric, Ref, Time}
 import com.daml.lf.language.{Ast, Util => AstUtil}
+import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.{SBuiltin, SExpr, SValue}
+import com.daml.lf.speedy.SExpr.SEImportValue
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.value.Value
 import com.daml.lf.value.TypedValueGenerators.genAddend
@@ -473,12 +475,11 @@ class OrderingSpec
   )
 
   private def translatePrimValue(v: Value[Value.AbsoluteContractId]) = {
-    val ctrl = Speedy.CtrlImportValue(v)
     val machine = dummyMachine
-    machine.ctrl = Speedy.CtrlCrash(ctrl)
-    ctrl.execute(machine)
-    machine.ctrl match {
-      case Speedy.CtrlValue(value) => value
+    machine.ctrl = SEImportValue(v)
+    //machine.translateValue(v)
+    machine.run() match {
+      case SResultFinalValue(value) => value
       case _ => throw new Error(s"error while translating value $v")
     }
   }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -13,6 +13,7 @@ import com.daml.lf.language.Util._
 import com.daml.lf.speedy.Pretty._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
+import com.daml.lf.speedy.SExpr.SEValue
 import com.daml.lf.types.Ledger
 import com.daml.lf.speedy.SExpr.LfDefRef
 import com.daml.lf.validation.Validation
@@ -414,12 +415,11 @@ object Repl {
             val startTime = System.nanoTime()
             var errored = false
             while (!machine.isFinal && !errored) {
-              machine.step match {
+              machine.run match {
                 case SResultError(err) =>
                   println(prettyError(err, machine.ptx).render(128))
                   errored = true
-                case SResultContinue =>
-                  ()
+                case SResultFinalValue(_) => ()
                 case other =>
                   sys.error("unimplemented callback: " + other.toString)
               }
@@ -432,7 +432,7 @@ object Repl {
             println(s"time: ${diff}ms")
             if (!errored) {
               val result = machine.ctrl match {
-                case Speedy.CtrlValue(sv) =>
+                case SEValue(sv) =>
                   prettyValue(true)(sv.toValue).render(128)
                 case x => x.toString
               }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -48,9 +48,10 @@ final case class ScenarioRunner(
     var steps = 0
     while (!machine.isFinal) {
       //machine.print(steps)
-      machine.step match {
-        case SResultContinue =>
-          steps += 1
+      steps += 1 // this counts the number of external `Need` interactions
+      val res: SResult = machine.run()
+      res match {
+        case SResultFinalValue(_) =>
         case SResultError(err) =>
           throw SRunnerException(err)
 

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -7,6 +7,7 @@ import com.daml.lf.PureCompiledPackages
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast.ScenarioGetParty
+import com.daml.lf.speedy.SExpr.SEValue
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
@@ -24,7 +25,7 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
       )
       val sr = ScenarioRunner(m, _ + "-XXX")
       sr.run()
-      m.ctrl shouldBe Speedy.CtrlValue(SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX")))
+      m.ctrl shouldBe SEValue(SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX")))
     }
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -219,24 +219,17 @@ object Converter {
         seeding = InitialSeeding.NoSeed,
         Set.empty,
       )
-    @tailrec
-    def iter(): Either[String, (SValue, SValue)] = {
-      if (machine.isFinal) {
-        machine.toSValue match {
+    machine.run() match {
+      case SResultFinalValue(v) =>
+        v match {
           case SStruct(_, values) if values.size == 2 => {
             Right((values.get(0), values.get(1)))
           }
           case v => Left(s"Expected SStruct but got $v")
         }
-      } else {
-        machine.step() match {
-          case SResultContinue => iter()
-          case SResultError(err) => Left(Pretty.prettyError(err, machine.ptx).render(80))
-          case res => Left(res.toString())
-        }
-      }
+      case SResultError(err) => Left(Pretty.prettyError(err, machine.ptx).render(80))
+      case res => Left(res.toString())
     }
-    iter()
   }
 
   // Walk over the free applicative and extract the list of commands

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -298,8 +298,8 @@ class Runner(
     @SuppressWarnings(Array("org.wartremover.warts.Return"))
     def stepToValue(): Either[RuntimeException, Unit] = {
       while (!machine.isFinal) {
-        machine.step() match {
-          case SResultContinue => ()
+        machine.run() match {
+          case SResultFinalValue(_) => ()
           case SResultError(err) => {
             logger.error(Pretty.prettyError(err, machine.ptx).render(80))
             return Left(err)
@@ -353,7 +353,7 @@ class Runner(
                                     freeAp,
                                     results))
                               v <- {
-                                machine.ctrl = Speedy.CtrlExpr(filled)
+                                machine.ctrl = filled
                                 go()
                               }
                             } yield v
@@ -364,8 +364,7 @@ class Runner(
                                 Converter
                                   .fromStatusException(script.scriptIds, statusEx))
                               v <- {
-                                machine.ctrl =
-                                  Speedy.CtrlExpr(SEApp(SEValue(vals.get(2)), Array(SEValue(res))))
+                                machine.ctrl = SEApp(SEValue(vals.get(2)), Array(SEValue(res)))
                                 go()
                               }
                             } yield v
@@ -398,8 +397,7 @@ class Runner(
                             .traverseU(Converter
                               .fromCreated(valueTranslator, _)))
                         v <- {
-                          machine.ctrl =
-                            Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SList(res)))))
+                          machine.ctrl = SEApp(SEValue(continue), Array(SEValue(SList(res))))
                           go()
                         }
                       } yield v
@@ -446,8 +444,7 @@ class Runner(
                                 party_participants = clients.party_participants + (Party(
                                   party.value) -> participant))
                           }
-                          machine.ctrl =
-                            Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(party))))
+                          machine.ctrl = SEApp(SEValue(continue), Array(SEValue(party)))
                           go()
                         }
                       } yield v
@@ -459,8 +456,7 @@ class Runner(
                 }
                 case SVariant(_, "GetTime", _, continue) => {
                   val t = Timestamp.assertFromInstant(timeProvider.getCurrentTime)
-                  machine.ctrl =
-                    Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(STimestamp(t)))))
+                  machine.ctrl = SEApp(SEValue(continue), Array(SEValue(STimestamp(t))))
                   go()
                 }
                 case SVariant(_, "Sleep", _, v) => {
@@ -482,8 +478,7 @@ class Runner(
                           val sleepMillis = sleepMicros / 1000
                           val sleepNanos = (sleepMicros % 1000) * 1000
                           Thread.sleep(sleepMillis, sleepNanos.toInt)
-                          machine.ctrl =
-                            Speedy.CtrlExpr(SEApp(SEValue(continue), Array(SEValue(SUnit))))
+                          machine.ctrl = SEApp(SEValue(continue), Array(SEValue(SUnit)))
                           go()
                         }
                       } yield v
@@ -517,7 +512,7 @@ class Runner(
         case SRecord(_, _, vals) if vals.size == 1 => {
           vals.get(0) match {
             case SPAP(_, _, _) =>
-              machine.ctrl = Speedy.CtrlExpr(SEApp(SEValue(vals.get(0)), Array(SEValue(SUnit))))
+              machine.ctrl = SEApp(SEValue(vals.get(0)), Array(SEValue(SUnit)))
               Future.unit
             case v =>
               Future.failed(


### PR DESCRIPTION
Add instrumentation to the Speedy machine & optimize. 
See issue #5764

Specific changes include:
- Flags: `enableClassifyInstrumentation`, `enableLightweightStepTracing'
- Running the machine: `step()` --> `run()` (`SResultContinue` --> `SResultFinalValue`)
- No more `Ctrl` type; Speedy control is now always an expression.
- We never construct full-applied PAPs (they don't make sense as a value!)

Performance improvement is in the region: x1.2 .. x1.3

Additional details:

I changed Speedy so the machine.ctrl is always an SExpr. This
avoids a virtual dispatch on every step of the machine. It also
roughly halves the number of steps taken (two old steps becomes
one new step)

I've changed the top level control of Speedy: from machine.step()
to machine.run, with the control of stepping while the machine
returns SResultContinue moved into speedy itself. (And so
SResultContinue is removed in favour of SResultFinalValue.) The
main advantage of this approach is that the tight while loop can
be moved inside the exception handler, rather than having to wrap
the handler every step.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
