### PR TITLE
Avoid redundant bazel build //...

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,9 +18,7 @@ if [[ "$execution_log_postfix" == "_Darwin" ]]; then
   tag_filter="-dont-run-on-darwin,-scaladoc,-pdfdocs"
 fi
 
-# Bazel test only builds targets that are dependencies of a test suite
-# so do a full build first.
-bazel build //... --build_tag_filters "$tag_filter"
+# bazel test //... will also build targets that are not tests.
 bazel test //... --build_tag_filters "$tag_filter" --test_tag_filters "$tag_filter" --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
 # Make sure that Bazel query works.
 bazel query 'deps(//...)' > /dev/null

--- a/compatibility/test.sh
+++ b/compatibility/test.sh
@@ -18,10 +18,11 @@ eval "$(../dev-env/bin/dade-assist)"
 # it unconditionally since it should be cheap enough.
 cp ../.bazelrc .bazelrc
 
-bazel build //...
 if [ "${1:-}" = "--quick" ]; then
+    bazel build //...
     bazel test //:head-quick
 else
+    # bazel test //... will also build targets that are not tests.
     bazel test //...
 fi
 


### PR DESCRIPTION
`bazel test //...` will also build targets that are not tests and not dependencies of tests. See https://github.com/bazelbuild/bazel/issues/4257. I've verified this with a simple `genrule` and `cc_binary` target. The advantage of `bazel test //...` over `bazel build //... && bazel test //...` is that the former can interleave building and testing and therefore make better use of multiple cores.

I've left the Windows test scripts untouched as they include a `bazel shutdown` inbetween build and test.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
