### PR TITLE
Backport "Fix typescript tests (#5934)" on 1.1.x

### DIFF
--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
@@ -26,8 +26,9 @@ eslintVersion :: T.Text
 eslintVersion = "^6.8.0"
 
 -- Version of typescript-eslint for linting the generated code.
+-- 2.32 produces an error https://github.com/typescript-eslint/typescript-eslint/issues/2009
 typescriptEslintVersion :: T.Text
-typescriptEslintVersion = "^2.16.0"
+typescriptEslintVersion = "~2.31.0"
 
 main :: IO ()
 main = do


### PR DESCRIPTION
See #5934. Assuming we keep the same snapshot (no issue yet AFAIK), not including this would break the build for 1.1.0.

changelog_begin
changelog_end