### PR TITLE
disable https check for JWT tokens in JSON API, warn instead

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -383,7 +383,10 @@ class Endpoints(
 
   private[this] def ensureHttpsForwarded(req: HttpRequest): Unauthorized \/ Unit =
     if (allowNonHttps || isForwardedForHttps(req.headers)) \/-(())
-    else -\/(Unauthorized(nonHttpsErrorMessage))
+    else {
+      logger.warn(nonHttpsErrorMessage)
+      \/-(())
+    }
 
   private[this] def isForwardedForHttps(headers: Seq[HttpHeader]): Boolean =
     headers exists {

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceIntegrationTest.scala
@@ -7,9 +7,7 @@ import java.io.File
 import java.nio.file.Files
 
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.headers.`X-Forwarded-Proto`
-import akka.http.scaladsl.model.{HttpHeader, HttpMethods, HttpRequest, StatusCode, StatusCodes, Uri}
-import com.daml.http.HttpServiceTestFixture.LeakPasswords
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, StatusCodes, Uri}
 import com.daml.http.Statement.discard
 import com.daml.http.util.TestUtil.writeToFile
 import org.scalacheck.Gen
@@ -71,46 +69,6 @@ class HttpServiceIntegrationTest extends AbstractHttpServiceIntegrationTest with
     "can 'parse' quoted sample" in {
       Forwarded("for=192.168.0.1;proto = \"https\" ;by=192.168.0.42").proto should ===(
         Some("https"))
-    }
-
-    import spray.json._, json.JsonProtocol._
-    Seq(
-      (
-        "without header",
-        Seq.empty[HttpHeader],
-        StatusCodes.Unauthorized: StatusCode,
-        "errors" -> Seq(Endpoints.nonHttpsErrorMessage).toJson),
-      (
-        "with old-style Forwarded",
-        Seq(`X-Forwarded-Proto`("https")),
-        StatusCodes.OK,
-        "result" -> JsArray(Vector())),
-      (
-        "with new-style Forwarded",
-        Seq(Forwarded("for=192.168.0.1;proto = \"https\" ;by=192.168.0.42")),
-        StatusCodes.OK,
-        "result" -> JsArray(Vector())),
-    ) foreach {
-      case (lbl, extraHeaders, expectedStatus, expectedOutput) =>
-        s"is checked $lbl" in HttpServiceTestFixture.withHttpService(
-          testId,
-          List.empty,
-          jdbcConfig,
-          staticContentConfig,
-          leakPasswords = LeakPasswords.No) { (uri, _, _, _) =>
-          getRequest(
-            uri = uri.withPath(Uri.Path("/v1/query")),
-            headers = headersWithAuth ++ extraHeaders)
-            .map {
-              case (status, output) =>
-                discard { status shouldBe expectedStatus }
-                discard { assertStatus(output, expectedStatus) }
-                inside(output) {
-                  case JsObject(fields) =>
-                    (fields: Iterable[(String, JsValue)]) should contain(expectedOutput)
-                }
-            }: Future[Assertion]
-        }
     }
   }
 }


### PR DESCRIPTION
```rst
CHANGELOG_BEGIN
- [JSON API] The check that connections are made through a reverse-proxy
  providing HTTPS, ensuring that JWT tokens don't leak, only logs a warning
  rather than rejecting the request.
CHANGELOG_END
```

As discussed with @gerolf-da @garyverhaegen-da @bame-da @leo-da .

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
