### PR TITLE
Restart triggers that fail

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.trigger
+
+import akka.actor.typed.{Behavior, PostStop}
+import akka.actor.typed.scaladsl.AbstractBehavior
+import akka.actor.typed.SupervisorStrategy._
+import akka.actor.typed.Signal
+import akka.actor.typed.PostStop
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.ActorContext
+import akka.stream.Materializer
+import com.typesafe.scalalogging.StrictLogging
+import com.daml.grpc.adapter.ExecutionSequencerFactory
+
+object TriggerRunner {
+  type Config = TriggerRunnerImpl.Config
+
+  trait Message
+  final case object Stop extends Message
+
+  def apply(config: Config, name: String)(
+      implicit esf: ExecutionSequencerFactory,
+      mat: Materializer): Behavior[TriggerRunner.Message] =
+    Behaviors.setup(ctx => new TriggerRunner(ctx, config, name))
+}
+
+class TriggerRunner(
+    ctx: ActorContext[TriggerRunner.Message],
+    config: TriggerRunner.Config,
+    name: String)(implicit esf: ExecutionSequencerFactory, mat: Materializer)
+    extends AbstractBehavior[TriggerRunner.Message](ctx)
+    with StrictLogging {
+
+  import TriggerRunner.{Message, Stop}
+
+  private val child =
+    ctx.spawn(Behaviors.supervise(TriggerRunnerImpl(config)).onFailure(restart), name)
+
+  override def onMessage(msg: Message): Behavior[Message] =
+    Behaviors.receiveMessagePartial[Message] {
+      case Stop =>
+        child ! Stop
+        Behaviors.stopped
+    }
+
+  override def onSignal: PartialFunction[Signal, Behavior[Message]] = {
+    case PostStop =>
+      logger.info(s"Trigger ${name} stopped")
+      this
+  }
+
+}

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -1,0 +1,138 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.trigger
+
+import akka.actor.typed.{Behavior, PostStop}
+import akka.actor.typed.PostStop
+import akka.actor.typed.PreRestart
+import akka.actor.typed.scaladsl.Behaviors
+import akka.stream.{KillSwitch, KillSwitches, Materializer}
+import com.daml.ledger.api.refinements.ApiTypes.Party
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+import scalaz.syntax.tag._
+import com.daml.lf.CompiledPackages
+import com.daml.grpc.adapter.{ExecutionSequencerFactory}
+import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
+import com.daml.ledger.api.v1.event.CreatedEvent
+import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import com.daml.ledger.client.LedgerClient
+import com.daml.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement
+}
+
+object TriggerRunnerImpl {
+  case class Config(
+      compiledPackages: CompiledPackages,
+      trigger: Trigger,
+      ledgerConfig: LedgerConfig,
+      party: Party,
+  )
+
+  import TriggerRunner.{Message, Stop}
+  final case class Failed(error: Throwable) extends Message
+  final case class QueryACSFailed(cause: Throwable) extends Message
+  final case class QueriedACS(runner: Runner, acs: Seq[CreatedEvent], offset: LedgerOffset)
+      extends Message
+
+  def apply(config: Config)(
+      implicit esf: ExecutionSequencerFactory,
+      mat: Materializer): Behavior[Message] =
+    Behaviors.setup { ctx =>
+      implicit val ec: ExecutionContext = ctx.executionContext
+      val name = ctx.self.path.name
+      ctx.log.info(s"Trigger ${name} is starting")
+      val appId = ApplicationId(name)
+      val clientConfig = LedgerClientConfiguration(
+        applicationId = appId.unwrap,
+        ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
+        commandClient = CommandClientConfiguration.default.copy(
+          defaultDeduplicationTime = config.ledgerConfig.commandTtl),
+        sslContext = None,
+      )
+
+      // Waiting for the ACS query to finish so we can build the
+      // initial state.
+      def queryingACS(wasStopped: Boolean): Behaviors.Receive[Message] =
+        Behaviors.receiveMessagePartial[Message] {
+          case QueryACSFailed(cause) =>
+            if (wasStopped) {
+              // Never mind that it failed - we were asked to stop
+              // anyway.
+              Behaviors.stopped;
+            } else {
+              throw new RuntimeException("ACS query failed", cause)
+            }
+          case QueriedACS(runner, acs, offset) =>
+            if (wasStopped) {
+              Behaviors.stopped;
+            } else {
+              val (killSwitch, trigger) = runner.runWithACS(
+                acs,
+                offset,
+                msgFlow = KillSwitches.single[TriggerMsg],
+                name,
+              )
+              // TODO If we are stopped we will end up causing the
+              // future to complete which will trigger a message that
+              // is sent to a now terminated actor. We should fix this
+              // somehow™.
+              ctx.pipeToSelf(trigger) {
+                case Success(_) => Failed(new RuntimeException("Trigger exited unexpectedly"))
+                case Failure(cause) => Failed(cause)
+              }
+              running(killSwitch)
+            }
+          case Stop =>
+            // We got a stop message but the ACS query hasn't
+            // completed yet.
+            queryingACS(wasStopped = true)
+        }
+
+      // Trigger loop is started, wait until we should stop.
+      def running(killSwitch: KillSwitch) =
+        Behaviors
+          .receiveMessagePartial[Message] {
+            case Stop =>
+              Behaviors.stopped
+            case Failed(cause) =>
+              // In the event 'runWithACS' completes it's because the
+              // stream is broken. Throw an exception allowing our
+              // supervisor to restart us.
+              throw new RuntimeException(cause)
+          }
+          .receiveSignal {
+            case (_, PostStop) =>
+              ctx.log.info(s"Trigger ${name} is stopping")
+              killSwitch.shutdown
+              Behaviors.stopped
+            case (_, PreRestart) =>
+              ctx.log.info(s"Trigger ${name} is being restarted")
+              Behaviors.same
+          }
+
+      val acsQuery: Future[QueriedACS] = for {
+        client <- LedgerClient.singleHost(
+          config.ledgerConfig.host,
+          config.ledgerConfig.port,
+          clientConfig)
+        runner = new Runner(
+          config.compiledPackages,
+          config.trigger,
+          client,
+          config.ledgerConfig.timeProvider,
+          appId,
+          config.party.unwrap)
+        (acs, offset) <- runner.queryACS()
+      } yield QueriedACS(runner, acs, offset)
+
+      ctx.pipeToSelf(acsQuery) {
+        case Success(msg) => msg
+        case Failure(cause) => QueryACSFailed(cause)
+      }
+      queryingACS(wasStopped = false)
+    }
+}


### PR DESCRIPTION
This PR adds some fault tolerance to the trigger service. The idea is that triggers run under the supervision of trigger runners. If a trigger fails the triggers' supervisor will restart it. The strategy is to not try to apply recovery at the level of streams (fiddly) but rather, adopt the Erlang approach of "let it crash". Stream exceptions bubble up to the runner which bubble up to the  monitor which deals with it by restarting the runner.

- `TriggerActor` is now `TriggerRunnerImpl`;
-  A new object `TriggerRunner` monitors its contained `TriggerRunnerImpl`.

Additional "info" level logging has been added so that triggers emit messages (with their IDs so they can be disambiguated) when they start, stop or are about to be restarted.

It seemed easier to understand this program written in the OO style so I've decided to keep it that way. I've manually tested the feature and I'm happy to report it works. I would like to lock this down further with a unit-test but am still working out the details of that; one will be forthcoming.  