### PR TITLE
Measure translation time for full result from DB

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTable.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTable.scala
@@ -8,9 +8,9 @@ import java.time.Instant
 
 import anorm.SqlParser.{array, binaryStream, bool, str}
 import anorm.{RowParser, ~}
-import com.codahale.metrics.Timer
 import com.daml.ledger.participant.state.v1.Offset
 import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
+import com.daml.ledger.api.v1.event.Event
 import com.daml.ledger.api.v1.transaction.{
   TreeEvent,
   Transaction => ApiTransaction,
@@ -22,9 +22,9 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse
 }
-import com.daml.metrics.Timed
 import com.daml.platform.ApiOffset
 import com.daml.platform.api.v1.event.EventOps.{EventOps, TreeEventOps}
+import com.daml.platform.index.TransactionConversion
 import com.daml.platform.store.Conversions.{identifier, instant, offset}
 import com.google.protobuf.timestamp.Timestamp
 
@@ -38,11 +38,9 @@ private[events] object EventsTable
     extends EventsTable
     with EventsTableInsert
     with EventsTableFlatEvents
-    with EventsTableTreeEvents
+    with EventsTableTreeEvents {
 
-private[events] trait EventsTable {
-
-  case class Entry[+E](
+  final case class Entry[+E](
       eventOffset: Offset,
       transactionId: String,
       ledgerEffectiveTime: Instant,
@@ -53,49 +51,13 @@ private[events] trait EventsTable {
 
   object Entry {
 
-    private def eventOnly[E](verbose: Boolean)(entry: Entry[Raw[E]]): E =
-      entry.event.applyDeserialization(verbose)
-
-    private def fullEntry[E](verbose: Boolean)(entry: Entry[Raw[E]]): Entry[E] =
-      entry.copy(event = eventOnly(verbose)(entry))
-
-    private def deserialize[E1, E2](
-        rawEntries: Vector[Entry[Raw[E1]]],
-        verbose: Boolean,
-        timer: Timer,
-    )(deserializeEntry: Boolean => Entry[Raw[E1]] => E2): Vector[E2] =
-      Timed.value(
-        timer = timer,
-        value = rawEntries.map(deserializeEntry(verbose)),
-      )
-
     private def instantToTimestamp(t: Instant): Timestamp =
       Timestamp(seconds = t.getEpochSecond, nanos = t.getNano)
 
-    private def permanent(entries: Vector[Entry[Raw.FlatEvent]]): Set[String] = {
-      entries.foldLeft(Set.empty[String]) { (contractIds, entry) =>
-        if (entry.event.isCreated || !contractIds.contains(entry.event.contractId)) {
-          contractIds + entry.event.contractId
-        } else {
-          contractIds - entry.event.contractId
-        }
-      }
-    }
-
-    private def removeTransient(
-        entries: Vector[Entry[Raw.FlatEvent]]): Vector[Entry[Raw.FlatEvent]] = {
-      val toKeep = permanent(entries)
-      entries.filter(entry => toKeep(entry.event.contractId))
-    }
-
-    private def flatTransaction(
-        events: Vector[Entry[Raw.FlatEvent]],
-        verbose: Boolean,
-        deserializationTimer: Timer,
-    ): Option[ApiTransaction] =
+    private def flatTransaction(events: Vector[Entry[Event]]): Option[ApiTransaction] =
       events.headOption.flatMap { first =>
-        val withoutTransients = removeTransient(events)
-        val flatEvents = deserialize(withoutTransients, verbose, deserializationTimer)(eventOnly)
+        val flatEvents =
+          TransactionConversion.removeTransient(events.iterator.map(_.event).toVector)
         if (flatEvents.nonEmpty || first.commandId.nonEmpty)
           Some(
             ApiTransaction(
@@ -110,22 +72,19 @@ private[events] trait EventsTable {
         else None
       }
 
-    def toGetTransactionsResponse(verbose: Boolean, deserializationTimer: Timer)(
-        events: Vector[Entry[Raw.FlatEvent]],
+    def toGetTransactionsResponse(
+        events: Vector[Entry[Event]],
     ): List[GetTransactionsResponse] =
-      flatTransaction(events, verbose, deserializationTimer).toList.map(tx =>
-        GetTransactionsResponse(Seq(tx)))
+      flatTransaction(events).toList.map(tx => GetTransactionsResponse(Seq(tx)))
 
-    def toGetFlatTransactionResponse(verbose: Boolean, deserializationTimer: Timer)(
-        events: Vector[Entry[Raw.FlatEvent]],
+    def toGetFlatTransactionResponse(
+        events: Vector[Entry[Event]],
     ): Option[GetFlatTransactionResponse] =
-      flatTransaction(events, verbose, deserializationTimer).map(tx =>
-        GetFlatTransactionResponse(Some(tx)))
+      flatTransaction(events).map(tx => GetFlatTransactionResponse(Some(tx)))
 
-    def toGetActiveContractsResponse(verbose: Boolean, deserializationTimer: Timer)(
-        rawEvents: Vector[Entry[Raw.FlatEvent]],
+    def toGetActiveContractsResponse(
+        events: Vector[Entry[Event]],
     ): Vector[GetActiveContractsResponse] = {
-      val events = deserialize(rawEvents, verbose, deserializationTimer)(fullEntry)
       events.map {
         case entry if entry.event.isCreated =>
           GetActiveContractsResponse(
@@ -142,12 +101,8 @@ private[events] trait EventsTable {
     }
 
     private def treeOf(
-        rawEvents: Vector[Entry[Raw.TreeEvent]],
-        verbose: Boolean,
-        deserializationTimer: Timer,
+        events: Vector[Entry[TreeEvent]],
     ): (Map[String, TreeEvent], Vector[String]) = {
-
-      val events = deserialize(rawEvents, verbose, deserializationTimer)(fullEntry)
 
       // The identifiers of all visible events in this transactions, preserving
       // the order in which they are retrieved from the index
@@ -174,13 +129,11 @@ private[events] trait EventsTable {
     }
 
     private def transactionTree(
-        events: Vector[Entry[Raw.TreeEvent]],
-        verbose: Boolean,
-        deserializationTimer: Timer,
+        events: Vector[Entry[TreeEvent]],
     ): Option[ApiTransactionTree] =
       events.headOption.map(
         first => {
-          val (eventsById, rootEventIds) = treeOf(events, verbose, deserializationTimer)
+          val (eventsById, rootEventIds) = treeOf(events)
           ApiTransactionTree(
             transactionId = first.transactionId,
             commandId = first.commandId,
@@ -194,19 +147,21 @@ private[events] trait EventsTable {
         }
       )
 
-    def toGetTransactionTreesResponse(verbose: Boolean, deserializationTimer: Timer)(
-        events: Vector[Entry[Raw.TreeEvent]],
+    def toGetTransactionTreesResponse(
+        events: Vector[Entry[TreeEvent]],
     ): List[GetTransactionTreesResponse] =
-      transactionTree(events, verbose, deserializationTimer).toList.map(tx =>
-        GetTransactionTreesResponse(Seq(tx)))
+      transactionTree(events).toList.map(tx => GetTransactionTreesResponse(Seq(tx)))
 
-    def toGetTransactionResponse(verbose: Boolean, deserializationTimer: Timer)(
-        events: Vector[Entry[Raw.TreeEvent]],
+    def toGetTransactionResponse(
+        events: Vector[Entry[TreeEvent]],
     ): Option[GetTransactionResponse] =
-      transactionTree(events, verbose, deserializationTimer).map(tx =>
-        GetTransactionResponse(Some(tx)))
+      transactionTree(events).map(tx => GetTransactionResponse(Some(tx)))
 
   }
+
+}
+
+private[events] trait EventsTable {
 
   private type SharedRow =
     Offset ~ String ~ String ~ String ~ Instant ~ Identifier ~ Option[String] ~ Option[String] ~ Array[

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableFlatEvents.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableFlatEvents.scala
@@ -10,10 +10,10 @@ import com.daml.platform.store.Conversions._
 
 private[events] trait EventsTableFlatEvents { this: EventsTable =>
 
-  private val createdFlatEventParser: RowParser[Entry[Raw.FlatEvent.Created]] =
+  private val createdFlatEventParser: RowParser[EventsTable.Entry[Raw.FlatEvent.Created]] =
     createdEventRow map {
       case eventOffset ~ transactionId ~ eventId ~ contractId ~ ledgerEffectiveTime ~ templateId ~ commandId ~ workflowId ~ eventWitnesses ~ createArgument ~ createSignatories ~ createObservers ~ createAgreementText ~ createKeyValue =>
-        Entry(
+        EventsTable.Entry(
           eventOffset = eventOffset,
           transactionId = transactionId,
           ledgerEffectiveTime = ledgerEffectiveTime,
@@ -33,10 +33,10 @@ private[events] trait EventsTableFlatEvents { this: EventsTable =>
         )
     }
 
-  private val archivedFlatEventParser: RowParser[Entry[Raw.FlatEvent.Archived]] =
+  private val archivedFlatEventParser: RowParser[EventsTable.Entry[Raw.FlatEvent.Archived]] =
     archivedEventRow map {
       case eventOffset ~ transactionId ~ eventId ~ contractId ~ ledgerEffectiveTime ~ templateId ~ commandId ~ workflowId ~ eventWitnesses =>
-        Entry(
+        EventsTable.Entry(
           eventOffset = eventOffset,
           transactionId = transactionId,
           ledgerEffectiveTime = ledgerEffectiveTime,
@@ -51,7 +51,7 @@ private[events] trait EventsTableFlatEvents { this: EventsTable =>
         )
     }
 
-  val rawFlatEventParser: RowParser[Entry[Raw.FlatEvent]] =
+  val rawFlatEventParser: RowParser[EventsTable.Entry[Raw.FlatEvent]] =
     createdFlatEventParser | archivedFlatEventParser
 
   private val selectColumns =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableTreeEvents.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableTreeEvents.scala
@@ -10,10 +10,10 @@ import com.daml.platform.store.Conversions._
 
 private[events] trait EventsTableTreeEvents { this: EventsTable =>
 
-  private val createdTreeEventParser: RowParser[Entry[Raw.TreeEvent.Created]] =
+  private val createdTreeEventParser: RowParser[EventsTable.Entry[Raw.TreeEvent.Created]] =
     createdEventRow map {
       case eventOffset ~ transactionId ~ eventId ~ contractId ~ ledgerEffectiveTime ~ templateId ~ commandId ~ workflowId ~ eventWitnesses ~ createArgument ~ createSignatories ~ createObservers ~ createAgreementText ~ createKeyValue =>
-        Entry(
+        EventsTable.Entry(
           eventOffset = eventOffset,
           transactionId = transactionId,
           ledgerEffectiveTime = ledgerEffectiveTime,
@@ -33,10 +33,10 @@ private[events] trait EventsTableTreeEvents { this: EventsTable =>
         )
     }
 
-  private val exercisedTreeEventParser: RowParser[Entry[Raw.TreeEvent.Exercised]] =
+  private val exercisedTreeEventParser: RowParser[EventsTable.Entry[Raw.TreeEvent.Exercised]] =
     exercisedEventRow map {
       case eventOffset ~ transactionId ~ eventId ~ contractId ~ ledgerEffectiveTime ~ templateId ~ commandId ~ workflowId ~ eventWitnesses ~ exerciseConsuming ~ exerciseChoice ~ exerciseArgument ~ exerciseResult ~ exerciseActors ~ exerciseChildEventIds =>
-        Entry(
+        EventsTable.Entry(
           eventOffset = eventOffset,
           transactionId = transactionId,
           ledgerEffectiveTime = ledgerEffectiveTime,
@@ -57,7 +57,7 @@ private[events] trait EventsTableTreeEvents { this: EventsTable =>
         )
     }
 
-  val rawTreeEventParser: RowParser[Entry[Raw.TreeEvent]] =
+  val rawTreeEventParser: RowParser[EventsTable.Entry[Raw.TreeEvent]] =
     createdTreeEventParser | exercisedTreeEventParser
 
   private val selectColumns = Seq(


### PR DESCRIPTION
Furthermore, uses a work stealing thread pool for work JdbcLedgerDao has
to perform outside of the database thread pool. This solves some
flakiness observed in conformance tests against PostgreSQL-backed
ledgers.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
