### PR TITLE
Fix ledger api test tool multi-node CommandService test flake

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
@@ -396,6 +396,7 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
     case Participants(Participant(alpha, giver, newReceiver), Participant(beta, receiver)) =>
       for {
         callablePayout <- alpha.create(giver, CallablePayout(giver, receiver))
+        _ <- synchronize(alpha, beta)
         tree <- beta.exercise(receiver, callablePayout.exerciseTransfer(_, newReceiver))
       } yield {
         val created = assertSingleton("There should only be one creation", createdEvents(tree))


### PR DESCRIPTION
by adding synchronize call between an alpha-participant-create and the
corresponding beta-participant-exercise.

We occasionally run into this in Canton

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
