### PR TITLE
Upgrade to Scala 2.12.11

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -612,11 +612,11 @@ load(
 )
 
 scala_repositories((
-    "2.12.6",
+    "2.12.11",
     {
-        "scala_compiler": "3023b07cc02f2b0217b2c04f8e636b396130b3a8544a8dfad498a19c3e57a863",
-        "scala_library": "f81d7144f0ce1b8123335b72ba39003c4be2870767aca15dd0888ba3dab65e98",
-        "scala_reflect": "ffa70d522fc9f9deec14358aa674e6dd75c9dfa39d4668ef15bb52f002ce99fa",
+        "scala_compiler": "e901937dbeeae1715b231a7cfcd547a10d5bbf0dfb9d52d2886eae18b4d62ab6",
+        "scala_library": "dbfe77a3fc7a16c0c7cb6cb2b91fecec5438f2803112a744cb1b187926a138be",
+        "scala_reflect": "5f9e156aeba45ef2c4d24b303405db259082739015190b3b334811843bd90d6a",
     },
 ))
 

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -615,7 +615,7 @@ class DecodeV1Spec
     "translate generic comparison builtins as is if version < 1.9" in {
       forEvery(preGenericComparisonVersion) { version =>
         val decoder = moduleDecoder(version)
-        forEvery(genericComparisonBuiltinCases) { (proto, scala) =>
+        forEvery(genericComparisonBuiltinCases) { (proto, _) =>
           a[ParseError] shouldBe thrownBy(decoder.decodeExpr(toProtoExpr(proto), "test"))
         }
       }

--- a/daml-lf/engine/BUILD.bazel
+++ b/daml-lf/engine/BUILD.bazel
@@ -20,7 +20,6 @@ da_scala_library(
         "//daml-lf/interpreter",
         "//daml-lf/language",
         "//daml-lf/transaction",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_typelevel_paiges_core_2_12",
     ],

--- a/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
+++ b/daml-lf/interface/src/main/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReader.scala
@@ -105,7 +105,7 @@ object InterfaceReader {
     es.collectAndPrune { case x: InvalidDataTypeDefinition => x }
 
   private[reader] def foldModule(module: Ast.Module): State =
-    (State() /: module.definitions) {
+    (module.definitions foldLeft State()) {
       case (state, (name, Ast.DDataType(true, params, dataType))) =>
         val fullName = QualifiedName(module.name, name)
         val tyVars: ImmArraySeq[Ast.TypeVarName] = params.map(_._1).toSeq

--- a/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
+++ b/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/TypeSpec.scala
@@ -27,6 +27,7 @@ class TypeSpec extends WordSpec with Matchers {
       if (!typs.isEmpty)
         sys.error(s"expected 0 arguments, got ${typs.toImmArray.length}")
 
+    @scala.annotation.tailrec
     def go(typ0: Pkg.Type, args: BackStack[Type]): Type = typ0 match {
       case Pkg.TVar(v) =>
         assertZeroArgs(args)
@@ -101,14 +102,14 @@ class TypeSpec extends WordSpec with Matchers {
   }
 
   "mapTypeVars should replace all type variables in `List (List a)`" in {
-    val result: Type = t"List (List a)".mapTypeVars(v => t"Text")
+    val result: Type = t"List (List a)".mapTypeVars(_ => t"Text")
     val expected: Type = t"List (List Text)"
 
     result shouldBe expected
   }
 
   "mapTypeVars should replace all type variables in `GenMap a b`" in {
-    val result: Type = t"GenMap a b".mapTypeVars(a => t"GenMap a b")
+    val result: Type = t"GenMap a b".mapTypeVars(_ => t"GenMap a b")
     val expected: Type = t"GenMap (GenMap a b) (GenMap a b)"
 
     result shouldBe expected

--- a/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReaderSpec.scala
+++ b/daml-lf/interface/src/test/scala/com/digitalasset/daml/lf/iface/reader/InterfaceReaderSpec.scala
@@ -164,7 +164,7 @@ class InterfaceReaderSpec extends WordSpec with Matchers with Inside {
     field -> Ast.TVar(var_)
 
   private def primField(field: Ref.Name, primType: Ast.BuiltinType, args: Ast.Type*) =
-    field -> ((Ast.TBuiltin(primType): Ast.Type) /: args)(Ast.TApp)
+    field -> (args foldLeft (Ast.TBuiltin(primType): Ast.Type))(Ast.TApp)
 
   private def typeConstructorField(field: Ast.FieldName, segments: List[String]) =
     field -> typeConName(segments)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -901,7 +901,7 @@ private[lf] final case class Compiler(packages: PackageId PartialFunction Packag
 
   private def withBinders[A](binders: ExprVarName*)(f: Unit => A): A =
     withEnv { _ =>
-      env = (env /: binders)(_ addExprVar _)
+      env = (binders foldLeft env)(_ addExprVar _)
       f(())
     }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
@@ -23,7 +23,7 @@ private[lf] object Equality {
       h2: Iterator[Y],
       stack: FrontStack[(X, Y)],
   ): FrontStack[(X, Y)] =
-    (stack /: (h1 zip h2))(_.+:(_))
+    ((h1 zip h2) foldLeft stack)(_.+:(_))
 
   @tailrec
   private[this] def equality(stack0: FrontStack[(SValue, SValue)]): Boolean = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Hasher.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Hasher.scala
@@ -29,7 +29,7 @@ private[speedy] object Hasher {
     loop(List(Value(v)))
 
   private def pushOrderedValues(size: Int, values: Iterator[SValue], cmds: List[Command]) =
-    ((Ordered(size) :: cmds) /: values) { case (acc, v) => Value(v) :: acc }
+    (values foldLeft (Ordered(size) :: cmds)) { case (acc, v) => Value(v) :: acc }
 
   @tailrec
   private def loop(cmds: List[Command], stack: List[Int] = List.empty): Int =
@@ -77,12 +77,12 @@ private[speedy] object Hasher {
               case SList(values) =>
                 loop(pushOrderedValues(values.length, values.iterator, cmdsRest), stack)
               case STextMap(value) =>
-                val newCmds = ((Unordered(value.size) :: cmdsRest) /: value) {
+                val newCmds = (value foldLeft (Unordered(value.size) :: cmdsRest)) {
                   case (acc, (k, v)) => Value(v) :: Mix(k.hashCode) :: acc
                 }
                 loop(newCmds, stack)
               case SGenMap(values) =>
-                val newCmds = ((Unordered(values.size) :: cmdsRest) /: values) {
+                val newCmds = (values foldLeft (Unordered(values.size) :: cmdsRest)) {
                   case (acc, (k, v)) => Value(v) :: Mix(k.hashCode) :: acc
                 }
                 loop(newCmds, stack)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -795,7 +795,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
   "TextMap operations" - {
 
     def buildMap[X](typ: String, l: (String, X)*) =
-      ("TEXTMAP_EMPTY @Int64" /: l) {
+      (l foldLeft "TEXTMAP_EMPTY @Int64") {
         case (acc, (k, v)) => s"""(TEXTMAP_INSERT @$typ "$k" $v $acc)"""
       }
 
@@ -909,7 +909,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
   "GenMap operations" - {
 
     def buildMap[X](typ: String, l: (String, X)*) =
-      ("GENMAP_EMPTY @Text @Int64" /: l) {
+      (l foldLeft "GENMAP_EMPTY @Text @Int64") {
         case (acc, (k, v)) => s"""(GENMAP_INSERT @Text @$typ "$k" $v $acc)"""
       }
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -43,11 +43,11 @@ object Ast {
 
     /** Infix alias for repeated [[EApp]] application. */
     @inline final def eApp(arg: Expr, args: Expr*): EApp =
-      (EApp(this, arg) /: args)(EApp)
+      (args foldLeft EApp(this, arg))(EApp)
 
     /** Infix alias for repeated [[ETyApp]] application. */
     @inline final def eTyApp(typ: Type, typs: Type*): ETyApp =
-      (ETyApp(this, typ) /: typs)(ETyApp)
+      (typs foldLeft ETyApp(this, typ))(ETyApp)
   }
 
   /** Reference to a variable in current lexical scope. */

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -69,7 +69,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
   lazy val expr: Parser[Expr] = {
     expr0 ~ rep(eAppAgr) ^^ {
       case e0 ~ args =>
-        (e0 /: args) {
+        (args foldLeft e0) {
           case (acc, EAppExprArg(e)) => EApp(acc, e)
           case (acc, EAppTypArg(t)) => ETyApp(acc, t)
         }
@@ -150,12 +150,12 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
 
   private lazy val eAbs: Parser[Expr] =
     `\\` ~>! rep1(varBinder) ~ (`->` ~> expr) ^^ {
-      case binders ~ body => (binders :\ body)(EAbs(_, _, None))
+      case binders ~ body => (binders foldRight body)(EAbs(_, _, None))
     }
 
   private lazy val eTyAbs: Parser[Expr] =
     `/\\` ~>! rep1(typeBinder) ~ (`.` ~> expr) ^^ {
-      case binders ~ body => (binders :\ body)(ETyAbs)
+      case binders ~ body => (binders foldRight body)(ETyAbs)
     }
 
   private lazy val bindings: Parser[ImmArray[Binding]] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -19,7 +19,7 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
   import exprParser.{expr, expr0}
 
   private def split(defs: Seq[Def]) = {
-    ((Seq.empty[(DottedName, Definition)], Seq.empty[(DottedName, Template)]) /: defs) {
+    defs.foldLeft((Seq.empty[(DottedName, Definition)], Seq.empty[(DottedName, Template)])) {
       case ((definitions, templates), DataDef(name, defn)) =>
         ((name -> defn) +: definitions, templates)
       case ((definitions, templates), TemplDef(name, defn)) =>

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/TypeParser.scala
@@ -51,7 +51,7 @@ private[parser] class TypeParser[P](parameters: ParserParameters[P]) {
     })
 
   private lazy val tForall: Parser[Type] =
-    `forall` ~>! rep1(typeBinder) ~ `.` ~ typ ^^ { case bs ~ _ ~ t => (bs :\ t)(TForall) }
+    `forall` ~>! rep1(typeBinder) ~ `.` ~ typ ^^ { case bs ~ _ ~ t => (bs foldRight t)(TForall) }
 
   private lazy val fieldType: Parser[(FieldName, Type)] =
     id ~ `:` ~ typ ^^ { case name ~ _ ~ t => name -> t }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -49,7 +49,7 @@ class TransactionCoderSpec
 
     "do NodeCreate" in {
       forAll(malformedCreateNodeGen, valueVersionGen()) {
-        (node: NodeCreate[Tx.TContractId, Tx.Value[Tx.TContractId]], valVer: ValueVersion) =>
+        (node: NodeCreate[Tx.TContractId, Tx.Value[Tx.TContractId]], _: ValueVersion) =>
           val encodedNode = TransactionCoder
             .encodeNode(
               TransactionCoder.NidEncoder,
@@ -76,7 +76,7 @@ class TransactionCoderSpec
 
     "do NodeFetch" in {
       forAll(fetchNodeGen, valueVersionGen()) {
-        (node: NodeFetch.WithTxValue[Tx.TContractId], valVer: ValueVersion) =>
+        (node: NodeFetch.WithTxValue[Tx.TContractId], _: ValueVersion) =>
           val encodedNode =
             TransactionCoder
               .encodeNode(

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Recursion.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Recursion.scala
@@ -29,14 +29,14 @@ private[validation] object Recursion {
 
       def modRefsInType(acc: Set[ModuleName], typ0: Type): Set[ModuleName] = typ0 match {
         case TSynApp(typeSynName, _) if typeSynName.packageId == pkgId =>
-          ((acc + typeSynName.qualifiedName.module) /: TypeTraversable(typ0))(modRefsInType)
+          (TypeTraversable(typ0) foldLeft (acc + typeSynName.qualifiedName.module))(modRefsInType)
         case TTyCon(typeConName) if typeConName.packageId == pkgId =>
           acc + typeConName.qualifiedName.module
         case otherwise =>
-          (acc /: TypeTraversable(otherwise))(modRefsInType)
+          (TypeTraversable(otherwise) foldLeft acc)(modRefsInType)
       }
 
-      (Set.empty[ModuleName] /: TypeTraversable(definition))(modRefsInType)
+      (TypeTraversable(definition) foldLeft Set.empty[ModuleName])(modRefsInType)
     }
 
     val modRefsInVal: Set[ModuleName] = {
@@ -46,12 +46,12 @@ private[validation] object Recursion {
           acc + valRef.qualifiedName.module
         case EAbs(binder @ _, body, ref) =>
           ref.iterator.toSet.filter(_.packageId == pkgId).map(_.qualifiedName.module) |
-            (acc /: ExprTraversable(body))(modRefsInVal)
+            (ExprTraversable(body) foldLeft acc)(modRefsInVal)
         case otherwise =>
-          (acc /: ExprTraversable(otherwise))(modRefsInVal)
+          (ExprTraversable(otherwise) foldLeft acc)(modRefsInVal)
       }
 
-      (Set.empty[ModuleName] /: ExprTraversable(definition))(modRefsInVal)
+      (ExprTraversable(definition) foldLeft Set.empty[ModuleName])(modRefsInVal)
 
     }
 
@@ -73,9 +73,9 @@ private[validation] object Recursion {
 
   private def synRefsOfType(acc: Set[TypeSynName], typ: Type): Set[TypeSynName] = typ match {
     case TSynApp(typeSynName, _) =>
-      ((acc + typeSynName) /: TypeTraversable(typ))(synRefsOfType)
+      (TypeTraversable(typ) foldLeft (acc + typeSynName))(synRefsOfType)
     case otherwise =>
-      (acc /: TypeTraversable(otherwise))(synRefsOfType)
+      (TypeTraversable(otherwise) foldLeft acc)(synRefsOfType)
   }
 
 }

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Serializability.scala
@@ -119,7 +119,8 @@ private[validation] object Serializability {
       params: ImmArray[(TypeVarName, Kind)],
       dataCons: DataCons): Unit = {
     val context = ContextDefDataType(tyCon.tycon)
-    val env = (Env(version, world, context, SRDataType, tyCon) /: params.iterator)(_.introVar(_))
+    val env =
+      (params.iterator foldLeft Env(version, world, context, SRDataType, tyCon))(_.introVar(_))
     val typs = dataCons match {
       case DataVariant(variants) =>
         if (variants.isEmpty) env.unserializable(URUninhabitatedType)

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/TypeSubst.scala
@@ -64,7 +64,7 @@ private[validation] object TypeSubst {
     case TVar(name) =>
       acc + name
     case otherwise @ _ =>
-      (acc /: TypeTraversable(typ))(freeVars)
+      (TypeTraversable(typ) foldLeft acc)(freeVars)
   }
 
   private def freeVars(subst: Map[TypeVarName, Type]): Set[TypeVarName] =

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -19,7 +19,7 @@ private[validation] object Typing {
   /* Typing */
 
   private def checkUniq[A](xs: Iterator[A], mkError: A => ValidationError): Unit = {
-    (Set.empty[A] /: xs)((acc, x) => if (acc(x)) throw mkError(x) else acc + x)
+    (xs foldLeft Set.empty[A])((acc, x) => if (acc(x)) throw mkError(x) else acc + x)
     ()
   }
 

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/traversable/TypeTraversable.scala
@@ -11,7 +11,7 @@ private[validation] object TypeTraversable {
   that =>
 
   private def toType(tyCon: TypeConApp): Type =
-    ((TTyCon(tyCon.tycon): Type) /: tyCon.args.iterator)(TApp)
+    (tyCon.args.iterator foldLeft (TTyCon(tyCon.tycon): Type))(TApp)
 
   private[validation] def foreach[U](typ: Type, f: Type => U): Unit =
     typ match {

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/HierarchicalOutput.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/HierarchicalOutput.scala
@@ -49,7 +49,7 @@ private[codegen] object HierarchicalOutput {
               Vector(
                 (
                   firstFile,
-                  (Set.empty[Tree] /: multiple.map(_._2))(_ | _),
+                  (multiple.map(_._2) foldLeft Set.empty[Tree])(_ | _),
                   Iterable(q"""object ${TermName(k)} {
                                 ..${multiple flatMap (_._3)}
                               }""")))

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -109,7 +109,6 @@ da_scala_test(
         "//daml-lf/parser",
         "//daml-lf/transaction",
         "//daml-lf/transaction:transaction_java_proto",
-        "//daml-lf/transaction:value_java_proto",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",
         "//ledger/ledger-api-common",

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -19,7 +19,6 @@ da_scala_binary(
         "@maven//:ch_qos_logback_logback_classic",
     ],
     deps = [
-        "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
         "//daml-lf/engine",
         "//ledger/metrics",


### PR DESCRIPTION
Scala v2.12.6 has been around for longer than 2 years (released on Apr 27, 2018). I think it is time to upgrade, given:

https://github.com/scala/scala/releases/tag/v2.12.11
> Performance improvements in the collections library: algorithmic improvements and changes to avoid unnecessary allocations (list of PRs)
https://github.com/scala/scala/pulls?q=is%3Apr+milestone%3A2.12.11+is%3Aclosed+sort%3Acreated-desc+label%3Alibrary%3Acollections+label%3Aperformance

Sorry @remyhaemmerle-da but `/:`and `:\` have been deprecated in favor of `foldLeft` and `foldRight`.

Or should we upgrade straight to Scala 2.13.2? This may require more changes. We should do it in a separate PR.

### TODO
- [x] Run a perftest.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
