### PR TITLE
Pass on command ID as correlation ID for transaction submissions

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -17,7 +17,6 @@ import com.daml.metrics.Metrics
 import scala.compat.java8.FutureConverters
 
 class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) extends WriteService {
-
   private val keyValueSubmission = new KeyValueSubmission(metrics)
 
   override def submitTransaction(
@@ -31,7 +30,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
         transactionMeta,
         transaction.assertNoRelCid(cid => s"Unexpected relative contract id: $cid"),
       )
-    val correlationId = nextSubmissionId()
+    val correlationId = submitterInfo.commandId
     commit(correlationId, submission)
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -17,6 +17,7 @@ import com.daml.metrics.Metrics
 import scala.compat.java8.FutureConverters
 
 class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) extends WriteService {
+
   private val keyValueSubmission = new KeyValueSubmission(metrics)
 
   override def submitTransaction(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -31,8 +31,7 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
         transactionMeta,
         transaction.assertNoRelCid(cid => s"Unexpected relative contract id: $cid"),
       )
-    val correlationId = submitterInfo.commandId
-    commit(correlationId, submission)
+    commit(correlationId = submitterInfo.commandId, submission = submission)
   }
 
   override def uploadPackages(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriter.scala
@@ -77,8 +77,6 @@ class KeyValueParticipantStateWriter(writer: LedgerWriter, metrics: Metrics) ext
   private def generateRandomParty(): Ref.Party =
     Ref.Party.assertFromString(s"party-${UUID.randomUUID().toString.take(8)}")
 
-  private def nextSubmissionId(): String = UUID.randomUUID().toString
-
   private def commit(
       correlationId: String,
       submission: DamlSubmission): CompletionStage[SubmissionResult] =

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -56,6 +56,7 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with Matchers {
       val instance = new KeyValueParticipantStateWriter(writer, newMetrics)
 
       instance.uploadPackages(aSubmissionId, List.empty, sourceDescription = None)
+
       verify(writer, times(1)).commit(anyString(), any[Bytes]())
       verifyEnvelope(packageUploadCaptor.getValue)(_.hasPackageUploadEntry)
     }
@@ -66,6 +67,7 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with Matchers {
       val instance = new KeyValueParticipantStateWriter(writer, newMetrics)
 
       instance.submitConfiguration(newRecordTime().addMicros(10000), aSubmissionId, aConfiguration)
+
       verify(writer, times(1)).commit(anyString(), any[Bytes]())
       verifyEnvelope(configurationCaptor.getValue)(_.hasConfigurationSubmission)
     }
@@ -76,6 +78,7 @@ class KeyValueParticipantStateWriterSpec extends WordSpec with Matchers {
       val instance = new KeyValueParticipantStateWriter(writer, newMetrics)
 
       instance.allocateParty(hint = None, displayName = None, aSubmissionId)
+
       verify(writer, times(1)).commit(anyString(), any[Bytes]())
       verifyEnvelope(partyAllocationCaptor.getValue)(_.hasPartyAllocationEntry)
     }
@@ -114,12 +117,12 @@ object KeyValueParticipantStateWriterSpec {
     writer
   }
 
-  private def submitterInfo(rt: Timestamp, party: Ref.Party, commandId: String = "X") =
+  private def submitterInfo(recordTime: Timestamp, party: Ref.Party, commandId: String = "X") =
     SubmitterInfo(
       submitter = party,
       applicationId = Ref.LedgerString.assertFromString("tests"),
       commandId = Ref.LedgerString.assertFromString(commandId),
-      deduplicateUntil = rt.addMicros(Duration.ofDays(1).toNanos / 1000).toInstant,
+      deduplicateUntil = recordTime.addMicros(Duration.ofDays(1).toNanos / 1000).toInstant,
     )
 
   private def transactionMeta(let: Timestamp) = TransactionMeta(


### PR DESCRIPTION
Summary of changes:
* Instead of generating a random correlation ID now we use the command ID specified by the submitter for transactions submitted through `KeyValueParticipantStateWriter`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
