### PR TITLE
detect cancellation in notify-user

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -579,7 +579,7 @@ jobs:
           PR_BRANCH: $(pr.branch)
 
   - job: notify_user
-    condition: eq(variables['Build.Reason'], 'PullRequest')
+    condition: and(eq(variables['Build.Reason'], 'PullRequest'), not(canceled()))
     dependsOn:
       - git_sha
       - collect_build_data


### PR DESCRIPTION
This PR changes the notify_user job to not run when the job has been canceled, which happens mostly when we push new code.

Not sure how I failed to see the `canceled` function in the past, but this does seem to do exactly what we want.

CHANGELOG_BEGIN
CHANGELOG_END