### PR TITLE
Implement version name shortening for Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -189,8 +189,6 @@ jobs:
       - template: ci/report-start.yml
       - checkout: self
       - template: ci/compatibility.yml
-        parameters:
-          test_flags: '--quick'
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
 
@@ -204,8 +202,6 @@ jobs:
       - template: ci/report-start.yml
       - checkout: self
       - template: ci/compatibility.yml
-        parameters:
-          test_flags: '--quick'
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
 
@@ -219,8 +215,6 @@ jobs:
       - template: ci/report-start.yml
       - checkout: self
       - template: ci/compatibility-windows.yml
-        parameters:
-          test_flags: '--quick'
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -189,6 +189,8 @@ jobs:
       - template: ci/report-start.yml
       - checkout: self
       - template: ci/compatibility.yml
+        parameters:
+          test_flags: '--quick'
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
 
@@ -202,6 +204,8 @@ jobs:
       - template: ci/report-start.yml
       - checkout: self
       - template: ci/compatibility.yml
+        parameters:
+          test_flags: '--quick'
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
 
@@ -215,6 +219,8 @@ jobs:
       - template: ci/report-start.yml
       - checkout: self
       - template: ci/compatibility-windows.yml
+        parameters:
+          test_flags: '--quick'
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
       - task: PublishBuildArtifacts@1

--- a/compatibility/bazel_tools/daml_script/daml_script.bzl
+++ b/compatibility/bazel_tools/daml_script/daml_script.bzl
@@ -5,6 +5,7 @@ load(
     "@daml//bazel_tools/client_server:client_server_test.bzl",
     "client_server_test",
 )
+load("//bazel_tools:versions.bzl", "version_to_name")
 
 def daml_script_dar(sdk_version):
     daml = "@daml-sdk-{sdk_version}//:daml".format(
@@ -12,11 +13,11 @@ def daml_script_dar(sdk_version):
     )
     native.genrule(
         name = "script-example-dar-{sdk_version}".format(
-            sdk_version = sdk_version,
+            sdk_version = version_to_name(sdk_version),
         ),
         srcs = ["//bazel_tools/daml_script:example/src/ScriptExample.daml"],
         outs = ["script-example-{sdk_version}.dar".format(
-            sdk_version = sdk_version,
+            sdk_version = version_to_name(sdk_version),
         )],
         tools = [daml],
         cmd = """\
@@ -51,15 +52,15 @@ $(location {daml}) build --project-root=$$TMP_DIR -o $$PWD/$(OUTS)
 
 def daml_script_test(compiler_version, runner_version):
     compiled_dar = "//:script-example-dar-{version}".format(
-        version = compiler_version,
+        version = version_to_name(compiler_version),
     )
     daml_runner = "@daml-sdk-{version}//:daml".format(
         version = runner_version,
     )
     client_server_test(
         name = "daml-script-test-compiler-{compiler_version}-runner-{runner_version}".format(
-            compiler_version = compiler_version,
-            runner_version = runner_version,
+            compiler_version = version_to_name(compiler_version),
+            runner_version = version_to_name(runner_version),
         ),
         client = daml_runner,
         client_args = [

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -6,6 +6,7 @@ load(
     "client_server_test",
 )
 load("@os_info//:os_info.bzl", "is_windows")
+load("//bazel_tools:versions.bzl", "version_to_name")
 load("//:versions.bzl", "latest_stable_version")
 
 # Indexed first by test tool version and then by sandbox version.
@@ -228,8 +229,8 @@ def sdk_platform_test(sdk_version, platform_version):
 
     # ledger-api-test-tool test-cases
     name = "ledger-api-test-tool-{sdk_version}-platform-{platform_version}".format(
-        sdk_version = sdk_version,
-        platform_version = platform_version,
+        sdk_version = version_to_name(sdk_version),
+        platform_version = version_to_name(platform_version),
     )
     exclusions = ["--exclude=" + test for test in get_excluded_tests(test_tool_version = sdk_version, sandbox_version = platform_version)]
     client_server_test(
@@ -274,8 +275,8 @@ def sdk_platform_test(sdk_version, platform_version):
 
     # daml-ledger test-cases
     name = "daml-ledger-{sdk_version}-platform-{platform_version}".format(
-        sdk_version = sdk_version,
-        platform_version = platform_version,
+        sdk_version = version_to_name(sdk_version),
+        platform_version = version_to_name(platform_version),
     )
     daml_ledger_test(
         name = name,

--- a/compatibility/bazel_tools/versions.bzl
+++ b/compatibility/bazel_tools/versions.bzl
@@ -1,0 +1,73 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//lib:versions.bzl", _bazel_versions = "versions")
+load("@os_info//:os_info.bzl", "is_windows")
+
+def _semver_components(version):
+    """Separates a semver into its components.
+
+    I.e. separates `MAJOR.MINOR.PATCH-PRERELEASE+BUILD` into
+
+    * the version core `MAJOR.MINOR.PATCH`
+    * the optional `PRERELEASE` identifier, `None` if missing
+    * the optional `BUILD` identifier, `None` if missing
+
+    Returns:
+      The tuple `(version, prerelease, build)`.
+    """
+    dash_pos = version.find("-")
+    plus_pos = version.find("+")
+
+    if dash_pos != -1:
+        core_end = dash_pos
+    elif plus_pos != -1:
+        core_end = plus_pos
+    else:
+        core_end = len(version)
+
+    if plus_pos != -1:
+        prerelease_end = plus_pos
+    else:
+        prerelease_end = len(version)
+
+    build_end = len(version)
+
+    core = version[:core_end]
+
+    if dash_pos != -1:
+        prerelease = version[core_end + 1:prerelease_end]
+    else:
+        prerelease = None
+
+    if plus_pos != -1:
+        build = version[prerelease_end + 1:build_end]
+    else:
+        build = None
+
+    return (core, prerelease, build)
+
+def _extract_git_revision(prerelease):
+    """Extracts the git revision from the prerelease identifier.
+
+    This is assumed to be the last `.` separated component.
+    """
+    return prerelease.split(".")[-1]
+
+def version_to_name(version):
+    """Render a version to a target name or path component.
+
+    On Windows snapshot versions are shortened to `MAJOR.MINOR.PATCH-REV`,
+    where `REV` is the git revision. This is to avoid exceeding the `MAX_PATH`
+    limit on Windows.
+    """
+    if is_windows:
+        (core, prerelease, _) = _semver_components(version)
+        components = [core]
+        if prerelease != None:
+            components.append(_extract_git_revision(prerelease))
+        name = "-".join(components)
+    else:
+        name = version
+
+    return name


### PR DESCRIPTION
Avoid exceeding `MAX_PATH` on Windows with the compatibility tests by shortening the snapshot version names that enter test-names.

This doesn't change the workspace names for the release tarballs yet. Those haven't been causing issues so far and it is nice to have the full version name in them to know which version they are referring to. If they cause issues in the future they can be shortened as well.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
