### PR TITLE
Scenario service: drop useless resolveRelCid

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/types/Ledger.scala
@@ -181,9 +181,7 @@ object Ledger {
       committer: Party,
       effectiveAt: Time.Timestamp,
       enrichedTx: EnrichedTransaction,
-  ): RichTransaction = {
-    def makeAbs(cid: Value.RelativeContractId) =
-      Ref.ContractIdString.assertFromString(relativeToContractIdString(commitPrefix, cid))
+  ): RichTransaction =
     RichTransaction(
       committer = committer,
       effectiveAt = effectiveAt,
@@ -191,7 +189,7 @@ object Ledger {
       nodes = enrichedTx.nodes.map {
         case (nodeId, node) =>
           ScenarioNodeId(commitPrefix, nodeId) -> node
-            .resolveRelCid(makeAbs)
+            .assertNoRelCid(_ => "Unexpected relative contract ID.")
             .mapNodeId(ScenarioNodeId(commitPrefix, _))
       }(breakOut),
       explicitDisclosure = enrichedTx.explicitDisclosure.map {
@@ -205,7 +203,6 @@ object Ledger {
       globalImplicitDisclosure = enrichedTx.globalImplicitDisclosure,
       failedAuthorizations = enrichedTx.failedAuthorizations,
     )
-  }
 
   /** Scenario step representing the actions executed in a scenario. */
   sealed trait ScenarioStep


### PR DESCRIPTION
We remove the `resolveRelCid` used by the scenario service, in preparation of removing completely relative contract Id in DAML engine.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
