### PR TITLE
Fix a stackoverflow in the script runner

### DIFF
--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -52,6 +52,7 @@ ScriptTest:traceOrder SUCCESS
 ScriptTest:partyIdHintTest SUCCESS
 ScriptTest:sleepTest SUCCESS
 ScriptExample:initializeFixed SUCCESS
+ScriptTest:testStack SUCCESS
 ScriptTest:testMaxInboundMessageSize SUCCESS
 EOF
 )"

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -5,6 +5,7 @@
 
 module ScriptTest where
 
+import DA.Action
 import DA.Assert
 import DA.Foldable hiding (length)
 import DA.Time
@@ -140,6 +141,13 @@ failingTest = do
   cid <- submit alice $ createCmd (C alice 42)
   submit alice $ exerciseCmd cid ShouldFail
   pure ()
+
+-- | This used to produce a stackoverflow
+testStack : Script ()
+testStack = do
+  p <- allocateParty "p"
+  results <- submit p $ replicateA 1000 (createCmd (C p 42))
+  assert (length results == 1000)
 
 time : Script (Time, Time)
 time = do

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -258,6 +258,20 @@ case class PartyIdHintTest(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   }
 }
 
+case class TestStack(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId =
+    Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:testStack"))
+  def runTests() = {
+    runner.genericTest(
+      "testStack",
+      scriptId,
+      None,
+      // We only want to check that this does not crash so the check here is trivial.
+      v => TestRunner.assertEqual(v, SUnit, "Script result")
+    )
+  }
+}
+
 case class TestMaxInboundMessageSize(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId =
     Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:testMaxInboundMessageSize"))
@@ -385,6 +399,7 @@ object SingleParticipant {
             Time(dar, runner).runTests()
             Sleep(dar, runner).runTests()
             PartyIdHintTest(dar, runner).runTests()
+            TestStack(dar, runner).runTests()
             TestMaxInboundMessageSize(dar, runner).runTests()
             ScriptExample(dar, runner).runTests()
           case Some(_) =>


### PR DESCRIPTION
Previously, we used the stack to recurse when filling in the command
results which obviously breaks once you have large multi-command
submissions.

You probably want to view the diff with whitespace disabled.

changelog_begin

- [DAML Script] Fix a bug where large multi-command transactions
  produced a stack overflow.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
