### PR TITLE
Add filterA to Prelude

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Action.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Action.daml
@@ -66,11 +66,7 @@ foldl1A _ [] = error "foldl1M: empty list"
 -- Some [0, 2, 4]
 -- ```
 filterA : Applicative m => (a -> m Bool) -> [a] -> m [a]
-filterA p =
-  foldr filtering (pure [])
-  where
-    filtering a = liftA2 (prependIf a) (p a)
-    prependIf a prepend filtered = if prepend then a :: filtered else filtered
+filterA p = foldr (\x -> liftA2 (\pHolds -> if pHolds then (x ::) else identity) (p x)) (pure [])
 
 -- | `replicateA n act` performs the action `n` times, gathering the
 --  results.

--- a/compiler/damlc/daml-stdlib-src/DA/Action.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Action.daml
@@ -59,6 +59,19 @@ foldl1A : Action m => (a -> a -> m a) -> [a] -> m a
 foldl1A f (x :: xs) = foldlA f x xs
 foldl1A _ [] = error "foldl1M: empty list"
 
+-- | Filters the list using the applicative function: keeps only the elements where the predicate holds.
+--
+-- ```
+-- >>> filterA (\x -> Some (x % 2 == 0)) [0..5]
+-- Some [0, 2, 4]
+-- ```
+filterA : Applicative m => (a -> m Bool) -> [a] -> m [a]
+filterA p =
+  foldr filtering (pure [])
+  where
+    filtering a = liftA2 (prependIf a) (p a)
+    prependIf a prepend filtered = if prepend then a :: filtered else filtered
+
 -- | `replicateA n act` performs the action `n` times, gathering the
 --  results.
 replicateA : (Applicative m) => Int -> m a -> m [a]

--- a/compiler/damlc/daml-stdlib-src/DA/Action.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Action.daml
@@ -63,7 +63,7 @@ foldl1A _ [] = error "foldl1M: empty list"
 -- Example: given a collection of Iou contract IDs one can find only the GBPs.
 --
 -- ```
--- >>> filterA (fmap (\iou -> iou.currency == "GBP") . fetch) iouCids
+-- filterA (fmap (\iou -> iou.currency == "GBP") . fetch) iouCids
 -- ```
 filterA : Applicative m => (a -> m Bool) -> [a] -> m [a]
 filterA p = foldr (\x -> liftA2 (\pHolds -> if pHolds then (x ::) else identity) (p x)) (pure [])

--- a/compiler/damlc/daml-stdlib-src/DA/Action.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Action.daml
@@ -60,10 +60,10 @@ foldl1A f (x :: xs) = foldlA f x xs
 foldl1A _ [] = error "foldl1M: empty list"
 
 -- | Filters the list using the applicative function: keeps only the elements where the predicate holds.
+-- Example: given a collection of Iou contract IDs one can find only the GBPs.
 --
 -- ```
--- >>> filterA (\x -> Some (x % 2 == 0)) [0..5]
--- Some [0, 2, 4]
+-- >>> filterA (fmap (\iou -> iou.currency == "GBP") . fetch) iouCids
 -- ```
 filterA : Applicative m => (a -> m Bool) -> [a] -> m [a]
 filterA p = foldr (\x -> liftA2 (\pHolds -> if pHolds then (x ::) else identity) (p x)) (pure [])

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -628,19 +628,6 @@ null _ = False
 filter : (a -> Bool) -> [a] -> [a]
 filter p = foldr (\x xs -> if p x then x :: xs else xs) []
 
--- | Filters the list using the applicative function: keeps only the elements where the predicate holds.
---
--- ```
--- >>> filterA (\x -> Some (x % 2 == 0)) [0..5]
--- Some [0, 2, 4]
--- ```
-filterA : Applicative m => (a -> m Bool) -> [a] -> m [a]
-filterA p =
-  foldr filtering (pure [])
-  where
-    filtering a = liftA2 (prependIf a) (p a)
-    prependIf a prepend filtered = if prepend then a :: filtered else filtered
-
 -- | HIDE
 fixedpoint : ((a -> b) -> a -> b) -> a -> b
 fixedpoint g v = g ( fixedpoint g ) v

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -624,9 +624,24 @@ null : [a] -> Bool
 null [] = True
 null _ = False
 
--- | Filter the list using the function: keep only the elements where the predicate holds.
+-- | Filters the list using the function: keep only the elements where the predicate holds.
 filter : (a -> Bool) -> [a] -> [a]
 filter p = foldr (\x xs -> if p x then x :: xs else xs) []
+
+-- | Filters the list using the applicative function: keeps only the elements where the predicate holds.
+-- Useful for example when a list of contract IDs are known, which should be filtered based on some
+-- condition for the correspodning contracts.
+--
+-- ```
+-- >>> filterA (\x -> Some (x % 2 == 0)) [0..5]
+-- Some [0, 2, 4]
+-- ```
+filterA : Applicative m => (a -> m Bool) -> [a] -> m [a]
+filterA p =
+  foldr filtering (pure [])
+  where
+    filtering a = liftA2 (prependIf a) (p a)
+    prependIf a prepend filtered = if prepend then a :: filtered else filtered
 
 -- | HIDE
 fixedpoint : ((a -> b) -> a -> b) -> a -> b

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -630,7 +630,7 @@ filter p = foldr (\x xs -> if p x then x :: xs else xs) []
 
 -- | Filters the list using the applicative function: keeps only the elements where the predicate holds.
 -- Useful for example when a list of contract IDs are known, which should be filtered based on some
--- condition for the correspodning contracts.
+-- condition for the corresponding contracts.
 --
 -- ```
 -- >>> filterA (\x -> Some (x % 2 == 0)) [0..5]

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -629,8 +629,6 @@ filter : (a -> Bool) -> [a] -> [a]
 filter p = foldr (\x xs -> if p x then x :: xs else xs) []
 
 -- | Filters the list using the applicative function: keeps only the elements where the predicate holds.
--- Useful for example when a list of contract IDs are known, which should be filtered based on some
--- condition for the corresponding contracts.
 --
 -- ```
 -- >>> filterA (\x -> Some (x % 2 == 0)) [0..5]

--- a/compiler/damlc/tests/daml-test-files/ActionTest.daml
+++ b/compiler/damlc/tests/daml-test-files/ActionTest.daml
@@ -1,0 +1,31 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+module ActionTest where
+
+import DA.Assert
+import DA.Action
+
+import Iou12
+
+testFilterA: Scenario ()
+testFilterA = scenario do
+  bank <- getParty "Acme Bank"
+  alice <- getParty "Alice"
+  bob <- getParty "Bob"
+  charlie <- getParty "Charlie"
+  let
+    aliceIou = Iou bank alice "USD" 1.23 []
+    bobIou = Iou bank bob "GBP" 2.34 []
+    charlieIou = Iou bank charlie "EUR" 3.45 []
+    ious = [aliceIou, bobIou, charlieIou]
+
+  iouIds <- bank `submit` forA ious create
+
+  aliceIouIds <- bank `submit` filterA (fmap (\iou -> iou.owner == alice) . fetch) iouIds
+  aliceIous <- bank `submit` forA aliceIouIds fetch
+  [aliceIou] === aliceIous
+
+  largeIouIds <- bank `submit` filterA (fmap (\iou -> iou.amount > (2.0 : Decimal)) . fetch) iouIds
+  largeIous <- bank `submit` forA largeIouIds fetch
+  [bobIou, charlieIou] === largeIous


### PR DESCRIPTION
### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

# filterA

Implemented a `filterA` function using the approach borrowed from `mapA` in the standard library (and the `filterM` in Haskell).

Given the "classic" **[Iou](https://docs.daml.com/app-dev/bindings-java/quickstart.html#develop-with-daml-studio)** example if one has a collection of `ContractId Iou`s and is interested in only the "large ones" he could use this new filter like this:

```haskell
filter_ious: Scenario ()
filter_ious = scenario do
  issuer <- getParty "John Doe"

  let
    usd = Iou issuer issuer "USD" 1.23 []
    gbp = Iou issuer issuer "GBP" 2.34 []
    eur = Iou issuer issuer "EUR" 3.45 []
    ious = [usd, gbp, eur]

    largeIou iouId = do
      iou <- fetch iouId
      pure $ iou.amount > (2.0 : Decimal)

  iouIds <- issuer `submit` forA ious create

  largeIds <- issuer `submit` filterA largeIou iouIds

  largeIous <- issuer `submit` forA largeIds fetch
  [gbp, eur] === largeIous
```