### PR TITLE
Offload value deserialization from DB threadpool and add metrics

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -273,6 +273,8 @@ class Metrics(val registry: MetricRegistry) {
         val stopDeduplicatingCommand: Timer =
           registry.timer(prefix :+ "stop_deduplicating_command")
 
+        def deserialization(description: String): Timer =
+          registry.timer(prefix :+ description :+ "deserialization")
         def wait(description: String): Timer = registry.timer(prefix :+ description :+ "wait")
         def exec(description: String): Timer = registry.timer(prefix :+ description :+ "exec")
         val waitAll: Timer = wait("all")

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -84,6 +84,7 @@ private class JdbcLedgerDao(
     executionContext: ExecutionContext,
     eventsPageSize: Int,
     performPostCommitValidation: Boolean,
+    metrics: Metrics,
 )(implicit logCtx: LoggingContext)
     extends LedgerDao {
 
@@ -865,13 +866,13 @@ private class JdbcLedgerDao(
     }
 
   private val transactionsWriter: TransactionsWriter =
-    new TransactionsWriter(dbType)
+    new TransactionsWriter(dbType, metrics)
 
   override val transactionsReader: TransactionsReader =
-    new TransactionsReader(dbDispatcher, executionContext, eventsPageSize)
+    new TransactionsReader(dbDispatcher, executionContext, eventsPageSize, metrics)
 
   private val contractsReader: ContractsReader =
-    ContractsReader(dbDispatcher, executionContext, dbType)
+    ContractsReader(dbDispatcher, executionContext, dbType, metrics)
 
   override val completions: CommandCompletionsReader =
     new CommandCompletionsReader(dbDispatcher)
@@ -952,6 +953,7 @@ object JdbcLedgerDao {
         ExecutionContext.fromExecutor(executor),
         eventsPageSize,
         validate,
+        metrics
       )
 
   sealed trait Queries {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTable.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTable.scala
@@ -53,14 +53,18 @@ private[events] trait EventsTable {
 
   object Entry {
 
+    private def deserialize[E](verbose: Boolean)(entry: Entry[Raw[E]]): Entry[E] =
+      entry.copy(event = entry.event.applyDeserialization(verbose))
+
     private def deserialize[E](
         rawEntries: Vector[Entry[Raw[E]]],
         verbose: Boolean,
         timer: Timer,
     ): Vector[Entry[E]] =
       Timed.value(
-        timer,
-        rawEntries.map(entry => entry.copy(event = entry.event.applyDeserialization(verbose))))
+        timer = timer,
+        value = rawEntries.map(deserialize(verbose)),
+      )
 
     private def instantToTimestamp(t: Instant): Timestamp =
       Timestamp(seconds = t.getEpochSecond, nanos = t.getNano)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/Raw.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/Raw.scala
@@ -1,0 +1,263 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+import java.io.InputStream
+
+import com.daml.ledger.api.v1.event.{
+  ArchivedEvent => PbArchivedEvent,
+  CreatedEvent => PbCreatedEvent,
+  Event => PbFlatEvent,
+  ExercisedEvent => PbExercisedEvent
+}
+import com.daml.ledger.api.v1.transaction.{TreeEvent => PbTreeEvent}
+import com.daml.platform.participant.util.LfEngineToApi
+import com.daml.platform.store.serialization.ValueSerializer
+
+sealed trait Raw[+E] {
+  def applyDeserialization(verbose: Boolean): E
+}
+
+object Raw {
+
+  private[events] sealed abstract class Created[E] private[Raw] (
+      raw: PbCreatedEvent,
+      createArgument: InputStream,
+      createKeyValue: Option[InputStream],
+  ) extends Raw[E] {
+    protected def wrap(event: PbCreatedEvent): E
+    final override def applyDeserialization(verbose: Boolean): E =
+      wrap(
+        raw.copy(
+          contractKey = createKeyValue.map(
+            key =>
+              LfEngineToApi.assertOrRuntimeEx(
+                failureContext = s"attempting to deserialize persisted key to value",
+                LfEngineToApi
+                  .lfVersionedValueToApiValue(
+                    verbose = verbose,
+                    value = ValueSerializer.deserializeValue(key),
+                  ),
+            )
+          ),
+          createArguments = Some(
+            LfEngineToApi.assertOrRuntimeEx(
+              failureContext = s"attempting to deserialize persisted create argument to record",
+              LfEngineToApi
+                .lfVersionedValueToApiRecord(
+                  verbose = verbose,
+                  recordValue = ValueSerializer.deserializeValue(createArgument),
+                ),
+            )
+          ),
+        )
+      )
+  }
+
+  private object Created {
+    def apply(
+        eventId: String,
+        contractId: String,
+        templateId: Identifier,
+        createSignatories: Array[String],
+        createObservers: Array[String],
+        createAgreementText: Option[String],
+        eventWitnesses: Array[String],
+    ): PbCreatedEvent =
+      PbCreatedEvent(
+        eventId = eventId,
+        contractId = contractId,
+        templateId = Some(LfEngineToApi.toApiIdentifier(templateId)),
+        contractKey = null,
+        createArguments = null,
+        witnessParties = eventWitnesses,
+        signatories = createSignatories,
+        observers = createObservers,
+        agreementText = createAgreementText.orElse(Some("")),
+      )
+  }
+
+  sealed trait FlatEvent extends Raw[PbFlatEvent] {
+    def isCreated: Boolean
+    def contractId: String
+  }
+
+  object FlatEvent {
+
+    final class Created private[Raw] (
+        raw: PbCreatedEvent,
+        createArgument: InputStream,
+        createKeyValue: Option[InputStream],
+    ) extends Raw.Created[PbFlatEvent](raw, createArgument, createKeyValue)
+        with FlatEvent {
+      override val isCreated: Boolean = true
+      override val contractId: String = raw.contractId
+      override protected def wrap(event: PbCreatedEvent): PbFlatEvent =
+        PbFlatEvent(PbFlatEvent.Event.Created(event))
+    }
+
+    object Created {
+      def apply(
+          eventId: String,
+          contractId: String,
+          templateId: Identifier,
+          createArgument: InputStream,
+          createSignatories: Array[String],
+          createObservers: Array[String],
+          createAgreementText: Option[String],
+          createKeyValue: Option[InputStream],
+          eventWitnesses: Array[String],
+      ): Raw.FlatEvent.Created =
+        new Created(
+          raw = Raw.Created(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = templateId,
+            createSignatories = createSignatories,
+            createObservers = createObservers,
+            createAgreementText = createAgreementText,
+            eventWitnesses = eventWitnesses
+          ),
+          createArgument = createArgument,
+          createKeyValue = createKeyValue,
+        )
+    }
+
+    final class Archived private[Raw] (
+        raw: PbArchivedEvent,
+    ) extends FlatEvent {
+      override val isCreated: Boolean = false
+      override val contractId: String = raw.contractId
+      override def applyDeserialization(verbose: Boolean): PbFlatEvent =
+        PbFlatEvent(PbFlatEvent.Event.Archived(raw))
+    }
+
+    object Archived {
+      def apply(
+          eventId: String,
+          contractId: String,
+          templateId: Identifier,
+          eventWitnesses: Array[String],
+      ): Raw.FlatEvent.Archived =
+        new Archived(
+          raw = PbArchivedEvent(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = Some(LfEngineToApi.toApiIdentifier(templateId)),
+            witnessParties = eventWitnesses,
+          )
+        )
+
+    }
+
+  }
+
+  sealed trait TreeEvent extends Raw[PbTreeEvent]
+
+  object TreeEvent {
+
+    final class Created private[Raw] (
+        raw: PbCreatedEvent,
+        createArgument: InputStream,
+        createKeyValue: Option[InputStream],
+    ) extends Raw.Created[PbTreeEvent](raw, createArgument, createKeyValue)
+        with TreeEvent {
+      override protected def wrap(event: PbCreatedEvent): PbTreeEvent =
+        PbTreeEvent(PbTreeEvent.Kind.Created(event))
+    }
+
+    object Created {
+      def apply(
+          eventId: String,
+          contractId: String,
+          templateId: Identifier,
+          createArgument: InputStream,
+          createSignatories: Array[String],
+          createObservers: Array[String],
+          createAgreementText: Option[String],
+          createKeyValue: Option[InputStream],
+          eventWitnesses: Array[String],
+      ): Raw.TreeEvent.Created =
+        new Created(
+          raw = Raw.Created(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = templateId,
+            createSignatories = createSignatories,
+            createObservers = createObservers,
+            createAgreementText = createAgreementText,
+            eventWitnesses = eventWitnesses
+          ),
+          createArgument = createArgument,
+          createKeyValue = createKeyValue,
+        )
+    }
+
+    final class Exercised(
+        base: PbExercisedEvent,
+        exerciseArgument: InputStream,
+        exerciseResult: Option[InputStream],
+    ) extends TreeEvent {
+      override def applyDeserialization(verbose: Boolean): PbTreeEvent =
+        PbTreeEvent(
+          PbTreeEvent.Kind.Exercised(
+            base.copy(
+              choiceArgument = Some(
+                LfEngineToApi.assertOrRuntimeEx(
+                  failureContext = s"attempting to deserialize persisted exercise argument to value",
+                  LfEngineToApi
+                    .lfVersionedValueToApiValue(
+                      verbose = verbose,
+                      value = ValueSerializer.deserializeValue(exerciseArgument),
+                    ),
+                )
+              ),
+              exerciseResult = exerciseResult.map(
+                key =>
+                  LfEngineToApi.assertOrRuntimeEx(
+                    failureContext = s"attempting to deserialize persisted exercise result to value",
+                    LfEngineToApi
+                      .lfVersionedValueToApiValue(
+                        verbose = verbose,
+                        value = ValueSerializer.deserializeValue(key),
+                      ),
+                )
+              ),
+            )
+          ))
+    }
+
+    object Exercised {
+      def apply(
+          eventId: String,
+          contractId: String,
+          templateId: Identifier,
+          exerciseConsuming: Boolean,
+          exerciseChoice: String,
+          exerciseArgument: InputStream,
+          exerciseResult: Option[InputStream],
+          exerciseActors: Array[String],
+          exerciseChildEventIds: Array[String],
+          eventWitnesses: Array[String],
+      ): Raw.TreeEvent.Exercised =
+        new Exercised(
+          base = PbExercisedEvent(
+            eventId = eventId,
+            contractId = contractId,
+            templateId = Some(LfEngineToApi.toApiIdentifier(templateId)),
+            choice = exerciseChoice,
+            choiceArgument = null,
+            actingParties = exerciseActors,
+            consuming = exerciseConsuming,
+            witnessParties = eventWitnesses,
+            childEventIds = exerciseChildEventIds,
+            exerciseResult = null,
+          ),
+          exerciseArgument = exerciseArgument,
+          exerciseResult = exerciseResult,
+        )
+    }
+  }
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsWriter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsWriter.scala
@@ -11,10 +11,14 @@ import com.daml.ledger.participant.state.v1.{DivulgedContract, Offset, Submitter
 import com.daml.ledger.{EventId, TransactionId, WorkflowId}
 import com.daml.lf.engine.Blinding
 import com.daml.lf.transaction.BlindingInfo
+import com.daml.metrics.Metrics
 import com.daml.platform.events.EventIdFormatter
 import com.daml.platform.store.DbType
 
-private[dao] final class TransactionsWriter(dbType: DbType) {
+private[dao] final class TransactionsWriter(
+    dbType: DbType,
+    metrics: Metrics,
+) {
 
   private val contractsTable = ContractsTable(dbType)
   private val contractWitnessesTable = WitnessesTable.ForContracts(dbType)


### PR DESCRIPTION
Performance tests revealed that for services reading DAML-LF values off the participant index ~30% of the time is consistently spent deserializing those values.

This PR

1. adds metrics for deserialization time when fetching events and contracts
2. offloads deserialization from the DB thread pool to free up the resource
3. postpones deserialization of values in flat events _after_ filtering out transient contracts

Fixes #5909

CHANGELOG_BEGIN
[Ledger Integration Kit] Added new metrics to time the translation of serialized DAML-LF values when fetched from the participant index.
- ``daml.index.db.get_active_contracts.deserialization`` 
- ``daml.index.db.get_flat_transactions.deserialization`` 
- ``daml.index.db.get_transaction_trees.deserialization`` 
- ``daml.index.db.lookup_transaction_tree_by_id.deserialization`` 
- ``daml.index.db.lookup_flat_transaction_by_id.deserialization`` 
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
