### PR TITLE
Revert "Fix typescript tests (#5934) (#5943)"

### DIFF
--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
@@ -26,9 +26,8 @@ eslintVersion :: T.Text
 eslintVersion = "^6.8.0"
 
 -- Version of typescript-eslint for linting the generated code.
--- 2.32 produces an error https://github.com/typescript-eslint/typescript-eslint/issues/2009
 typescriptEslintVersion :: T.Text
-typescriptEslintVersion = "~2.31.0"
+typescriptEslintVersion = "^2.16.0"
 
 main :: IO ()
 main = do


### PR DESCRIPTION
This reverts commit a0ee6477d7398309c721a53e4ad8687b66ac5516.

It has not been included in the final 1.1.0 release and I would rather keep this branch as close to released artifacts as possible. My preferred solution would have been to forcibly reset the branch, but I guess that doesn't mesh well with our other processes.

CHANGELOG_BEGIN
CHANGELOG_END