### PR TITLE
Refactor damlc visualize tests

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -652,6 +652,7 @@ exports_files(["stack.exe"], visibility = ["//visibility:public"])
             "tar-conduit",
             "tasty",
             "tasty-ant-xml",
+            "tasty-expected-failure",
             "tasty-golden",
             "tasty-hunit",
             "tasty-quickcheck",

--- a/compiler/damlc/daml-ide-core/BUILD.bazel
+++ b/compiler/damlc/daml-ide-core/BUILD.bazel
@@ -77,6 +77,7 @@ da_haskell_library(
         "containers",
         "data-default",
         "directory",
+        "either",
         "extra",
         "filepath",
         "ghcide",

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing.hs
@@ -52,6 +52,7 @@ import qualified Development.IDE.Types.Diagnostics as D
 import qualified Development.IDE.Types.Location as D
 import DA.Bazel.Runfiles
 import DA.Daml.LF.ScenarioServiceClient as SS
+import Development.IDE.Core.API.Testing.Visualize
 import Development.IDE.Core.Rules.Daml
 import Development.IDE.Types.Logger
 import Development.IDE.Types.Options (IdeReportProgress(..))
@@ -61,21 +62,18 @@ import Development.IDE.Core.Service.Daml(VirtualResource(..), mkDamlEnv)
 import DA.Test.Util (standardizeQuotes)
 import Language.Haskell.LSP.Messages (FromServerMessage(..))
 import Language.Haskell.LSP.Types
-import qualified DA.Daml.Visual as V
-import qualified DA.Daml.LF.Ast as LF
 
 -- * external dependencies
 import Control.Concurrent.STM
 import Control.Exception.Extra
 import qualified Control.Monad.Reader   as Reader
-import Data.Bifunctor (bimap)
 import Data.Default
+import Data.Either.Combinators
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Vector as V
-import qualified Data.NameMap as NM
 import qualified Data.Text              as T
 import qualified Data.Text.IO           as T.IO
 import qualified Data.HashSet as HashSet
@@ -107,7 +105,7 @@ data ShakeTestError
     | ExpectedVirtualResourceNote VirtualResource T.Text (Map VirtualResource T.Text)
     | ExpectedNoVirtualResourceNote VirtualResource (Map VirtualResource T.Text)
     | ExpectedNoErrors [D.FileDiagnostic]
-    | ExpectedGraphProps ExpectedGraph V.Graph
+    | ExpectedGraphProps FailedGraphExpectation
     | ExpectedDefinition Cursor GoToDefinitionPattern (Maybe D.Location)
     | ExpectedHoverText Cursor HoverExpectation [T.Text]
     | TimedSectionTookTooLong Clock.NominalDiffTime Clock.NominalDiffTime
@@ -126,25 +124,6 @@ data ShakeTestEnv = ShakeTestEnv
     , steVirtualResources :: TVar (Map VirtualResource T.Text)
     , steVirtualResourcesNotes :: TVar (Map VirtualResource T.Text)
     }
-
-type TemplateName = String
-type ChoiceName = String
-
-data ExpectedChoiceDetails = ExpectedChoiceDetails
-    { expectedConsuming :: Bool
-    , expectedName :: String
-    } deriving (Eq, Ord, Show )
-
-data ExpectedSubGraph = ExpectedSubGraph
-    { expectedNodes :: [ChoiceName]
-    , expectedTplFields :: [String]
-    , expectedTemplate :: TemplateName
-    } deriving (Eq, Ord, Show )
-
-data ExpectedGraph = ExpectedGraph
-    { expectedSubgraphs :: [ExpectedSubGraph]
-    , expectedEdges :: [(ExpectedChoiceDetails, ExpectedChoiceDetails)]
-    } deriving (Eq, Ord, Show )
 
 -- | Monad for specifying Shake API tests. This type is abstract.
 newtype ShakeTest t = ShakeTest (ExceptT ShakeTestError (ReaderT ShakeTestEnv IO) t)
@@ -543,25 +522,6 @@ timedSection targetDiffTime block = do
         throwError $ TimedSectionTookTooLong targetDiffTime actualDiffTime
     return value
 
-subgraphToExpectedSubgraph :: V.SubGraph -> ExpectedSubGraph
-subgraphToExpectedSubgraph vSubgraph = ExpectedSubGraph vNodes vFields vTplName
-    where vNodes = map (T.unpack . LF.unChoiceName . V.displayChoiceName) (V.nodes vSubgraph)
-          vFields = map T.unpack (V.templateFields vSubgraph)
-          vTplName = T.unpack $ V.tplNameUnqual (V.clusterTemplate vSubgraph)
-
-graphToExpectedGraph :: V.Graph -> ExpectedGraph
-graphToExpectedGraph vGraph = ExpectedGraph vSubgrpaghs vEdges
-    where vSubgrpaghs = map subgraphToExpectedSubgraph (V.subgraphs vGraph)
-          vEdges = map (bimap expectedChcDetails expectedChcDetails) (V.edges vGraph)
-          expectedChcDetails chc = ExpectedChoiceDetails (V.consuming chc)
-                                ((T.unpack . LF.unChoiceName . V.displayChoiceName) chc)
-
-graphTest :: LF.World -> LF.Package -> ExpectedGraph -> ShakeTest ()
-graphTest wrld pkg expectedGraph = do
-    let actualGraph = V.graphFromModule (NM.toList $ LF.packageModules pkg) wrld
-    unless (expectedGraph == graphToExpectedGraph actualGraph) $
-        throwError $ ExpectedGraphProps expectedGraph actualGraph
-
 -- Not using the ide call as we do not have a rule defined for visualization because of memory overhead
 expectedGraph :: D.NormalizedFilePath -> ExpectedGraph -> ShakeTest ()
 expectedGraph damlFilePath expectedGraph = do
@@ -570,7 +530,7 @@ expectedGraph damlFilePath expectedGraph = do
     expectNoErrors
     Just lfPkg <- pure mbDalf
     wrld <- Reader.liftIO $ API.runActionSync ideState (API.worldForFile damlFilePath)
-    graphTest wrld lfPkg expectedGraph
+    whenLeft (graphTest wrld lfPkg expectedGraph) $ throwError . ExpectedGraphProps
 
 -- | Example testing scenario.
 example :: ShakeTest ()

--- a/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing/Visualize.hs
+++ b/compiler/damlc/daml-ide-core/test/Development/IDE/Core/API/Testing/Visualize.hs
@@ -1,0 +1,65 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Development.IDE.Core.API.Testing.Visualize
+    ( ExpectedGraph(..)
+    , ExpectedSubGraph(..)
+    , ExpectedChoiceDetails(..)
+    , FailedGraphExpectation(..)
+    , graphTest
+    )
+    where
+
+import Control.Monad
+import Data.Bifunctor
+import qualified Data.NameMap as NM
+import qualified Data.Text as T
+
+import qualified DA.Daml.LF.Ast as LF
+import qualified DA.Daml.Visual as V
+
+type TemplateName = String
+type ChoiceName = String
+
+data ExpectedGraph = ExpectedGraph
+    { expectedSubgraphs :: [ExpectedSubGraph]
+    , expectedEdges :: [(ExpectedChoiceDetails, ExpectedChoiceDetails)]
+    } deriving (Eq, Ord, Show )
+
+data ExpectedSubGraph = ExpectedSubGraph
+    { expectedNodes :: [ChoiceName]
+    , expectedTplFields :: [String]
+    , expectedTemplate :: TemplateName
+    } deriving (Eq, Ord, Show )
+
+data ExpectedChoiceDetails = ExpectedChoiceDetails
+    { expectedConsuming :: Bool
+    , expectedName :: String
+    } deriving (Eq, Ord, Show )
+
+subgraphToExpectedSubgraph :: V.SubGraph -> ExpectedSubGraph
+subgraphToExpectedSubgraph vSubgraph = ExpectedSubGraph vNodes vFields vTplName
+    where vNodes = map (T.unpack . LF.unChoiceName . V.displayChoiceName) (V.nodes vSubgraph)
+          vFields = map T.unpack (V.templateFields vSubgraph)
+          vTplName = T.unpack $ V.tplNameUnqual (V.clusterTemplate vSubgraph)
+
+graphToExpectedGraph :: V.Graph -> ExpectedGraph
+graphToExpectedGraph vGraph = ExpectedGraph vSubgrpaghs vEdges
+    where vSubgrpaghs = map subgraphToExpectedSubgraph (V.subgraphs vGraph)
+          vEdges = map (bimap expectedChcDetails expectedChcDetails) (V.edges vGraph)
+          expectedChcDetails chc = ExpectedChoiceDetails (V.consuming chc)
+                                ((T.unpack . LF.unChoiceName . V.displayChoiceName) chc)
+
+
+data FailedGraphExpectation = FailedGraphExpectation
+  { expected :: ExpectedGraph
+  , actual :: ExpectedGraph
+  }
+  deriving (Eq, Show)
+
+graphTest :: LF.World -> LF.Package -> ExpectedGraph -> Either FailedGraphExpectation ()
+graphTest wrld pkg expectedGraph = do
+    let actualGraph = V.graphFromModule (NM.toList $ LF.packageModules pkg) wrld
+    let actual = graphToExpectedGraph actualGraph
+    unless (expectedGraph == actual) $
+        Left $ FailedGraphExpectation expectedGraph actual

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -26,7 +26,7 @@ da_haskell_test(
     ],
 )
 
-# Tests for damlc visual
+# Tests for the dar reader
 da_haskell_test(
     name = "daml-lf-reader",
     srcs = ["src/DarReaderTest.hs"],
@@ -41,6 +41,38 @@ da_haskell_test(
     visibility = ["//visibility:private"],
     deps = [
         "//compiler/daml-lf-reader",
+    ],
+)
+
+# Tests for visualization
+da_haskell_test(
+    name = "visualization",
+    srcs = ["src/DamlcVisualize.hs"],
+    data = [
+        "//compiler/damlc",
+    ],
+    hackage_deps = [
+        "base",
+        "bytestring",
+        "directory",
+        "either",
+        "extra",
+        "filepath",
+        "tasty",
+        "tasty-expected-failure",
+        "tasty-hunit",
+        "zip-archive",
+    ],
+    main_function = "DamlcVisualize.main",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//:sdk-version-hs-lib",
+        "//compiler/daml-lf-ast",
+        "//compiler/daml-lf-proto",
+        "//compiler/daml-lf-reader",
+        "//compiler/damlc/daml-ide-core:ide-testing",
+        "//libs-haskell/bazel-runfiles",
+        "//libs-haskell/test-utils",
     ],
 )
 

--- a/compiler/damlc/tests/src/DamlcVisualize.hs
+++ b/compiler/damlc/tests/src/DamlcVisualize.hs
@@ -1,0 +1,179 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DamlcVisualize (main) where
+
+import qualified "zip-archive" Codec.Archive.Zip as Zip
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Either.Combinators
+import DA.Bazel.Runfiles
+import qualified DA.Daml.LF.Proto3.Archive as Archive
+import Development.IDE.Core.API.Testing.Visualize
+import DA.Daml.LF.Ast (ExternalPackage(..), World, getWorldSelf, initWorldSelf)
+import DA.Daml.LF.Reader (Dalfs(..), readDalfs)
+import DA.Test.Process
+import SdkVersion
+import System.Directory
+import System.Environment.Blank
+import System.FilePath
+import System.IO.Extra
+import Test.Tasty
+import Test.Tasty.ExpectedFailure
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = do
+    setEnv "TASTY_NUM_THREADS" "1" True
+    damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
+    defaultMain $ testGroup "visualize"
+        [ testCase "single package" $ withTempDir $ \dir -> do
+              writeFileUTF8 (dir </> "daml.yaml") $ unlines
+                  [ "sdk-version: " <> sdkVersion
+                  , "name: foobar"
+                  , "source: ."
+                  , "version: 0.0.1"
+                  , "dependencies: [daml-stdlib, daml-prim]"
+                  ]
+              writeFileUTF8 (dir </> "A.daml") $ unlines
+                 [ "module A where"
+                 , "import B"
+                 , "template A with"
+                 , "    p : Party"
+                 , "  where"
+                 , "    signatory p"
+                 , "    choice CreateB : ContractId B"
+                 , "      controller p"
+                 , "      do create B with p"
+                 ]
+              writeFileUTF8 (dir </> "B.daml") $ unlines
+                 [ "module B where"
+                 , "template B with"
+                 , "    p : Party"
+                 , "  where"
+                 , "    signatory p"
+                 ]
+              withCurrentDirectory dir $ callProcessSilent damlc ["build", "-o", "foobar.dar"]
+              testFile (dir </> "foobar.dar") ExpectedGraph
+                  { expectedSubgraphs =
+                        [ ExpectedSubGraph
+                              { expectedNodes = ["Create", "Archive"]
+                              , expectedTplFields = ["p"]
+                              , expectedTemplate = "B"
+                              }
+                        , ExpectedSubGraph
+                              { expectedNodes = ["Create", "Archive", "CreateB"]
+                              , expectedTplFields = ["p"]
+                              , expectedTemplate = "A"
+                              }
+                        ]
+                  , expectedEdges =
+                        [ ( ExpectedChoiceDetails
+                                { expectedConsuming = True
+                                , expectedName = "CreateB"
+                                }
+                          , ExpectedChoiceDetails
+                               { expectedConsuming = False
+                               , expectedName = "Create"
+                               }
+                          )
+                        ]
+                  }
+        , expectFailBecause "Multi-package projects are not yet supported (#5760)" $
+          multiPackageTests damlc
+        ]
+
+multiPackageTests :: FilePath -> TestTree
+multiPackageTests damlc = testGroup "multiple packages"
+    [ testCase "multiple packages" $ withTempDir $ \dir -> do
+          createDirectory (dir </> "foobar-a")
+          createDirectory (dir </> "foobar-b")
+          writeFileUTF8 (dir </> "foobar-b" </> "daml.yaml") $ unlines
+              [ "sdk-version: " <> sdkVersion
+              , "name: foobar-b"
+              , "source: ."
+              , "version: 0.0.1"
+              , "dependencies: [daml-stdlib, daml-prim]"
+              ]
+          writeFileUTF8 (dir </> "foobar-b" </> "B.daml") $ unlines
+             [ "module B where"
+             , "template B with"
+             , "    p : Party"
+             , "  where"
+             , "    signatory p"
+             ]
+          withCurrentDirectory (dir </> "foobar-b") $ callProcessSilent damlc ["build", "-o", "foobar-b.dar"]
+          writeFileUTF8 (dir </> "foobar-a" </> "daml.yaml") $ unlines
+              [ "sdk-version: " <> sdkVersion
+              , "name: foobar-a"
+              , "source: ."
+              , "version: 0.0.1"
+              , "dependencies: [daml-stdlib, daml-prim, " <>
+                show (dir </> "foobar-b" </> "foobar-b.dar") <> "]"
+              ]
+          writeFileUTF8 (dir </> "foobar-a" </> "A.daml") $ unlines
+             [ "module A where"
+             , "import B"
+             , "template A with"
+             , "    p : Party"
+             , "  where"
+             , "    signatory p"
+             , "    choice CreateB : ContractId B"
+             , "      controller p"
+             , "      do create B with p"
+             ]
+          withCurrentDirectory (dir </> "foobar-a") $ callProcessSilent damlc ["build", "-o", "foobar-a.dar"]
+          testFile (dir </> "foobar-a" </> "foobar-a.dar") ExpectedGraph
+              { expectedSubgraphs =
+                    [ ExpectedSubGraph
+                          { expectedNodes = ["Create", "Archive"]
+                          , expectedTplFields = ["p"]
+                          , expectedTemplate = "B"
+                          }
+                    , ExpectedSubGraph
+                          { expectedNodes = ["Create", "Archive", "CreateB"]
+                          , expectedTplFields = ["p"]
+                          , expectedTemplate = "A"
+                          }
+                    ]
+              , expectedEdges =
+                    [ ( ExpectedChoiceDetails
+                            { expectedConsuming = True
+                            , expectedName = "CreateB"
+                            }
+                      , ExpectedChoiceDetails
+                           { expectedConsuming = False
+                           , expectedName = "Create"
+                           }
+                      )
+                    ]
+              }
+    ]
+
+testFile :: FilePath -> ExpectedGraph -> Assertion
+testFile dar expected = do
+    darBytes <- BS.readFile dar
+    dalfs <- either fail pure $ readDalfs $ Zip.toArchive (BSL.fromStrict darBytes)
+    !world <- pure $ darToWorld dalfs
+    whenLeft (graphTest world (getWorldSelf world) expected) $
+        \(FailedGraphExpectation expected actual) ->
+        assertFailure $ unlines
+           [ "Failed graph expectation:"
+           , "Expected:"
+           , show expected
+           , "Actual:"
+           , show actual
+           ]
+
+dalfBytesToPakage :: BSL.ByteString -> ExternalPackage
+dalfBytesToPakage bytes = case Archive.decodeArchive Archive.DecodeAsDependency $ BSL.toStrict bytes of
+    Right (pkgId, pkg) -> ExternalPackage pkgId pkg
+    Left err -> error (show err)
+
+darToWorld :: Dalfs -> World
+darToWorld Dalfs{..} = case Archive.decodeArchive Archive.DecodeAsMain $ BSL.toStrict mainDalf of
+    Right (_, mainPkg) -> initWorldSelf pkgs mainPkg
+    Left err -> error (show err)
+    where
+        pkgs = map dalfBytesToPakage dalfs
+


### PR DESCRIPTION
This moves the code from the Shake testing module to a separate
module. This is required since the Shake test setup is not really
intended to test multiple packages. I’ve added a new test suite that
makes use of this and has an expected failure for the issue with
multiple packages. The issue is not actually fixed in this PR, I just
wanted to keep the refactoring separate since it is quite large and
noisy.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
