### PR TITLE
Engine: factorize a bit constant objects

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -277,7 +277,8 @@ final class Engine {
           seeds = seeding,
           globalCids,
         )
-        .copy(validating = validating, committers = submitters)
+      machine.validating = validating
+      machine.committers = submitters
       interpretLoop(machine, ledgerTime)
     }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -223,6 +223,7 @@ object SValue {
     val EmptyMap = STextMap(HashMap.empty)
     val EmptyGenMap = SGenMap.Empty
     val Token = SToken
+    val EmptyText = SText("")
   }
 
   abstract class SValueContainer[X] {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -91,9 +91,9 @@ object Speedy {
   type Actuals = util.ArrayList[SValue]
 
   /** The speedy CEK machine. */
-  final case class Machine(
+  final class Machine(
       /* Value versions that the machine can output */
-      supportedValueVersions: VersionRange[value.ValueVersion],
+      val supportedValueVersions: VersionRange[value.ValueVersion],
       /* The control is what the machine should be evaluating. If this is not
        * null, then `returnValue` must be null.
        */
@@ -125,7 +125,7 @@ object Speedy {
        */
       var validating: Boolean,
       /* The trace log. */
-      traceLog: TraceLog,
+      val traceLog: TraceLog,
       /* Compiled packages (DAML-LF ast + compiled speedy expressions). */
       var compiledPackages: CompiledPackages,
       /* Flag to trace usage of get_time builtins */
@@ -140,7 +140,7 @@ object Speedy {
       var track: Instrumentation,
       /* Profile of the run when the packages haven been compiled with profiling enabled. */
       var profile: Profile
-  ) extends SomeArrayEquals {
+  ) {
 
     /* kont manipulation... */
 
@@ -519,7 +519,7 @@ object Speedy {
         initialSeeding: InitialSeeding,
         globalCids: Set[V.ContractId]
     ) =
-      Machine(
+      new Machine(
         supportedValueVersions = value.ValueVersions.DefaultSupportedVersions,
         ctrl = null,
         returnValue = null,
@@ -609,8 +609,11 @@ object Speedy {
         submissionTime: Time.Timestamp,
         seeding: InitialSeeding,
         globalCids: Set[V.ContractId],
-    ): Machine =
-      initial(compiledPackages, submissionTime, seeding, globalCids).copy(ctrl = sexpr)
+    ): Machine = {
+      val m = initial(compiledPackages, submissionTime, seeding, globalCids)
+      m.ctrl = sexpr
+      m
+    }
   }
 
   // Environment


### PR DESCRIPTION
This PR factorize a bit some constant in Speedy to limit allocation of object.

I cannot measure an impact (good or bad) on performance.  

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
