### PR TITLE
Include puppeteer tests in compat tests

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -34,7 +34,7 @@ jobs:
 
   - job: compatibility
     dependsOn: compatibility_ts_libs
-    timeoutInMinutes: 240
+    timeoutInMinutes: 360
     strategy:
       matrix:
         linux:
@@ -65,7 +65,7 @@ jobs:
 
   - job: compatibility_windows
     dependsOn: compatibility_ts_libs
-    timeoutInMinutes: 240
+    timeoutInMinutes: 360
     pool:
       name: windows-pool
       demands: assignment -equals default

--- a/compatibility/bazel-haskell-deps.bzl
+++ b/compatibility/bazel-haskell-deps.bzl
@@ -40,6 +40,7 @@ def daml_haskell_deps():
         local_snapshot = "//:stack-snapshot.yaml",
         packages = [
             "aeson",
+            "aeson-extra",
             "async",
             "base",
             "bytestring",

--- a/compatibility/bazel_tools/BUILD
+++ b/compatibility/bazel_tools/BUILD
@@ -2,4 +2,5 @@ exports_files([
     "daml_ledger_test.sh",
     "create_daml_app_test.sh",
     "sandbox-with-postgres.sh",
+    "daml.cc",
 ])

--- a/compatibility/bazel_tools/create-daml-app/BUILD.bazel
+++ b/compatibility/bazel_tools/create-daml-app/BUILD.bazel
@@ -12,6 +12,7 @@ da_haskell_binary(
     srcs = ["Main.hs"],
     hackage_deps = [
         "aeson",
+        "aeson-extra",
         "base",
         "bytestring",
         "conduit",
@@ -34,4 +35,12 @@ da_haskell_binary(
         "//bazel_tools/test_utils",
         "@rules_haskell//tools/runfiles",
     ],
+)
+
+exports_files(
+    [
+        "testDeps.json",
+        "index.test.ts",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/compatibility/bazel_tools/create-daml-app/index.test.ts
+++ b/compatibility/bazel_tools/create-daml-app/index.test.ts
@@ -1,0 +1,410 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// The tests here are identical to the ones in
+// templates/create-daml-app-test-resources/index.test.ts.
+// The main difference is in the test setup. Since we want to be able to run
+// this against a different platform version than SDK version we use `daml sandbox`
+// and `daml json-api` directly instead of going via `daml start`.
+// In addition to that, these tests here work on Windows.
+// We could in principle just drop the other tests. However, they are
+// used in documentation which we probably don’t want to make
+// even more complex and you can argue that there is value in testing
+// `daml start` which is what users use.
+
+import child_process from "child_process";
+import { ChildProcess, spawn, SpawnOptions } from "child_process";
+import { promises as fs } from "fs";
+import puppeteer, { Browser, Page } from "puppeteer";
+import waitOn from "wait-on";
+
+import Ledger from "@daml/ledger";
+import { User } from "@daml.js/create-daml-app";
+import { computeCredentials } from "./Credentials";
+
+const DAR_PATH = ".daml/dist/create-daml-app-0.1.0.dar";
+const SANDBOX_LEDGER_ID = "create-daml-app-sandbox";
+const SANDBOX_PORT_FILE_NAME = "sandbox.port";
+const JSON_API_PORT_FILE_NAME = "json-api.port";
+const SANDBOX_PORT_FILE_PATH = `../${SANDBOX_PORT_FILE_NAME}`;
+const JSON_API_PORT_FILE_PATH = `../${JSON_API_PORT_FILE_NAME}`;
+
+const JSON_API_PORT = 7575;
+const UI_PORT = 3000;
+
+let sandbox: ChildProcess | undefined = undefined;
+let jsonApi: ChildProcess | undefined = undefined;
+
+// `yarn start` process
+let uiProc: ChildProcess | undefined = undefined;
+
+// Chrome browser that we run in headless mode
+let browser: Browser | undefined = undefined;
+
+// Function to generate unique party names for us.
+// This should be replaced by the party management service once that is exposed
+// in the HTTP JSON API.
+let nextPartyId = 1;
+function getParty(): string {
+  const party = `P${nextPartyId}`;
+  nextPartyId++;
+  return party;
+}
+
+test("Party names are unique", async () => {
+  const parties = new Set(
+    Array(10)
+      .fill({})
+      .map(() => getParty())
+  );
+  expect(parties.size).toEqual(10);
+});
+
+const removeFile = async (path: string) => {
+  try {
+    await fs.stat(path);
+    await fs.unlink(path);
+  } catch (_e) {
+    // Do nothing if the file does not exist.
+  }
+};
+
+// promisified-version of exec.
+const exec = (command) => {
+  return new Promise((done, failed) => {
+    child_process.exec(command, {}, (err, stdout, stderr) => {
+      if (err) {
+        err.stdout = stdout;
+        err.stderr = stderr;
+        failed(err);
+        return;
+      }
+
+      done({ stdout, stderr });
+    });
+  });
+};
+
+// The node.js process API doesn’t seem to even attempt
+// to provide sensible semantics across platforms:
+// On Unix you can set detached: true which will create a new
+// process group and then kill the whole group by passing a negative pid.
+// On Windows, detached does not create a new group. Instead it runs
+// the process in a new (graphical by default) terminal.
+// There is no way to use `process.kill` to kill a process including
+// its children. You have to shell out to taskkill instead.
+const killTree = async (p: ChildProcess) => {
+  if (process.platform == "win32") {
+    await exec(`taskkill /pid ${p.pid} /t /f`);
+  } else {
+    process.kill(-p.pid);
+  }
+};
+
+const detached = process.platform != "win32";
+
+// Start the DAML and UI processes before the tests begin.
+// To reduce test times, we reuse the same processes between all the tests.
+// This means we need to use a different set of parties and a new browser page for each test.
+beforeAll(async () => {
+  await removeFile(`../${SANDBOX_PORT_FILE_NAME}`);
+  await removeFile(`../${JSON_API_PORT_FILE_NAME}`);
+  const sandboxOptions = [
+    "sandbox",
+    `--ledgerid=${SANDBOX_LEDGER_ID}`,
+    `--port=0`,
+    `--port-file=${SANDBOX_PORT_FILE_NAME}`,
+    DAR_PATH,
+  ];
+
+  sandbox = spawn(process.env.DAML_SANDBOX, sandboxOptions, {
+    cwd: "..",
+    stdio: "inherit",
+    detached: detached,
+    env: { ...process.env, DAML_SDK_VERSION: process.env.SANDBOX_VERSION },
+  });
+
+  await waitOn({ resources: [`file:../${SANDBOX_PORT_FILE_NAME}`] });
+  const sandboxPort = parseInt(
+    await fs.readFile(SANDBOX_PORT_FILE_PATH, "utf8")
+  );
+
+  const jsonApiOptions = [
+    "json-api",
+    "--allow-insecure-tokens",
+    "--ledger-host=localhost",
+    `--ledger-port=${sandboxPort}`,
+    `--http-port=${JSON_API_PORT}`,
+    `--port-file=${JSON_API_PORT_FILE_NAME}`,
+  ];
+  jsonApi = spawn(process.env.DAML_JSON_API, jsonApiOptions, {
+    cwd: "..",
+    stdio: "inherit",
+    detached: detached,
+    env: { ...process.env, DAML_SDK_VERSION: process.env.JSON_API_VERSION },
+  });
+  await waitOn({ resources: [`file:../${JSON_API_PORT_FILE_NAME}`] });
+
+  uiProc = spawn("yarn", ["start"], {
+    env: { ...process.env, BROWSER: "none" },
+    stdio: "inherit",
+    shell: true,
+    detached: detached,
+  });
+  await waitOn({ resources: [`tcp:localhost:${UI_PORT}`] });
+
+  // Launch a single browser for all tests.
+  browser = await puppeteer.launch();
+}, 40_000);
+
+afterAll(async () => {
+  if (browser) {
+    await browser.close();
+  }
+  if (uiProc) {
+    await killTree(uiProc);
+  }
+  if (jsonApi) {
+    await killTree(jsonApi);
+  }
+  if (sandbox) {
+    await killTree(sandbox);
+  }
+}, 40_000);
+
+test("create and look up user using ledger library", async () => {
+  const partyName = getParty();
+  const { party, token } = computeCredentials(partyName);
+  const ledger = new Ledger({ token });
+  const users0 = await ledger.query(User.User);
+  expect(users0).toEqual([]);
+  const user = { username: party, following: [] };
+  const userContract1 = await ledger.create(User.User, user);
+  const userContract2 = await ledger.fetchByKey(User.User, party);
+  expect(userContract1).toEqual(userContract2);
+  const users = await ledger.query(User.User);
+  expect(users[0]).toEqual(userContract1);
+}, 40_000);
+
+// The tests following use the headless browser to interact with the app.
+// We select the relevant DOM elements using CSS class names that we embedded
+// specifically for testing.
+// See https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors.
+
+const newUiPage = async (): Promise<Page> => {
+  if (!browser) {
+    throw Error("Puppeteer browser has not been launched");
+  }
+  const page = await browser.newPage();
+  await page.setDefaultNavigationTimeout(60 * 1000);
+  await page.goto(`http://localhost:${UI_PORT}`); // ignore the Response
+  return page;
+};
+
+// LOGIN_FUNCTION_BEGIN
+// Log in using a party name and wait for the main screen to load.
+const login = async (page: Page, partyName: string) => {
+  const usernameInput = await page.waitForSelector(
+    ".test-select-username-field"
+  );
+  await usernameInput.click();
+  await usernameInput.type(partyName);
+  await page.click(".test-select-login-button");
+  await page.waitForSelector(".test-select-main-menu");
+};
+// LOGIN_FUNCTION_END
+
+// Log out and wait to get back to the login screen.
+const logout = async (page: Page) => {
+  await page.click(".test-select-log-out");
+  await page.waitForSelector(".test-select-login-screen");
+};
+
+// Follow a user using the text input in the follow panel.
+const follow = async (page: Page, userToFollow: string) => {
+  await page.click(".test-select-follow-input");
+  await page.type(".test-select-follow-input", userToFollow);
+  await page.click(".test-select-follow-button");
+
+  // Wait for the request to complete, either successfully or after the error
+  // dialog has been handled.
+  // We check this by the absence of the `loading` class.
+  // (Both the `test-...` and `loading` classes appear in `div`s surrounding
+  // the `input`, due to the translation of Semantic UI's `Input` element.)
+  await page.waitForSelector(".test-select-follow-input > :not(.loading)", {
+    timeout: 40_000,
+  });
+};
+
+// LOGIN_TEST_BEGIN
+test("log in as a new user, log out and log back in", async () => {
+  const partyName = getParty();
+
+  // Log in as a new user.
+  const page = await newUiPage();
+  await login(page, partyName);
+
+  // Check that the ledger contains the new User contract.
+  const { token } = computeCredentials(partyName);
+  const ledger = new Ledger({ token });
+  const users = await ledger.query(User.User);
+  expect(users).toHaveLength(1);
+  expect(users[0].payload.username).toEqual(partyName);
+
+  // Log out and in again as the same user.
+  await logout(page);
+  await login(page, partyName);
+
+  // Check we have the same one user.
+  const usersFinal = await ledger.query(User.User);
+  expect(usersFinal).toHaveLength(1);
+  expect(usersFinal[0].payload.username).toEqual(partyName);
+
+  await page.close();
+}, 40_000);
+// LOGIN_TEST_END
+
+// This tests following users in a few different ways:
+// - using the text box in the Follow panel
+// - using the icon in the Network panel
+// - while the user that is followed is logged in
+// - while the user that is followed is logged out
+// These are all successful cases.
+
+test("log in as three different users and start following each other", async () => {
+  const party1 = getParty();
+  const party2 = getParty();
+  const party3 = getParty();
+
+  // Log in as Party 1.
+  const page1 = await newUiPage();
+  await login(page1, party1);
+
+  // Party 1 should initially follow no one.
+  const noFollowing1 = await page1.$$(".test-select-following");
+  expect(noFollowing1).toEqual([]);
+
+  // Follow Party 2 using the text input.
+  // This should work even though Party 2 has not logged in yet.
+  // Check Party 1 follows exactly Party 2.
+  await follow(page1, party2);
+  await page1.waitForSelector(".test-select-following");
+  const followingList1 = await page1.$$eval(
+    ".test-select-following",
+    (following) => following.map((e) => e.innerHTML)
+  );
+  expect(followingList1).toEqual([party2]);
+
+  // Add Party 3 as well and check both are in the list.
+  await follow(page1, party3);
+  await page1.waitForSelector(".test-select-following");
+  const followingList11 = await page1.$$eval(
+    ".test-select-following",
+    (following) => following.map((e) => e.innerHTML)
+  );
+  expect(followingList11).toHaveLength(2);
+  expect(followingList11).toContain(party2);
+  expect(followingList11).toContain(party3);
+
+  // Log in as Party 2.
+  const page2 = await newUiPage();
+  await login(page2, party2);
+
+  // Party 2 should initially follow no one.
+  const noFollowing2 = await page2.$$(".test-select-following");
+  expect(noFollowing2).toEqual([]);
+
+  // However, Party 2 should see Party 1 in the network.
+  await page2.waitForSelector(".test-select-user-in-network");
+  const network2 = await page2.$$eval(".test-select-user-in-network", (users) =>
+    users.map((e) => e.innerHTML)
+  );
+  expect(network2).toEqual([party1]);
+
+  // Follow Party 1 using the 'add user' icon on the right.
+  await page2.waitForSelector(".test-select-add-user-icon");
+  const userIcons = await page2.$$(".test-select-add-user-icon");
+  expect(userIcons).toHaveLength(1);
+  await userIcons[0].click();
+
+  // Also follow Party 3 using the text input.
+  // Note that we can also use the icon to follow Party 3 as they appear in the
+  // Party 1's Network panel, but that's harder to test at the
+  // moment because there is no loading indicator to tell when it's done.
+  await follow(page2, party3);
+
+  // Check the following list is updated correctly.
+  await page2.waitForSelector(".test-select-following");
+  const followingList2 = await page2.$$eval(
+    ".test-select-following",
+    (following) => following.map((e) => e.innerHTML)
+  );
+  expect(followingList2).toHaveLength(2);
+  expect(followingList2).toContain(party1);
+  expect(followingList2).toContain(party3);
+
+  // Party 1 should now also see Party 2 in the network (but not Party 3 as they
+  // didn't yet started following Party 1).
+  await page1.waitForSelector(".test-select-user-in-network");
+  const network1 = await page1.$$eval(
+    ".test-select-user-in-network",
+    (following) => following.map((e) => e.innerHTML)
+  );
+  expect(network1).toEqual([party2]);
+
+  // Log in as Party 3.
+  const page3 = await newUiPage();
+  await login(page3, party3);
+
+  // Party 3 should follow no one.
+  const noFollowing3 = await page3.$$(".test-select-following");
+  expect(noFollowing3).toEqual([]);
+
+  // However, Party 3 should see both Party 1 and Party 2 in the network.
+  await page3.waitForSelector(".test-select-user-in-network");
+  const network3 = await page3.$$eval(
+    ".test-select-user-in-network",
+    (following) => following.map((e) => e.innerHTML)
+  );
+  expect(network3).toHaveLength(2);
+  expect(network3).toContain(party1);
+  expect(network3).toContain(party2);
+
+  await page1.close();
+  await page2.close();
+  await page3.close();
+}, 60_000);
+
+test("error when following self", async () => {
+  const party = getParty();
+  const page = await newUiPage();
+
+  const dismissError = jest.fn((dialog) => dialog.dismiss());
+  page.on("dialog", dismissError);
+
+  await login(page, party);
+  await follow(page, party);
+
+  expect(dismissError).toHaveBeenCalled();
+
+  await page.close();
+}, 40_000);
+
+test("error when adding a user that you are already following", async () => {
+  const party1 = getParty();
+  const party2 = getParty();
+  const page = await newUiPage();
+
+  const dismissError = jest.fn((dialog) => dialog.dismiss());
+  page.on("dialog", dismissError);
+
+  await login(page, party1);
+  // First attempt should succeed
+  await follow(page, party2);
+  // Second attempt should result in an error
+  await follow(page, party2);
+
+  expect(dismissError).toHaveBeenCalled();
+
+  await page.close();
+}, 40_000);

--- a/compatibility/bazel_tools/create-daml-app/testDeps.json
+++ b/compatibility/bazel_tools/create-daml-app/testDeps.json
@@ -1,0 +1,10 @@
+{
+  "devDependencies": {
+    "@types/jest": "^25.2.1",
+    "@types/node": "^13.11.1",
+    "@types/puppeteer": "^2.0.1",
+    "@types/wait-on": "^4.0.0",
+    "puppeteer": "^2.1.1",
+    "wait-on": "^4.0.2"
+  }
+}

--- a/compatibility/bazel_tools/create_daml_app_test.sh
+++ b/compatibility/bazel_tools/create_daml_app_test.sh
@@ -11,27 +11,35 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
-set -euox pipefail
+set -euo pipefail
 
 RUNNER="$(rlocation "$TEST_WORKSPACE/$1")"
 DAML="$(rlocation "$TEST_WORKSPACE/$2")"
-SANDBOX="$(rlocation "$TEST_WORKSPACE/$3")"
-JSON_API="$(rlocation "$TEST_WORKSPACE/$4")"
-DAML_TYPES="$(rlocation "$TEST_WORKSPACE/$5")"
-DAML_LEDGER="$(rlocation "$TEST_WORKSPACE/$6")"
-DAML_REACT="$(rlocation "$TEST_WORKSPACE/$7")"
-MESSAGING_PATCH="$(rlocation "$TEST_WORKSPACE/$8")"
-YARN="$(rlocation "$TEST_WORKSPACE/$9")"
-PATCH="$(rlocation "$TEST_WORKSPACE/${10}")"
+# These things are only used in the jest tests so rather
+# than adding a lot of boilerplate to the Haskell code
+# to parse them only to pass them on, we simply set them here.
+export DAML_SANDBOX="$(rlocation "$TEST_WORKSPACE/$3")"
+export SANDBOX_VERSION="${4}"
+export DAML_JSON_API="$(rlocation "$TEST_WORKSPACE/$5")"
+export JSON_API_VERSION="${6}"
+DAML_TYPES="$(rlocation "$TEST_WORKSPACE/$7")"
+DAML_LEDGER="$(rlocation "$TEST_WORKSPACE/$8")"
+DAML_REACT="$(rlocation "$TEST_WORKSPACE/$9")"
+MESSAGING_PATCH="$(rlocation "$TEST_WORKSPACE/${10}")"
+# Adding yarn to path here seems tempting but ends up in a mess
+# due to unix/windows paths so we only do that in the Haskell code.
+YARN="$(rlocation "$TEST_WORKSPACE/${11}")"
+PATCH="$(rlocation "$TEST_WORKSPACE/${12}")"
+TEST_DEPS="$(rlocation "$TEST_WORKSPACE/${13}")"
+TEST_TS="$(rlocation "$TEST_WORKSPACE/${14}")"
 
 "$RUNNER" \
   --daml "$DAML" \
-  --sandbox "$SANDBOX" \
-  --json-api "$JSON_API" \
   --daml-types "$DAML_TYPES" \
   --daml-ledger "$DAML_LEDGER" \
   --daml-react "$DAML_REACT" \
   --messaging-patch "$MESSAGING_PATCH" \
   --yarn "$YARN" \
   --patch "$PATCH" \
-  "${@:11}"
+  --test-deps "$TEST_DEPS" \
+  --test-ts "$TEST_TS" \

--- a/compatibility/bazel_tools/daml.cc.tpl
+++ b/compatibility/bazel_tools/daml.cc.tpl
@@ -1,0 +1,87 @@
+#include "tools/cpp/runfiles/runfiles.h"
+#include <codecvt>
+#include <iostream>
+#include <locale>
+#include <memory>
+#include <unistd.h>
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+using bazel::tools::cpp::runfiles::Runfiles;
+
+/*
+NOTE (MK): Why is this not just an sh_binary?
+Good question! It turns out that on Windows, an
+sh_binary creates a custom executable that then launches
+bash. Somehow this seems to result in a double fork
+(or the Windows-equivalent) thereof which results in
+child processes not being childs of the original process.
+This makes it really hard to kill a process including
+all child processes which is really important since
+otherwise you are left with a running JVM process
+if you kill `daml sandbox`.
+*/
+
+int main(int argc, char **argv) {
+    std::string error;
+    std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], &error));
+    if (runfiles == nullptr) {
+        std::cerr << "Failed to initialize runfiles: " << error << "\n";
+        exit(1);
+    }
+    const char *java_home = getenv("JAVA_HOME");
+    std::string path_prefix = "";
+    // NOTE (MK) I don’t entirely understand when Bazel defines
+    // JAVA_HOME and when it doesn’t but it looks like it defines
+    // it in tests but not in genrules which is good enough for us.
+    if (java_home) {
+#if defined(_WIN32)
+        path_prefix = std::string(java_home) + "/bin;";
+#else
+        path_prefix = std::string(java_home) + "/bin:";
+#endif
+    }
+    std::string new_path = path_prefix + getenv("PATH");
+#if defined(_WIN32)
+    _putenv_s("PATH", new_path.c_str());
+#else
+    setenv("PATH", new_path.c_str(), 1);
+#endif
+    std::string path =
+        runfiles->Rlocation("daml-sdk-{SDK_VERSION}/sdk/bin/daml");
+#if defined(_WIN32)
+    // To keep things as simple as possible, we simply take
+    // the existing command line, strip everything up to the first space
+    // and replace it. This is obviously not correct if there are spaces
+    // in the path name but Bazel doesn’t like that either so
+    // it should be good enough™.
+    LPWSTR oldCmdLine = GetCommandLineW();
+    wchar_t *index = wcschr(oldCmdLine, ' ');
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    std::wstring cmdLine = converter.from_bytes(path.c_str());
+    cmdLine += std::wstring(index);
+    const int MAX_CMDLINE_LENGTH = 32768;
+    wchar_t result[MAX_CMDLINE_LENGTH];
+    wcsncpy(result, cmdLine.c_str(), MAX_CMDLINE_LENGTH - 1);
+    result[MAX_CMDLINE_LENGTH - 1] = 0;
+    PROCESS_INFORMATION processInfo = {0};
+    STARTUPINFOW startupInfo = {0};
+    startupInfo.cb = sizeof(startupInfo);
+    BOOL ok = CreateProcessW(NULL, result, NULL, NULL, TRUE, 0, NULL, NULL,
+                             &startupInfo, &processInfo);
+    if (!ok) {
+        std::wcerr << "Cannot launch process: " << cmdLine << "\n";
+        return GetLastError();
+    }
+    WaitForSingleObject(processInfo.hProcess, INFINITE);
+    DWORD exit_code;
+    GetExitCodeProcess(processInfo.hProcess, &exit_code);
+    CloseHandle(processInfo.hProcess);
+    CloseHandle(processInfo.hThread);
+    return exit_code;
+
+#else
+    execvp(path.c_str(), argv);
+#endif
+}

--- a/compatibility/bazel_tools/daml_sdk.bzl
+++ b/compatibility/bazel_tools/daml_sdk.bzl
@@ -109,6 +109,11 @@ export PATH=$JAVA_HOME/bin:$PATH
 $(rlocation daml-sdk-{version}/sdk/bin/daml) $@
 """.format(version = ctx.attr.version, runfiles_library = runfiles_library),
     )
+    ctx.template(
+        "daml.cc",
+        Label("@compatibility//bazel_tools:daml.cc.tpl"),
+        substitutions = {"{SDK_VERSION}": ctx.attr.version},
+    )
     ctx.file(
         "BUILD",
         content =
@@ -120,11 +125,11 @@ sh_binary(
   data = [":ledger-api-test-tool.jar"],
   deps = ["@bazel_tools//tools/bash/runfiles"],
 )
-sh_binary(
+cc_binary(
   name = "daml",
-  srcs = [":daml.sh"],
+  srcs = ["daml.cc"],
   data = [":sdk/bin/daml"],
-  deps = ["@bazel_tools//tools/bash/runfiles"],
+  deps = ["@bazel_tools//tools/cpp/runfiles:runfiles"],
 )
 # Needed to provide the same set of DARs to the ledger that
 # are used by the ledger API test tool.

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -319,6 +319,7 @@ def daml_ledger_test(
             #"--sandbox",
             "$(rootpath %s)" % sandbox,
         ] + _concat([["--sandbox-arg", arg] for arg in sandbox_args]),
+        deps = ["@bazel_tools//tools/bash/runfiles"],
         data = data + depset(direct = [
             "//bazel_tools/daml_ledger:runner",
             "//bazel_tools/daml_ledger:test-certificates",
@@ -333,7 +334,9 @@ def create_daml_app_test(
         name,
         daml,
         sandbox,
+        sandbox_version,
         json_api,
+        json_api_version,
         daml_types,
         daml_react,
         daml_ledger,
@@ -353,20 +356,26 @@ def create_daml_app_test(
                    "$(rootpath %s)" % daml,
                    #"--sandbox",
                    "$(rootpath %s)" % sandbox,
+                   sandbox_version,
                    #"--json-api",
                    "$(rootpath %s)" % json_api,
+                   json_api_version,
                    "$(rootpath %s)" % daml_types,
                    "$(rootpath %s)" % daml_ledger,
                    "$(rootpath %s)" % daml_react,
                    "$(rootpath %s)" % messaging_patch,
                    "$(rootpath @nodejs//:yarn)",
                    "$(rootpath @patch_dev_env//:patch)",
+                   "$(rootpath //bazel_tools/create-daml-app:testDeps.json)",
+                   "$(rootpath //bazel_tools/create-daml-app:index.test.ts)",
                ] + _concat([["--sandbox-arg", arg] for arg in sandbox_args]) +
                _concat([["--json-api-arg", arg] for arg in json_api_args]),
         data = data + depset(direct = [
             "//bazel_tools/create-daml-app:runner",
             "@nodejs//:yarn",
             "@patch_dev_env//:patch",
+            "//bazel_tools/create-daml-app:testDeps.json",
+            "//bazel_tools/create-daml-app:index.test.ts",
             # Deduplicate if daml and sandbox come from the same release.
             daml,
             sandbox,
@@ -376,6 +385,9 @@ def create_daml_app_test(
             daml_ledger,
             messaging_patch,
         ]).to_list(),
+        deps = [
+            "@bazel_tools//tools/bash/runfiles",
+        ],
         **kwargs
     )
 
@@ -466,11 +478,18 @@ def sdk_platform_test(sdk_version, platform_version):
         size = "large",
         tags = extra_tags(sdk_version, platform_version),
     )
+
+    # For now, we only cover the DABL usecase where
+    # sandbox and the JSON API come from the same SDK.
+    # However, the test setup is flexible enough, that we
+    # can control them individually.
     create_daml_app_test(
         name = "create-daml-app-{sdk_version}-platform-{platform_version}".format(sdk_version = version_to_name(sdk_version), platform_version = version_to_name(platform_version)),
         daml = daml_assistant,
         sandbox = sandbox,
+        sandbox_version = platform_version,
         json_api = json_api,
+        json_api_version = platform_version,
         daml_types = "@daml-sdk-{}//:daml-types.tgz".format(sdk_version),
         daml_react = "@daml-sdk-{}//:daml-react.tgz".format(sdk_version),
         daml_ledger = "@daml-sdk-{}//:daml-ledger.tgz".format(sdk_version),

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Keep in sync with compatibility/bazel_tools/create-daml-app/index.test.ts
+
 import { ChildProcess, spawn, SpawnOptions } from 'child_process';
 import { promises as fs } from 'fs';
 import puppeteer, { Browser, Page } from 'puppeteer';


### PR DESCRIPTION
This PR adds the puppeteer based tests to the compatibility
tests. This also means that they are now actually compatibility
tests. Before, we only tested the SDK side.

Apart from process management being a nightmare on Windows as usually,
there are two things that might stick out here:

1. I’ve replaced the `sh_binary` wrapper by a `cc_binary`. There is a
   lengthy comment explaining why. I think at the moment, we could
   actually get rid of the wraper completely and add JAVA to path in
   the tests that need it but at least for now, I’d like to keep it
   until we are sure that we don’t need to add more to it (and then
   it’s also in the git history if we do need to resurrect it).
2. These tests are duplicated now similar to the `daml ledger *`
   tests. The reasoning here is different. They depend on the SDK
   tarball either way so performance wise there is no reason to keep
   them. However, we reference the other file in the docs which means
   we cannot change it freely. What we could do is to make this
   sufficiently flexible to handle both the `daml start` case and
   separate `daml sandbox`/`daml json-api` processes and then we can
   reference it in the docs. There is still added complexity for
   Windows but that’s necessary for users as well that want to run
   this on Windows so that seems unavoidable. (I should probably also
   remove my snarky comments :innocent:) I’d like to kee it duplicated
   for this PR and then we can clean it up afterwards.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
