### PR TITLE
Fix quadratic runtime when reading events

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTable.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTable.scala
@@ -152,13 +152,14 @@ private[events] trait EventsTable {
       // The identifiers of all visible events in this transactions, preserving
       // the order in which they are retrieved from the index
       val visible = events.map(_.event.eventId)
+      val visibleSet = visible.toSet
 
       // All events in this transaction by their identifier, with their children
       // filtered according to those visible for this request
       val eventsById =
         events.iterator
           .map(_.event)
-          .map(e => e.eventId -> e.filterChildEventIds(visible.toSet))
+          .map(e => e.eventId -> e.filterChildEventIds(visibleSet))
           .toMap
 
       // All event identifiers that appear as a child of another item in this response


### PR DESCRIPTION
Fixes #5980.

CHANGELOG_BEGIN
[Sandbox] Improved performance when loading transactions with many
events. See `issue #5980
<https://github.com/digital-asset/daml/issues/5980>`__.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
