### PR TITLE
Fix the DAML-LF spec regarding text/codepoints conversion

### DIFF
--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2895,18 +2895,18 @@ String functions
 
   Returns string such as.
 
-* ``TEXT_FROM_CODE_POINTS``: 'Text' → 'List' 'Int64'
+* ``TEXT_TO_CODE_POINTS``: 'Text' → 'List' 'Int64'
 
-  Returns the list of the Unicode `codepoint
+  Returns the list of the Unicode `codepoints
   <https://en.wikipedia.org/wiki/Code_point>`_ of the input
-  string represented as integer.
+  string represented as integers.
 
   [*Available in versions >= 1.6*]
 
-* ``TEXT_TO_CODE_POINTS``: 'List' 'Int64' → 'Text'
+* ``TEXT_FROM_CODE_POINTS``: 'List' 'Int64' → 'Text'
 
-  Given a list of integer representation of Unicode codepoint,
-  return the string built from those codepoint. Throws an error
+  Given a list of integer representations of Unicode codepoints,
+  return the string built from those codepoints. Throws an error
   if one of the elements of the input list is not in the range
   from `0x000000` to `0x00D7FF` or in the range from `0x00DFFF`
   to `0x10FFFF` (bounds included).


### PR DESCRIPTION
The two functions to convert between text and a list of codepoints
were documented the wrong way around. This PR fixes the issue. We
also sprinkle in a few plural "s" where needed.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5818)
<!-- Reviewable:end -->
