### PR TITLE
Bazel rule to inspect dar file when compiling daml

### DIFF
--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -53,6 +53,7 @@ da_scala_benchmark_jmh(
     srcs = glob(["src/perf/benches/**/*.scala"]),
     data = [
         ":CollectAuthority.dar",
+        ":CollectAuthority.dar.pp",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -238,6 +238,20 @@ _daml_validate_test = rule(
     test = True,
 )
 
+def _inspect_dar(base):
+    name = base + "-inspect"
+    dar = base + ".dar"
+    pp = base + ".dar.pp"
+    native.genrule(
+        name = name,
+        srcs = [
+            dar,
+            "//compiler/damlc",
+        ],
+        outs = [pp],
+        cmd = "$(location //compiler/damlc) inspect $(location :" + dar + ") > $@",
+    )
+
 _default_project_version = "1.0.0"
 
 def daml_compile(
@@ -265,6 +279,9 @@ def daml_compile(
         dar_dict = {},
         dar = name + ".dar",
         **kwargs
+    )
+    _inspect_dar(
+        base = name,
     )
 
 def daml_compile_with_dalf(


### PR DESCRIPTION
This change extends the bazel rule for `compile_daml` to add a stage which will pretty-print the generated .dar file, suitable for human inspection. The generated file is named with a `.dar.pp` suffix, and will only be generated if explicitly requested as a build target or listed as a dependency.

Make use of the new rule by demanding CollectAuthority.dar.pp when the perf benchmark is built.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
