### PR TITLE
Don't update running triggers until we know the trigger is running

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -36,7 +36,7 @@ class TriggerRunner(
   import TriggerRunner.{Message, Stop}
 
   private val child =
-    ctx.spawn(Behaviors.supervise(TriggerRunnerImpl(config)).onFailure(restart), name)
+    ctx.spawn(Behaviors.supervise(TriggerRunnerImpl(ctx.self, config)).onFailure(restart), name)
 
   override def onMessage(msg: Message): Behavior[Message] =
     Behaviors.receiveMessagePartial[Message] {

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -189,6 +189,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
       resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Alice")
       triggerId <- parseTriggerId(resp)
 
+      _ <- Future { Thread.sleep(1000); true }
       resp <- listTriggers(uri, "Alice")
       result <- parseTriggerIds(resp)
       _ <- result should equal(Vector(triggerId))
@@ -202,31 +203,34 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
   it should "start multiple triggers and list them by party" in withHttpService(Some(dar)) {
     (uri: Uri, client) =>
       for {
-        // no triggers running initially
         resp <- listTriggers(uri, "Alice")
         result <- parseTriggerIds(resp)
         _ <- result should equal(Vector())
         // start trigger for Alice
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Alice")
         aliceTrigger <- parseTriggerId(resp)
+        _ <- Future { Thread.sleep(1000); true }
         resp <- listTriggers(uri, "Alice")
         result <- parseTriggerIds(resp)
         _ <- result should equal(Vector(aliceTrigger))
         // start trigger for Bob
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Bob")
         bobTrigger1 <- parseTriggerId(resp)
+        _ <- Future { Thread.sleep(1000); true }
         resp <- listTriggers(uri, "Bob")
         result <- parseTriggerIds(resp)
         _ <- result should equal(Vector(bobTrigger1))
         // start another trigger for Bob
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Bob")
         bobTrigger2 <- parseTriggerId(resp)
+        _ <- Future { Thread.sleep(1000); true }
         resp <- listTriggers(uri, "Bob")
         result <- parseTriggerIds(resp)
         _ <- result should equal(Vector(bobTrigger1, bobTrigger2))
         // stop Alice's trigger
         resp <- stopTrigger(uri, aliceTrigger, "Alice")
         _ <- assert(resp.status.isSuccess)
+        _ <- Future { Thread.sleep(1000); true }
         resp <- listTriggers(uri, "Alice")
         result <- parseTriggerIds(resp)
         _ <- result should equal(Vector())
@@ -238,6 +242,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers {
         _ <- assert(resp.status.isSuccess)
         resp <- stopTrigger(uri, bobTrigger2, "Bob")
         _ <- assert(resp.status.isSuccess)
+        _ <- Future { Thread.sleep(1000); true }
         resp <- listTriggers(uri, "Bob")
         result <- parseTriggerIds(resp)
         _ <- result should equal(Vector())


### PR DESCRIPTION
In this PR, we add a trigger to the running triggers tables only when we are sure it's started.