### PR TITLE
Add debugging output to inclusion errors

### DIFF
--- a/ci/patch_bazel_windows/patch-bazel
+++ b/ci/patch_bazel_windows/patch-bazel
@@ -1,13 +1,32 @@
-diff --git a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
-index 0fa1b5db2e..e6a1494ae5 100644
---- a/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
-+++ b/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java
-@@ -144,7 +144,7 @@ public final class RemoteModule extends BlazeModule {
-     env.getEventBus().register(this);
-     String invocationId = env.getCommandId().toString();
-     String buildRequestId = env.getBuildRequestId();
--    env.getReporter().handle(Event.info(String.format("Invocation ID: %s", invocationId)));
-+    env.getReporter().handle(Event.info(String.format("Invocation id: %s", invocationId)));
+diff --git a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+index 72da2b2f85..72f70bfe58 100644
+--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
++++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
+@@ -993,6 +993,7 @@ public class CppCompileAction extends AbstractAction implements IncludeScannable
+             Sets.newHashSet(ccCompilationContext.getDeclaredIncludeDirs().toList());
+       }
+       if (!isDeclaredIn(cppConfiguration, actionExecutionContext, input, declaredIncludeDirs)) {
++        System.err.println("DA-DEBUG: isDeclaredIn was false" + input.getExecPath().toString());
+         errors.add(input.getExecPath().toString());
+       }
+     }
+diff --git a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+index 157cd5f36a..fb9dbc723f 100644
+--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
++++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/HeaderDiscovery.java
+@@ -148,6 +148,7 @@ public class HeaderDiscovery {
+         if (execPath.startsWith(execRoot)) {
+           execPathFragment = execPath.relativeTo(execRoot); // funky but tolerable path
+         } else {
++          System.err.println("DA-DEBUG: Absolute path " + execPathFragment.getPathString() + " outside of execroot " + execRoot);
+           problems.add(execPathFragment.getPathString());
+           continue;
+         }
+@@ -184,6 +185,7 @@ public class HeaderDiscovery {
  
-     Path logDir =
-         env.getOutputBase().getRelative(env.getRuntime().getProductName() + "-remote-logs");
+       // Abort if we see files that we can't resolve, likely caused by
+       // undeclared includes or illegal include constructs.
++      System.err.println("DA-DEBUG: Valid system includes: " + permittedSystemIncludePrefixes.toString());
+       problems.add(execPathFragment.getPathString());
+     }
+     if (shouldValidateInclusions) {

--- a/dev-env/windows/manifests/bazel.json
+++ b/dev-env/windows/manifests/bazel.json
@@ -5,8 +5,8 @@
   "bin": "bazel.exe",
   "architecture": {
     "64bit": {
-      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-fd12df4ebdd9cfe98bd623c5a827a288.zip",
-      "hash": "e1d742eeb0752d74af5257edf1d7bc0a332ddb3a76420aef137bc33738ecc165"
+      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-46cfe9da3d303f42d8bd469653ffc41b.zip",
+      "hash": "3ac6975cacf00963eb41277cd27d75babe405bdb2bef1eb02f0c9d9607fbc93f"
     }
   },
   "depends": [


### PR DESCRIPTION
This adds some more debugging output to inclusion errors in Bazel
which should hopefully help us track it down. These are the only call sites
in the Bazel source that can produce them. My suspicion is that it’s
coming from HeaderDiscovery but I’m not entirely sure what is off.

We’ll almost certainly have to add more output once we know which of
those 3 cases we hit but let’s do it step by step.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
