### PR TITLE
Optimize Speedy machine.ctrl

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -995,6 +995,12 @@ private[lf] final case class Compiler(packages: PackageId PartialFunction Packag
           closureConvert(remaps, bound, handler),
           closureConvert(remaps, bound, fin),
         )
+
+      case x: SEWronglyTypeContractId =>
+        throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
+
+      case x: SEImportValue =>
+        throw CompilationError(s"unexpected SEImportValue: $x")
     }
   }
 
@@ -1043,6 +1049,10 @@ private[lf] final case class Compiler(packages: PackageId PartialFunction Packag
           go(body)
           go(handler)
           go(fin)
+        case x: SEWronglyTypeContractId =>
+          throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
+        case x: SEImportValue =>
+          throw CompilationError(s"unexpected SEImportValue: $x")
       }
     go(expr)
     free
@@ -1119,6 +1129,10 @@ private[lf] final case class Compiler(packages: PackageId PartialFunction Packag
           go(fin)
         case SELocation(_, body) =>
           go(body)
+        case x: SEWronglyTypeContractId =>
+          throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
+        case x: SEImportValue =>
+          throw CompilationError(s"unexpected SEImportValue: $x")
       }
     go(expr)
     expr

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -790,8 +790,8 @@ object SBuiltin {
 
       machine.addLocalContract(coid, templateId, createArg)
       machine.ptx = newPtx
-      machine.returnValue = SContractId(coid)
       checkAborted(machine.ptx)
+      machine.returnValue = SContractId(coid)
     }
   }
 
@@ -871,8 +871,8 @@ object SBuiltin {
           case Left(err) => crash(err)
           case Right(x) => x
         })
-      machine.returnValue = SUnit
       checkAborted(machine.ptx)
+      machine.returnValue = SUnit
     }
   }
 
@@ -959,8 +959,8 @@ object SBuiltin {
         key,
         byKey,
       )
-      machine.returnValue = SUnit
       checkAborted(machine.ptx)
+      machine.returnValue = SUnit
     }
   }
 
@@ -1034,8 +1034,8 @@ object SBuiltin {
         ),
         mbCoid,
       )
-      machine.returnValue = SV.Unit
       checkAborted(machine.ptx)
+      machine.returnValue = SV.Unit
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -109,12 +109,10 @@ object SBuiltin {
 
   sealed abstract class SBBinaryOpInt64(op: (Long, Long) => Long) extends SBuiltin(2) {
     final def execute(args: util.ArrayList[SValue], machine: Machine): Unit =
-      machine.returnValue(
-        (args.get(0), args.get(1)) match {
-          case (SInt64(a), SInt64(b)) => SInt64(op(a, b))
-          case _ => crash(s"type mismatch add: $args")
-        },
-      )
+      machine.returnValue = (args.get(0), args.get(1)) match {
+        case (SInt64(a), SInt64(b)) => SInt64(op(a, b))
+        case _ => crash(s"type mismatch add: $args")
+      }
   }
 
   final case object SBAddInt64 extends SBBinaryOpInt64(add)
@@ -161,7 +159,7 @@ object SBuiltin {
       val a = args.get(1).asInstanceOf[SNumeric].value
       val b = args.get(2).asInstanceOf[SNumeric].value
       assert(a.scale == scale && b.scale == scale)
-      machine.returnValue(SNumeric(op(a, b)))
+      machine.returnValue = SNumeric(op(a, b))
     }
   }
 
@@ -174,7 +172,7 @@ object SBuiltin {
       val a = args.get(3).asInstanceOf[SNumeric].value
       val b = args.get(4).asInstanceOf[SNumeric].value
       assert(a.scale == scaleA && b.scale == scaleB)
-      machine.returnValue(SNumeric(op(scale, a, b)))
+      machine.returnValue = SNumeric(op(scale, a, b))
     }
   }
 
@@ -188,10 +186,8 @@ object SBuiltin {
       val scale = args.get(0).asInstanceOf[STNat].n
       val prec = args.get(1).asInstanceOf[SInt64].value
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.returnValue(
-        SNumeric(
-          rightOrArithmeticError(s"Error while rounding (Numeric $scale)", Numeric.round(prec, x)),
-        ),
+      machine.returnValue = SNumeric(
+        rightOrArithmeticError(s"Error while rounding (Numeric $scale)", Numeric.round(prec, x)),
       )
     }
   }
@@ -201,12 +197,10 @@ object SBuiltin {
       val inputScale = args.get(0).asInstanceOf[STNat].n
       val outputScale = args.get(1).asInstanceOf[STNat].n
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.returnValue(
-        SNumeric(
-          rightOrArithmeticError(
-            s"Error while casting (Numeric $inputScale) to (Numeric $outputScale)",
-            Numeric.fromBigDecimal(outputScale, x),
-          ),
+      machine.returnValue = SNumeric(
+        rightOrArithmeticError(
+          s"Error while casting (Numeric $inputScale) to (Numeric $outputScale)",
+          Numeric.fromBigDecimal(outputScale, x),
         ),
       )
     }
@@ -217,12 +211,10 @@ object SBuiltin {
       val inputScale = args.get(0).asInstanceOf[STNat].n
       val outputScale = args.get(1).asInstanceOf[STNat].n
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.returnValue(
-        SNumeric(
-          rightOrArithmeticError(
-            s"Error while shifting (Numeric $inputScale) to (Numeric $outputScale)",
-            Numeric.fromBigDecimal(outputScale, x.scaleByPowerOfTen(inputScale - outputScale)),
-          ),
+      machine.returnValue = SNumeric(
+        rightOrArithmeticError(
+          s"Error while shifting (Numeric $inputScale) to (Numeric $outputScale)",
+          Numeric.fromBigDecimal(outputScale, x.scaleByPowerOfTen(inputScale - outputScale)),
         ),
       )
     }
@@ -233,51 +225,45 @@ object SBuiltin {
   //
   final case object SBExplodeText extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(
-        args.get(0) match {
-          case SText(t) =>
-            SList(FrontStack(Utf8.explode(t).map(SText)))
-          case _ =>
-            throw SErrorCrash(s"type mismatch explodeText: $args")
-        },
-      )
+      machine.returnValue = args.get(0) match {
+        case SText(t) =>
+          SList(FrontStack(Utf8.explode(t).map(SText)))
+        case _ =>
+          throw SErrorCrash(s"type mismatch explodeText: $args")
+      }
     }
   }
 
   final case object SBImplodeText extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(
-        args.get(0) match {
-          case SList(xs) =>
-            val ts = xs.map {
-              case SText(t) => t
-              case v =>
-                throw SErrorCrash(s"type mismatch implodeText: expected SText, got $v")
-            }
-            SText(Utf8.implode(ts.toImmArray))
-          case _ =>
-            throw SErrorCrash(s"type mismatch implodeText: $args")
-        },
-      )
+      machine.returnValue = args.get(0) match {
+        case SList(xs) =>
+          val ts = xs.map {
+            case SText(t) => t
+            case v =>
+              throw SErrorCrash(s"type mismatch implodeText: expected SText, got $v")
+          }
+          SText(Utf8.implode(ts.toImmArray))
+        case _ =>
+          throw SErrorCrash(s"type mismatch implodeText: $args")
+      }
     }
   }
 
   final case object SBAppendText extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(
-        (args.get(0), args.get(1)) match {
-          case (SText(head), SText(tail)) =>
-            SText(head + tail)
-          case _ =>
-            throw SErrorCrash(s"type mismatch appendText: $args")
-        },
-      )
+      machine.returnValue = (args.get(0), args.get(1)) match {
+        case (SText(head), SText(tail)) =>
+          SText(head + tail)
+        case _ =>
+          throw SErrorCrash(s"type mismatch appendText: $args")
+      }
     }
   }
 
   final case object SBToText extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(litToText(args))
+      machine.returnValue = litToText(args)
     }
 
     def litToText(vs: util.ArrayList[SValue]): SValue = {
@@ -298,30 +284,30 @@ object SBuiltin {
   final case object SBToTextNumeric extends SBuiltin(2) {
     override def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val x = args.get(1).asInstanceOf[SNumeric].value
-      machine.returnValue(SText(Numeric.toUnscaledString(x)))
+      machine.returnValue = SText(Numeric.toUnscaledString(x))
     }
   }
 
   final case object SBToQuotedTextParty extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val v = args.get(0).asInstanceOf[SParty]
-      machine.returnValue(SText(s"'${v.value: String}'"))
+      machine.returnValue = SText(s"'${v.value: String}'")
     }
   }
 
   final case object SBToTextCodePoints extends SBuiltin(1) {
     override def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val codePoints = args.get(0).asInstanceOf[SList].list.map(_.asInstanceOf[SInt64].value)
-      machine.returnValue(SText(Utf8.pack(codePoints.toImmArray)))
+      machine.returnValue = SText(Utf8.pack(codePoints.toImmArray))
     }
   }
 
   final case object SBFromTextParty extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val v = args.get(0).asInstanceOf[SText]
-      Party.fromString(v.value) match {
-        case Left(_) => machine.returnValue(SV.None)
-        case Right(p) => machine.returnValue(SOptional(Some(SParty(p))))
+      machine.returnValue = Party.fromString(v.value) match {
+        case Left(_) => SV.None
+        case Right(p) => SOptional(Some(SParty(p)))
       }
     }
   }
@@ -331,14 +317,15 @@ object SBuiltin {
 
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val s = args.get(0).asInstanceOf[SText].value
-      if (pattern.matcher(s).matches())
-        try {
-          machine.returnValue(SOptional(Some(SInt64(java.lang.Long.parseLong(s)))))
-        } catch {
-          case _: NumberFormatException =>
-            machine.returnValue(SV.None)
-        } else
-        machine.returnValue(SV.None)
+      machine.returnValue =
+        if (pattern.matcher(s).matches())
+          try {
+            SOptional(Some(SInt64(java.lang.Long.parseLong(s))))
+          } catch {
+            case _: NumberFormatException =>
+              SV.None
+          } else
+          SV.None
     }
   }
 
@@ -353,7 +340,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val string = args.get(1).asInstanceOf[SText].value
-      string match {
+      machine.returnValue = string match {
         case validFormat(signPart, intPart, _, decPartOrNull) =>
           val decPart = Option(decPartOrNull).filterNot(_ == "0").getOrElse("")
           // First, we count the number of significant digits to avoid the conversion attempts that
@@ -365,14 +352,12 @@ object SBuiltin {
             // potentially very costly String to BigDecimal conversions. Take for example the String
             // "1." followed by millions of '0's
             val newString = s"$signPart$intPart.${Option(decPartOrNull).getOrElse("")}"
-            machine.returnValue(
-              SOptional(Some(SNumeric(Numeric.assertFromBigDecimal(scale, BigDecimal(newString))))),
-            )
+            SOptional(Some(SNumeric(Numeric.assertFromBigDecimal(scale, BigDecimal(newString)))))
           } else {
-            machine.returnValue(SV.None)
+            SV.None
           }
         case _ =>
-          machine.returnValue(SV.None)
+          SV.None
       }
     }
   }
@@ -381,23 +366,23 @@ object SBuiltin {
     override def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val string = args.get(0).asInstanceOf[SText].value
       val codePoints = Utf8.unpack(string)
-      machine.returnValue(SList(FrontStack(codePoints.map(SInt64))))
+      machine.returnValue = SList(FrontStack(codePoints.map(SInt64)))
     }
   }
 
   final case object SBSHA256Text extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SText(t) => SText(Utf8.sha256(t))
         case _ =>
           throw SErrorCrash(s"type mismatch textSHA256: $args")
-      })
+      }
     }
   }
 
   final case object SBTextMapInsert extends SBuiltin(3) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(2) match {
+      machine.returnValue = args.get(2) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -407,13 +392,13 @@ object SBuiltin {
           }
         case x =>
           throw SErrorCrash(s"type mismatch SBTextMapInsert, expected TextMap got $x")
-      })
+      }
     }
   }
 
   final case object SBTextMapLookup extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(1) match {
+      machine.returnValue = args.get(1) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -423,13 +408,13 @@ object SBuiltin {
           }
         case x =>
           throw SErrorCrash(s"type mismatch SBTextMapLookup, expected TextMap get $x")
-      })
+      }
     }
   }
 
   final case object SBTextMapDelete extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(1) match {
+      machine.returnValue = args.get(1) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -439,102 +424,102 @@ object SBuiltin {
           }
         case x =>
           throw SErrorCrash(s"type mismatch SBTextMapDelete, expected TextMap get $x")
-      })
+      }
     }
   }
 
   final case object SBTextMapToList extends SBuiltin(1) {
 
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case map: STextMap =>
           SValue.toList(map)
         case x =>
           throw SErrorCrash(s"type mismatch SBTextMapToList, expected TextMap get $x")
-      })
+      }
     }
   }
 
   final case object SBTextMapSize extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case STextMap(map) =>
           SInt64(map.size.toLong)
         case x =>
           throw SErrorCrash(s"type mismatch SBTextMapSize, expected TextMap get $x")
-      })
+      }
     }
   }
 
   final case object SBGenMapInsert extends SBuiltin(3) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(2) match {
+      machine.returnValue = args.get(2) match {
         case SGenMap(map) =>
           val key = args.get(0)
           SGenMap.comparable(key)
           SGenMap(map.updated(key, args.get(1)))
         case x =>
           throw SErrorCrash(s"type mismatch SBGenMapInsert, expected GenMap got $x")
-      })
+      }
     }
   }
 
   final case object SBGenMapLookup extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(1) match {
+      machine.returnValue = args.get(1) match {
         case SGenMap(value) =>
           val key = args.get(0)
           SGenMap.comparable(key)
           SOptional(value.get(key))
         case x =>
           throw SErrorCrash(s"type mismatch SBGenMapLookup, expected GenMap get $x")
-      })
+      }
     }
   }
 
   final case object SBGenMapDelete extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(1) match {
+      machine.returnValue = args.get(1) match {
         case SGenMap(value) =>
           val key = args.get(0)
           SGenMap.comparable(key)
           SGenMap(value - key)
         case x =>
           throw SErrorCrash(s"type mismatch SBGenMapDelete, expected GenMap get $x")
-      })
+      }
     }
   }
 
   final case object SBGenMapKeys extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SGenMap(value) =>
           SList(ImmArray(value.keys) ++: FrontStack.empty)
         case x =>
           throw SErrorCrash(s"type mismatch SBGenMapKeys, expected GenMap get $x")
-      })
+      }
     }
   }
 
   final case object SBGenMapValues extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SGenMap(value) =>
           SList(ImmArray(value.values) ++: FrontStack.empty)
         case x =>
           throw SErrorCrash(s"type mismatch SBGenMapValues, expected GenMap get $x")
-      })
+      }
     }
   }
 
   final case object SBGenMapSize extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SGenMap(value) =>
           SInt64(value.size.toLong)
         case x =>
           throw SErrorCrash(s"type mismatch SBGenMapSize, expected GenMap get $x")
-      })
+      }
     }
   }
 
@@ -546,12 +531,10 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val x = args.get(1).asInstanceOf[SInt64].value
-      machine.returnValue(
-        SNumeric(
-          rightOrArithmeticError(
-            s"overflow when converting $x to (Numeric $scale)",
-            Numeric.fromLong(scale, x),
-          ),
+      machine.returnValue = SNumeric(
+        rightOrArithmeticError(
+          s"overflow when converting $x to (Numeric $scale)",
+          Numeric.fromLong(scale, x),
         ),
       )
     }
@@ -560,12 +543,10 @@ object SBuiltin {
   final case object SBNumericToInt64 extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val x = args.get(1).asInstanceOf[SNumeric].value
-      machine.returnValue(
-        SInt64(
-          rightOrArithmeticError(
-            s"Int64 overflow when converting ${Numeric.toString(x)} to Int64",
-            Numeric.toLong(x),
-          ),
+      machine.returnValue = SInt64(
+        rightOrArithmeticError(
+          s"Int64 overflow when converting ${Numeric.toString(x)} to Int64",
+          Numeric.toLong(x),
         ),
       )
     }
@@ -573,59 +554,53 @@ object SBuiltin {
 
   final case object SBDateToUnixDays extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SDate(d) => SInt64(d.days.toLong)
         case _ =>
           throw SErrorCrash(s"type mismatch dateToUnixDays: $args")
-      })
+      }
     }
   }
 
   final case object SBUnixDaysToDate extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(
-        args.get(0) match {
-          case SInt64(days) =>
-            SDate(
-              rightOrArithmeticError(
-                s"Could not convert Int64 $days to Date.",
-                Time.Date.asInt(days) flatMap Time.Date.fromDaysSinceEpoch,
-              ),
-            )
-          case _ =>
-            throw SErrorCrash(s"type mismatch unixDaysToDate: $args")
-        },
-      )
+      machine.returnValue = args.get(0) match {
+        case SInt64(days) =>
+          SDate(
+            rightOrArithmeticError(
+              s"Could not convert Int64 $days to Date.",
+              Time.Date.asInt(days) flatMap Time.Date.fromDaysSinceEpoch,
+            ),
+          )
+        case _ =>
+          throw SErrorCrash(s"type mismatch unixDaysToDate: $args")
+      }
     }
   }
 
   final case object SBTimestampToUnixMicroseconds extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(
-        args.get(0) match {
-          case STimestamp(t) => SInt64(t.micros)
-          case _ =>
-            throw SErrorCrash(s"type mismatch timestampToUnixMicroseconds: $args")
-        },
-      )
+      machine.returnValue = args.get(0) match {
+        case STimestamp(t) => SInt64(t.micros)
+        case _ =>
+          throw SErrorCrash(s"type mismatch timestampToUnixMicroseconds: $args")
+      }
     }
   }
 
   final case object SBUnixMicrosecondsToTimestamp extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(
-        args.get(0) match {
-          case SInt64(t) =>
-            STimestamp(
-              rightOrArithmeticError(
-                s"Could not convert Int64 $t to Timestamp.",
-                Time.Timestamp.fromLong(t),
-              ),
-            )
-          case _ =>
-            throw SErrorCrash(s"type mismatch unixMicrosecondsToTimestamp: $args")
-        },
-      )
+      machine.returnValue = args.get(0) match {
+        case SInt64(t) =>
+          STimestamp(
+            rightOrArithmeticError(
+              s"Could not convert Int64 $t to Timestamp.",
+              Time.Timestamp.fromLong(t),
+            ),
+          )
+        case _ =>
+          throw SErrorCrash(s"type mismatch unixMicrosecondsToTimestamp: $args")
+      }
     }
   }
 
@@ -634,13 +609,13 @@ object SBuiltin {
   //
   final case object SBEqual extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(SBool(svalue.Equality.areEqual(args.get(0), args.get(1))))
+      machine.returnValue = SBool(svalue.Equality.areEqual(args.get(0), args.get(1)))
     }
   }
 
   sealed abstract class SBCompare(pred: Int => Boolean) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(SBool(pred(svalue.Ordering.compare(args.get(0), args.get(1)))))
+      machine.returnValue = SBool(pred(svalue.Ordering.compare(args.get(0), args.get(1))))
     }
   }
 
@@ -652,19 +627,19 @@ object SBuiltin {
   /** $consMany[n] :: a -> ... -> List a -> List a */
   final case class SBConsMany(n: Int) extends SBuiltin(1 + n) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(n) match {
+      machine.returnValue = args.get(n) match {
         case SList(tail) =>
           SList(ImmArray(args.subList(0, n).asScala) ++: tail)
         case x =>
           crash(s"Cons onto non-list: $x")
-      })
+      }
     }
   }
 
   /** $some :: a -> Optional a */
   final case object SBSome extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(SOptional(Some(args.get(0))))
+      machine.returnValue = SOptional(Some(args.get(0)))
     }
   }
 
@@ -673,14 +648,14 @@ object SBuiltin {
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(SRecord(id, fields, args))
+      machine.returnValue = SRecord(id, fields, args)
     }
   }
 
   /** $rupd[R, field] :: R -> a -> R */
   final case class SBRecUpd(id: Identifier, field: Int) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SRecord(id2, fields, values) =>
           if (id != id2) {
             crash(s"type mismatch on record update: expected $id, got record of type $id2")
@@ -690,18 +665,18 @@ object SBuiltin {
           SRecord(id2, fields, values2)
         case v =>
           crash(s"RecUpd on non-record: $v")
-      })
+      }
     }
   }
 
   /** $rproj[R, field] :: R -> a */
   final case class SBRecProj(id: Identifier, field: Int) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SRecord(id @ _, _, values) => values.get(field)
         case v =>
           crash(s"RecProj on non-record: $v")
-      })
+      }
     }
   }
 
@@ -710,33 +685,33 @@ object SBuiltin {
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(SStruct(fields, args))
+      machine.returnValue = SStruct(fields, args)
     }
   }
 
   /** $tproj[field] :: Struct -> a */
   final case class SBStructProj(field: Ast.FieldName) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SStruct(fields, values) =>
           values.get(fields.indexOf(field))
         case v =>
           crash(s"StructProj on non-struct: $v")
-      })
+      }
     }
   }
 
   /** $tupd[field] :: Struct -> a -> Struct */
   final case class SBStructUpd(field: Ast.FieldName) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SStruct(fields, values) =>
           val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
           values2.set(fields.indexOf(field), args.get(1))
           SStruct(fields, values2)
         case v =>
           crash(s"StructUpd on non-struct: $v")
-      })
+      }
     }
   }
 
@@ -744,7 +719,7 @@ object SBuiltin {
   final case class SBVariantCon(id: Identifier, variant: Ast.VariantConName, constructorRank: Int)
       extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(SVariant(id, variant, constructorRank, args.get(0)))
+      machine.returnValue = SVariant(id, variant, constructorRank, args.get(0))
     }
   }
 
@@ -773,7 +748,7 @@ object SBuiltin {
         case v =>
           crash(s"PrecondCheck on non-boolean: $v")
       }
-      machine.returnValue(SUnit)
+      machine.returnValue = SUnit
     }
   }
 
@@ -815,7 +790,7 @@ object SBuiltin {
 
       machine.addLocalContract(coid, templateId, createArg)
       machine.ptx = newPtx
-      machine.returnValue(SContractId(coid))
+      machine.returnValue = SContractId(coid)
       checkAborted(machine.ptx)
     }
   }
@@ -878,7 +853,7 @@ object SBuiltin {
         )
         .fold(err => throw DamlETransactionError(err), identity)
       checkAborted(machine.ptx)
-      machine.returnValue(SUnit)
+      machine.returnValue = SUnit
     }
   }
 
@@ -896,7 +871,7 @@ object SBuiltin {
           case Left(err) => crash(err)
           case Right(x) => x
         })
-      machine.returnValue(SUnit)
+      machine.returnValue = SUnit
       checkAborted(machine.ptx)
     }
   }
@@ -919,7 +894,7 @@ object SBuiltin {
           if (tmplId != templateId)
             crash(s"contract $coid ($templateId) not found from partial transaction")
           else
-            machine.returnValue(contract)
+            machine.returnValue = contract
         case None =>
           coid match {
             case acoid: V.AbsoluteContractId =>
@@ -984,7 +959,7 @@ object SBuiltin {
         key,
         byKey,
       )
-      machine.returnValue(SUnit)
+      machine.returnValue = SUnit
       checkAborted(machine.ptx)
     }
   }
@@ -1002,9 +977,9 @@ object SBuiltin {
       // check if we find it locally
       machine.ptx.keys.get(gkey) match {
         case Some(mbCoid) =>
-          machine.returnValue(SOptional(mbCoid.map { coid =>
+          machine.returnValue = SOptional(mbCoid.map { coid =>
             SContractId(coid)
-          }))
+          })
         case None =>
           // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
           // that.
@@ -1021,7 +996,7 @@ object SBuiltin {
                   true
                 case SKeyLookupResult.NotFound =>
                   machine.ptx = machine.ptx.copy(keys = machine.ptx.keys + (gkey -> None))
-                  machine.returnValue(SV.None)
+                  machine.returnValue = SV.None
                   true
                 case SKeyLookupResult.NotVisible =>
                   machine.tryHandleException()
@@ -1059,7 +1034,7 @@ object SBuiltin {
         ),
         mbCoid,
       )
-      machine.returnValue(SV.Unit)
+      machine.returnValue = SV.Unit
       checkAborted(machine.ptx)
     }
   }
@@ -1079,7 +1054,7 @@ object SBuiltin {
         case Some(None) =>
           crash(s"Could not find key $gkey")
         case Some(Some(coid)) =>
-          machine.returnValue(SContractId(coid))
+          machine.returnValue = SContractId(coid)
         case None =>
           // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
           // that.
@@ -1110,7 +1085,7 @@ object SBuiltin {
       checkToken(args.get(0))
       // $ugettime :: Token -> Timestamp
       throw SpeedyHungry(
-        SResultNeedTime(timestamp => machine.returnValue(STimestamp(timestamp))),
+        SResultNeedTime(timestamp => machine.returnValue = STimestamp(timestamp)),
       )
     }
   }
@@ -1123,7 +1098,7 @@ object SBuiltin {
       machine.globalDiscriminators = Set.empty
       machine.committers = extractParties(args.get(0))
       machine.commitLocation = optLocation
-      machine.returnValue(SV.Unit)
+      machine.returnValue = SV.Unit
     }
   }
 
@@ -1149,19 +1124,19 @@ object SBuiltin {
           // update expression threw an exception. we're
           // now done.
           machine.clearCommit
-          machine.returnValue(SV.Unit)
+          machine.returnValue = SV.Unit
           throw SpeedyHungry(SResultScenarioInsertMustFail(committerOld, commitLocationOld))
 
         case SBool(false) =>
           ptxOld.finish match {
             case Left(_) =>
               machine.clearCommit
-              machine.returnValue(SV.Unit)
+              machine.returnValue = SV.Unit
             case Right(tx) =>
               // Transaction finished successfully. It might still
               // fail when committed, so tell the scenario runner to
               // do that.
-              machine.returnValue(SV.Unit)
+              machine.returnValue = SV.Unit
               throw SpeedyHungry(
                 SResultScenarioMustFail(tx, committerOld, _ => machine.clearCommit))
           }
@@ -1187,7 +1162,7 @@ object SBuiltin {
           committers = machine.committers,
           callback = newValue => {
             machine.clearCommit
-            machine.returnValue(newValue)
+            machine.returnValue = newValue
           },
         ),
       )
@@ -1206,7 +1181,7 @@ object SBuiltin {
       throw SpeedyHungry(
         SResultScenarioPassTime(
           relTime,
-          timestamp => machine.returnValue(STimestamp(timestamp)),
+          timestamp => machine.returnValue = STimestamp(timestamp),
         ),
       )
     }
@@ -1219,7 +1194,7 @@ object SBuiltin {
       args.get(0) match {
         case SText(name) =>
           throw SpeedyHungry(
-            SResultScenarioGetParty(name, party => machine.returnValue(SParty(party))),
+            SResultScenarioGetParty(name, party => machine.returnValue = SParty(party)),
           )
         case v =>
           crash(s"invalid argument to GetParty: $v")
@@ -1233,7 +1208,7 @@ object SBuiltin {
       args.get(0) match {
         case SText(message) =>
           machine.traceLog.add(message, machine.lastLocation)
-          machine.returnValue(args.get(1))
+          machine.returnValue = args.get(1)
         case v =>
           crash(s"invalid argument to trace: $v")
       }
@@ -1252,7 +1227,7 @@ object SBuiltin {
     */
   final case class SBToAny(ty: Ast.Type) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(SAny(ty, args.get(0)))
+      machine.returnValue = SAny(ty, args.get(0))
     }
   }
 
@@ -1262,11 +1237,11 @@ object SBuiltin {
     */
   final case class SBFromAny(expectedTy: Ast.Type) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.returnValue(args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SAny(actualTy, v) =>
           SOptional(if (actualTy == expectedTy) Some(v) else None)
         case v => crash(s"FromAny applied to non-Any: $v")
-      })
+      }
     }
   }
 
@@ -1277,7 +1252,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       args.get(0) match {
         case SText(t) =>
-          machine.returnValue(SText(t.toUpperCase(util.Locale.ROOT)))
+          machine.returnValue = SText(t.toUpperCase(util.Locale.ROOT))
         // TODO [FM]: replace with ASCII-specific function, or not
         case x =>
           throw SErrorCrash(s"type mismatch SBTextoUpper, expected Text got $x")
@@ -1290,7 +1265,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       args.get(0) match {
         case SText(t) =>
-          machine.returnValue(SText(t.toLowerCase(util.Locale.ROOT)))
+          machine.returnValue = SText(t.toLowerCase(util.Locale.ROOT))
         // TODO [FM]: replace with ASCII-specific function, or not
         case x =>
           throw SErrorCrash(s"type mismatch SBTextToLower, expected Text got $x")
@@ -1301,7 +1276,7 @@ object SBuiltin {
   /** $text_slice :: Int -> Int -> Text -> Text */
   final case object SBTextSlice extends SBuiltin(3) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SInt64(from) =>
           args.get(1) match {
             case SInt64(to) =>
@@ -1309,7 +1284,7 @@ object SBuiltin {
                 case SText(t) =>
                   val length = t.codePointCount(0, t.length).toLong
                   if (to <= 0 || from >= length || to <= from) {
-                    machine.returnValue(SText(""))
+                    SText("")
                   } else {
                     val rfrom = from.max(0).toInt
                     val rto = to.min(length).toInt
@@ -1320,7 +1295,7 @@ object SBuiltin {
                     // empty string below even though `to` was larger than length.
                     val ifrom = t.offsetByCodePoints(0, rfrom)
                     val ito = t.offsetByCodePoints(ifrom, rto - rfrom)
-                    machine.returnValue(SText(t.slice(ifrom, ito)))
+                    SText(t.slice(ifrom, ito))
                   }
                 case x =>
                   throw SErrorCrash(s"type mismatch SBTextSlice, expected Text got $x")
@@ -1337,16 +1312,16 @@ object SBuiltin {
   /** $text_slice_index :: Text -> Text -> Optional Int */
   final case object SBTextSliceIndex extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SText(slice) =>
           args.get(1) match {
             case SText(t) =>
               val n = t.indexOfSlice(slice) // n is -1 if slice is not found.
               if (n < 0) {
-                machine.returnValue(SOptional(None))
+                SOptional(None)
               } else {
                 val rn = t.codePointCount(0, n).toLong // we want to return the number of codepoints!
-                machine.returnValue(SOptional(Some(SInt64(rn))))
+                SOptional(Some(SInt64(rn)))
               }
             case x =>
               throw SErrorCrash(s"type mismatch SBTextSliceIndex, expected Text got $x")
@@ -1360,13 +1335,13 @@ object SBuiltin {
   /** $text_contains_only :: Text -> Text -> Bool */
   final case object SBTextContainsOnly extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SText(alphabet) =>
           args.get(1) match {
             case SText(t) =>
               val alphabetSet = alphabet.codePoints().iterator().asScala.toSet
               val result = t.codePoints().iterator().asScala.forall(alphabetSet.contains(_))
-              machine.returnValue(SBool(result))
+              SBool(result)
             case x =>
               throw SErrorCrash(s"type mismatch SBTextContainsOnly, expected Text got $x")
           }
@@ -1379,15 +1354,15 @@ object SBuiltin {
   /** $text_replicate :: Int -> Text -> Text */
   final case object SBTextReplicate extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SInt64(n) =>
           args.get(1) match {
             case SText(t) =>
               if (n < 0) {
-                machine.returnValue(SText(""))
+                SText("")
               } else {
                 val rn = n.min(Int.MaxValue.toLong).toInt
-                machine.returnValue(SText(t * rn))
+                SText(t * rn)
               }
             case x =>
               throw SErrorCrash(s"type mismatch SBTextReplicate, expected Text got $x")
@@ -1401,7 +1376,7 @@ object SBuiltin {
   /** $text_split_on :: Text -> Text -> List Text */
   final case object SBTextSplitOn extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SText(pattern) =>
           args.get(1) match {
             case SText(t) =>
@@ -1415,7 +1390,7 @@ object SBuiltin {
                   // and we want to keep empty strings, so we use -1 as the second argument.
                   t.split(Pattern.quote(pattern), -1).map(SText).toSeq
                 }
-              machine.returnValue(SList(FrontStack(seq)))
+              SList(FrontStack(seq))
             case x =>
               throw SErrorCrash(s"type mismatch SBTextSplitOn, expected Text got $x")
           }
@@ -1428,7 +1403,7 @@ object SBuiltin {
   /** $text_intercalate :: Text -> List Text -> Text */
   final case object SBTextIntercalate extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      args.get(0) match {
+      machine.returnValue = args.get(0) match {
         case SText(sep) =>
           args.get(1) match {
             case SList(vs) =>
@@ -1441,7 +1416,7 @@ object SBuiltin {
                     )
                 }
               }
-              machine.returnValue(SText(xs.iterator.mkString(sep)))
+              SText(xs.iterator.mkString(sep))
             case x =>
               throw SErrorCrash(s"type mismatch SBTextIntercalate, expected List got $x")
           }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -13,15 +13,10 @@ import com.daml.lf.data.Numeric.Scale
 import com.daml.lf.language.Ast
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.Speedy.{
-  CtrlImportValue,
-  CtrlValue,
-  CtrlWronglyTypeContractId,
-  Machine,
-  SpeedyHungry
-}
+import com.daml.lf.speedy.Speedy.{Machine, SpeedyHungry}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SValue.{SValue => SV}
 import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.{Value => V}
 import com.daml.lf.value.ValueVersions.asVersionedValue
@@ -114,7 +109,7 @@ object SBuiltin {
 
   sealed abstract class SBBinaryOpInt64(op: (Long, Long) => Long) extends SBuiltin(2) {
     final def execute(args: util.ArrayList[SValue], machine: Machine): Unit =
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         (args.get(0), args.get(1)) match {
           case (SInt64(a), SInt64(b)) => SInt64(op(a, b))
           case _ => crash(s"type mismatch add: $args")
@@ -166,7 +161,7 @@ object SBuiltin {
       val a = args.get(1).asInstanceOf[SNumeric].value
       val b = args.get(2).asInstanceOf[SNumeric].value
       assert(a.scale == scale && b.scale == scale)
-      machine.ctrl = CtrlValue(SNumeric(op(a, b)))
+      machine.returnValue(SNumeric(op(a, b)))
     }
   }
 
@@ -179,7 +174,7 @@ object SBuiltin {
       val a = args.get(3).asInstanceOf[SNumeric].value
       val b = args.get(4).asInstanceOf[SNumeric].value
       assert(a.scale == scaleA && b.scale == scaleB)
-      machine.ctrl = CtrlValue(SNumeric(op(scale, a, b)))
+      machine.returnValue(SNumeric(op(scale, a, b)))
     }
   }
 
@@ -193,7 +188,7 @@ object SBuiltin {
       val scale = args.get(0).asInstanceOf[STNat].n
       val prec = args.get(1).asInstanceOf[SInt64].value
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SNumeric(
           rightOrArithmeticError(s"Error while rounding (Numeric $scale)", Numeric.round(prec, x)),
         ),
@@ -206,7 +201,7 @@ object SBuiltin {
       val inputScale = args.get(0).asInstanceOf[STNat].n
       val outputScale = args.get(1).asInstanceOf[STNat].n
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SNumeric(
           rightOrArithmeticError(
             s"Error while casting (Numeric $inputScale) to (Numeric $outputScale)",
@@ -222,7 +217,7 @@ object SBuiltin {
       val inputScale = args.get(0).asInstanceOf[STNat].n
       val outputScale = args.get(1).asInstanceOf[STNat].n
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SNumeric(
           rightOrArithmeticError(
             s"Error while shifting (Numeric $inputScale) to (Numeric $outputScale)",
@@ -238,7 +233,7 @@ object SBuiltin {
   //
   final case object SBExplodeText extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case SText(t) =>
             SList(FrontStack(Utf8.explode(t).map(SText)))
@@ -251,7 +246,7 @@ object SBuiltin {
 
   final case object SBImplodeText extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case SList(xs) =>
             val ts = xs.map {
@@ -269,7 +264,7 @@ object SBuiltin {
 
   final case object SBAppendText extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         (args.get(0), args.get(1)) match {
           case (SText(head), SText(tail)) =>
             SText(head + tail)
@@ -282,7 +277,7 @@ object SBuiltin {
 
   final case object SBToText extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(litToText(args))
+      machine.returnValue(litToText(args))
     }
 
     def litToText(vs: util.ArrayList[SValue]): SValue = {
@@ -303,30 +298,30 @@ object SBuiltin {
   final case object SBToTextNumeric extends SBuiltin(2) {
     override def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val x = args.get(1).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(SText(Numeric.toUnscaledString(x)))
+      machine.returnValue(SText(Numeric.toUnscaledString(x)))
     }
   }
 
   final case object SBToQuotedTextParty extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val v = args.get(0).asInstanceOf[SParty]
-      machine.ctrl = CtrlValue(SText(s"'${v.value: String}'"))
+      machine.returnValue(SText(s"'${v.value: String}'"))
     }
   }
 
   final case object SBToTextCodePoints extends SBuiltin(1) {
     override def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val codePoints = args.get(0).asInstanceOf[SList].list.map(_.asInstanceOf[SInt64].value)
-      machine.ctrl = CtrlValue(SText(Utf8.pack(codePoints.toImmArray)))
+      machine.returnValue(SText(Utf8.pack(codePoints.toImmArray)))
     }
   }
 
   final case object SBFromTextParty extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val v = args.get(0).asInstanceOf[SText]
-      machine.ctrl = Party.fromString(v.value) match {
-        case Left(_) => CtrlValue.None
-        case Right(p) => CtrlValue(SOptional(Some(SParty(p))))
+      Party.fromString(v.value) match {
+        case Left(_) => machine.returnValue(SV.None)
+        case Right(p) => machine.returnValue(SOptional(Some(SParty(p))))
       }
     }
   }
@@ -336,15 +331,14 @@ object SBuiltin {
 
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val s = args.get(0).asInstanceOf[SText].value
-      machine.ctrl =
-        if (pattern.matcher(s).matches())
-          try {
-            CtrlValue(SOptional(Some(SInt64(java.lang.Long.parseLong(s)))))
-          } catch {
-            case _: NumberFormatException =>
-              CtrlValue.None
-          } else
-          CtrlValue.None
+      if (pattern.matcher(s).matches())
+        try {
+          machine.returnValue(SOptional(Some(SInt64(java.lang.Long.parseLong(s)))))
+        } catch {
+          case _: NumberFormatException =>
+            machine.returnValue(SV.None)
+        } else
+        machine.returnValue(SV.None)
     }
   }
 
@@ -359,7 +353,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val string = args.get(1).asInstanceOf[SText].value
-      machine.ctrl = string match {
+      string match {
         case validFormat(signPart, intPart, _, decPartOrNull) =>
           val decPart = Option(decPartOrNull).filterNot(_ == "0").getOrElse("")
           // First, we count the number of significant digits to avoid the conversion attempts that
@@ -371,14 +365,14 @@ object SBuiltin {
             // potentially very costly String to BigDecimal conversions. Take for example the String
             // "1." followed by millions of '0's
             val newString = s"$signPart$intPart.${Option(decPartOrNull).getOrElse("")}"
-            CtrlValue(
+            machine.returnValue(
               SOptional(Some(SNumeric(Numeric.assertFromBigDecimal(scale, BigDecimal(newString))))),
             )
           } else {
-            CtrlValue.None
+            machine.returnValue(SV.None)
           }
         case _ =>
-          CtrlValue.None
+          machine.returnValue(SV.None)
       }
     }
   }
@@ -387,13 +381,13 @@ object SBuiltin {
     override def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val string = args.get(0).asInstanceOf[SText].value
       val codePoints = Utf8.unpack(string)
-      machine.ctrl = CtrlValue(SList(FrontStack(codePoints.map(SInt64))))
+      machine.returnValue(SList(FrontStack(codePoints.map(SInt64))))
     }
   }
 
   final case object SBSHA256Text extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SText(t) => SText(Utf8.sha256(t))
         case _ =>
           throw SErrorCrash(s"type mismatch textSHA256: $args")
@@ -403,7 +397,7 @@ object SBuiltin {
 
   final case object SBTextMapInsert extends SBuiltin(3) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(2) match {
+      machine.returnValue(args.get(2) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -419,7 +413,7 @@ object SBuiltin {
 
   final case object SBTextMapLookup extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(1) match {
+      machine.returnValue(args.get(1) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -435,7 +429,7 @@ object SBuiltin {
 
   final case object SBTextMapDelete extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(1) match {
+      machine.returnValue(args.get(1) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -452,7 +446,7 @@ object SBuiltin {
   final case object SBTextMapToList extends SBuiltin(1) {
 
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case map: STextMap =>
           SValue.toList(map)
         case x =>
@@ -463,7 +457,7 @@ object SBuiltin {
 
   final case object SBTextMapSize extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case STextMap(map) =>
           SInt64(map.size.toLong)
         case x =>
@@ -474,7 +468,7 @@ object SBuiltin {
 
   final case object SBGenMapInsert extends SBuiltin(3) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(2) match {
+      machine.returnValue(args.get(2) match {
         case SGenMap(map) =>
           val key = args.get(0)
           SGenMap.comparable(key)
@@ -487,7 +481,7 @@ object SBuiltin {
 
   final case object SBGenMapLookup extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(1) match {
+      machine.returnValue(args.get(1) match {
         case SGenMap(value) =>
           val key = args.get(0)
           SGenMap.comparable(key)
@@ -500,7 +494,7 @@ object SBuiltin {
 
   final case object SBGenMapDelete extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(1) match {
+      machine.returnValue(args.get(1) match {
         case SGenMap(value) =>
           val key = args.get(0)
           SGenMap.comparable(key)
@@ -513,7 +507,7 @@ object SBuiltin {
 
   final case object SBGenMapKeys extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SGenMap(value) =>
           SList(ImmArray(value.keys) ++: FrontStack.empty)
         case x =>
@@ -524,7 +518,7 @@ object SBuiltin {
 
   final case object SBGenMapValues extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SGenMap(value) =>
           SList(ImmArray(value.values) ++: FrontStack.empty)
         case x =>
@@ -535,7 +529,7 @@ object SBuiltin {
 
   final case object SBGenMapSize extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SGenMap(value) =>
           SInt64(value.size.toLong)
         case x =>
@@ -552,7 +546,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val x = args.get(1).asInstanceOf[SInt64].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SNumeric(
           rightOrArithmeticError(
             s"overflow when converting $x to (Numeric $scale)",
@@ -566,7 +560,7 @@ object SBuiltin {
   final case object SBNumericToInt64 extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val x = args.get(1).asInstanceOf[SNumeric].value
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         SInt64(
           rightOrArithmeticError(
             s"Int64 overflow when converting ${Numeric.toString(x)} to Int64",
@@ -579,7 +573,7 @@ object SBuiltin {
 
   final case object SBDateToUnixDays extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SDate(d) => SInt64(d.days.toLong)
         case _ =>
           throw SErrorCrash(s"type mismatch dateToUnixDays: $args")
@@ -589,7 +583,7 @@ object SBuiltin {
 
   final case object SBUnixDaysToDate extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case SInt64(days) =>
             SDate(
@@ -607,7 +601,7 @@ object SBuiltin {
 
   final case object SBTimestampToUnixMicroseconds extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case STimestamp(t) => SInt64(t.micros)
           case _ =>
@@ -619,7 +613,7 @@ object SBuiltin {
 
   final case object SBUnixMicrosecondsToTimestamp extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(
+      machine.returnValue(
         args.get(0) match {
           case SInt64(t) =>
             STimestamp(
@@ -640,13 +634,13 @@ object SBuiltin {
   //
   final case object SBEqual extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue.bool(svalue.Equality.areEqual(args.get(0), args.get(1)))
+      machine.returnValue(SBool(svalue.Equality.areEqual(args.get(0), args.get(1))))
     }
   }
 
   sealed abstract class SBCompare(pred: Int => Boolean) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue.bool(pred(svalue.Ordering.compare(args.get(0), args.get(1))))
+      machine.returnValue(SBool(pred(svalue.Ordering.compare(args.get(0), args.get(1)))))
     }
   }
 
@@ -658,7 +652,7 @@ object SBuiltin {
   /** $consMany[n] :: a -> ... -> List a -> List a */
   final case class SBConsMany(n: Int) extends SBuiltin(1 + n) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(n) match {
+      machine.returnValue(args.get(n) match {
         case SList(tail) =>
           SList(ImmArray(args.subList(0, n).asScala) ++: tail)
         case x =>
@@ -670,7 +664,7 @@ object SBuiltin {
   /** $some :: a -> Optional a */
   final case object SBSome extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SOptional(Some(args.get(0))))
+      machine.returnValue(SOptional(Some(args.get(0))))
     }
   }
 
@@ -679,14 +673,14 @@ object SBuiltin {
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SRecord(id, fields, args))
+      machine.returnValue(SRecord(id, fields, args))
     }
   }
 
   /** $rupd[R, field] :: R -> a -> R */
   final case class SBRecUpd(id: Identifier, field: Int) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SRecord(id2, fields, values) =>
           if (id != id2) {
             crash(s"type mismatch on record update: expected $id, got record of type $id2")
@@ -703,7 +697,7 @@ object SBuiltin {
   /** $rproj[R, field] :: R -> a */
   final case class SBRecProj(id: Identifier, field: Int) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SRecord(id @ _, _, values) => values.get(field)
         case v =>
           crash(s"RecProj on non-record: $v")
@@ -716,14 +710,14 @@ object SBuiltin {
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SStruct(fields, args))
+      machine.returnValue(SStruct(fields, args))
     }
   }
 
   /** $tproj[field] :: Struct -> a */
   final case class SBStructProj(field: Ast.FieldName) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SStruct(fields, values) =>
           values.get(fields.indexOf(field))
         case v =>
@@ -735,7 +729,7 @@ object SBuiltin {
   /** $tupd[field] :: Struct -> a -> Struct */
   final case class SBStructUpd(field: Ast.FieldName) extends SBuiltin(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SStruct(fields, values) =>
           val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
           values2.set(fields.indexOf(field), args.get(1))
@@ -750,7 +744,7 @@ object SBuiltin {
   final case class SBVariantCon(id: Identifier, variant: Ast.VariantConName, constructorRank: Int)
       extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SVariant(id, variant, constructorRank, args.get(0)))
+      machine.returnValue(SVariant(id, variant, constructorRank, args.get(0)))
     }
   }
 
@@ -779,7 +773,7 @@ object SBuiltin {
         case v =>
           crash(s"PrecondCheck on non-boolean: $v")
       }
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SUnit)
     }
   }
 
@@ -821,7 +815,7 @@ object SBuiltin {
 
       machine.addLocalContract(coid, templateId, createArg)
       machine.ptx = newPtx
-      machine.ctrl = CtrlValue(SContractId(coid))
+      machine.returnValue(SContractId(coid))
       checkAborted(machine.ptx)
     }
   }
@@ -884,7 +878,7 @@ object SBuiltin {
         )
         .fold(err => throw DamlETransactionError(err), identity)
       checkAborted(machine.ptx)
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SUnit)
     }
   }
 
@@ -902,7 +896,7 @@ object SBuiltin {
           case Left(err) => crash(err)
           case Right(x) => x
         })
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SUnit)
       checkAborted(machine.ptx)
     }
   }
@@ -925,7 +919,7 @@ object SBuiltin {
           if (tmplId != templateId)
             crash(s"contract $coid ($templateId) not found from partial transaction")
           else
-            machine.ctrl = CtrlValue(contract)
+            machine.returnValue(contract)
         case None =>
           coid match {
             case acoid: V.AbsoluteContractId =>
@@ -940,9 +934,9 @@ object SBuiltin {
                     // set the control appropriately which will crash the machine
                     // correctly later.
                     if (coinst.template != templateId)
-                      machine.ctrl = CtrlWronglyTypeContractId(acoid, templateId, coinst.template)
+                      machine.ctrl = SEWronglyTypeContractId(acoid, templateId, coinst.template)
                     else
-                      machine.ctrl = CtrlImportValue(coinst.arg.value)
+                      machine.ctrl = SEImportValue(coinst.arg.value)
                   },
                 ),
               )
@@ -990,7 +984,7 @@ object SBuiltin {
         key,
         byKey,
       )
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SUnit)
       checkAborted(machine.ptx)
     }
   }
@@ -1008,7 +1002,9 @@ object SBuiltin {
       // check if we find it locally
       machine.ptx.keys.get(gkey) match {
         case Some(mbCoid) =>
-          machine.ctrl = CtrlValue(SOptional(mbCoid.map(SContractId)))
+          machine.returnValue(SOptional(mbCoid.map { coid =>
+            SContractId(coid)
+          }))
         case None =>
           // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
           // that.
@@ -1021,11 +1017,11 @@ object SBuiltin {
                   // We have to check that the discriminator of cid does not conflict with a local ones
                   // however we cannot raise an exception in case of failure here.
                   // We delegate to CtrlImportValue the task to check cid.
-                  machine.ctrl = CtrlImportValue(V.ValueOptional(Some(V.ValueContractId(cid))))
+                  machine.ctrl = SEImportValue(V.ValueOptional(Some(V.ValueContractId(cid))))
                   true
                 case SKeyLookupResult.NotFound =>
                   machine.ptx = machine.ptx.copy(keys = machine.ptx.keys + (gkey -> None))
-                  machine.ctrl = CtrlValue.None
+                  machine.returnValue(SV.None)
                   true
                 case SKeyLookupResult.NotVisible =>
                   machine.tryHandleException()
@@ -1063,7 +1059,7 @@ object SBuiltin {
         ),
         mbCoid,
       )
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SV.Unit)
       checkAborted(machine.ptx)
     }
   }
@@ -1083,7 +1079,7 @@ object SBuiltin {
         case Some(None) =>
           crash(s"Could not find key $gkey")
         case Some(Some(coid)) =>
-          machine.ctrl = CtrlValue(SContractId(coid))
+          machine.returnValue(SContractId(coid))
         case None =>
           // if we cannot find it here, send help, and make sure to update [[PartialTransaction.key]] after
           // that.
@@ -1096,7 +1092,7 @@ object SBuiltin {
                   // We have to check that the discriminator of cid does not conflict with a local ones
                   // however we cannot raise an exception in case of failure here.
                   // We delegate to CtrlImportValue the task to check cid.
-                  machine.ctrl = CtrlImportValue(V.ValueContractId(cid))
+                  machine.ctrl = SEImportValue(V.ValueContractId(cid))
                   true
                 case SKeyLookupResult.NotFound | SKeyLookupResult.NotVisible =>
                   machine.ptx = machine.ptx.copy(keys = machine.ptx.keys + (gkey -> None))
@@ -1114,7 +1110,7 @@ object SBuiltin {
       checkToken(args.get(0))
       // $ugettime :: Token -> Timestamp
       throw SpeedyHungry(
-        SResultNeedTime(timestamp => machine.ctrl = CtrlValue(STimestamp(timestamp))),
+        SResultNeedTime(timestamp => machine.returnValue(STimestamp(timestamp))),
       )
     }
   }
@@ -1127,7 +1123,7 @@ object SBuiltin {
       machine.globalDiscriminators = Set.empty
       machine.committers = extractParties(args.get(0))
       machine.commitLocation = optLocation
-      machine.ctrl = CtrlValue.Unit
+      machine.returnValue(SV.Unit)
     }
   }
 
@@ -1153,19 +1149,19 @@ object SBuiltin {
           // update expression threw an exception. we're
           // now done.
           machine.clearCommit
-          machine.ctrl = CtrlValue.Unit
+          machine.returnValue(SV.Unit)
           throw SpeedyHungry(SResultScenarioInsertMustFail(committerOld, commitLocationOld))
 
         case SBool(false) =>
           ptxOld.finish match {
             case Left(_) =>
               machine.clearCommit
-              machine.ctrl = CtrlValue.Unit
+              machine.returnValue(SV.Unit)
             case Right(tx) =>
               // Transaction finished successfully. It might still
               // fail when committed, so tell the scenario runner to
               // do that.
-              machine.ctrl = CtrlValue.Unit
+              machine.returnValue(SV.Unit)
               throw SpeedyHungry(
                 SResultScenarioMustFail(tx, committerOld, _ => machine.clearCommit))
           }
@@ -1191,7 +1187,7 @@ object SBuiltin {
           committers = machine.committers,
           callback = newValue => {
             machine.clearCommit
-            machine.ctrl = CtrlValue(newValue)
+            machine.returnValue(newValue)
           },
         ),
       )
@@ -1210,7 +1206,7 @@ object SBuiltin {
       throw SpeedyHungry(
         SResultScenarioPassTime(
           relTime,
-          timestamp => machine.ctrl = CtrlValue(STimestamp(timestamp)),
+          timestamp => machine.returnValue(STimestamp(timestamp)),
         ),
       )
     }
@@ -1223,7 +1219,7 @@ object SBuiltin {
       args.get(0) match {
         case SText(name) =>
           throw SpeedyHungry(
-            SResultScenarioGetParty(name, party => machine.ctrl = CtrlValue(SParty(party))),
+            SResultScenarioGetParty(name, party => machine.returnValue(SParty(party))),
           )
         case v =>
           crash(s"invalid argument to GetParty: $v")
@@ -1237,7 +1233,7 @@ object SBuiltin {
       args.get(0) match {
         case SText(message) =>
           machine.traceLog.add(message, machine.lastLocation)
-          machine.ctrl = CtrlValue(args.get(1))
+          machine.returnValue(args.get(1))
         case v =>
           crash(s"invalid argument to trace: $v")
       }
@@ -1256,7 +1252,7 @@ object SBuiltin {
     */
   final case class SBToAny(ty: Ast.Type) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(SAny(ty, args.get(0)))
+      machine.returnValue(SAny(ty, args.get(0)))
     }
   }
 
@@ -1266,7 +1262,7 @@ object SBuiltin {
     */
   final case class SBFromAny(expectedTy: Ast.Type) extends SBuiltin(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
-      machine.ctrl = CtrlValue(args.get(0) match {
+      machine.returnValue(args.get(0) match {
         case SAny(actualTy, v) =>
           SOptional(if (actualTy == expectedTy) Some(v) else None)
         case v => crash(s"FromAny applied to non-Any: $v")
@@ -1281,7 +1277,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       args.get(0) match {
         case SText(t) =>
-          machine.ctrl = CtrlValue(SText(t.toUpperCase(util.Locale.ROOT)))
+          machine.returnValue(SText(t.toUpperCase(util.Locale.ROOT)))
         // TODO [FM]: replace with ASCII-specific function, or not
         case x =>
           throw SErrorCrash(s"type mismatch SBTextoUpper, expected Text got $x")
@@ -1294,7 +1290,7 @@ object SBuiltin {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       args.get(0) match {
         case SText(t) =>
-          machine.ctrl = CtrlValue(SText(t.toLowerCase(util.Locale.ROOT)))
+          machine.returnValue(SText(t.toLowerCase(util.Locale.ROOT)))
         // TODO [FM]: replace with ASCII-specific function, or not
         case x =>
           throw SErrorCrash(s"type mismatch SBTextToLower, expected Text got $x")
@@ -1313,7 +1309,7 @@ object SBuiltin {
                 case SText(t) =>
                   val length = t.codePointCount(0, t.length).toLong
                   if (to <= 0 || from >= length || to <= from) {
-                    machine.ctrl = CtrlValue(SText(""))
+                    machine.returnValue(SText(""))
                   } else {
                     val rfrom = from.max(0).toInt
                     val rto = to.min(length).toInt
@@ -1324,7 +1320,7 @@ object SBuiltin {
                     // empty string below even though `to` was larger than length.
                     val ifrom = t.offsetByCodePoints(0, rfrom)
                     val ito = t.offsetByCodePoints(ifrom, rto - rfrom)
-                    machine.ctrl = CtrlValue(SText(t.slice(ifrom, ito)))
+                    machine.returnValue(SText(t.slice(ifrom, ito)))
                   }
                 case x =>
                   throw SErrorCrash(s"type mismatch SBTextSlice, expected Text got $x")
@@ -1347,10 +1343,10 @@ object SBuiltin {
             case SText(t) =>
               val n = t.indexOfSlice(slice) // n is -1 if slice is not found.
               if (n < 0) {
-                machine.ctrl = CtrlValue(SOptional(None))
+                machine.returnValue(SOptional(None))
               } else {
                 val rn = t.codePointCount(0, n).toLong // we want to return the number of codepoints!
-                machine.ctrl = CtrlValue(SOptional(Some(SInt64(rn))))
+                machine.returnValue(SOptional(Some(SInt64(rn))))
               }
             case x =>
               throw SErrorCrash(s"type mismatch SBTextSliceIndex, expected Text got $x")
@@ -1370,7 +1366,7 @@ object SBuiltin {
             case SText(t) =>
               val alphabetSet = alphabet.codePoints().iterator().asScala.toSet
               val result = t.codePoints().iterator().asScala.forall(alphabetSet.contains(_))
-              machine.ctrl = CtrlValue(SBool(result))
+              machine.returnValue(SBool(result))
             case x =>
               throw SErrorCrash(s"type mismatch SBTextContainsOnly, expected Text got $x")
           }
@@ -1388,10 +1384,10 @@ object SBuiltin {
           args.get(1) match {
             case SText(t) =>
               if (n < 0) {
-                machine.ctrl = CtrlValue(SText(""))
+                machine.returnValue(SText(""))
               } else {
                 val rn = n.min(Int.MaxValue.toLong).toInt
-                machine.ctrl = CtrlValue(SText(t * rn))
+                machine.returnValue(SText(t * rn))
               }
             case x =>
               throw SErrorCrash(s"type mismatch SBTextReplicate, expected Text got $x")
@@ -1419,7 +1415,7 @@ object SBuiltin {
                   // and we want to keep empty strings, so we use -1 as the second argument.
                   t.split(Pattern.quote(pattern), -1).map(SText).toSeq
                 }
-              machine.ctrl = CtrlValue(SList(FrontStack(seq)))
+              machine.returnValue(SList(FrontStack(seq)))
             case x =>
               throw SErrorCrash(s"type mismatch SBTextSplitOn, expected Text got $x")
           }
@@ -1445,7 +1441,7 @@ object SBuiltin {
                     )
                 }
               }
-              machine.ctrl = CtrlValue(SText(xs.iterator.mkString(sep)))
+              machine.returnValue(SText(xs.iterator.mkString(sep)))
             case x =>
               throw SErrorCrash(s"type mismatch SBTextIntercalate, expected List got $x")
           }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -9,8 +9,11 @@ package com.daml.lf.speedy
   * This reduces the number of binding forms by moving update and scenario
   * expressions into builtins.
   */
+import java.util
+
 import com.daml.lf.language.Ast._
 import com.daml.lf.data.Ref._
+import com.daml.lf.value.{Value => V}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SError._
@@ -24,8 +27,7 @@ import java.util.ArrayList
   * - all update and scenario operations converted to builtin functions.
   */
 sealed abstract class SExpr extends Product with Serializable {
-  def execute(machine: Machine): Ctrl
-
+  def execute(machine: Machine): Unit
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override def toString: String =
     productPrefix + productIterator.map(SExpr.prettyPrint).mkString("(", ",", ")")
@@ -39,8 +41,8 @@ object SExpr {
     * https://en.wikipedia.org/wiki/De_Bruijn_index
     */
   final case class SEVar(index: Int) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
-      CtrlValue(machine.getEnv(index))
+    def execute(machine: Machine): Unit = {
+      machine.returnValue(machine.getEnv(index))
     }
   }
 
@@ -51,27 +53,29 @@ object SExpr {
       ref: SDefinitionRef,
       var cached: Option[(SValue, List[Location])],
   ) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       machine.lookupVal(this)
     }
   }
 
   /** Reference to a builtin function */
   final case class SEBuiltin(b: SBuiltin) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       /* special case for nullary record constructors */
       b match {
         case SBRecCon(id, fields) if b.arity == 0 =>
-          CtrlValue(SRecord(id, fields, new ArrayList()))
+          machine.returnValue(SRecord(id, fields, new ArrayList()))
         case _ =>
-          Ctrl.fromPrim(PBuiltin(b), b.arity)
+          machine.returnValue(SPAP(PBuiltin(b), new util.ArrayList[SValue](), b.arity))
       }
     }
   }
 
   /** A pre-computed value, usually primitive literal, e.g. integer, text, boolean etc. */
   final case class SEValue(v: SValue) extends SExpr {
-    def execute(machine: Machine): Ctrl = CtrlValue(v)
+    def execute(machine: Machine): Unit = {
+      machine.returnValue(v)
+    }
   }
 
   object SEValue extends SValueContainer[SEValue]
@@ -80,9 +84,9 @@ object SExpr {
     * evaluates to a builtin or a closure.
     */
   final case class SEApp(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       machine.pushKont(KArg(args))
-      CtrlExpr(fun)
+      machine.ctrl = fun
     }
   }
 
@@ -91,7 +95,7 @@ object SExpr {
     * can be written against this simplified expression type.
     */
   final case class SEAbs(arity: Int, body: SExpr) extends SExpr {
-    def execute(machine: Machine): Ctrl =
+    def execute(machine: Machine): Unit =
       crash("unexpected SEAbs, expected SEMakeClo")
   }
 
@@ -110,7 +114,7 @@ object SExpr {
       extends SExpr
       with SomeArrayEquals {
 
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       def convertToSValues(fv: Array[Int], getEnv: Int => SValue) = {
         val sValues = new Array[SValue](fv.length)
         var i = 0
@@ -122,15 +126,15 @@ object SExpr {
       }
 
       val sValues = convertToSValues(fv, machine.getEnv)
-      Ctrl.fromPrim(PClosure(body, sValues), arity)
+      machine.returnValue(SPAP(PClosure(body, sValues), new util.ArrayList[SValue](), arity))
     }
   }
 
   /** Pattern match. */
   final case class SECase(scrut: SExpr, alts: Array[SCaseAlt]) extends SExpr with SomeArrayEquals {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       machine.pushKont(KMatch(alts))
-      CtrlExpr(scrut)
+      machine.ctrl = scrut
     }
 
     override def toString: String = s"SECase($scrut, ${alts.mkString("[", ",", "]")})"
@@ -155,7 +159,7 @@ object SExpr {
     * with later expressions possibly referring to earlier.
     */
   final case class SELet(bounds: Array[SExpr], body: SExpr) extends SExpr with SomeArrayEquals {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       // Pop the block once we're done evaluating the body
       machine.pushKont(KPop(bounds.size))
 
@@ -167,7 +171,7 @@ object SExpr {
         val b = bounds(bounds.size - i)
         machine.pushKont(KPushTo(machine.env, b))
       }
-      CtrlExpr(bounds.head)
+      machine.ctrl = bounds.head
     }
   }
 
@@ -193,9 +197,9 @@ object SExpr {
     * variable of the machine. When commit is begun the location is stored in 'commitLocation'.
     */
   final case class SELocation(loc: Location, expr: SExpr) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       machine.pushLocation(loc)
-      CtrlExpr(expr)
+      machine.ctrl = expr
     }
   }
 
@@ -207,9 +211,29 @@ object SExpr {
     * to access the value returned from 'body'.
     */
   final case class SECatch(body: SExpr, handler: SExpr, fin: SExpr) extends SExpr {
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       machine.pushKont(KCatch(handler, fin, machine.env.size))
-      CtrlExpr(body)
+      machine.ctrl = body
+    }
+  }
+
+  /** When we fetch a contract id from upstream we cannot crash in the upstream
+    * calls. Rather, we set the control to this expression and then crash when executing.
+    */
+  final case class SEWronglyTypeContractId(
+      acoid: V.AbsoluteContractId,
+      expected: TypeConName,
+      actual: TypeConName,
+  ) extends SExpr {
+    def execute(machine: Machine): Unit = {
+      throw DamlEWronglyTypedContract(acoid, expected, actual)
+    }
+  }
+
+  final case class SEImportValue(value: V[V.ContractId]) extends SExpr {
+    def execute(machine: Machine): Unit = {
+      machine.importValue(value)
+//>>>>>>> ddfe844ec... Optimize Speedy machine.ctrl
     }
   }
 
@@ -263,7 +287,7 @@ object SExpr {
 
     import SEBuiltinRecursiveDefinition._
 
-    def execute(machine: Machine): Ctrl = {
+    def execute(machine: Machine): Unit = {
       val body = ref match {
         case Reference.FoldL => foldLBody
         case Reference.FoldR => foldRBody

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -233,7 +233,6 @@ object SExpr {
   final case class SEImportValue(value: V[V.ContractId]) extends SExpr {
     def execute(machine: Machine): Unit = {
       machine.importValue(value)
-//>>>>>>> ddfe844ec... Optimize Speedy machine.ctrl
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -42,7 +42,7 @@ object SExpr {
     */
   final case class SEVar(index: Int) extends SExpr {
     def execute(machine: Machine): Unit = {
-      machine.returnValue(machine.getEnv(index))
+      machine.returnValue = machine.getEnv(index)
     }
   }
 
@@ -62,11 +62,11 @@ object SExpr {
   final case class SEBuiltin(b: SBuiltin) extends SExpr {
     def execute(machine: Machine): Unit = {
       /* special case for nullary record constructors */
-      b match {
+      machine.returnValue = b match {
         case SBRecCon(id, fields) if b.arity == 0 =>
-          machine.returnValue(SRecord(id, fields, new ArrayList()))
+          SRecord(id, fields, new ArrayList())
         case _ =>
-          machine.returnValue(SPAP(PBuiltin(b), new util.ArrayList[SValue](), b.arity))
+          SPAP(PBuiltin(b), new util.ArrayList[SValue](), b.arity)
       }
     }
   }
@@ -74,7 +74,7 @@ object SExpr {
   /** A pre-computed value, usually primitive literal, e.g. integer, text, boolean etc. */
   final case class SEValue(v: SValue) extends SExpr {
     def execute(machine: Machine): Unit = {
-      machine.returnValue(v)
+      machine.returnValue = v
     }
   }
 
@@ -126,7 +126,7 @@ object SExpr {
       }
 
       val sValues = convertToSValues(fv, machine.getEnv)
-      machine.returnValue(SPAP(PClosure(body, sValues), new util.ArrayList[SValue](), arity))
+      machine.returnValue = SPAP(PClosure(body, sValues), new util.ArrayList[SValue](), arity)
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -124,13 +124,13 @@ object SValue {
     override def toString: String = s"PClosure($expr, ${closure.mkString("[", ",", "]")})"
   }
 
-  /** A partially (or fully) applied primitive.
-    * This is constructed when an argument is applied. When it becomes fully
-    * applied (args.size == arity), the machine will apply the arguments to the primitive.
-    * If the primitive is a closure, the arguments are pushed to the environment and the
-    * closure body is entered.
+  /** A partially applied primitive.
+    * An SPAP is *never* fully applied. This is asserted on construction.
     */
   final case class SPAP(prim: Prim, args: util.ArrayList[SValue], arity: Int) extends SValue {
+    if (args.size >= arity) {
+      throw SErrorCrash(s"SPAP: unexpected args.size >= arity")
+    }
     override def toString: String = s"SPAP($prim, ${args.asScala.mkString("[", ",", "]")}, $arity)"
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -187,6 +187,7 @@ object Speedy {
         val kcatch = kontStack.get(catchIndex).asInstanceOf[KCatch]
         kontStack.subList(catchIndex, kontStack.size).clear()
         env.subList(kcatch.envSize, env.size).clear()
+        returnValue = null
         ctrl = kcatch.handler
         true
       } else

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -21,10 +21,15 @@ import scala.util.control.NoStackTrace
 
 object Speedy {
 
+  // Avoid chains of calls to returnDepth, which will blow the JVM stack
+  val limitReturnDepth = 1000
+
   /** The speedy CEK machine. */
   final case class Machine(
+      /* So we can limit chains of calls to returnDepth. */
+      var returnDepth: Int,
       /* The control is what the machine should be evaluating. */
-      var ctrl: Ctrl,
+      var ctrl: SExpr,
       /* The environment: an array of values */
       var env: Env,
       /* Kont, or continuation specifies what should be done next
@@ -141,10 +146,11 @@ object Speedy {
         // note: exception handler is outside while loop
         try {
           while (!isFinal) {
+            returnDepth = 0
             ctrl.execute(this) // make a single step
           }
           ctrl match {
-            case CtrlValue(value) => {
+            case SEValue(value) => {
               result = SResultFinalValue(value) //stop
             }
             case _ =>
@@ -175,24 +181,24 @@ object Speedy {
         val kcatch = kontStack.get(catchIndex).asInstanceOf[KCatch]
         kontStack.subList(catchIndex, kontStack.size).clear()
         env.subList(kcatch.envSize, env.size).clear()
-        ctrl = CtrlExpr(kcatch.handler)
+        ctrl = kcatch.handler
         true
       } else
         false
     }
 
-    def lookupVal(eval: SEVal): Ctrl = {
+    def lookupVal(eval: SEVal): Unit = {
       eval.cached match {
         case Some((v, stack_trace)) =>
           pushStackTrace(stack_trace)
-          CtrlValue(v)
+          returnValue(v)
 
         case None =>
           val ref = eval.ref
           compiledPackages.getDefinition(ref) match {
             case Some(body) =>
               pushKont(KCacheVal(eval, Nil))
-              CtrlExpr(body)
+              ctrl = body
             case None =>
               if (compiledPackages.getPackage(ref.packageId).isDefined)
                 crash(
@@ -205,7 +211,7 @@ object Speedy {
                       this.compiledPackages = packages
                       // To avoid infinite loop in case the packages are not updated properly by the caller
                       assert(compiledPackages.getPackage(ref.packageId).isDefined)
-                      this.ctrl = lookupVal(eval)
+                      lookupVal(eval)
                     }
                   ),
                 )
@@ -215,24 +221,60 @@ object Speedy {
 
     /** Returns true when the machine has finished evaluation.
       * The machine is considered final when the kont stack
-      * is empty, and the value is not a fully applied PAP.
+      * is empty, and the control expression is a value
       */
-    def isFinal(): Boolean =
-      if (!kontStack.isEmpty)
-        // Kont stack not empty, can always reduce further.
-        false
-      else
+    def isFinal(): Boolean = {
+      if (kontStack.isEmpty) {
         ctrl match {
-          case CtrlValue(v) =>
-            v match {
-              // control is a PAP, but fully applied so it
-              // can be reduced further.
-              case pap: SPAP if pap.args.size == pap.arity => false
-              case _ => true
-            }
-          case _ =>
-            false
+          case SEValue(_) => true
+          case _ => false
         }
+      } else
+        false
+    }
+
+    // Return a value to the waiting continutaion
+    def returnValue(value: SValue): Unit = {
+      returnDepth += 1
+      if (kontStack.isEmpty) {
+        ctrl = SEValue(value) // The final resulting value
+      } else {
+        if (returnDepth < limitReturnDepth) {
+          val kont = popKont()
+          kont.execute(value, this)
+        } else {
+          ctrl = SEValue(value) // force the current step to end
+        }
+      }
+    }
+
+    def enterFullyAppliedFunction(prim: Prim, args: util.ArrayList[SValue]): Unit = {
+      prim match {
+        case PClosure(expr, vars) =>
+          // Pop the arguments once we're done evaluating the body.
+          pushKont(KPop(args.size + vars.size))
+
+          // Add all the variables we closed over
+          vars.foreach(env.add)
+
+          // Add the arguments
+          env.addAll(args)
+
+          // And start evaluating the body of the closure.
+          ctrl = expr
+
+        case PBuiltin(b) =>
+          try {
+            b.execute(args, this)
+          } catch {
+            // We turn arithmetic exceptions into a daml exception
+            // that can be caught.
+            case e: ArithmeticException =>
+              throw DamlEArithmeticError(e.getMessage)
+          }
+      }
+
+    }
 
     def toValue: V[V.ContractId] =
       toSValue.toValue
@@ -242,7 +284,7 @@ object Speedy {
         crash("toSValue: machine not final")
       } else {
         ctrl match {
-          case CtrlValue(v) => v
+          case SEValue(v) => v
           case _ => crash("machine did not evaluate to a value")
         }
       }
@@ -278,6 +320,105 @@ object Speedy {
       )
     }
 
+    // This translates a well-typed LF value (typically coming from the ledger)
+    // to speedy value and set the control of with the result.
+    // All the contract IDs contained in the value are considered global.
+    // Raises an exception if missing a package.
+
+    def importValue(value: V[V.ContractId]): Unit = {
+      def go(value0: V[V.ContractId]): SValue =
+        value0 match {
+          case V.ValueList(vs) => SList(vs.map[SValue](go))
+          case V.ValueContractId(coid) =>
+            addGlobalCid(coid)
+            SContractId(coid)
+          case V.ValueInt64(x) => SInt64(x)
+          case V.ValueNumeric(x) => SNumeric(x)
+          case V.ValueText(t) => SText(t)
+          case V.ValueTimestamp(t) => STimestamp(t)
+          case V.ValueParty(p) => SParty(p)
+          case V.ValueBool(b) => SBool(b)
+          case V.ValueDate(x) => SDate(x)
+          case V.ValueUnit => SUnit
+          case V.ValueRecord(Some(id), fs) =>
+            val fields = Name.Array.ofDim(fs.length)
+            val values = new util.ArrayList[SValue](fields.length)
+            fs.foreach {
+              case (optk, v) =>
+                optk match {
+                  case None =>
+                    crash("SValue.fromValue: record missing field name")
+                  case Some(k) =>
+                    fields(values.size) = k
+                    val _ = values.add(go(v))
+                }
+            }
+            SRecord(id, fields, values)
+          case V.ValueRecord(None, _) =>
+            crash("SValue.fromValue: record missing identifier")
+          case V.ValueStruct(fs) =>
+            val fields = Name.Array.ofDim(fs.length)
+            val values = new util.ArrayList[SValue](fields.length)
+            fs.foreach {
+              case (k, v) =>
+                fields(values.size) = k
+                val _ = values.add(go(v))
+            }
+            SStruct(fields, values)
+          case V.ValueVariant(None, _variant @ _, _value @ _) =>
+            crash("SValue.fromValue: variant without identifier")
+          case V.ValueEnum(None, constructor @ _) =>
+            crash("SValue.fromValue: enum without identifier")
+          case V.ValueOptional(mbV) =>
+            SOptional(mbV.map(go))
+          case V.ValueTextMap(map) =>
+            STextMap(map.mapValue(go).toHashMap)
+          case V.ValueGenMap(entries) =>
+            SGenMap(
+              entries.iterator.map { case (k, v) => go(k) -> go(v) }
+            )
+          case V.ValueVariant(Some(id), variant, arg) =>
+            compiledPackages.getPackage(id.packageId) match {
+              case Some(pkg) =>
+                pkg.lookupIdentifier(id.qualifiedName).fold(crash, identity) match {
+                  case DDataType(_, _, data: DataVariant) =>
+                    SVariant(id, variant, data.constructorRank(variant), go(arg))
+                  case _ =>
+                    crash(s"definition for variant $id not found")
+                }
+              case None =>
+                throw SpeedyHungry(
+                  SResultNeedPackage(
+                    id.packageId,
+                    pkg => {
+                      compiledPackages = pkg
+                      returnValue(go(value))
+                    }
+                  ))
+            }
+          case V.ValueEnum(Some(id), constructor) =>
+            compiledPackages.getPackage(id.packageId) match {
+              case Some(pkg) =>
+                pkg.lookupIdentifier(id.qualifiedName).fold(crash, identity) match {
+                  case DDataType(_, _, data: DataEnum) =>
+                    SEnum(id, constructor, data.constructorRank(constructor))
+                  case _ =>
+                    crash(s"definition for variant $id not found")
+                }
+              case None =>
+                throw SpeedyHungry(
+                  SResultNeedPackage(
+                    id.packageId,
+                    pkg => {
+                      compiledPackages = pkg
+                      returnValue(go(value))
+                    }
+                  ))
+            }
+        }
+      returnValue(go(value))
+    }
+
   }
 
   object Machine {
@@ -291,6 +432,7 @@ object Speedy {
         globalCids: Set[V.AbsoluteContractId]
     ) =
       Machine(
+        returnDepth = 0,
         ctrl = null,
         env = emptyEnv,
         kontStack = new util.ArrayList[Kont](128),
@@ -305,7 +447,7 @@ object Speedy {
         localContracts = Map.empty,
         globalDiscriminators = globalCids.collect {
           case V.AbsoluteContractId.V1(discriminator, _) => discriminator
-        }
+        },
       )
 
     def newBuilder(
@@ -374,186 +516,7 @@ object Speedy {
         seeding: InitialSeeding,
         globalCids: Set[V.AbsoluteContractId],
     ): Machine =
-      initial(compiledPackages, submissionTime, seeding, globalCids).copy(ctrl = CtrlExpr(sexpr))
-  }
-
-  /** Control specifies the thing that the machine should be reducing.
-    * If the control is fully evaluated then the top-most continuation
-    * is executed.
-    */
-  sealed trait Ctrl {
-
-    /** Execute a single step to reduce the control */
-    def execute(machine: Machine): Unit
-  }
-
-  /** A special control object to guard against misbehaving operations.
-    * It is set by default, so for example if an action forgets to set the
-    * control we won't loop but rather we'll crash.
-    */
-  final case class CtrlCrash(before: Ctrl) extends Ctrl {
-    def execute(machine: Machine) =
-      crash(s"CtrlCrash: control set to crash after evaluting: $before")
-  }
-
-  final case class CtrlExpr(expr: SExpr) extends Ctrl {
-    def execute(machine: Machine) =
-      machine.ctrl = expr.execute(machine)
-  }
-
-  final case class CtrlValue(value: SValue) extends Ctrl {
-    def execute(machine: Machine): Unit = value match {
-      case pap: SPAP if pap.args.size == pap.arity =>
-        pap.prim match {
-          case PClosure(expr, vars) =>
-            // Pop the arguments once we're done evaluating the body.
-            machine.pushKont(KPop(pap.arity + vars.size))
-
-            // Add all the variables we closed over
-            vars.foreach(machine.env.add)
-
-            // Add the arguments
-            machine.env.addAll(pap.args)
-
-            // And start evaluating the body of the closure.
-            machine.ctrl = CtrlExpr(expr)
-
-          case PBuiltin(b) =>
-            try {
-              b.execute(pap.args, machine)
-            } catch {
-              // We turn arithmetic exceptions into a daml exception
-              // that can be caught.
-              case e: ArithmeticException =>
-                throw DamlEArithmeticError(e.getMessage)
-            }
-        }
-      case _ =>
-        machine.ctrl = this
-        machine.popKont.execute(value, machine)
-    }
-  }
-
-  object CtrlValue extends SValueContainer[CtrlValue]
-
-  /** When we fetch a contract id from upstream we cannot crash in the
-    * that upstream calls. Rather, we set the control to this and then crash
-    * when executing.
-    */
-  final case class CtrlWronglyTypeContractId(
-      acoid: V.AbsoluteContractId,
-      expected: TypeConName,
-      actual: TypeConName,
-  ) extends Ctrl {
-    override def execute(machine: Machine): Unit = {
-      throw DamlEWronglyTypedContract(acoid, expected, actual)
-    }
-  }
-
-  object Ctrl {
-    def fromPrim(prim: Prim, arity: Int): Ctrl =
-      CtrlValue(SPAP(prim, new util.ArrayList[SValue](), arity))
-  }
-
-  // This translates a well-typed LF value (typically coming from the ledger)
-  // to speedy value and set the control of with the result.
-  // All the contract IDs contained in the value are considered global.
-  // Raises an exception if missing a package.
-  final case class CtrlImportValue(value: V[V.ContractId]) extends Ctrl {
-    override def execute(machine: Machine): Unit = {
-      def go(value0: V[V.ContractId]): SValue =
-        value0 match {
-          case V.ValueList(vs) => SList(vs.map[SValue](go))
-          case V.ValueContractId(coid) =>
-            machine.addGlobalCid(coid)
-            SContractId(coid)
-          case V.ValueInt64(x) => SInt64(x)
-          case V.ValueNumeric(x) => SNumeric(x)
-          case V.ValueText(t) => SText(t)
-          case V.ValueTimestamp(t) => STimestamp(t)
-          case V.ValueParty(p) => SParty(p)
-          case V.ValueBool(b) => SBool(b)
-          case V.ValueDate(x) => SDate(x)
-          case V.ValueUnit => SUnit
-          case V.ValueRecord(Some(id), fs) =>
-            val fields = Name.Array.ofDim(fs.length)
-            val values = new util.ArrayList[SValue](fields.length)
-            fs.foreach {
-              case (optk, v) =>
-                optk match {
-                  case None =>
-                    crash("SValue.fromValue: record missing field name")
-                  case Some(k) =>
-                    fields(values.size) = k
-                    val _ = values.add(go(v))
-                }
-            }
-            SRecord(id, fields, values)
-          case V.ValueRecord(None, _) =>
-            crash("SValue.fromValue: record missing identifier")
-          case V.ValueStruct(fs) =>
-            val fields = Name.Array.ofDim(fs.length)
-            val values = new util.ArrayList[SValue](fields.length)
-            fs.foreach {
-              case (k, v) =>
-                fields(values.size) = k
-                val _ = values.add(go(v))
-            }
-            SStruct(fields, values)
-          case V.ValueVariant(None, _variant @ _, _value @ _) =>
-            crash("SValue.fromValue: variant without identifier")
-          case V.ValueEnum(None, constructor @ _) =>
-            crash("SValue.fromValue: enum without identifier")
-          case V.ValueOptional(mbV) =>
-            SOptional(mbV.map(go))
-          case V.ValueTextMap(map) =>
-            STextMap(map.mapValue(go).toHashMap)
-          case V.ValueGenMap(entries) =>
-            SGenMap(
-              entries.iterator.map { case (k, v) => go(k) -> go(v) }
-            )
-          case V.ValueVariant(Some(id), variant, arg) =>
-            machine.compiledPackages.getPackage(id.packageId) match {
-              case Some(pkg) =>
-                pkg.lookupIdentifier(id.qualifiedName).fold(crash, identity) match {
-                  case DDataType(_, _, data: DataVariant) =>
-                    SVariant(id, variant, data.constructorRank(variant), go(arg))
-                  case _ =>
-                    crash(s"definition for variant $id not found")
-                }
-              case None =>
-                throw SpeedyHungry(
-                  SResultNeedPackage(
-                    id.packageId,
-                    pkg => {
-                      machine.compiledPackages = pkg
-                      machine.ctrl = this
-                    }
-                  ))
-            }
-          case V.ValueEnum(Some(id), constructor) =>
-            machine.compiledPackages.getPackage(id.packageId) match {
-              case Some(pkg) =>
-                pkg.lookupIdentifier(id.qualifiedName).fold(crash, identity) match {
-                  case DDataType(_, _, data: DataEnum) =>
-                    SEnum(id, constructor, data.constructorRank(constructor))
-                  case _ =>
-                    crash(s"definition for variant $id not found")
-                }
-              case None =>
-                throw SpeedyHungry(
-                  SResultNeedPackage(
-                    id.packageId,
-                    pkg => {
-                      machine.compiledPackages = pkg
-                      machine.ctrl = this
-                    }
-                  ))
-            }
-        }
-
-      machine.ctrl = CtrlValue(go(value))
-    }
+      initial(compiledPackages, submissionTime, seeding, globalCids).copy(ctrl = sexpr)
   }
 
   //
@@ -581,6 +544,7 @@ object Speedy {
   final case class KPop(count: Int) extends Kont {
     def execute(v: SValue, machine: Machine) = {
       machine.popEnv(count)
+      machine.returnValue(v)
     }
   }
 
@@ -613,7 +577,7 @@ object Speedy {
             machine.pushKont(KPushTo(extendedArgs, arg))
             i = i + 1
           }
-          machine.ctrl = CtrlExpr(newArgs(0))
+          machine.ctrl = newArgs(0)
 
         case _ =>
           crash(s"Applying non-PAP: $v")
@@ -627,7 +591,12 @@ object Speedy {
   final case class KFun(prim: Prim, args: util.ArrayList[SValue], var arity: Int) extends Kont {
     def execute(v: SValue, machine: Machine) = {
       args.add(v) // Add last argument
-      machine.ctrl = CtrlValue(SPAP(prim, args, arity))
+      if (args.size == arity) {
+        machine.enterFullyAppliedFunction(prim, args)
+      } else {
+        // args.size < arity (we already dealt with args.size > args in Karg)
+        machine.returnValue(SPAP(prim, args, arity))
+      }
     }
   }
 
@@ -707,11 +676,9 @@ object Speedy {
           crash("Match on non-matchable value")
       }
 
-      machine.ctrl = CtrlExpr(
-        altOpt
-          .getOrElse(throw DamlEMatchError(s"No match for $v in ${alts.toList}"))
-          .body,
-      )
+      machine.ctrl = altOpt
+        .getOrElse(throw DamlEMatchError(s"No match for $v in ${alts.toList}"))
+        .body,
     }
 
   }
@@ -725,7 +692,7 @@ object Speedy {
   final case class KPushTo(to: util.ArrayList[SValue], next: SExpr) extends Kont {
     def execute(v: SValue, machine: Machine) = {
       to.add(v)
-      machine.ctrl = CtrlExpr(next)
+      machine.ctrl = next
     }
   }
 
@@ -735,10 +702,11 @@ object Speedy {
     * accessed. In older compilers which did not use the builtin record and struct
     * updates this solves the blow-up which would happen when a large record is
     * updated multiple times. */
-  final case class KCacheVal(v: SEVal, stack_trace: List[Location]) extends Kont {
-    def execute(sv: SValue, machine: Machine) = {
+  final case class KCacheVal(eval: SEVal, stack_trace: List[Location]) extends Kont {
+    def execute(v: SValue, machine: Machine) = {
       machine.pushStackTrace(stack_trace)
-      v.cached = Some((sv, stack_trace))
+      eval.cached = Some((v, stack_trace))
+      machine.returnValue(v)
     }
   }
 
@@ -748,16 +716,15 @@ object Speedy {
     * evaluated. If 'KCatch' is encountered naturally, then 'fin' is evaluated.
     */
   final case class KCatch(handler: SExpr, fin: SExpr, envSize: Int) extends Kont {
-
     def execute(v: SValue, machine: Machine) = {
-      machine.ctrl = CtrlExpr(fin)
+      machine.ctrl = fin
     }
   }
 
   /** A location frame stores a location annotation found in the AST. */
   final case class KLocation(location: Location) extends Kont {
     def execute(v: SValue, machine: Machine) = {
-      machine.ctrl = CtrlValue(v)
+      machine.returnValue(v)
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -187,7 +187,6 @@ object Speedy {
         val kcatch = kontStack.get(catchIndex).asInstanceOf[KCatch]
         kontStack.subList(catchIndex, kontStack.size).clear()
         env.subList(kcatch.envSize, env.size).clear()
-        returnValue = null
         ctrl = kcatch.handler
         true
       } else

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -141,7 +141,7 @@ object Speedy {
       // wrap the exception handler on each of these steps. This is a performace gain.
       // However, we still need the outer loop because of the case:
       //    case _:SErrorDamlException if tryHandleException =>
-      // where we must continue interation.
+      // where we must continue iteration.
       var result: SResult = null
       while (result == null) {
         // note: exception handler is outside while loop

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -9,7 +9,9 @@ import java.util
 import com.daml.lf.crypto
 import com.daml.lf.data.{FrontStack, ImmArray, Numeric, Ref, Time}
 import com.daml.lf.language.{Ast, Util => AstUtil}
+import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SExpr.SEImportValue
 import com.daml.lf.speedy.{SBuiltin, SExpr, SValue}
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.value.Value
@@ -482,12 +484,10 @@ class OrderingSpec
   )
 
   private def translatePrimValue(v: Value[Value.AbsoluteContractId]) = {
-    val ctrl = Speedy.CtrlImportValue(v)
     val machine = dummyMachine
-    machine.ctrl = Speedy.CtrlCrash(ctrl)
-    ctrl.execute(machine)
-    machine.ctrl match {
-      case Speedy.CtrlValue(value) => value
+    machine.ctrl = SEImportValue(v)
+    machine.run() match {
+      case SResultFinalValue(value) => value
       case _ => throw new Error(s"error while translating value $v")
     }
   }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -14,7 +14,7 @@ import com.daml.lf.speedy.Pretty._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.types.Ledger
-import com.daml.lf.speedy.SExpr.LfDefRef
+import com.daml.lf.speedy.SExpr.{LfDefRef, SEValue}
 import com.daml.lf.validation.Validation
 import com.daml.lf.testing.parser
 import com.daml.lf.language.LanguageVersion
@@ -431,7 +431,7 @@ object Repl {
             println(s"time: ${diff}ms")
             if (!errored) {
               val result = machine.ctrl match {
-                case Speedy.CtrlValue(sv) =>
+                case SEValue(sv) =>
                   prettyValue(true)(sv.toValue).render(128)
                 case x => x.toString
               }

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -7,6 +7,7 @@ import com.daml.lf.PureCompiledPackages
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast.ScenarioGetParty
+import com.daml.lf.speedy.SExpr.SEValue
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
@@ -24,7 +25,7 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
       )
       val sr = ScenarioRunner(m, _ + "-XXX")
       sr.run()
-      m.ctrl shouldBe Speedy.CtrlValue(SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX")))
+      m.ctrl shouldBe SEValue(SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX")))
     }
   }
 

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -7,7 +7,6 @@ import com.daml.lf.PureCompiledPackages
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast.ScenarioGetParty
-import com.daml.lf.speedy.SExpr.SEValue
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
@@ -25,7 +24,8 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
       )
       val sr = ScenarioRunner(m, _ + "-XXX")
       sr.run()
-      m.ctrl shouldBe SEValue(SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX")))
+      m.ctrl shouldBe null
+      m.returnValue shouldBe SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX"))
     }
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -309,7 +309,7 @@ class Runner(
       }
 
     def run(expr: SExpr): Future[SValue] = {
-      machine.ctrl = Speedy.CtrlExpr(expr)
+      machine.ctrl = expr
       stepToValue()
         .fold(Future.failed, Future.successful)
         .flatMap {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -310,6 +310,7 @@ class Runner(
 
     def run(expr: SExpr): Future[SValue] = {
       machine.ctrl = expr
+      machine.returnValue = null
       stepToValue()
         .fold(Future.failed, Future.successful)
         .flatMap {

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -357,7 +357,7 @@ class Runner(
           SEValue(SParty(Party.assertFromString(party))),
           SEValue(STimestamp(clientTime)): SExpr,
           createdExpr))
-    machine.ctrl = Speedy.CtrlExpr(initialState)
+    machine.ctrl = initialState
     Machine.stepToValue(machine)
     val evaluatedInitialState = handleStepResult(machine.toSValue, submit)
     logger.debug(s"Initial state: $evaluatedInitialState")
@@ -409,8 +409,8 @@ class Runner(
         }
         val clientTime: Timestamp =
           Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
-        machine.ctrl = Speedy.CtrlExpr(
-          SEApp(update, Array(SEValue(STimestamp(clientTime)): SExpr, SEValue(messageVal), state)))
+        machine.ctrl =
+          SEApp(update, Array(SEValue(STimestamp(clientTime)): SExpr, SEValue(messageVal), state))
         Machine.stepToValue(machine)
         val newState = handleStepResult(machine.toSValue, submit)
         SEValue(newState)

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -358,6 +358,7 @@ class Runner(
           SEValue(STimestamp(clientTime)): SExpr,
           createdExpr))
     machine.ctrl = initialState
+    machine.returnValue = null
     Machine.stepToValue(machine)
     val evaluatedInitialState = handleStepResult(machine.toSValue, submit)
     logger.debug(s"Initial state: $evaluatedInitialState")
@@ -411,6 +412,7 @@ class Runner(
           Timestamp.assertFromInstant(Runner.getTimeProvider(timeProviderType).getCurrentTime)
         machine.ctrl =
           SEApp(update, Array(SEValue(STimestamp(clientTime)): SExpr, SEValue(messageVal), state))
+        machine.returnValue = null
         Machine.stepToValue(machine)
         val newState = handleStepResult(machine.toSValue, submit)
         SEValue(newState)


### PR DESCRIPTION
Remove the `Ctrl` trait and separate `Machine.ctrl: Ctrl` into `Machine.ctrl: SExpr` and `Machine.returnValue: SValue` instead. This allows for avoiding dynamic dispatch on `ctrl` and instead allows for checking a pointer for `null` to decide if we have an expression that needs further break-down or a return value ready to be passed to the next continuation.

To make this check really only a pointer comparison we also needed to remove the abomination of "fully applied partially applied primitives". In order to achieve this, we check whether a PAP will be fully applied afterward when applying the last argument.

On the `collect-authority` benchmark, this increases throughput by around 13%, on another more computation heave benchmark by about 21%.

`collect-authority` benchmark on `master`:
```
Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
  112.361 ±(99.9%) 1.965 ms/op [Average]
  (min, avg, max) = (107.047, 112.361, 120.745), stdev = 3.493
  CI (99.9%): [110.396, 114.326] (assumes normal distribution)
```

`collect-authority` benchmark on this branch:
```
Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
  98.196 ±(99.9%) 1.933 ms/op [Average]
  (min, avg, max) = (91.580, 98.196, 105.478), stdev = 3.436
  CI (99.9%): [96.263, 100.129] (assumes normal distribution)
```

computation heavy benchmark on master
```
Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
  44.030 ±(99.9%) 0.742 ms/op [Average]
  (min, avg, max) = (42.124, 44.030, 46.781), stdev = 1.319
  CI (99.9%): [43.289, 44.772] (assumes normal distribution)
```

computation heave benchmark on this branch:
```
Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
  36.222 ±(99.9%) 0.580 ms/op [Average]
  (min, avg, max) = (34.897, 36.222, 39.787), stdev = 1.031
  CI (99.9%): [35.643, 36.802] (assumes normal distribution)
```






changelog_begin
changelog_end

