### PR TITLE
daml-sdk-head: Delete the SDK temporary directory after installation.

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -97,6 +97,10 @@ echo ""
 function cleanup() {
   echo "SDK 0.0.0 failed to build/install - if you need help ask on #product-daml"
   echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
+
+  if [[ -n "${SDK_TEMP_DIR+x}" && -d "$SDK_TEMP_DIR" ]]; then
+    rm -rf "$SDK_TEMP_DIR"
+  fi
 }
 trap cleanup EXIT
 
@@ -104,19 +108,24 @@ trap cleanup EXIT
 bazel build "${BAZEL_MODE_FLAGS[@]}" //release:sdk-release-tarball.tar.gz
 
 readonly TARBALL="$(bazel info bazel-bin "${BAZEL_MODE_FLAGS[@]}")/release/sdk-release-tarball.tar.gz"
-readonly TMPDIR="$(mktemp -d)"
-mkdir -p "${TMPDIR}/sdk-head"
+readonly SDK_TEMP_DIR="$(mktemp -d)"
+readonly SDK_DIR="${SDK_TEMP_DIR}/sdk-head"
+mkdir -p "$SDK_DIR"
 
-tar xzf "$TARBALL" -C "${TMPDIR}/sdk-head" --strip-components 1
+tar xzf "$TARBALL" -C "$SDK_DIR" --strip-components 1
 
 readonly DAML_CMD="$(command -v daml)"
 if [[ -x "$DAML_CMD" && "$DAML_CMD" == "$DAML_HOME/bin/daml" ]]; then
   # A daml installation already exists, so just install SDK version 0.0.0.
-  "${DAML_HOME}/bin/daml" install "${TMPDIR}/sdk-head" --force
+  "${DAML_HOME}/bin/daml" install "$SDK_DIR" --force
 else
   # No daml installation detected, so install the tarball normally but disable auto-install.
-  "${TMPDIR}/sdk-head/install.sh" --force
+  "${SDK_DIR}/install.sh" --force
   echo "auto-install: false" > "${DAML_HOME}/daml-config.yaml"
+fi
+
+if [[ -d "$SDK_TEMP_DIR" ]]; then
+  rm -rf "$SDK_TEMP_DIR"
 fi
 
 cat > "${DAML_HOME}/bin/daml-head" << EOF


### PR DESCRIPTION
I'm aggregating a lot of SDKs.

```
$ du -h -d1 $TMPDIR | sort -rh | head -5
1.9G    /var/folders/5x/36ws6_n96qz_b4tbpvfbcth80000gn/T/
501M    /var/folders/5x/36ws6_n96qz_b4tbpvfbcth80000gn/T/tmp.ahBTENEeZw
500M    /var/folders/5x/36ws6_n96qz_b4tbpvfbcth80000gn/T/tmp.S4sB7DIjkA
500M    /var/folders/5x/36ws6_n96qz_b4tbpvfbcth80000gn/T/tmp.Q3VeVV8DIU
405M    /var/folders/5x/36ws6_n96qz_b4tbpvfbcth80000gn/T/tmp.b5ZWnPhLkH
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
