### PR TITLE
Shutdown protocol

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -53,7 +53,7 @@ object ServiceConfig {
     parser.parse(
       args,
       ServiceConfig(
-        darPath = null,
+        darPath = None,
         ledgerHost = null,
         ledgerPort = 0,
         timeProviderType = TimeProviderType.Static,


### PR DESCRIPTION
- Fixed a bug in the config that causes a null-pointer exception if the `--dar` argument is not passed;
- Add code to shut down the service with Ctrl+C.