### PR TITLE
fail collect_build_data for windows_compat

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -529,6 +529,7 @@ jobs:
               || "$(Windows.status)" != "Succeeded"
               || "$(compatibility_linux.status)" != "Succeeded"
               || "$(compatibility_macos.status)" != "Succeeded"
+              || "$(compatibility_windows.status)" != "Succeeded"
               || "$(dump.status)" == "Canceled"
               || "$(release.status)" == "Canceled" ]]; then
               exit 1


### PR DESCRIPTION
At the moment, collect_build_data will wait for the Windows compatibility test to have "finished", but doesn't check its return status. This means two things:

1. Should the compatibility test end without a success or error (e.g. communication broken between Azure and the node), the option to rerun failed jobs will not appear, as there will be no failed job.
2. The subsequent notify_user step will ignore failures in the compatibility_windows job when reporting to Slack, making for confusing reports.

CHANGELOG_BEGIN
CHANGELOG_END