### PR TITLE
postgresql-testing: Use a new, random database name every time.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -821,12 +821,14 @@ dev_env_tool(
     nix_label = "@postgresql_nix",
     nix_paths = [
         "bin/createdb",
+        "bin/dropdb",
         "bin/initdb",
         "bin/pg_ctl",
         "bin/postgres",
     ],
     tools = [
         "createdb",
+        "dropdb",
         "initdb",
         "pg_ctl",
         "postgres",
@@ -845,6 +847,7 @@ dev_env_tool(
     },
     win_paths = [
         "bin/createdb.exe",
+        "bin/dropdb.exe",
         "bin/initdb.exe",
         "bin/pg_ctl.exe",
         "bin/postgres.exe",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -820,8 +820,8 @@ dev_env_tool(
     ],
     nix_label = "@postgresql_nix",
     nix_paths = [
-        "bin/initdb",
         "bin/createdb",
+        "bin/initdb",
         "bin/pg_ctl",
         "bin/postgres",
     ],
@@ -829,7 +829,7 @@ dev_env_tool(
         "createdb",
         "initdb",
         "pg_ctl",
-        "postgresql",
+        "postgres",
     ],
     win_include = [
         "mingw64/bin",
@@ -844,8 +844,8 @@ dev_env_tool(
         "mingw64/share": "share",
     },
     win_paths = [
-        "bin/initdb.exe",
         "bin/createdb.exe",
+        "bin/initdb.exe",
         "bin/pg_ctl.exe",
         "bin/postgres.exe",
     ],

--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
@@ -4,15 +4,15 @@
 package com.daml.extractor.services
 
 import cats.effect.{ContextShift, IO}
-import com.daml.lf.data.Ref.Party
 import com.daml.extractor.Extractor
 import com.daml.extractor.config.{ExtractorConfig, SnapshotEndSetting}
 import com.daml.extractor.targets.PostgreSQLTarget
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import com.daml.lf.data.Ref.Party
 import com.daml.platform.sandbox.services.SandboxFixture
 import com.daml.ports.Port
-import com.daml.testing.postgresql.PostgresAround
+import com.daml.testing.postgresql.{PostgresAround, PostgresAroundSuite}
 import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor.Aux
@@ -22,7 +22,7 @@ import scalaz.OneAnd
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
 
-trait ExtractorFixture extends SandboxFixture with PostgresAround with Types {
+trait ExtractorFixture extends SandboxFixture with PostgresAroundSuite with Types {
   self: Suite =>
 
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)

--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
@@ -49,7 +49,7 @@ trait ExtractorFixture extends SandboxFixture with PostgresAround with Types {
   protected def configureExtractor(ec: ExtractorConfig): ExtractorConfig = ec
 
   protected def target: PostgreSQLTarget = PostgreSQLTarget(
-    connectUrl = postgresFixture.jdbcUrl,
+    connectUrl = postgresJdbcUrl.url,
     user = "test",
     password = "",
     outputFormat = outputFormat,

--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
@@ -50,8 +50,8 @@ trait ExtractorFixture extends SandboxFixture with PostgresAround with Types {
 
   protected def target: PostgreSQLTarget = PostgreSQLTarget(
     connectUrl = postgresJdbcUrl.url,
-    user = "test",
-    password = "",
+    user = PostgresAround.userName,
+    password = PostgresAround.password,
     outputFormat = outputFormat,
     schemaPerPackage = false,
     mergeIdentical = false,

--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
@@ -49,7 +49,7 @@ trait ExtractorFixture extends SandboxFixture with PostgresAroundSuite with Type
   protected def configureExtractor(ec: ExtractorConfig): ExtractorConfig = ec
 
   protected def target: PostgreSQLTarget = PostgreSQLTarget(
-    connectUrl = postgresJdbcUrl.url,
+    connectUrl = postgresDatabase.url,
     user = PostgresAround.userName,
     password = PostgresAround.password,
     outputFormat = outputFormat,

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
@@ -20,7 +20,7 @@ class HttpServiceWithPostgresIntTest
   // has to be lazy because postgresFixture is NOT initialized yet
   private lazy val jdbcConfig_ = JdbcConfig(
     driver = "org.postgresql.Driver",
-    url = postgresJdbcUrl.url,
+    url = postgresDatabase.url,
     user = "test",
     password = "",
     createSchema = true)

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/HttpServiceWithPostgresIntTest.scala
@@ -20,7 +20,7 @@ class HttpServiceWithPostgresIntTest
   // has to be lazy because postgresFixture is NOT initialized yet
   private lazy val jdbcConfig_ = JdbcConfig(
     driver = "org.postgresql.Driver",
-    url = postgresFixture.jdbcUrl,
+    url = postgresJdbcUrl.url,
     user = "test",
     password = "",
     createSchema = true)

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
@@ -15,11 +15,11 @@ object MainWithEphemeralPostgresql extends PostgresAround {
         .getOrElse(sys.exit(1))
 
     startEphemeralPostgres()
-    val jdbcUrl = createNewRandomDatabase()
+    val database = createNewRandomDatabase()
     sys.addShutdownHook(stopAndCleanUpPostgres())
     val config = originalConfig.copy(
-      participants = originalConfig.participants.map(_.copy(serverJdbcUrl = jdbcUrl.url)),
-      extra = ExtraConfig(jdbcUrl = Some(jdbcUrl.url)),
+      participants = originalConfig.participants.map(_.copy(serverJdbcUrl = database.url)),
+      extra = ExtraConfig(jdbcUrl = Some(database.url)),
     )
     new ProgramResource(new Runner("SQL Ledger", SqlLedgerFactory).owner(config)).run()
   }

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
@@ -15,11 +15,11 @@ object MainWithEphemeralPostgresql extends PostgresAround {
         .getOrElse(sys.exit(1))
 
     startEphemeralPostgres()
-    createNewDatabase()
+    val jdbcUrl = createNewRandomDatabase()
     sys.addShutdownHook(stopAndCleanUpPostgres())
     val config = originalConfig.copy(
-      participants = originalConfig.participants.map(_.copy(serverJdbcUrl = postgresJdbcUrl.url)),
-      extra = ExtraConfig(jdbcUrl = Some(postgresJdbcUrl.url)),
+      participants = originalConfig.participants.map(_.copy(serverJdbcUrl = jdbcUrl.url)),
+      extra = ExtraConfig(jdbcUrl = Some(jdbcUrl.url)),
     )
     new ProgramResource(new Runner("SQL Ledger", SqlLedgerFactory).owner(config)).run()
   }

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
@@ -17,9 +17,8 @@ object MainWithEphemeralPostgresql extends PostgresAround {
     startEphemeralPostgres()
     sys.addShutdownHook(stopAndCleanUpPostgres())
     val config = originalConfig.copy(
-      participants =
-        originalConfig.participants.map(_.copy(serverJdbcUrl = postgresFixture.jdbcUrl)),
-      extra = ExtraConfig(jdbcUrl = Some(postgresFixture.jdbcUrl)),
+      participants = originalConfig.participants.map(_.copy(serverJdbcUrl = postgresJdbcUrl.url)),
+      extra = ExtraConfig(jdbcUrl = Some(postgresJdbcUrl.url)),
     )
     new ProgramResource(new Runner("SQL Ledger", SqlLedgerFactory).owner(config)).run()
   }

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
@@ -15,6 +15,7 @@ object MainWithEphemeralPostgresql extends PostgresAround {
         .getOrElse(sys.exit(1))
 
     startEphemeralPostgres()
+    createNewDatabase()
     sys.addShutdownHook(stopAndCleanUpPostgres())
     val config = originalConfig.copy(
       participants = originalConfig.participants.map(_.copy(serverJdbcUrl = postgresJdbcUrl.url)),

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/PostgresqlSqlLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/PostgresqlSqlLedgerReaderWriterIntegrationSpec.scala
@@ -15,8 +15,8 @@ class PostgresqlSqlLedgerReaderWriterIntegrationSpec
 
   override protected def jdbcUrl(id: String): String = {
     if (!databases.contains(id)) {
-      val jdbcUrl = createNewDatabase(id).jdbcUrl
-      databases += id -> jdbcUrl
+      val jdbcUrl = createNewDatabase(id)
+      databases += id -> jdbcUrl.url
     }
     databases(id)
   }

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/PostgresqlSqlLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/PostgresqlSqlLedgerReaderWriterIntegrationSpec.scala
@@ -15,8 +15,8 @@ class PostgresqlSqlLedgerReaderWriterIntegrationSpec
 
   override protected def jdbcUrl(id: String): String = {
     if (!databases.contains(id)) {
-      val jdbcUrl = createNewDatabase(id)
-      databases += id -> jdbcUrl.url
+      val database = createNewDatabase(id)
+      databases += id -> database.url
     }
     databases(id)
   }

--- a/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/LedgerFactories.scala
+++ b/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/LedgerFactories.scala
@@ -47,7 +47,7 @@ object LedgerFactories {
           case `mem` =>
             ResourceOwner.successful(None)
           case `sql` =>
-            PostgresResource.owner().map(jdbcUrl => Some(jdbcUrl.url))
+            PostgresResource.owner().map(database => Some(database.url))
         }
         server <- SandboxServer.owner(sandboxConfig(jdbcUrl, darFiles))
         channel <- GrpcClientResource.owner(server.port)

--- a/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/LedgerFactories.scala
+++ b/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/LedgerFactories.scala
@@ -5,10 +5,10 @@ package com.daml.platform.sandbox.perf
 
 import java.io.File
 
-import com.daml.lf.archive.UniversalArchiveReader
-import com.daml.lf.data.Ref
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.testing.utils.{OwnedResource, Resource}
+import com.daml.lf.archive.UniversalArchiveReader
+import com.daml.lf.data.Ref
 import com.daml.platform.common.LedgerIdMode
 import com.daml.platform.sandbox.SandboxServer
 import com.daml.platform.sandbox.config.SandboxConfig
@@ -47,7 +47,7 @@ object LedgerFactories {
           case `mem` =>
             ResourceOwner.successful(None)
           case `sql` =>
-            PostgresResource.owner().map(fixture => Some(fixture.jdbcUrl))
+            PostgresResource.owner().map(jdbcUrl => Some(jdbcUrl.url))
         }
         server <- SandboxServer.owner(sandboxConfig(jdbcUrl, darFiles))
         channel <- GrpcClientResource.owner(server.port)

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
@@ -5,11 +5,11 @@ package com.daml.platform.sandbox
 
 import akka.stream.Materializer
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.api.util.TimeProvider
-import com.daml.lf.data.ImmArray
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.testing.utils.{OwnedResource, Resource}
+import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.lf.data.ImmArray
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.common.LedgerIdMode
@@ -60,10 +60,10 @@ object LedgerResource {
   ): Resource[Ledger] =
     new OwnedResource(
       for {
-        postgres <- PostgresResource.owner()
+        jdbcUrl <- PostgresResource.owner()
         ledger <- SqlLedger.owner(
           serverRole = ServerRole.Testing(testClass),
-          jdbcUrl = postgres.jdbcUrl,
+          jdbcUrl = jdbcUrl.url,
           ledgerId = LedgerIdMode.Static(ledgerId),
           participantId = participantId,
           timeProvider = timeProvider,

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
@@ -60,10 +60,10 @@ object LedgerResource {
   ): Resource[Ledger] =
     new OwnedResource(
       for {
-        jdbcUrl <- PostgresResource.owner()
+        database <- PostgresResource.owner()
         ledger <- SqlLedger.owner(
           serverRole = ServerRole.Testing(testClass),
-          jdbcUrl = jdbcUrl.url,
+          jdbcUrl = database.url,
           ledgerId = LedgerIdMode.Static(ledgerId),
           participantId = participantId,
           timeProvider = timeProvider,

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/SandboxBackend.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/SandboxBackend.scala
@@ -15,7 +15,7 @@ object SandboxBackend {
 
   trait Postgresql { this: AbstractSandboxFixture =>
     override protected final def database: Option[ResourceOwner[DbInfo]] =
-      Some(PostgresResource.owner().map(resource => DbInfo(resource.jdbcUrl, DbType.Postgres)))
+      Some(PostgresResource.owner().map(jdbcUrl => DbInfo(jdbcUrl.url, DbType.Postgres)))
   }
 
   trait H2Database { this: AbstractSandboxFixture =>

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/SandboxBackend.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/SandboxBackend.scala
@@ -15,7 +15,7 @@ object SandboxBackend {
 
   trait Postgresql { this: AbstractSandboxFixture =>
     override protected final def database: Option[ResourceOwner[DbInfo]] =
-      Some(PostgresResource.owner().map(jdbcUrl => DbInfo(jdbcUrl.url, DbType.Postgres)))
+      Some(PostgresResource.owner().map(database => DbInfo(database.url, DbType.Postgres)))
   }
 
   trait H2Database { this: AbstractSandboxFixture =>

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
@@ -9,6 +9,7 @@ import com.daml.testing.postgresql.PostgresAround
 object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
     startEphemeralPostgres()
+    createNewDatabase()
     sys.addShutdownHook(stopAndCleanUpPostgres())
     SandboxMain.main(args ++ Array("--sql-backend-jdbcurl", postgresJdbcUrl.url))
   }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
@@ -10,6 +10,6 @@ object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
     startEphemeralPostgres()
     sys.addShutdownHook(stopAndCleanUpPostgres())
-    SandboxMain.main(args ++ Array("--sql-backend-jdbcurl", postgresFixture.jdbcUrl))
+    SandboxMain.main(args ++ Array("--sql-backend-jdbcurl", postgresJdbcUrl.url))
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
@@ -9,8 +9,8 @@ import com.daml.testing.postgresql.PostgresAround
 object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
     startEphemeralPostgres()
-    createNewDatabase()
+    val jdbcUrl = createNewRandomDatabase()
     sys.addShutdownHook(stopAndCleanUpPostgres())
-    SandboxMain.main(args ++ Array("--sql-backend-jdbcurl", postgresJdbcUrl.url))
+    SandboxMain.main(args ++ Array("--sql-backend-jdbcurl", jdbcUrl.url))
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
@@ -9,8 +9,8 @@ import com.daml.testing.postgresql.PostgresAround
 object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
     startEphemeralPostgres()
-    val jdbcUrl = createNewRandomDatabase()
+    val database = createNewRandomDatabase()
     sys.addShutdownHook(stopAndCleanUpPostgres())
-    SandboxMain.main(args ++ Array("--sql-backend-jdbcurl", jdbcUrl.url))
+    SandboxMain.main(args ++ Array("--sql-backend-jdbcurl", database.url))
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
@@ -9,8 +9,8 @@ import com.daml.testing.postgresql.PostgresAround
 object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
     startEphemeralPostgres()
-    createNewDatabase()
+    val jdbcUrl = createNewRandomDatabase()
     sys.addShutdownHook(stopAndCleanUpPostgres())
-    Main.main(args ++ Array("--sql-backend-jdbcurl", postgresJdbcUrl.url))
+    Main.main(args ++ Array("--sql-backend-jdbcurl", jdbcUrl.url))
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
@@ -10,6 +10,6 @@ object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
     startEphemeralPostgres()
     sys.addShutdownHook(stopAndCleanUpPostgres())
-    Main.main(args ++ Array("--sql-backend-jdbcurl", postgresFixture.jdbcUrl))
+    Main.main(args ++ Array("--sql-backend-jdbcurl", postgresJdbcUrl.url))
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
@@ -9,8 +9,8 @@ import com.daml.testing.postgresql.PostgresAround
 object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
     startEphemeralPostgres()
-    val jdbcUrl = createNewRandomDatabase()
+    val database = createNewRandomDatabase()
     sys.addShutdownHook(stopAndCleanUpPostgres())
-    Main.main(args ++ Array("--sql-backend-jdbcurl", jdbcUrl.url))
+    Main.main(args ++ Array("--sql-backend-jdbcurl", database.url))
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
@@ -9,6 +9,7 @@ import com.daml.testing.postgresql.PostgresAround
 object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
     startEphemeralPostgres()
+    createNewDatabase()
     sys.addShutdownHook(stopAndCleanUpPostgres())
     Main.main(args ++ Array("--sql-backend-jdbcurl", postgresJdbcUrl.url))
   }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackendPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackendPostgresql.scala
@@ -12,6 +12,6 @@ private[dao] trait JdbcLedgerDaoBackendPostgresql
     with PostgresAroundAll { this: Suite =>
 
   override protected val dbType: DbType = DbType.Postgres
-  override protected def jdbcUrl: String = postgresFixture.jdbcUrl
+  override protected def jdbcUrl: String = postgresJdbcUrl.url
 
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackendPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoBackendPostgresql.scala
@@ -12,6 +12,6 @@ private[dao] trait JdbcLedgerDaoBackendPostgresql
     with PostgresAroundAll { this: Suite =>
 
   override protected val dbType: DbType = DbType.Postgres
-  override protected def jdbcUrl: String = postgresJdbcUrl.url
+  override protected def jdbcUrl: String = postgresDatabase.url
 
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/persistence/PostgresIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/persistence/PostgresIT.scala
@@ -26,7 +26,7 @@ class PostgresIT extends AsyncWordSpec with Matchers with PostgresAroundAll with
     connectionProviderResource = HikariJdbcConnectionProvider
       .owner(
         ServerRole.Testing(getClass),
-        postgresJdbcUrl.url,
+        postgresDatabase.url,
         maxConnections = 4,
         new MetricRegistry,
       )
@@ -55,7 +55,7 @@ class PostgresIT extends AsyncWordSpec with Matchers with PostgresAroundAll with
   "Flyway" should {
     "execute initialisation script" in {
       newLoggingContext { implicit logCtx =>
-        new FlywayMigrations(postgresJdbcUrl.url).migrate()(DirectExecutionContext)
+        new FlywayMigrations(postgresDatabase.url).migrate()(DirectExecutionContext)
       }.map { _ =>
         connectionProvider.runSQL { conn =>
           def checkTableExists(table: String) = {

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/persistence/PostgresIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/persistence/PostgresIT.scala
@@ -26,7 +26,7 @@ class PostgresIT extends AsyncWordSpec with Matchers with PostgresAroundAll with
     connectionProviderResource = HikariJdbcConnectionProvider
       .owner(
         ServerRole.Testing(getClass),
-        postgresFixture.jdbcUrl,
+        postgresJdbcUrl.url,
         maxConnections = 4,
         new MetricRegistry,
       )
@@ -55,7 +55,7 @@ class PostgresIT extends AsyncWordSpec with Matchers with PostgresAroundAll with
   "Flyway" should {
     "execute initialisation script" in {
       newLoggingContext { implicit logCtx =>
-        new FlywayMigrations(postgresFixture.jdbcUrl).migrate()(DirectExecutionContext)
+        new FlywayMigrations(postgresJdbcUrl.url).migrate()(DirectExecutionContext)
       }.map { _ =>
         connectionProvider.runSQL { conn =>
           def checkTableExists(table: String) = {

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/identity/LedgerIdentityServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/identity/LedgerIdentityServiceIT.scala
@@ -5,9 +5,9 @@ package com.daml.platform.sandbox.services.identity
 
 import java.util.UUID
 
-import com.daml.lf.data.Ref
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundEach
+import com.daml.lf.data.Ref
 import com.daml.platform.common.LedgerIdMode
 import com.daml.platform.sandbox.SandboxBackend
 import com.daml.platform.sandbox.config.SandboxConfig
@@ -97,7 +97,7 @@ final class LedgerIdentityServicePostgresDynamicSharedPostgresIT
   override protected def config: SandboxConfig =
     super.config
       .copy(
-        jdbcUrl = Some(postgresFixture.jdbcUrl),
+        jdbcUrl = Some(postgresJdbcUrl.url),
         ledgerIdMode = Option(firstRunLedgerId).fold[LedgerIdMode](LedgerIdMode.Dynamic)(id =>
           LedgerIdMode.Static(LedgerId(Ref.LedgerString.assertFromString(id))))
       )

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/identity/LedgerIdentityServiceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/identity/LedgerIdentityServiceIT.scala
@@ -97,7 +97,7 @@ final class LedgerIdentityServicePostgresDynamicSharedPostgresIT
   override protected def config: SandboxConfig =
     super.config
       .copy(
-        jdbcUrl = Some(postgresJdbcUrl.url),
+        jdbcUrl = Some(postgresDatabase.url),
         ledgerIdMode = Option(firstRunLedgerId).fold[LedgerIdMode](LedgerIdMode.Dynamic)(id =>
           LedgerIdMode.Static(LedgerId(Ref.LedgerString.assertFromString(id))))
       )

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -6,15 +6,15 @@ package com.daml.platform.sandbox.stores.ledger.sql
 import java.nio.file.Paths
 import java.time.Instant
 
-import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.api.util.TimeProvider
 import com.daml.bazeltools.BazelRunfiles.rlocation
-import com.daml.lf.archive.DarReader
-import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.health.{Healthy, Unhealthy}
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
+import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.lf.archive.DarReader
+import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.common.LedgerIdMode
@@ -202,7 +202,7 @@ class SqlLedgerSpec
       SqlLedger
         .owner(
           serverRole = ServerRole.Testing(getClass),
-          jdbcUrl = postgresJdbcUrl.url,
+          jdbcUrl = postgresDatabase.url,
           ledgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
           participantId = participantId,
           timeProvider = TimeProvider.UTC,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -202,7 +202,7 @@ class SqlLedgerSpec
       SqlLedger
         .owner(
           serverRole = ServerRole.Testing(getClass),
-          jdbcUrl = postgresFixture.jdbcUrl,
+          jdbcUrl = postgresJdbcUrl.url,
           ledgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
           participantId = participantId,
           timeProvider = TimeProvider.UTC,

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/JdbcUrl.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/JdbcUrl.scala
@@ -1,0 +1,8 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.testing.postgresql
+
+final case class JdbcUrl(url: String) extends AnyVal {
+  override def toString: String = url
+}

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/JdbcUrl.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/JdbcUrl.scala
@@ -1,8 +1,0 @@
-// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-package com.daml.testing.postgresql
-
-final case class JdbcUrl(url: String) extends AnyVal {
-  override def toString: String = url
-}

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -103,8 +103,9 @@ trait PostgresAround {
     createNewDatabase(UUID.randomUUID().toString)
 
   protected def createNewDatabase(name: String): PostgresDatabase = {
-    createTestDatabase(name)
-    PostgresDatabase(hostName, fixture.port, userName, name)
+    val database = PostgresDatabase(hostName, fixture.port, userName, name)
+    createDatabase(database)
+    database
   }
 
   private def initializeDatabase(): Unit = run(
@@ -141,16 +142,28 @@ trait PostgresAround {
     ()
   }
 
-  private def createTestDatabase(name: String): Unit = run(
+  private def createDatabase(database: PostgresDatabase): Unit = run(
     "create the database",
     Tool.createdb,
-    "-h",
-    hostName,
-    "-U",
-    userName,
-    "-p",
-    fixture.port.toString,
-    name,
+    "--host",
+    database.hostName,
+    "--port",
+    database.port.toString,
+    "--username",
+    database.userName,
+    database.databaseName,
+  )
+
+  protected def dropDatabase(database: PostgresDatabase): Unit = run(
+    "drop a database",
+    Tool.dropdb,
+    "--host",
+    database.hostName,
+    "--port",
+    database.port.toString,
+    "--username",
+    database.userName,
+    database.databaseName,
   )
 
   private def run(description: String, tool: Tool, args: String*): Unit = {

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -99,12 +99,12 @@ trait PostgresAround {
     }
   }
 
-  protected def createNewRandomDatabase(): JdbcUrl =
+  protected def createNewRandomDatabase(): PostgresDatabase =
     createNewDatabase(UUID.randomUUID().toString)
 
-  protected def createNewDatabase(name: String): JdbcUrl = {
+  protected def createNewDatabase(name: String): PostgresDatabase = {
     createTestDatabase(name)
-    JdbcUrl(s"jdbc:postgresql://$hostName:${fixture.port}/$name?user=$userName")
+    PostgresDatabase(hostName, fixture.port, userName, name)
   }
 
   private def initializeDatabase(): Unit = run(

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -199,8 +199,9 @@ object PostgresAround {
   private val logger = LoggerFactory.getLogger(getClass)
 
   private val hostName = InetAddress.getLoopbackAddress.getHostName
-  private val userName = "test"
-  private val databaseName = "test"
+
+  val userName = "test"
+  val password = ""
 
   private class ProcessFailedException(
       description: String,

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -21,11 +21,6 @@ trait PostgresAround {
   @volatile
   private var fixture: PostgresFixture = _
 
-  @volatile
-  private var _jdbcUrl: Option[JdbcUrl] = None
-
-  protected def postgresJdbcUrl: JdbcUrl = _jdbcUrl.get
-
   private val started: AtomicBoolean = new AtomicBoolean(false)
 
   protected def startEphemeralPostgres(): Unit = {
@@ -49,7 +44,6 @@ trait PostgresAround {
         lockedPort.unlock()
         stopPostgres()
         deleteRecursively(tempDir)
-        _jdbcUrl = None
         fixture = null
         throw e
     }
@@ -60,7 +54,6 @@ trait PostgresAround {
     stopPostgres()
     deleteRecursively(fixture.tempDir)
     logger.info("PostgreSQL has stopped, and the data directory has been deleted.")
-    _jdbcUrl = None
     fixture = null
   }
 
@@ -106,10 +99,8 @@ trait PostgresAround {
     }
   }
 
-  protected def createNewDatabase(): JdbcUrl = {
-    _jdbcUrl = Some(createNewDatabase(UUID.randomUUID().toString))
-    postgresJdbcUrl
-  }
+  protected def createNewRandomDatabase(): JdbcUrl =
+    createNewDatabase(UUID.randomUUID().toString)
 
   protected def createNewDatabase(name: String): JdbcUrl = {
     createTestDatabase(name)

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundAll.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundAll.scala
@@ -3,10 +3,10 @@
 
 package com.daml.testing.postgresql
 
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{BeforeAndAfterAll, Suite}
 
-trait PostgresAroundAll extends PostgresAround with BeforeAndAfterAll {
-  self: org.scalatest.Suite =>
+trait PostgresAroundAll extends PostgresAroundSuite with BeforeAndAfterAll {
+  self: Suite =>
 
   override protected def beforeAll(): Unit = {
     // we start pg before running the rest because _generally_ the database

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundAll.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundAll.scala
@@ -9,10 +9,8 @@ trait PostgresAroundAll extends PostgresAroundSuite with BeforeAndAfterAll {
   self: Suite =>
 
   override protected def beforeAll(): Unit = {
-    // we start pg before running the rest because _generally_ the database
-    // needs to be up before everything else. this is relevant for
-    // ScenarioLoadingITPostgres at least. we could much with the mixin
-    // order but this was easier...
+    // We start PostgreSQL before calling `super` because _generally_ the database needs to be up
+    // before everything else.
     startEphemeralPostgres()
     createNewDatabase()
     super.beforeAll()

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundAll.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundAll.scala
@@ -14,6 +14,7 @@ trait PostgresAroundAll extends PostgresAround with BeforeAndAfterAll {
     // ScenarioLoadingITPostgres at least. we could much with the mixin
     // order but this was easier...
     startEphemeralPostgres()
+    createNewDatabase()
     super.beforeAll()
   }
 

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundEach.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundEach.scala
@@ -3,23 +3,34 @@
 
 package com.daml.testing.postgresql
 
-import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
-trait PostgresAroundEach extends PostgresAroundSuite with BeforeAndAfterEach {
+trait PostgresAroundEach
+    extends PostgresAroundSuite
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach {
   self: Suite =>
 
-  override protected def beforeEach(): Unit = {
-    // we start pg before running the rest because _generally_ the database
-    // needs to be up before everything else. this is relevant for
-    // ScenarioLoadingITPostgres at least. we could much with the mixin
-    // order but this was easier...
+  override protected def beforeAll(): Unit = {
+    // We start PostgreSQL before calling `super` because _generally_ the database needs to be up
+    // before everything else.
     startEphemeralPostgres()
+    super.beforeAll()
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    stopAndCleanUpPostgres()
+  }
+
+  override protected def beforeEach(): Unit = {
+    // We create the database before calling `super` for the same reasons as above.
     createNewDatabase()
     super.beforeEach()
   }
 
   override protected def afterEach(): Unit = {
     super.afterEach()
-    stopAndCleanUpPostgres()
+    dropDatabase()
   }
 }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundEach.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundEach.scala
@@ -3,10 +3,10 @@
 
 package com.daml.testing.postgresql
 
-import org.scalatest.BeforeAndAfterEach
+import org.scalatest.{BeforeAndAfterEach, Suite}
 
-trait PostgresAroundEach extends PostgresAround with BeforeAndAfterEach {
-  self: org.scalatest.Suite =>
+trait PostgresAroundEach extends PostgresAroundSuite with BeforeAndAfterEach {
+  self: Suite =>
 
   override protected def beforeEach(): Unit = {
     // we start pg before running the rest because _generally_ the database

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundEach.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundEach.scala
@@ -14,6 +14,7 @@ trait PostgresAroundEach extends PostgresAround with BeforeAndAfterEach {
     // ScenarioLoadingITPostgres at least. we could much with the mixin
     // order but this was easier...
     startEphemeralPostgres()
+    createNewDatabase()
     super.beforeEach()
   }
 

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundSuite.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundSuite.scala
@@ -17,4 +17,9 @@ trait PostgresAroundSuite extends PostgresAround {
     database = Some(createNewRandomDatabase())
     postgresDatabase
   }
+
+  protected def dropDatabase(): Unit = {
+    dropDatabase(postgresDatabase)
+    database = None
+  }
 }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundSuite.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundSuite.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.testing.postgresql
+
+import org.scalatest.Suite
+
+trait PostgresAroundSuite extends PostgresAround {
+  self: Suite =>
+
+  @volatile
+  private var _jdbcUrl: Option[JdbcUrl] = None
+
+  protected def postgresJdbcUrl: JdbcUrl = _jdbcUrl.get
+
+  protected def createNewDatabase(): JdbcUrl = {
+    _jdbcUrl = Some(createNewRandomDatabase())
+    postgresJdbcUrl
+  }
+}

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundSuite.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundSuite.scala
@@ -9,12 +9,12 @@ trait PostgresAroundSuite extends PostgresAround {
   self: Suite =>
 
   @volatile
-  private var _jdbcUrl: Option[JdbcUrl] = None
+  private var database: Option[PostgresDatabase] = None
 
-  protected def postgresJdbcUrl: JdbcUrl = _jdbcUrl.get
+  protected def postgresDatabase: PostgresDatabase = database.get
 
-  protected def createNewDatabase(): JdbcUrl = {
-    _jdbcUrl = Some(createNewRandomDatabase())
-    postgresJdbcUrl
+  protected def createNewDatabase(): PostgresDatabase = {
+    database = Some(createNewRandomDatabase())
+    postgresDatabase
   }
 }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresDatabase.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresDatabase.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.testing.postgresql
+
+import com.daml.ports.Port
+
+final case class PostgresDatabase(
+    hostName: String,
+    port: Port,
+    userName: String,
+    databaseName: String,
+) {
+  def url: String = s"jdbc:postgresql://$hostName:$port/$databaseName?user=$userName"
+
+  override def toString: String = url
+}

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresFixture.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresFixture.scala
@@ -7,8 +7,7 @@ import java.nio.file.Path
 
 import com.daml.ports.Port
 
-case class PostgresFixture(
-    jdbcUrl: String,
+final case class PostgresFixture(
     port: Port,
     tempDir: Path,
     dataDir: Path,

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
@@ -8,14 +8,14 @@ import com.daml.resources.{Resource, ResourceOwner}
 import scala.concurrent.{ExecutionContext, Future}
 
 object PostgresResource {
-  def owner(): ResourceOwner[PostgresFixture] =
-    new ResourceOwner[PostgresFixture] with PostgresAround {
+  def owner(): ResourceOwner[JdbcUrl] =
+    new ResourceOwner[JdbcUrl] with PostgresAround {
       override def acquire()(
           implicit executionContext: ExecutionContext
-      ): Resource[PostgresFixture] =
+      ): Resource[JdbcUrl] =
         Resource(Future {
           startEphemeralPostgres()
-          postgresFixture
+          postgresJdbcUrl
         })(_ => Future(stopAndCleanUpPostgres()))
     }
 }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
@@ -15,7 +15,7 @@ object PostgresResource {
       ): Resource[JdbcUrl] =
         Resource(Future {
           startEphemeralPostgres()
-          postgresJdbcUrl
+          createNewDatabase()
         })(_ => Future(stopAndCleanUpPostgres()))
     }
 }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
@@ -15,7 +15,7 @@ object PostgresResource {
       ): Resource[JdbcUrl] =
         Resource(Future {
           startEphemeralPostgres()
-          createNewDatabase()
+          createNewRandomDatabase()
         })(_ => Future(stopAndCleanUpPostgres()))
     }
 }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
@@ -8,11 +8,11 @@ import com.daml.resources.{Resource, ResourceOwner}
 import scala.concurrent.{ExecutionContext, Future}
 
 object PostgresResource {
-  def owner(): ResourceOwner[JdbcUrl] =
-    new ResourceOwner[JdbcUrl] with PostgresAround {
+  def owner(): ResourceOwner[PostgresDatabase] =
+    new ResourceOwner[PostgresDatabase] with PostgresAround {
       override def acquire()(
           implicit executionContext: ExecutionContext
-      ): Resource[JdbcUrl] =
+      ): Resource[PostgresDatabase] =
         Resource(Future {
           startEphemeralPostgres()
           createNewRandomDatabase()

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/Tool.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/Tool.scala
@@ -23,7 +23,8 @@ private[postgresql] object Tool {
     else
       ""
 
-  val createdb = Tool("createdb")
-  val initdb = Tool("initdb")
-  val pg_ctl = Tool("pg_ctl")
+  val createdb: Tool = Tool("createdb")
+  val dropdb: Tool = Tool("dropdb")
+  val initdb: Tool = Tool("initdb")
+  val pg_ctl: Tool = Tool("pg_ctl")
 }


### PR DESCRIPTION
This is the first step in sharing a PostgreSQL database across tests.

I managed to get a change in which should speed up a couple of tests. If you're using `PostgresAroundEach`, it now will start PostgreSQL once and then create a new database for each test case.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
