### PR TITLE
Make max-inbound-message-size in DAML script/repl configurable

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -62,7 +62,7 @@ main = do
     withTempFile $ \portFile ->
         withBinaryFile nullDevice WriteMode $ \devNull ->
         bracket (createSandbox portFile devNull defaultSandboxConf { dars = [testDar] }) destroySandbox $ \SandboxResource{sandboxPort} ->
-        ReplClient.withReplClient (ReplClient.Options replJar "localhost" (show sandboxPort) Nothing Nothing CreatePipe) $ \replHandle mbServiceOut processHandle ->
+        ReplClient.withReplClient (ReplClient.Options replJar "localhost" (show sandboxPort) Nothing Nothing Nothing CreatePipe) $ \replHandle mbServiceOut processHandle ->
         -- TODO We could share some of this setup with the actual repl code in damlc.
         withTempDir $ \dir ->
         withCurrentDirectory dir $ do

--- a/compiler/repl-service/client/src/DA/Daml/LF/ReplClient.hs
+++ b/compiler/repl-service/client/src/DA/Daml/LF/ReplClient.hs
@@ -1,11 +1,12 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiWayIf #-}
 module DA.Daml.LF.ReplClient
   ( Options(..)
+  , MaxInboundMessageSize(..)
   , Handle
   , withReplClient
   , loadPackage
@@ -34,12 +35,16 @@ import qualified System.IO as IO
 import System.IO.Extra (withTempFile)
 import System.Process
 
+newtype MaxInboundMessageSize = MaxInboundMessageSize Int
+  deriving newtype Read
+
 data Options = Options
   { optServerJar :: FilePath
   , optLedgerHost :: String
   , optLedgerPort :: String
   , optMbAuthTokenFile :: Maybe FilePath
   , optMbSslConfig :: Maybe ClientSSLConfig
+  , optMaxInboundMessageSize :: Maybe MaxInboundMessageSize
   , optStdout :: StdStream
   -- ^ This is intended for testing so we can redirect stdout there.
   }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
@@ -25,11 +25,13 @@ case class RunnerConfig(
     accessTokenFile: Option[Path],
     tlsConfig: Option[TlsConfiguration],
     jsonApi: Boolean,
+    maxInboundMessageSize: Int,
 )
 
 object RunnerConfig {
 
   val DefaultTimeProviderType: TimeProviderType = TimeProviderType.WallClock
+  val DefaultMaxInboundMessageSize: Int = 4194304
 
   private def validatePath(path: String, message: String): Either[String, Unit] = {
     val readable = Try(Paths.get(path).toFile.canRead).getOrElse(false)
@@ -140,6 +142,12 @@ object RunnerConfig {
       }
       .text("Run DAML Script via the HTTP JSON API instead of via gRPC (experimental).")
 
+    opt[Int]("max-inbound-message-size")
+      .action((x, c) => c.copy(maxInboundMessageSize = x))
+      .optional()
+      .text(
+        s"Optional max inbound message size in bytes. Defaults to $DefaultMaxInboundMessageSize")
+
     help("help").text("Print this usage text")
 
     checkConfig(c => {
@@ -185,6 +193,7 @@ object RunnerConfig {
         accessTokenFile = None,
         tlsConfig = None,
         jsonApi = false,
+        maxInboundMessageSize = DefaultMaxInboundMessageSize,
       )
     )
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -115,7 +115,7 @@ object RunnerMain {
               sslContext = config.tlsConfig.flatMap(_.client),
               token = tokenHolder.flatMap(_.token),
             )
-            Runner.connect(participantParams, clientConfig)
+            Runner.connect(participantParams, clientConfig, config.maxInboundMessageSize)
           }
           result <- Runner.run(dar, scriptId, inputValue, clients, applicationId, timeProvider)
           _ <- Future {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
@@ -15,6 +15,7 @@ case class TestConfig(
     participantConfig: Option[File],
     timeProviderType: TimeProviderType,
     commandTtl: Duration,
+    maxInboundMessageSize: Int,
 )
 
 object TestConfig {
@@ -53,6 +54,12 @@ object TestConfig {
       }
       .text("TTL in seconds used for commands emitted by the trigger. Defaults to 30s.")
 
+    opt[Int]("max-inbound-message-size")
+      .action((x, c) => c.copy(maxInboundMessageSize = x))
+      .optional()
+      .text(
+        s"Optional max inbound message size in bytes. Defaults to ${RunnerConfig.DefaultMaxInboundMessageSize}")
+
     help("help").text("Print this usage text")
 
     checkConfig(c => {
@@ -75,6 +82,7 @@ object TestConfig {
         participantConfig = None,
         timeProviderType = TimeProviderType.Static,
         commandTtl = Duration.ofSeconds(30L),
+        maxInboundMessageSize = RunnerConfig.DefaultMaxInboundMessageSize,
       )
     )
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -123,7 +123,7 @@ object TestMain extends StrictLogging {
         }
 
         val flow: Future[Boolean] = for {
-          clients <- Runner.connect(participantParams, clientConfig)
+          clients <- Runner.connect(participantParams, clientConfig, config.maxInboundMessageSize)
           _ <- clients.getParticipant(None) match {
             case Left(err) => throw new RuntimeException(err)
             case Right(client) =>

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -21,7 +21,7 @@ GREP=$4
 SORT=$5
 
 set +e
-TEST_OUTPUT="$($TEST_RUNNER --dar=$DAR_FILE 2>&1)"
+TEST_OUTPUT="$($TEST_RUNNER --dar=$DAR_FILE --max-inbound-message-size 41943040 2>&1)"
 TEST_RESULT=$?
 set -e
 
@@ -52,6 +52,7 @@ ScriptTest:traceOrder SUCCESS
 ScriptTest:partyIdHintTest SUCCESS
 ScriptTest:sleepTest SUCCESS
 ScriptExample:initializeFixed SUCCESS
+ScriptTest:testMaxInboundMessageSize SUCCESS
 EOF
 )"
 

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -209,3 +209,26 @@ jsonExpectedFailureCreateAndExercise p = submitMustFail p $ createAndExerciseCmd
 
 jsonAllocateParty : Text -> Script Party
 jsonAllocateParty p = allocatePartyWithHint p (PartyIdHint p)
+
+-- maxInboundMessageSize
+
+template MessageSize
+  with
+    p : Party
+  where
+    signatory p
+    nonconsuming choice CreateN : ()
+      with
+        n : Int
+      controller p
+      do
+        res <- forA [1..n] (\_ -> do
+              create this
+          )
+        return()
+
+testMaxInboundMessageSize : Script () = do
+  p <- allocateParty "p"
+  b <- submit p do createCmd (MessageSize p)
+  submit p do exerciseCmd b CreateN with n = 50000
+  return ()

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -258,6 +258,22 @@ case class PartyIdHintTest(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   }
 }
 
+case class TestMaxInboundMessageSize(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId =
+    Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:testMaxInboundMessageSize"))
+  def runTests(): Unit = {
+    runner.genericTest(
+      "MaxInboundMessageSize",
+      scriptId,
+      None, {
+        case SUnit => Right(())
+        case v => Left(s"Expected SUnit but got $v")
+      },
+      maxInboundMessageSize = RunnerConfig.DefaultMaxInboundMessageSize * 10,
+    )
+  }
+}
+
 // Runs the example from the docs to make sure it doesn’t produce a runtime error.
 case class ScriptExample(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptExample:test"))
@@ -369,6 +385,7 @@ object SingleParticipant {
             Time(dar, runner).runTests()
             Sleep(dar, runner).runTests()
             PartyIdHintTest(dar, runner).runTests()
+            TestMaxInboundMessageSize(dar, runner).runTests()
             ScriptExample(dar, runner).runTests()
           case Some(_) =>
             // We can’t test much with auth since most of our tests rely on party allocation and being

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -93,7 +93,8 @@ class TestRunner(
       scriptId: Identifier,
       inputValue: Option[JsValue],
       assertResult: SValue => Either[String, Unit],
-      expectedLog: Option[Seq[String]] = None
+      expectedLog: Option[Seq[String]] = None,
+      maxInboundMessageSize: Int = RunnerConfig.DefaultMaxInboundMessageSize,
   ) = {
 
     LogCollector.clear()
@@ -106,7 +107,8 @@ class TestRunner(
     implicit val materializer: Materializer = Materializer(system)
     implicit val ec: ExecutionContext = system.dispatcher
 
-    val clientsF = Runner.connect(participantParams, clientConfig)
+    val clientsF =
+      Runner.connect(participantParams, clientConfig, maxInboundMessageSize)
 
     val testFlow: Future[Unit] = for {
       clients <- clientsF


### PR DESCRIPTION
Fixes #5592

The CLI syntax and the defaults follow the JSON API here.

changelog_begin

- [DAML Script] The maximum inbound message size can now be configured
using `--max-inbound-message-size``. This matches the flag in the JSON
API.

- [DAML REPL] The maximum inbound message size can now be configured
using `--max-inbound-message-size``. This matches the flag in the JSON API.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
