### PR TITLE
Add metric for the translation of the create argument for contract lookups

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -262,7 +262,7 @@ class Metrics(val registry: MetricRegistry) {
           registry.timer(prefix :+ "lookup_ledger_configuration")
         val lookupKey: Timer = registry.timer(prefix :+ "lookup_key")
         val lookupActiveContract: Timer = registry.timer(prefix :+ "lookup_active_contract")
-        val translateCreateArgument: Timer = registry.timer(prefix :+ "translate_create_argument")
+        val lookupActiveContractValueTranslation: Timer = registry.timer(prefix :+ "lookup_active_contract_value_translation")
         val lookupMaximumLedgerTime: Timer = registry.timer(prefix :+ "lookup_maximum_ledger_time")
         val getParties: Timer = registry.timer(prefix :+ "get_parties")
         val listKnownParties: Timer = registry.timer(prefix :+ "list_known_parties")

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -262,6 +262,7 @@ class Metrics(val registry: MetricRegistry) {
           registry.timer(prefix :+ "lookup_ledger_configuration")
         val lookupKey: Timer = registry.timer(prefix :+ "lookup_key")
         val lookupActiveContract: Timer = registry.timer(prefix :+ "lookup_active_contract")
+        val translateCreateArgument: Timer = registry.timer(prefix :+ "translate_create_argument")
         val lookupMaximumLedgerTime: Timer = registry.timer(prefix :+ "lookup_maximum_ledger_time")
         val getParties: Timer = registry.timer(prefix :+ "get_parties")
         val listKnownParties: Timer = registry.timer(prefix :+ "list_known_parties")

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -84,6 +84,7 @@ private class JdbcLedgerDao(
     executionContext: ExecutionContext,
     eventsPageSize: Int,
     performPostCommitValidation: Boolean,
+    metrics: Metrics,
 )(implicit logCtx: LoggingContext)
     extends LedgerDao {
 
@@ -871,7 +872,7 @@ private class JdbcLedgerDao(
     new TransactionsReader(dbDispatcher, executionContext, eventsPageSize)
 
   private val contractsReader: ContractsReader =
-    ContractsReader(dbDispatcher, executionContext, dbType)
+    ContractsReader(dbDispatcher, executionContext, dbType, metrics)
 
   override val completions: CommandCompletionsReader =
     new CommandCompletionsReader(dbDispatcher)
@@ -952,6 +953,7 @@ object JdbcLedgerDao {
         ExecutionContext.fromExecutor(executor),
         eventsPageSize,
         validate,
+        metrics
       )
 
   sealed trait Queries {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
@@ -63,7 +63,7 @@ private[dao] sealed abstract class ContractsReader(
         Contract(
           template = Identifier.assertFromString(templateId),
           arg = Timed.value(
-            metrics.daml.index.db.translateCreateArgument,
+            metrics.daml.index.db.lookupActiveContractValueTranslation,
             deserialize(
               stream = createArgument,
               errorContext = s"Failed to deserialize create argument for contract $contractId",

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 import anorm.SqlParser.{binaryStream, str}
 import anorm.{Row, RowParser, SimpleSql, SqlStringInterpolation, ~}
 import com.daml.ledger.participant.state.index.v2.ContractStore
+import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.Conversions._
 import com.daml.platform.store.DbType
 import com.daml.platform.store.dao.DbDispatcher
@@ -22,6 +23,7 @@ private[dao] sealed abstract class ContractsReader(
     val committedContracts: PostCommitValidationData,
     dispatcher: DbDispatcher,
     executionContext: ExecutionContext,
+    metrics: Metrics,
 ) extends ContractStore {
 
   import ContractsReader._
@@ -52,6 +54,25 @@ private[dao] sealed abstract class ContractsReader(
       }
       .map(_.get)(executionContext)
 
+  // The contracts table _does not_ store agreement texts as they are
+  // unnecessary for interpretation and validation. The contracts returned
+  // from this table will _always_ have an empty agreement text.
+  private val contractRowParser: RowParser[Contract] =
+    str("contract_id") ~ str("template_id") ~ binaryStream("create_argument") map {
+      case contractId ~ templateId ~ createArgument =>
+        Contract(
+          template = Identifier.assertFromString(templateId),
+          arg = Timed.value(
+            metrics.daml.index.db.translateCreateArgument,
+            deserialize(
+              stream = createArgument,
+              errorContext = s"Failed to deserialize create argument for contract $contractId",
+            )
+          ),
+          agreementText = ""
+        )
+    }
+
 }
 
 object ContractsReader {
@@ -60,11 +81,12 @@ object ContractsReader {
       dispatcher: DbDispatcher,
       executionContext: ExecutionContext,
       dbType: DbType,
+      metrics: Metrics,
   ): ContractsReader = {
     val table = ContractsTable(dbType)
     dbType match {
-      case DbType.Postgres => new Postgresql(table, dispatcher, executionContext)
-      case DbType.H2Database => new H2Database(table, dispatcher, executionContext)
+      case DbType.Postgres => new Postgresql(table, dispatcher, executionContext, metrics)
+      case DbType.H2Database => new H2Database(table, dispatcher, executionContext, metrics)
     }
   }
 
@@ -72,7 +94,8 @@ object ContractsReader {
       table: ContractsTable,
       dispatcher: DbDispatcher,
       executionContext: ExecutionContext,
-  ) extends ContractsReader(table, dispatcher, executionContext) {
+      metrics: Metrics,
+  ) extends ContractsReader(table, dispatcher, executionContext, metrics) {
     override protected def lookupContractKeyQuery(
         submitter: Party,
         key: Key,
@@ -84,29 +107,14 @@ object ContractsReader {
       table: ContractsTable,
       dispatcher: DbDispatcher,
       executionContext: ExecutionContext,
-  ) extends ContractsReader(table, dispatcher, executionContext) {
+      metrics: Metrics,
+  ) extends ContractsReader(table, dispatcher, executionContext, metrics) {
     override protected def lookupContractKeyQuery(
         submitter: Party,
         key: Key,
     ): SimpleSql[Row] =
       SQL"select participant_contracts.contract_id from #$contractsTable where array_contains(create_stakeholders, $submitter) and contract_witness = $submitter and create_key_hash = ${key.hash}"
   }
-
-  // The contracts table _does not_ store agreement texts as they are
-  // unnecessary for interpretation and validation. The contracts returned
-  // from this table will _always_ have an empty agreement text.
-  private val contractRowParser: RowParser[Contract] =
-    str("contract_id") ~ str("template_id") ~ binaryStream("create_argument") map {
-      case contractId ~ templateId ~ createArgument =>
-        Contract(
-          template = Identifier.assertFromString(templateId),
-          arg = deserialize(
-            stream = createArgument,
-            errorContext = s"Failed to deserialize create argument for contract $contractId",
-          ),
-          agreementText = ""
-        )
-    }
 
   private val contractsTable = "participant_contracts natural join participant_contract_witnesses"
 


### PR DESCRIPTION
CHANGELOG_BEGIN
[Ledger Integration Kit] Added new metric
``daml.index.db.translate_create_argument`` to measure the duration of
the translation of the create argument from byte array to DAML LF value
that can be used by the DAML engine.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
