### PR TITLE
Simplify how speedy returns its final result.

### DIFF
--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -477,14 +477,13 @@ class OrderingSpec
   private def initMachine(expr: SExpr) = Speedy.Machine fromSExpr (
     sexpr = expr,
     compiledPackages = PureCompiledPackages(Map.empty, Map.empty),
-    Time.Timestamp.now(),
-    InitialSeeding(Some(txSeed)),
-    Set.empty,
+    submissionTime = Time.Timestamp.now(),
+    seeding = InitialSeeding(Some(txSeed)),
+    globalCids = Set.empty,
   )
 
   private def translatePrimValue(v: Value[Value.AbsoluteContractId]) = {
-    val expr = SEImportValue(v)
-    val machine = initMachine(expr)
+    val machine = initMachine(SEImportValue(v))
     machine.run() match {
       case SResultFinalValue(value) => value
       case _ => throw new Error(s"error while translating value $v")


### PR DESCRIPTION
- Have a special continuation `KFinished` which is pushed on the initially empty `kontStack`.
- `KFinished.execute` throws `SpeedyHungry` when it has the `SResultFinalValue`.
- This unifies the behaviour w.r.t other kinds of `SResult`.
- The `kontStack` is never empty during evaluation.
- So we no longer require an`isFinal` test, and so the inner loop is a little tighter.

The performance improvement here is marginal (1% maybe). But the clarity is better. Also, it's a nice invariant that there is always at least one continuation on the stack. An invariant which will be useful in a change planned to improve handling of `KPop` and `KLocation`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
