### PR TITLE
Make DAML execution benchmarks more flexible

### DIFF
--- a/daml-lf/README.md
+++ b/daml-lf/README.md
@@ -150,6 +150,12 @@ precise benchmark which takes around 1 minute can be invoked with
 ```
 bazel run //daml-lf/scenario-interpreter:scenario-perf -- -f 0
 ```
+To benchmark scenarios other than the ones configured by default, you can
+invoke
+```
+bazel run //daml-lf/scenario-interpreter:scenario-perf -- -p dar=/path/to/some/dar -p scenario=Some.Module:test
+```
+This can be combined with the `-f 0` flag as well.
 
 These benchmarks are focused on DAML execution speed and try to avoid noise
 caused by, say, I/O as much as possible.

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -15,27 +15,37 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 
-@State(Scope.Thread)
+@State(Scope.Benchmark)
 class CollectAuthorityState {
-  private val darFile = new File(rlocation("daml-lf/scenario-interpreter/CollectAuthority.dar"))
-  private val packages = UniversalArchiveReader().readFile(darFile).get
-  private val packagesMap = Map(packages.all.map {
-    case (pkgId, pkgArchive) => Decode.readArchivePayloadAndVersion(pkgId, pkgArchive)._1
-  }: _*)
+  private var buildMachine: Expr => Speedy.Machine = null
+  private var expr: Expr = null
 
-  // NOTE(MH): We use a static seed to get reproducible runs.
-  private val seeding = crypto.Hash.secureRandom(crypto.Hash.hashPrivateKey("scenario-perf"))
-  private val buildMachine = Speedy.Machine
-    .newBuilder(
-      PureCompiledPackages(packagesMap).right.get,
-      Time.Timestamp.MinValue,
-      Some(seeding()))
-    .fold(err => sys.error(err.toString), identity)
-  private val expr = EVal(
-    Identifier(packages.main._1, QualifiedName.assertFromString("CollectAuthority:test")))
-  // NOTE(MH): We run the machine once to initialize all data that is shared
-  // between runs.
-  run()
+  @Param(Array("//daml-lf/scenario-interpreter/CollectAuthority.dar"))
+  private var dar: String = _
+  @Param(Array("CollectAuthority:test"))
+  private var scenario: String = _
+
+  @Setup(Level.Trial)
+  def init(): Unit = {
+    val darFile = new File(if (dar.startsWith("//")) rlocation(dar.substring(2)) else dar)
+    val packages = UniversalArchiveReader().readFile(darFile).get
+    val packagesMap = packages.all.map {
+      case (pkgId, pkgArchive) => Decode.readArchivePayloadAndVersion(pkgId, pkgArchive)._1
+    }.toMap
+
+    // NOTE(MH): We use a static seed to get reproducible runs.
+    val seeding = crypto.Hash.secureRandom(crypto.Hash.hashPrivateKey("scenario-perf"))
+    buildMachine = Speedy.Machine
+      .newBuilder(
+        PureCompiledPackages(packagesMap).right.get,
+        Time.Timestamp.MinValue,
+        Some(seeding()))
+      .fold(err => sys.error(err.toString), identity)
+    expr = EVal(Identifier(packages.main._1, QualifiedName.assertFromString(scenario)))
+    // NOTE(MH): We run the machine once to initialize all data that is shared
+    // between runs.
+    val steps1 = run()
+  }
 
   def run(): Int = {
     val machine = buildMachine(expr)


### PR DESCRIPTION
Instead of always benchmarking the hardcoded scenarios, we can now
pass a DAR and a scenario to the benchmark as well.

This is part of https://github.com/digital-asset/daml/issues/5746.

CHANGELOG_BEGIN
CHANGELOG_END