### PR TITLE
Engine: Add in-execution-order traversal for transactions.

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -334,6 +334,40 @@ final case class GenTransaction[Nid, +Cid, +Val](
   def foreach3(fNid: Nid => Unit, fCid: Cid => Unit, fVal: Val => Unit): Unit =
     GenTransaction.foreach3(fNid, fCid, fVal)(self)
 
+  // This method visits to all nodes of the transaction in execution order.
+  // Exercise nodes are visited twice: when execution reaches them and when execution leaves their body.
+  def foreachInExecutionOrder(
+      exerciseBegin: (Nid, Node.NodeExercises[Nid, Cid, Val]) => Unit,
+      leaf: (Nid, Node.LeafOnlyNode[Cid, Val]) => Unit,
+      exerciseEnd: (Nid, Node.NodeExercises[Nid, Cid, Val]) => Unit,
+  ): Unit = {
+    @tailrec
+    def loop(
+        currNodes: FrontStack[Nid],
+        stack: FrontStack[((Nid, Node.NodeExercises[Nid, Cid, Val]), FrontStack[Nid])],
+    ): Unit =
+      currNodes match {
+        case FrontStackCons(nid, rest) =>
+          nodes(nid) match {
+            case exe: NodeExercises[Nid, Cid, Val] =>
+              exerciseBegin(nid, exe)
+              loop(FrontStack(exe.children), (((nid, exe), rest)) +: stack)
+            case node: Node.LeafOnlyNode[Cid, Val] =>
+              leaf(nid, node)
+              loop(rest, stack)
+          }
+        case FrontStack() =>
+          stack match {
+            case FrontStackCons(((nid, exe), brothers), rest) =>
+              exerciseEnd(nid, exe)
+              loop(brothers, rest)
+            case FrontStack() =>
+          }
+      }
+
+    loop(FrontStack(roots), FrontStack.empty)
+  }
+
 }
 
 object GenTransaction extends value.CidContainer3WithDefaultCidResolver[GenTransaction] {

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -87,7 +87,7 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
 
   }
 
-  "foreachInExecutionOrder" - {
+  "foldInExecutionOrder" - {
     "should traverse the transaction in execution order" in {
 
       val tx = mkTransaction(
@@ -100,15 +100,13 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
         ImmArray(V.NodeId(0), V.NodeId(1), V.NodeId(3)),
       )
 
-      val trace = List.newBuilder[String]
-
-      tx.foreachInExecutionOrder(
-        { case (nid, _) => trace += s"exerciseBegin(${nid.index})"; () },
-        { case (nid, _) => trace += s"leaf(${nid.index})"; () },
-        { case (nid, _) => trace += s"exerciseEnd(${nid.index})"; () },
+      val result = tx.foldInExecutionOrder(List.empty[String])(
+        (acc, nid, _) => s"exerciseBegin(${nid.index})" :: acc,
+        (acc, nid, _) => s"leaf(${nid.index})" :: acc,
+        (acc, nid, _) => s"exerciseEnd(${nid.index})" :: acc,
       )
 
-      trace.result().mkString(", ") shouldBe
+      result.reverse.mkString(", ") shouldBe
         "leaf(0), exerciseBegin(1), exerciseBegin(2), exerciseEnd(2), exerciseEnd(1), leaf(3)"
     }
   }


### PR DESCRIPTION
We add a new foreach to GenTransaction that visit all ht enodes in execution order.
Exercise nodes are visited twice: when execution reaches them and when execution leaves their body.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
