### PR TITLE
Centralize and time serialization

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
@@ -13,7 +13,7 @@ final class DatabaseMetrics private[metrics] (
 
   val waitTimer: Timer = registry.timer(prefix :+ name :+ "wait")
   val executionTimer: Timer = registry.timer(prefix :+ name :+ "exec")
-  val deserializationTimer: Timer = registry.timer(prefix :+ name :+ "deserialization")
+  val translationTimer: Timer = registry.timer(prefix :+ name :+ "translation")
 
 }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
@@ -50,8 +50,7 @@ private[dao] sealed abstract class ContractsReader(
             contractId = contractId,
             templateId = templateId,
             createArgument = createArgument,
-            deserializationTimer =
-              metrics.daml.index.db.lookupActiveContractDao.deserializationTimer,
+            deserializationTimer = metrics.daml.index.db.lookupActiveContractDao.translationTimer,
           )
       })(executionContext)
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableInsert.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableInsert.scala
@@ -8,41 +8,9 @@ import java.time.Instant
 import anorm.{BatchSql, NamedParameter}
 import com.daml.ledger.participant.state.v1.{Offset, SubmitterInfo}
 import com.daml.ledger._
-import com.daml.platform.events.EventIdFormatter.fromTransactionId
 import com.daml.platform.store.Conversions._
-import com.daml.platform.store.serialization.ValueSerializer.{serializeValue => serialize}
 
 private[events] trait EventsTableInsert { this: EventsTable =>
-
-  private def cantSerialize(attribute: String, forContract: ContractId): String =
-    s"Cannot serialize $attribute for ${forContract.coid}"
-
-  private def serializeCreateArgOrThrow(node: Create): Array[Byte] =
-    serialize(
-      value = node.coinst.arg,
-      errorContext = cantSerialize(attribute = "create argument", forContract = node.coid),
-    )
-
-  private def serializeNullableKeyOrThrow(node: Create): Option[Array[Byte]] =
-    node.key.map(
-      k =>
-        serialize(
-          value = k.key,
-          errorContext = cantSerialize(attribute = "key", forContract = node.coid),
-      ))
-
-  private def serializeExerciseArgOrThrow(node: Exercise): Array[Byte] =
-    serialize(
-      value = node.chosenValue,
-      errorContext = cantSerialize(attribute = "exercise argument", forContract = node.targetCoid),
-    )
-
-  private def serializeNullableExerciseResultOrThrow(node: Exercise): Option[Array[Byte]] =
-    node.exerciseResult.map(exerciseResult =>
-      serialize(
-        value = exerciseResult,
-        errorContext = cantSerialize(attribute = "exercise result", forContract = node.targetCoid),
-    ))
 
   private def insertEvent(columnNameAndValues: (String, String)*): String = {
     val (columns, values) = columnNameAndValues.unzip
@@ -70,36 +38,6 @@ private[events] trait EventsTableInsert { this: EventsTable =>
       "create_key_value" -> "{create_key_value}"
     )
 
-  private def create(
-      applicationId: Option[ApplicationId],
-      workflowId: Option[WorkflowId],
-      commandId: Option[CommandId],
-      transactionId: TransactionId,
-      nodeId: NodeId,
-      submitter: Option[Party],
-      ledgerEffectiveTime: Instant,
-      offset: Offset,
-      create: Create,
-  ): Vector[NamedParameter] =
-    Vector[NamedParameter](
-      "event_id" -> fromTransactionId(transactionId, nodeId),
-      "event_offset" -> offset,
-      "contract_id" -> create.coid.coid,
-      "transaction_id" -> transactionId,
-      "workflow_id" -> workflowId,
-      "ledger_effective_time" -> ledgerEffectiveTime,
-      "template_id" -> create.coinst.template,
-      "node_index" -> nodeId.index,
-      "command_id" -> commandId,
-      "application_id" -> applicationId,
-      "submitter" -> submitter,
-      "create_argument" -> serializeCreateArgOrThrow(create),
-      "create_signatories" -> create.signatories.toArray[String],
-      "create_observers" -> create.stakeholders.diff(create.signatories).toArray[String],
-      "create_agreement_text" -> Some(create.coinst.agreementText).filter(_.nonEmpty),
-      "create_key_value" -> serializeNullableKeyOrThrow(create),
-    )
-
   private val insertExercise =
     insertEvent(
       "event_id" -> "{event_id}",
@@ -121,39 +59,6 @@ private[events] trait EventsTableInsert { this: EventsTable =>
       "exercise_child_event_ids" -> "{exercise_child_event_ids}"
     )
 
-  private def exercise(
-      applicationId: Option[ApplicationId],
-      workflowId: Option[WorkflowId],
-      commandId: Option[CommandId],
-      transactionId: TransactionId,
-      nodeId: NodeId,
-      submitter: Option[Party],
-      ledgerEffectiveTime: Instant,
-      offset: Offset,
-      exercise: Exercise,
-  ): Vector[NamedParameter] =
-    Vector[NamedParameter](
-      "event_id" -> fromTransactionId(transactionId, nodeId),
-      "event_offset" -> offset,
-      "contract_id" -> exercise.targetCoid.coid,
-      "transaction_id" -> transactionId,
-      "workflow_id" -> workflowId,
-      "ledger_effective_time" -> ledgerEffectiveTime,
-      "template_id" -> exercise.templateId,
-      "node_index" -> nodeId.index,
-      "command_id" -> commandId,
-      "application_id" -> applicationId,
-      "submitter" -> submitter,
-      "exercise_consuming" -> exercise.consuming,
-      "exercise_choice" -> exercise.choiceId,
-      "exercise_argument" -> serializeExerciseArgOrThrow(exercise),
-      "exercise_result" -> serializeNullableExerciseResultOrThrow(exercise),
-      "exercise_actors" -> exercise.actingParties.toArray[String],
-      "exercise_child_event_ids" -> exercise.children
-        .map(fromTransactionId(transactionId, _))
-        .toArray[String],
-    )
-
   private val updateArchived =
     """update participant_events set create_consumed_at={consumed_at} where contract_id={contract_id} and create_argument is not null"""
 
@@ -166,13 +71,39 @@ private[events] trait EventsTableInsert { this: EventsTable =>
       "contract_id" -> contractId.coid,
     )
 
-  sealed abstract case class PreparedBatches(
+  final class RawBatches private[EventsTableInsert] (
+      creates: Option[RawBatch],
+      exercises: Option[RawBatch],
+      archives: Option[BatchSql],
+  ) {
+    def applySerialization(): SerializedBatches =
+      new SerializedBatches(
+        creates = creates.map(_.applySerialization()),
+        exercises = exercises.map(_.applySerialization()),
+        archives = archives,
+      )
+  }
+
+  final class SerializedBatches(
+      creates: Option[Vector[Vector[NamedParameter]]],
+      exercises: Option[Vector[Vector[NamedParameter]]],
+      archives: Option[BatchSql],
+  ) {
+    def applyBatching(): PreparedBatches =
+      new PreparedBatches(
+        creates = creates.map(cs => BatchSql(insertCreate, cs.head, cs.tail: _*)),
+        exercises = exercises.map(es => BatchSql(insertExercise, es.head, es.tail: _*)),
+        archives = archives,
+      )
+  }
+
+  final class PreparedBatches(
       creates: Option[BatchSql],
       exercises: Option[BatchSql],
       archives: Option[BatchSql],
   ) {
-    final def isEmpty: Boolean = creates.isEmpty && exercises.isEmpty && archives.isEmpty
-    final def foreach[U](f: BatchSql => U): Unit = {
+    def isEmpty: Boolean = creates.isEmpty && exercises.isEmpty && archives.isEmpty
+    def foreach[U](f: BatchSql => U): Unit = {
       creates.foreach(f)
       exercises.foreach(f)
       archives.foreach(f)
@@ -180,19 +111,25 @@ private[events] trait EventsTableInsert { this: EventsTable =>
   }
 
   private case class AccumulatingBatches(
-      creates: Vector[Vector[NamedParameter]],
-      exercises: Vector[Vector[NamedParameter]],
+      creates: Vector[RawBatch.Event.Created],
+      exercises: Vector[RawBatch.Event.Exercised],
       archives: Vector[Vector[NamedParameter]],
   ) {
 
-    def addCreate(create: Vector[NamedParameter]): AccumulatingBatches =
+    def add(create: RawBatch.Event.Created): AccumulatingBatches =
       copy(creates = creates :+ create)
 
-    def addExercise(exercise: Vector[NamedParameter]): AccumulatingBatches =
+    def add(exercise: RawBatch.Event.Exercised): AccumulatingBatches =
       copy(exercises = exercises :+ exercise)
 
-    def addArchive(archive: Vector[NamedParameter]): AccumulatingBatches =
+    def add(archive: Vector[NamedParameter]): AccumulatingBatches =
       copy(archives = archives :+ archive)
+
+    private def prepareRawNonEmpty(
+        query: String,
+        params: Vector[RawBatch.Event],
+    ): Option[RawBatch] =
+      if (params.nonEmpty) Some(new RawBatch(query, params)) else None
 
     private def prepareNonEmpty(
         query: String,
@@ -200,12 +137,12 @@ private[events] trait EventsTableInsert { this: EventsTable =>
     ): Option[BatchSql] =
       if (params.nonEmpty) Some(BatchSql(query, params.head, params.tail: _*)) else None
 
-    def prepare: PreparedBatches =
-      new PreparedBatches(
-        prepareNonEmpty(insertCreate, creates),
-        prepareNonEmpty(insertExercise, exercises),
+    def prepare: RawBatches =
+      new RawBatches(
+        prepareRawNonEmpty(insertCreate, creates),
+        prepareRawNonEmpty(insertExercise, exercises),
         prepareNonEmpty(updateArchived, archives),
-      ) {}
+      )
 
   }
 
@@ -228,12 +165,12 @@ private[events] trait EventsTableInsert { this: EventsTable =>
       ledgerEffectiveTime: Instant,
       offset: Offset,
       transaction: Transaction,
-  ): PreparedBatches =
+  ): RawBatches =
     transaction
       .fold(AccumulatingBatches.empty) {
         case (batches, (nodeId, node: Create)) =>
-          batches.addCreate(
-            create(
+          batches.add(
+            new RawBatch.Event.Created(
               applicationId = submitterInfo.map(_.applicationId),
               workflowId = workflowId,
               commandId = submitterInfo.map(_.commandId),
@@ -247,8 +184,8 @@ private[events] trait EventsTableInsert { this: EventsTable =>
           )
         case (batches, (nodeId, node: Exercise)) =>
           val batchWithExercises =
-            batches.addExercise(
-              exercise(
+            batches.add(
+              new RawBatch.Event.Exercised(
                 applicationId = submitterInfo.map(_.applicationId),
                 workflowId = workflowId,
                 commandId = submitterInfo.map(_.commandId),
@@ -261,7 +198,7 @@ private[events] trait EventsTableInsert { this: EventsTable =>
               )
             )
           if (node.consuming) {
-            batchWithExercises.addArchive(
+            batchWithExercises.add(
               archive(
                 contractId = node.targetCoid,
                 consumedAt = offset,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/RawBatch.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/RawBatch.scala
@@ -1,0 +1,187 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+import java.time.Instant
+
+import anorm.NamedParameter
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger.{ApplicationId, CommandId, TransactionId, WorkflowId}
+import com.daml.platform.events.EventIdFormatter.fromTransactionId
+import com.daml.platform.store.Conversions._
+import com.daml.platform.store.dao.events.RawBatch.PartialParameters
+import com.daml.platform.store.serialization.ValueSerializer
+
+private[events] final class RawBatch(query: String, parameters: Vector[PartialParameters]) {
+  def applySerialization(): Vector[Vector[NamedParameter]] =
+    parameters.map(_.applySerialization())
+}
+
+private[events] object RawBatch {
+
+  sealed abstract class PartialParameters {
+    def applySerialization(): Vector[NamedParameter]
+  }
+
+  final class Contract(
+      contractId: ContractId,
+      templateId: Identifier,
+      createArgument: Value,
+      createLedgerEffectiveTime: Option[Instant],
+      stakeholders: Set[Party],
+      key: Option[Key],
+  ) extends PartialParameters {
+
+    private val partial =
+      Vector[NamedParameter](
+        "contract_id" -> contractId,
+        "template_id" -> templateId,
+        "create_ledger_effective_time" -> createLedgerEffectiveTime,
+        "create_stakeholders" -> stakeholders.toArray[String],
+        "create_key_hash" -> key.map(_.hash),
+      )
+
+    override def applySerialization(): Vector[NamedParameter] =
+      partial :+
+        ("create_argument" -> ValueSerializer.serializeValue(
+          value = createArgument,
+          errorContext = s"Cannot serialize create argument for ${contractId.coid}",
+        ): NamedParameter)
+  }
+
+  sealed abstract class Event(
+      applicationId: Option[ApplicationId],
+      workflowId: Option[WorkflowId],
+      commandId: Option[CommandId],
+      transactionId: TransactionId,
+      nodeId: NodeId,
+      submitter: Option[Party],
+      ledgerEffectiveTime: Instant,
+      offset: Offset,
+  ) extends PartialParameters {
+    final protected val base: Vector[NamedParameter] =
+      Vector[NamedParameter](
+        "event_id" -> fromTransactionId(transactionId, nodeId),
+        "event_offset" -> offset,
+        "transaction_id" -> transactionId,
+        "workflow_id" -> workflowId,
+        "ledger_effective_time" -> ledgerEffectiveTime,
+        "node_index" -> nodeId.index,
+        "command_id" -> commandId,
+        "application_id" -> applicationId,
+        "submitter" -> submitter,
+      )
+  }
+
+  object Event {
+
+    final class Created(
+        applicationId: Option[ApplicationId],
+        workflowId: Option[WorkflowId],
+        commandId: Option[CommandId],
+        transactionId: TransactionId,
+        nodeId: NodeId,
+        submitter: Option[Party],
+        ledgerEffectiveTime: Instant,
+        offset: Offset,
+        create: Create,
+    ) extends Event(
+          applicationId = applicationId,
+          workflowId = workflowId,
+          commandId = commandId,
+          transactionId = transactionId,
+          nodeId = nodeId,
+          submitter = submitter,
+          ledgerEffectiveTime = ledgerEffectiveTime,
+          offset = offset,
+        ) {
+      val partial: Vector[NamedParameter] =
+        base ++ Vector[NamedParameter](
+          "contract_id" -> create.coid.coid,
+          "template_id" -> create.coinst.template,
+          "create_signatories" -> create.signatories.toArray[String],
+          "create_observers" -> create.stakeholders.diff(create.signatories).toArray[String],
+          "create_agreement_text" -> Some(create.coinst.agreementText).filter(_.nonEmpty),
+        )
+      override def applySerialization(): Vector[NamedParameter] =
+        partial ++ Vector[NamedParameter](
+          "create_argument" -> serializeCreateArgOrThrow(create),
+          "create_key_value" -> serializeNullableKeyOrThrow(create),
+        )
+    }
+
+    final class Exercised(
+        applicationId: Option[ApplicationId],
+        workflowId: Option[WorkflowId],
+        commandId: Option[CommandId],
+        transactionId: TransactionId,
+        nodeId: NodeId,
+        submitter: Option[Party],
+        ledgerEffectiveTime: Instant,
+        offset: Offset,
+        exercise: Exercise,
+    ) extends Event(
+          applicationId = applicationId,
+          workflowId = workflowId,
+          commandId = commandId,
+          transactionId = transactionId,
+          nodeId = nodeId,
+          submitter = submitter,
+          ledgerEffectiveTime = ledgerEffectiveTime,
+          offset = offset,
+        ) {
+      val partial: Vector[NamedParameter] =
+        base ++ Vector[NamedParameter](
+          "contract_id" -> exercise.targetCoid,
+          "template_id" -> exercise.templateId,
+          "exercise_consuming" -> exercise.consuming,
+          "exercise_choice" -> exercise.choiceId,
+          "exercise_actors" -> exercise.actingParties.toArray[String],
+          "exercise_child_event_ids" -> exercise.children
+            .map(fromTransactionId(transactionId, _))
+            .toArray[String],
+        )
+      override def applySerialization(): Vector[NamedParameter] =
+        partial ++ Vector[NamedParameter](
+          "exercise_argument" -> serializeExerciseArgOrThrow(exercise),
+          "exercise_result" -> serializeNullableExerciseResultOrThrow(exercise),
+        )
+    }
+
+    private def cantSerialize(attribute: String, forContract: ContractId): String =
+      s"Cannot serialize $attribute for ${forContract.coid}"
+
+    private def serializeCreateArgOrThrow(c: Create): Array[Byte] =
+      ValueSerializer.serializeValue(
+        value = c.coinst.arg,
+        errorContext = cantSerialize(attribute = "create argument", forContract = c.coid),
+      )
+
+    private def serializeNullableKeyOrThrow(c: Create): Option[Array[Byte]] =
+      c.key.map(
+        k =>
+          ValueSerializer.serializeValue(
+            value = k.key,
+            errorContext = cantSerialize(attribute = "key", forContract = c.coid),
+        )
+      )
+
+    private def serializeExerciseArgOrThrow(e: Exercise): Array[Byte] =
+      ValueSerializer.serializeValue(
+        value = e.chosenValue,
+        errorContext = cantSerialize(attribute = "exercise argument", forContract = e.targetCoid),
+      )
+
+    private def serializeNullableExerciseResultOrThrow(e: Exercise): Option[Array[Byte]] =
+      e.exerciseResult.map(
+        exerciseResult =>
+          ValueSerializer.serializeValue(
+            value = exerciseResult,
+            errorContext = cantSerialize(attribute = "exercise result", forContract = e.targetCoid),
+        )
+      )
+
+  }
+
+}

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsReader.scala
@@ -68,7 +68,7 @@ private[dao] final class TransactionsReader(
       .flatMapConcat { events =>
         val response = EventsTable.Entry.toGetTransactionsResponse(
           verbose = verbose,
-          deserializationTimer = dbMetrics.getFlatTransactions.deserializationTimer,
+          deserializationTimer = dbMetrics.getFlatTransactions.translationTimer,
         )(events)
         Source(response.map(r => offsetFor(r) -> r))
       }
@@ -89,7 +89,7 @@ private[dao] final class TransactionsReader(
       .map(
         EventsTable.Entry.toGetFlatTransactionResponse(
           verbose = true,
-          deserializationTimer = dbMetrics.lookupFlatTransactionById.deserializationTimer,
+          deserializationTimer = dbMetrics.lookupFlatTransactionById.translationTimer,
         )
       )(executionContext)
   }
@@ -121,7 +121,7 @@ private[dao] final class TransactionsReader(
       .flatMapConcat { events =>
         val response = EventsTable.Entry.toGetTransactionTreesResponse(
           verbose = verbose,
-          deserializationTimer = dbMetrics.getTransactionTrees.deserializationTimer,
+          deserializationTimer = dbMetrics.getTransactionTrees.translationTimer,
         )(events)
         Source(response.map(r => offsetFor(r) -> r))
       }
@@ -142,7 +142,7 @@ private[dao] final class TransactionsReader(
       .map(
         EventsTable.Entry.toGetTransactionResponse(
           verbose = true,
-          deserializationTimer = dbMetrics.lookupTransactionTreeById.deserializationTimer,
+          deserializationTimer = dbMetrics.lookupTransactionTreeById.translationTimer,
         ))(executionContext)
   }
 
@@ -172,7 +172,7 @@ private[dao] final class TransactionsReader(
         Source(
           EventsTable.Entry.toGetActiveContractsResponse(
             verbose = verbose,
-            deserializationTimer = dbMetrics.getActiveContracts.deserializationTimer,
+            deserializationTimer = dbMetrics.getActiveContracts.translationTimer,
           )(events)
         )
       }


### PR DESCRIPTION
changelog_begin
OVERRIDES CHANGELOG ENTRY FROM 2a8c93a614ccd21d9ed54d1293116ad2eaf50b09
[Ledger Integration Kit] Added new metrics for
``daml.index.db.*.translation`` to measure the time spent
translating to and from the serialized DAML-LF values when
fetched from the participant index.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
