### PR TITLE
hopefully fix memory issue with pg on macos CI

### DIFF
--- a/infra/macos/1-create-box/user-script.sh
+++ b/infra/macos/1-create-box/user-script.sh
@@ -4,3 +4,12 @@
 
 
 echo "nix" > "$1/private/etc/synthetic.conf"
+
+# taken from https://www.postgresql.org/docs/12/kernel-resources.html
+cat > "$1/private/etc/sysctl.conf" <<END
+kern.sysv.shmmax=4194304
+kern.sysv.shmmin=1
+kern.sysv.shmmni=32
+kern.sysv.shmseg=8
+kern.sysv.shmall=1024
+END


### PR DESCRIPTION
We have seen the following error message crop up a couple times
recently:

```
FATAL:  could not create shared memory segment: No space left on device
DETAIL:  Failed system call was shmget(key=5432001, size=56, 03600).
HINT:  This error does *not* mean that you have run out of disk space.
It occurs either if all available shared memory IDs have been taken, in
which case you need to raise the SHMMNI parameter in your kernel, or
because the system's overall limit for shared memory has been reached.
    The PostgreSQL documentation contains more information about shared
memory configuration.
child process exited with exit code 1
```

Based on [the PostgreSQL
documentation](https://www.postgresql.org/docs/12/kernel-resources.html),
this should fix it.

CHANGELOG_BEGIN
CHANGELOG_END