### PR TITLE
Remove useless `cd compiler` from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,10 +20,7 @@ fi
 
 # Bazel test only builds targets that are dependencies of a test suite
 # so do a full build first.
-(
-  cd compiler
-  bazel build //... --build_tag_filters "$tag_filter"
-)
+bazel build //... --build_tag_filters "$tag_filter"
 bazel test //... --build_tag_filters "$tag_filter" --test_tag_filters "$tag_filter" --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' > /dev/null


### PR DESCRIPTION
I have no idea why we added this in the first place tbh. It looks like
it was here since we open sourced DAML.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
