### PR TITLE
Inline typeclass projections.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- | Alpha equivalence of types and expressions.
 module DA.Daml.LF.Ast.Alpha
     ( alphaType
@@ -341,3 +344,4 @@ alphaType = alphaType' initialAlphaEnv
 
 alphaExpr :: Expr -> Expr -> Bool
 alphaExpr = alphaExpr' initialAlphaEnv
+

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -22,10 +22,10 @@ data AlphaEnv = AlphaEnv
     -- ^ Maps bound type variables from the right-hand-side to
     -- the depth of the binder which introduced them.
   , boundExprVarsLhs :: !(Map.Map ExprVarName Int)
-    -- ^ Maps bound type variables from the left-hand-side  to
+    -- ^ Maps bound expr variables from the left-hand-side  to
     -- the depth of the binder which introduced them.
   , boundExprVarsRhs :: !(Map.Map ExprVarName Int)
-    -- ^ Maps bound type variables from the right-hand-side to
+    -- ^ Maps bound expr variables from the right-hand-side to
     -- the depth of the binder which introduced them.
   }
 
@@ -344,4 +344,3 @@ alphaType = alphaType' initialAlphaEnv
 
 alphaExpr :: Expr -> Expr -> Bool
 alphaExpr = alphaExpr' initialAlphaEnv
-

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -30,13 +30,11 @@ data AlphaEnv = AlphaEnv
   }
 
 onMaybe :: (a -> a -> Bool) -> Maybe a -> Maybe a -> Bool
-onMaybe f = \case
-    Just e1 -> \case
-        Just e2 -> f e1 e2
-        Nothing -> False
-    Nothing -> \case
-        Just _ -> False
-        Nothing -> True
+onMaybe f me1 me2 = case (me1, me2) of
+    (Nothing, Nothing) -> True
+    (Nothing, Just _) -> False
+    (Just _, Nothing) -> False
+    (Just e1, Just e2) -> f e1 e2
 
 onList :: (a -> a -> Bool) -> [a] -> [a] -> Bool
 onList f xs ys = length xs == length ys

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -1,0 +1,343 @@
+-- | Alpha equivalence of types and expressions.
+module DA.Daml.LF.Ast.Alpha
+    ( alphaType
+    , alphaExpr
+    ) where
+
+import qualified Data.Map.Strict as Map
+
+import DA.Daml.LF.Ast.Base
+
+-- | Auxiliary data structure to track bound variables.
+data AlphaEnv = AlphaEnv
+  { currentDepth :: !Int
+    -- ^ Current binding depth.
+  , boundTypeVarsLhs :: !(Map.Map TypeVarName Int)
+    -- ^ Maps bound type variables from the left-hand-side to
+    -- the depth of the binder which introduced them.
+  , boundTypeVarsRhs :: !(Map.Map TypeVarName Int)
+    -- ^ Maps bound type variables from the right-hand-side to
+    -- the depth of the binder which introduced them.
+  , boundExprVarsLhs :: !(Map.Map ExprVarName Int)
+    -- ^ Maps bound type variables from the left-hand-side  to
+    -- the depth of the binder which introduced them.
+  , boundExprVarsRhs :: !(Map.Map ExprVarName Int)
+    -- ^ Maps bound type variables from the right-hand-side to
+    -- the depth of the binder which introduced them.
+  }
+
+onMaybe :: (a -> a -> Bool) -> Maybe a -> Maybe a -> Bool
+onMaybe f = \case
+    Just e1 -> \case
+        Just e2 -> f e1 e2
+        Nothing -> False
+    Nothing -> \case
+        Just _ -> False
+        Nothing -> True
+
+onList :: (a -> a -> Bool) -> [a] -> [a] -> Bool
+onList f xs ys = length xs == length ys
+    && and (zipWith f xs ys)
+
+onFieldList :: Eq a => (b -> b -> Bool) -> [(a,b)] -> [(a,b)] -> Bool
+onFieldList f xs ys = map fst xs == map fst ys
+    && and (zipWith f (map snd xs) (map snd ys))
+
+bindTypeVar :: TypeVarName -> TypeVarName -> AlphaEnv -> AlphaEnv
+bindTypeVar x1 x2 env@AlphaEnv{..} = env
+    { currentDepth = currentDepth + 1
+    , boundTypeVarsLhs = Map.insert x1 currentDepth boundTypeVarsLhs
+    , boundTypeVarsRhs = Map.insert x2 currentDepth boundTypeVarsRhs }
+
+bindExprVar :: ExprVarName -> ExprVarName -> AlphaEnv -> AlphaEnv
+bindExprVar x1 x2 env@AlphaEnv{..} = env
+    { currentDepth = currentDepth + 1
+    , boundExprVarsLhs = Map.insert x1 currentDepth boundExprVarsLhs
+    , boundExprVarsRhs = Map.insert x2 currentDepth boundExprVarsRhs }
+
+alphaTypeVar :: AlphaEnv -> TypeVarName -> TypeVarName -> Bool
+alphaTypeVar AlphaEnv{..} x1 x2 =
+    case (Map.lookup x1 boundTypeVarsLhs, Map.lookup x2 boundTypeVarsRhs) of
+        (Just l1, Just l2) -> l1 == l2
+        (Nothing, Nothing) -> x1 == x2
+        _ -> False
+
+alphaExprVar :: AlphaEnv -> ExprVarName -> ExprVarName -> Bool
+alphaExprVar AlphaEnv{..} x1 x2 =
+    case (Map.lookup x1 boundExprVarsLhs, Map.lookup x2 boundExprVarsRhs) of
+        (Just l1, Just l2) -> l1 == l2
+        (Nothing, Nothing) -> x1 == x2
+        _ -> False
+
+-- | Strongly typed version of (==) for qualified type constructor names.
+alphaTypeCon :: Qualified TypeConName -> Qualified TypeConName -> Bool
+alphaTypeCon = (==)
+
+alphaType' :: AlphaEnv -> Type -> Type -> Bool
+alphaType' env = \case
+    TVar x1 -> \case
+        TVar x2 -> alphaTypeVar env x1 x2
+        _ -> False
+    TCon c1 -> \case
+        TCon c2 -> alphaTypeCon c1 c2
+        _ -> False
+    TApp t1a t1b -> \case
+        TApp t2a t2b -> alphaType' env t1a t2a && alphaType' env t1b t2b
+        _ -> False
+    TBuiltin b1 -> \case
+        TBuiltin b2 -> b1 == b2
+        _ -> False
+    TForall (x1, k1) t1' -> \case
+        TForall (x2, k2) t2' -> k1 == k2 &&
+            let env' = bindTypeVar x1 x2 env
+            in alphaType' env' t1' t2'
+        _ -> False
+    TStruct fs1 -> \case
+        TStruct fs2 -> onFieldList (alphaType' env) fs1 fs2
+        _ -> False
+    TNat n1 -> \case
+        TNat n2 -> n1 == n2
+        _ -> False
+    TSynApp s1 ts1 -> \case
+        TSynApp s2 ts2 -> s1 == s2 && onList (alphaType' env) ts1 ts2
+        _ -> False
+
+alphaTypeConApp :: AlphaEnv -> TypeConApp -> TypeConApp -> Bool
+alphaTypeConApp env (TypeConApp c1 ts1) (TypeConApp c2 ts2) =
+    c1 == c2 && onList (alphaType' env) ts1 ts2
+
+alphaExpr' :: AlphaEnv -> Expr -> Expr -> Bool
+alphaExpr' env = \case
+    EVar x1 -> \case
+        EVar x2 -> alphaExprVar env x1 x2
+        _ -> False
+    EVal v1 -> \case
+        EVal v2 -> v1 == v2
+        _ -> False
+    EBuiltin b1 -> \case
+        EBuiltin b2 -> b1 == b2
+        _ -> False
+    ERecCon t1 fs1 -> \case
+        ERecCon t2 fs2 -> alphaTypeConApp env t1 t2
+            && onFieldList (alphaExpr' env) fs1 fs2
+        _ -> False
+    ERecProj t1 f1 e1 -> \case
+        ERecProj t2 f2 e2 -> f1 == f2
+            && alphaTypeConApp env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    ERecUpd t1 f1 e1a e1b -> \case
+        ERecUpd t2 f2 e2a e2b -> f1 == f2
+            && alphaTypeConApp env t1 t2
+            && alphaExpr' env e1a e2a
+            && alphaExpr' env e1b e2b
+        _ -> False
+    EVariantCon t1 c1 e1 -> \case
+        EVariantCon t2 c2 e2 -> c1 == c2
+            && alphaTypeConApp env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    EEnumCon t1 c1 -> \case
+        EEnumCon t2 c2 -> alphaTypeCon t1 t2 && c1 == c2
+        _ -> False
+    EStructCon fs1 -> \case
+        EStructCon fs2 -> onFieldList (alphaExpr' env) fs1 fs2
+        _ -> False
+    EStructProj f1 e1 -> \case
+        EStructProj f2 e2 -> f1 == f2
+            && alphaExpr' env e1 e2
+        _ -> False
+    EStructUpd f1 e1a e1b -> \case
+        EStructUpd f2 e2a e2b -> f1 == f2
+            && alphaExpr' env e1a e2a
+            && alphaExpr' env e1b e2b
+        _ -> False
+    ETmApp e1a e1b -> \case
+        ETmApp e2a e2b -> alphaExpr' env e1a e2a
+            && alphaExpr' env e1b e2b
+        _ -> False
+    ETyApp e1 t1 -> \case
+        ETyApp e2 t2 -> alphaExpr' env e1 e2
+            && alphaType' env t1 t2
+        _ -> False
+    ETmLam (x1,t1) e1 -> \case
+        ETmLam (x2,t2) e2 -> alphaType' env t1 t2
+            && alphaExpr' (bindExprVar x1 x2 env) e1 e2
+        _ -> False
+    ETyLam (x1,k1) e1 -> \case
+        ETyLam (x2,k2) e2 -> k1 == k2
+            && alphaExpr' (bindTypeVar x1 x2 env) e1 e2
+        _ -> False
+    ECase e1 ps1 -> \case
+        ECase e2 ps2 -> alphaExpr' env e1 e2
+            && onList (alphaCase env) ps1 ps2
+        _ -> False
+    ELet b1 e1 -> \case
+        ELet b2 e2 ->
+            alphaBinding env b1 b2 (\env' -> alphaExpr' env' e1 e2)
+        _ -> False
+    ENil t1 -> \case
+        ENil t2 -> alphaType' env t1 t2
+        _ -> False
+    ECons t1 e1a e1b -> \case
+        ECons t2 e2a e2b -> alphaType' env t1 t2
+            && alphaExpr' env e1a e2a
+            && alphaExpr' env e1b e2b
+        _ -> False
+    ESome t1 e1 -> \case
+        ESome t2 e2 -> alphaType' env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    ENone t1 -> \case
+        ENone t2 -> alphaType' env t1 t2
+        _ -> False
+    EToAny t1 e1 -> \case
+        EToAny t2 e2 -> alphaType' env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    EFromAny t1 e1 -> \case
+        EFromAny t2 e2 -> alphaType' env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    ETypeRep t1 -> \case
+        ETypeRep t2 -> alphaType' env t1 t2
+        _ -> False
+    EUpdate u1 -> \case
+        EUpdate u2 -> alphaUpdate env u1 u2
+        _ -> False
+    EScenario s1 -> \case
+        EScenario s2 -> alphaScenario env s1 s2
+        _ -> False
+    ELocation _ e1 -> \case
+        ELocation _ e2 -> alphaExpr' env e1 e2
+        _ -> False
+
+alphaBinding :: AlphaEnv -> Binding -> Binding -> (AlphaEnv -> Bool) -> Bool
+alphaBinding env (Binding (x1,t1) e1) (Binding (x2,t2) e2) k =
+    alphaType' env t1 t2 && alphaExpr' env e1 e2 && k (bindExprVar x1 x2 env)
+
+alphaCase :: AlphaEnv -> CaseAlternative -> CaseAlternative -> Bool
+alphaCase env (CaseAlternative p1 e1) (CaseAlternative p2 e2) =
+    alphaPattern env p1 p2 (\env' -> alphaExpr' env' e1 e2)
+
+alphaPattern :: AlphaEnv -> CasePattern -> CasePattern -> (AlphaEnv -> Bool) -> Bool
+alphaPattern env p1 p2 k = case p1 of
+    CPVariant t1 c1 x1 -> case p2 of
+        CPVariant t2 c2 x2 -> alphaTypeCon t1 t2 && c1 == c2 && k (bindExprVar x1 x2 env)
+        _ -> False
+    CPEnum t1 c1 -> case p2 of
+        CPEnum t2 c2 -> alphaTypeCon t1 t2 && c1 == c2 && k env
+        _ -> False
+    CPUnit -> case p2 of
+        CPUnit -> k env
+        _ -> False
+    CPBool b1 -> case p2 of
+        CPBool b2 -> b1 == b2 && k env
+        _ -> False
+    CPNil -> case p2 of
+        CPNil -> k env
+        _ -> False
+    CPCons x1a x1b -> case p2 of
+        CPCons x2a x2b -> k (bindExprVar x1a x2a (bindExprVar x1b x2b env))
+        _ -> False
+    CPNone -> case p2 of
+        CPNone -> k env
+        _ -> False
+    CPSome x1 -> case p2 of
+        CPSome x2 -> k (bindExprVar x1 x2 env)
+        _ -> False
+    CPDefault -> case p2 of
+        CPDefault -> k env
+        _ -> False
+
+alphaUpdate :: AlphaEnv -> Update -> Update -> Bool
+alphaUpdate env = \case
+    UPure t1 e1 -> \case
+        UPure t2 e2 -> alphaType' env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    UBind b1 e1 -> \case
+        UBind b2 e2 ->
+            alphaBinding env b1 b2 (\env' -> alphaExpr' env' e1 e2)
+        _ -> False
+    UCreate t1 e1 -> \case
+        UCreate t2 e2 -> alphaTypeCon t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    UExercise t1 c1 e1a e1b e1c -> \case
+        UExercise t2 c2 e2a e2b e2c -> alphaTypeCon t1 t2
+            && c1 == c2
+            && alphaExpr' env e1a e2a
+            && onMaybe (alphaExpr' env) e1b e2b
+            && alphaExpr' env e1c e2c
+        _ -> False
+    UFetch t1 e1 -> \case
+        UFetch t2 e2 -> alphaTypeCon t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    UGetTime -> \case
+        UGetTime -> True
+        _ -> False
+    UEmbedExpr t1 e1 -> \case
+        UEmbedExpr t2 e2 -> alphaType' env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    ULookupByKey r1 -> \case
+        ULookupByKey r2 -> alphaRetrieveByKey env r1 r2
+        _ -> False
+    UFetchByKey r1 -> \case
+        UFetchByKey r2 -> alphaRetrieveByKey env r1 r2
+        _ -> False
+
+alphaRetrieveByKey :: AlphaEnv -> RetrieveByKey -> RetrieveByKey -> Bool
+alphaRetrieveByKey env (RetrieveByKey t1 e1) (RetrieveByKey t2 e2) =
+    alphaTypeCon t1 t2 && alphaExpr' env e1 e2
+
+alphaScenario :: AlphaEnv -> Scenario -> Scenario -> Bool
+alphaScenario env = \case
+    SPure t1 e1 -> \case
+        SPure t2 e2 -> alphaType' env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    SBind b1 e1 -> \case
+        SBind b2 e2 ->
+            alphaBinding env b1 b2 (\env' -> alphaExpr' env' e1 e2)
+        _ -> False
+    SCommit t1 e1a e1b -> \case
+        SCommit t2 e2a e2b -> alphaType' env t1 t2
+            && alphaExpr' env e1a e2a
+            && alphaExpr' env e1b e2b
+        _ -> False
+    SMustFailAt t1 e1a e1b -> \case
+        SMustFailAt t2 e2a e2b -> alphaType' env t1 t2
+            && alphaExpr' env e1a e2a
+            && alphaExpr' env e1b e2b
+        _ -> False
+    SPass e1 -> \case
+        SPass e2 -> alphaExpr' env e1 e2
+        _ -> False
+    SGetTime -> \case
+        SGetTime -> True
+        _ -> False
+    SGetParty e1 -> \case
+        SGetParty e2 -> alphaExpr' env e1 e2
+        _ -> False
+    SEmbedExpr t1 e1 -> \case
+        SEmbedExpr t2 e2 -> alphaType' env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+
+initialAlphaEnv :: AlphaEnv
+initialAlphaEnv = AlphaEnv
+    { currentDepth = 0
+    , boundTypeVarsLhs = Map.empty
+    , boundTypeVarsRhs = Map.empty
+    , boundExprVarsLhs = Map.empty
+    , boundExprVarsRhs = Map.empty
+    }
+
+alphaType :: Type -> Type -> Bool
+alphaType = alphaType' initialAlphaEnv
+
+alphaExpr :: Expr -> Expr -> Bool
+alphaExpr = alphaExpr' initialAlphaEnv

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
@@ -1,3 +1,5 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module DA.Daml.LF.Ast.FreeVars
     ( FreeVars

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
@@ -101,7 +101,19 @@ freeVarsStep = \case
   where
 
     goCase :: (CasePattern, FreeVars) -> FreeVars
-    goCase = snd -- overapproximation is fine and cheap
+    goCase = uncurry goPattern
+
+    goPattern :: CasePattern -> FreeVars -> FreeVars
+    goPattern = \case
+        CPVariant _ _ x -> bindExprVar x
+        CPEnum _ _ -> id
+        CPUnit -> id
+        CPBool _ -> id
+        CPNil -> id
+        CPCons x1 x2 -> bindExprVar x1 . bindExprVar x2
+        CPNone -> id
+        CPSome x -> bindExprVar x
+        CPDefault -> id
 
     goBinding :: BindingF FreeVars -> FreeVars -> FreeVars
     goBinding (BindingF (x, t) e1) e2 =

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
@@ -1,0 +1,139 @@
+
+module DA.Daml.LF.Ast.FreeVars
+    ( FreeVars
+    , freeTypeVars
+    , freeExprVars
+    , freeTypeVar
+    , freeExprVar
+    , bindTypeVar
+    , bindExprVar
+    , isFreeTypeVar
+    , isFreeExprVar
+    , freeVarsInType
+    , freeVarsInTypeConApp
+    , freeVarsInExpr
+    , freeVarsStep
+    , freshenTypeVar
+    , freshenExprVar
+    ) where
+
+import DA.Daml.LF.Ast
+import DA.Daml.LF.Ast.Recursive
+import qualified DA.Daml.LF.Ast.Type as Type
+
+import Data.Functor.Foldable (cata)
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import Safe (findJust)
+
+data FreeVars = FreeVars
+    { freeTypeVars :: Set.Set TypeVarName
+    , freeExprVars :: Set.Set ExprVarName
+    }
+
+instance Semigroup FreeVars where
+    FreeVars a1 b1 <> FreeVars a2 b2 =
+        FreeVars (Set.union a1 a2) (Set.union b1 b2)
+
+instance Monoid FreeVars where
+    mempty = FreeVars Set.empty Set.empty
+
+freeTypeVar :: TypeVarName -> FreeVars
+freeTypeVar x = FreeVars (Set.singleton x) Set.empty
+
+freeExprVar :: ExprVarName -> FreeVars
+freeExprVar x = FreeVars Set.empty (Set.singleton x)
+
+bindTypeVar :: TypeVarName -> FreeVars -> FreeVars
+bindTypeVar x fvs = fvs { freeTypeVars = Set.delete x (freeTypeVars fvs) }
+
+bindExprVar :: ExprVarName -> FreeVars -> FreeVars
+bindExprVar x fvs = fvs { freeExprVars = Set.delete x (freeExprVars fvs) }
+
+isFreeTypeVar :: TypeVarName -> FreeVars -> Bool
+isFreeTypeVar x = Set.member x . freeTypeVars
+
+isFreeExprVar :: ExprVarName -> FreeVars -> Bool
+isFreeExprVar x = Set.member x . freeExprVars
+
+freeVarsInType :: Type -> FreeVars
+freeVarsInType ty = FreeVars (Type.freeVars ty) Set.empty
+
+freeVarsInTypeConApp :: TypeConApp -> FreeVars
+freeVarsInTypeConApp (TypeConApp _ tys) = foldMap freeVarsInType tys
+
+freeVarsInExpr :: Expr -> FreeVars
+freeVarsInExpr = cata freeVarsStep
+
+freeVarsStep :: ExprF FreeVars -> FreeVars
+freeVarsStep = \case
+    EVarF x -> freeExprVar x
+    EValF _ -> mempty
+    EBuiltinF _ -> mempty
+    ERecConF t fs -> freeVarsInTypeConApp t <> foldMap snd fs
+    ERecProjF t _ e -> freeVarsInTypeConApp t <> e
+    ERecUpdF t _ e1 e2 -> freeVarsInTypeConApp t <> e1 <> e2
+    EVariantConF t _ e -> freeVarsInTypeConApp t <> e
+    EEnumConF _ _ -> mempty
+    EStructConF fs -> foldMap snd fs
+    EStructProjF _ e -> e
+    EStructUpdF _ e1 e2 -> e1 <> e2
+    ETmAppF e1 e2 -> e1 <> e2
+    ETyAppF e t -> e <> freeVarsInType t
+    ETmLamF (x, t) e -> freeVarsInType t <> bindExprVar x e
+    ETyLamF (x, _) e -> bindTypeVar x e
+    ECaseF e cs -> e <> foldMap goCase cs
+    ELetF b e -> goBinding b e
+    ENilF t -> freeVarsInType t
+    EConsF t e1 e2 -> freeVarsInType t <> e1 <> e2
+    EUpdateF u -> goUpdate u
+    EScenarioF s -> goScenario s
+    ELocationF _ e -> e
+    ENoneF t -> freeVarsInType t
+    ESomeF t e -> freeVarsInType t <> e
+    EToAnyF t e -> freeVarsInType t <> e
+    EFromAnyF t e -> freeVarsInType t <> e
+    ETypeRepF t -> freeVarsInType t
+
+  where
+
+    goCase :: (CasePattern, FreeVars) -> FreeVars
+    goCase = snd -- overapproximation is fine and cheap
+
+    goBinding :: BindingF FreeVars -> FreeVars -> FreeVars
+    goBinding (BindingF (x, t) e1) e2 =
+        freeVarsInType t <> e1 <> bindExprVar x e2
+
+    goUpdate :: UpdateF FreeVars -> FreeVars
+    goUpdate = \case
+        UPureF t e -> freeVarsInType t <> e
+        UBindF b e -> goBinding b e
+        UCreateF _ e -> e
+        UExerciseF _ _ e1 e2M e3 -> e1 <> fromMaybe mempty e2M <> e3
+        UFetchF _ e -> e
+        UGetTimeF -> mempty
+        UEmbedExprF t e -> freeVarsInType t <> e
+        UFetchByKeyF r -> retrieveByKeyFKey r
+        ULookupByKeyF r -> retrieveByKeyFKey r
+
+    goScenario :: ScenarioF FreeVars -> FreeVars
+    goScenario = \case
+        SPureF t e -> freeVarsInType t <> e
+        SBindF b e -> goBinding b e
+        SCommitF t e1 e2 -> freeVarsInType t <> e1 <> e2
+        SMustFailAtF t e1 e2 -> freeVarsInType t <> e1 <> e2
+        SPassF e -> e
+        SGetTimeF -> mempty
+        SGetPartyF e -> e
+        SEmbedExprF t e -> freeVarsInType t <> e
+
+freshenTypeVar :: FreeVars -> TypeVarName -> TypeVarName
+freshenTypeVar fvs (TypeVarName v) =
+  let candidates = map (\n -> TypeVarName (v <> T.pack (show n))) [1 :: Int ..]
+  in findJust (\x -> not (isFreeTypeVar x fvs)) candidates
+
+freshenExprVar :: FreeVars -> ExprVarName -> ExprVarName
+freshenExprVar fvs (ExprVarName v) =
+  let candidates = map (\n -> ExprVarName (v <> T.pack (show n))) [1 :: Int ..]
+  in findJust (\x -> not (isFreeExprVar x fvs)) candidates

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
@@ -248,7 +248,7 @@ substExpr subst@Subst{..} = \case
         (map (substAlternative subst) alts)
     ELet (Binding (x, t) e1) e2 ->
         substWithBoundExprVar subst x $ \ subst' x' ->
-            ELet (Binding (x', (substType subst t)) (substExpr subst e1))
+            ELet (Binding (x', substType subst t) (substExpr subst e1))
                 (substExpr subst' e2)
     ENil t -> ENil
         (substType subst t)
@@ -368,4 +368,3 @@ freshenExprVar :: Subst -> ExprVarName -> ExprVarName
 freshenExprVar Subst{..} (ExprVarName v) =
   let candidates = map (\n -> ExprVarName (v <> T.pack (show n))) [1 :: Int ..]
   in findJust (`Set.notMember` substExhaustedExprVars) candidates
-

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
@@ -1,3 +1,6 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- | Substitution in LF expressions.
 module DA.Daml.LF.Ast.Subst
     ( Subst (..)
@@ -365,3 +368,4 @@ freshenExprVar :: Subst -> ExprVarName -> ExprVarName
 freshenExprVar Subst{..} (ExprVarName v) =
   let candidates = map (\n -> ExprVarName (v <> T.pack (show n))) [1 :: Int ..]
   in findJust (`Set.notMember` substExhaustedExprVars) candidates
+

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
@@ -5,152 +5,71 @@
 module DA.Daml.LF.Ast.Subst
     ( Subst (..)
     , typeSubst
+    , typeSubst'
     , exprSubst
+    , exprSubst'
     , substExpr
     , substType
     ) where
 
 import DA.Daml.LF.Ast
-import DA.Daml.LF.Ast.Recursive
+import DA.Daml.LF.Ast.FreeVars
 import qualified DA.Daml.LF.Ast.Type as Type
 
 import Control.Arrow (second)
-import Data.Functor.Foldable (cata)
-import Data.Maybe (fromMaybe)
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
-import qualified Data.Text as T
-import Safe (findJust)
 
 data Subst = Subst
     { substTypes :: !(Map.Map TypeVarName Type)
         -- ^ types to substitute
     , substExprs :: !(Map.Map ExprVarName Expr)
         -- ^ expressions to substitute
-    , substExhaustedTypeVars :: !(Set.Set TypeVarName)
-        -- ^ set of exhausted type variables
-        -- (these are all the free type vars that appear in substTypes
-        -- or substExprs, plus the type vars that were bound above us,
-        -- plus the type vars that were substituted away)
-    , substExhaustedExprVars :: !(Set.Set ExprVarName)
-        -- ^ set of exhausted expr variables
-        -- (these are all the free expr vars that appear in substExprs,
-        -- plus the expr vars that were bound above us, plus the expr
-        -- vars that were substituted away)
+    , substExhausted :: !FreeVars
+        -- ^ exhausted variables. These are all the free variables that
+        -- appear in substTypes or substExprs, plus the variables that
+        -- were bound above us, plus the variables that were substituted
+        -- away. This is mainly used to generate fresh variables that
+        -- don't conflict with existing variables, so over-approximation
+        -- is fine.
     }
 
 instance Monoid Subst where
     mempty = Subst
         { substTypes = Map.empty
         , substExprs = Map.empty
-        , substExhaustedTypeVars = Set.empty
-        , substExhaustedExprVars = Set.empty
+        , substExhausted = mempty
         }
 
 instance Semigroup Subst where
     s1 <> s2 = Subst
         { substTypes = substTypes s1 <> substTypes s2
         , substExprs = substExprs s1 <> substExprs s2
-        , substExhaustedExprVars = substExhaustedExprVars s1 <> substExhaustedExprVars s2
-        , substExhaustedTypeVars = substExhaustedTypeVars s1 <> substExhaustedTypeVars s2
+        , substExhausted = substExhausted s1 <> substExhausted s2
         }
 
-typeSubst :: TypeVarName -> Type -> Subst
-typeSubst x t = Subst
+typeSubst' :: TypeVarName -> Type -> FreeVars -> Subst
+typeSubst' x t fvs = Subst
     { substTypes = Map.fromList [(x,t)]
     , substExprs = Map.empty
-    , substExhaustedTypeVars = Set.insert x (freeVarsInType t)
-    , substExhaustedExprVars = Set.empty
+    , substExhausted = freeTypeVar x <> fvs
     }
 
-exprSubst :: ExprVarName -> Expr -> Subst
-exprSubst x e = Subst
+exprSubst' :: ExprVarName -> Expr -> FreeVars -> Subst
+exprSubst' x e fvs = Subst
     { substTypes = Map.empty
     , substExprs = Map.fromList [(x,e)]
-    , substExhaustedTypeVars = typeVars0
-    , substExhaustedExprVars = Set.insert x exprVars0
+    , substExhausted = freeExprVar x <> fvs
     }
-  where
-    (typeVars0, exprVars0) = freeVarsInExpr e
 
+typeSubst :: TypeVarName -> Type -> Subst
+typeSubst x t = typeSubst' x t (freeVarsInType t)
 
-freeVarsInType :: Type -> Set.Set TypeVarName
-freeVarsInType = Type.freeVars
-
-freeVarsInTypeConApp :: TypeConApp -> Set.Set TypeVarName
-freeVarsInTypeConApp (TypeConApp _ tys) = foldMap freeVarsInType tys
-
-freeVarsInExpr :: Expr -> (Set.Set TypeVarName, Set.Set ExprVarName)
-freeVarsInExpr = cata go
-  where
-    go :: ExprF (Set.Set TypeVarName, Set.Set ExprVarName)
-        -> (Set.Set TypeVarName, Set.Set ExprVarName)
-    go = \case
-        EVarF x -> (Set.empty, Set.singleton x)
-        EValF _ -> (Set.empty, Set.empty)
-        EBuiltinF _ -> (Set.empty, Set.empty)
-        ERecConF t fs -> (freeVarsInTypeConApp t, Set.empty) <> foldMap snd fs
-        ERecProjF t _ e -> (freeVarsInTypeConApp t, Set.empty) <> e
-        ERecUpdF t _ e1 e2 -> (freeVarsInTypeConApp t, Set.empty) <> e1 <> e2
-        EVariantConF t _ e -> (freeVarsInTypeConApp t, Set.empty) <> e
-        EEnumConF _ _ -> (Set.empty, Set.empty)
-        EStructConF fs -> foldMap snd fs
-        EStructProjF _ e -> e
-        EStructUpdF _ e1 e2 -> e1 <> e2
-        ETmAppF e1 e2 -> e1 <> e2
-        ETyAppF e t -> e <> (freeVarsInType t, Set.empty)
-        ETmLamF (x, t) (ftv, fev) -> (ftv <> freeVarsInType t, Set.delete x fev)
-        ETyLamF (x, _) (ftv, fev) -> (Set.delete x ftv, fev)
-        ECaseF e cs -> e <> foldMap goCase cs
-        ELetF b e -> goBinding b e
-        ENilF t -> (freeVarsInType t, Set.empty)
-        EConsF t e1 e2 -> (freeVarsInType t, Set.empty) <> e1 <> e2
-        EUpdateF u -> goUpdate u
-        EScenarioF s -> goScenario s
-        ELocationF _ e -> e
-        ENoneF t -> (freeVarsInType t, Set.empty)
-        ESomeF t e -> (freeVarsInType t, Set.empty) <> e
-        EToAnyF t e -> (freeVarsInType t, Set.empty) <> e
-        EFromAnyF t e -> (freeVarsInType t, Set.empty) <> e
-        ETypeRepF t -> (freeVarsInType t, Set.empty)
-
-    goCase :: (CasePattern, (Set.Set TypeVarName, Set.Set ExprVarName))
-        -> (Set.Set TypeVarName, Set.Set ExprVarName)
-    goCase = snd -- overapproximation is fine and cheap
-
-    goBinding :: BindingF (Set.Set TypeVarName, Set.Set ExprVarName)
-        -> (Set.Set TypeVarName, Set.Set ExprVarName)
-        -> (Set.Set TypeVarName, Set.Set ExprVarName)
-    goBinding (BindingF (x, t) e) (ftv, fev) =
-        e <> (ftv <> freeVarsInType t, Set.delete x fev)
-
-    goUpdate :: UpdateF (Set.Set TypeVarName, Set.Set ExprVarName)
-        -> (Set.Set TypeVarName, Set.Set ExprVarName)
-    goUpdate = \case
-        UPureF t e -> (freeVarsInType t, Set.empty) <> e
-        UBindF b e -> goBinding b e
-        UCreateF _ e -> e
-        UExerciseF _ _ e1 e2M e3 -> e1 <> fromMaybe mempty e2M <> e3
-        UFetchF _ e -> e
-        UGetTimeF -> mempty
-        UEmbedExprF t e -> (freeVarsInType t, Set.empty) <> e
-        UFetchByKeyF r -> retrieveByKeyFKey r
-        ULookupByKeyF r -> retrieveByKeyFKey r
-
-    goScenario :: ScenarioF (Set.Set TypeVarName, Set.Set ExprVarName)
-        -> (Set.Set TypeVarName, Set.Set ExprVarName)
-    goScenario = \case
-        SPureF t e -> (freeVarsInType t, Set.empty) <> e
-        SBindF b e -> goBinding b e
-        SCommitF t e1 e2 -> (freeVarsInType t, Set.empty) <> e1 <> e2
-        SMustFailAtF t e1 e2 -> (freeVarsInType t, Set.empty) <> e1 <> e2
-        SPassF e -> e
-        SGetTimeF -> mempty
-        SGetPartyF e -> e
-        SEmbedExprF t e -> (freeVarsInType t, Set.empty) <> e
+exprSubst :: ExprVarName -> Expr -> Subst
+exprSubst x e = exprSubst' x e (freeVarsInExpr e)
 
 substType :: Subst -> Type -> Type
-substType Subst{..} = Type.substituteAux substExhaustedTypeVars substTypes
+substType Subst{..} =
+    Type.substituteAux (freeTypeVars substExhausted) substTypes
 
 substTypeConApp :: Subst -> TypeConApp -> TypeConApp
 substTypeConApp subst (TypeConApp qtcon ts) =
@@ -161,39 +80,33 @@ substFields subst = map (second (substExpr subst))
 
 substWithBoundExprVar :: Subst -> ExprVarName -> (Subst -> ExprVarName -> t) -> t
 substWithBoundExprVar subst@Subst{..} x f
-    | Set.member x substExhaustedExprVars =
-        let x' = freshenExprVar subst x
+    | isFreeExprVar x substExhausted =
+        let x' = freshenExprVar substExhausted x
             subst' = subst
-                { substExhaustedExprVars =
-                    Set.insert x (Set.insert x' substExhaustedExprVars)
-                , substExprs =
-                    Map.insert x (EVar x') substExprs
+                { substExhausted = freeExprVar x' <> substExhausted
+                , substExprs = Map.insert x (EVar x') substExprs
                 }
         in f subst' x'
 
     | otherwise =
         let subst' = subst
-                { substExhaustedExprVars =
-                    Set.insert x substExhaustedExprVars
+                { substExhausted = freeExprVar x <> substExhausted
                 }
         in f subst' x
 
 substWithBoundTypeVar :: Subst -> TypeVarName -> (Subst -> TypeVarName -> t) -> t
 substWithBoundTypeVar subst@Subst{..} x f
-    | Set.member x substExhaustedTypeVars =
-        let x' = freshenTypeVar subst x
+    | isFreeTypeVar x substExhausted =
+        let x' = freshenTypeVar substExhausted x
             subst' = subst
-                { substExhaustedTypeVars =
-                    Set.insert x (Set.insert x' substExhaustedTypeVars)
-                , substTypes =
-                    Map.insert x (TVar x') substTypes
+                { substExhausted = freeTypeVar x' <> substExhausted
+                , substTypes = Map.insert x (TVar x') substTypes
                 }
         in f subst' x'
 
     | otherwise =
         let subst' = subst
-                { substExhaustedTypeVars =
-                    Set.insert x substExhaustedTypeVars
+                { substExhausted = freeTypeVar x <> substExhausted
                 }
         in f subst' x
 
@@ -358,13 +271,3 @@ substScenario subst = \case
     SEmbedExpr t e -> SEmbedExpr
         (substType subst t)
         (substExpr subst e)
-
-freshenTypeVar :: Subst -> TypeVarName -> TypeVarName
-freshenTypeVar Subst{..} (TypeVarName v) =
-  let candidates = map (\n -> TypeVarName (v <> T.pack (show n))) [1 :: Int ..]
-  in findJust (`Set.notMember` substExhaustedTypeVars) candidates
-
-freshenExprVar :: Subst -> ExprVarName -> ExprVarName
-freshenExprVar Subst{..} (ExprVarName v) =
-  let candidates = map (\n -> ExprVarName (v <> T.pack (show n))) [1 :: Int ..]
-  in findJust (`Set.notMember` substExhaustedExprVars) candidates

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
@@ -1,0 +1,367 @@
+-- | Substitution in LF expressions.
+module DA.Daml.LF.Ast.Subst
+    ( Subst (..)
+    , typeSubst
+    , exprSubst
+    , substExpr
+    , substType
+    ) where
+
+import DA.Daml.LF.Ast
+import DA.Daml.LF.Ast.Recursive
+import qualified DA.Daml.LF.Ast.Type as Type
+
+import Control.Arrow (second)
+import Data.Functor.Foldable (cata)
+import Data.Maybe (fromMaybe)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import Safe (findJust)
+
+data Subst = Subst
+    { substTypes :: !(Map.Map TypeVarName Type)
+        -- ^ types to substitute
+    , substExprs :: !(Map.Map ExprVarName Expr)
+        -- ^ expressions to substitute
+    , substExhaustedTypeVars :: !(Set.Set TypeVarName)
+        -- ^ set of exhausted type variables
+        -- (these are all the free type vars that appear in substTypes
+        -- or substExprs, plus the type vars that were bound above us,
+        -- plus the type vars that were substituted away)
+    , substExhaustedExprVars :: !(Set.Set ExprVarName)
+        -- ^ set of exhausted expr variables
+        -- (these are all the free expr vars that appear in substExprs,
+        -- plus the expr vars that were bound above us, plus the expr
+        -- vars that were substituted away)
+    }
+
+instance Monoid Subst where
+    mempty = Subst
+        { substTypes = Map.empty
+        , substExprs = Map.empty
+        , substExhaustedTypeVars = Set.empty
+        , substExhaustedExprVars = Set.empty
+        }
+
+instance Semigroup Subst where
+    s1 <> s2 = Subst
+        { substTypes = substTypes s1 <> substTypes s2
+        , substExprs = substExprs s1 <> substExprs s2
+        , substExhaustedExprVars = substExhaustedExprVars s1 <> substExhaustedExprVars s2
+        , substExhaustedTypeVars = substExhaustedTypeVars s1 <> substExhaustedTypeVars s2
+        }
+
+typeSubst :: TypeVarName -> Type -> Subst
+typeSubst x t = Subst
+    { substTypes = Map.fromList [(x,t)]
+    , substExprs = Map.empty
+    , substExhaustedTypeVars = Set.insert x (freeVarsInType t)
+    , substExhaustedExprVars = Set.empty
+    }
+
+exprSubst :: ExprVarName -> Expr -> Subst
+exprSubst x e = Subst
+    { substTypes = Map.empty
+    , substExprs = Map.fromList [(x,e)]
+    , substExhaustedTypeVars = typeVars0
+    , substExhaustedExprVars = Set.insert x exprVars0
+    }
+  where
+    (typeVars0, exprVars0) = freeVarsInExpr e
+
+
+freeVarsInType :: Type -> Set.Set TypeVarName
+freeVarsInType = Type.freeVars
+
+freeVarsInTypeConApp :: TypeConApp -> Set.Set TypeVarName
+freeVarsInTypeConApp (TypeConApp _ tys) = foldMap freeVarsInType tys
+
+freeVarsInExpr :: Expr -> (Set.Set TypeVarName, Set.Set ExprVarName)
+freeVarsInExpr = cata go
+  where
+    go :: ExprF (Set.Set TypeVarName, Set.Set ExprVarName)
+        -> (Set.Set TypeVarName, Set.Set ExprVarName)
+    go = \case
+        EVarF x -> (Set.empty, Set.singleton x)
+        EValF _ -> (Set.empty, Set.empty)
+        EBuiltinF _ -> (Set.empty, Set.empty)
+        ERecConF t fs -> (freeVarsInTypeConApp t, Set.empty) <> foldMap snd fs
+        ERecProjF t _ e -> (freeVarsInTypeConApp t, Set.empty) <> e
+        ERecUpdF t _ e1 e2 -> (freeVarsInTypeConApp t, Set.empty) <> e1 <> e2
+        EVariantConF t _ e -> (freeVarsInTypeConApp t, Set.empty) <> e
+        EEnumConF _ _ -> (Set.empty, Set.empty)
+        EStructConF fs -> foldMap snd fs
+        EStructProjF _ e -> e
+        EStructUpdF _ e1 e2 -> e1 <> e2
+        ETmAppF e1 e2 -> e1 <> e2
+        ETyAppF e t -> e <> (freeVarsInType t, Set.empty)
+        ETmLamF (x, t) (ftv, fev) -> (ftv <> freeVarsInType t, Set.delete x fev)
+        ETyLamF (x, _) (ftv, fev) -> (Set.delete x ftv, fev)
+        ECaseF e cs -> e <> foldMap goCase cs
+        ELetF b e -> goBinding b e
+        ENilF t -> (freeVarsInType t, Set.empty)
+        EConsF t e1 e2 -> (freeVarsInType t, Set.empty) <> e1 <> e2
+        EUpdateF u -> goUpdate u
+        EScenarioF s -> goScenario s
+        ELocationF _ e -> e
+        ENoneF t -> (freeVarsInType t, Set.empty)
+        ESomeF t e -> (freeVarsInType t, Set.empty) <> e
+        EToAnyF t e -> (freeVarsInType t, Set.empty) <> e
+        EFromAnyF t e -> (freeVarsInType t, Set.empty) <> e
+        ETypeRepF t -> (freeVarsInType t, Set.empty)
+
+    goCase :: (CasePattern, (Set.Set TypeVarName, Set.Set ExprVarName))
+        -> (Set.Set TypeVarName, Set.Set ExprVarName)
+    goCase = snd -- overapproximation is fine and cheap
+
+    goBinding :: BindingF (Set.Set TypeVarName, Set.Set ExprVarName)
+        -> (Set.Set TypeVarName, Set.Set ExprVarName)
+        -> (Set.Set TypeVarName, Set.Set ExprVarName)
+    goBinding (BindingF (x, t) e) (ftv, fev) =
+        e <> (ftv <> freeVarsInType t, Set.delete x fev)
+
+    goUpdate :: UpdateF (Set.Set TypeVarName, Set.Set ExprVarName)
+        -> (Set.Set TypeVarName, Set.Set ExprVarName)
+    goUpdate = \case
+        UPureF t e -> (freeVarsInType t, Set.empty) <> e
+        UBindF b e -> goBinding b e
+        UCreateF _ e -> e
+        UExerciseF _ _ e1 e2M e3 -> e1 <> fromMaybe mempty e2M <> e3
+        UFetchF _ e -> e
+        UGetTimeF -> mempty
+        UEmbedExprF t e -> (freeVarsInType t, Set.empty) <> e
+        UFetchByKeyF r -> retrieveByKeyFKey r
+        ULookupByKeyF r -> retrieveByKeyFKey r
+
+    goScenario :: ScenarioF (Set.Set TypeVarName, Set.Set ExprVarName)
+        -> (Set.Set TypeVarName, Set.Set ExprVarName)
+    goScenario = \case
+        SPureF t e -> (freeVarsInType t, Set.empty) <> e
+        SBindF b e -> goBinding b e
+        SCommitF t e1 e2 -> (freeVarsInType t, Set.empty) <> e1 <> e2
+        SMustFailAtF t e1 e2 -> (freeVarsInType t, Set.empty) <> e1 <> e2
+        SPassF e -> e
+        SGetTimeF -> mempty
+        SGetPartyF e -> e
+        SEmbedExprF t e -> (freeVarsInType t, Set.empty) <> e
+
+substType :: Subst -> Type -> Type
+substType Subst{..} = Type.substituteAux substExhaustedTypeVars substTypes
+
+substTypeConApp :: Subst -> TypeConApp -> TypeConApp
+substTypeConApp subst (TypeConApp qtcon ts) =
+    TypeConApp qtcon (map (substType subst) ts)
+
+substFields :: Subst -> [(FieldName, Expr)] -> [(FieldName, Expr)]
+substFields subst = map (second (substExpr subst))
+
+substWithBoundExprVar :: Subst -> ExprVarName -> (Subst -> ExprVarName -> t) -> t
+substWithBoundExprVar subst@Subst{..} x f
+    | Set.member x substExhaustedExprVars =
+        let x' = freshenExprVar subst x
+            subst' = subst
+                { substExhaustedExprVars =
+                    Set.insert x (Set.insert x' substExhaustedExprVars)
+                , substExprs =
+                    Map.insert x (EVar x') substExprs
+                }
+        in f subst' x'
+
+    | otherwise =
+        let subst' = subst
+                { substExhaustedExprVars =
+                    Set.insert x substExhaustedExprVars
+                }
+        in f subst' x
+
+substWithBoundTypeVar :: Subst -> TypeVarName -> (Subst -> TypeVarName -> t) -> t
+substWithBoundTypeVar subst@Subst{..} x f
+    | Set.member x substExhaustedTypeVars =
+        let x' = freshenTypeVar subst x
+            subst' = subst
+                { substExhaustedTypeVars =
+                    Set.insert x (Set.insert x' substExhaustedTypeVars)
+                , substTypes =
+                    Map.insert x (TVar x') substTypes
+                }
+        in f subst' x'
+
+    | otherwise =
+        let subst' = subst
+                { substExhaustedTypeVars =
+                    Set.insert x substExhaustedTypeVars
+                }
+        in f subst' x
+
+substExpr :: Subst -> Expr -> Expr
+substExpr subst@Subst{..} = \case
+    EVar x ->
+        case Map.lookup x substExprs of
+            Just e -> e
+            Nothing -> EVar x
+    e@(EVal _) -> e
+    e@(EBuiltin _) -> e
+    ERecCon t fs -> ERecCon
+        (substTypeConApp subst t)
+        (substFields subst fs)
+    ERecProj t f e -> ERecProj
+        (substTypeConApp subst t)
+        f
+        (substExpr subst e)
+    ERecUpd t f e1 e2 -> ERecUpd
+        (substTypeConApp subst t)
+        f
+        (substExpr subst e1)
+        (substExpr subst e2)
+    EVariantCon t v e -> EVariantCon
+        (substTypeConApp subst t)
+        v
+        (substExpr subst e)
+    e@(EEnumCon _ _) -> e
+    EStructCon fs -> EStructCon
+        (substFields subst fs)
+    EStructProj f e -> EStructProj
+        f
+        (substExpr subst e)
+    EStructUpd f e1 e2 -> EStructUpd
+        f
+        (substExpr subst e1)
+        (substExpr subst e2)
+    ETmApp e1 e2 -> ETmApp
+        (substExpr subst e1)
+        (substExpr subst e2)
+    ETyApp e t -> ETyApp
+        (substExpr subst e)
+        (substType subst t)
+    ETmLam (x,t) e ->
+        substWithBoundExprVar subst x $ \ subst' x' ->
+            ETmLam (x', substType subst t) (substExpr subst' e)
+    ETyLam (x,k) e ->
+        substWithBoundTypeVar subst x $ \ subst' x' ->
+            ETyLam (x', k) (substExpr subst' e)
+    ECase e alts -> ECase
+        (substExpr subst e)
+        (map (substAlternative subst) alts)
+    ELet (Binding (x, t) e1) e2 ->
+        substWithBoundExprVar subst x $ \ subst' x' ->
+            ELet (Binding (x', (substType subst t)) (substExpr subst e1))
+                (substExpr subst' e2)
+    ENil t -> ENil
+        (substType subst t)
+    ECons t e1 e2 -> ECons
+        (substType subst t)
+        (substExpr subst e1)
+        (substExpr subst e2)
+    ENone t -> ENone
+        (substType subst t)
+    ESome t e -> ESome
+        (substType subst t)
+        (substExpr subst e)
+    EToAny t e -> EToAny
+        (substType subst t)
+        (substExpr subst e)
+    EFromAny t e -> EFromAny
+        (substType subst t)
+        (substExpr subst e)
+    ETypeRep t -> ETypeRep
+        (substType subst t)
+    EUpdate u -> EUpdate
+        (substUpdate subst u)
+    EScenario s -> EScenario
+        (substScenario subst s)
+    ELocation l e -> ELocation
+        l
+        (substExpr subst e)
+
+substAlternative :: Subst -> CaseAlternative -> CaseAlternative
+substAlternative subst (CaseAlternative p e) =
+    substWithPattern subst p $ \ subst' p' ->
+        CaseAlternative p' (substExpr subst' e)
+
+substWithPattern :: Subst -> CasePattern -> (Subst -> CasePattern -> t) -> t
+substWithPattern subst p f = case p of
+    CPVariant t v x ->
+        substWithBoundExprVar subst x $ \ subst' x' ->
+            f subst' (CPVariant t v x')
+    CPEnum _ _ -> f subst p
+    CPUnit -> f subst p
+    CPBool _ -> f subst p
+    CPNil -> f subst p
+    CPCons x1 x2 ->
+        substWithBoundExprVar subst  x1 $ \ subst'  x1' ->
+        substWithBoundExprVar subst' x2 $ \ subst'' x2' ->
+            f subst'' (CPCons x1' x2')
+    CPNone -> f subst p
+    CPSome x ->
+        substWithBoundExprVar subst x $ \ subst' x' ->
+            f subst' (CPSome x')
+    CPDefault -> f subst p
+
+substUpdate :: Subst -> Update -> Update
+substUpdate subst = \case
+    UPure t e -> UPure
+        (substType subst t)
+        (substExpr subst e)
+    UBind (Binding (x, t) e1) e2 ->
+        substWithBoundExprVar subst x $ \ subst' x' ->
+            UBind (Binding (x', substType subst t) (substExpr subst e1))
+                (substExpr subst' e2)
+    UCreate templateName e -> UCreate
+        templateName
+        (substExpr subst e)
+    UExercise templateName choiceName e1 e2M e3 -> UExercise
+        templateName
+        choiceName
+        (substExpr subst e1)
+        (substExpr subst <$> e2M)
+        (substExpr subst e3)
+    UFetch templateName e -> UFetch
+        templateName
+        (substExpr subst e)
+    e@UGetTime -> e
+    UEmbedExpr t e -> UEmbedExpr
+        (substType subst t)
+        (substExpr subst e)
+    ULookupByKey (RetrieveByKey templateName e) -> ULookupByKey $ RetrieveByKey
+        templateName
+        (substExpr subst e)
+    UFetchByKey (RetrieveByKey templateName e) -> UFetchByKey $ RetrieveByKey
+        templateName
+        (substExpr subst e)
+
+substScenario :: Subst -> Scenario -> Scenario
+substScenario subst = \case
+    SPure t e -> SPure
+        (substType subst t)
+        (substExpr subst e)
+    SBind (Binding (x,t) e1) e2 ->
+        substWithBoundExprVar subst x $ \ subst' x' ->
+            SBind (Binding (x', substType subst t) (substExpr subst e1))
+                (substExpr subst' e2)
+    SCommit t e1 e2 -> SCommit
+        (substType subst t)
+        (substExpr subst e1)
+        (substExpr subst e2)
+    SMustFailAt t e1 e2 -> SMustFailAt
+        (substType subst t)
+        (substExpr subst e1)
+        (substExpr subst e2)
+    SPass e -> SPass
+        (substExpr subst e)
+    e@SGetTime -> e
+    SGetParty e -> SGetParty
+        (substExpr subst e)
+    SEmbedExpr t e -> SEmbedExpr
+        (substType subst t)
+        (substExpr subst e)
+
+freshenTypeVar :: Subst -> TypeVarName -> TypeVarName
+freshenTypeVar Subst{..} (TypeVarName v) =
+  let candidates = map (\n -> TypeVarName (v <> T.pack (show n))) [1 :: Int ..]
+  in findJust (`Set.notMember` substExhaustedTypeVars) candidates
+
+freshenExprVar :: Subst -> ExprVarName -> ExprVarName
+freshenExprVar Subst{..} (ExprVarName v) =
+  let candidates = map (\n -> ExprVarName (v <> T.pack (show n))) [1 :: Int ..]
+  in findJust (`Set.notMember` substExhaustedExprVars) candidates

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
@@ -7,6 +7,7 @@ module DA.Daml.LF.Ast.Type
   , alphaEquiv
   , Subst
   , substitute
+  , substituteAux
   ) where
 
 import           Data.Bifunctor
@@ -103,7 +104,12 @@ type Subst = Map.Map TypeVarName Type
 -- substituting into but not contained in the domain of the substitution, then
 -- both free occurrences refer to the same binder.
 substitute :: Subst -> Type -> Type
-substitute subst = go (Map.foldl' (\acc t -> acc `Set.union` freeVars t) Set.empty subst) subst
+substitute subst = substituteAux
+    (Map.foldl' (\acc t -> acc `Set.union` freeVars t) Set.empty subst)
+    subst
+
+substituteAux :: Set.Set TypeVarName -> Subst -> Type -> Type
+substituteAux = go
   where
     -- NOTE(MH): We maintain the invariant that @fvSubst0@ contains the free
     -- variables of @subst0@ or an over-approximation thereof.

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Type.hs
@@ -4,7 +4,6 @@
 module DA.Daml.LF.Ast.Type
   ( freeVars
   , referencedSyns
-  , alphaEquiv
   , Subst
   , substitute
   , substituteAux
@@ -17,7 +16,6 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.List
 import           Safe (findJust)
-import           Safe.Exact (zipWithExactMay)
 
 import DA.Daml.LF.Ast.Base
 
@@ -50,51 +48,6 @@ referencedSyns = go HS.empty
       TForall _ body -> go acc body
       TStruct fs -> foldl' go acc (map snd fs)
       TNat _ -> acc
-
--- | Auxiliary data structure to track bound variables in the test for alpha
--- equivalence.
-data AlphaEnv = AlphaEnv
-  { currentDepth :: !Int
-    -- ^ Current quantifier depth.
-  , binderDepthLhs :: !(Map.Map TypeVarName Int)
-    -- ^ Maps bound type variables from the left-hand-side of 'alphaEquiv' to
-    -- the depth of the quantifier which introduced them.
-  , binderDepthRhs :: !(Map.Map TypeVarName Int)
-    -- ^ Maps bound type variables from the right-hand-side of 'alphaEquiv' to
-    -- the depth of the quantifier which introduced them.
-  }
-
--- | Test two types for alpha equivalence.
-alphaEquiv :: Type -> Type -> Bool
-alphaEquiv = go (AlphaEnv 0 Map.empty Map.empty)
-  where
-    go :: AlphaEnv -> Type -> Type -> Bool
-    go env0@AlphaEnv{currentDepth, binderDepthLhs, binderDepthRhs} = curry $ \case
-      (TVar v1, TVar v2) ->
-        case (Map.lookup v1 binderDepthLhs, Map.lookup v2 binderDepthRhs) of
-          (Just l1, Just l2) -> l1 == l2
-          (Nothing, Nothing) -> v1 == v2
-          (Just _ , Nothing) -> False
-          (Nothing, Just _ ) -> False
-      (TCon c1, TCon c2) -> c1 == c2
-      (TApp tf1 ta1, TApp tf2 ta2) -> go0 tf1 tf2 && go0 ta1 ta2
-      (TBuiltin b1, TBuiltin b2) -> b1 == b2
-      (TForall (v1, k1) t1, TForall (v2, k2) t2) ->
-        let env1 = AlphaEnv
-              { currentDepth   = currentDepth + 1
-              , binderDepthLhs = Map.insert v1 currentDepth binderDepthLhs
-              , binderDepthRhs = Map.insert v2 currentDepth binderDepthRhs
-              }
-        in  k1 == k2 && go env1 t1 t2
-      (TStruct fs1, TStruct fs2)
-        | Just bs <- zipWithExactMay agree (sortOn fst fs1) (sortOn fst fs2) ->
-            and bs
-        where
-          agree (l1, t1) (l2, t2) = l1 == l2 && go0 t1 t2
-      (TNat n1, TNat n2) -> n1 == n2
-      (_, _) -> False
-      where
-        go0 = go env0
 
 -- | Substitution of types for type variables.
 type Subst = Map.Map TypeVarName Type

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -124,6 +124,7 @@ allFeatures =
     [ featureNumeric
     , featureAnyType
     , featureTypeRep
+    , featureTypeSynonyms
     , featureStringInterning
     , featureGenericComparison
     , featureGenMap

--- a/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
+++ b/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
@@ -145,7 +145,7 @@ substitutionTests = testGroup "substitution"
           (substitute subst (TForall (y,       KStar) $ TVar x              :-> TVar y))
                             (TForall (yRenamed,KStar) $ typeWithNatAndFreeY :-> TVar yRenamed)
 
-    , testCase "substExpr" $ do
+    , testCase "applySubstInExpr" $ do
         let x = ExprVarName "x"
             x1 = ExprVarName "x1"
             y = ExprVarName "y"
@@ -157,25 +157,25 @@ substitutionTests = testGroup "substitution"
 
             assertExprSubst x e a b =
                 let subst = exprSubst x e
-                    test = alphaExpr (substExpr subst a) b
+                    test = alphaExpr (applySubstInExpr subst a) b
                     msg = unlines
                         ["substitution test failed:"
                         , "\tsubst = exprSubst (" <> show x <> ") (" <> show e <> ")"
                         , "\toriginal = " <> show a
                         , "\texpected = " <> show b
-                        , "\tgot = " <> show (substExpr subst a)
+                        , "\tgot = " <> show (applySubstInExpr subst a)
                         ]
                 in assertBool msg test
 
             assertTypeSubst x t a b =
                 let subst = typeSubst x t
-                    test = alphaExpr (substExpr subst a) b
+                    test = alphaExpr (applySubstInExpr subst a) b
                     msg = unlines
                         ["substitution test failed:"
                         , "\tsubst = typeSubst (" <> show x <> ") (" <> show t <> ")"
                         , "\toriginal = " <> show a
                         , "\texpected = " <> show b
-                        , "\tgot = " <> show (substExpr subst a)
+                        , "\tgot = " <> show (applySubstInExpr subst a)
                         ]
                 in assertBool msg test
 

--- a/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
+++ b/compiler/daml-lf-ast/test/DA/Daml/LF/Ast/Tests.hs
@@ -29,6 +29,7 @@ import DA.Test.Util
 main :: IO ()
 main = defaultMain $ testGroup "DA.Daml.LF.Ast"
     [ numericTests
+    , alphaTests
     , substitutionTests
     , typeSynTests
     ]
@@ -56,6 +57,72 @@ numericTests = testGroup "Numeric"
             assertEqual "read produced wrong numeric or failed" (Just num) (readMaybe str)
     ]
 
+alphaTests :: TestTree
+alphaTests = testGroup "alpha equivalence"
+    [ testCase "alphaExpr" $ do
+        let assertAlpha a b =
+                assertBool (show a <> " should be alpha equivalent to " <> show b) $
+                    alphaExpr a b
+            assertNotAlpha a b =
+                assertBool (show a <> " should not be alpha equivalent to " <> show b) $
+                    not (alphaExpr a b)
+
+
+
+        assertAlpha
+            (EVar (ExprVarName "x"))
+            (EVar (ExprVarName "x"))
+        assertNotAlpha
+            (EVar (ExprVarName "x"))
+            (EVar (ExprVarName "y"))
+        assertAlpha
+            (ETmLam (ExprVarName "x", TInt64) (EVar (ExprVarName "x")))
+            (ETmLam (ExprVarName "y", TInt64) (EVar (ExprVarName "y")))
+        assertNotAlpha
+            (ETmLam (ExprVarName "x", TInt64) (EVar (ExprVarName "x")))
+            (ETmLam (ExprVarName "y", TText) (EVar (ExprVarName "y")))
+        assertNotAlpha
+            (ETmLam (ExprVarName "x", TVar (TypeVarName "a")) (EVar (ExprVarName "x")))
+            (ETmLam (ExprVarName "y", TVar (TypeVarName "b")) (EVar (ExprVarName "y")))
+        assertAlpha
+            (ETyLam (TypeVarName "a", KStar) (ETmLam (ExprVarName "x", TVar (TypeVarName "a")) (EVar (ExprVarName "x"))))
+            (ETyLam (TypeVarName "b", KStar) (ETmLam (ExprVarName "y", TVar (TypeVarName "b")) (EVar (ExprVarName "y"))))
+        assertAlpha
+            (ETmLam (ExprVarName "x", TInt64) (ETmLam (ExprVarName "y", TInt64) (EVar (ExprVarName "x"))))
+            (ETmLam (ExprVarName "y", TInt64) (ETmLam (ExprVarName "x", TInt64) (EVar (ExprVarName "y"))))
+        assertNotAlpha
+            (ETmLam (ExprVarName "x", TInt64) (ETmLam (ExprVarName "y", TInt64) (EVar (ExprVarName "x"))))
+            (ETmLam (ExprVarName "y", TInt64) (ETmLam (ExprVarName "x", TInt64) (EVar (ExprVarName "x"))))
+        assertAlpha
+            (ELet (Binding (ExprVarName "x", TInt64) (ENone TInt64)) (EVar (ExprVarName "x")))
+            (ELet (Binding (ExprVarName "y", TInt64) (ENone TInt64)) (EVar (ExprVarName "y")))
+        assertNotAlpha -- NOTE: "let" is not recursive in DAML-LF
+            (ELet (Binding (ExprVarName "x", TInt64) (EVar (ExprVarName "x"))) (EVar (ExprVarName "x")))
+            (ELet (Binding (ExprVarName "y", TInt64) (EVar (ExprVarName "y"))) (EVar (ExprVarName "y")))
+        assertAlpha
+            (ELet (Binding (ExprVarName "x", TInt64) (EVar (ExprVarName "x"))) (EVar (ExprVarName "x")))
+            (ELet (Binding (ExprVarName "y", TInt64) (EVar (ExprVarName "x"))) (EVar (ExprVarName "y")))
+        assertNotAlpha
+            (ECase (ENone TInt64) [CaseAlternative CPNone (ENone TInt64)])
+            (ECase (ENone TInt64) [CaseAlternative (CPSome (ExprVarName "x")) (ENone TInt64)])
+        assertAlpha
+            (ECase (ENone TInt64) [CaseAlternative (CPSome (ExprVarName "x")) (EVar (ExprVarName "x"))])
+            (ECase (ENone TInt64) [CaseAlternative (CPSome (ExprVarName "y")) (EVar (ExprVarName "y"))])
+        assertNotAlpha
+            (ECase (ENone TInt64) [CaseAlternative (CPSome (ExprVarName "x")) (EVar (ExprVarName "x"))])
+            (ECase (ENone TInt64) [CaseAlternative (CPSome (ExprVarName "y")) (EVar (ExprVarName "x"))])
+        assertAlpha
+            (ECase (ENil TInt64) [CaseAlternative (CPCons (ExprVarName "a") (ExprVarName "b")) (EVar (ExprVarName "a"))])
+            (ECase (ENil TInt64) [CaseAlternative (CPCons (ExprVarName "x") (ExprVarName "y")) (EVar (ExprVarName "x"))])
+        assertNotAlpha
+            (ECase (ENil TInt64) [CaseAlternative (CPCons (ExprVarName "a") (ExprVarName "b")) (EVar (ExprVarName "a"))])
+            (ECase (ENil TInt64) [CaseAlternative (CPCons (ExprVarName "x") (ExprVarName "y")) (EVar (ExprVarName "y"))])
+        assertAlpha
+            (ECase (ENil TInt64) [CaseAlternative (CPCons (ExprVarName "a") (ExprVarName "b")) (EVar (ExprVarName "b"))])
+            (ECase (ENil TInt64) [CaseAlternative (CPCons (ExprVarName "x") (ExprVarName "y")) (EVar (ExprVarName "y"))])
+        -- Don't need tests for CPCons pattern variable names being
+        -- the same because that is not allowed, caught by typechecker.
+    ]
 
 substitutionTests :: TestTree
 substitutionTests = testGroup "substitution"
@@ -78,14 +145,150 @@ substitutionTests = testGroup "substitution"
           (substitute subst (TForall (y,       KStar) $ TVar x              :-> TVar y))
                             (TForall (yRenamed,KStar) $ typeWithNatAndFreeY :-> TVar yRenamed)
 
-    , testCase "ETmLam" $ do
-        let x1 = ExprVarName "x1"
-            x11 = ExprVarName "x11"
-            subst = exprSubst x11 (EVar x1)
-            e1 = ETmLam (x11, TInt64) $ ETmLam (x1, TInt64) $
-                EBuiltin BEAddInt64 `ETmApp` EVar x11 `ETmApp` EVar x1
-            e2 = substExpr subst e1
-        assertBool "wrong substitution" (alphaExpr e1 e2)
+    , testCase "substExpr" $ do
+        let x = ExprVarName "x"
+            x1 = ExprVarName "x1"
+            y = ExprVarName "y"
+            z = ExprVarName "z"
+            a = TypeVarName "a"
+            a1 = TypeVarName "a1"
+            b = TypeVarName "b"
+            c = TypeVarName "c"
+
+            assertExprSubst x e a b =
+                let subst = exprSubst x e
+                    test = alphaExpr (substExpr subst a) b
+                    msg = unlines
+                        ["substitution test failed:"
+                        , "\tsubst = exprSubst (" <> show x <> ") (" <> show e <> ")"
+                        , "\toriginal = " <> show a
+                        , "\texpected = " <> show b
+                        , "\tgot = " <> show (substExpr subst a)
+                        ]
+                in assertBool msg test
+
+            assertTypeSubst x t a b =
+                let subst = typeSubst x t
+                    test = alphaExpr (substExpr subst a) b
+                    msg = unlines
+                        ["substitution test failed:"
+                        , "\tsubst = typeSubst (" <> show x <> ") (" <> show t <> ")"
+                        , "\toriginal = " <> show a
+                        , "\texpected = " <> show b
+                        , "\tgot = " <> show (substExpr subst a)
+                        ]
+                in assertBool msg test
+
+        -- no binder tests
+        assertExprSubst x (EBuiltin (BEInt64 42))
+            (EVar y)
+            (EVar y)
+        assertExprSubst x (EBuiltin (BEInt64 42))
+            (EVar x)
+            (EBuiltin (BEInt64 42))
+        assertExprSubst x (EBuiltin (BEInt64 42))
+            (EBuiltin BEAddInt64 `ETmApp` EVar x `ETmApp` EVar y)
+            (EBuiltin BEAddInt64 `ETmApp` EBuiltin (BEInt64 42) `ETmApp` EVar y)
+        assertTypeSubst a TInt64
+            (ENone (TVar b))
+            (ENone (TVar b))
+        assertTypeSubst a TInt64
+            (ENone (TVar a))
+            (ENone TInt64)
+        assertTypeSubst a TInt64
+            (ENone (TVar a :-> TVar b))
+            (ENone (TInt64 :-> TVar b))
+
+        -- bound variable matches substitution variable
+        assertExprSubst x (EBuiltin (BEInt64 42))
+            (ETmLam (x, TInt64) (EVar x))
+            (ETmLam (x, TInt64) (EVar x))
+        assertTypeSubst a TInt64
+            (ETyLam (a, KStar) (ENone (TVar a)))
+            (ETyLam (a, KStar) (ENone (TVar a)))
+        assertTypeSubst a TInt64
+            (ENone (TForall (a, KStar) (TVar a)))
+            (ENone (TForall (a, KStar) (TVar a)))
+
+        -- bound variable does not match substitution variable nor appears free in substitution body
+        assertExprSubst x (EBuiltin (BEInt64 42))
+            (ETmLam (y, TInt64) (EVar x))
+            (ETmLam (y, TInt64) (EBuiltin (BEInt64 42)))
+        assertExprSubst x (EBuiltin (BEInt64 42))
+            (ETmLam (y, TInt64) (EVar y))
+            (ETmLam (y, TInt64) (EVar y))
+        assertExprSubst x (EBuiltin (BEInt64 42))
+            (ETmLam (y, TInt64) (EVar z))
+            (ETmLam (y, TInt64) (EVar z))
+        assertTypeSubst a TInt64
+            (ETyLam (b, KStar) (ENone (TVar a)))
+            (ETyLam (b, KStar) (ENone TInt64))
+        assertTypeSubst a TInt64
+            (ETyLam (b, KStar) (ENone (TVar b)))
+            (ETyLam (b, KStar) (ENone (TVar b)))
+        assertTypeSubst a TInt64
+            (ETyLam (b, KStar) (ENone (TVar c)))
+            (ETyLam (b, KStar) (ENone (TVar c)))
+        assertTypeSubst a TInt64
+            (ENone (TForall (b, KStar) (TVar a)))
+            (ENone (TForall (b, KStar) TInt64))
+        assertTypeSubst a TInt64
+            (ENone (TForall (b, KStar) (TVar b)))
+            (ENone (TForall (b, KStar) (TVar b)))
+        assertTypeSubst a TInt64
+            (ENone (TForall (b, KStar) (TVar c)))
+            (ENone (TForall (b, KStar) (TVar c)))
+
+        -- mixture of both cases above
+        assertExprSubst x (EBuiltin (BEInt64 42))
+            (ETmLam (y, TInt64) (ETmLam (x, TInt64) (EVar x) `ETmApp` EVar x))
+            (ETmLam (y, TInt64) (ETmLam (x, TInt64) (EVar x) `ETmApp` EBuiltin (BEInt64 42)))
+        assertTypeSubst a TInt64
+            (ETyLam (b, KStar) (ETyLam (a, KStar) (ENone (TVar a)) `ETmApp` ENone (TVar a)))
+            (ETyLam (b, KStar) (ETyLam (a, KStar) (ENone (TVar a)) `ETmApp` ENone TInt64))
+        assertTypeSubst a TInt64
+            (ETyLam (b, KStar) (ENone (TForall (a, KStar) (TVar a) :-> TVar a)))
+            (ETyLam (b, KStar) (ENone (TForall (a, KStar) (TVar a) :-> TInt64)))
+
+        -- bound variable appears in substitution body
+        assertExprSubst x (EVar y)
+            (ETmLam (y, TInt64) (EBuiltin (BEInt64 42)))
+            (ETmLam (y, TInt64) (EBuiltin (BEInt64 42)))
+        assertExprSubst x (EVar y)
+            (ETmLam (y, TInt64) (EVar x))
+            (ETmLam (z, TInt64) (EVar y))
+        assertTypeSubst a (TVar b)
+            (ETyLam (b, KStar) (ENone TInt64))
+            (ETyLam (b, KStar) (ENone TInt64))
+        assertTypeSubst a (TVar b)
+            (ETyLam (b, KStar) (ENone (TVar a)))
+            (ETyLam (c, KStar) (ENone (TVar b)))
+        assertTypeSubst a (TVar b)
+            (ENone (TForall (b, KStar) TInt64))
+            (ENone (TForall (b, KStar) TInt64))
+        assertTypeSubst a (TVar b)
+            (ENone (TForall (b, KStar) (TVar a)))
+            (ENone (TForall (c, KStar) (TVar b)))
+
+        -- interaction between fresh variables & binders (a port of the TForall regression test)
+        assertExprSubst x1 (EVar x)
+            (ETmLam (x1, TInt64) (ETmLam (x, TInt64) (EVar x)))
+            (ETmLam (x1, TInt64) (ETmLam (x, TInt64) (EVar x)))
+        assertExprSubst x1 (EVar x)
+            (ETmLam (x1, TInt64) (ETmLam (x, TInt64) (EVar x1)))
+            (ETmLam (x1, TInt64) (ETmLam (x, TInt64) (EVar x1)))
+        assertTypeSubst a1 (TVar a)
+            (ETyLam (a1, KStar) (ETyLam (a, KStar) (ENone (TVar a))))
+            (ETyLam (a1, KStar) (ETyLam (a, KStar) (ENone (TVar a))))
+        assertTypeSubst a1 (TVar a)
+            (ETyLam (a1, KStar) (ETyLam (a, KStar) (ENone (TVar a1))))
+            (ETyLam (a1, KStar) (ETyLam (a, KStar) (ENone (TVar a1))))
+        assertTypeSubst a1 (TVar a)
+            (ENone (TForall (a1, KStar) (TForall (a, KStar) (TVar a))))
+            (ENone (TForall (a1, KStar) (TForall (a, KStar) (TVar a))))
+        assertTypeSubst a1 (TVar a)
+            (ENone (TForall (a1, KStar) (TForall (a, KStar) (TVar a1))))
+            (ENone (TForall (a1, KStar) (TForall (a, KStar) (TVar a1))))
 
     ]
 

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -431,6 +431,6 @@ simplifyExpr world = fst . cata go
       -- e    ==>    e
       e -> (embed (fmap fst e), infoStep world (fmap snd e))
 
-simplifyModule :: World -> Version -> Module -> Module
-simplifyModule world _version m =
+simplifyModule :: World -> Module -> Module
+simplifyModule world m =
     over moduleExpr (simplifyExpr (extendWorldSelf m world)) m

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -45,6 +45,7 @@ import           Safe.Exact (zipExactMay)
 import           DA.Daml.LF.Ast
 import           DA.Daml.LF.Ast.Optics (dataConsType)
 import           DA.Daml.LF.Ast.Type
+import           DA.Daml.LF.Ast.Alpha
 import           DA.Daml.LF.Ast.Numeric
 import           DA.Daml.LF.TypeChecker.Env
 import           DA.Daml.LF.TypeChecker.Error
@@ -600,7 +601,7 @@ checkExpr' :: MonadGamma m => Expr -> Type -> m Type
 checkExpr' expr typ = do
   exprType <- typeOf expr
   typX <- expandTypeSynonyms typ
-  unless (alphaEquiv exprType typX) $
+  unless (alphaType exprType typX) $
     throwWithContext ETypeMismatch{foundType = exprType, expectedType = typX, expr = Just expr}
   pure exprType
 

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -42,7 +42,7 @@ import "ghc-lib-parser" TysPrim
 import "ghc-lib-parser" TysWiredIn
 
 import qualified DA.Daml.LF.Ast as LF
-import qualified DA.Daml.LF.Ast.Type as LF
+import qualified DA.Daml.LF.Ast.Alpha as LF
 import qualified DA.Daml.LF.TypeChecker.Check as LF
 import qualified DA.Daml.LF.TypeChecker.Env as LF
 import DA.Daml.Options
@@ -148,7 +148,7 @@ safeToReexport env syn1 syn2 =
         LF.runGamma (envWorld env) (envLfVersion env) $ do
             esyn1 <- LF.expandTypeSynonyms (closedType syn1)
             esyn2 <- LF.expandTypeSynonyms (closedType syn2)
-            pure (LF.alphaEquiv esyn1 esyn2)
+            pure (LF.alphaType esyn1 esyn2)
 
   where
     -- | Turn a type synonym definition into a closed type.
@@ -164,7 +164,7 @@ isDuplicate env ty1 ty2 =
         LF.runGamma (envWorld env) (envLfVersion env) $ do
             esyn1 <- LF.expandTypeSynonyms ty1
             esyn2 <- LF.expandTypeSynonyms ty2
-            pure (LF.alphaEquiv esyn1 esyn2)
+            pure (LF.alphaType esyn1 esyn2)
 
 data ImportOrigin = FromCurrentSdk UnitId | FromPackage LF.PackageId
     deriving (Eq, Ord)

--- a/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
+++ b/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
@@ -139,11 +139,11 @@ startFromUpdate seen world update = case update of
     -- in dictionaries for the template and choice typeclasses (`HasCreate`
     -- `HasExercise`, `HasArchive`, `HasFetch`, `HasFetchByKey`, `HasLookupByKey`)
     -- which we ignore below.
-    LF.UCreate{} -> error "IMPOSSIBLE"
-    LF.UExercise{} -> error "IMPOSSIBLE"
-    LF.UFetch{} -> error "IMPOSSIBLE"
-    LF.ULookupByKey{} -> error "IMPOSSIBLE"
-    LF.UFetchByKey{} -> error "IMPOSSIBLE"
+    LF.UCreate tpl _ -> Set.singleton (ACreate tpl)
+    LF.UExercise tpl choice _ _ _ -> Set.singleton (AExercise tpl choice)
+    LF.UFetch{} -> Set.empty
+    LF.ULookupByKey{} -> Set.empty
+    LF.UFetchByKey{} -> Set.empty
 
 startFromExpr :: Set.Set (LF.Qualified LF.ExprValName) -> LF.World -> LF.Expr -> Set.Set Action
 startFromExpr seen world e = case e of

--- a/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
+++ b/compiler/damlc/daml-visual/src/DA/Daml/Visual.hs
@@ -135,10 +135,6 @@ startFromUpdate seen world update = case update of
     LF.UBind (LF.Binding _ e1) e2 -> startFromExpr seen world e1 `Set.union` startFromExpr seen world e2
     LF.UGetTime -> Set.empty
     LF.UEmbedExpr _ upEx -> startFromExpr seen world upEx
-    -- NOTE(MH): The cases below are impossible because they only appear
-    -- in dictionaries for the template and choice typeclasses (`HasCreate`
-    -- `HasExercise`, `HasArchive`, `HasFetch`, `HasFetchByKey`, `HasLookupByKey`)
-    -- which we ignore below.
     LF.UCreate tpl _ -> Set.singleton (ACreate tpl)
     LF.UExercise tpl choice _ _ _ -> Set.singleton (AExercise tpl choice)
     LF.UFetch{} -> Set.empty


### PR DESCRIPTION
TL;DR: This PR offers 1.10x to 1.15x speedups on our benchmarks, by removing layers of indirection when it comes to calling typeclass functions at known typeclasses. To do this, it also implements additional functions for manipulating the DAML-LF AST in Haskell (in particular substitution and alpha equivalence for expressions), which will be very useful for implementing future optimizations.

This PR:

* refactors free variable set calculation to a FreeVars module
* adds an Alpha module for calculation of alpha equivalence of LF expressions and types. Previously we only had alpha equivalenc for types, and it was incomplete (no case for `TSynApp`).
* adds a Subst module for substitution within LF expressions.
  This implementation piggybacks on the existing type
  substition.
* adds lots of tests for Alpha and Subst.
* passes World data into the simplifier, in order to have
  have the ability to inline functions.
    * Except when doing incremental builds, in which case the simplifier gets an empty World. This 100% prevents cross-module inlining when incremental builds are turned on. As @cocreature pointed out, incremental builds only rebuild whenever a module ABI changes, which means the implementation of module A could change without module B being recomputed, even if B depends on A, so it's unsafe to do any inlining in this case (or rely on implementations in any way).
* inlines and beta-reduces typeclass projection functions applied to typeclass dictionary functions, and so fixes #5748 (see sample results)
* provides 10-13% time reduction, i.e. 1.10x to 1.15x speedup, in the benchmarks.

Sample results:

DAML input:

```
module Main where

hello : Int
hello = 10 + 30
```

Original DAML-LF output:

```
module Main where
    @location(7:0-7:5)
    def hello : Int64 =
      a284919a95c4a515cd1efac0d89be302d0e9d61e692a2176128c871ad8067e36:GHC.Num:+
        @Int64
        a284919a95c4a515cd1efac0d89be302d0e9d61e692a2176128c871ad8067e36:GHC.Num:$fAdditiveInt
        10
        30
```

Current DAML-LF output:

```
 module Main where
    @location(7:0-7:5)
    def hello : Int64 = ADD_INT64 10 30
```

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
