### PR TITLE
Fix find: ./local-spawn-runner not found issue

### DIFF
--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -159,10 +159,16 @@ def _extract_main_dalf_impl(ctx):
         outputs = [output_dalf],
         progress_message = "Extract DALF from DAR (%s)" % project_name,
         command = """
-            set -eou pipefail
-            {zipper} x {input_dar}
-            main_dalf=$({find} . -name '{project_name}-{project_version}-[a-z0-9]*.dalf')
-            cp $main_dalf {output_dalf}
+set -eoux pipefail
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+# While zipper has a -d option, it insists on it
+# being a relative path so we don't use it.
+ZIPPER=$PWD/{zipper}
+DAR=$PWD/{input_dar}
+(cd $TMPDIR && $ZIPPER x $DAR)
+main_dalf=$({find} $TMPDIR/ -name '{project_name}-{project_version}-[a-z0-9]*.dalf')
+cp $main_dalf {output_dalf}
         """.format(
             zipper = zipper.path,
             find = posix.commands["find"],


### PR DESCRIPTION
CWD will be set to the same execroot for all targets on Windows. While
this will contain the things we are searching for it contains a whole
bunch of other stuff and in particular it can also change during the
execution of `find`. This resulted in errors with temporary files such
as the local-spawn-runner-* stuff that appear and disappear while
find is running.

This PR switches it to a tmp dir which works around this issue and
makes more sense anyway since we clearly don’t want to search in the
whole execroot.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
