### PR TITLE
Use a custom Gen instead of Arbitrary, to generate nonempty Vec[Int],

### DIFF
--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
@@ -45,5 +45,5 @@ class FlowUtilTest
   }
 
   private val nonEmptyVectorOfInts: Gen[Vector[Int]] =
-    Gen.nonEmptyBuildableOf[Vector[Int], Int](Arbitrary.arbInt.arbitrary)
+    Gen.nonEmptyBuildableOf[Vector[Int], Int](Arbitrary.arbitrary[Int])
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
@@ -7,6 +7,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
+import org.scalacheck.{Gen, Arbitrary}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
@@ -24,22 +25,25 @@ class FlowUtilTest
   implicit val asys: ActorSystem = ActorSystem(this.getClass.getSimpleName)
   implicit val materializer: Materializer = Materializer(asys)
 
-  "allowOnlyFirstInput" should "pass 1st message through and replace all others with errors" in forAll {
-    xs: Vector[Int] =>
-      val error = "Error"
-      val errorNum = Math.max(xs.size - 1, 0)
-      val expected: Vector[String \/ Int] =
-        xs.take(1).map(\/-(_)) ++ Vector.fill(errorNum)(-\/(error))
-      val input: Source[String \/ Int, NotUsed] =
-        Source.fromIterator(() => xs.toIterator).map(\/-(_))
+  "allowOnlyFirstInput" should "pass 1st message through and replace all others with errors" in forAll(
+    nonEmptyVectorOfInts) { xs: Vector[Int] =>
+    val error = "Error"
+    val errorNum = Math.max(xs.size - 1, 0)
+    val expected: Vector[String \/ Int] =
+      xs.take(1).map(\/-(_)) ++ Vector.fill(errorNum)(-\/(error))
+    val input: Source[String \/ Int, NotUsed] =
+      Source.fromIterator(() => xs.toIterator).map(\/-(_))
 
-      val actualF: Future[Vector[String \/ Int]] =
-        input
-          .via(allowOnlyFirstInput[String, Int](error))
-          .runFold(Vector.empty[String \/ Int])(_ :+ _)
+    val actualF: Future[Vector[String \/ Int]] =
+      input
+        .via(allowOnlyFirstInput[String, Int](error))
+        .runFold(Vector.empty[String \/ Int])(_ :+ _)
 
-      whenReady(actualF) { actual =>
-        actual shouldBe expected
-      }
+    whenReady(actualF) { actual =>
+      actual shouldBe expected
+    }
   }
+
+  private val nonEmptyVectorOfInts: Gen[Vector[Int]] =
+    Gen.nonEmptyBuildableOf[Vector[Int], Int](Arbitrary.arbInt.arbitrary)
 }


### PR DESCRIPTION
the test could fail on empty input, it expects at least one input message. This change prevents empty inputs.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
