### PR TITLE
`LedgerFactory.metricsRegistry` -> `LedgerFactory.metrics: Metrics`

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -90,7 +90,6 @@ da_scala_library(
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
-        "@maven//:io_dropwizard_metrics_metrics_core",
     ],
 )
 

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -15,7 +15,6 @@ import com.daml.ledger.participant.state.kvutils.app.{
 import com.daml.ledger.participant.state.kvutils.caching
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
-import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.apiserver.ApiServerConfig
 import com.daml.platform.configuration.LedgerConfiguration
@@ -48,10 +47,7 @@ object Main {
       for {
         readerWriter <- owner(config, participantConfig, engine)
       } yield
-        new KeyValueParticipantState(
-          readerWriter,
-          readerWriter,
-          new Metrics(metricRegistry(participantConfig, config)))
+        new KeyValueParticipantState(readerWriter, readerWriter, metrics(participantConfig, config))
 
     def owner(config: Config[ExtraConfig], participantConfig: ParticipantConfig, engine: Engine)(
         implicit materializer: Materializer,
@@ -60,7 +56,7 @@ object Main {
       new InMemoryLedgerReaderWriter.Owner(
         initialLedgerId = config.ledgerId,
         participantId = participantConfig.participantId,
-        metrics = new Metrics(metricRegistry(participantConfig, config)),
+        metrics = metrics(participantConfig, config),
         stateValueCache = caching.Cache.from(config.stateValueCache),
         dispatcher = dispatcher,
         state = state,

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -47,7 +47,10 @@ object Main {
       for {
         readerWriter <- owner(config, participantConfig, engine)
       } yield
-        new KeyValueParticipantState(readerWriter, readerWriter, metrics(participantConfig, config))
+        new KeyValueParticipantState(
+          readerWriter,
+          readerWriter,
+          createMetrics(participantConfig, config))
 
     def owner(config: Config[ExtraConfig], participantConfig: ParticipantConfig, engine: Engine)(
         implicit materializer: Materializer,
@@ -56,7 +59,7 @@ object Main {
       new InMemoryLedgerReaderWriter.Owner(
         initialLedgerId = config.ledgerId,
         participantId = participantConfig.participantId,
-        metrics = metrics(participantConfig, config),
+        metrics = createMetrics(participantConfig, config),
         stateValueCache = caching.Cache.from(config.stateValueCache),
         dispatcher = dispatcher,
         state = state,

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -134,7 +134,6 @@ da_scala_library(
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
-        "@maven//:io_dropwizard_metrics_metrics_core",
     ],
 )
 
@@ -177,7 +176,6 @@ da_scala_library(
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
-        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:org_scalactic_scalactic_2_12",
         "@maven//:org_scalatest_scalatest_2_12",
     ],

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -17,7 +17,6 @@ import com.daml.ledger.participant.state.kvutils.caching
 import com.daml.ledger.participant.state.v1.SeedService
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
-import com.daml.metrics.Metrics
 import com.daml.platform.configuration.LedgerConfiguration
 import com.daml.resources.{Resource, ResourceOwner}
 import scopt.OptionParser
@@ -63,18 +62,18 @@ object SqlLedgerFactory extends LedgerFactory[ReadWriteService, ExtraConfig] {
       val jdbcUrl = config.extra.jdbcUrl.getOrElse {
         throw new IllegalStateException("No JDBC URL provided.")
       }
-      val metrics = new Metrics(metricRegistry(participantConfig, config))
+      val theMetrics = metrics(participantConfig, config)
       new SqlLedgerReaderWriter.Owner(
         config.ledgerId,
         participantConfig.participantId,
-        metrics = metrics,
+        metrics = theMetrics,
         engine,
         jdbcUrl,
         stateValueCache = caching.Cache.from(config.stateValueCache),
         seedService = SeedService(config.seeding),
         resetOnStartup = false
       ).acquire()
-        .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter, metrics))
+        .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter, theMetrics))
     }
   }
 }

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -62,18 +62,18 @@ object SqlLedgerFactory extends LedgerFactory[ReadWriteService, ExtraConfig] {
       val jdbcUrl = config.extra.jdbcUrl.getOrElse {
         throw new IllegalStateException("No JDBC URL provided.")
       }
-      val theMetrics = metrics(participantConfig, config)
+      val metrics = createMetrics(participantConfig, config)
       new SqlLedgerReaderWriter.Owner(
         config.ledgerId,
         participantConfig.participantId,
-        metrics = theMetrics,
+        metrics = metrics,
         engine,
         jdbcUrl,
         stateValueCache = caching.Cache.from(config.stateValueCache),
         seedService = SeedService(config.seeding),
         resetOnStartup = false
       ).acquire()
-        .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter, theMetrics))
+        .map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter, metrics))
     }
   }
 }

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.participant.state.kvutils.app
 
 import akka.stream.Materializer
-import com.codahale.metrics.{MetricRegistry, SharedMetricRegistries}
+import com.codahale.metrics.SharedMetricRegistries
 import com.daml.ledger.api.auth.{AuthService, AuthServiceWildcard}
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantState
 import com.daml.ledger.participant.state.v1.{ReadService, WriteService}
@@ -78,11 +78,11 @@ trait ConfigProvider[ExtraConfig] {
   def authService(config: Config[ExtraConfig]): AuthService =
     AuthServiceWildcard
 
-  def metricRegistry(
+  def metrics(
       participantConfig: ParticipantConfig,
       config: Config[ExtraConfig],
-  ): MetricRegistry =
-    SharedMetricRegistries.getOrCreate(participantConfig.participantId)
+  ): Metrics =
+    new Metrics(SharedMetricRegistries.getOrCreate(participantConfig.participantId))
 }
 
 trait ReadServiceOwner[+RS <: ReadService, ExtraConfig] extends ConfigProvider[ExtraConfig] {
@@ -146,7 +146,7 @@ object LedgerFactory {
         new KeyValueParticipantState(
           readerWriter,
           readerWriter,
-          new Metrics(metricRegistry(participantConfig, config)),
+          metrics(participantConfig, config),
         )
 
     def owner(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -78,7 +78,7 @@ trait ConfigProvider[ExtraConfig] {
   def authService(config: Config[ExtraConfig]): AuthService =
     AuthServiceWildcard
 
-  def metrics(
+  def createMetrics(
       participantConfig: ParticipantConfig,
       config: Config[ExtraConfig],
   ): Metrics =
@@ -146,7 +146,7 @@ object LedgerFactory {
         new KeyValueParticipantState(
           readerWriter,
           readerWriter,
-          metrics(participantConfig, config),
+          createMetrics(participantConfig, config),
         )
 
     def owner(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -55,7 +55,7 @@ final class Runner[T <: ReadWriteService, Extra](
 
           // initialize all configured participants
           _ <- Resource.sequence(config.participants.map { participantConfig =>
-            val metrics = factory.metrics(participantConfig, config)
+            val metrics = factory.createMetrics(participantConfig, config)
             metrics.registry.registerAll(new JvmMetricSet)
             for {
               _ <- config.metricsReporter.fold(Resource.unit)(


### PR DESCRIPTION
This delegates the responsibility of creating the `Metrics` wrapper around the metrics registry to `LedgerFactory` (since it already creates the registry itself). This allows to avoid creating a new `Metrics` instance in `LedgerFactory` implementations.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
