### PR TITLE
Add control to speedy compiler to choose if stack-trace support occurs at runtime.

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -183,7 +183,10 @@ class ReplService(
       respObs: StreamObserver[LoadPackageResponse]): Unit = {
     val (pkgId, pkg) = Decode.decodeArchiveFromInputStream(req.getPackage.newInput)
     packages = packages + (pkgId -> pkg)
-    compiledDefinitions = compiledDefinitions ++ Compiler(packages, Compiler.NoProfile)
+    compiledDefinitions = compiledDefinitions ++ Compiler(
+      packages,
+      Compiler.FullStackTrace,
+      Compiler.NoProfile)
       .unsafeCompilePackage(pkgId)
     respObs.onNext(LoadPackageResponse.newBuilder.build)
     respObs.onCompleted()
@@ -219,9 +222,14 @@ class ReplService(
     }
 
     val allPkgs = packages + (homePackageId -> pkg)
-    val defs = Compiler(allPkgs, Compiler.NoProfile).unsafeCompilePackage(homePackageId)
+    val defs = Compiler(allPkgs, Compiler.FullStackTrace, Compiler.NoProfile)
+      .unsafeCompilePackage(homePackageId)
     val compiledPackages =
-      PureCompiledPackages(allPkgs, compiledDefinitions ++ defs, Compiler.NoProfile)
+      PureCompiledPackages(
+        allPkgs,
+        compiledDefinitions ++ defs,
+        Compiler.FullStackTrace,
+        Compiler.NoProfile)
     val runner = new Runner(
       compiledPackages,
       Script.Action(scriptExpr, ScriptIds(scriptPackageId)),

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -109,7 +109,8 @@ class Context(val contextId: Context.ContextId) {
         // if any change we recompile everything
         extPackages --= unloadPackages
         extPackages ++= newPackages
-        extDefns = assert(Compiler.compilePackages(extPackages, Compiler.NoProfile))
+        extDefns =
+          assert(Compiler.compilePackages(extPackages, Compiler.FullStackTrace, Compiler.NoProfile))
         modDefns = HashMap.empty
         modules.values
       } else {
@@ -118,7 +119,7 @@ class Context(val contextId: Context.ContextId) {
       }
 
     val pkgs = allPackages
-    val compiler = Compiler(pkgs, Compiler.NoProfile)
+    val compiler = Compiler(pkgs, Compiler.FullStackTrace, Compiler.NoProfile)
 
     modulesToCompile.foreach { mod =>
       if (!omitValidation)
@@ -152,7 +153,8 @@ class Context(val contextId: Context.ContextId) {
       Speedy.Machine
         .build(
           sexpr = defn,
-          compiledPackages = PureCompiledPackages(allPackages, defns, Compiler.NoProfile),
+          compiledPackages =
+            PureCompiledPackages(allPackages, defns, Compiler.FullStackTrace, Compiler.NoProfile),
           submissionTime,
           initialSeeding,
           Set.empty,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -26,6 +26,7 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
   def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
     Option(_defns.get(dref))
 
+  def stackTraceMode = speedy.Compiler.FullStackTrace
   def profilingMode = speedy.Compiler.NoProfile
 
   /** Might ask for a package if the package you're trying to add references it.
@@ -83,7 +84,7 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
               // Compile the speedy definitions for this package.
               val defns =
                 speedy
-                  .Compiler(packages orElse state.packages, profilingMode)
+                  .Compiler(packages orElse state.packages, stackTraceMode, profilingMode)
                   .unsafeCompilePackage(pkgId)
               defns.foreach {
                 case (defnId, defn) => _defns.put(defnId, defn)

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -22,7 +22,7 @@ object PlaySpeedy {
 
   def main(args0: List[String]) = {
     val config: Config = parseArgs(args0)
-    val compiler: Compiler = Compiler(Map.empty, Compiler.NoProfile)
+    val compiler: Compiler = Compiler(Map.empty, Compiler.FullStackTrace, Compiler.NoProfile)
 
     val names: List[String] = config.names match {
       case Nil => examples.toList.map(_._1)
@@ -66,7 +66,7 @@ object PlaySpeedy {
 
   def makeMachine(sexpr: SExpr): Machine = {
     val compiledPackages: CompiledPackages =
-      PureCompiledPackages(Map.empty, Compiler.NoProfile).right.get
+      PureCompiledPackages(Map.empty, Compiler.NoStackTrace, Compiler.NoProfile).right.get
     Machine.fromSExpr(
       sexpr,
       compiledPackages,

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -33,6 +33,7 @@ object PlaySpeedy {
   def parseArgs(args0: List[String]): Config = {
     var funcName: String = "triangle"
     var argValue: Long = 10
+    var stacktracing: Compiler.StackTraceMode = Compiler.NoStackTrace
     def loop(args: List[String]): Unit = args match {
       case Nil => {}
       case "-h" :: _ => usage()
@@ -40,17 +41,21 @@ object PlaySpeedy {
       case "--arg" :: x :: args =>
         argValue = x.toLong
         loop(args)
+      case "--stacktracing" :: args =>
+        stacktracing = Compiler.FullStackTrace
+        loop(args)
       case x :: args =>
         funcName = x
         loop(args)
     }
     loop(args0)
-    Config(funcName, argValue)
+    Config(funcName, argValue, stacktracing)
   }
 
   final case class Config(
       funcName: String,
       argValue: Long,
+      stacktracing: Compiler.StackTraceMode,
   )
 
   def main(args0: List[String]) = {
@@ -68,8 +73,11 @@ object PlaySpeedy {
         case (pkgId, pkgArchive) => Decode.readArchivePayloadAndVersion(pkgId, pkgArchive)._1
       }.toMap
 
-    println("Compiling packages...")
-    val compiledPackages: CompiledPackages = PureCompiledPackages(packagesMap).right.get
+    println(s"Compiling packages... ${config.stacktracing}")
+    val compiledPackages: CompiledPackages = PureCompiledPackages(
+      packagesMap,
+      config.stacktracing
+    ).right.get
 
     val machine: Machine = {
       println(s"Setup machine for: ${config.funcName}(${config.argValue})")

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -476,7 +476,8 @@ class OrderingSpec
   private val txSeed = crypto.Hash.hashPrivateKey("SBuiltinTest")
   private def initMachine(expr: SExpr) = Speedy.Machine fromSExpr (
     sexpr = expr,
-    compiledPackages = PureCompiledPackages(Map.empty, Map.empty, Compiler.NoProfile),
+    compiledPackages =
+      PureCompiledPackages(Map.empty, Map.empty, Compiler.FullStackTrace, Compiler.NoProfile),
     submissionTime = Time.Timestamp.now(),
     seeding = InitialSeeding.TransactionSeed(txSeed),
     globalCids = Set.empty,

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -180,7 +180,7 @@ object Repl {
       profiling: Compiler.ProfilingMode) {
     private val build = Speedy.Machine
       .newBuilder(
-        PureCompiledPackages(packages, profiling).right.get,
+        PureCompiledPackages(packages, Compiler.FullStackTrace, profiling).right.get,
         Time.Timestamp.MinValue,
         nextSeed())
       .fold(err => sys.error(err.toString), identity)
@@ -389,7 +389,8 @@ object Repl {
   }
 
   def speedyCompile(state: State, args: Seq[String]): Unit = {
-    val defs = assertRight(Compiler.compilePackages(state.packages, Compiler.NoProfile))
+    val defs = assertRight(
+      Compiler.compilePackages(state.packages, Compiler.FullStackTrace, Compiler.NoProfile))
     defs.get(idToRef(state, args(0))) match {
       case None =>
         println("Error: definition '" + args(0) + "' not found. Try :list."); usage

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -32,12 +32,13 @@ class CollectAuthorityState {
     val packagesMap = packages.all.map {
       case (pkgId, pkgArchive) => Decode.readArchivePayloadAndVersion(pkgId, pkgArchive)._1
     }.toMap
+    val stacktracing = Compiler.FullStackTrace
 
     // NOTE(MH): We use a static seed to get reproducible runs.
     val seeding = crypto.Hash.secureRandom(crypto.Hash.hashPrivateKey("scenario-perf"))
     buildMachine = Speedy.Machine
       .newBuilder(
-        PureCompiledPackages(packagesMap).right.get,
+        PureCompiledPackages(packagesMap, stacktracing).right.get,
         Time.Timestamp.MinValue,
         seeding(),
       )

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -281,6 +281,7 @@ class Runner(
       override def packages = compiledPackages.packages
       def packageIds = compiledPackages.packageIds
       override def definitions = fromLedgerValue.orElse(compiledPackages.definitions)
+      override def stackTraceMode = Compiler.FullStackTrace
       override def profilingMode = Compiler.NoProfile
     }
   }


### PR DESCRIPTION

Choices for `stacktracing` are `NoStackTrace` / `FullStackTrace`.

Adapted code so the selection is made by the original caller:
- `engine`
- `scenario-service`
- `repl-service`
- `daml-script` runner
etc

Currently, all callers pass `FullStackTrace` (the existing behaviour), except for the
exploration dev-code: `daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore`.

The idea is that once this control is in place, we can discuss if we can change how we
might expose it to the user, and/or perhaps change the default behaviour to have
`stacktracing` disabled.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
