### PR TITLE
contract IDs' suffixes must match in emptiness, not mismatch

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Ordering.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Ordering.scala
@@ -123,7 +123,7 @@ object Ordering extends scala.math.Ordering[SValue] {
         val c1 = crypto.Hash.ordering.compare(hash1, hash2)
         if (c1 != 0)
           c1
-        else if (suffix1.isEmpty != suffix2.isEmpty)
+        else if (suffix1.isEmpty == suffix2.isEmpty)
           Bytes.ordering.compare(suffix1, suffix2)
         else
           throw SErrorCrash("Conflicting discriminators between a local and global contract id")


### PR DESCRIPTION
Instead, to compare two SContractIDs of V1, either both discriminators must be empty, or both must be non-empty. This permits certain sets of them to be generally comparable; we test that comparison against a total ordering. This also makes that comparison reflexive and transitive, where it was not before.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
