### PR TITLE
Trigger service: Use response format from JSON API

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -76,6 +76,7 @@ da_scala_test(
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:com_typesafe_akka_akka_actor_typed_2_12",
         "@maven//:com_typesafe_akka_akka_http_core_2_12",
+        "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalatest_scalatest_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Response.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Response.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.trigger
+
+import akka.http.scaladsl.model._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+// The HTTP service can `complete` using one of these functions to construct a
+// a response with a JSON object and status code matching the one in the body.
+object Response {
+  def successResponse[A: JsonWriter](a: A): (StatusCode, JsObject) = {
+    (StatusCodes.OK, resultJsObject(a))
+  }
+
+  def errorResponse(status: StatusCode, es: String*): (StatusCode, JsObject) = {
+    (status, errorsJsObject(status, es))
+  }
+
+  // These functions are borrowed from the HTTP JSON ledger API but I haven't
+  // factored them out for now as they are fairly small.
+  def errorsJsObject(status: StatusCode, es: Seq[String]): JsObject = {
+    val errors = es.toJson
+    JsObject(statusField(status), ("errors", errors))
+  }
+
+  def resultJsObject[A: JsonWriter](a: A): JsObject = {
+    resultJsObject(a.toJson)
+  }
+
+  def resultJsObject(a: JsValue): JsObject = {
+    JsObject(statusField(StatusCodes.OK), ("result", a))
+  }
+
+  def statusField(status: StatusCode): (String, JsNumber) =
+    ("status", JsNumber(status.intValue()))
+}

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -66,7 +66,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
     TriggerServiceFixture
       .withTriggerService[A](testId, List(darPath), triggerDar)
 
-  def startTrigger(uri: Uri, id: String, party: String) = {
+  def startTrigger(uri: Uri, id: String, party: String): Future[HttpResponse] = {
     val req = HttpRequest(
       method = HttpMethods.POST,
       uri = uri.withPath(Uri.Path("/start")),
@@ -78,7 +78,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
     Http().singleRequest(req)
   }
 
-  def listTriggers(uri: Uri, party: String) = {
+  def listTriggers(uri: Uri, party: String): Future[HttpResponse] = {
     val req = HttpRequest(
       method = HttpMethods.GET,
       uri = uri.withPath(Uri.Path(s"/list")),
@@ -90,7 +90,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
     Http().singleRequest(req)
   }
 
-  def stopTrigger(uri: Uri, id: String) = {
+  def stopTrigger(uri: Uri, id: String): Future[HttpResponse] = {
     val req = HttpRequest(
       method = HttpMethods.DELETE,
       uri = uri.withPath(Uri.Path(s"/stop/$id")),
@@ -98,7 +98,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
     Http().singleRequest(req)
   }
 
-  def uploadDar(uri: Uri, file: File) = {
+  def uploadDar(uri: Uri, file: File): Future[HttpResponse] = {
     val fileContentsSource: Source[ByteString, Any] = FileIO.fromPath(file.toPath)
     val multipartForm = Multipart.FormData(
       Multipart.FormData.BodyPart(
@@ -113,7 +113,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
     Http().singleRequest(req)
   }
 
-  def responseBodyToString(resp: HttpResponse) = {
+  def responseBodyToString(resp: HttpResponse): Future[String] = {
     resp.entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
   }
 


### PR DESCRIPTION
See https://docs.daml.com/json-api/index.html#error-reporting. A response message is now a JSON object with a `status` field and either an `errors` or `result` field.

This also adds a bit more logic in the tests to check for specific JSON fields in the responses.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
