### PR TITLE
Speedy: run() dont step()

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -286,9 +286,8 @@ final class Engine {
       time: Time.Timestamp
   ): Result[(Tx.Transaction, Tx.Metadata)] = {
     while (!machine.isFinal) {
-      machine.step() match {
-        case SResultContinue =>
-          ()
+      machine.run() match {
+        case SResultFinalValue(_) => ()
 
         case SResultError(err) =>
           return ResultError(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -18,7 +18,9 @@ sealed abstract class SResult extends Product with Serializable
 
 object SResult {
   final case class SResultError(err: SError) extends SResult
-  final case object SResultContinue extends SResult
+
+  /** The speedy machine has completed evaluation to reach a final value.  */
+  final case class SResultFinalValue(v: SValue) extends SResult
 
   /** Update or scenario interpretation requires the current
     * ledger time. */

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -10,7 +10,7 @@ import com.daml.lf.data._
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SError.{DamlEArithmeticError, SError, SErrorCrash}
-import com.daml.lf.speedy.SResult.{SResultContinue, SResultError}
+import com.daml.lf.speedy.SResult.{SResultFinalValue, SResultError}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.testing.parser.Implicits._
 import org.scalactic.Equality
@@ -1459,8 +1459,8 @@ object SBuiltinTest {
     )
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {
-      while (!machine.isFinal) machine.step() match {
-        case SResultContinue => ()
+      while (!machine.isFinal) machine.run() match {
+        case SResultFinalValue(_) => ()
         case SResultError(err) => throw Goodbye(err)
         case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -12,7 +12,7 @@ import com.daml.lf.data.{FrontStack, Ref, Time}
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SError.SError
-import com.daml.lf.speedy.SResult.{SResultContinue, SResultError}
+import com.daml.lf.speedy.SResult.{SResultFinalValue, SResultError}
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.validation.Validation
@@ -260,8 +260,8 @@ object SpeedyTest {
     )
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {
-      while (!machine.isFinal) machine.step() match {
-        case SResultContinue => ()
+      while (!machine.isFinal) machine.run() match {
+        case SResultFinalValue(_) => ()
         case SResultError(err) => throw Goodbye(err)
         case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -12,7 +12,6 @@ import com.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.daml.lf.language.Util._
 import com.daml.lf.speedy.Pretty._
 import com.daml.lf.speedy.SError._
-import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.types.Ledger
 import com.daml.lf.speedy.SExpr.LfDefRef
@@ -432,7 +431,7 @@ object Repl {
             println(s"time: ${diff}ms")
             if (!errored) {
               val result = machine.ctrl match {
-                case CtrlValue(sv) =>
+                case Speedy.CtrlValue(sv) =>
                   prettyValue(true)(sv.toValue).render(128)
                 case x => x.toString
               }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -12,6 +12,7 @@ import com.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.daml.lf.language.Util._
 import com.daml.lf.speedy.Pretty._
 import com.daml.lf.speedy.SError._
+import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.types.Ledger
 import com.daml.lf.speedy.SExpr.LfDefRef
@@ -414,12 +415,11 @@ object Repl {
             val startTime = System.nanoTime()
             var errored = false
             while (!machine.isFinal && !errored) {
-              machine.step match {
+              machine.run match {
                 case SResultError(err) =>
                   println(prettyError(err, machine.ptx).render(128))
                   errored = true
-                case SResultContinue =>
-                  ()
+                case SResultFinalValue(_) => ()
                 case other =>
                   sys.error("unimplemented callback: " + other.toString)
               }
@@ -432,7 +432,7 @@ object Repl {
             println(s"time: ${diff}ms")
             if (!errored) {
               val result = machine.ctrl match {
-                case Speedy.CtrlValue(sv) =>
+                case CtrlValue(sv) =>
                   prettyValue(true)(sv.toValue).render(128)
                 case x => x.toString
               }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -52,6 +52,7 @@ final case class ScenarioRunner(
       val res: SResult = machine.run()
       res match {
         case SResultFinalValue(_) =>
+          ()
         case SResultError(err) =>
           throw SRunnerException(err)
 

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -48,9 +48,10 @@ final case class ScenarioRunner(
     var steps = 0
     while (!machine.isFinal) {
       //machine.print(steps)
-      machine.step match {
-        case SResultContinue =>
-          steps += 1
+      steps += 1 // this counts the number of external `Need` interactions
+      val res: SResult = machine.run()
+      res match {
+        case SResultFinalValue(_) =>
         case SResultError(err) =>
           throw SRunnerException(err)
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -219,24 +219,17 @@ object Converter {
         seeding = InitialSeeding.NoSeed,
         Set.empty,
       )
-    @tailrec
-    def iter(): Either[String, (SValue, SValue)] = {
-      if (machine.isFinal) {
-        machine.toSValue match {
+    machine.run() match {
+      case SResultFinalValue(v) =>
+        v match {
           case SStruct(_, values) if values.size == 2 => {
             Right((values.get(0), values.get(1)))
           }
           case v => Left(s"Expected SStruct but got $v")
         }
-      } else {
-        machine.step() match {
-          case SResultContinue => iter()
-          case SResultError(err) => Left(Pretty.prettyError(err, machine.ptx).render(80))
-          case res => Left(res.toString())
-        }
-      }
+      case SResultError(err) => Left(Pretty.prettyError(err, machine.ptx).render(80))
+      case res => Left(res.toString())
     }
-    iter()
   }
 
   // Walk over the free applicative and extract the list of commands

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -298,8 +298,8 @@ class Runner(
     @SuppressWarnings(Array("org.wartremover.warts.Return"))
     def stepToValue(): Either[RuntimeException, Unit] = {
       while (!machine.isFinal) {
-        machine.step() match {
-          case SResultContinue => ()
+        machine.run() match {
+          case SResultFinalValue(_) => ()
           case SResultError(err) => {
             logger.error(Pretty.prettyError(err, machine.ptx).render(80))
             return Left(err)

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -61,8 +61,8 @@ object Machine extends StrictLogging {
   // Run speedy until we arrive at a value.
   def stepToValue(machine: Speedy.Machine): Unit = {
     while (!machine.isFinal) {
-      machine.step() match {
-        case SResultContinue => ()
+      machine.run() match {
+        case SResultFinalValue(_) => ()
         case SResultError(err) => {
           logger.error(Pretty.prettyError(err, machine.ptx).render(80))
           throw err


### PR DESCRIPTION
Run the Speedy machine with  `run()` instead of `step()`
- Remove: `SResultContinue`
- Add: `SResultFinalValue(_)`

We change the top level control of Speedy: from machine.step() to machine.run, with the control of stepping while the machine returns SResultContinue moved into speedy itself. (And so SResultContinue is removed in favour of SResultFinalValue.) The main advantage of this approach is that the tight while loop can be moved inside the exception handler, rather than having to wrap the handler every step.

changelog_begin
changelog_end

Benchmarked against master with `CollectAuthority`.  Speedup x1.09

this branch
```
Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
  125.359 ±(99.9%) 1.410 ms/op [Average]
  (min, avg, max) = (121.084, 125.359, 131.553), stdev = 2.506
  CI (99.9%): [123.949, 126.769] (assumes normal distribution)
```

master
```
Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
  136.720 ±(99.9%) 1.752 ms/op [Average]
  (min, avg, max) = (132.623, 136.720, 150.845), stdev = 3.114
  CI (99.9%): [134.968, 138.471] (assumes normal distribution)
```


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
