### PR TITLE
Adjust PostCommitValidation

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
@@ -3,10 +3,9 @@
 
 package com.daml.platform.store.dao.events
 
-import java.sql.Connection
 import java.time.Instant
 
-import anorm.SqlParser.{binaryStream, int, str}
+import anorm.SqlParser.{binaryStream, str}
 import anorm.{Row, RowParser, SimpleSql, SqlStringInterpolation, ~}
 import com.daml.ledger.participant.state.index.v2.ContractStore
 import com.daml.platform.store.Conversions._
@@ -15,35 +14,17 @@ import com.daml.platform.store.dao.DbDispatcher
 import com.daml.platform.store.serialization.ValueSerializer.{deserializeValue => deserialize}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 /**
   * @see [[ContractsTable]]
   */
 private[dao] sealed abstract class ContractsReader(
+    val committedContracts: PostCommitValidationData,
     dispatcher: DbDispatcher,
     executionContext: ExecutionContext,
 ) extends ContractStore {
 
   import ContractsReader._
-
-  object InTransaction extends PostCommitValidationData {
-
-    override def lookupContractKey(submitter: Party, key: Key)(
-        implicit connection: Connection): Option[ContractId] =
-      lookupContractKeyQuery(submitter, key).as(contractId("contract_id").singleOpt)
-
-    override def lookupMaximumLedgerTime(ids: Set[ContractId])(
-        implicit connection: Connection): Try[Option[Instant]] =
-      SQL"select max(create_ledger_effective_time) as max_create_ledger_effective_time, count(*) as num_contracts from participant_contracts where participant_contracts.contract_id in ($ids)"
-        .as(
-          (instant("max_create_ledger_effective_time").? ~ int("num_contracts")).single
-            .map {
-              case result ~ numContracts if numContracts == ids.size => Success(result)
-              case _ => Failure(notFound(ids))
-            })
-
-  }
 
   protected def lookupContractKeyQuery(submitter: Party, key: Key): SimpleSql[Row]
 
@@ -61,13 +42,13 @@ private[dao] sealed abstract class ContractsReader(
       key: Key,
   ): Future[Option[ContractId]] =
     dispatcher.executeSql("lookup_contract_by_key") { implicit connection =>
-      InTransaction.lookupContractKey(submitter, key)
+      lookupContractKeyQuery(submitter, key).as(contractId("contract_id").singleOpt)
     }
 
   override def lookupMaximumLedgerTime(ids: Set[ContractId]): Future[Option[Instant]] =
     dispatcher
       .executeSql("lookup_maximum_ledger_time") { implicit connection =>
-        InTransaction.lookupMaximumLedgerTime(ids)
+        committedContracts.lookupMaximumLedgerTime(ids)
       }
       .map(_.get)(executionContext)
 
@@ -79,14 +60,19 @@ object ContractsReader {
       dispatcher: DbDispatcher,
       executionContext: ExecutionContext,
       dbType: DbType,
-  ): ContractsReader =
+  ): ContractsReader = {
+    val table = ContractsTable(dbType)
     dbType match {
-      case DbType.Postgres => new Postgresql(dispatcher, executionContext)
-      case DbType.H2Database => new H2Database(dispatcher, executionContext)
+      case DbType.Postgres => new Postgresql(table, dispatcher, executionContext)
+      case DbType.H2Database => new H2Database(table, dispatcher, executionContext)
     }
+  }
 
-  private final class Postgresql(dispatcher: DbDispatcher, executionContext: ExecutionContext)
-      extends ContractsReader(dispatcher, executionContext) {
+  private final class Postgresql(
+      table: ContractsTable,
+      dispatcher: DbDispatcher,
+      executionContext: ExecutionContext,
+  ) extends ContractsReader(table, dispatcher, executionContext) {
     override protected def lookupContractKeyQuery(
         submitter: Party,
         key: Key,
@@ -94,8 +80,11 @@ object ContractsReader {
       SQL"select participant_contracts.contract_id from #$contractsTable where $submitter =ANY(create_stakeholders) and contract_witness = $submitter and create_key_hash = ${key.hash}"
   }
 
-  private final class H2Database(dispatcher: DbDispatcher, executionContext: ExecutionContext)
-      extends ContractsReader(dispatcher, executionContext) {
+  private final class H2Database(
+      table: ContractsTable,
+      dispatcher: DbDispatcher,
+      executionContext: ExecutionContext,
+  ) extends ContractsReader(table, dispatcher, executionContext) {
     override protected def lookupContractKeyQuery(
         submitter: Party,
         key: Key,
@@ -120,15 +109,5 @@ object ContractsReader {
     }
 
   private val contractsTable = "participant_contracts natural join participant_contract_witnesses"
-
-  private def emptyContractIds: Throwable =
-    new IllegalArgumentException(
-      "Cannot lookup the maximum ledger time for an empty set of contract identifiers"
-    )
-
-  private def notFound(contractIds: Set[ContractId]): Throwable =
-    new IllegalArgumentException(
-      s"One or more of the following contract identifiers has been found: ${contractIds.map(_.coid).mkString(", ")}"
-    )
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationData.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationData.scala
@@ -10,8 +10,7 @@ import scala.util.Try
 
 private[events] trait PostCommitValidationData {
 
-  def lookupContractKey(submitter: Party, key: Key)(
-      implicit connection: Connection): Option[ContractId]
+  def lookupContractKeyGlobally(key: Key)(implicit connection: Connection): Option[ContractId]
 
   def lookupMaximumLedgerTime(ids: Set[ContractId])(
       implicit connection: Connection): Try[Option[Instant]]

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationSpec.scala
@@ -32,7 +32,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(createWithKey),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -48,7 +47,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(createWithoutKey),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -65,7 +63,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(createContract, exerciseContract),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -82,7 +79,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(exerciseContract),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set(divulgedContract.coid),
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -99,7 +95,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(exerciseContract),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe Some(UnknownContract)
@@ -115,7 +110,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(createContract, fetch(createContract)),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -131,7 +125,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(fetch(divulgedContract)),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set(divulgedContract.coid),
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -147,7 +140,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(fetch(missingCreate)),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe Some(UnknownContract)
@@ -163,7 +155,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(createContract, lookupByKey(createContract, found = true)),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -179,7 +170,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(lookupByKey(missingCreate, found = true)),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe Some(
@@ -200,7 +190,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(lookupByKey(missingContract, found = false)),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -232,7 +221,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(committedContract),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe Some(DuplicateKey)
@@ -246,7 +234,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(exerciseOnCommittedContract),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -260,7 +247,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(exerciseOnCommittedContract),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime.minusNanos(1),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe Some(
@@ -279,7 +265,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(fetch(committedContract)),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -293,7 +278,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(fetch(committedContract)),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime.minusNanos(1),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe Some(
@@ -312,7 +296,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(lookupByKey(committedContract, found = true)),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -326,7 +309,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(lookupByKey(committedContract, found = false)),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe Some(
@@ -358,7 +340,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(exerciseOnDivulgedContract),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None
@@ -372,7 +353,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             transaction = just(fetch(divulgedContract)),
             transactionLedgerEffectiveTime = Instant.now(),
             divulged = Set.empty,
-            submitter = Party.assertFromString("Alice"),
           )
 
         error shouldBe None

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/store/dao/events/PostCommitValidationSpec.scala
@@ -27,7 +27,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
         val createWithKey = genTestCreate()
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(createWithKey),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -35,7 +35,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
@@ -43,7 +43,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
         val createWithoutKey = genTestCreate().copy(key = None)
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(createWithoutKey),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -51,7 +51,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
@@ -60,7 +60,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
         val createContract = genTestCreate()
         val exerciseContract = genTestExercise(createContract)
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(createContract, exerciseContract),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -68,7 +68,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
@@ -77,7 +77,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
         val divulgedContract = genTestCreate()
         val exerciseContract = genTestExercise(divulgedContract)
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(exerciseContract),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -85,7 +85,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
@@ -94,7 +94,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
         val missingCreate = genTestCreate()
         val exerciseContract = genTestExercise(missingCreate)
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(exerciseContract),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -102,7 +102,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation should contain theSameElementsAs Seq(UnknownContract)
+        error shouldBe Some(UnknownContract)
 
       }
 
@@ -110,7 +110,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
         val createContract = genTestCreate()
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(createContract, fetch(createContract)),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -118,7 +118,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
@@ -126,7 +126,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
         val divulgedContract = genTestCreate()
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(fetch(divulgedContract)),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -134,7 +134,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
@@ -142,7 +142,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
         val missingCreate = genTestCreate()
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(fetch(missingCreate)),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -150,7 +150,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation should contain theSameElementsAs Seq(UnknownContract)
+        error shouldBe Some(UnknownContract)
 
       }
 
@@ -158,7 +158,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
         val createContract = genTestCreate()
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(createContract, lookupByKey(createContract, found = true)),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -166,7 +166,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
@@ -174,7 +174,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
         val missingCreate = genTestCreate()
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(lookupByKey(missingCreate, found = true)),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -182,7 +182,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation should contain allElementsOf Seq(
+        error shouldBe Some(
           MismatchingLookup(
             expectation = Some(missingCreate.coid),
             result = None,
@@ -195,7 +195,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
         val missingContract = genTestCreate()
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(lookupByKey(missingContract, found = false)),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -203,7 +203,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
@@ -220,7 +220,6 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
           committed(
             id = committedContract.coid.coid,
             ledgerEffectiveTime = committedContractLedgerEffectiveTime,
-            witnesses = Set("Alice"),
             key = committedContract.key.map(convert(committedContract.coinst.template, _))
           )
         )
@@ -228,7 +227,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
       "reject a create that would introduce a duplicate key" in {
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(committedContract),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
@@ -236,13 +235,13 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation should contain theSameElementsAs Seq(DuplicateKey)
+        error shouldBe Some(DuplicateKey)
 
       }
 
       "accept an exercise on the committed contract" in {
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(exerciseOnCommittedContract),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
@@ -250,13 +249,13 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
       "reject an exercise pre-dating the committed contract" in {
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(exerciseOnCommittedContract),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime.minusNanos(1),
@@ -264,7 +263,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation should contain theSameElementsAs Seq(
+        error shouldBe Some(
           CausalMonotonicityViolation(
             contractLedgerEffectiveTime = committedContractLedgerEffectiveTime,
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime.minusNanos(1),
@@ -275,7 +274,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
       "accept a fetch on the committed contract" in {
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(fetch(committedContract)),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
@@ -283,13 +282,13 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
       "reject a fetch pre-dating the committed contract" in {
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(fetch(committedContract)),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime.minusNanos(1),
@@ -297,7 +296,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation should contain theSameElementsAs Seq(
+        error shouldBe Some(
           CausalMonotonicityViolation(
             contractLedgerEffectiveTime = committedContractLedgerEffectiveTime,
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime.minusNanos(1),
@@ -308,7 +307,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
       "accept a successful lookup of the committed contract" in {
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(lookupByKey(committedContract, found = true)),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
@@ -316,13 +315,13 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
       "reject a failed lookup of the committed contract" in {
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(lookupByKey(committedContract, found = false)),
             transactionLedgerEffectiveTime = committedContractLedgerEffectiveTime,
@@ -330,7 +329,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation should contain allElementsOf Seq(
+        error shouldBe Some(
           MismatchingLookup(
             result = Some(committedContract.coid),
             expectation = None,
@@ -348,16 +347,13 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
       val store = new PostCommitValidation.BackedBy(
         committedContracts(
-          divulged(
-            id = divulgedContract.coid.coid,
-            witnesses = Set("Alice"),
-          )
+          divulged(divulgedContract.coid.coid),
         )
       )
 
       "accept an exercise on the divulged contract" in {
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(exerciseOnDivulgedContract),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -365,13 +361,13 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
 
       "accept a fetch on the divulged contract" in {
 
-        val validation =
+        val error =
           store.validate(
             transaction = just(fetch(divulgedContract)),
             transactionLedgerEffectiveTime = Instant.now(),
@@ -379,7 +375,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             submitter = Party.assertFromString("Alice"),
           )
 
-        validation shouldBe Set.empty
+        error shouldBe None
 
       }
     }
@@ -412,7 +408,6 @@ object PostCommitValidationSpec {
   private final case class ContractFixture private (
       id: ContractId,
       ledgerEffectiveTime: Option[Instant],
-      witnesses: Set[Party],
       key: Option[Key],
   )
 
@@ -422,9 +417,9 @@ object PostCommitValidationSpec {
   private final case class ContractStoreFixture private (contracts: Set[ContractFixture])
       extends PostCommitValidationData {
 
-    override def lookupContractKey(submitter: Party, key: Key)(
+    override def lookupContractKeyGlobally(key: Key)(
         implicit connection: Connection = null): Option[ContractId] =
-      contracts.find(c => c.key.contains(key) && c.witnesses.contains(submitter)).map(_.id)
+      contracts.find(c => c.key.contains(key)).map(_.id)
 
     override def lookupMaximumLedgerTime(ids: Set[ContractId])(
         implicit connection: Connection = null): Try[Option[Instant]] = {
@@ -432,11 +427,11 @@ object PostCommitValidationSpec {
         case c if ids.contains(c.id) => c.ledgerEffectiveTime
       }
       if (lookup.isEmpty) Failure(notFound(ids))
-      else Success(lookup.fold[Option[Instant]](None)(pickTheGreater))
+      else Success(lookup.fold[Option[Instant]](None)(pickTheGreatest))
     }
   }
 
-  private def pickTheGreater(l: Option[Instant], r: Option[Instant]): Option[Instant] =
+  private def pickTheGreatest(l: Option[Instant], r: Option[Instant]): Option[Instant] =
     l.fold(r)(left => r.fold(l)(right => if (left.isAfter(right)) l else r))
 
   private def notFound(contractIds: Set[ContractId]): Throwable =
@@ -456,21 +451,18 @@ object PostCommitValidationSpec {
   private def committed(
       id: String,
       ledgerEffectiveTime: Instant,
-      witnesses: Set[String],
       key: Option[Key] = None,
   ): ContractFixture =
     ContractFixture(
       ContractId.assertFromString(id),
       Some(ledgerEffectiveTime),
-      witnesses.map(Party.assertFromString),
       key,
     )
 
-  private def divulged(id: String, witnesses: Set[String]): ContractFixture =
+  private def divulged(id: String): ContractFixture =
     ContractFixture(
       ContractId.assertFromString(id),
       None,
-      witnesses.map(Party.assertFromString),
       None,
     )
 


### PR DESCRIPTION
- do not require a party for validation (to validate divulged contracts)
- stop validation after first error and don't accumulate rejection reasons
- address https://github.com/digital-asset/daml/pull/5737/files/01da7393b32f8eb4cf5f4866f745997007cb8fdd#r416719399

### Added in https://github.com/digital-asset/daml/pull/5774/commits/b208c9d51f505257c8c052f18112ab0b6a13da0c
- use participant state rejection reasons instead of domain ones

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
