### PR TITLE
Remove deprecated vscode-resource scheme

### DIFF
--- a/compiler/daml-extension/package.json
+++ b/compiler/daml-extension/package.json
@@ -7,7 +7,7 @@
     "repository": "https://github.com/digital-asset/daml/tree/master/compiler/daml-extension",
     "icon": "images/daml-studio.png",
     "engines": {
-        "vscode": "^1.33.0"
+        "vscode": "^1.38.0"
     },
     "license": "Apache-2.0",
     "private": true,
@@ -149,7 +149,7 @@
     "devDependencies": {
         "@bazel/hide-bazel-files": "1.6.0",
         "@types/node": "12.7.11",
-        "@types/vscode": "1.33",
+        "@types/vscode": "1.38",
         "typescript": "3.6.3",
         "vsce": "1.66.0"
     }

--- a/compiler/daml-extension/src/extension.ts
+++ b/compiler/daml-extension/src/extension.ts
@@ -45,12 +45,8 @@ export async function activate(context: vscode.ExtensionContext) {
     damlLanguageClient.registerProposedFeatures();
 
     const webviewFiles: WebviewFiles = {
-        src:
-            vscode.Uri.file(path.join(context.extensionPath, 'src', 'webview.js')).
-            with({scheme: 'vscode-resource'}),
-        css:
-            vscode.Uri.file(path.join(context.extensionPath, 'src', 'webview.css')).
-            with({scheme: 'vscode-resource'}),
+        src: vscode.Uri.file(path.join(context.extensionPath, 'src', 'webview.js')),
+        css: vscode.Uri.file(path.join(context.extensionPath, 'src', 'webview.css')),
     };
     let virtualResourceManager = new VirtualResourceManager(damlLanguageClient, webviewFiles);
     context.subscriptions.push(virtualResourceManager);
@@ -428,11 +424,11 @@ class VirtualResourceManager {
     }
 
     public setContent(uri: UriString, contents: ScenarioResult) {
-        contents = contents.replace('$webviewSrc', this._webviewFiles.src.toString());
-        contents = contents.replace('$webviewCss', this._webviewFiles.css.toString());
-        this._panelContents.set(uri, contents);
         const panel = this._panels.get(uri);
         if (panel) {
+            contents = contents.replace('$webviewSrc', panel.webview.asWebviewUri(this._webviewFiles.src).toString());
+            contents = contents.replace('$webviewCss', panel.webview.asWebviewUri(this._webviewFiles.css).toString());
+            this._panelContents.set(uri, contents);
             // append timestamp to force page reload (prevent using cache) as otherwise notes are not getting cleared
             panel.webview.html = contents + "<!-- " + new Date() + " -->";
             const panelState = this._panelStates.get(uri);

--- a/compiler/daml-extension/yarn.lock
+++ b/compiler/daml-extension/yarn.lock
@@ -29,10 +29,10 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.29.tgz#3f188a758327375766babca50fee224aff09a13f"
   integrity sha1-PxiKdYMnN1dmurylD+4iSv8JoT8=
 
-"@types/vscode@1.33":
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.33.0.tgz#da400abcb4caaeea18fd37287a3f48b18c785c94"
-  integrity sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==
+"@types/vscode@1.38":
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.38.0.tgz#1e53953406ef662354e2e62451c3c71c9ff19a6d"
+  integrity sha512-aGo8LQ4J1YF0T9ORuCO+bhQ5sGR1MXa7VOyOdEP685se3wyQWYUExcdiDi6rvaK61KUwfzzA19JRLDrUbDl7BQ==
 
 "@types/which@1.3.1":
   version "1.3.1"


### PR DESCRIPTION
fixes #6005

Take a look at #6005 for details. I verified manually that things
still work as expected. It does require bumping the vscode version to
1.38 which was released almost a year ago so hopefully that should be
safe.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
