### PR TITLE
ledger-api-client: Make it Closeable.

### DIFF
--- a/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/LedgerClientIT.scala
+++ b/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/LedgerClientIT.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.client
+
+import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundEach}
+import com.daml.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement
+}
+import com.daml.platform.sandboxnext.SandboxNextFixture
+import io.grpc.ManagedChannel
+import org.scalatest.{AsyncWordSpec, Inside, Matchers}
+
+final class LedgerClientIT
+    extends AsyncWordSpec
+    with Matchers
+    with Inside
+    with AkkaBeforeAndAfterAll
+    with SuiteResourceManagementAroundEach
+    with SandboxNextFixture {
+  "the ledger client" should {
+    "shut down the channel when closed" in {
+      val clientConfig = LedgerClientConfiguration(
+        applicationId = classOf[LedgerClientIT].getSimpleName,
+        ledgerIdRequirement = LedgerIdRequirement("", enabled = false),
+        commandClient = CommandClientConfiguration.default,
+        sslContext = None,
+        token = None,
+      )
+
+      for {
+        client <- LedgerClient(channel, clientConfig)
+      } yield {
+        inside(channel) {
+          case channel: ManagedChannel =>
+            channel.isShutdown should be(false)
+            channel.isTerminated should be(false)
+
+            client.close()
+
+            channel.isShutdown should be(true)
+            channel.isTerminated should be(true)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #5304.

Add `LedgerClient#close`, which will shut down the channel and await termination. This is optional; the channel will still be shut down on JVM exit if this method is not called.

This is offered as a compromise for those who would like to ensure resources are shut down cleanly, while not making the API more complicated. I originally wanted to make `LedgerClient.fromBuilder` return a `Resource[LedgerClient]`, but the `Resource` API would lead to an increased learning curve for users.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
