### PR TITLE
Implement a simple profiler for DAML scenarios

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -183,7 +183,8 @@ class ReplService(
       respObs: StreamObserver[LoadPackageResponse]): Unit = {
     val (pkgId, pkg) = Decode.decodeArchiveFromInputStream(req.getPackage.newInput)
     packages = packages + (pkgId -> pkg)
-    compiledDefinitions = compiledDefinitions ++ Compiler(packages, Compiler.NoProfile).unsafeCompilePackage(pkgId)
+    compiledDefinitions = compiledDefinitions ++ Compiler(packages, Compiler.NoProfile)
+      .unsafeCompilePackage(pkgId)
     respObs.onNext(LoadPackageResponse.newBuilder.build)
     respObs.onCompleted()
   }
@@ -219,7 +220,8 @@ class ReplService(
 
     val allPkgs = packages + (homePackageId -> pkg)
     val defs = Compiler(allPkgs, Compiler.NoProfile).unsafeCompilePackage(homePackageId)
-    val compiledPackages = PureCompiledPackages(allPkgs, compiledDefinitions ++ defs, Compiler.NoProfile)
+    val compiledPackages =
+      PureCompiledPackages(allPkgs, compiledDefinitions ++ defs, Compiler.NoProfile)
     val runner = new Runner(
       compiledPackages,
       Script.Action(scriptExpr, ScriptIds(scriptPackageId)),

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -220,7 +220,8 @@ class ReplService(
 
     val allPkgs = packages + (homePackageId -> pkg)
     val defs = Compiler(allPkgs, Compiler.NoProfile).unsafeCompilePackage(homePackageId)
-    val compiledPackages = PureCompiledPackages(allPkgs, compiledDefinitions ++ defs, Compiler.NoProfile)
+    val compiledPackages =
+      PureCompiledPackages(allPkgs, compiledDefinitions ++ defs, Compiler.NoProfile)
     val runner = new Runner(
       compiledPackages,
       Script.Action(scriptExpr, ScriptIds(scriptPackageId)),

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -220,7 +220,7 @@ class ReplService(
 
     val allPkgs = packages + (homePackageId -> pkg)
     val defs = Compiler(allPkgs, Compiler.NoProfile).unsafeCompilePackage(homePackageId)
-    val compiledPackages = PureCompiledPackages(allPkgs, compiledDefinitions ++ defs)
+    val compiledPackages = PureCompiledPackages(allPkgs, compiledDefinitions ++ defs, Compiler.NoProfile)
     val runner = new Runner(
       compiledPackages,
       Script.Action(scriptExpr, ScriptIds(scriptPackageId)),

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -220,8 +220,7 @@ class ReplService(
 
     val allPkgs = packages + (homePackageId -> pkg)
     val defs = Compiler(allPkgs, Compiler.NoProfile).unsafeCompilePackage(homePackageId)
-    val compiledPackages =
-      PureCompiledPackages(allPkgs, compiledDefinitions ++ defs, Compiler.NoProfile)
+    val compiledPackages = PureCompiledPackages(allPkgs, compiledDefinitions ++ defs)
     val runner = new Runner(
       compiledPackages,
       Script.Action(scriptExpr, ScriptIds(scriptPackageId)),

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -183,7 +183,7 @@ class ReplService(
       respObs: StreamObserver[LoadPackageResponse]): Unit = {
     val (pkgId, pkg) = Decode.decodeArchiveFromInputStream(req.getPackage.newInput)
     packages = packages + (pkgId -> pkg)
-    compiledDefinitions = compiledDefinitions ++ Compiler(packages).unsafeCompilePackage(pkgId)
+    compiledDefinitions = compiledDefinitions ++ Compiler(packages, Compiler.NoProfile).unsafeCompilePackage(pkgId)
     respObs.onNext(LoadPackageResponse.newBuilder.build)
     respObs.onCompleted()
   }
@@ -218,8 +218,8 @@ class ReplService(
     }
 
     val allPkgs = packages + (homePackageId -> pkg)
-    val defs = Compiler(allPkgs).unsafeCompilePackage(homePackageId)
-    val compiledPackages = PureCompiledPackages(allPkgs, compiledDefinitions ++ defs)
+    val defs = Compiler(allPkgs, Compiler.NoProfile).unsafeCompilePackage(homePackageId)
+    val compiledPackages = PureCompiledPackages(allPkgs, compiledDefinitions ++ defs, Compiler.NoProfile)
     val runner = new Runner(
       compiledPackages,
       Script.Action(scriptExpr, ScriptIds(scriptPackageId)),

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -152,7 +152,7 @@ class Context(val contextId: Context.ContextId) {
       Speedy.Machine
         .build(
           sexpr = defn,
-          compiledPackages = PureCompiledPackages(allPackages, defns),
+          compiledPackages = PureCompiledPackages(allPackages, defns, Compiler.NoProfile),
           submissionTime,
           initialSeeding,
           Set.empty,

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -152,7 +152,7 @@ class Context(val contextId: Context.ContextId) {
       Speedy.Machine
         .build(
           sexpr = defn,
-          compiledPackages = PureCompiledPackages(allPackages, defns, Compiler.NoProfile),
+          compiledPackages = PureCompiledPackages(allPackages, defns),
           submissionTime,
           initialSeeding,
           Set.empty,

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -109,7 +109,7 @@ class Context(val contextId: Context.ContextId) {
         // if any change we recompile everything
         extPackages --= unloadPackages
         extPackages ++= newPackages
-        extDefns = assert(Compiler.compilePackages(extPackages))
+        extDefns = assert(Compiler.compilePackages(extPackages, Compiler.NoProfile))
         modDefns = HashMap.empty
         modules.values
       } else {
@@ -118,7 +118,7 @@ class Context(val contextId: Context.ContextId) {
       }
 
     val pkgs = allPackages
-    val compiler = Compiler(pkgs)
+    val compiler = Compiler(pkgs, Compiler.NoProfile)
 
     modulesToCompile.foreach { mod =>
       if (!omitValidation)
@@ -152,7 +152,7 @@ class Context(val contextId: Context.ContextId) {
       Speedy.Machine
         .build(
           sexpr = defn,
-          compiledPackages = PureCompiledPackages(allPackages, defns),
+          compiledPackages = PureCompiledPackages(allPackages, defns, Compiler.NoProfile),
           submissionTime,
           initialSeeding,
           Set.empty,

--- a/daml-lf/README.md
+++ b/daml-lf/README.md
@@ -186,6 +186,29 @@ $ bazel run //:daml-lf-repl -- test Project.tests $PWD/project.dalf
 
 NOTE: When running via `bazel run` one needs to specify full path (or relative path from repo root), since Bazel runs all commands from repository root.
 
+Profiling scenarios
+-------------------
+
+DAML-LF-REPL provides a command to run a scenario and collect profiling
+information while running it. This information is then written into a file that
+can be viewed using the [speedscope](https://www.speedscope.app/) flamegraph
+visualizer. The easiest way to install speedscope is to run
+```shell
+$ npm install -g speedscope
+```
+See the [Offline usage](https://github.com/jlfwong/speedscope#usage) section of
+its documentation for alternatives.
+
+Once speedscope is installed, the profiler can be invoked via
+```shell
+$ bazel run //:daml-lf-repl -- profile Module.Name:scenarioName /path/to.dar /path/to/output.json
+```
+and the profile viewed via
+```shell
+$ speedscope /path/to/output.json
+```
+
+
 Scala house rules
 -----------------
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -26,6 +26,8 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
   def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
     Option(_defns.get(dref))
 
+  def profilingMode = speedy.Compiler.NoProfile
+
   /** Might ask for a package if the package you're trying to add references it.
     *
     * Note that when resuming from a [[Result]] the continuation will modify the
@@ -80,7 +82,9 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
             pkgId, { _ =>
               // Compile the speedy definitions for this package.
               val defns =
-                speedy.Compiler(packages orElse state.packages).unsafeCompilePackage(pkgId)
+                speedy
+                  .Compiler(packages orElse state.packages, profilingMode)
+                  .unsafeCompilePackage(pkgId)
               defns.foreach {
                 case (defnId, defn) => _defns.put(defnId, defn)
               }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -269,7 +269,7 @@ final class Engine {
     ) {
       val machine = Machine
         .build(
-          sexpr = speedy.Compiler(compiledPackages.packages).unsafeCompile(commands),
+          sexpr = compiledPackages.compiler.unsafeCompile(commands),
           compiledPackages = compiledPackages,
           submissionTime = submissionTime,
           seeds = seeding,

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -28,6 +28,7 @@ da_scala_library(
         "//daml-lf/transaction",
         "//daml-lf/validation",
         "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_slf4j_slf4j_api",
         "@maven//:org_typelevel_paiges_core_2_12",

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -22,7 +22,7 @@ object PlaySpeedy {
 
   def main(args0: List[String]) = {
     val config: Config = parseArgs(args0)
-    val compiler: Compiler = Compiler(Map.empty)
+    val compiler: Compiler = Compiler(Map.empty, Compiler.NoProfile)
 
     val e: SExpr = compiler.unsafeClosureConvert(examples(config.exampleName))
     val m: Machine = makeMachine(e)
@@ -58,8 +58,7 @@ object PlaySpeedy {
   private val txSeed = crypto.Hash.hashPrivateKey("SpeedyExplore")
 
   def makeMachine(sexpr: SExpr): Machine = {
-    val compiledPackages: CompiledPackages = PureCompiledPackages(Map.empty).right.get
-    val compiler = Compiler(compiledPackages.packages)
+    val compiledPackages: CompiledPackages = PureCompiledPackages(Map.empty, Compiler.NoProfile).right.get
     Machine.fromSExpr(
       sexpr,
       compiledPackages,

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -58,7 +58,8 @@ object PlaySpeedy {
   private val txSeed = crypto.Hash.hashPrivateKey("SpeedyExplore")
 
   def makeMachine(sexpr: SExpr): Machine = {
-    val compiledPackages: CompiledPackages = PureCompiledPackages(Map.empty, Compiler.NoProfile).right.get
+    val compiledPackages: CompiledPackages =
+      PureCompiledPackages(Map.empty, Compiler.NoProfile).right.get
     Machine.fromSExpr(
       sexpr,
       compiledPackages,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
@@ -50,7 +50,8 @@ object PureCompiledPackages {
 
   def apply(
       packages: Map[PackageId, Package],
-      profiling: Compiler.ProfilingMode): Either[String, PureCompiledPackages] =
+      profiling: Compiler.ProfilingMode = Compiler.NoProfile,
+  ): Either[String, PureCompiledPackages] =
     Compiler
       .compilePackages(packages, profiling)
       .map(new PureCompiledPackages(packages, _, profiling))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -114,8 +114,7 @@ object Classify { // classify the machine state w.r.t what step occurs next
       case KMatch(_) => counts.kmatch += 1
       case KCatch(_, _, _) => counts.kcatch += 1
       case KFinished => counts.kfinished += 1
-      case KLabelClosure(_) => ()
-      case KLeaveClosure(_) => ()
+      case KLabelClosure(_) | KLeaveClosure(_) => ()
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -97,6 +97,7 @@ object Classify { // classify the machine state w.r.t what step occurs next
       case SEBuiltinRecursiveDefinition(_) => counts.ebuiltinrecursivedefinition += 1
       case SECatch(_, _, _) => counts.ecatch += 1
       case SEAbs(_, _) => //never expect these!
+      case SELabelClosure(_, _) => ()
       case SEImportValue(_) => counts.eimportvalue += 1
       case SEWronglyTypeContractId(_, _, _) => counts.ewronglytypedcontractid += 1
     }
@@ -113,6 +114,8 @@ object Classify { // classify the machine state w.r.t what step occurs next
       case KMatch(_) => counts.kmatch += 1
       case KCatch(_, _, _) => counts.kcatch += 1
       case KFinished => counts.kfinished += 1
+      case KLabelClosure(_) => ()
+      case KLeaveClosure(_) => ()
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -33,7 +33,7 @@ private[lf] object Compiler {
   // NOTE(MH): We make this an enum type to avoid boolean blindness. In fact,
   // other profiling modes like "only trace the ledger interactions" might also
   // be useful.
-  sealed abstract class ProfilingMode
+  sealed abstract class ProfilingMode extends Product with Serializable
   case object NoProfile extends ProfilingMode
   case object FullProfile extends ProfilingMode
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -45,6 +45,8 @@ object PrettyLightweight { // lightweight pretty printer for CEK machine states
     case KMatch(_) => "KMatch"
     case KCatch(_, _, _) => "KCatch" //never seen
     case KFinished => "KFinished"
+    case KLabelClosure(_) => "KLabelClosure"
+    case KLeaveClosure(_) => "KLeaveClosure"
   }
 
   def ppVarRef(n: Int): String = {
@@ -66,6 +68,7 @@ object PrettyLightweight { // lightweight pretty printer for CEK machine states
     case SEBuiltinRecursiveDefinition(_) => "<SEBuiltinRecursiveDefinition...>"
     case SECatch(_, _, _) => "<SECatch...>" //not seen one yet
     case SEAbs(_, _) => "<SEAbs...>" // will never get these on a running machine
+    case SELabelClosure(_, _) => "<SELabelClosure...>"
     case SEImportValue(_) => "<SEImportValue...>"
     case SEWronglyTypeContractId(_, _, _) => "<SEWronglyTypeContractId...>"
   }
@@ -85,7 +88,7 @@ object PrettyLightweight { // lightweight pretty printer for CEK machine states
 
   def pp(prim: Prim): String = prim match {
     case PBuiltin(b) => s"$b"
-    case PClosure(expr, fvs) =>
+    case PClosure(_, expr, fvs) =>
       s"clo[${commas(fvs.map(pp))}]:${pp(expr)}"
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -56,7 +56,6 @@ object Profile {
     }
   }
 
-
   /** Utility object to convert the profile into the JSON format required by
     * https://www.speedscope.app/. For a description of the format, see
     * https://github.com/jlfwong/speedscope/wiki/Importing-from-custom-sources#speedscopes-file-format

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -16,7 +16,7 @@ final class Profile {
   import Profile._
   private val start: Long = System.nanoTime()
   private val events: ArrayList[Event] = new ArrayList()
-  private var name: String = "DAML Engine profile"
+  var name: String = "DAML Engine profile"
 
   def addOpenEvent(label: AnyRef) = {
     val time = System.nanoTime()
@@ -26,10 +26,6 @@ final class Profile {
   def addCloseEvent(label: AnyRef) = {
     val time = System.nanoTime()
     events.add(Event(false, label, time))
-  }
-
-  def setName(name: String) = {
-    this.name = name
   }
 
   def writeSpeedscopeJson(filename: String) = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -1,0 +1,150 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import java.lang.System
+import java.util.ArrayList
+
+/** Class for profiling information collected by Speedy. We use [[AnyRef]] for
+  * the labels to avoid any conversions into a common label format at runtime
+  * since this might skew the profile. Instead, we convert the labels to strings
+  * when we write out the profile.
+  */
+final class Profile {
+  import Profile._
+  private val start: Long = System.nanoTime()
+  private val events: ArrayList[Event] = new ArrayList()
+  private var name: String = "DAML Engine profile"
+
+  def addOpenEvent(label: AnyRef) = {
+    val time = System.nanoTime()
+    events.add(Event(true, label, time))
+  }
+
+  def addCloseEvent(label: AnyRef) = {
+    val time = System.nanoTime()
+    events.add(Event(false, label, time))
+  }
+
+  def setName(name: String) = {
+    this.name = name
+  }
+
+  def writeSpeedscopeJson(filename: String) = {
+    val fileJson = SpeedscopeJson.FileJson.fromProfile(this)
+    fileJson.write(filename)
+  }
+}
+
+object Profile {
+  // NOTE(MH): See the documenation of [[Profile]] above for why we use
+  // [[AnyRef]] for the labels.
+  private final case class Event(val open: Boolean, val rawLabel: AnyRef, val time: Long) {
+    def label: String = {
+      import com.daml.lf.speedy.SExpr._
+      rawLabel match {
+        case null => "<null>" // NOTE(MH): We should never see this but it's no problem if we do.
+        case AnonymousClosure => "<anonymous closure>"
+        case LfDefRef(ref) => ref.toString()
+        case ChoiceDefRef(tmplRef, name) => s"<exercise ${tmplRef}:${name}>"
+        case ref: SEBuiltinRecursiveDefinition.Reference => s"<${ref.toString().toLowerCase()}>"
+        case str: String => str
+        case any => s"<unknown ${any}>"
+      }
+    }
+  }
+
+
+  /** Utility object to convert the profile into the JSON format required by
+    * https://www.speedscope.app/. For a description of the format, see
+    * https://github.com/jlfwong/speedscope/wiki/Importing-from-custom-sources#speedscopes-file-format
+    */
+  private object SpeedscopeJson {
+    import java.io.{BufferedWriter, FileWriter}
+    import spray.json._
+
+    val schemaURI = "https://www.speedscope.app/file-format-schema.json"
+
+    object JsonProtocol extends DefaultJsonProtocol {
+      implicit val eventFormat = jsonFormat3(EventJson.apply)
+      implicit val profileFormat = jsonFormat6(ProfileJson.apply)
+      implicit val frameFormat = jsonFormat1(FrameJson.apply)
+      implicit val sharedFormat = jsonFormat1(SharedJson.apply)
+      implicit val fileFormat = jsonFormat6(FileJson.apply)
+    }
+
+    case class EventJson(`type`: String, at: Long, frame: Int)
+    case class ProfileJson(
+        `type`: String,
+        name: String,
+        unit: String,
+        startValue: Long,
+        endValue: Long,
+        events: List[EventJson],
+    )
+    case class FrameJson(name: String)
+    case class SharedJson(frames: List[FrameJson])
+    case class FileJson(
+        `$schema`: String,
+        profiles: List[ProfileJson],
+        shared: SharedJson,
+        activeProfileIndex: Int,
+        exporter: String,
+        name: String,
+    ) {
+      def write(filename: String): Unit = {
+        import JsonProtocol.fileFormat
+        val writer = new BufferedWriter(new FileWriter(filename))
+        writer.write(this.toJson.compactPrint)
+        writer.close()
+      }
+    }
+
+    object FileJson {
+      def fromProfile(profile: Profile) = {
+        import scala.collection.mutable.HashMap
+        import scala.collection.JavaConverters._
+
+        val frames = new ArrayList[FrameJson]()
+        val frameIndices = new HashMap[String, Int]()
+        var endValue = 0L
+        val events = profile.events.asScala.toList.map { event =>
+          val eventType = if (event.open) "O" else "C"
+          val label = event.label
+          val frameIndex = frameIndices.get(label) match {
+            case Some(index) => index
+            case None =>
+              val index = frames.size()
+              frames.add(FrameJson(label))
+              frameIndices.put(label, index)
+              index
+          }
+          val at = event.time - profile.start
+          if (at > endValue) {
+            endValue = at
+          }
+          EventJson(`type` = eventType, at = at, frame = frameIndex)
+        }
+        val profileJson = ProfileJson(
+          `type` = "evented",
+          name = profile.name,
+          unit = "nanoseconds",
+          startValue = 0,
+          endValue = endValue,
+          events = events,
+        )
+        val sharedJson = SharedJson(frames.asScala.toList)
+        FileJson(
+          `$schema` = schemaURI,
+          profiles = List(profileJson),
+          shared = sharedJson,
+          activeProfileIndex = 0,
+          exporter = "DAML Engine",
+          name = profile.name,
+        )
+      }
+    }
+  }
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -120,6 +120,7 @@ object SValue {
   /** "Primitives" that can be applied. */
   sealed trait Prim
   final case class PBuiltin(b: SBuiltin) extends Prim
+
   /** A closure consisting of an expression together with the values the
     * expression is closing over.
     * The [[label]] field is only used during profiling. During non-profiling

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
@@ -176,7 +176,7 @@ class EqualitySpec extends WordSpec with Matchers with TableDrivenPropertyChecks
 
   private val funs = List(
     lfFunction,
-    SPAP(PClosure(SExpr.SEVar(2), Array()), ArrayList(SValue.SValue.Unit), 2),
+    SPAP(PClosure(null, SExpr.SEVar(2), Array()), ArrayList(SValue.SValue.Unit), 2),
   )
 
   private def nonEquatableLists(atLeast2InEquatableValues: List[SValue]) = {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -330,7 +330,7 @@ class OrderingSpec
 
   private val funs = List(
     lfFunction,
-    SPAP(PClosure(SExpr.SEVar(2), Array()), ArrayList(SValue.SValue.Unit), 2),
+    SPAP(PClosure(null, SExpr.SEVar(2), Array()), ArrayList(SValue.SValue.Unit), 2),
   )
 
   private def nonEquatableLists(atLeast2InEquatableValues: List[SValue]) = {
@@ -476,7 +476,7 @@ class OrderingSpec
   private val txSeed = crypto.Hash.hashPrivateKey("SBuiltinTest")
   private def initMachine(expr: SExpr) = Speedy.Machine fromSExpr (
     sexpr = expr,
-    compiledPackages = PureCompiledPackages(Map.empty, Map.empty),
+    compiledPackages = PureCompiledPackages(Map.empty, Map.empty, Compiler.NoProfile),
     submissionTime = Time.Timestamp.now(),
     seeding = InitialSeeding.TransactionSeed(txSeed),
     globalCids = Set.empty,

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -551,7 +551,7 @@ object Repl {
             (false, state)
           case Right((diff @ _, steps @ _, ledger, value @ _)) =>
             println("Writing profile...")
-            machine.profile.setName(scenarioId)
+            machine.profile.name = scenarioId
             machine.profile.writeSpeedscopeJson(outputFile)
             (true, state)
         }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -357,7 +357,8 @@ object Repl {
   // Load DAML-LF packages from a set of files.
   def load(
       darFile: String,
-      profiling: Compiler.ProfilingMode = Compiler.NoProfile): (Boolean, State) = {
+      profiling: Compiler.ProfilingMode = Compiler.NoProfile,
+  ): (Boolean, State) = {
     val state = initialState(profiling)
     try {
       val packages =
@@ -425,8 +426,7 @@ object Repl {
             val machine =
               Speedy.Machine.fromExpr(
                 expr = expr,
-                compiledPackages =
-                  PureCompiledPackages(state.packages, Compiler.NoProfile).right.get,
+                compiledPackages = PureCompiledPackages(state.packages).right.get,
                 scenario = false,
                 submissionTime = Time.Timestamp.now(),
                 initialSeeding = InitialSeeding.NoSeed,

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -36,6 +36,8 @@ object Main extends App {
   val out = new PrintStream(System.out, true, "UTF-8")
   System.setOut(out)
 
+  case class ProfileArgs(scenarioId: String, inputFile: String, outputFile: String)
+
   def usage(): Unit = {
     println(
       """
@@ -45,6 +47,7 @@ object Main extends App {
      |  repl [file]             Run the interactive repl. Load the given packages if any.
      |  test <name> [file]      Load given packages and run the named scenario with verbose output.
      |  testAll [file]          Load the given packages and run all scenarios.
+     |  profile <name> [infile] [outfile]  Run the name scenario and write a profile in speedscope.app format
      |  validate [file]         Load the given packages and validate them.
      |  [file]                  Same as 'repl' when all given files exist.
     """.stripMargin)
@@ -78,6 +81,8 @@ object Main extends App {
         if (!Repl.testAll(allowDev, file)._1) System.exit(1)
       case List("test", id, file) =>
         if (!Repl.test(allowDev, id, file)._1) System.exit(1)
+      case List("profile", scenarioId, inputFile, outputFile) =>
+        if (!Repl.profile(allowDev, scenarioId, inputFile, outputFile)._1) System.exit(1)
       case List("validate", file) =>
         if (!Repl.validate(allowDev, file)._1) System.exit(1)
       case List(possibleFile) =>
@@ -137,6 +142,15 @@ object Repl {
   def test(allowDev: Boolean, id: String, file: String): (Boolean, State) =
     load(file) fMap cmdValidate fMap (x => invokeScenario(x, Seq(id)))
 
+  def profile(
+      allowDev: Boolean,
+      scenarioId: String,
+      inputFile: String,
+      outputFile: String,
+  ): (Boolean, State) =
+    load(inputFile, Compiler.FullProfile) fMap cmdValidate fMap (state =>
+      cmdProfile(state, scenarioId, outputFile))
+
   def validate(allowDev: Boolean, file: String): (Boolean, State) =
     load(file) fMap cmdValidate
 
@@ -161,13 +175,20 @@ object Repl {
       quit: Boolean
   )
 
-  case class ScenarioRunnerHelper(packages: Map[PackageId, Package]) {
+  case class ScenarioRunnerHelper(
+      packages: Map[PackageId, Package],
+      profiling: Compiler.ProfilingMode) {
     private val build = Speedy.Machine
-      .newBuilder(PureCompiledPackages(packages).right.get, Time.Timestamp.MinValue, nextSeed())
+      .newBuilder(
+        PureCompiledPackages(packages, profiling).right.get,
+        Time.Timestamp.MinValue,
+        nextSeed())
       .fold(err => sys.error(err.toString), identity)
     def run(expr: Expr)
-      : (Speedy.Machine, Either[(SError, Ledger.Ledger), (Double, Int, Ledger.Ledger, SValue)]) =
-      (build(expr), ScenarioRunner(build(expr)).run())
+      : (Speedy.Machine, Either[(SError, Ledger.Ledger), (Double, Int, Ledger.Ledger, SValue)]) = {
+      val machine = build(expr)
+      (machine, ScenarioRunner(machine).run())
+    }
   }
 
   case class Command(help: String, action: (State, Seq[String]) => State)
@@ -205,12 +226,12 @@ object Repl {
     cmpl
   }
 
-  def initialState(): State =
+  def initialState(profiling: Compiler.ProfilingMode = Compiler.NoProfile): State =
     rebuildReader(
       State(
         packages = Map.empty,
         packageFiles = Seq(),
-        ScenarioRunnerHelper(Map.empty),
+        ScenarioRunnerHelper(Map.empty, profiling),
         reader = null,
         history = new DefaultHistory(),
         quit = false
@@ -334,8 +355,10 @@ object Repl {
   }
 
   // Load DAML-LF packages from a set of files.
-  def load(darFile: String): (Boolean, State) = {
-    val state = initialState()
+  def load(
+      darFile: String,
+      profiling: Compiler.ProfilingMode = Compiler.NoProfile): (Boolean, State) = {
+    val state = initialState(profiling)
     try {
       val packages =
         UniversalArchiveReader().readFile(new File(darFile)).get
@@ -352,7 +375,7 @@ object Repl {
       true -> rebuildReader(
         state.copy(
           packages = packagesMap,
-          scenarioRunner = ScenarioRunnerHelper(packagesMap)
+          scenarioRunner = ScenarioRunnerHelper(packagesMap, profiling)
         ))
     } catch {
       case ex: Throwable => {
@@ -365,7 +388,7 @@ object Repl {
   }
 
   def speedyCompile(state: State, args: Seq[String]): Unit = {
-    val defs = assertRight(Compiler.compilePackages(state.packages))
+    val defs = assertRight(Compiler.compilePackages(state.packages, Compiler.NoProfile))
     defs.get(idToRef(state, args(0))) match {
       case None =>
         println("Error: definition '" + args(0) + "' not found. Try :list."); usage
@@ -402,7 +425,8 @@ object Repl {
             val machine =
               Speedy.Machine.fromExpr(
                 expr = expr,
-                compiledPackages = PureCompiledPackages(state.packages).right.get,
+                compiledPackages =
+                  PureCompiledPackages(state.packages, Compiler.NoProfile).right.get,
                 scenario = false,
                 submissionTime = Time.Timestamp.now(),
                 initialSeeding = InitialSeeding.NoSeed,
@@ -508,6 +532,31 @@ object Repl {
     println(
       s"\n$successes passed, $failures failed, total time ${totalTime.formatted("%.2f")}ms, total steps $totalSteps.")
     (failures == 0, state)
+  }
+
+  def cmdProfile(state: State, scenarioId: String, outputFile: String): (Boolean, State) = {
+    buildExpr(state, Seq(scenarioId))
+      .map { expr =>
+        println("Warming up JVM for 10s...")
+        val start = System.nanoTime()
+        while (System.nanoTime() - start < 10L * 1000 * 1000 * 1000) {
+          state.scenarioRunner.run(expr)
+        }
+        println("Collecting profile...")
+        val (machine, errOrLedger) =
+          state.scenarioRunner.run(expr)
+        errOrLedger match {
+          case Left((err, ledger @ _)) =>
+            println(prettyError(err, machine.ptx).render(128))
+            (false, state)
+          case Right((diff @ _, steps @ _, ledger, value @ _)) =>
+            println("Writing profile...")
+            machine.profile.setName(scenarioId)
+            machine.profile.writeSpeedscopeJson(outputFile)
+            (true, state)
+        }
+      }
+      .getOrElse((false, state))
   }
 
   private val unknownPackageId = PackageId.assertFromString("-unknownPackage-")

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -37,7 +37,7 @@ class CollectAuthorityState {
     val seeding = crypto.Hash.secureRandom(crypto.Hash.hashPrivateKey("scenario-perf"))
     buildMachine = Speedy.Machine
       .newBuilder(
-        PureCompiledPackages(packagesMap).right.get,
+        PureCompiledPackages(packagesMap, Compiler.NoProfile).right.get,
         Time.Timestamp.MinValue,
         seeding(),
       )

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -37,7 +37,7 @@ class CollectAuthorityState {
     val seeding = crypto.Hash.secureRandom(crypto.Hash.hashPrivateKey("scenario-perf"))
     buildMachine = Speedy.Machine
       .newBuilder(
-        PureCompiledPackages(packagesMap, Compiler.NoProfile).right.get,
+        PureCompiledPackages(packagesMap).right.get,
         Time.Timestamp.MinValue,
         seeding(),
       )

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -26,7 +26,7 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.iface.EnvironmentInterface
 import com.daml.lf.iface.reader.InterfaceReader
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.{InitialSeeding, Pretty, SExpr, SValue, Speedy}
+import com.daml.lf.speedy.{Compiler, InitialSeeding, Pretty, SExpr, SValue, Speedy}
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
@@ -207,7 +207,7 @@ object Runner {
       implicit ec: ExecutionContext,
       mat: Materializer): Future[SValue] = {
     val darMap = dar.all.toMap
-    val compiledPackages = PureCompiledPackages(darMap).right.get
+    val compiledPackages = PureCompiledPackages(darMap, Compiler.NoProfile).right.get
     val script = data.assertRight(Script.fromIdentifier(compiledPackages, scriptId))
     val scriptAction: Script.Action = (script, inputValue) match {
       case (script: Script.Action, None) => script
@@ -281,6 +281,7 @@ class Runner(
       override def packages = compiledPackages.packages
       def packageIds = compiledPackages.packageIds
       override def definitions = fromLedgerValue.orElse(compiledPackages.definitions)
+      override def profilingMode = Compiler.NoProfile
     }
   }
   private val valueTranslator = new preprocessing.ValueTranslator(extendedCompiledPackages)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -207,7 +207,7 @@ object Runner {
       implicit ec: ExecutionContext,
       mat: Materializer): Future[SValue] = {
     val darMap = dar.all.toMap
-    val compiledPackages = PureCompiledPackages(darMap, Compiler.NoProfile).right.get
+    val compiledPackages = PureCompiledPackages(darMap).right.get
     val script = data.assertRight(Script.fromIdentifier(compiledPackages, scriptId))
     val scriptAction: Script.Action = (script, inputValue) match {
       case (script: Script.Action, None) => script

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -108,7 +108,7 @@ object TestMain extends StrictLogging {
         }
 
         val darMap = dar.all.toMap
-        val compiledPackages = PureCompiledPackages(darMap, Compiler.NoProfile).right.get
+        val compiledPackages = PureCompiledPackages(darMap).right.get
         val testScripts = dar.main._2.modules.flatMap {
           case (moduleName, module) => {
             module.definitions.collect(Function.unlift {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -14,7 +14,6 @@ import com.daml.lf.PureCompiledPackages
 import com.daml.lf.archive.{Dar, DarReader, Decode}
 import com.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName}
 import com.daml.lf.language.Ast.Package
-import com.daml.lf.speedy.Compiler
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -14,6 +14,7 @@ import com.daml.lf.PureCompiledPackages
 import com.daml.lf.archive.{Dar, DarReader, Decode}
 import com.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName}
 import com.daml.lf.language.Ast.Package
+import com.daml.lf.speedy.Compiler
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
@@ -107,7 +108,7 @@ object TestMain extends StrictLogging {
         }
 
         val darMap = dar.all.toMap
-        val compiledPackages = PureCompiledPackages(darMap).right.get
+        val compiledPackages = PureCompiledPackages(darMap, Compiler.NoProfile).right.get
         val testScripts = dar.main._2.modules.flatMap {
           case (moduleName, module) => {
             module.definitions.collect(Function.unlift {

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -110,7 +110,7 @@ object Trigger extends StrictLogging {
       }
     }
 
-    val compiler = Compiler(compiledPackages.packages)
+    val compiler = compiledPackages.compiler
     for {
       pkg <- compiledPackages
         .getPackage(triggerId.packageId)
@@ -208,7 +208,7 @@ class Runner(
     party: String,
 ) extends StrictLogging {
   // Compiles LF expressions into Speedy expressions.
-  private val compiler: Compiler = Compiler(compiledPackages.packages)
+  private val compiler: Compiler = compiledPackages.compiler
   // Converts between various objects and SValues.
   private val converter: Converter = Converter(compiledPackages, trigger.triggerIds)
   // This is a map from the command IDs used on the ledger API to the
@@ -508,7 +508,7 @@ object Runner extends StrictLogging {
       party: String
   )(implicit materializer: Materializer, executionContext: ExecutionContext): Future[SExpr] = {
     val darMap = dar.all.toMap
-    val compiledPackages = PureCompiledPackages(darMap).right.get
+    val compiledPackages = PureCompiledPackages(darMap, Compiler.NoProfile).right.get
     val trigger = Trigger.fromIdentifier(compiledPackages, triggerId) match {
       case Left(err) => throw new RuntimeException(s"Invalid trigger: $err")
       case Right(trigger) => trigger

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -508,7 +508,7 @@ object Runner extends StrictLogging {
       party: String
   )(implicit materializer: Materializer, executionContext: ExecutionContext): Future[SExpr] = {
     val darMap = dar.all.toMap
-    val compiledPackages = PureCompiledPackages(darMap, Compiler.NoProfile).right.get
+    val compiledPackages = PureCompiledPackages(darMap).right.get
     val trigger = Trigger.fromIdentifier(compiledPackages, triggerId) match {
       case Left(err) => throw new RuntimeException(s"Invalid trigger: $err")
       case Right(trigger) => trigger


### PR DESCRIPTION
The profiler runs a single scenario and records timing information when
each function (and some other closures) are entered and left. The
resulting information can be visualized as a flamegraph using
[speedscope](https://www.speedscope.app/).

The profiler works by instrumenting the CEK machine at the heart of
DAML Engine. Unfortunetaly, this causes a very small overhead on
non-profiling runs too. However, in my benchmarks I could not measure
any significant impact on the overall runtime at all. More precisely,
the overhead is as follows:

Every closure now has an additional field called `label`. In
non-profiling runs this field is always set to `null`. This field needs
to be allocated, copied whenever we copy a closure and scanned during
garbage collection. Additionally, whenever we enter a closure, we check
this field and whenever it is _not_ `null`, i.e. never during
non-profiling runs, we record an "open event" and set up a hook for the
corresponding "close event". Thus, the additional cost during
non-profiling runs are a single pointer comparison and a jump beyond
the "then branch".

Since this is still very much in active development, there are no
documentation, other than an entry in a README, and no tests yet. They
will come before we promote this. However, the UX will look very
different then since we already have plans to significantly change it.