### PR TITLE
add default capability to macos

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,6 +134,7 @@ jobs:
     timeoutInMinutes: 360
     pool:
       name: macOS-pool
+      demands: assignment -equals default
     variables:
       release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
       release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
@@ -239,6 +240,7 @@ jobs:
     timeoutInMinutes: 360
     pool:
       name: macOS-pool
+      demands: assignment -equals default
     steps:
       - template: ci/report-start.yml
       - template: ci/clear-shared-segments-macos.yml

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -44,8 +44,7 @@ jobs:
           pool: macOS-pool
     pool:
       name: $(pool)
-      ${{ if eq(variables['pool'], 'linux-pool') }}:
-        demands: assignment -equals default
+      demands: assignment -equals default
     steps:
       - checkout: self
       - ${{ if eq(variables['pool'], 'macos-pool') }}:

--- a/infra/macos/3-running-box/init.sh
+++ b/infra/macos/3-running-box/init.sh
@@ -33,6 +33,7 @@ VSTS_TOKEN=$1
 
 mkdir -p ~/agent
 cd ~/agent
+echo 'assignment=default' > .capabilities
 
 echo Determining matching VSTS agent...
 VSTS_AGENT_RESPONSE=\$(curl -sSfL \


### PR DESCRIPTION
This is the macOS part of #5912, which I have separated because our macOS nodes have a different deployment process so it seemed easier to track the deployment of the change separately.

CHANGELOG_BEGIN
CHANGELOG_END