### PR TITLE
Include Bazel patch to cache exclusive tests on Windows

### DIFF
--- a/ci/patch_bazel_windows/patch-bazel
+++ b/ci/patch_bazel_windows/patch-bazel
@@ -1,3 +1,37 @@
+diff --git a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
+index 87d91de5e6..32f85a9201 100644
+--- a/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
++++ b/src/main/java/com/google/devtools/build/docgen/templates/attributes/common/tags.html
+@@ -88,8 +88,9 @@
+   <li><code>exclusive</code> keyword will force the test to be run in the
+     &quot;exclusive&quot; mode, ensuring that no other tests are running at the
+     same time. Such tests will be executed in serial fashion after all build
+-    activity and non-exclusive tests have been completed. They will also always
+-    run locally and thus without sandboxing.
++    activity and non-exclusive tests have been completed. Remote execution is
++    disabled for such tests because Bazel doesn't have control over what's
++    running on a remote machine.
+   </li>
+ 
+   <li><code>manual</code> keyword will force the test target to not be included in target pattern
+diff --git a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+index dbbf8274a6..92084b3008 100644
+--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
++++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestTargetProperties.java
+@@ -88,9 +88,12 @@ public class TestTargetProperties {
+ 
+     Map<String, String> executionInfo = Maps.newLinkedHashMap();
+     executionInfo.putAll(TargetUtils.getExecutionInfo(rule));
+-    if (TargetUtils.isLocalTestRule(rule) || TargetUtils.isExclusiveTestRule(rule)) {
++    if (TargetUtils.isLocalTestRule(rule)) {
+       executionInfo.put(ExecutionRequirements.LOCAL, "");
+     }
++    if (TargetUtils.isExclusiveTestRule(rule)) {
++      executionInfo.put(ExecutionRequirements.NO_REMOTE_EXEC, "");
++    }
+ 
+     if (executionRequirements != null) {
+       // This will overwrite whatever TargetUtils put there, which might be confusing.
 diff --git a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java b/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
 index 72da2b2f85..72f70bfe58 100644
 --- a/src/main/java/com/google/devtools/build/lib/rules/cpp/CppCompileAction.java
@@ -30,3 +64,77 @@ index 157cd5f36a..fb9dbc723f 100644
        problems.add(execPathFragment.getPathString());
      }
      if (shouldValidateInclusions) {
+diff --git a/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java b/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java
+index 5571f5fcde..0c0b113bba 100644
+--- a/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java
++++ b/src/test/java/com/google/devtools/build/lib/rules/test/TestTargetPropertiesTest.java
+@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.rules.test;
+ 
+ import static com.google.common.truth.Truth.assertThat;
+ 
++import com.google.devtools.build.lib.actions.ExecutionRequirements;
+ import com.google.devtools.build.lib.actions.ResourceSet;
+ import com.google.devtools.build.lib.analysis.ConfiguredTarget;
+ import com.google.devtools.build.lib.analysis.test.TestProvider;
+@@ -50,4 +51,22 @@ public class TestTargetPropertiesTest extends BuildViewTestCase {
+             .getLocalResourceUsage(testAction.getOwner().getLabel(), false);
+     assertThat(localResourceUsage.getCpuUsage()).isEqualTo(4.0);
+   }
++
++  @Test
++  public void testTestWithExclusiveDisablesRemoteExecution() throws Exception {
++    scratch.file("tests/test.sh", "#!/bin/bash", "exit 0");
++    scratch.file(
++        "tests/BUILD",
++        "sh_test(",
++        "  name = 'test',",
++        "  size = 'small',",
++        "  srcs = ['test.sh'],",
++        "  tags = ['exclusive'],",
++        ")");
++    ConfiguredTarget testTarget = getConfiguredTarget("//tests:test");
++    TestRunnerAction testAction =
++        (TestRunnerAction)
++            getGeneratingAction(TestProvider.getTestStatusArtifacts(testTarget).get(0));
++    assertThat(testAction.getExecutionInfo()).isEqualTo(ExecutionRequirements.NO_REMOTE_EXEC);
++  }
+ }
+diff --git a/src/test/shell/bazel/remote/remote_execution_test.sh b/src/test/shell/bazel/remote/remote_execution_test.sh
+index 6cd04261a4..bd5415c53c 100755
+--- a/src/test/shell/bazel/remote/remote_execution_test.sh
++++ b/src/test/shell/bazel/remote/remote_execution_test.sh
+@@ -1751,6 +1751,34 @@ EOF
+   expect_log "exceeded deadline"
+ }
+ 
++function test_exclusive_tag() {
++  # Test that the exclusive tag works with the remote cache.
++  mkdir -p a
++  cat > a/success.sh <<'EOF'
++#!/bin/sh
++exit 0
++EOF
++  chmod 755 a/success.sh
++  cat > a/BUILD <<'EOF'
++sh_test(
++  name = "success_test",
++  srcs = ["success.sh"],
++  tags = ["exclusive"],
++)
++EOF
++
++  bazel test \
++    --remote_cache=grpc://localhost:${worker_port} \
++    //a:success_test || fail "Failed to test //a:success_test"
++
++  bazel test \
++    --remote_cache=grpc://localhost:${worker_port} \
++    --nocache_test_results \
++    //a:success_test >& $TEST_log || fail "Failed to test //a:success_test"
++
++  expect_log "remote cache hit"
++}
++
+ # TODO(alpha): Add a test that fails remote execution when remote worker
+ # supports sandbox.
+ 

--- a/dev-env/windows/manifests/bazel.json
+++ b/dev-env/windows/manifests/bazel.json
@@ -5,8 +5,8 @@
   "bin": "bazel.exe",
   "architecture": {
     "64bit": {
-      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-46cfe9da3d303f42d8bd469653ffc41b.zip",
-      "hash": "3ac6975cacf00963eb41277cd27d75babe405bdb2bef1eb02f0c9d9607fbc93f"
+      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-8e606d2495d967cbbf2d247269765cec.zip",
+      "hash": "9641d25c739e77932fcce51bf4756e1a51afd5cc844b1095b3cd39f24d399728"
     }
   },
   "depends": [


### PR DESCRIPTION
This includes the patch that we already use on Linux and MacOS to fix
caching of things marked exclusive. I’ve kept in the debugging output
that I added in the last patch for now. While our workaround seems to
be working, I’d like to wait a bit longer in case the issue reappears.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
