### PR TITLE
Include sources directory in the Bazel cache key

### DIFF
--- a/ci/configure-bazel.sh
+++ b/ci/configure-bazel.sh
@@ -63,8 +63,10 @@ if is_windows; then
   # (this is what bazel does to determine the execroot name).
   # To avoid exceeding the maximum path limit on Windows we limit the suffix to
   # three characters.
+  echo "Working directory: $PWD"
   SUFFIX="$(echo $PWD | md5sum)"
   SUFFIX="${SUFFIX:0:2}"
+  echo "Platform suffix: $SUFFIX"
   echo "build --platform_suffix=-$SUFFIX" >> .bazelrc.local
 fi
 

--- a/ci/configure-bazel.sh
+++ b/ci/configure-bazel.sh
@@ -48,16 +48,24 @@ if is_windows; then
   echo "build --config windows" > .bazelrc.local
   echo "build --config windows-ci" >> .bazelrc.local
 
-  # Modify the output path (x64_windows-opt-co) to avoid shared action keys
-  # between external dependencies of the daml and compatibility workspaces.
-  # These are causing issues on Windows, namely sporadic failures due to
-  # "undeclared inclusion(s)" with the mingw toolchain. This doesn't modify all
-  # action keys, e.g. metadata actions like `Mnemonic: Middleman` are
-  # unaffected. However, all actions that produce artifacts will be affected.
+  # Modify the output path to avoid shared action keys.
+  # The issue appears to be that GCC produces absolute paths
+  # to system includes in .d files. These files are cached
+  # so the absolute paths leak into different builds. Most of the time
+  # this works since Azure reuses the working directory. However,
+  # between the daily compatibility job seems to get a different
+  # working directory because it is in a different pipeline.
+  # To make matters worse, the working directory depends on which
+  # job runs first afaict. There is a counter that simply gets incremented.
+  # Sharing between the compatibility workspace and the main workspace
+  # runs into the same issue.
+  # To sidestep this we take a md5 hash of PWD
+  # (this is what bazel does to determine the execroot name).
   # To avoid exceeding the maximum path limit on Windows we limit the suffix to
   # three characters.
-  CONFIG=${BAZEL_CONFIG_DIR-default}
-  echo "build --platform_suffix=-${CONFIG:0:2}" >> .bazelrc.local
+  SUFFIX="$(echo $PWD | md5sum)"
+  SUFFIX="${SUFFIX:0:2}"
+  echo "build --platform_suffix=-$SUFFIX" >> .bazelrc.local
 fi
 
 # sets up write access to the shared remote cache if the branch is not a fork


### PR DESCRIPTION
This should hopefully fix the “undeclared inclusion” errors we have
been getting daily on CI

The details are in a comment but the short summary is that
the daily cron job is running in D:\a\1 whereas jobs on the same
machine afterwards run in D:\a\2. Because absolute paths leak in some
places, this fucks things up.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
