### PR TITLE
CI: Run PostgreSQL once for all Scala tests.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -826,6 +826,12 @@ dev_env_tool(
         "bin/pg_ctl",
         "bin/postgres",
     ],
+    tool_dependencies = [
+        "postgres",
+        "postgres",
+        "postgres",
+        "",
+    ],
     tools = [
         "createdb",
         "dropdb",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -828,12 +828,10 @@ dev_env_tool(
         "bin/pg_ctl",
         "bin/postgres",
     ],
-    tool_dependencies = [
-        "postgres",
-        "postgres",
-        "postgres",
-        "",
-    ],
+    required_tools = {
+        "initdb": ["postgres"],
+        "pg_ctl": ["postgres"],
+    },
     tools = [
         "createdb",
         "dropdb",

--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -19,19 +19,13 @@ filegroup(
     for i in range(0, len(tools)):
         if is_windows:
             content += """
+# Running tools with `bazel run` is not supported on Windows.
 filegroup(
     name = "{tool}",
     srcs = ["{path}"],
 )
-
-sh_binary(
-    name = "{tool}.exe",
-    srcs = [":{tool}"],
-    data = {dependencies},
-)
 """.format(
                 tool = tools[i],
-                dependencies = [":{}.exe".format(dep) for dep in required_tools.get(tools[i], [])],
                 path = win_paths[i],
             )
         else:

--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,9 @@
 # Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-
 set -euo pipefail
 
-eval "$($(dirname "$0")/dev-env/bin/dade-assist)"
+eval "$("$(dirname "$0")/dev-env/bin/dade-assist")"
 
 execution_log_postfix=${1:-}
 
@@ -17,24 +16,21 @@ tag_filter=""
 if [[ "$execution_log_postfix" == "_Darwin" ]]; then
   tag_filter="-dont-run-on-darwin,-scaladoc,-pdfdocs"
 fi
-
 # Bazel test only builds targets that are dependencies of a test suite
 # so do a full build first.
 bazel build //... --build_tag_filters "$tag_filter"
 bazel test //... --build_tag_filters "$tag_filter" --test_tag_filters "$tag_filter" --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
+
 # Make sure that Bazel query works.
-bazel query 'deps(//...)' > /dev/null
+bazel query 'deps(//...)' >/dev/null
+
 # Check that we can load damlc in ghci
-GHCI_SCRIPT=$(mktemp)
-function cleanup {
-  rm -rf "$GHCI_SCRIPT"
-}
-trap cleanup EXIT
 # Disabled on darwin since it sometimes seem to hang and this only
 # tests our dev setup rather than our code so issues are not critical.
 if [[ "$(uname)" != "Darwin" ]]; then
-    da-ghci --data yes //compiler/damlc:damlc -e ':main --help'
+  da-ghci --data yes //compiler/damlc:damlc -e ':main --help'
 fi
+
 # Check that our IDE works on our codebase
 ghcide compiler/damlc/exe/Main.hs 2>&1 | tee ide-log
 grep -q "1 file worked, 0 files failed" ide-log

--- a/build.sh
+++ b/build.sh
@@ -16,10 +16,43 @@ tag_filter=""
 if [[ "$execution_log_postfix" == "_Darwin" ]]; then
   tag_filter="-dont-run-on-darwin,-scaladoc,-pdfdocs"
 fi
-# Bazel test only builds targets that are dependencies of a test suite
-# so do a full build first.
+
+# Bazel test only builds targets that are dependencies of a test suite so do a full build first.
 bazel build //... --build_tag_filters "$tag_filter"
-bazel test //... --build_tag_filters "$tag_filter" --test_tag_filters "$tag_filter" --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
+
+# Set up a shared PostgreSQL instance.
+export POSTGRESQL_ROOT_DIR="/${TMPDIR:-/tmp}/daml/postgresql"
+export POSTGRESQL_DATA_DIR="/${POSTGRESQL_ROOT_DIR}/data"
+export POSTGRESQL_LOG_FILE="/${POSTGRESQL_ROOT_DIR}/postgresql.log"
+export POSTGRESQL_HOST='localhost'
+export POSTGRESQL_PORT=54321
+export POSTGRESQL_USERNAME='test'
+export POSTGRESQL_PASSWORD=''
+function start_postgresql() {
+  mkdir -p "$POSTGRESQL_DATA_DIR"
+  bazel run -- @postgresql_dev_env//:initdb --auth=trust --encoding=UNICODE --locale=en_US.UTF-8 --username="$POSTGRESQL_USERNAME" "$POSTGRESQL_DATA_DIR"
+  envsubst -no-unset -i ci/postgresql.conf -o "$POSTGRESQL_DATA_DIR/postgresql.conf"
+  bazel run -- @postgresql_dev_env//:pg_ctl -w --pgdata="$POSTGRESQL_DATA_DIR" --log="$POSTGRESQL_LOG_FILE" start
+}
+function stop_postgresql() {
+  if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    bazel run -- @postgresql_dev_env//:pg_ctl -w --pgdata="$POSTGRESQL_DATA_DIR" --mode=immediate stop || :
+    rm -rf "$POSTGRESQL_ROOT_DIR"
+  fi
+}
+trap stop_postgresql EXIT
+stop_postgresql # in case it's running from a previous build
+start_postgresql
+
+# Run the tests.
+bazel test //... \
+  --build_tag_filters "$tag_filter" \
+  --test_tag_filters "$tag_filter" \
+  --test_env "POSTGRESQL_HOST=${POSTGRESQL_HOST}" \
+  --test_env "POSTGRESQL_PORT=${POSTGRESQL_PORT}" \
+  --test_env "POSTGRESQL_USERNAME=${POSTGRESQL_USERNAME}" \
+  --test_env "POSTGRESQL_PASSWORD=${POSTGRESQL_PASSWORD}" \
+  --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
 
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' >/dev/null

--- a/build.sh
+++ b/build.sh
@@ -21,9 +21,9 @@ fi
 bazel build //... --build_tag_filters "$tag_filter"
 
 # Set up a shared PostgreSQL instance.
-export POSTGRESQL_ROOT_DIR="/${TMPDIR:-/tmp}/daml/postgresql"
-export POSTGRESQL_DATA_DIR="/${POSTGRESQL_ROOT_DIR}/data"
-export POSTGRESQL_LOG_FILE="/${POSTGRESQL_ROOT_DIR}/postgresql.log"
+export POSTGRESQL_ROOT_DIR="${TMPDIR:-/tmp}/daml/postgresql"
+export POSTGRESQL_DATA_DIR="${POSTGRESQL_ROOT_DIR}/data"
+export POSTGRESQL_LOG_FILE="${POSTGRESQL_ROOT_DIR}/postgresql.log"
 export POSTGRESQL_HOST='localhost'
 export POSTGRESQL_PORT=54321
 export POSTGRESQL_USERNAME='test'

--- a/ci/postgresql.conf
+++ b/ci/postgresql.conf
@@ -1,5 +1,6 @@
-listen_addresses = ${POSTGRESQL_HOST}
+listen_addresses = '${POSTGRESQL_HOST}'
 port = ${POSTGRESQL_PORT}
+unix_socket_directories = '${POSTGRESQL_ROOT_DIR}'
 fsync = off
 synchronous_commit = off
 full_page_writes = off

--- a/ci/postgresql.conf
+++ b/ci/postgresql.conf
@@ -1,0 +1,7 @@
+listen_addresses = ${POSTGRESQL_HOST}
+port = ${POSTGRESQL_PORT}
+fsync = off
+synchronous_commit = off
+full_page_writes = off
+log_min_duration_statement = 0
+log_connections = on

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -27,8 +27,10 @@ genrule(
       set -euo pipefail
       TMP_DIR=$$(mktemp -d)
       MVN_DB="$$TMP_DIR/m2"
+      MVN=($(locations @mvn_dev_env//:mvn))
+      MVN="$${{MVN[0]}}"
       install_mvn() {{
-          $(location @mvn_dev_env//:mvn) -q install:install-file \
+          "$$MVN" -q install:install-file \
           -Dmaven.repo.local=$$MVN_DB \
           "-DgroupId=$$1" \
           "-DartifactId=$$2" \
@@ -62,7 +64,7 @@ genrule(
         "com.daml" "ledger-api-auth-client" \
         $(location //ledger/ledger-api-auth-client:libledger-api-auth-client.jar) \
         $(location //ledger/ledger-api-auth-client:ledger-api-auth-client_pom.xml)
-      $(location @mvn_dev_env//:mvn) -q -Dmaven.repo.local=$$MVN_DB -f "$$TMP_DIR/quickstart-java/pom.xml" dependency:resolve dependency:resolve-plugins
+      "$$MVN" -q -Dmaven.repo.local=$$MVN_DB -f "$$TMP_DIR/quickstart-java/pom.xml" dependency:resolve dependency:resolve-plugins
       tar cf $(location integration-tests-mvn.tar) -C $$(dirname $$MVN_DB) $$(basename $$MVN_DB) \
         --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name
     """.format(mvn = mvn_version),

--- a/dev-env/bin/envsubst
+++ b/dev-env/bin/envsubst
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-bin-tool

--- a/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
+++ b/extractor/src/test/lib/scala/com/digitalasset/extractor/services/ExtractorFixture.scala
@@ -50,8 +50,8 @@ trait ExtractorFixture extends SandboxFixture with PostgresAroundSuite with Type
 
   protected def target: PostgreSQLTarget = PostgreSQLTarget(
     connectUrl = postgresDatabase.url,
-    user = PostgresAround.userName,
-    password = PostgresAround.password,
+    user = postgresDatabase.userName,
+    password = postgresDatabase.password,
     outputFormat = outputFormat,
     schemaPerPackage = false,
     mergeIdentical = false,

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralPostgresql.scala
@@ -14,9 +14,9 @@ object MainWithEphemeralPostgresql extends PostgresAround {
         .parse[Unit]("SQL Ledger", _ => (), (), args)
         .getOrElse(sys.exit(1))
 
-    startEphemeralPostgres()
+    connectToPostgresqlServer()
     val database = createNewRandomDatabase()
-    sys.addShutdownHook(stopAndCleanUpPostgres())
+    sys.addShutdownHook(disconnectFromPostgresqlServer())
     val config = originalConfig.copy(
       participants = originalConfig.participants.map(_.copy(serverJdbcUrl = database.url)),
       extra = ExtraConfig(jdbcUrl = Some(database.url)),

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/persistence/MainWithEphemeralPostgresql.scala
@@ -8,9 +8,9 @@ import com.daml.testing.postgresql.PostgresAround
 
 object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
-    startEphemeralPostgres()
+    connectToPostgresqlServer()
     val database = createNewRandomDatabase()
-    sys.addShutdownHook(stopAndCleanUpPostgres())
+    sys.addShutdownHook(disconnectFromPostgresqlServer())
     SandboxMain.main(args ++ Array("--sql-backend-jdbcurl", database.url))
   }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandboxnext/persistence/MainWithEphemeralPostgresql.scala
@@ -8,9 +8,9 @@ import com.daml.testing.postgresql.PostgresAround
 
 object MainWithEphemeralPostgresql extends PostgresAround {
   def main(args: Array[String]): Unit = {
-    startEphemeralPostgres()
+    connectToPostgresqlServer()
     val database = createNewRandomDatabase()
-    sys.addShutdownHook(stopAndCleanUpPostgres())
+    sys.addShutdownHook(disconnectFromPostgresqlServer())
     Main.main(args ++ Array("--sql-backend-jdbcurl", database.url))
   }
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -10,7 +10,7 @@ import com.daml.api.util.TimeProvider
 import com.daml.bazeltools.BazelRunfiles.rlocation
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.domain.LedgerId
-import com.daml.ledger.api.health.{Healthy, Unhealthy}
+import com.daml.ledger.api.health.Healthy
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.archive.DarReader
@@ -143,32 +143,6 @@ class SqlLedgerSpec
         ledger <- createSqlLedger()
       } yield {
         ledger.currentHealth() should be(Healthy)
-      }
-    }
-
-    "be unhealthy if the underlying database is inaccessible 3 or more times in a row" in {
-      for {
-        ledger <- createSqlLedger()
-      } yield {
-        withClue("before shutting down postgres,") {
-          ledger.currentHealth() should be(Healthy)
-        }
-
-        stopPostgres()
-
-        eventually {
-          withClue("after shutting down postgres,") {
-            ledger.currentHealth() should be(Unhealthy)
-          }
-        }
-
-        startPostgres()
-
-        eventually {
-          withClue("after starting up postgres,") {
-            ledger.currentHealth() should be(Healthy)
-          }
-        }
       }
     }
   }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -10,54 +10,86 @@ import java.nio.file.{Files, Path}
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 
+import com.daml.ports.Port
 import com.daml.testing.postgresql.PostgresAround._
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.util.Try
 import scala.util.control.NonFatal
 
 trait PostgresAround {
-  @volatile
-  private var fixture: PostgresFixture = _
+  @volatile private var server: PostgresServer = _
+  @volatile private var paths: Option[PostgresServerPaths] = None
 
   private val started: AtomicBoolean = new AtomicBoolean(false)
 
-  protected def startEphemeralPostgres(): Unit = {
+  protected def connectToPostgresqlServer(): Unit = {
+    (
+      sys.env.get("POSTGRESQL_HOST"),
+      sys.env.get("POSTGRESQL_PORT").map(port => Port(port.toInt)),
+      sys.env.get("POSTGRESQL_USERNAME"),
+      sys.env.get("POSTGRESQL_PASSWORD"),
+    ) match {
+      case (Some(hostName), Some(port), Some(userName), Some(password)) =>
+        connectToSharedServer(hostName, port, userName, password)
+      case _ =>
+        startEphemeralServer()
+    }
+  }
+
+  private def connectToSharedServer(
+      hostName: String,
+      port: Port,
+      userName: String,
+      password: String,
+  ): Unit = {
+    logger.info(s"Connected to PostgreSQL on $hostName:$port.")
+    server = PostgresServer(hostName, port, userName, password)
+  }
+
+  private def startEphemeralServer(): Unit = {
     logger.info("Starting an ephemeral PostgreSQL instance...")
-    val tempDir = Files.createTempDirectory("postgres_test")
-    val dataDir = tempDir.resolve("data")
-    val confFile = dataDir.resolve("postgresql.conf")
-    val logFile = Files.createFile(tempDir.resolve("postgresql.log"))
+    val root = Files.createTempDirectory("postgres_test")
+    val dataDir = root.resolve("data")
+    val configPath = dataDir.resolve("postgresql.conf")
+    val logFile = Files.createFile(root.resolve("postgresql.log"))
     val lockedPort = FreePort.find()
+    val hostName = InetAddress.getLoopbackAddress.getHostName
     val port = lockedPort.port
-    fixture = PostgresFixture(port, tempDir, dataDir, confFile, logFile)
+    val userName = "test"
+    val password = ""
+    server = PostgresServer(hostName, port, userName, password)
+    paths = Some(PostgresServerPaths(root, dataDir, logFile))
 
     try {
-      initializeDatabase()
-      createConfigFile()
-      startPostgres()
+      initializeDatabase(dataDir, userName)
+      createConfigFile(configPath)
+      startPostgresql(dataDir, logFile)
       lockedPort.unlock()
       logger.info(s"PostgreSQL has started on port $port.")
     } catch {
       case NonFatal(e) =>
         lockedPort.unlock()
-        stopPostgres()
-        deleteRecursively(tempDir)
-        fixture = null
+        stopPostgresql(dataDir)
+        deleteRecursively(root)
         throw e
     }
   }
 
-  protected def stopAndCleanUpPostgres(): Unit = {
-    logger.info("Stopping and cleaning up PostgreSQL...")
-    stopPostgres()
-    deleteRecursively(fixture.tempDir)
-    logger.info("PostgreSQL has stopped, and the data directory has been deleted.")
-    fixture = null
+  protected def disconnectFromPostgresqlServer(): Unit = {
+    paths foreach {
+      case PostgresServerPaths(root, dataDir, _) =>
+        logger.info("Stopping and cleaning up PostgreSQL...")
+        stopPostgresql(dataDir)
+        deleteRecursively(root)
+        logger.info("PostgreSQL has stopped, and the data directory has been deleted.")
+    }
+    server = null
   }
 
-  private def startPostgres(): Unit = {
+  private def startPostgresql(dataDir: Path, logFile: Path): Unit = {
     if (!started.compareAndSet(false, true)) {
       throw new IllegalStateException(
         "Attempted to start PostgreSQL, but it has already been started.",
@@ -69,9 +101,9 @@ trait PostgresAround {
         Tool.pg_ctl,
         "-w",
         "-D",
-        fixture.dataDir.toString,
+        dataDir.toString,
         "-l",
-        fixture.logFile.toString,
+        logFile.toString,
         "start",
       )
     } catch {
@@ -82,7 +114,7 @@ trait PostgresAround {
     }
   }
 
-  private def stopPostgres(): Unit = {
+  private def stopPostgresql(dataDir: Path): Unit = {
     if (started.compareAndSet(true, false)) {
       logger.info("Stopping PostgreSQL...")
       run(
@@ -90,7 +122,7 @@ trait PostgresAround {
         Tool.pg_ctl,
         "-w",
         "-D",
-        fixture.dataDir.toString,
+        dataDir.toString,
         "-m",
         "immediate",
         "stop",
@@ -103,12 +135,12 @@ trait PostgresAround {
     createNewDatabase(UUID.randomUUID().toString)
 
   protected def createNewDatabase(name: String): PostgresDatabase = {
-    val database = PostgresDatabase(hostName, fixture.port, userName, name)
+    val database = PostgresDatabase(server, name)
     createDatabase(database)
     database
   }
 
-  private def initializeDatabase(): Unit = run(
+  private def initializeDatabase(dataDir: Path, userName: String): Unit = run(
     "initialize the PostgreSQL database",
     Tool.initdb,
     s"--username=$userName",
@@ -117,10 +149,10 @@ trait PostgresAround {
     "UNICODE",
     "-A",
     "trust",
-    fixture.dataDir.toString.replaceAllLiterally("\\", "/"),
+    dataDir.toString.replaceAllLiterally("\\", "/"),
   )
 
-  private def createConfigFile(): Unit = {
+  private def createConfigFile(configPath: Path): Unit = {
     // taken from here: https://bitbucket.org/eradman/ephemeralpg/src/1b5a3c6be81c69a860b7bd540a16b1249d3e50e2/pg_tmp.sh?at=default&fileviewer=file-view-default#pg_tmp.sh-54
     // We set unix_socket_directories to /tmp rather than tempDir
     // since the latter will refer to a temporary directory set by
@@ -129,16 +161,16 @@ trait PostgresAround {
     // this option is ignored.
     val configText =
       s"""|unix_socket_directories = '/tmp'
-          |shared_buffers = 12MB
-          |fsync = off
-          |synchronous_commit = off
-          |full_page_writes = off
-          |log_min_duration_statement = 0
-          |log_connections = on
-          |listen_addresses = '$hostName'
-          |port = ${fixture.port}
+        |shared_buffers = 12MB
+        |fsync = off
+        |synchronous_commit = off
+        |full_page_writes = off
+        |log_min_duration_statement = 0
+        |log_connections = on
+        |listen_addresses = '${server.hostName}'
+        |port = ${server.port}
           """.stripMargin
-    Files.write(fixture.confFile, configText.getBytes(StandardCharsets.UTF_8))
+    Files.write(configPath, configText.getBytes(StandardCharsets.UTF_8))
     ()
   }
 
@@ -176,7 +208,7 @@ trait PostgresAround {
         IOUtils.copy(process.getInputStream, stdout, StandardCharsets.UTF_8)
         val stderr = new StringWriter
         IOUtils.copy(process.getErrorStream, stderr, StandardCharsets.UTF_8)
-        val logs = Files.readAllLines(fixture.logFile).asScala
+        val logs = readLogs()
         throw new ProcessFailedException(
           description = description,
           command = command,
@@ -189,7 +221,7 @@ trait PostgresAround {
       case e: ProcessFailedException =>
         throw e
       case NonFatal(e) =>
-        val logs = Files.readAllLines(fixture.logFile).asScala
+        val logs = readLogs()
         throw new ProcessFailedException(
           description = description,
           command = command,
@@ -199,17 +231,16 @@ trait PostgresAround {
     }
   }
 
+  private def readLogs(): Seq[String] =
+    Try(paths.map(paths => Files.readAllLines(paths.logFile).asScala).getOrElse(Seq.empty))
+      .getOrElse(Seq.empty)
+
   private def deleteRecursively(tempDir: Path): Unit =
     FileUtils.deleteDirectory(tempDir.toFile)
 }
 
 object PostgresAround {
   private val logger = LoggerFactory.getLogger(getClass)
-
-  private val hostName = InetAddress.getLoopbackAddress.getHostName
-
-  val userName = "test"
-  val password = ""
 
   private class ProcessFailedException(
       description: String,

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -56,7 +56,7 @@ trait PostgresAround {
     val configPath = dataDir.resolve("postgresql.conf")
     val logFile = Files.createFile(root.resolve("postgresql.log"))
     val lockedPort = FreePort.find()
-    val hostName = InetAddress.getLoopbackAddress.getHostName
+    val hostName = InetAddress.getLoopbackAddress.getHostAddress
     val port = lockedPort.port
     val userName = "test"
     val password = ""

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -57,7 +57,7 @@ trait PostgresAround {
     fixture = null
   }
 
-  protected def startPostgres(): Unit = {
+  private def startPostgres(): Unit = {
     if (!started.compareAndSet(false, true)) {
       throw new IllegalStateException(
         "Attempted to start PostgreSQL, but it has already been started.",
@@ -82,7 +82,7 @@ trait PostgresAround {
     }
   }
 
-  protected def stopPostgres(): Unit = {
+  private def stopPostgres(): Unit = {
     if (started.compareAndSet(true, false)) {
       logger.info("Stopping PostgreSQL...")
       run(

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundAll.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundAll.scala
@@ -11,13 +11,13 @@ trait PostgresAroundAll extends PostgresAroundSuite with BeforeAndAfterAll {
   override protected def beforeAll(): Unit = {
     // We start PostgreSQL before calling `super` because _generally_ the database needs to be up
     // before everything else.
-    startEphemeralPostgres()
+    connectToPostgresqlServer()
     createNewDatabase()
     super.beforeAll()
   }
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    stopAndCleanUpPostgres()
+    disconnectFromPostgresqlServer()
   }
 }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundEach.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAroundEach.scala
@@ -14,13 +14,13 @@ trait PostgresAroundEach
   override protected def beforeAll(): Unit = {
     // We start PostgreSQL before calling `super` because _generally_ the database needs to be up
     // before everything else.
-    startEphemeralPostgres()
+    connectToPostgresqlServer()
     super.beforeAll()
   }
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    stopAndCleanUpPostgres()
+    disconnectFromPostgresqlServer()
   }
 
   override protected def beforeEach(): Unit = {

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresDatabase.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresDatabase.scala
@@ -5,13 +5,20 @@ package com.daml.testing.postgresql
 
 import com.daml.ports.Port
 
-final case class PostgresDatabase(
-    hostName: String,
-    port: Port,
-    userName: String,
+final case class PostgresDatabase private[postgresql] (
+    private val server: PostgresServer,
     databaseName: String,
 ) {
-  def url: String = s"jdbc:postgresql://$hostName:$port/$databaseName?user=$userName"
+  def hostName: String = server.hostName
+
+  def port: Port = server.port
+
+  def userName: String = server.userName
+
+  def password: String = server.password
+
+  def url: String =
+    s"jdbc:postgresql://$hostName:$port/$databaseName?user=$userName&password=$password"
 
   override def toString: String = url
 }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresResource.scala
@@ -14,8 +14,8 @@ object PostgresResource {
           implicit executionContext: ExecutionContext
       ): Resource[PostgresDatabase] =
         Resource(Future {
-          startEphemeralPostgres()
+          connectToPostgresqlServer()
           createNewRandomDatabase()
-        })(_ => Future(stopAndCleanUpPostgres()))
+        })(_ => Future(disconnectFromPostgresqlServer()))
     }
 }

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresServer.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresServer.scala
@@ -3,14 +3,11 @@
 
 package com.daml.testing.postgresql
 
-import java.nio.file.Path
-
 import com.daml.ports.Port
 
-final case class PostgresFixture(
+final case class PostgresServer(
+    hostName: String,
     port: Port,
-    tempDir: Path,
-    dataDir: Path,
-    confFile: Path,
-    logFile: Path,
+    userName: String,
+    password: String,
 )

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresServerPaths.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresServerPaths.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.testing.postgresql
+
+import java.nio.file.Path
+
+case class PostgresServerPaths(
+    root: Path,
+    dataDir: Path,
+    logFile: Path,
+)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -204,6 +204,7 @@ in rec {
     xmlstarlet = pkgs.xmlstarlet;
     grep = pkgs.gnugrep;
     bc = pkgs.bc;
+    envsubst = pkgs.envsubst;
 
     # Cryptography tooling
     gnupg = pkgs.gnupg;


### PR DESCRIPTION
Hopefully this will make the build much faster and less likely to run out of memory.

To do this, I had to:

- make the PostgreSQL binaries runnable with `bazel run` (I did it for all `dev_env_tool` binaries), and
- delete the Sandbox test that restarts PostgreSQL, because it no longer makes sense (and also it's really slow and flaky).

This currently only works on Linux and macOS (i.e. I did it in _build.sh_). I tried to make it work on Windows, but it hurt too much.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
