### PR TITLE
Add /etc/nsswitch.conf to our Dockerfile

### DIFF
--- a/ci/docker/daml-sdk/Dockerfile
+++ b/ci/docker/daml-sdk/Dockerfile
@@ -1,6 +1,10 @@
 FROM openjdk:8u212-alpine
 RUN apk add --no-cache curl bash
 ARG VERSION
+# This is needed to get the DNS requests
+# from Haskell binaries to succeed.
+# Otherwise they fail to even resolve localhost.
+RUN echo 'hosts: files dns' > /etc/nsswitch.conf
 RUN addgroup -S daml && adduser -S daml -G daml
 USER daml
 RUN curl https://get.daml.com | sh -s $VERSION \


### PR DESCRIPTION
As mentioned in the comment, this is required to get DNS requests to
work. This is more important than one might realize at first:

`daml start` tries to make an HTTP request to localhost:7500 to wait
for Navigator to start up. However, in our docker image, these
requests currently fail completely since they fail to resolve
`localhost`. This stops all following steps, in particular,
`init-script` and the JSON API from starting up.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
