### PR TITLE
Fix evaluation order for create with contract keys

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1533,6 +1533,74 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
   }
 
+  "contract key" should {
+    val now = Time.Timestamp.now()
+    val submissionSeed = crypto.Hash.hashPrivateKey("contract key")
+    val txSeed = crypto.Hash.deriveTransactionSeed(submissionSeed, participant, now)
+
+    "be evaluated only when executing create" in {
+      val templateId =
+        Identifier(basicTestsPkgId, "BasicTests:ComputeContractKeyWhenExecutingCreate")
+      val createArg =
+        ValueRecord(
+          Some(templateId),
+          ImmArray((Some[Name]("owner"), ValueParty(alice))),
+        )
+      val exerciseArg =
+        ValueRecord(
+          Some(Identifier(basicTestsPkgId, "BasicTests:DontExecuteCreate")),
+          ImmArray.empty,
+        )
+
+      val Right((cmds, globalCids)) = preprocessor
+        .preprocessCommands(ImmArray(
+          CreateAndExerciseCommand(templateId, createArg, "DontExecuteCreate", exerciseArg)))
+        .consume(_ => None, lookupPackage, lookupKey)
+
+      val result = engine
+        .interpretCommands(
+          validating = false,
+          submitters = Set(alice),
+          commands = cmds,
+          ledgerTime = now,
+          submissionTime = now,
+          seeding = InitialSeeding.TransactionSeed(txSeed),
+          globalCids = globalCids,
+        )
+        .consume(_ => None, lookupPackage, lookupKey)
+      result shouldBe 'right
+    }
+
+    "be evaluated after ensure clause" in {
+      val templateId =
+        Identifier(basicTestsPkgId, "BasicTests:ComputeContractKeyAfterEnsureClause")
+      val createArg =
+        ValueRecord(
+          Some(templateId),
+          ImmArray((Some[Name]("owner"), ValueParty(alice)))
+        )
+
+      val Right((cmds, globalCids)) = preprocessor
+        .preprocessCommands(ImmArray(CreateCommand(templateId, createArg)))
+        .consume(_ => None, lookupPackage, lookupKey)
+
+      val result = engine
+        .interpretCommands(
+          validating = false,
+          submitters = Set(alice),
+          commands = cmds,
+          ledgerTime = now,
+          submissionTime = now,
+          seeding = InitialSeeding.TransactionSeed(txSeed),
+          globalCids = globalCids,
+        )
+        .consume(_ => None, lookupPackage, lookupKey)
+      result shouldBe 'left
+      val Left(err) = result
+      err.msg should not include ("Boom")
+      err.msg should include("precondition violation")
+    }
+  }
 }
 
 object EngineTest {

--- a/daml-lf/tests/BasicTests.daml
+++ b/daml-lf/tests/BasicTests.daml
@@ -571,4 +571,21 @@ template TimeGetter with
         do
           pure $ product [1, 2, 3]
 
+template ComputeContractKeyAfterEnsureClause with
+    owner: Party
+  where
+    signatory owner
+    ensure False
+    key (error "Boom"): Party
+    maintainer key
 
+template ComputeContractKeyWhenExecutingCreate with
+    owner: Party
+  where
+    signatory owner
+
+    nonconsuming choice DontExecuteCreate: ()
+      controller owner
+      do
+        let _ignore = create ComputeContractKeyAfterEnsureClause with owner
+        pure ()


### PR DESCRIPTION
Currently, a call to `create` for a template with a contract key
evaluates the key even before _executing_ the `create`, which is _way_
too early. See #5967 for examples what this implies.

This change moves the evaluation of the key into the execution of the
`create` and therein _after_ the evaluation of the `ensure` clauses,
which is where it belongs according to the DAML-LF specification.
Unfortunately, the specification does not say anything about the
relative evaluation order of the `agreement`, `signatory`, `observer`
and `key` clauses. Thus, I've deciced to evaluate the key after the
other three, which seems to be its natural place given its optionality.

This fixes #5967.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/5972)
<!-- Reviewable:end -->
