### PR TITLE
Change references to replicateM to replicateA in dlint rules

### DIFF
--- a/compiler/damlc/daml-ide-core/dlint.yaml
+++ b/compiler/damlc/daml-ide-core/dlint.yaml
@@ -392,13 +392,10 @@
 
     # MONAD LIST
 
-    - warn: {lhs: fmap unzip (mapA f x), rhs: DA.Action.mapAndUnzipM f x}
-    - warn: {lhs: sequence (zipWith f x y), rhs: DA.Action.zipWithM f x y}
-    - warn: {lhs: sequence_ (zipWith f x y), rhs: DA.Action.zipWithM_ f x y}
-    - warn: {lhs: sequence (replicate n x), rhs: DA.Action.replicateM n x}
-    - warn: {lhs: sequence_ (replicate n x), rhs: DA.Action.replicateM_ n x}
-    - warn: {lhs: mapA f (replicate n x), rhs: DA.Action.replicateM n (f x)}
-    - warn: {lhs: mapA_ f (replicate n x), rhs: DA.Action.replicateM_ n (f x)}
+    - warn: {lhs: sequence (replicate n x), rhs: DA.Action.replicateA n x}
+    - warn: {lhs: sequence_ (replicate n x), rhs: DA.Action.replicateA_ n x}
+    - warn: {lhs: mapA f (replicate n x), rhs: DA.Action.replicateA n (f x)}
+    - warn: {lhs: mapA_ f (replicate n x), rhs: DA.Action.replicateA_ n (f x)}
     - warn: {lhs: mapA f (map g x), rhs: mapA (f . g) x, name: Fuse mapA/map}
     - warn: {lhs: mapA_ f (map g x), rhs: mapA_ (f . g) x, name: Fuse mapA_/map}
     - warn: {lhs: traverse f (map g x), rhs: traverse (f . g) x, name: Fuse traverse/map}


### PR DESCRIPTION
changelog_begin
Change references to replicateM to replicateA in dlint rules; remove some Haskell-based rules that do not yet apply in DAML.
changelog_end

Noticed this when writing

```hs
mapA create $ replicate copies book
```

and dlint suggested:

```
….daml:37:11-45: Warning: Use replicateM
Found:
  mapA create $ replicate copies book
Perhaps:
  replicateM copies (create book)
```

When applying the fix, I also noticed a comment a few lines up about `zipWithA` not existing in the stdlib, so I commented out a few rules in the same block as well.