### PR TITLE
Randomize postgres ports in compatibility tests

### DIFF
--- a/compatibility/bazel_tools/client_server/with-postgres/BUILD
+++ b/compatibility/bazel_tools/client_server/with-postgres/BUILD
@@ -11,6 +11,7 @@ da_haskell_library(
         "directory",
         "extra",
         "filepath",
+        "network",
         "process",
         "safe-exceptions",
         "text",


### PR DESCRIPTION
While the tests are exclusive and I’ve kept them exclusive for
resource usage, the hardcoded port numbers can still cause issues if
for whatever reason you have a postgres instance running outside of
Bazel. This could happen because you simply have a local postgres
instance for testing other things or, what seems to have happened on
CI, due to a leftover postgres instance from a previous test.

While we should do something about the latter, this at least gets us
into a situation where the node isn’t completely broken at this point.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
