### PR TITLE
Trigger service: Use JSON object in result of upload dar response

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -57,6 +57,7 @@ import com.daml.ledger.client.configuration.{
 import com.daml.lf.engine.trigger.Request.{ListParams, StartParams}
 import com.daml.lf.engine.trigger.Response._
 import com.daml.platform.services.time.TimeProviderType
+import spray.json.{JsObject, JsString}
 
 case class LedgerConfig(
     host: String,
@@ -268,8 +269,9 @@ object Server {
                             case (pkgId, payload) => Decode.readArchivePayload(pkgId, payload)
                           }
                           addDar(compiledPackages, dar)
-                          complete(
-                            successResponse(s"DAR uploaded, main package id: ${dar.main._1}"))
+                          val mainPackageId =
+                            JsObject(Map() + ("mainPackageId" -> JsString(dar.main._1)))
+                          complete(successResponse(mainPackageId))
                         } catch {
                           case err: ParseError =>
                             complete(errorResponse(StatusCodes.UnprocessableEntity, err.toString))

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -152,8 +152,9 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
   it should "start a trigger after uploading it" in withHttpService(None) { (uri: Uri, client) =>
     for {
       resp <- uploadDar(uri, darPath)
-      JsString(result) <- parseResult(resp)
-      _ <- result should startWith("DAR uploaded")
+      JsObject(fields) <- parseResult(resp)
+      Some(JsString(mainPackageId)) = fields.get("mainPackageId")
+      _ <- mainPackageId should not be empty
 
       resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Alice")
       triggerId <- parseTriggerId(resp)


### PR DESCRIPTION
This simply formats the current response message into a JSON object.

Thinking about it more however, why would the user who uploads the DAR need to receive the main package id back in the response? Wouldn't they already know that from the DAR they uploaded? Maybe no extra information is needed in the success case, but I suppose we want the practice of having a nonempty `result` field in every success response.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
