### PR TITLE
Trigger service: Use tagged Party type instead of String

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Request.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Request.scala
@@ -6,6 +6,8 @@ package com.daml.lf.engine.trigger
 import com.daml.lf.data.Ref.{DottedName, Identifier, PackageId, QualifiedName}
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsString, JsValue, JsonFormat, deserializationError}
+import com.daml.ledger.api.refinements.ApiTypes.{Party}
+import scalaz.syntax.tag._
 
 object Request {
   implicit object IdentifierFormat extends JsonFormat[Identifier] {
@@ -28,12 +30,21 @@ object Request {
       }
       case _ => deserializationError("Expected trigger identifier of the form pkgid:mod:name")
     }
-    def write(id: Identifier) = JsString(s"${id.packageId}:${id.qualifiedName}")
+    def write(id: Identifier) = JsString(id.toString)
   }
 
-  case class StartParams(identifier: Identifier, party: String)
+  implicit object PartyFormat extends JsonFormat[Party] {
+    def read(value: JsValue) = value match {
+      case JsString(s) => Party(s)
+      case _ => deserializationError("Expected Party string")
+    }
+
+    def write(party: Party) = JsString(party.unwrap)
+  }
+
+  case class StartParams(identifier: Identifier, party: Party)
   implicit val startParamsFormat = jsonFormat2(StartParams)
 
-  case class ListParams(party: String)
+  case class ListParams(party: Party)
   implicit val listParamsFormat = jsonFormat1(ListParams)
 }


### PR DESCRIPTION
I've not propagated the change into the Trigger Runner, but we may want to do that too.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
