### PR TITLE
language: send live event when reconnecting

### DIFF
--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -527,9 +527,7 @@ class Ledger {
           lastOffset = jtv.Result.withException(jtv.string().run(json.offset));
           if (isLiveSince === undefined) {
             isLiveSince = Date.now();
-            if (!isReconnecting) {
-              emitter.emit('live', state);
-            }
+            emitter.emit('live', state);
           }
         }
       } else if (isRecordWith('warnings', json)) {


### PR DESCRIPTION
not sending a live event after reconnecting means that the 'loading' indicater
is never updated to 'false'. we could also not set it to 'true' on the 'close'
event, but that can lead to a rather unintuitive behaviour where data is stale
and then suddenly updated without any indication.

cc @brianweir-da 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
