### PR TITLE
Clarify documentation around --project-root

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -197,7 +197,7 @@ projectOpts name = ProjectOpts <$> projectRootOpt <*> projectCheckOpt name
             help
                 (mconcat
                      [ "Path to the root of a project containing daml.yaml. "
-                     , "If unspecified this will use the DAML_PROJECT environment variable set by the assistant."
+                     , "If you use the assistant, you should set the DAML_PROJECT environment variable instead."
                      ])
         projectCheckOpt cmdName = fmap (ProjectCheck cmdName) . switch $
                help "Check if running in DAML project."


### PR DESCRIPTION
--project-root is a bit confusing when using the assistant since it
will choose the SDK version before going to the project
directory. This is almost never what you intend to do so setting
DAML_PROJECT seems like a better option in most cases.

See https://github.com/digital-asset/daml/issues/5769 for details

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
