### PR TITLE
Added minor logging to scala command client

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
@@ -58,7 +58,7 @@ final class CommandClient(
       submit(token)(submitRequest)
 
   private def submit(token: Option[String])(submitRequest: SubmitRequest): Future[Empty] = {
-    logger.debug(s"Invoking grpc-submission on commandId=${submitRequest.commands.map(_.commandId).getOrElse("no-command-id")}")
+    logger.debug("Invoking grpc-submission on commandId={}", submitRequest.commands.map(_.commandId).getOrElse("no-command-id"))
     LedgerClient
       .stub(commandSubmissionService, token)
       .submit(submitRequest)


### PR DESCRIPTION
Before, the scala command client did not log anything when a command was
leaving the application. Now, we get a small debug message that logs the
command id, which is going to be helpful for debugging and tracing
purposes.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
