### PR TITLE
Trigger service: endpoint to list running triggers for a party

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -279,8 +279,8 @@ object Server {
       // List all running triggers
       get {
         path("list") {
-          val allTriggers = triggers.keys.mkString(",")
-          complete(s"Triggers currently running: $allTriggers")
+          val allTriggers = triggers.keys.map(_.toString).toList.toJson
+          complete(allTriggers)
         }
       },
       // Stop a trigger given its UUID

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -276,6 +276,14 @@ object Server {
           }
         )
       },
+      get {
+        path("list") {
+//          System.out.println("Listing all trigger IDs:")
+//          triggers.keys.foreach((uuid: UUID) => System.out.println(uuid.toString))
+          val allTriggers = triggers.keys.mkString(",")
+          complete(allTriggers)
+        }
+      },
       // Stop a trigger given its UUID
       delete {
         pathPrefix("stop" / JavaUUID) { id =>

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -276,12 +276,11 @@ object Server {
           }
         )
       },
+      // List all running triggers
       get {
         path("list") {
-//          System.out.println("Listing all trigger IDs:")
-//          triggers.keys.foreach((uuid: UUID) => System.out.println(uuid.toString))
           val allTriggers = triggers.keys.mkString(",")
-          complete(allTriggers)
+          complete(s"Running triggers: $allTriggers")
         }
       },
       // Stop a trigger given its UUID

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -280,7 +280,7 @@ object Server {
       get {
         path("list") {
           val allTriggers = triggers.keys.mkString(",")
-          complete(s"Running triggers: $allTriggers")
+          complete(s"Triggers currently running: $allTriggers")
         }
       },
       // Stop a trigger given its UUID

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -187,6 +187,9 @@ object Server {
   }
   implicit val triggerParamsFormat = jsonFormat2(TriggerParams)
 
+  case class ListParams(party: String) // May also need an auth token later
+  implicit val listParamsFormat = jsonFormat1(ListParams)
+
   private def addDar(compiledPackages: MutableCompiledPackages, dar: Dar[(PackageId, Package)]) = {
     val darMap = dar.all.toMap
     darMap.foreach {
@@ -204,6 +207,11 @@ object Server {
     }
   }
 
+  case class TriggerActorWithParty(
+      ref: ActorRef[TriggerActor.Message],
+      party: String,
+  )
+
   def apply(
       host: String,
       port: Int,
@@ -216,7 +224,9 @@ object Server {
     implicit val esf: ExecutionSequencerFactory =
       new AkkaExecutionSequencerPool("TriggerService")(untypedSystem)
 
-    var triggers: Map[UUID, ActorRef[TriggerActor.Message]] = Map.empty
+    var triggers: Map[UUID, TriggerActorWithParty] = Map.empty
+    var triggersByParty: Map[String, Set[UUID]] = Map.empty
+
     // Mutable in preparation for dynamic package upload.
     val compiledPackages: MutableCompiledPackages = ConcurrentCompiledPackages()
     dar.foreach(addDar(compiledPackages, _))
@@ -236,15 +246,17 @@ object Server {
                   case Left(err) =>
                     complete((StatusCodes.UnprocessableEntity, err))
                   case Right(trigger) =>
+                    val party = params.party
                     val uuid = UUID.randomUUID
                     val ref = ctx.spawn(
                       TriggerActor(
-                        TriggerActor.Config(compiledPackages, trigger, ledgerConfig, params.party)),
+                        TriggerActor.Config(compiledPackages, trigger, ledgerConfig, party)),
                       uuid.toString,
                     )
-                    triggers = triggers + (uuid -> ref)
+                    triggers = triggers + (uuid -> TriggerActorWithParty(ref, party))
+                    val newTriggerSet = triggersByParty.getOrElse(party, Set()) + uuid
+                    triggersByParty = triggersByParty + (party -> newTriggerSet)
                     complete(uuid.toString)
-
                 }
             }
           },
@@ -276,18 +288,27 @@ object Server {
           }
         )
       },
-      // List all running triggers
+      // List triggers currently running for the given party
       get {
         path("list") {
-          val allTriggers = triggers.keys.map(_.toString).toList.toJson
-          complete(allTriggers)
+          entity(as[ListParams]) { params =>
+            {
+              val list =
+                triggersByParty.getOrElse(params.party, Set()).map(_.toString).toList.toJson
+              complete(list)
+            }
+          }
         }
       },
       // Stop a trigger given its UUID
       delete {
         pathPrefix("stop" / JavaUUID) { id =>
-          triggers.get(id).get ! TriggerActor.Stop
+          val actorWithParty = triggers.get(id).get
+          actorWithParty.ref ! TriggerActor.Stop
           triggers = triggers - id
+          val party = actorWithParty.party
+          val newTriggerSet = triggersByParty.get(party).get - id
+          triggersByParty = triggersByParty + (party -> newTriggerSet)
           complete(s"Trigger $id has been stopped.")
         }
       },

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -150,7 +150,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
         resp <- listTriggers(uri, "Alice")
         _ <- assert(resp.status.isSuccess)
         body <- responseBodyToString(resp)
-        _ <- body should endWith(": ")
+        _ <- body should equal("[]")
         // start trigger for Alice
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Alice")
         _ <- assert(resp.status.isSuccess)
@@ -158,7 +158,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
         resp <- listTriggers(uri, "Alice")
         _ <- assert(resp.status.isSuccess)
         body <- responseBodyToString(resp)
-        _ <- body should endWith(s": $aliceTrigger")
+        _ <- body should equal(s"""["$aliceTrigger"]""")
         // start trigger for Bob
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Bob")
         _ <- assert(resp.status.isSuccess)
@@ -166,14 +166,14 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
         resp <- listTriggers(uri, "Bob")
         _ <- assert(resp.status.isSuccess)
         body <- responseBodyToString(resp)
-        _ <- body should endWith(s": $aliceTrigger,$bobTrigger")
+        _ <- body should equal(s"""["$aliceTrigger","$bobTrigger"]""")
         // stop Alice's trigger
         resp <- stopTrigger(uri, aliceTrigger)
         _ <- assert(resp.status.isSuccess)
         resp <- listTriggers(uri, "Bob")
         _ <- assert(resp.status.isSuccess)
         body <- responseBodyToString(resp)
-        _ <- body should endWith(s": $bobTrigger")
+        _ <- body should equal(s"""["$bobTrigger"]""")
         // stop Bob's trigger
         resp <- stopTrigger(uri, bobTrigger)
         _ <- assert(resp.status.isSuccess)
@@ -181,7 +181,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
         resp <- listTriggers(uri, "Bob")
         _ <- assert(resp.status.isSuccess)
         body <- responseBodyToString(resp)
-        _ <- body should endWith(": ")
+        _ <- body should equal("[]")
       } yield succeed
   }
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -77,6 +77,14 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
     Http().singleRequest(req)
   }
 
+  def listTriggers(uri: Uri, party: String) = {
+    val req = HttpRequest(
+      method = HttpMethods.GET,
+      uri = uri.withPath(Uri.Path(s"/list")),
+    )
+    Http().singleRequest(req)
+  }
+
   def stopTrigger(uri: Uri, id: String) = {
     val req = HttpRequest(
       method = HttpMethods.DELETE,
@@ -122,6 +130,9 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
       resp <- startTrigger(uri, s"${dar.main._1}:TestTrigger:trigger", "Alice")
       _ <- assert(resp.status.isSuccess)
       triggerId <- resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
+      resp <- listTriggers(uri, "Alice")
+      body <- resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
+      _ <- body should include(triggerId)
       resp <- stopTrigger(uri, triggerId)
       _ <- assert(resp.status.isSuccess)
     } yield succeed


### PR DESCRIPTION
Introduce new `/list` endpoint to list ids of triggers currently running for a given party. The party name is passed in the GET request body, and the response is a JSON list of trigger ids.

My approach was to store an extra map from each party name to the set of trigger ids running for that party. I also store party names in the values of the original trigger id map, so we can update the party map when stopping a trigger. It might be possible to streamline these data structures but this was my shot at it.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
