### PR TITLE
Make the type argument order in DA.Numeric explicit

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Numeric.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Numeric.daml
@@ -12,32 +12,32 @@ import GHC.Types (primitive)
 -- different scales, unlike `(*)` which forces all numeric scales
 -- to be the same. Raises an error on overflow, rounds to chosen
 -- scale otherwise.
-mul : NumericScale n3 => Numeric n1 -> Numeric n2 -> Numeric n3
+mul : forall n3 n1 n2. NumericScale n3 => Numeric n1 -> Numeric n2 -> Numeric n3
 mul = primitive @"BEMulNumeric"
 
 -- | Divide two numerics. Both inputs and the output may have
 -- different scales, unlike `(/)` which forces all numeric scales
 -- to be the same. Raises an error on overflow, rounds to chosen
 -- scale otherwise.
-div : NumericScale n3 => Numeric n1 -> Numeric n2 -> Numeric n3
+div : forall n3 n1 n2. NumericScale n3 => Numeric n1 -> Numeric n2 -> Numeric n3
 div = primitive @"BEDivNumeric"
 
 -- | Cast a Numeric. Raises an error on overflow or loss of precision.
-cast : NumericScale n2 => Numeric n1 -> Numeric n2
+cast : forall n2 n1. NumericScale n2 => Numeric n1 -> Numeric n2
 cast = primitive @"BECastNumeric"
 
 -- | Cast a Numeric. Raises an error on overflow, rounds to chosen
 -- scale otherwise.
-castAndRound : NumericScale n2 => Numeric n1 -> Numeric n2
+castAndRound : forall n2 n1. NumericScale n2 => Numeric n1 -> Numeric n2
 castAndRound = mul (1.0 : Numeric 0)
 
 -- | Move the decimal point left or right by multiplying the numeric
--- value by 10^(n2 - n1). Does not overflow or underflow.
-shift : NumericScale n2 => Numeric n1 -> Numeric n2
+-- value by 10^(n1 - n2). Does not overflow or underflow.
+shift : forall n2 n1. NumericScale n2 => Numeric n1 -> Numeric n2
 shift = primitive @"BEShiftNumeric"
 
 -- | The number pi.
-pi : NumericScale n => Numeric n
+pi : forall n. NumericScale n => Numeric n
 pi = castAndRound (3.14159_26535_89793_23846_26433_83279_50288_41 : Numeric 37)
 
 #else

--- a/compiler/damlc/tests/daml-test-files/Numeric.daml
+++ b/compiler/damlc/tests/daml-test-files/Numeric.daml
@@ -1,0 +1,12 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @SINCE-LF 1.7
+module Numeric where
+
+import DA.Assert
+import DA.Numeric
+
+testShift = scenario do
+  shift @1 @2 1.0 === 10.0
+  shift @2 @1 1.0 === 0.1


### PR DESCRIPTION
All functions in `DA.Numeric` take the scale of the result as their
first type argument. IMO, this is a nice API since you usually only
want to specify the scale of the result since the scale of the
term arguments is most of the times inferred.

However, the current type signatures in `DA.Numeric` bear quite some
risk of being confusing. For instance, in
```haskell
mul : NumericScale n3 => Numeric n1 -> Numeric n2 -> Numeric n3
```
the naming of the type variables suggests that the order of the
type parameters is `n1 n2 n3` when it actually is `n3 n1 n2`.

I consider the knowledge of implicit `forall`s are filled in quite
expert and hence think we should make the order of these type arguments
explicit.

There is also a related mistake in the docs of `shift`. Running a
scenario confirmed that
```haskell
shift @1 @2 1.0 == 10.0
```
Hence, `shift` has multiplied its argument by `10^(2-1)`, which is
`10^(n1 - n2)`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5817)
<!-- Reviewable:end -->
