### PR TITLE
switch back to Azure-provided macos nodes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,7 +124,7 @@ jobs:
       - check_for_release
     timeoutInMinutes: 360
     pool:
-      name: 'macOS-pool'
+      vmImage: macOS-10.14
     variables:
       release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
       release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
@@ -205,7 +205,7 @@ jobs:
       - check_for_release
     timeoutInMinutes: 60
     pool:
-      name: macos-pool
+      vmImage: macOS-10.14
     steps:
       - template: ci/report-start.yml
       - checkout: self

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -25,14 +25,8 @@ schedules:
 jobs:
   - job: compatibility
     timeoutInMinutes: 240
-    strategy:
-      matrix:
-        linux:
-          pool: 'linux-pool'
-        macos:
-          pool: 'macOS-pool'
     pool:
-      name: $(pool)
+      name: linux-pool
     steps:
       - checkout: self
       - template: ../compatibility.yml
@@ -52,6 +46,31 @@ jobs:
                $(Slack.team-daml)
         displayName: report
         condition: always()
+
+  - job: compatibility
+    timeoutInMinutes: 240
+    pool:
+      vmImage: macos-10.14
+    steps:
+      - checkout: self
+      - template: ../compatibility.yml
+      - bash: |
+          set -euo pipefail
+          COMMIT_TITLE=$(git log --pretty=format:%s -n1)
+          COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$COMMIT_TITLE>"
+          if [ "$(Agent.JobStatus)" != "Succeeded" ]; then
+              MESSAGE=":fire: <!here> :fire: :fire:\n$(Agent.JobName) *FAILED*: $COMMIT_LINK\n:fire: :fire:"
+          else
+              MESSAGE="$(Agent.JobName) passed: $COMMIT_LINK"
+          fi
+          curl -XPOST \
+               -i \
+               -H 'Content-type: application/json' \
+               --data "{\"text\":\"$MESSAGE\n\"}" \
+               $(Slack.team-daml)
+        displayName: report
+        condition: always()
+
   - job: compatibility_windows
     timeoutInMinutes: 240
     pool:


### PR DESCRIPTION
This is temporary. It looks like the macOS nodes are dead; @nycnewman is
looking into it, but in case he doesn't fix it in time, at least we
have a backup plan so we're not completely blocked on Monday.

CHANGELOG_BEGIN
CHANGELOG_END