### PR TITLE
Trigger service: initialize database command

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -53,7 +53,6 @@ da_scala_library(
         "@maven//:org_slf4j_slf4j_api",
         "@maven//:org_tpolecat_doobie_core_2_12",
         "@maven//:org_tpolecat_doobie_free_2_12",
-#        "@maven//:org_tpolecat_doobie_postgres_2_12",
         "@maven//:org_typelevel_cats_core_2_12",
         "@maven//:org_typelevel_cats_effect_2_12",
         "@maven//:org_typelevel_cats_free_2_12",

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -19,6 +19,8 @@ da_scala_library(
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:ch_qos_logback_logback_core",
         "@maven//:com_typesafe_akka_akka_slf4j_2_12",
+        "@maven//:org_postgresql_postgresql",
+        "@maven//:org_tpolecat_doobie_postgres_2_12",
     ],
     deps = [
         "//daml-lf/archive:daml_lf_archive_reader",
@@ -35,7 +37,9 @@ da_scala_library(
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
         "//triggers/runner:trigger-runner-lib",
+        "@maven//:com_chuusai_shapeless_2_12",
         "@maven//:com_github_scopt_scopt_2_12",
+        "@maven//:com_lihaoyi_sourcecode_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_actor_typed_2_12",
         "@maven//:com_typesafe_akka_akka_http_2_12",
@@ -47,6 +51,13 @@ da_scala_library(
         "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_slf4j_slf4j_api",
+        "@maven//:org_tpolecat_doobie_core_2_12",
+        "@maven//:org_tpolecat_doobie_free_2_12",
+#        "@maven//:org_tpolecat_doobie_postgres_2_12",
+        "@maven//:org_typelevel_cats_core_2_12",
+        "@maven//:org_typelevel_cats_effect_2_12",
+        "@maven//:org_typelevel_cats_free_2_12",
+        "@maven//:org_typelevel_cats_kernel_2_12",
     ],
 )
 

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -89,6 +89,7 @@ da_scala_test(
         "//ledger/participant-state",
         "//ledger/sandbox",
         "//libs-scala/ports",
+        "//libs-scala/postgresql-testing",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:com_typesafe_akka_akka_actor_typed_2_12",
         "@maven//:com_typesafe_akka_akka_http_core_2_12",

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -24,7 +24,6 @@ case class ServiceConfig(
 )
 
 final case class JdbcConfig(
-    driver: String,
     url: String,
     user: String,
     password: String,
@@ -32,51 +31,47 @@ final case class JdbcConfig(
 
 object JdbcConfig {
   implicit val showInstance: Show[JdbcConfig] = Show.shows(a =>
-    s"JdbcConfig(driver=${a.driver}, url=${a.url}, user=${a.user})")
+    s"JdbcConfig(url=${a.url}, user=${a.user})")
 
-  lazy val help: String =
-    "Contains comma-separated key-value pairs. Where:\n" +
-      s"${indent}driver -- JDBC driver class name, only org.postgresql.Driver supported right now,\n" +
-      s"${indent}url -- JDBC connection URL, only jdbc:postgresql supported right now,\n" +
-      s"${indent}user -- user name for database user with permissions to create tables,\n" +
-      s"${indent}password -- password of database user,\n" +
-      s"${indent}Example: " + helpString(
-      "org.postgresql.Driver",
-      "jdbc:postgresql://localhost:5432/triggers",
-      "operator",
-      "password")
-
-  lazy val usage: String = helpString(
-    "<JDBC driver class name>",
-    "<JDBC connection url>",
-    "<user>",
-    "<password>")
-
-  private def requiredField(m: Map[String, String])(k: String): Either[String, String] =
-    m.get(k).filter(_.nonEmpty).toRight(s"Invalid JDBC config, must contain '$k' field")
+  val driver: String = "org.postgresql.Driver"
 
   def create(x: Map[String, String]): Either[String, JdbcConfig] =
     for {
-      driver <- requiredField(x)("driver")
       url <- requiredField(x)("url")
       user <- requiredField(x)("user")
       password <- requiredField(x)("password")
     } yield
       JdbcConfig(
-        driver = driver,
         url = url,
         user = user,
         password = password,
       )
 
-  private val indent: String = List.fill(8)(" ").mkString
+  private def requiredField(m: Map[String, String])(k: String): Either[String, String] =
+    m.get(k).filter(_.nonEmpty).toRight(s"Invalid JDBC config, must contain '$k' field")
+
+  lazy val usage: String = helpString(
+    "<JDBC connection url>",
+    "<user>",
+    "<password>")
+
+  lazy val help: String =
+    "Contains comma-separated key-value pairs. Where:\n" +
+      s"${indent}url -- JDBC connection URL, beginning with jdbc:postgresql,\n" +
+      s"${indent}user -- user name for database user with permissions to create tables,\n" +
+      s"${indent}password -- password of database user,\n" +
+      s"${indent}Example: " + helpString(
+      "jdbc:postgresql://localhost:5432/triggers",
+      "operator",
+      "password")
 
   private def helpString(
-                          driver: String,
                           url: String,
                           user: String,
                           password: String): String =
-    s"""\"driver=$driver,url=$url,user=$user,password=$password\""""
+    s"""\"url=$url,user=$user,password=$password\""""
+
+  private val indent: String = List.fill(8)(" ").mkString
 }
 
 object ServiceConfig {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -18,6 +18,7 @@ case class ServiceConfig(
     maxInboundMessageSize: Int,
     timeProviderType: TimeProviderType,
     commandTtl: Duration,
+    init: Boolean,
 )
 
 object ServiceConfig {
@@ -64,6 +65,10 @@ object ServiceConfig {
         c.copy(commandTtl = Duration.ofSeconds(t))
       }
       .text("TTL in seconds used for commands emitted by the trigger. Defaults to 30s.")
+
+    cmd("init")
+      .action((_, c) => c.copy(init = true))
+      .text("Initialize database and terminate.")
   }
   def parse(args: Array[String]): Option[ServiceConfig] =
     parser.parse(
@@ -76,6 +81,7 @@ object ServiceConfig {
         maxInboundMessageSize = DefaultMaxInboundMessageSize,
         timeProviderType = TimeProviderType.Static,
         commandTtl = Duration.ofSeconds(30L),
+        init = false,
       ),
     )
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -7,6 +7,7 @@ import java.nio.file.{Path, Paths}
 import java.time.Duration
 
 import com.daml.platform.services.time.TimeProviderType
+import scalaz.Show
 
 case class ServiceConfig(
     // For convenience, we allow passing in a DAR on startup
@@ -19,7 +20,64 @@ case class ServiceConfig(
     timeProviderType: TimeProviderType,
     commandTtl: Duration,
     init: Boolean,
+    jdbcConfig: Option[JdbcConfig],
 )
+
+final case class JdbcConfig(
+    driver: String,
+    url: String,
+    user: String,
+    password: String,
+)
+
+object JdbcConfig {
+  implicit val showInstance: Show[JdbcConfig] = Show.shows(a =>
+    s"JdbcConfig(driver=${a.driver}, url=${a.url}, user=${a.user})")
+
+  lazy val help: String =
+    "Contains comma-separated key-value pairs. Where:\n" +
+      s"${indent}driver -- JDBC driver class name, only org.postgresql.Driver supported right now,\n" +
+      s"${indent}url -- JDBC connection URL, only jdbc:postgresql supported right now,\n" +
+      s"${indent}user -- user name for database user with permissions to create tables,\n" +
+      s"${indent}password -- password of database user,\n" +
+      s"${indent}Example: " + helpString(
+      "org.postgresql.Driver",
+      "jdbc:postgresql://localhost:5432/triggers",
+      "operator",
+      "password")
+
+  lazy val usage: String = helpString(
+    "<JDBC driver class name>",
+    "<JDBC connection url>",
+    "<user>",
+    "<password>")
+
+  private def requiredField(m: Map[String, String])(k: String): Either[String, String] =
+    m.get(k).filter(_.nonEmpty).toRight(s"Invalid JDBC config, must contain '$k' field")
+
+  def create(x: Map[String, String]): Either[String, JdbcConfig] =
+    for {
+      driver <- requiredField(x)("driver")
+      url <- requiredField(x)("url")
+      user <- requiredField(x)("user")
+      password <- requiredField(x)("password")
+    } yield
+      JdbcConfig(
+        driver = driver,
+        url = url,
+        user = user,
+        password = password,
+      )
+
+  private val indent: String = List.fill(8)(" ").mkString
+
+  private def helpString(
+                          driver: String,
+                          url: String,
+                          user: String,
+                          password: String): String =
+    s"""\"driver=$driver,url=$url,user=$user,password=$password\""""
+}
 
 object ServiceConfig {
   val DefaultHttpPort: Int = 8088
@@ -66,10 +124,17 @@ object ServiceConfig {
       }
       .text("TTL in seconds used for commands emitted by the trigger. Defaults to 30s.")
 
-    cmd("init")
+    opt[Map[String, String]]("jdbc")
+      .action((x, c) => c.copy(jdbcConfig = Some(JdbcConfig.create(x).fold(e => sys.error(e), identity))))
+      .optional()
+      .valueName(JdbcConfig.usage)
+      .text("JDBC configuration parameters. If omitted the service runs without a database.")
+
+    cmd("init-db")
       .action((_, c) => c.copy(init = true))
       .text("Initialize database and terminate.")
   }
+
   def parse(args: Array[String]): Option[ServiceConfig] =
     parser.parse(
       args,
@@ -82,6 +147,7 @@ object ServiceConfig {
         timeProviderType = TimeProviderType.Static,
         commandTtl = Duration.ofSeconds(30L),
         init = false,
+        jdbcConfig = None,
       ),
     )
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -30,8 +30,8 @@ final case class JdbcConfig(
 )
 
 object JdbcConfig {
-  implicit val showInstance: Show[JdbcConfig] = Show.shows(a =>
-    s"JdbcConfig(url=${a.url}, user=${a.user})")
+  implicit val showInstance: Show[JdbcConfig] =
+    Show.shows(a => s"JdbcConfig(url=${a.url}, user=${a.user})")
 
   val driver: String = "org.postgresql.Driver"
 
@@ -50,10 +50,7 @@ object JdbcConfig {
   private def requiredField(m: Map[String, String])(k: String): Either[String, String] =
     m.get(k).filter(_.nonEmpty).toRight(s"Invalid JDBC config, must contain '$k' field")
 
-  lazy val usage: String = helpString(
-    "<JDBC connection url>",
-    "<user>",
-    "<password>")
+  lazy val usage: String = helpString("<JDBC connection url>", "<user>", "<password>")
 
   lazy val help: String =
     "Contains comma-separated key-value pairs. Where:\n" +
@@ -65,10 +62,7 @@ object JdbcConfig {
       "operator",
       "password")
 
-  private def helpString(
-                          url: String,
-                          user: String,
-                          password: String): String =
+  private def helpString(url: String, user: String, password: String): String =
     s"""\"url=$url,user=$user,password=$password\""""
 
   private val indent: String = List.fill(8)(" ").mkString
@@ -120,7 +114,8 @@ object ServiceConfig {
       .text("TTL in seconds used for commands emitted by the trigger. Defaults to 30s.")
 
     opt[Map[String, String]]("jdbc")
-      .action((x, c) => c.copy(jdbcConfig = Some(JdbcConfig.create(x).fold(e => sys.error(e), identity))))
+      .action((x, c) =>
+        c.copy(jdbcConfig = Some(JdbcConfig.create(x).fold(e => sys.error(e), identity))))
       .optional()
       .valueName(JdbcConfig.usage)
       .text("JDBC configuration parameters. If omitted the service runs without a database.")

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -3,7 +3,7 @@
 
 package com.daml.lf.engine.trigger
 
-import akka.actor.typed.{ActorRef, ActorSystem, Behavior, PostStop, Scheduler}
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior, Scheduler}
 import akka.actor.typed.PostStop
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
@@ -20,17 +20,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.{ByteString, Timeout}
 
-import com.daml.jwt.{JwtDecoder}
-import com.daml.jwt.domain.{DecodedJwt}
-import com.daml.jwt.domain.Jwt
-
-import com.daml.ledger.api.refinements.ApiTypes.Party
-import com.daml.ledger.api.auth.{AuthServiceJWTCodec}
-
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
-import scalaz.syntax.traverse._
+import scala.util.Try
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -400,17 +400,20 @@ object ServiceMain {
         implicit val scheduler: Scheduler = system.scheduler
         implicit val ec: ExecutionContext = system.executionContext
 
-        val triggerDao = TriggerDao(
-          "org.postgresql.Driver",
-          "jdbc:postgresql://localhost:5432/triggers",
-          "operator",
-          "operatorpass")
-        Try(triggerDao.transact(TriggerDao.initialize(triggerDao.logHandler)).unsafeRunSync()) match {
-          case Success(()) =>
-            system.log.info("Initialized running triggers database.")
-            System.exit(0)
-          case Failure(err) =>
-            sys.error(s"Failed to initialize database: $err")
+        if (config.init) {
+          val triggerDao = TriggerDao(
+            "org.postgresql.Driver",
+            "jdbc:postgresql://localhost:5432/triggers",
+            "operator",
+            "operatorpass")
+          Try(triggerDao.transact(TriggerDao.initialize(triggerDao.logHandler)).unsafeRunSync()) match {
+            case Success(()) =>
+              system.log.info("Initialized running triggers database.")
+              sys.exit(0)
+            case Failure(err) =>
+              system.log.error(err.toString)
+              sys.exit(1)
+          }
         }
 
         // Shutdown gracefully on SIGINT.

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -408,7 +408,7 @@ object ServiceMain {
             "operatorpass")
           Try(triggerDao.transact(TriggerDao.initialize(triggerDao.logHandler)).unsafeRunSync()) match {
             case Success(()) =>
-              system.log.info("Initialized running triggers database.")
+              system.log.info("Initialized database.")
               sys.exit(0)
             case Failure(err) =>
               system.log.error(err.toString)

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -47,7 +47,13 @@ import spray.json._
 import com.daml.lf.archive.{Dar, DarReader, Decode}
 import com.daml.lf.archive.Reader.ParseError
 import com.daml.lf.data.Ref.PackageId
-import com.daml.lf.engine.{ConcurrentCompiledPackages, MutableCompiledPackages, Result, ResultDone, ResultNeedPackage}
+import com.daml.lf.engine.{
+  ConcurrentCompiledPackages,
+  MutableCompiledPackages,
+  Result,
+  ResultDone,
+  ResultNeedPackage
+}
 import com.daml.lf.language.Ast._
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
@@ -406,7 +412,8 @@ object ServiceMain {
             system.log.error("No JDBC configuration for database initialization.")
             sys.exit(1)
           case (true, Some(jdbcConfig)) =>
-            val triggerDao = TriggerDao(JdbcConfig.driver, jdbcConfig.url, jdbcConfig.user, jdbcConfig.password)
+            val triggerDao =
+              TriggerDao(JdbcConfig.driver, jdbcConfig.url, jdbcConfig.user, jdbcConfig.password)
             Try(triggerDao.transact(TriggerDao.initialize(triggerDao.logHandler)).unsafeRunSync()) match {
               case Success(()) =>
                 system.log.info("Initialized database.")

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -369,6 +369,7 @@ object ServiceMain {
     val bindingFuture = system.ask((ref: ActorRef[ServerBinding]) => Server.GetServerBinding(ref))
     bindingFuture.map(server => (server, system))
   }
+
   def main(args: Array[String]): Unit = {
     ServiceConfig.parse(args) match {
       case None => sys.exit(1)
@@ -405,7 +406,7 @@ object ServiceMain {
             system.log.error("No JDBC configuration for database initialization.")
             sys.exit(1)
           case (true, Some(jdbcConfig)) =>
-            val triggerDao = TriggerDao(jdbcConfig.driver, jdbcConfig.url, jdbcConfig.user, jdbcConfig.password)
+            val triggerDao = TriggerDao(JdbcConfig.driver, jdbcConfig.url, jdbcConfig.user, jdbcConfig.password)
             Try(triggerDao.transact(TriggerDao.initialize(triggerDao.logHandler)).unsafeRunSync()) match {
               case Success(()) =>
                 system.log.info("Initialized database.")

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
@@ -18,7 +18,7 @@ object Connection {
   type T = Transactor.Aux[IO, Unit]
 
   def connect(jdbcDriver: String, jdbcUrl: String, username: String, password: String)(
-    implicit cs: ContextShift[IO]): T =
+      implicit cs: ContextShift[IO]): T =
     Transactor
       .fromDriverManager[IO](jdbcDriver, jdbcUrl, username, password)(IO.ioConcurrentEffect(cs), cs)
 }
@@ -34,7 +34,7 @@ class TriggerDao(xa: Connection.T) {
 
 object TriggerDao {
   def apply(jdbcDriver: String, jdbcUrl: String, username: String, password: String)(
-    implicit ec: ExecutionContext): TriggerDao = {
+      implicit ec: ExecutionContext): TriggerDao = {
     val cs: ContextShift[IO] = IO.contextShift(ec)
     new TriggerDao(Connection.connect(jdbcDriver, jdbcUrl, username, password)(cs))
   }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.trigger
+
+import cats.effect.{ContextShift, IO}
+import cats.syntax.apply._
+import cats.syntax.functor._
+import doobie._
+import doobie.LogHandler
+import doobie.free.connection.ConnectionIO
+import doobie.implicits._
+import doobie.util.log
+import scala.concurrent.ExecutionContext
+
+object Connection {
+
+  type T = Transactor.Aux[IO, Unit]
+
+  def connect(jdbcDriver: String, jdbcUrl: String, username: String, password: String)(
+    implicit cs: ContextShift[IO]): T =
+    Transactor
+      .fromDriverManager[IO](jdbcDriver, jdbcUrl, username, password)(IO.ioConcurrentEffect(cs), cs)
+}
+
+class TriggerDao(xa: Connection.T) {
+
+  implicit val logHandler: log.LogHandler = doobie.util.log.LogHandler.jdkLogHandler
+
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
+  def transact[A](query: ConnectionIO[A]): IO[A] =
+    query.transact(xa)
+}
+
+object TriggerDao {
+  def apply(jdbcDriver: String, jdbcUrl: String, username: String, password: String)(
+    implicit ec: ExecutionContext): TriggerDao = {
+    val cs: ContextShift[IO] = IO.contextShift(ec)
+    new TriggerDao(Connection.connect(jdbcDriver, jdbcUrl, username, password)(cs))
+  }
+
+  def initialize(implicit log: LogHandler): ConnectionIO[Unit] = {
+    val createTriggerTable: Fragment = sql"""
+        create table running_triggers(
+          trigger_id uuid primary key,
+          party varchar not null,
+          trigger_name varchar not null
+        )
+      """
+    val createDarTable: Fragment = sql"""
+        create table dar_packages(
+          package_id varchar primary key,
+          package varchar not null
+        )
+      """
+//    val insertTrigger: Fragment =
+//      sql"""
+//        insert into dar_packages values ('thisisyetanotherid', 'thisisapackage')
+//      """
+    (createTriggerTable.update.run
+      *> createDarTable.update.run).void
+//    insertTrigger.update.run.void
+  }
+}

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
@@ -47,13 +47,13 @@ object TriggerDao {
           trigger_name text not null
         )
       """
-    val createDarTable: Fragment = sql"""
-        create table dar_packages(
+    val createDalfTable: Fragment = sql"""
+        create table dalfs(
           package_id text primary key,
-          package text not null
+          package bytea not null
         )
       """
     (createTriggerTable.update.run
-      *> createDarTable.update.run).void
+      *> createDalfTable.update.run).void
   }
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
@@ -43,7 +43,7 @@ object TriggerDao {
     val createTriggerTable: Fragment = sql"""
         create table running_triggers(
           trigger_id uuid primary key,
-          party text not null,
+          party_token text not null,
           trigger_name text not null
         )
       """

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
@@ -53,12 +53,7 @@ object TriggerDao {
           package text not null
         )
       """
-//    val insertTrigger: Fragment =
-//      sql"""
-//        insert into dar_packages values ('thisisyetanotherid', 'thisisapackage')
-//      """
     (createTriggerTable.update.run
       *> createDarTable.update.run).void
-//    insertTrigger.update.run.void
   }
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
@@ -44,6 +44,8 @@ object TriggerDao {
         create table running_triggers(
           trigger_id uuid primary key,
           party_token text not null,
+          package_id text not null,
+          module_name text not null,
           trigger_name text not null
         )
       """

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
@@ -43,14 +43,14 @@ object TriggerDao {
     val createTriggerTable: Fragment = sql"""
         create table running_triggers(
           trigger_id uuid primary key,
-          party varchar not null,
-          trigger_name varchar not null
+          party text not null,
+          trigger_name text not null
         )
       """
     val createDarTable: Fragment = sql"""
         create table dar_packages(
-          package_id varchar primary key,
-          package varchar not null
+          package_id text primary key,
+          package text not null
         )
       """
 //    val insertTrigger: Fragment =


### PR DESCRIPTION
Minimal database initialization with schemas for `running_triggers` and `dalfs` tables. The user passes in the database URL, username and password in a config string argument (approach and code adapted from the JSON API).

In future the idea is to also create a "service" role with permissions to read and write to the new tables. Then the user can pass in the service role to connect to the database when running the service for real.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
