### PR TITLE
Add instrumentation and lightweight tracing to Speedy CEK machine

### DIFF
--- a/daml-lf/interpreter/perf/BUILD.bazel
+++ b/daml-lf/interpreter/perf/BUILD.bazel
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+)
+
+da_scala_binary(
+    name = "explore",
+    srcs = glob(["src/main/**/*.scala"]),
+    main_class = "com.daml.lf.speedy.explore.Explore",
+    runtime_deps = [
+        "@maven//:ch_qos_logback_logback_classic",
+    ],
+    deps = [
+        "//daml-lf/data",
+        "//daml-lf/interpreter",
+        "//daml-lf/language",
+        "//daml-lf/transaction",
+    ],
+)

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -1,0 +1,114 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+package explore
+
+import com.daml.lf.data._
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SResult._
+import com.daml.lf.speedy.SBuiltin._
+import com.daml.lf.speedy.Speedy._
+
+// Explore the execution of speedy machine on small examples.
+
+object Explore extends App {
+  PlaySpeedy.main(args.toList)
+}
+
+object PlaySpeedy {
+
+  def main(args0: List[String]) = {
+    val config: Config = parseArgs(args0)
+    val compiler: Compiler = Compiler(Map.empty)
+
+    val e: SExpr = compiler.unsafeClosureConvert(examples(config.exampleName))
+    val m: Machine = makeMachine(e)
+    runMachine(config, m)
+  }
+
+  final case class Config(
+      exampleName: String,
+  )
+
+  def usage(): Unit = {
+    println("""
+     |usage: explore [EXAMPLE-NAME]
+    """.stripMargin)
+  }
+
+  def parseArgs(args0: List[String]): Config = {
+
+    var exampleName: String = "thrice-thrice"
+
+    def loop(args: List[String]): Unit = args match {
+      case Nil => {}
+      case "-h" :: _ => usage()
+      case "--help" :: _ => usage()
+      case name :: args =>
+        exampleName = name
+        loop(args)
+    }
+    loop(args0)
+    Config(exampleName)
+  }
+
+  private val txSeed = crypto.Hash.hashPrivateKey("SpeedyExplore")
+
+  def makeMachine(sexpr: SExpr): Machine = {
+    val compiledPackages: CompiledPackages = PureCompiledPackages(Map.empty).right.get
+    val compiler = Compiler(compiledPackages.packages)
+    Machine.fromSExpr(
+      sexpr,
+      compiledPackages,
+      Time.Timestamp.now(),
+      InitialSeeding(Some(txSeed)),
+      Set.empty,
+    )
+  }
+
+  def runMachine(config: Config, machine: Machine): Unit = {
+
+    println(s"example name: ${config.exampleName}")
+
+    machine.run() match {
+      case SResultFinalValue(value) => {
+        println(s"final-value: $value")
+      }
+      case res =>
+        throw new MachineProblem(s"Unexpected result from machine $res")
+    }
+  }
+
+  final case class MachineProblem(s: String) extends RuntimeException(s, null, false, false)
+
+  def examples: Map[String, SExpr] = {
+
+    def num(n: Long): SExpr = SEValue(SInt64(n))
+
+    // The trailing numeral is the number of args at the scala level
+
+    def decrement1(x: SExpr): SExpr = SEApp(SEBuiltin(SBSubInt64), Array(x, SEValue(SInt64(1))))
+    val decrement = SEAbs(1, decrement1(SEVar(1)))
+
+    def subtract2(x: SExpr, y: SExpr): SExpr = SEApp(SEBuiltin(SBSubInt64), Array(x, y))
+    val subtract = SEAbs(2, subtract2(SEVar(2), SEVar(1)))
+
+    def twice2(f: SExpr, x: SExpr): SExpr = SEApp(f, Array(SEApp(f, Array(x))))
+    val twice = SEAbs(2, twice2(SEVar(2), SEVar(1)))
+
+    def thrice2(f: SExpr, x: SExpr): SExpr = SEApp(f, Array(SEApp(f, Array(SEApp(f, Array(x))))))
+    val thrice = SEAbs(2, thrice2(SEVar(2), SEVar(1)))
+
+    Map(
+      "sub" -> subtract2(num(11), num(33)),
+      "sub/sub" -> subtract2(subtract2(num(1), num(3)), subtract2(num(5), num(10))),
+      "subF" -> SEApp(subtract, Array(num(88), num(55))),
+      "thrice" -> SEApp(thrice, Array(decrement, num(0))),
+      "thrice-thrice" -> SEApp(thrice, Array(thrice, decrement, num(0))),
+    )
+  }
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -1,0 +1,121 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import com.daml.lf.speedy.Speedy._
+import com.daml.lf.speedy.SExpr._
+
+object Classify { // classify the machine state w.r.t what step occurs next
+
+  case class Counts(
+      var ctrlExpr: Int,
+      var ctrlValue: Int,
+      // expression classification (ctrlExpr)
+      var evalue: Int,
+      var evar: Int,
+      var eapp: Int,
+      var eclose: Int,
+      var ebuiltin: Int,
+      var eval: Int,
+      var elocation: Int,
+      var elet: Int,
+      var ecase: Int,
+      var ebuiltinrecursivedefinition: Int,
+      var ecatch: Int,
+      var eimportvalue: Int,
+      var ewronglytypedcontractid: Int,
+      // kont classification (ctrlValue)
+      var kfinished: Int,
+      var kpop: Int,
+      var karg: Int,
+      var kfun: Int,
+      var kpushto: Int,
+      var kcacheval: Int,
+      var klocation: Int,
+      var kmatch: Int,
+      var kcatch: Int,
+  ) {
+    def steps = ctrlExpr + ctrlValue
+    def pp: String = {
+      List(
+        ("CtrlExpr:", ctrlExpr),
+        ("- evalue", evalue),
+        ("- evar", evar),
+        ("- eapp", eapp),
+        ("- eclose", eclose),
+        ("- ebuiltin", ebuiltin),
+        ("- eval", eval),
+        ("- elocation", elocation),
+        ("- elet", elet),
+        ("- ecase", ecase),
+        ("- ebuiltinrecursivedefinition", ebuiltinrecursivedefinition),
+        ("- ecatch", ecatch),
+        ("- eimportvalue", eimportvalue),
+        ("CtrlValue:", ctrlValue),
+        ("- kfinished", kfinished),
+        ("- kpop", kpop),
+        ("- karg", karg),
+        ("- kfun", kfun),
+        ("- kpushto", kpushto),
+        ("- kcacheval", kcacheval),
+        ("- klocation", klocation),
+        ("- kmatch", kmatch),
+        ("- kcatch", kcatch),
+      ).map { case (tag, n) => s"$tag : $n" }.mkString("\n")
+    }
+  }
+
+  def newEmptyCounts(): Counts = {
+    Counts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+  }
+
+  def classifyMachine(machine: Machine, counts: Counts): Unit = {
+    if (machine.returnValue != null) {
+      // classify a value by the continution it is about to return to
+      counts.ctrlValue += 1
+      val kont = machine.kontStack.get(machine.kontStack.size - 1)
+      classifyKont(kont, counts)
+    } else {
+      counts.ctrlExpr += 1
+      classifyExpr(machine.ctrl, counts)
+    }
+  }
+
+  def classifyExpr(exp: SExpr, counts: Counts): Unit = {
+    exp match {
+      case SEValue(_) => counts.evalue += 1
+      case SEVar(_) => counts.evar += 1
+      case SEApp(_, _) => counts.eapp += 1
+      case SEMakeClo(_, _, _) => counts.eclose += 1
+      case SEBuiltin(_) => counts.ebuiltin += 1
+      case SEVal(_) => counts.eval += 1
+      case SELocation(_, _) => counts.elocation += 1
+      case SELet(_, _) => counts.elet += 1
+      case SECase(_, _) => counts.ecase += 1
+      case SEBuiltinRecursiveDefinition(_) => counts.ebuiltinrecursivedefinition += 1
+      case SECatch(_, _, _) => counts.ecatch += 1
+      case SEAbs(_, _) => //never expect these!
+      case SEImportValue(_) => counts.eimportvalue += 1
+      case SEWronglyTypeContractId(_, _, _) => counts.ewronglytypedcontractid += 1
+    }
+  }
+
+  def classifyKont(kont: Kont, counts: Counts): Unit = {
+    kont match {
+      case KPop(_) => counts.kpop += 1
+      case KArg(_) => counts.karg += 1
+      case KFun(_, _, _) => counts.kfun += 1
+      case KPushTo(_, _) => counts.kpushto += 1
+      case KCacheVal(_, _) => counts.kcacheval += 1
+      case KLocation(_) => counts.klocation += 1
+      case KMatch(_) => counts.kmatch += 1
+      case KCatch(_, _, _) => counts.kcatch += 1
+      case KFinished => counts.kfinished += 1
+    }
+  }
+
+  final case class ClassifyError(s: String) extends RuntimeException(s, null, false, false)
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -134,6 +134,11 @@ private[lf] final case class Compiler(packages: PackageId PartialFunction Packag
 
   @throws[PackageNotFound]
   @throws[CompilationError]
+  def unsafeClosureConvert(sexpr: SExpr): SExpr =
+    validate(closureConvert(Map.empty, 0, sexpr))
+
+  @throws[PackageNotFound]
+  @throws[CompilationError]
   def unsafeCompileDefn(
       identifier: Identifier,
       defn: Definition,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -1,0 +1,94 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import java.util
+import scala.collection.JavaConverters._
+
+import com.daml.lf.speedy.Speedy._
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.SValue._
+
+object PrettyLightweight { // lightweight pretty printer for CEK machine states
+
+  def ppMachine(m: Machine): String = {
+    s"${ppEnv(m.env)} -- ${ppCtrl(m.ctrl, m.returnValue)} -- ${ppKontStack(m.kontStack)}"
+  }
+
+  def ppCtrl(e: SExpr, v: SValue): String =
+    if (v != null) {
+      s"V-${pp(v)}"
+    } else {
+      s"E-${pp(e)}"
+    }
+
+  def ppEnv(env: Env): String = {
+    //s"{${commas(env.asScala.map(pp))}}"
+    s"{#${env.size()}}" //show just the env size
+  }
+
+  def ppKontStack(ks: util.ArrayList[Kont]): String = {
+    //ks.asScala.reverse.map(ppKont).mkString(" -- ")
+    s"[#${ks.size()}]" //show just the kont-stack depth
+  }
+
+  def ppKont(k: Kont): String = k match {
+    case KPop(n) => s"KPop($n)"
+    case KArg(es) => s"KArg(${commas(es.map(pp))})"
+    case KFun(prim, extendedArgs, arity) =>
+      s"KFun(${pp(prim)}/$arity,[${commas(extendedArgs.asScala.map(pp))}])"
+    case KPushTo(_, e) => s"KPushTo(_, ${pp(e)})"
+    case KCacheVal(_, _) => "KCacheVal"
+    case KLocation(_) => "KLocation"
+    case KMatch(_) => "KMatch"
+    case KCatch(_, _, _) => "KCatch" //never seen
+    case KFinished => "KFinished"
+  }
+
+  def ppVarRef(n: Int): String = {
+    s"#$n"
+  }
+
+  def pp(e: SExpr): String = e match {
+    case SEValue(v) => pp(v)
+    case SEVar(n) => ppVarRef(n)
+    //case SEApp(func, args) => s"@(${pp(func)},${commas(args.map(pp))})"
+    case SEApp(_, _) => s"@(...)"
+    //case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(ppVarRef))}]lam/$arity->${pp(body)}"
+    case SEMakeClo(fvs, arity, _) => s"[${commas(fvs.map(ppVarRef))}]lam/$arity->..."
+    case SEBuiltin(b) => s"${b}"
+    case SEVal(_) => "<SEVal...>"
+    case SELocation(_, _) => "<SELocation...>"
+    case SELet(_, _) => "<SELet...>"
+    case SECase(_, _) => "<SECase...>"
+    case SEBuiltinRecursiveDefinition(_) => "<SEBuiltinRecursiveDefinition...>"
+    case SECatch(_, _, _) => "<SECatch...>" //not seen one yet
+    case SEAbs(_, _) => "<SEAbs...>" // will never get these on a running machine
+    case SEImportValue(_) => "<SEImportValue...>"
+    case SEWronglyTypeContractId(_, _, _) => "<SEWronglyTypeContractId...>"
+  }
+
+  def pp(v: SValue): String = v match {
+    case SInt64(n) => s"$n"
+    case SPAP(prim, args, arity) =>
+      s"PAP[${args.size}/$arity](${pp(prim)}(${commas(args.asScala.map(pp))})))"
+    case SToken => "SToken"
+    case SText(s) => s"'$s'"
+    case SParty(_) => "<SParty>"
+    case SStruct(_, _) => "<SStruct...>"
+    case SUnit => "SUnit"
+    case SList(_) => "SList"
+    case _ => "<Unknown-value>" // TODO: complete cases
+  }
+
+  def pp(prim: Prim): String = prim match {
+    case PBuiltin(b) => s"$b"
+    case PClosure(expr, fvs) =>
+      s"clo[${commas(fvs.map(pp))}]:${pp(expr)}"
+  }
+
+  def commas(xs: Seq[String]): String = xs.mkString(",")
+
+}


### PR DESCRIPTION
Add instrumentation and lightweight tracing to Speedy execution.
- Disabled by default.
- Enabled with compile time flags
- When these flags are constant `false`, there should be no cost to to the code

I have benchmarked this branch against master, and can see no measurable performance impact. If there is any, it is not visible in the noise.

Flags to enable are:
-  `enableInstrumentation` 
-  `enableLightweightStepTracing`

Instrumentation:
- tracks #pushes and maximum-depth for the `kont`-stack and the `env`ironment
- counts #steps
- classifies  each step:
    - for `CtrlExpr`, what kind of expression is it?
    - for `CtrlValue`, what kind of continuation is at the head of the `kont`-stack?
- the information is printed when the machine finalizes

Lightweight tracing shows an abbreviated output line per step:
- the control expression / value
- the size of the environment
- the depth of the `kont`-stack

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
