### PR TITLE
trigger service: Move request params to separate file

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -76,7 +76,6 @@ da_scala_test(
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:com_typesafe_akka_akka_actor_typed_2_12",
         "@maven//:com_typesafe_akka_akka_http_core_2_12",
-        "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalatest_scalatest_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Request.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Request.scala
@@ -8,7 +8,6 @@ import spray.json.DefaultJsonProtocol._
 import spray.json.{JsString, JsValue, JsonFormat, deserializationError}
 
 object Request {
-  case class TriggerParams(identifier: Identifier, party: String)
   implicit object IdentifierFormat extends JsonFormat[Identifier] {
     def read(value: JsValue) = value match {
       case JsString(s) => {
@@ -32,8 +31,9 @@ object Request {
     def write(id: Identifier) = JsString(s"${id.packageId}:${id.qualifiedName}")
   }
 
-  implicit val triggerParamsFormat = jsonFormat2(TriggerParams)
+  case class StartParams(identifier: Identifier, party: String)
+  implicit val startParamsFormat = jsonFormat2(StartParams)
 
-  case class ListParams(party: String) // May also need an auth token later
+  case class ListParams(party: String)
   implicit val listParamsFormat = jsonFormat1(ListParams)
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Request.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Request.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.trigger
+
+import com.daml.lf.data.Ref.{DottedName, Identifier, PackageId, QualifiedName}
+import spray.json.DefaultJsonProtocol._
+import spray.json.{JsString, JsValue, JsonFormat, deserializationError}
+
+object Request {
+  case class TriggerParams(identifier: Identifier, party: String)
+  implicit object IdentifierFormat extends JsonFormat[Identifier] {
+    def read(value: JsValue) = value match {
+      case JsString(s) => {
+        val components = s.split(":")
+        if (components.length == 3) {
+          val parsed = for {
+            pkgId <- PackageId.fromString(components(0))
+            mod <- DottedName.fromString(components(1))
+            entity <- DottedName.fromString(components(2))
+          } yield Identifier(pkgId, QualifiedName(mod, entity))
+          parsed match {
+            case Left(e) => deserializationError(e)
+            case Right(id) => id
+          }
+        } else {
+          deserializationError(s"Expected trigger identifier of the form pkgid:mod:name but got $s")
+        }
+      }
+      case _ => deserializationError("Expected trigger identifier of the form pkgid:mod:name")
+    }
+    def write(id: Identifier) = JsString(s"${id.packageId}:${id.qualifiedName}")
+  }
+
+  implicit val triggerParamsFormat = jsonFormat2(TriggerParams)
+
+  case class ListParams(party: String) // May also need an auth token later
+  implicit val listParamsFormat = jsonFormat1(ListParams)
+}

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -54,7 +54,7 @@ import com.daml.ledger.client.configuration.{
   LedgerClientConfiguration,
   LedgerIdRequirement
 }
-import com.daml.lf.engine.trigger.Request.{ListParams, TriggerParams}
+import com.daml.lf.engine.trigger.Request.{ListParams, StartParams}
 import com.daml.platform.services.time.TimeProviderType
 
 case class LedgerConfig(
@@ -210,7 +210,7 @@ object Server {
           // Start a new trigger given its identifier and the party it should be running as.
           // Returns a UUID for the newly started trigger.
           path("start") {
-            entity(as[TriggerParams]) {
+            entity(as[StartParams]) {
               params =>
                 Trigger.fromIdentifier(compiledPackages, params.identifier) match {
                   case Left(err) =>


### PR DESCRIPTION
Refactoring in preparation for adding more request and response types. Keeping things small at first as I am getting used to Scala! I think the `Request` should be an object and not a class as it only contains definitions and should not be instantiated.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
