### PR TITLE
Remove --pure-lockfile to yarn

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -588,7 +588,7 @@ buildPackages sdkVersion optScope optOutputDir dependencies = do
       pkgs = map (T.unpack . fst3 . nodeFromVertex) $ reverse (topSort g)
   withCurrentDirectory optOutputDir $ do
     BSL.writeFile "package.json" $ encodePretty packageJson
-    yarn ["install", "--pure-lockfile"]
+    yarn ["install"]
     createDirectoryIfMissing True $ "node_modules" </> scope
     mapM_ build pkgs
     removeFile "package.json" -- Any subsequent runs will regenerate it.


### PR DESCRIPTION
It seems yarn 2.0 series doesn't support this parameter causing daml2js to fail.