### PR TITLE
fix trailing newline in docs cron

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -110,7 +110,7 @@ to_v s = case Split.splitOn "-" s of
 build_docs_folder :: String -> [GitHubVersion] -> String -> IO String
 build_docs_folder path versions current = do
     restore_sha $ do
-        latest_release_notes_sha <- shell "git log -n1 --format=%H HEAD -- LATEST"
+        latest_release_notes_sha <- init <$> shell "git log -n1 --format=%H HEAD -- LATEST"
         let old = path </> "old"
         let new = path </> "new"
         shell_ $ "mkdir -p " <> new


### PR DESCRIPTION
CI currently errors with:

```
Subprocess:
git checkout efe6545c2c5482ef559492b764ba93b798f09971
 -- docs/source/support/release-notes.rst
failed with exit code 127; output:
---

---
err:
---
Previous HEAD position was 2af134c... WIP: Draft version constraint
generation (#5472)
HEAD is now at efe6545... 1.2.0-snapshot.20200520.4224.0.2af134ca
(#6040)
/bin/sh: 2: --: not found

---

```

because the line

```
latest_release_notes_sha <- shell "git log -n1 --format=%H HEAD -- LATEST"
```

will assign a string that ends in a newline, and then when we try to
construct the shell command:

```
(shell_ $ "git checkout " <> latest_sha <> " -- docs/source/support/release-notes.rst")
```

we actually get two lines for Bash to execute.

CHANGELOG_BEGIN
CHANGELOG_END