### PR TITLE
Simplify and clarify the public interface to Speedy.

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -167,8 +167,8 @@ class Context(val contextId: Context.ContextId) {
       Identifier(assert(PackageId.fromString(pkgId)), assert(QualifiedName.fromString(name))),
     ).map { machine =>
       ScenarioRunner(machine).run() match {
-        case Right((diff @ _, steps @ _, ledger)) =>
-          (ledger, machine, Right(machine.toSValue))
+        case Right((diff @ _, steps @ _, ledger, value)) =>
+          (ledger, machine, Right(value))
         case Left((err, ledger)) =>
           (ledger, machine, Left(err))
       }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -285,9 +285,10 @@ final class Engine {
       machine: Machine,
       time: Time.Timestamp
   ): Result[(Tx.Transaction, Tx.Metadata)] = {
-    while (!machine.isFinal) {
+    var finished: Boolean = false
+    while (!finished) {
       machine.run() match {
-        case SResultFinalValue(_) => ()
+        case SResultFinalValue(_) => finished = true
 
         case SResultError(err) =>
           return ResultError(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -133,6 +133,11 @@ object Speedy {
       case _ =>
     }
 
+    def setExpressionToEvaluate(expr: SExpr): Unit = {
+      ctrl = expr
+      returnValue = null
+    }
+
     /** Run a machine until we get a result: either a final-value or a request for data, with a callback */
     def run(): SResult = {
       // Note: We have an outer and inner while loop.
@@ -258,18 +263,7 @@ object Speedy {
               throw DamlEArithmeticError(e.getMessage)
           }
       }
-
     }
-
-    def toValue: V[V.ContractId] =
-      toSValue.toValue
-
-    def toSValue: SValue =
-      if (!isFinal) {
-        crash("toSValue: machine not final")
-      } else {
-        returnValue
-      }
 
     def print(count: Int) = {
       println(s"Step: $count")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -30,13 +30,10 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
       submissionTime = Time.Timestamp.now(),
       transactionSeed = None,
     )
-    while (!machine.isFinal) {
-      machine.run match {
-        case SResultFinalValue(_) => ()
-        case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
-      }
+    machine.run() match {
+      case SResultFinalValue(v) => v
+      case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
     }
-    machine.toSValue
   }
 
   "evaluator behaves responsibly" should {
@@ -148,13 +145,11 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
       )
     }
     "interpret" in {
-      while (!machine.isFinal) {
-        machine.run match {
-          case SResultFinalValue(_) => ()
-          case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
-        }
+      val value = machine.run() match {
+        case SResultFinalValue(v) => v
+        case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }
-      machine.toSValue match {
+      value match {
         case SValue.SList(lst) =>
           lst.length shouldBe 100000
           val arr = lst.toImmArray

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1459,13 +1459,13 @@ object SBuiltinTest {
     )
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {
-      while (!machine.isFinal) machine.run() match {
-        case SResultFinalValue(_) => ()
+      val value = machine.run() match {
+        case SResultFinalValue(v) => v
         case SResultError(err) => throw Goodbye(err)
         case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }
 
-      Right(machine.toSValue)
+      Right(value)
     } catch { case Goodbye(err) => Left(err) }
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -260,13 +260,12 @@ object SpeedyTest {
     )
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {
-      while (!machine.isFinal) machine.run() match {
-        case SResultFinalValue(_) => ()
+      val value = machine.run() match {
+        case SResultFinalValue(v) => v
         case SResultError(err) => throw Goodbye(err)
         case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
       }
-
-      Right(machine.toSValue)
+      Right(value)
     } catch {
       case Goodbye(err) => Left(err)
     }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -13,7 +13,6 @@ import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SExpr.SEImportValue
 import com.daml.lf.speedy.{SBuiltin, SExpr, SValue}
-import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.value.Value
 import com.daml.lf.value.TypedValueGenerators.genAddend
 import com.daml.lf.value.ValueGenerators.{absCoidV0Gen, comparableAbsCoidsGen}
@@ -475,17 +474,17 @@ class OrderingSpec
     new util.ArrayList[X](as.asJava)
 
   private val txSeed = crypto.Hash.hashPrivateKey("SBuiltinTest")
-  private def dummyMachine = Speedy.Machine fromExpr (
-    expr = e"NA:na ()",
+  private def initMachine(expr: SExpr) = Speedy.Machine fromSExpr (
+    sexpr = expr,
     compiledPackages = PureCompiledPackages(Map.empty, Map.empty),
-    scenario = false,
     Time.Timestamp.now(),
-    Some(txSeed),
+    InitialSeeding(Some(txSeed)),
+    Set.empty,
   )
 
   private def translatePrimValue(v: Value[Value.AbsoluteContractId]) = {
-    val machine = dummyMachine
-    machine.ctrl = SEImportValue(v)
+    val expr = SEImportValue(v)
+    val machine = initMachine(expr)
     machine.run() match {
       case SResultFinalValue(value) => value
       case _ => throw new Error(s"error while translating value $v")

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -411,14 +411,12 @@ object Repl {
                 transactionSeed = None
               )
             val startTime = System.nanoTime()
-            var finished: SValue = null
-            var errored = false
-            machine.run match {
+            val valueOpt = machine.run match {
               case SResultError(err) =>
                 println(prettyError(err, machine.ptx).render(128))
-                errored = true
+                None
               case SResultFinalValue(v) =>
-                finished = v
+                Some(v)
               case other =>
                 sys.error("unimplemented callback: " + other.toString)
             }
@@ -426,10 +424,12 @@ object Repl {
             val diff = (endTime - startTime) / 1000 / 1000
             machine.print(1)
             println(s"time: ${diff}ms")
-            if (!errored) {
-              val result = prettyValue(true)(finished.toValue).render(128)
-              println("result:")
-              println(result)
+            valueOpt match {
+              case None => ()
+              case Some(value) =>
+                val result = prettyValue(true)(value.toValue).render(128)
+                println("result:")
+                println(result)
             }
           case Some(_) =>
             println("Error: " + id + " not a value.")

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -410,26 +410,21 @@ object Repl {
                 submissionTime = Time.Timestamp.now(),
                 transactionSeed = None
               )
-            var count = 0
             val startTime = System.nanoTime()
             var finished: SValue = null
             var errored = false
-            while (finished == null && !errored) {
-              machine.run match {
-                case SResultError(err) =>
-                  println(prettyError(err, machine.ptx).render(128))
-                  errored = true
-                case SResultFinalValue(v) =>
-                  finished = v
-                case other =>
-                  sys.error("unimplemented callback: " + other.toString)
-              }
-              count += 1
+            machine.run match {
+              case SResultError(err) =>
+                println(prettyError(err, machine.ptx).render(128))
+                errored = true
+              case SResultFinalValue(v) =>
+                finished = v
+              case other =>
+                sys.error("unimplemented callback: " + other.toString)
             }
             val endTime = System.nanoTime()
             val diff = (endTime - startTime) / 1000 / 1000
-            machine.print(count)
-            println(s"steps: $count")
+            machine.print(1)
             println(s"time: ${diff}ms")
             if (!errored) {
               val result = prettyValue(true)(finished.toValue).render(128)

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -51,7 +51,7 @@ class CollectAuthorityState {
     val machine = buildMachine(expr)
     ScenarioRunner(machine).run() match {
       case Left((err, _)) => sys.error(prettyError(err, machine.ptx).render(80))
-      case Right((_, steps, _)) => steps
+      case Right((_, steps, _, _)) => steps
     }
   }
 }

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -23,9 +23,12 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
         transactionSeed = None
       )
       val sr = ScenarioRunner(m, _ + "-XXX")
-      sr.run()
-      m.ctrl shouldBe null
-      m.returnValue shouldBe SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX"))
+      sr.run() match {
+        case Right((_, _, _, value)) =>
+          value shouldBe SValue.SParty(Ref.Party.assertFromString("foo-bar-XXX"))
+        case res =>
+          sys.error(s"unexpected result $res")
+      }
     }
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -309,8 +309,7 @@ class Runner(
       }
 
     def run(expr: SExpr): Future[SValue] = {
-      machine.ctrl = expr
-      machine.returnValue = null
+      machine.setExpressionToEvaluate(expr)
       stepToValue()
         .fold(Future.failed, Future.successful)
         .flatMap {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -127,7 +127,7 @@ object ScenarioLoader {
     ScenarioRunner(speedyMachine).run match {
       case Left(e) =>
         throw new RuntimeException(s"error running scenario $scenarioRef in scenario $e")
-      case Right((_, _, l)) => l
+      case Right((_, _, l, _)) => l
     }
   }
 


### PR DESCRIPTION
- Remove `isFinal`. A client just uses `run()`.
- Remove `toSValue`. The value in available in `SResultFinalValue(v: SValue)`.
- A client never directly access the `.ctrl` (or `.returnValue`) components.
- A client may use `setExpressionToEvaluate(expr)` to evaluate a new expression on an existing machine.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
