### PR TITLE
DAML-LF: enforce size limit for Contract ID suffixes.

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/package.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/package.scala
@@ -15,4 +15,9 @@ package object data {
   }
   type Numeric = Numeric.Numeric
 
+  trait NoCopy {
+    // prevents autogeneration of copy method in case class
+    protected def copy(nothing: Nothing): Nothing = nothing
+  }
+
 }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
@@ -68,7 +68,7 @@ class ContractDiscriminatorFreshnessCheckSpec
   private val tmplId = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Mod:Contract"))
 
   private def contractId(discriminator: crypto.Hash, suffix: Bytes): Value.AbsoluteContractId =
-    Value.AbsoluteContractId.V1(discriminator, suffix)
+    Value.AbsoluteContractId.V1.assertBuild(discriminator, suffix)
 
   private def keyRecord(party: Ref.Party, idx: Int) =
     Value.ValueRecord(

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -102,20 +102,20 @@ trait CidContainer[+A] {
 
   // Sets the suffix of any the V1 AbsoluteContractId `coid` of the container that are not already suffixed.
   // Uses `f(coid.discriminator)` as suffix.
-  // Fails if encounters relative contract id or a V0 contract id.
   final def suffixCid[B](f: crypto.Hash => Bytes)(
       implicit suffixer: CidSuffixer[A, B]
-  ): Either[Value.ContractId, B] =
-    suffixer.traverse[Value.ContractId] {
+  ): Either[String, B] = {
+    suffixer.traverse[String] {
       case Value.AbsoluteContractId.V1(discriminator, Bytes.Empty) =>
-        Right(Value.AbsoluteContractId.V1(discriminator, f(discriminator)))
+        Value.AbsoluteContractId.V1.build(discriminator, f(discriminator))
       case acoid @ Value.AbsoluteContractId.V1(_, _) =>
         Right(acoid)
       case acoid @ Value.AbsoluteContractId.V0(_) =>
-        Left(acoid)
+        Left(s"expect a Contract ID V1, found $acoid")
       case rcoid @ Value.RelativeContractId(_) =>
-        Left(rcoid)
+        Left(s"expect a Contract Id V1, found $rcoid")
     }(self)
+  }
 
   final def assertNoRelCid[B](message: Value.ContractId => String)(
       implicit checker: NoRelCidChecker[A, B]

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -18,6 +18,8 @@ import scalaz.syntax.order._
 import scalaz.syntax.semigroup._
 import scalaz.syntax.std.option._
 
+import scala.util.hashing.MurmurHash3
+
 /** Values   */
 sealed abstract class Value[+Cid] extends CidContainer[Value[Cid]] with Product with Serializable {
   import Value._
@@ -360,16 +362,28 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
     */
   sealed abstract class ContractId
 
-  sealed abstract class AbsoluteContractId extends ContractId with Product with Serializable {
+  sealed abstract class AbsoluteContractId extends ContractId {
     def coid: String
   }
 
   object AbsoluteContractId {
-    final case class V0(coid: Ref.ContractIdString) extends AbsoluteContractId {
+    final class V0(val coid: Ref.ContractIdString) extends AbsoluteContractId {
       override def toString: String = s"AbsoluteContractId($coid)"
+
+      override def hashCode(): Int = coid.hashCode()
+
+      override def equals(obj: Any): Boolean = obj match {
+        case that: V0 => this.coid == that.coid
+        case _ => false
+      }
+
     }
 
     object V0 {
+      def apply(coid: Ref.ContractIdString): V0 = new V0(coid)
+
+      def unapply(arg: V0): Option[Ref.ContractIdString] = Some(arg.coid)
+
       def fromString(s: String): Either[String, V0] =
         Ref.ContractIdString.fromString(s).map(V0(_))
 
@@ -378,14 +392,47 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
       implicit val `V0 Order`: Order[V0] = Order.fromScalaOrdering[String] contramap (_.coid)
     }
 
-    final case class V1(discriminator: crypto.Hash, suffix: Bytes = Bytes.Empty)
-        extends AbsoluteContractId {
+    final class V1(val discriminator: crypto.Hash, val suffix: Bytes) extends AbsoluteContractId {
       lazy val toBytes: Bytes = V1.prefix ++ discriminator.bytes ++ suffix
       lazy val coid: Ref.HexString = toBytes.toHexString
       override def toString: String = s"AbsoluteContractId($coid)"
+
+      // We copy how hashcode evaluation is cached in String
+      // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/tip/src/share/classes/java/lang/String.java
+      private var _hashCode = 0
+
+      override def hashCode(): Int =
+        if (_hashCode != 0)
+          _hashCode
+        else {
+          val hash = MurmurHash3.mixLast(discriminator.hashCode(), suffix.hashCode())
+          _hashCode = if (hash == 0) 1 else hash
+          _hashCode
+        }
+
+      override def equals(obj: Any): Boolean = obj match {
+        case that: V1 =>
+          this.discriminator == that.discriminator && this.suffix == that.suffix
+        case _ => false
+      }
+
     }
 
     object V1 {
+      def apply(discriminator: crypto.Hash): V1 = new V1(discriminator, Bytes.Empty)
+
+      def unapply(arg: V1): Option[(crypto.Hash, Bytes)] =
+        Some((arg.discriminator, arg.suffix))
+
+      def build(discriminator: crypto.Hash, suffix: Bytes): Either[String, V1] =
+        Either.cond(
+          suffix.length <= 94,
+          new V1(discriminator, suffix),
+          s"suffix $suffix to long"
+        )
+
+      def assertBuild(discriminator: crypto.Hash, suffix: Bytes): V1 =
+        assertRight(build(discriminator, suffix))
 
       val prefix: Bytes = Bytes.assertFromString("00")
 
@@ -399,8 +446,8 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
               if (bytes.startsWith(prefix) && bytes.length >= suffixStart)
                 crypto.Hash
                   .fromBytes(bytes.slice(prefix.length, suffixStart))
-                  .map(
-                    V1(_, bytes.slice(suffixStart, bytes.length))
+                  .flatMap(
+                    V1.build(_, bytes.slice(suffixStart, bytes.length))
                   )
               else
                 Left(s"""cannot parse V1 ContractId "$s""""))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -359,9 +359,9 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
     * to be able to use AbsoluteContractId elsewhere, so that we can
     * automatically upcast to ContractId by subtyping.
     */
-  sealed abstract class ContractId extends Equals
+  sealed abstract class ContractId extends Product with Serializable
 
-  sealed abstract class AbsoluteContractId extends ContractId with Product with Serializable {
+  sealed abstract class AbsoluteContractId extends ContractId {
     def coid: String
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -360,9 +360,9 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
     * to be able to use AbsoluteContractId elsewhere, so that we can
     * automatically upcast to ContractId by subtyping.
     */
-  sealed abstract class ContractId
+  sealed abstract class ContractId extends Equals
 
-  sealed abstract class AbsoluteContractId extends ContractId {
+  sealed abstract class AbsoluteContractId extends ContractId with Equals {
     def coid: String
   }
 
@@ -382,7 +382,7 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
     object V0 {
       def apply(coid: Ref.ContractIdString): V0 = new V0(coid)
 
-      def unapply(arg: V0): Option[Ref.ContractIdString] = Some(arg.coid)
+      def unapply(arg: V0): Some[Ref.ContractIdString] = Some(arg.coid)
 
       def fromString(s: String): Either[String, V0] =
         Ref.ContractIdString.fromString(s).map(V0(_))
@@ -399,7 +399,7 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
 
       // We copy how hashcode evaluation is cached in String
       // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/tip/src/share/classes/java/lang/String.java
-      private var _hashCode = 0
+      private[this] var _hashCode = 0
 
       override def hashCode(): Int =
         if (_hashCode != 0)
@@ -421,7 +421,7 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
     object V1 {
       def apply(discriminator: crypto.Hash): V1 = new V1(discriminator, Bytes.Empty)
 
-      def unapply(arg: V1): Option[(crypto.Hash, Bytes)] =
+      def unapply(arg: V1): Some[(crypto.Hash, Bytes)] =
         Some((arg.discriminator, arg.suffix))
 
       def build(discriminator: crypto.Hash, suffix: Bytes): Either[String, V1] =

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -428,7 +428,7 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
         Either.cond(
           suffix.length <= 94,
           new V1(discriminator, suffix),
-          s"suffix $suffix to long"
+          s"the suffix is too long, expected at most 94 bytes, but got ${suffix.length}"
         )
 
       def assertBuild(discriminator: crypto.Hash, suffix: Bytes): V1 =

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -392,7 +392,7 @@ object Value extends CidContainer1WithDefaultCidResolver[Value] {
       implicit val `V0 Order`: Order[V0] = Order.fromScalaOrdering[String] contramap (_.coid)
     }
 
-    final class V1(val discriminator: crypto.Hash, val suffix: Bytes) extends AbsoluteContractId {
+    final class V1 private(val discriminator: crypto.Hash, val suffix: Bytes) extends AbsoluteContractId {
       lazy val toBytes: Bytes = V1.prefix ++ discriminator.bytes ++ suffix
       lazy val coid: Ref.HexString = toBytes.toHexString
       override def toString: String = s"AbsoluteContractId($coid)"

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -187,8 +187,8 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
       )
 
       val mapping2: V.ContractId => V.ContractId = Map(
-        cid1 -> cid1.copy(suffix = suffix1),
-        cid2 -> cid2.copy(suffix = suffix2),
+        cid1 -> V.AbsoluteContractId.V1.assertBuild(cid1.discriminator, suffix1),
+        cid2 -> V.AbsoluteContractId.V1.assertBuild(cid2.discriminator, suffix2),
       )
 
       dummyCreateNode("dd").coinst.suffixCid(mapping1)
@@ -236,7 +236,10 @@ object TransactionSpec {
       key = None,
     )
 
-  val dummyCid = toCid("dummyCid").copy(suffix = Bytes.assertFromString("f00d"))
+  val dummyCid = V.AbsoluteContractId.V1.assertBuild(
+    toCid("dummyCid").discriminator,
+    Bytes.assertFromString("f00d"),
+  )
 
   def dummyCreateNode(cid: String): NodeCreate[V.ContractId, Value] =
     NodeCreate(

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -4,12 +4,11 @@
 package com.daml.lf
 package value
 
-import data.{FrontStack, ImmArray, Ref, Unnatural}
+import data.{Bytes, FrontStack, ImmArray, Ref, Unnatural}
 import Value._
 import Ref.{Identifier, Name}
 import ValueGenerators.{absCoidGen, idGen, nameGen}
 import TypedValueGenerators.{RNil, genAddend, ValueAddend => VA}
-
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks, TableDrivenPropertyChecks}
 import org.scalatest.{FreeSpec, Inside, Matchers}
@@ -102,6 +101,24 @@ class ValueSpec
         value.resolveRelCid(resolver).version shouldBe ValueVersions.minVersion
         contract.resolveRelCid(resolver).arg.version shouldBe ValueVersions.minVersion
       }
+
+    }
+
+  }
+
+  "AbsoluteContractID.V1.build" - {
+
+    "reject to long suffix" in {
+
+      def suffix(size: Int) =
+        Bytes.fromByteArray(Array.iterate(0.toByte, size)(b => (b + 1).toByte))
+
+      val hash = crypto.Hash.hashPrivateKey("some hash")
+      AbsoluteContractId.V1.assertBuild(hash, suffix(0)) shouldBe 'right
+      AbsoluteContractId.V1.assertBuild(hash, suffix(94)) shouldBe 'right
+      AbsoluteContractId.V1.assertBuild(hash, suffix(95)) shouldBe 'left
+      AbsoluteContractId.V1.assertBuild(hash, suffix(96)) shouldBe 'left
+      AbsoluteContractId.V1.assertBuild(hash, suffix(127)) shouldBe 'left
 
     }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -108,17 +108,17 @@ class ValueSpec
 
   "AbsoluteContractID.V1.build" - {
 
-    "reject to long suffix" in {
+    "rejects to long suffix" in {
 
       def suffix(size: Int) =
         Bytes.fromByteArray(Array.iterate(0.toByte, size)(b => (b + 1).toByte))
 
       val hash = crypto.Hash.hashPrivateKey("some hash")
-      AbsoluteContractId.V1.assertBuild(hash, suffix(0)) shouldBe 'right
-      AbsoluteContractId.V1.assertBuild(hash, suffix(94)) shouldBe 'right
-      AbsoluteContractId.V1.assertBuild(hash, suffix(95)) shouldBe 'left
-      AbsoluteContractId.V1.assertBuild(hash, suffix(96)) shouldBe 'left
-      AbsoluteContractId.V1.assertBuild(hash, suffix(127)) shouldBe 'left
+      AbsoluteContractId.V1.build(hash, suffix(0)) shouldBe 'right
+      AbsoluteContractId.V1.build(hash, suffix(94)) shouldBe 'right
+      AbsoluteContractId.V1.build(hash, suffix(95)) shouldBe 'left
+      AbsoluteContractId.V1.build(hash, suffix(96)) shouldBe 'left
+      AbsoluteContractId.V1.build(hash, suffix(127)) shouldBe 'left
 
     }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -116,11 +116,10 @@ class ValueSpec
       val hash = crypto.Hash.hashPrivateKey("some hash")
       import AbsoluteContractId.V1.build
       build(hash, suffix(0)) shouldBe 'right
-      // ...
-      AbsoluteContractId.V1.build(hash, suffix(94)) shouldBe 'right
-      AbsoluteContractId.V1.build(hash, suffix(95)) shouldBe 'left
-      AbsoluteContractId.V1.build(hash, suffix(96)) shouldBe 'left
-      AbsoluteContractId.V1.build(hash, suffix(127)) shouldBe 'left
+      build(hash, suffix(94)) shouldBe 'right
+      build(hash, suffix(95)) shouldBe 'left
+      build(hash, suffix(96)) shouldBe 'left
+      build(hash, suffix(127)) shouldBe 'left
 
     }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -108,13 +108,15 @@ class ValueSpec
 
   "AbsoluteContractID.V1.build" - {
 
-    "rejects to long suffix" in {
+    "rejects too long suffix" in {
 
       def suffix(size: Int) =
         Bytes.fromByteArray(Array.iterate(0.toByte, size)(b => (b + 1).toByte))
 
       val hash = crypto.Hash.hashPrivateKey("some hash")
-      AbsoluteContractId.V1.build(hash, suffix(0)) shouldBe 'right
+      import AbsoluteContractId.V1.build
+      build(hash, suffix(0)) shouldBe 'right
+      // ...
       AbsoluteContractId.V1.build(hash, suffix(94)) shouldBe 'right
       AbsoluteContractId.V1.build(hash, suffix(95)) shouldBe 'left
       AbsoluteContractId.V1.build(hash, suffix(96)) shouldBe 'left


### PR DESCRIPTION
Following the Contract ID Specification, we limit the size of Contract ID suffixes to 94 bytes.

CHANGELOG_BEGIN
CHAGNELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
