### PR TITLE
Trigger service: use "triggerId" and "triggerIds" fields for response messages

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -289,7 +289,8 @@ object Server {
             {
               val triggerList =
                 triggersByParty.getOrElse(params.party, Set()).map(_.toString).toList
-              complete(successResponse(triggerList))
+              val result = JsObject(("triggerIds", triggerList.toJson))
+              complete(successResponse(result))
             }
           }
         }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -304,7 +304,8 @@ object Server {
           val party = actorWithParty.party
           val newTriggerSet = triggersByParty.get(party).get - id
           triggersByParty = triggersByParty + (party -> newTriggerSet)
-          complete(successResponse(s"Trigger $id has been stopped."))
+          val stoppedTriggerId = JsObject(Map() + ("triggerId" -> JsString(id.toString)))
+          complete(successResponse(stoppedTriggerId))
         }
       },
     )

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -246,7 +246,8 @@ object Server {
                     triggers = triggers + (uuid -> TriggerActorWithParty(ref, party))
                     val newTriggerSet = triggersByParty.getOrElse(party, Set()) + uuid
                     triggersByParty = triggersByParty + (party -> newTriggerSet)
-                    complete(successResponse(uuid.toString))
+                    val triggerIdResult = JsObject(Map() + ("triggerId" -> JsString(uuid.toString)))
+                    complete(successResponse(triggerIdResult))
                 }
             }
           },

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -31,6 +31,7 @@ import scala.util.{Failure, Success}
 import scalaz.syntax.tag._
 import scalaz.syntax.traverse._
 import spray.json.DefaultJsonProtocol._
+import spray.json._
 import com.daml.lf.CompiledPackages
 import com.daml.lf.archive.{Dar, DarReader, Decode}
 import com.daml.lf.archive.Reader.ParseError
@@ -57,7 +58,6 @@ import com.daml.ledger.client.configuration.{
 import com.daml.lf.engine.trigger.Request.{ListParams, StartParams}
 import com.daml.lf.engine.trigger.Response._
 import com.daml.platform.services.time.TimeProviderType
-import spray.json.{JsObject, JsString}
 
 case class LedgerConfig(
     host: String,
@@ -246,7 +246,7 @@ object Server {
                     triggers = triggers + (uuid -> TriggerActorWithParty(ref, party))
                     val newTriggerSet = triggersByParty.getOrElse(party, Set()) + uuid
                     triggersByParty = triggersByParty + (party -> newTriggerSet)
-                    val triggerIdResult = JsObject(Map() + ("triggerId" -> JsString(uuid.toString)))
+                    val triggerIdResult = JsObject(("triggerId", uuid.toString.toJson))
                     complete(successResponse(triggerIdResult))
                 }
             }
@@ -270,8 +270,7 @@ object Server {
                             case (pkgId, payload) => Decode.readArchivePayload(pkgId, payload)
                           }
                           addDar(compiledPackages, dar)
-                          val mainPackageId =
-                            JsObject(Map() + ("mainPackageId" -> JsString(dar.main._1)))
+                          val mainPackageId = JsObject(("mainPackageId", dar.main._1.name.toJson))
                           complete(successResponse(mainPackageId))
                         } catch {
                           case err: ParseError =>
@@ -297,14 +296,14 @@ object Server {
       },
       // Stop a trigger given its UUID
       delete {
-        pathPrefix("stop" / JavaUUID) { id =>
-          val actorWithParty = triggers.get(id).get
+        pathPrefix("stop" / JavaUUID) { uuid =>
+          val actorWithParty = triggers.get(uuid).get
           actorWithParty.ref ! TriggerActor.Stop
-          triggers = triggers - id
+          triggers = triggers - uuid
           val party = actorWithParty.party
-          val newTriggerSet = triggersByParty.get(party).get - id
+          val newTriggerSet = triggersByParty.get(party).get - uuid
           triggersByParty = triggersByParty + (party -> newTriggerSet)
-          val stoppedTriggerId = JsObject(Map() + ("triggerId" -> JsString(id.toString)))
+          val stoppedTriggerId = JsObject(("triggerId", uuid.toString.toJson))
           complete(successResponse(stoppedTriggerId))
         }
       },

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -130,7 +130,8 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
 
   def parseTriggerId(resp: HttpResponse): Future[String] = {
     for {
-      JsString(triggerId) <- parseResult(resp)
+      JsObject(fields) <- parseResult(resp)
+      Some(JsString(triggerId)) = fields.get("triggerId")
     } yield triggerId
   }
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -238,19 +238,20 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
         }
         // Query ACS until we see a B contract
         // format: off
-      _ <- Future {
-        val filter = TransactionFilter(List(("Alice", Filters(Some(InclusiveFilters(Seq(Identifier(testPkgId, "TestTrigger", "B"))))))).toMap)
-        eventually {
-          val acs = client.activeContractSetClient.getActiveContracts(filter).runWith(Sink.seq)
-            .map(acsPages => acsPages.flatMap(_.activeContracts))
-          // Once we switch to scalatest 3.1, we should no longer need the Await.result here since eventually
-          // handles Future results.
-          val r = Await.result(acs, Duration.Inf)
-          assert(r.length == 1)
+        _ <- Future {
+          val filter = TransactionFilter(List(("Alice", Filters(Some(InclusiveFilters(Seq(Identifier(testPkgId, "TestTrigger", "B"))))))).toMap)
+          eventually {
+            val acs = client.activeContractSetClient.getActiveContracts(filter).runWith(Sink.seq)
+              .map(acsPages => acsPages.flatMap(_.activeContracts))
+            // Once we switch to scalatest 3.1, we should no longer need the Await.result here since eventually
+            // handles Future results.
+            val r = Await.result(acs, Duration.Inf)
+            assert(r.length == 1)
+          }
         }
-      }
-      // format: on
+        // format: on
         resp <- stopTrigger(uri, triggerId)
-      } yield assert(resp.status.isSuccess)
+        _ <- assert(resp.status.isSuccess)
+      } yield succeed
   }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -165,8 +165,8 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
       _ <- result should equal(JsArray(JsString(triggerId)))
 
       resp <- stopTrigger(uri, triggerId)
-      JsString(result) <- parseResult(resp)
-      _ <- result should equal(s"Trigger $triggerId has been stopped.")
+      stoppedTriggerId <- parseTriggerId(resp)
+      _ <- stoppedTriggerId should equal(triggerId)
     } yield succeed
   }
 


### PR DESCRIPTION
This adds an extra layer of structure to the success responses for `start`, `stop` and `list`, with a bit of clean up along the way.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
