### PR TITLE
fix sitemap generation

### DIFF
--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -4,4 +4,7 @@
 
 set -euo pipefail
 
-echo "STABLE_VERSION_DATE $(TZ=UTC git log -n1 -s --format=%cd --date=short -- VERSION)"
+# This is used for building the sitemap, so we want the date of publication,
+# not the date of the release commit itself, hence we don't need to look into
+# LATEST to find the date of the referred commit.
+echo "STABLE_VERSION_DATE $(TZ=UTC git log -n1 -s --format=%cd --date=short -- LATEST)"


### PR DESCRIPTION
With the change in release model (VERSION to LATEST), I forgot to change the workspace_status script. The result is that our sitemap will forever indicate all the pages in the docs have been last modified on Feb 25, discouraging search engines from indexing them again at any point since.

This PR fixes that by updating the workspace_status script, which hopefully should result in search engines indexing us again.

CHANGELOG_BEGIN
CHANGELOG_END