### PR TITLE
Increase wait time in deduplication tests

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplication.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplication.scala
@@ -55,7 +55,7 @@ final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite
         failure1 <- ledger.submit(requestA).failed
 
         // Wait until the end of first deduplication window
-        _ <- Delayed.by(deduplicationSeconds.seconds)(())
+        _ <- Delayed.by((deduplicationSeconds + 1).seconds)(())
 
         // Submit command A (second deduplication window)
         _ <- ledger.submit(requestA)
@@ -160,7 +160,7 @@ final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite
         failure1 <- ledger.submitAndWait(requestA).failed
 
         // Wait until the end of first deduplication window
-        _ <- Delayed.by(deduplicationSeconds.seconds)(())
+        _ <- Delayed.by((deduplicationSeconds + 1).seconds)(())
 
         // Submit command A (second deduplication window)
         _ <- ledger.submitAndWait(requestA)


### PR DESCRIPTION
Deduplication is unreliable around the end of the deduplication window.

CHANGELOG_BEGIN
CHENGELOG_END