### PR TITLE
Handle record dot syntax in DAML REPL

### DIFF
--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -35,6 +35,7 @@ da_haskell_library(
         "text",
         "time",
         "transformers",
+        "uniplate",
         "unordered-containers",
         "utf8-string",
         "zip",

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -17,10 +17,12 @@ import DA.Daml.LF.Reader (readDalfs, Dalfs(..))
 import qualified DA.Daml.LF.ReplClient as ReplClient
 import DA.Daml.LFConversion.UtilGHC
 import DA.Daml.Options.Types
+import qualified DA.Daml.Preprocessor.Records as Preprocessor
 import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Functor.Alt
 import Data.Foldable
+import Data.Generics.Uniplate.Data (descendBi)
 import Data.Graph
 import Data.Maybe
 import qualified Data.NameMap as NM
@@ -172,8 +174,10 @@ parseReplInput input dflags =
     -- The most common input will be statements. So, we attempt parsing
     -- statements last to always emit statement parse errors on failure.
         (ReplImport . unLoc <$> tryParse (parseImport input dflags))
-    <!> (ReplStatement . unLoc <$> tryParse (parseStatement input dflags))
+    <!> (ReplStatement . preprocess . unLoc <$> tryParse (parseStatement input dflags))
   where
+    preprocess :: Stmt GhcPs (LHsExpr GhcPs) -> Stmt GhcPs (LHsExpr GhcPs)
+    preprocess = descendBi Preprocessor.onExp
     tryParse :: ParseResult a -> Either Error a
     tryParse (POk _ result) = Right result
     tryParse (PFailed _ _ errMsg) = Left (ParseError errMsg)

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/Records.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/Records.hs
@@ -6,6 +6,7 @@ module DA.Daml.Preprocessor.Records
     ( importGenerated
     , mkImport
     , recordDotPreprocessor
+    , onExp
     ) where
 
 

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -223,6 +223,15 @@ functionalTests replClient serviceOut testDar options ideState = describe "repl 
           [ input "abort \"foobar\""
           , matchServiceOutput "^Error: User abort: foobar$"
           ]
+    , testInteraction' "record dot syntax"
+          [ input "alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"alice\")"
+          , input "bob <- allocatePartyWithHint \"Bob\" (PartyIdHint \"bob\")"
+          , input "proposal <- pure (T alice bob)"
+          , input "debug proposal.proposer"
+          , matchServiceOutput "'alice'"
+          , input "debug proposal.accepter"
+          , matchServiceOutput "'bob'"
+          ]
     ]
   where
     testInteraction' testName steps =


### PR DESCRIPTION
Closes #6015 

* Adds an export to the record dot preprocessor module for the expression preprocessor and uses it in the DAML REPL parser. We're parsing individual statements in the DAML REPL so we cannot apply the full module preprocessor.
* Adds a regression test for record dot syntax entered into the DAML REPL.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
