### PR TITLE
Disentangle the execution of closures and builtin functions.

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -32,6 +32,8 @@ object Classify { // classify the machine state w.r.t what step occurs next
       var kfinished: Int = 0,
       var karg: Int = 0,
       var kfun: Int = 0,
+      var kbuiltin: Int = 0,
+      var kpap: Int = 0,
       var kpushto: Int = 0,
       var kcacheval: Int = 0,
       var klocation: Int = 0,
@@ -60,6 +62,8 @@ object Classify { // classify the machine state w.r.t what step occurs next
         ("- kfinished", kfinished),
         ("- karg", karg),
         ("- kfun", kfun),
+        ("- kbuiltin", kbuiltin),
+        ("- kpap", kpap),
         ("- kpushto", kpushto),
         ("- kcacheval", kcacheval),
         ("- klocation", klocation),
@@ -109,6 +113,8 @@ object Classify { // classify the machine state w.r.t what step occurs next
       case KFinished => counts.kfinished += 1
       case _: KArg => counts.karg += 1
       case _: KFun => counts.kfun += 1
+      case _: KBuiltin => counts.kbuiltin += 1
+      case _: KPap => counts.kpap += 1
       case _: KPushTo => counts.kpushto += 1
       case _: KCacheVal => counts.kcacheval += 1
       case _: KLocation => counts.klocation += 1

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -36,6 +36,8 @@ object PrettyLightweight { // lightweight pretty printer for CEK machine states
     case KFinished => "KFinished"
     case _: KArg => "KArg"
     case _: KFun => "KFun"
+    case _: KBuiltin => "KBuiltin"
+    case _: KPap => "KPap"
     case _: KPushTo => "KPushTo"
     case _: KCacheVal => "KCacheVal"
     case _: KLocation => "KLocation"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -103,7 +103,7 @@ object SExpr {
     */
   final case class SEApp(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KArg(args, machine.frame, machine.env.size))
+      machine.pushKont(KArg(args, machine.frame, machine.actuals, machine.env.size))
       machine.ctrl = fun
     }
   }
@@ -179,7 +179,7 @@ object SExpr {
   /** Pattern match. */
   final case class SECase(scrut: SExpr, alts: Array[SCaseAlt]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KMatch(alts, machine.frame, machine.env.size))
+      machine.pushKont(KMatch(alts, machine.frame, machine.actuals, machine.env.size))
       machine.ctrl = scrut
     }
 
@@ -209,13 +209,18 @@ object SExpr {
 
       // Evaluate the body after we've evaluated the binders
       machine.pushKont(
-        KPushTo(machine.env, body, machine.frame, machine.env.size + bounds.size - 1))
+        KPushTo(
+          machine.env,
+          body,
+          machine.frame,
+          machine.actuals,
+          machine.env.size + bounds.size - 1))
 
       // Start evaluating the let binders
       for (i <- 1 until bounds.size) {
         val b = bounds(bounds.size - i)
         val expectedEnvSize = machine.env.size + bounds.size - i - 1
-        machine.pushKont(KPushTo(machine.env, b, machine.frame, expectedEnvSize))
+        machine.pushKont(KPushTo(machine.env, b, machine.frame, machine.actuals, expectedEnvSize))
       }
       machine.ctrl = bounds.head
     }
@@ -258,7 +263,7 @@ object SExpr {
     */
   final case class SECatch(body: SExpr, handler: SExpr, fin: SExpr) extends SExpr {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KCatch(handler, fin, machine.frame, machine.env.size))
+      machine.pushKont(KCatch(handler, fin, machine.frame, machine.actuals, machine.env.size))
       machine.ctrl = body
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -131,20 +131,21 @@ object SValue {
     * See [[com.daml.lf.speedy.Profile]] for an explanation why we use
     * [[AnyRef]] for the label.
     */
-  final case class PClosure(label: AnyRef, expr: SExpr, fvs: Array[SValue])
+  final case class PClosure(label: AnyRef, expr: SExpr, frame: Array[SValue])
       extends Prim
       with SomeArrayEquals {
-    override def toString: String = s"PClosure($expr, ${fvs.mkString("[", ",", "]")})"
+    override def toString: String = s"PClosure($expr, ${frame.mkString("[", ",", "]")})"
   }
 
   /** A partially applied primitive.
     * An SPAP is *never* fully applied. This is asserted on construction.
     */
-  final case class SPAP(prim: Prim, args: util.ArrayList[SValue], arity: Int) extends SValue {
-    if (args.size >= arity) {
-      throw SErrorCrash(s"SPAP: unexpected args.size >= arity")
+  final case class SPAP(prim: Prim, actuals: util.ArrayList[SValue], arity: Int) extends SValue {
+    if (actuals.size >= arity) {
+      throw SErrorCrash(s"SPAP: unexpected actuals.size >= arity")
     }
-    override def toString: String = s"SPAP($prim, ${args.asScala.mkString("[", ",", "]")}, $arity)"
+    override def toString: String =
+      s"SPAP($prim, ${actuals.asScala.mkString("[", ",", "]")}, $arity)"
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.util.control.NoStackTrace
-
+@SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
 object Speedy {
 
   // Would like these to have zero cost when not enabled. Better still, to be switchable at runtime.
@@ -60,15 +60,23 @@ object Speedy {
 
   /*
    Speedy uses a caller-saves strategy for managing the environment.  In a Speedy machine,
-   the environment is represented by the `frame` and `env` components.
+   the environment is represented by the `frame`, `actuals`, and `env` components.
+
+   We use the terminology "frame" for the array of values which correspond to the
+   evaluated "free-vars" of a function closure.
+
+   We use the terminology "actuals" for the array of values which correspond to the
+   evaluated "args" of a function application. (The args being an array of expressions)
+
+   The environment "env" is now only used for let-bindings and pattern-matches.
 
    Continuations are responsible for restoring their own environment. In the general case,
    an arbitrary amount of computation may have occurred between the continuation being
    pushed and then later entered.
 
    When we push a continuation which requires it's environment to be preserved, we record
-   the current Frame and the current env-stack depth within the continuation. Then, when
-   the continuation is entered, it will call `restoreEnv`.
+   the current frame, actuals and env-stack-depth within the continuation. Then, when the
+   continuation is entered, it will call `restoreEnv`.
 
    We do this for KArg, KMatch, KPushTo, KCatch.
 
@@ -77,6 +85,10 @@ object Speedy {
    stack-variables within the body of the function. (They will have been translated to
    free-var reference by the compiler).
    */
+
+  type Frame = Array[SValue]
+
+  type Actuals = util.ArrayList[SValue]
 
   /** The speedy CEK machine. */
   final case class Machine(
@@ -88,8 +100,10 @@ object Speedy {
        * been fully evaluated. If this is not null, then `ctrl` must be null.
        */
       var returnValue: SValue,
-      /* Frame: to access values for function arguments and closure free-vars. */
+      /* Frame: to access values for a closure's free-vars. */
       var frame: Frame,
+      /* Actuals: to access values for a function application's arguments. */
+      var actuals: Actuals,
       /* Environment: values pushed to a stack: let-bindings and pattern-matches. */
       var env: Env,
       /* Kont, or continuation specifies what should be done next
@@ -153,13 +167,10 @@ object Speedy {
     @inline def getEnvStack(i: Int): SValue = env.get(env.size - i)
 
     // Variables which reside in the args array of the current frame. Indexed by absolute offset.
-    @inline def getEnvArg(i: Int): SValue = frame.args.get(i)
+    @inline def getEnvArg(i: Int): SValue = actuals.get(i)
 
     // Variables which reside in the free-vars array of the current frame. Indexed by absolute offset.
-    @inline def getEnvFree(i: Int): SValue = {
-      //TODO(NC) : modify types to avoid this asInstanceOf
-      frame.prim.asInstanceOf[PClosure].fvs(i)
-    }
+    @inline def getEnvFree(i: Int): SValue = frame(i)
 
     @inline def pushEnv(v: SValue): Unit = {
       env.add(v)
@@ -169,9 +180,13 @@ object Speedy {
       }
     }
 
-    @inline def restoreEnv(frameToBeRestored: Frame, envSize: Int): Unit = {
-      // Restore the frame pointer captured when the continuation was created.
+    @inline def restoreEnv(
+        frameToBeRestored: Frame,
+        actualsToBeRestored: Actuals,
+        envSize: Int): Unit = {
+      // Restore the frame and actuals to there state when the continuation was created.
       frame = frameToBeRestored
+      actuals = actualsToBeRestored
       // Pop the env-stack back to the size it was when the continuation was created.
       if (envSize != env.size) {
         val count = env.size - envSize
@@ -192,7 +207,7 @@ object Speedy {
         // NOTE(MH): If the top of the continuation stack is the monadic token,
         // we push location information under it to account for the implicit
         // lambda binding the token.
-        case Some(KArg(Array(SEValue.Token), _, _)) => {
+        case Some(KArg(Array(SEValue.Token), _, _, _)) => {
           // Can't call pushKont here, because we don't push at the top of the stack.
           kontStack.add(last_index, KLocation(loc))
           if (enableInstrumentation) {
@@ -347,30 +362,6 @@ object Speedy {
                     }
                   ),
                 )
-          }
-      }
-    }
-
-    def enterFullyAppliedFunction(prim: Prim, args: util.ArrayList[SValue]): Unit = {
-      prim match {
-        case PClosure(label, expr, _) =>
-          if (label != null) {
-            profile.addOpenEvent(label)
-            pushKont(KLeaveClosure(label))
-          }
-          // Start evaluating the body of the closure. (We dont do anything with the
-          // function arguments or free-varables, because the frame will have been set to
-          // allow their access within the body).
-          ctrl = expr
-
-        case PBuiltin(b) =>
-          try {
-            b.execute(args, this)
-          } catch {
-            // We turn arithmetic exceptions into a daml exception
-            // that can be caught.
-            case e: ArithmeticException =>
-              throw DamlEArithmeticError(e.getMessage)
           }
       }
     }
@@ -531,6 +522,7 @@ object Speedy {
         ctrl = null,
         returnValue = null,
         frame = null,
+        actuals = null,
         env = emptyEnv,
         kontStack = initialKontStack(),
         lastLocation = None,
@@ -619,15 +611,6 @@ object Speedy {
       initial(compiledPackages, submissionTime, seeding, globalCids).copy(ctrl = sexpr)
   }
 
-  //
-  // Frame
-  //
-  // For our frame, we use the KFun continuation directly.  From here
-  // we can access both the application arguments, and the values of
-  // the free-variables which were stored into the closure.
-  type Frame = KFun
-
-  //
   // Environment
   //
   // NOTE(JM): We use ArrayList instead of ArrayBuffer as
@@ -668,35 +651,54 @@ object Speedy {
   }
 
   /** The function has been evaluated to a value, now start evaluating the arguments. */
-  final case class KArg(newArgs: Array[SExpr], frame: Frame, envSize: Int)
+  final case class KArg(newArgs: Array[SExpr], frame: Frame, actuals: Actuals, envSize: Int)
       extends Kont
       with SomeArrayEquals {
     def execute(v: SValue, machine: Machine) = {
-      machine.restoreEnv(frame, envSize)
+      machine.restoreEnv(frame, actuals, envSize)
       v match {
-        case SPAP(prim, args, arity) =>
-          val missing = arity - args.size
+        case SPAP(prim, actualsSoFar, arity) =>
+          val missing = arity - actualsSoFar.size
           val newArgsLimit = Math.min(missing, newArgs.length)
 
-          // Keep some space free, because both `KFun` and `KPushTo` will add to the list.
-          val extendedArgs = new util.ArrayList[SValue](args.size + newArgsLimit)
-          extendedArgs.addAll(args)
+          val actuals = new util.ArrayList[SValue](actualsSoFar.size + newArgsLimit)
+          actuals.addAll(actualsSoFar)
 
-          // Stash away over-applied arguments, if any.
           val othersLength = newArgs.length - missing
-          if (othersLength > 0) {
-            val others = new Array[SExpr](othersLength)
-            System.arraycopy(newArgs, missing, others, 0, othersLength)
-            machine.pushKont(KArg(others, machine.frame, machine.env.size))
-          }
 
-          machine.pushKont(KFun(prim, extendedArgs, arity))
+          // Not enough arguments. Push a continuation to construct the PAP.
+          if (othersLength < 0) {
+            machine.pushKont(KPap(prim, actuals, arity))
+          } else {
+            // Too many arguments: Push a continuation to re-apply the over-applied args.
+            if (othersLength > 0) {
+              val others = new Array[SExpr](othersLength)
+              System.arraycopy(newArgs, missing, others, 0, othersLength)
+              machine.pushKont(KArg(others, machine.frame, machine.actuals, machine.env.size))
+            }
+            // Now the correct number of arguments is ensured. What kind of prim do we have?
+            prim match {
+              case PClosure(label, body, frame) =>
+                // Maybe push a continuation for the profiler
+                if (label != null) {
+                  machine.profile.addOpenEvent(label)
+                  machine.pushKont(KLeaveClosure(label))
+                }
+                // Push a continuation to execute the function body when the arguments have been evaluated
+                machine.pushKont(KFun(body, frame, actuals))
+
+              case PBuiltin(builtin) =>
+                // Push a continuation to execute the builtin when the arguments have been evaluated
+                machine.pushKont(KBuiltin(builtin, actuals))
+            }
+          }
 
           // Start evaluating the arguments.
           var i = 1
           while (i < newArgsLimit) {
             val arg = newArgs(newArgsLimit - i)
-            machine.pushKont(KPushTo(extendedArgs, arg, machine.frame, machine.env.size))
+            machine.pushKont(
+              KPushTo(actuals, arg, machine.frame, machine.actuals, machine.env.size))
             i = i + 1
           }
           machine.ctrl = newArgs(0)
@@ -707,29 +709,48 @@ object Speedy {
     }
   }
 
-  /** The function and the arguments have been evaluated. Construct a PAP from them.
-    * If the PAP is fully applied the machine will push the arguments to the environment
-    * and start evaluating the function body. */
-  final case class KFun(prim: Prim, args: util.ArrayList[SValue], var arity: Int) extends Kont {
+  /** The function-closure and arguments have been evaluated. Now execute the body. */
+  final case class KFun(body: SExpr, frame: Frame, actuals: util.ArrayList[SValue]) extends Kont {
     def execute(v: SValue, machine: Machine) = {
-      args.add(v) // Add last argument
-      if (args.size == arity) {
-        // Set the frame to enable access for Arg/Free variable references
-        machine.frame = this
-        machine.enterFullyAppliedFunction(prim, args)
-      } else {
-        // args.size < arity (we already dealt with args.size > args in Karg)
-        machine.returnValue = SPAP(prim, args, arity)
+      actuals.add(v)
+      // Set frame/actuals to allow access to the function arguments and closure free-varables.
+      machine.frame = frame
+      machine.actuals = actuals
+      // Start evaluating the body of the closure.
+      machine.ctrl = body
+    }
+  }
+
+  /** The builtin arguments have been evaluated. Now execute the builtin. */
+  final case class KBuiltin(builtin: SBuiltin, actuals: util.ArrayList[SValue]) extends Kont {
+    def execute(v: SValue, machine: Machine) = {
+      actuals.add(v)
+      // A builtin has no free-vars, so we dont have to set the frame.
+      machine.actuals = actuals
+      try {
+        builtin.execute(actuals, machine)
+      } catch {
+        // We turn arithmetic exceptions into a daml exception that can be caught.
+        case e: ArithmeticException =>
+          throw DamlEArithmeticError(e.getMessage)
       }
     }
   }
 
+  /** The function's partial-arguments have been evaluated. Construct and return the PAP */
+  final case class KPap(prim: Prim, actuals: util.ArrayList[SValue], arity: Int) extends Kont {
+    def execute(v: SValue, machine: Machine) = {
+      actuals.add(v)
+      machine.returnValue = SPAP(prim, actuals, arity)
+    }
+  }
+
   /** The scrutinee of a match has been evaluated, now match the alternatives against it. */
-  final case class KMatch(alts: Array[SCaseAlt], frame: Frame, envSize: Int)
+  final case class KMatch(alts: Array[SCaseAlt], frame: Frame, actuals: Actuals, envSize: Int)
       extends Kont
       with SomeArrayEquals {
     def execute(v: SValue, machine: Machine) = {
-      machine.restoreEnv(frame, envSize)
+      machine.restoreEnv(frame, actuals, envSize)
       val altOpt = v match {
         case SBool(b) =>
           alts.find { alt =>
@@ -808,14 +829,19 @@ object Speedy {
 
   /** Push the evaluated value to the array 'to', and start evaluating the expression 'next'.
     * This continuation is used to implement both function application and lets. In
-    * the case of function application the arguments are pushed into the 'args' array of
+    * the case of function application the arguments are pushed into the 'actuals' array of
     * the PAP that is being built, and in the case of lets the evaluated value is pushed
     * direy into the environment.
     */
-  final case class KPushTo(to: util.ArrayList[SValue], next: SExpr, frame: Frame, envSize: Int)
+  final case class KPushTo(
+      to: util.ArrayList[SValue],
+      next: SExpr,
+      frame: Frame,
+      actuals: Actuals,
+      envSize: Int)
       extends Kont {
     def execute(v: SValue, machine: Machine) = {
-      machine.restoreEnv(frame, envSize)
+      machine.restoreEnv(frame, actuals, envSize)
       to.add(v)
       machine.ctrl = next
     }
@@ -840,9 +866,10 @@ object Speedy {
     * If an exception is raised and 'KCatch' is found from kont-stack, then 'handler' is
     * evaluated. If 'KCatch' is encountered naturally, then 'fin' is evaluated.
     */
-  final case class KCatch(handler: SExpr, fin: SExpr, frame: Frame, envSize: Int) extends Kont {
+  final case class KCatch(handler: SExpr, fin: SExpr, frame: Frame, actuals: Actuals, envSize: Int)
+      extends Kont {
     def execute(v: SValue, machine: Machine) = {
-      machine.restoreEnv(frame, envSize)
+      machine.restoreEnv(frame, actuals, envSize)
       machine.ctrl = fin
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -183,17 +183,17 @@ object Speedy {
     @inline def restoreEnv(
         frameToBeRestored: Frame,
         actualsToBeRestored: Actuals,
-        envSize: Int): Unit = {
+        envSizeToBeRestored: Int): Unit = {
       // Restore the frame and actuals to there state when the continuation was created.
       frame = frameToBeRestored
       actuals = actualsToBeRestored
       // Pop the env-stack back to the size it was when the continuation was created.
-      if (envSize != env.size) {
-        val count = env.size - envSize
+      if (envSizeToBeRestored != env.size) {
+        val count = env.size - envSizeToBeRestored
         if (count < 1) {
           crash(s"restoreEnv, unexpected negative count: $count!")
         }
-        env.subList(envSize, env.size).clear
+        env.subList(envSizeToBeRestored, env.size).clear
       }
     }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.util.control.NoStackTrace
-@SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
+
 object Speedy {
 
   // Would like these to have zero cost when not enabled. Better still, to be switchable at runtime.
@@ -138,7 +138,7 @@ object Speedy {
       var track: Instrumentation,
       /* Profile of the run when the packages haven been compiled with profiling enabled. */
       var profile: Profile
-  ) {
+  ) extends SomeArrayEquals {
 
     /* kont manipulation... */
 
@@ -710,7 +710,9 @@ object Speedy {
   }
 
   /** The function-closure and arguments have been evaluated. Now execute the body. */
-  final case class KFun(body: SExpr, frame: Frame, actuals: util.ArrayList[SValue]) extends Kont {
+  final case class KFun(body: SExpr, frame: Frame, actuals: util.ArrayList[SValue])
+      extends Kont
+      with SomeArrayEquals {
     def execute(v: SValue, machine: Machine) = {
       actuals.add(v)
       // Set frame/actuals to allow access to the function arguments and closure free-varables.
@@ -839,7 +841,8 @@ object Speedy {
       frame: Frame,
       actuals: Actuals,
       envSize: Int)
-      extends Kont {
+      extends Kont
+      with SomeArrayEquals {
     def execute(v: SValue, machine: Machine) = {
       machine.restoreEnv(frame, actuals, envSize)
       to.add(v)
@@ -867,7 +870,8 @@ object Speedy {
     * evaluated. If 'KCatch' is encountered naturally, then 'fin' is evaluated.
     */
   final case class KCatch(handler: SExpr, fin: SExpr, frame: Frame, actuals: Actuals, envSize: Int)
-      extends Kont {
+      extends Kont
+      with SomeArrayEquals {
     def execute(v: SValue, machine: Machine) = {
       machine.restoreEnv(frame, actuals, envSize)
       machine.ctrl = fin


### PR DESCRIPTION
Both closures and builtins take arguments, but only closures have free variables.
Consequently, we split the machine component `frame` into `frame` and `actuals`.
Allowing them to be managed independently, and simplifying lookup for `SELocF` and `SELocA`.

The `KFun` continuation is split into 3 variants: `KFun`, `KBuiltin` and `KPap`.
These handle the execution of three different cases of function application:
- execution of a user function (a closure)
- execution of a builtin
- execution of a partial application (builtin or closure, it doesn't matter)

The choice of which continuation to push is made in the `KArg` continuation when the
function-expression has been evaluated and we have discovered what it is - builtin or
closure - and we know it's arity.

The prior code made some related decisions (for example, is this an over-application) but
left other choices to `KFun` (code was: `enterFullyAppliedFunction`). This required that
the `KFun` continuation had to stash the entire `Prim` (closure/builtin) and `arity`, only
to then re-examine it when the continuation was entered.

Now, all decisions are made within `KArg`, making the structure and execution of the three
new continuations much simpler. In particular, the `machine.frame` is only set when we
enter `KFun`.

All continuations which need to preserve their environment, now save both frame & actuals,
along with the env-stack-size. And `restoreEnv` is adapted accordingly.

There is no measurable impact on performance from this change.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
