### PR TITLE
scala/bindings: Remove the unnecessary `@silent` annotation.

### DIFF
--- a/language-support/scala/bindings/BUILD.bazel
+++ b/language-support/scala/bindings/BUILD.bazel
@@ -12,7 +12,6 @@ da_scala_library(
     srcs = glob(["src/main/**/*.scala"]),
     plugins = [
         "@maven//:org_spire_math_kind_projector_2_12",
-        "@maven//:com_github_ghik_silencer_plugin_2_12_11",
     ],
     scalacopts = [
         "-Xsource:2.13",
@@ -24,14 +23,12 @@ da_scala_library(
     exports = [
         "//daml-lf/data",
         "//ledger-api/grpc-definitions:ledger-api-scalapb",
-        "@maven//:com_github_ghik_silencer_lib_2_12_11",
         "@maven//:io_grpc_grpc_core",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],
     deps = [
         "//daml-lf/data",
         "//ledger-api/grpc-definitions:ledger-api-scalapb",
-        "@maven//:com_github_ghik_silencer_lib_2_12_11",
         "@maven//:io_grpc_grpc_core",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Value.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Value.scala
@@ -7,13 +7,12 @@ import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
 import com.daml.ledger.api.v1.value.Value.{Sum => VSum}
 import com.daml.ledger.api.v1.{value => rpcvalue}
 import com.daml.ledger.client.binding.{Primitive => P}
+import scalaz.std.option._
+import scalaz.syntax.traverse._
 
 import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
 import scala.{specialized => sp}
-import scalaz.std.option._
-import scalaz.syntax.traverse._
-import com.github.ghik.silencer.silent
 
 sealed trait DamlCodecs // always include `object DamlCodecs` in implicit search
 
@@ -52,8 +51,6 @@ object Value {
   @SuppressWarnings(Array("org.wartremover.warts.LeakingSealed"))
   private[binding] trait InternalImpl[A] extends Value[A]
 
-  // TODO remove dependency on deprecated .name and drop this @silent
-  @silent
   private[binding] def splattedVariantId(
       baseVariantId: rpcvalue.Identifier,
       caseName: String
@@ -94,7 +91,7 @@ object DamlCodecs extends encoding.ValuePrimitiveEncoding[Value] {
   }
 
   implicit override val valueTimestamp: Value[P.Timestamp] = P.Timestamp.subst {
-    import com.daml.api.util.TimestampConversion.{microsToInstant, instantToMicros}
+    import com.daml.api.util.TimestampConversion.{instantToMicros, microsToInstant}
     fromArgumentValueFuns({
       case ts @ VSum.Timestamp(_) => Some(microsToInstant(ts))
       case _ => None


### PR DESCRIPTION
This means we can remove the dependency on `silencer-lib`, which means
that users don't have to upgrade to Scala v2.12.11.

### Changelog

- **[Scala Bindings]**: We no longer require users to upgrade to Scala v2.12.11.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
