### PR TITLE
Add max-inbound-message-size in DAML trigger/service configurable

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -19,6 +19,7 @@ case class RunnerConfig(
     ledgerHost: String,
     ledgerPort: Int,
     ledgerParty: String,
+    maxInboundMessageSize: Int,
     // optional so we can detect if both --static-time and --wall-clock-time are passed.
     timeProviderType: Option[TimeProviderType],
     commandTtl: Duration,
@@ -27,7 +28,7 @@ case class RunnerConfig(
 )
 
 object RunnerConfig {
-
+  val DefaultMaxInboundMessageSize: Int = 4194304
   val DefaultTimeProviderType: TimeProviderType = TimeProviderType.WallClock
 
   private def validatePath(path: String, message: String): Either[String, Unit] = {
@@ -58,6 +59,12 @@ object RunnerConfig {
     opt[String]("ledger-party")
       .action((t, c) => c.copy(ledgerParty = t))
       .text("Ledger party")
+
+    opt[Int]("max-inbound-message-size")
+      .action((x, c) => c.copy(maxInboundMessageSize = x))
+      .optional()
+      .text(
+        s"Optional max inbound message size in bytes. Defaults to ${DefaultMaxInboundMessageSize}")
 
     opt[Unit]('w', "wall-clock-time")
       .action { (_, c) =>
@@ -165,6 +172,7 @@ object RunnerConfig {
         ledgerHost = null,
         ledgerPort = 0,
         ledgerParty = null,
+        maxInboundMessageSize = DefaultMaxInboundMessageSize,
         timeProviderType = None,
         commandTtl = Duration.ofSeconds(30L),
         accessTokenFile = None,

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -41,6 +41,7 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_http_spray_json_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
+        "@maven//:io_grpc_grpc_netty",
         "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_slf4j_slf4j_api",

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -15,11 +15,15 @@ case class ServiceConfig(
     httpPort: Int,
     ledgerHost: String,
     ledgerPort: Int,
+    maxInboundMessageSize: Int,
     timeProviderType: TimeProviderType,
     commandTtl: Duration,
 )
 
 object ServiceConfig {
+  val DefaultHttpPort: Int = 8088
+  val DefaultMaxInboundMessageSize: Int = RunnerConfig.DefaultMaxInboundMessageSize
+
   private val parser = new scopt.OptionParser[ServiceConfig]("trigger-service") {
     head("trigger-service")
 
@@ -31,7 +35,7 @@ object ServiceConfig {
     opt[Int]("http-port")
       .optional()
       .action((t, c) => c.copy(httpPort = t))
-      .text("Http port")
+      .text(s"Optional HTTP port. Defaults to ${DefaultHttpPort}")
 
     opt[String]("ledger-host")
       .required()
@@ -42,6 +46,12 @@ object ServiceConfig {
       .required()
       .action((t, c) => c.copy(ledgerPort = t))
       .text("Ledger port")
+
+    opt[Int]("max-inbound-message-size")
+      .action((x, c) => c.copy(maxInboundMessageSize = x))
+      .optional()
+      .text(
+        s"Optional max inbound message size in bytes. Defaults to ${DefaultMaxInboundMessageSize}")
 
     opt[Unit]('w', "wall-clock-time")
       .action { (t, c) =>
@@ -60,9 +70,10 @@ object ServiceConfig {
       args,
       ServiceConfig(
         darPath = None,
-        httpPort = 8088,
+        httpPort = DefaultHttpPort,
         ledgerHost = null,
         ledgerPort = 0,
+        maxInboundMessageSize = DefaultMaxInboundMessageSize,
         timeProviderType = TimeProviderType.Static,
         commandTtl = Duration.ofSeconds(30L),
       ),

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -63,7 +63,12 @@ object TriggerServiceFixture {
         ledgerPort,
         TimeProviderType.Static,
         Duration.ofSeconds(30))
-      service <- ServiceMain.startServer("localhost", 0, ledgerConfig, dar)
+      service <- ServiceMain.startServer(
+        "localhost",
+        0,
+        ledgerConfig,
+        ServiceConfig.DefaultMaxInboundMessageSize,
+        dar)
     } yield service
 
     val fa: Future[A] = for {

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -29,6 +29,7 @@ genrule(
       cp -L $(location :daml/Retry.daml) $$TMP_DIR/daml
       cp -L $(location :daml/ExerciseByKey.daml) $$TMP_DIR/daml
       cp -L $(location :daml/CreateAndExercise.daml) $$TMP_DIR/daml
+      cp -L $(location :daml/MaxInboundMessageTest.daml) $$TMP_DIR/daml
       cp -L $(location :daml/Numeric.daml) $$TMP_DIR/daml
       cp -L $(location :daml/CommandId.daml) $$TMP_DIR/daml
       cp -L $(location :daml/PendingSet.daml) $$TMP_DIR/daml

--- a/triggers/tests/daml/MaxInboundMessageTest.daml
+++ b/triggers/tests/daml/MaxInboundMessageTest.daml
@@ -1,0 +1,40 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+-- Apache-2.0
+
+module MaxInboundMessageTest where
+
+import DA.Action
+import DA.Next.Map (Map)
+import Daml.Trigger
+
+maxInboundMessageSizeTrigger : Trigger ()
+maxInboundMessageSizeTrigger = Trigger
+  { initialize = \_ -> ()
+  , updateState = \_ _ _ -> ()
+  , rule = maxInboundMessageSizeRule
+  , registeredTemplates = AllInDar
+  , heartbeat = None
+  }
+
+maxInboundMessageSizeRule : Party -> ACS -> Time -> Map CommandId [Command] -> ()
+  -> TriggerA ()
+maxInboundMessageSizeRule party acs _ _ _
+  | [] <- getContracts @MessageSize acs =
+      void $ emitCommands [createAndExerciseCmd (MessageSize { p = party }) (CreateN {n = 50000})] []
+  | otherwise = pure ()
+
+template MessageSize
+  with
+    p : Party
+  where
+    signatory p
+    nonconsuming choice CreateN : ()
+      with
+        n : Int
+      controller p
+      do
+        res <- forA [1..n] (\_ -> do
+              create this
+          )
+        return()

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -25,8 +25,10 @@ import com.daml.ledger.client.configuration.{
   LedgerClientConfiguration,
   LedgerIdRequirement
 }
+import com.daml.lf.engine.trigger.RunnerConfig
 import com.daml.platform.sandbox.services.{SandboxFixture, TestCommands}
 import org.scalatest._
+import io.grpc.netty.NettyChannelBuilder
 import scala.concurrent.{ExecutionContext, Future}
 import scalaz.syntax.tag._
 import scalaz.syntax.traverse._
@@ -45,8 +47,18 @@ trait AbstractTriggerTest extends SandboxFixture with TestCommands {
       token = None
     )
 
-  protected def ledgerClient()(implicit ec: ExecutionContext): Future[LedgerClient] =
-    LedgerClient.singleHost("localhost", serverPort.value, ledgerClientConfiguration)
+  protected def ledgerClient(
+      maxInboundMessageSize: Int = RunnerConfig.DefaultMaxInboundMessageSize)(
+      implicit ec: ExecutionContext): Future[LedgerClient] =
+    for {
+      client <- LedgerClient
+        .fromBuilder(
+          NettyChannelBuilder
+            .forAddress("localhost", serverPort.value)
+            .maxInboundMessageSize(maxInboundMessageSize),
+          ledgerClientConfiguration,
+        )
+    } yield client
 
   override protected def darFile = new File(rlocation("triggers/tests/acs.dar"))
 


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/5997.

Follows on from PR https://github.com/digital-asset/daml/pull/5996. The default follows the JSON API.