### PR TITLE
Print the postgres log on failures

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -70,11 +70,17 @@ test_suite(
 
 migration_test(
     name = "migration-stable",
-    tags = ["head-quick"],
+    # Exclusive due to hardcoded postgres ports.
+    tags = [
+        "exclusive",
+        "head-quick",
+    ],
     versions = stable_versions,
 ) if not is_windows else None
 
 migration_test(
     name = "migration-all",
+    # Exclusive due to hardcoded postgres ports.
+    tags = ["exclusive"],
     versions = platform_versions,
 ) if not is_windows else None

--- a/compatibility/bazel_tools/client_server/with-postgres/BUILD
+++ b/compatibility/bazel_tools/client_server/with-postgres/BUILD
@@ -12,6 +12,7 @@ da_haskell_library(
         "extra",
         "filepath",
         "process",
+        "safe-exceptions",
         "text",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This changes the code for starting postgres to print the log if
`pg_ctl start` fails.

In addition to that it marks the migration tests exclusive since they
rely on this code which has a hardcoded port number.

I tested this on CI by temporarily disabling --quick.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
