### PR TITLE
Fix MacOS version linking issues

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -363,6 +363,10 @@ haskell_register_ghc_nixpkgs(
         "-fexternal-dynamic-refs",
     ] + (["-g3"] if enable_ghc_dwarf else ([
         "-optl-unexported_symbols_list=*",
+        "-optc-mmacosx-version-min=10.14",
+        "-opta-mmacosx-version-min=10.14",
+        "-optl-mmacosx-version-min=10.14",
+        "-optP-mmacosx-version-min=10.14",
     ] if is_darwin else ["-optl-s"])),
     compiler_flags_select = {
         "@com_github_digital_asset_daml//:profiling_build": ["-fprof-auto"],

--- a/bazel_tools/haskell-pgmc.patch
+++ b/bazel_tools/haskell-pgmc.patch
@@ -1,0 +1,23 @@
+diff --git a/haskell/private/cabal_wrapper.py.tpl b/haskell/private/cabal_wrapper.py.tpl
+index 81269cc7..35c24cf4 100755
+--- a/haskell/private/cabal_wrapper.py.tpl
++++ b/haskell/private/cabal_wrapper.py.tpl
+@@ -143,6 +143,18 @@ with tmpdir() as distdir:
+         "--with-hc-pkg=" + ghc_pkg,
+         "--with-ar=" + ar,
+         "--with-gcc=" + cc,
++        "--ghc-option=-pgmc=" + cc,
++        "--ghc-option=-pgma=" + cc,
++        "--ghc-option=-pgmP=" + cc,
++        "--ghc-option=-pgml=" + cc,
++        # Setting -pgm* flags explicitly has the unfortunate side effect
++        # of resetting any program flags in the GHC settings file. So we
++        # restore them here. See
++        # https://ghc.haskell.org/trac/ghc/ticket/7929.
++        "--ghc-option=-optc-fno-stack-protector",
++        "--ghc-option=-optP-E",
++        "--ghc-option=-optP-undef",
++        "--ghc-option=-optP-traditional",
+         "--with-strip=" + strip,
+         "--enable-deterministic", \
+         ] +

--- a/compatibility/deps.bzl
+++ b/compatibility/deps.bzl
@@ -50,6 +50,7 @@ def daml_deps():
                 "@daml//bazel_tools:haskell-strict-source-names.patch",
                 "@daml//bazel_tools:haskell-windows-remove-fake-libs.patch",
                 "@daml//bazel_tools:haskell-windows-extra-libraries.patch",
+                "@daml//bazel_tools:haskell-pgmc.patch",
             ],
             patch_args = ["-p1"],
             sha256 = rules_haskell_sha256,

--- a/deps.bzl
+++ b/deps.bzl
@@ -73,6 +73,8 @@ def daml_deps():
                 # This should be made configurable in rules_haskell.
                 # Remove this patch once that's available.
                 "@com_github_digital_asset_daml//bazel_tools:haskell-opt.patch",
+                # This can be upstreamed.
+                "@com_github_digital_asset_daml//bazel_tools:haskell-pgmc.patch",
             ],
             patch_args = ["-p1"],
             sha256 = rules_haskell_sha256,


### PR DESCRIPTION
This should fix the following issue that we see constantly on CI:

```
ld: warning: object file _ was built for newer OSX version (10.15) than being linked (10.14)
```

The issue was that the CC toolchain was not fully used in
haskell_cabal_package. --with-gcc (which is really --with-cc) only
applies when Cabal is calling the C compiler. However, in most cases
it is actually GHC itself which calls the C compiler. To make sure
that the right compiler is used in those cases, we have to pass
`-pgmc` and friends to GHC. This matches what rules_haskell does for
non cabal targets.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
