### PR TITLE
fix daml-sdk-head for macOS

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -78,9 +78,9 @@ if [[ -d "$DAML_HEAD_SDK" && "$JUST_DAMLC" -ne 0 ]]; then
   }
   trap cleanup EXIT
 
-  bazel build "${BAZEL_MODE_FLAGS[@]}" //compiler/damlc:damlc-dist.tar.gz
+  bazel build ${BAZEL_MODE_FLAGS[@]:-} //compiler/damlc:damlc-dist.tar.gz
 
-  readonly TARBALL="$(bazel info bazel-bin "${BAZEL_MODE_FLAGS[@]}")/compiler/damlc/damlc-dist.tar.gz"
+  readonly TARBALL="$(bazel info bazel-bin "${BAZEL_MODE_FLAGS[@]:-}")/compiler/damlc/damlc-dist.tar.gz"
   chmod -R u+w "$DAML_HEAD_SDK"
   rm -rf "${DAML_HEAD_SDK}/damlc"
   mkdir -p "${DAML_HEAD_SDK}/damlc"
@@ -105,9 +105,9 @@ function cleanup() {
 trap cleanup EXIT
 
 # Building here separately so the user can see the build process which could take a while
-bazel build "${BAZEL_MODE_FLAGS[@]}" //release:sdk-release-tarball.tar.gz
+bazel build ${BAZEL_MODE_FLAGS[@]:-} //release:sdk-release-tarball.tar.gz
 
-readonly TARBALL="$(bazel info bazel-bin "${BAZEL_MODE_FLAGS[@]}")/release/sdk-release-tarball.tar.gz"
+readonly TARBALL="$(bazel info bazel-bin ${BAZEL_MODE_FLAGS[@]:-})/release/sdk-release-tarball.tar.gz"
 readonly SDK_TEMP_DIR="$(mktemp -d)"
 readonly SDK_DIR="${SDK_TEMP_DIR}/sdk-head"
 mkdir -p "$SDK_DIR"


### PR DESCRIPTION
Bash is not easy to add to dev-env because dev-env depends on Bash. This has not been an issue so far because Bash behaves in very sensible ways overall and is mostly backwards compatible.

A recent change to `daml-sdk-head` is, however, using some feature of Bash 4 that is not evailable in Bash 3. Bash 3 is ancient so in an ideal world that would not be an issue, but macOS still ships with Bash 3 for some obscure (licensing) reason.

It turns our that the line

```bash
arr=()
```

in Bash 4 sets the variable `arr` to an empty array, whereas it leaves it unset in Bash 3. This means that the later use of `arr`, in the case where no further element has been added to the array, will yield an error in combination with the `set -u` option we are using.

This PR changes the usage pattern from

```bash
"${arr[@]}"
```

which fails on Bash 3 to

```bash
${arr[@]}
```

which works as expected. Note that the quotes have been removed: the quotes in this case are not useful assuming that the flags themselves are never multiword. Without the quotes, this evaluates to `""` under Bash 3 (as the variable is not set), which confuses Bazel because now it thinks it's asked to build the `""` target, which it has no rule for.

Ignoring the quoting issue, the actual fix is to include `:-` inside the `{}`, which instructs Bash to replace the variable with what follows the `-` in case the variable is not set (in this case, an empty string), and therefore not crash on this specific variable not being set despite the `set -u` option.

CHANGELOG_BEGIN
CHANGELOG_END