### PR TITLE
Enforce a dependency on node_nix

### DIFF
--- a/bazel_tools/rules_nodejs_node_dependency.patch
+++ b/bazel_tools/rules_nodejs_node_dependency.patch
@@ -1,0 +1,16 @@
+diff --git a/internal/node/node_repositories.bzl b/internal/node/node_repositories.bzl
+index 038a7458..fedc43f2 100644
+--- a/internal/node/node_repositories.bzl
++++ b/internal/node/node_repositories.bzl
+@@ -347,6 +347,11 @@ def _prepare_node(repository_ctx):
+     is_windows = "_windows_" in repository_ctx.attr.name
+ 
+     if repository_ctx.attr.vendored_node:
++        if not is_windows:
++            # Introduce a dependency on the vendored node file or workspace.
++            node_attr = repository_ctx.attr.vendored_node
++            node_bin = node_attr.relative(":{}/bin/node".format(node_attr.name))
++            repository_ctx.read(node_bin)
+         node_path = "/".join([f for f in [
+             "../../..",
+             repository_ctx.attr.vendored_node.workspace_root,

--- a/compatibility/deps.bzl
+++ b/compatibility/deps.bzl
@@ -97,6 +97,9 @@ def daml_deps():
             patches = [
                 # Work around for https://github.com/bazelbuild/rules_nodejs/issues/1565
                 "@daml//bazel_tools:rules_nodejs_npm_cli_path.patch",
+                # Enforces a dependency of the rules_nodejs workspace on the
+                # workspace providing node.
+                "@daml//bazel_tools:rules_nodejs_node_dependency.patch",
             ],
             patch_args = ["-p1"],
         )

--- a/deps.bzl
+++ b/deps.bzl
@@ -194,6 +194,7 @@ def daml_deps():
             patches = [
                 # Work around for https://github.com/bazelbuild/rules_nodejs/issues/1565
                 "@com_github_digital_asset_daml//bazel_tools:rules_nodejs_npm_cli_path.patch",
+                "@com_github_digital_asset_daml//bazel_tools:rules_nodejs_node_dependency.patch",
             ],
             patch_args = ["-p1"],
         )


### PR DESCRIPTION
This tries to fix the errors of the following form that we've been seeing:
```
STDERR:
/private/var/tmp/_bazel_user/191c77e1bcea6e1b949558cf8ebb3be9/external/nodejs_darwin_amd64/bin/node: line 19: /private/var/tmp/_bazel_brianhealey/191c77e1bcea6e1b949558cf8ebb3be9/external/nodejs_darwin_amd64/bin/../../../external/node_nix/node_nix/bin/node: No such file or directory
```

The workspace for the vendored node wrapper script `@nodejs_linux_amd64` did previously not record a dependency on the nixpkgs provided node workspace. This patch enforces that dependency by introducing a dummy read of the vendored node binary.

With this change I've seen Linux and MacOS succeed four times in a row and no single failure. 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
