### PR TITLE
Add JSON output to `damlc inspect-dar`

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -36,7 +36,7 @@ infixr 1 `KArrow`
 -- > [a-zA-Z0-9]+
 newtype PackageId = PackageId{unPackageId :: T.Text}
     deriving stock (Eq, Data, Generic, Ord, Show)
-    deriving newtype (Hashable, NFData)
+    deriving newtype (Hashable, NFData, ToJSON, ToJSONKey)
 
 -- | Name for a module. Must match the regex
 --
@@ -113,14 +113,14 @@ newtype PartyLiteral = PartyLiteral{unPartyLiteral :: T.Text}
 -- > [a-zA-Z0-9_-]+
 newtype PackageName = PackageName{unPackageName :: T.Text}
     deriving stock (Eq, Data, Generic, Ord, Show)
-    deriving newtype (Hashable, NFData, FromJSON)
+    deriving newtype (Hashable, NFData, ToJSON, FromJSON)
 
 -- | Human-readable version of a package. Must match the regex
 --
 -- > (0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*
 newtype PackageVersion = PackageVersion{unPackageVersion :: T.Text}
     deriving stock (Eq, Data, Generic, Ord, Show)
-    deriving newtype (Hashable, NFData, FromJSON)
+    deriving newtype (Hashable, NFData, ToJSON, FromJSON)
 
 -- | Reference to a package.
 data PackageRef

--- a/compiler/damlc/lib/DA/Cli/Damlc/InspectDar.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/InspectDar.hs
@@ -99,7 +99,8 @@ renderInfo PlainText InspectInfo{..} = T.unlines $ concat
              dropExtension (takeFileName dalfFilePath) <> " " <>
              show (LF.unPackageId pkgId)
         )
-        (HashMap.toList packages)
+        -- Sort to not depend on the hash of the package id.
+        (sortOn (dalfFilePath . snd) $ HashMap.toList packages)
   ]
 renderInfo Json info =
     TL.toStrict (TL.toLazyText (encodePrettyToTextBuilder info))

--- a/compiler/damlc/lib/DA/Cli/Damlc/InspectDar.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/InspectDar.hs
@@ -1,0 +1,119 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Cli.Damlc.InspectDar
+    ( Format(..)
+    , inspectDar
+    ) where
+
+import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
+import qualified DA.Daml.LF.Ast as LF
+import qualified DA.Daml.LF.Proto3.Archive as Archive
+import DA.Daml.LF.Reader
+import DA.Pretty (renderPretty)
+import Data.Aeson
+import Data.Aeson.Encode.Pretty
+import Data.Bifunctor
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BSL
+import Data.Either.Extra
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.List
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TL
+import System.Exit
+import System.FilePath
+import System.IO
+
+data Format = PlainText | Json
+
+data InspectInfo = InspectInfo
+    { files :: [FilePath]
+    , packages :: HashMap LF.PackageId DalfInfo
+    , mainPackageId :: LF.PackageId
+    }
+
+instance ToJSON InspectInfo where
+    toJSON InspectInfo{..} = object
+      [ "files" .= files
+      , "packages" .= packages
+      , "main_package_id" .= mainPackageId
+      ]
+
+data DalfInfo = DalfInfo
+  { dalfFilePath :: FilePath
+  , dalfPackageName :: Maybe LF.PackageName
+  , dalfPackageVersion :: Maybe LF.PackageVersion
+  }
+
+instance ToJSON DalfInfo where
+    toJSON DalfInfo{..} = object
+      [ "path" .= dalfFilePath
+      , "name" .= dalfPackageName
+      , "version" .= dalfPackageVersion
+      ]
+
+collectInfo :: ZipArchive.Archive -> Either String InspectInfo
+collectInfo archive = do
+    DalfManifest{..} <- readDalfManifest archive
+    main@(mainPkgId, _) <- decodeEntry mainDalfPath
+    deps <- mapM (\path -> (path,) <$> decodeEntry path) (delete mainDalfPath dalfPaths)
+    pure InspectInfo
+        { files = [ZipArchive.eRelativePath e | e <- ZipArchive.zEntries archive]
+        , packages = HashMap.fromList (map handleDalf $ (mainDalfPath, main) : deps)
+        , mainPackageId = mainPkgId
+        }
+  where
+    handleDalf :: (FilePath, (LF.PackageId, LF.Package)) -> (LF.PackageId, DalfInfo)
+    handleDalf (path, (pkgId, pkg)) =
+        ( pkgId
+        , DalfInfo
+              path
+              (LF.packageName <$> LF.packageMetadata pkg)
+              (LF.packageVersion <$> LF.packageMetadata pkg)
+        )
+    decodeEntry :: FilePath -> Either String (LF.PackageId, LF.Package)
+    decodeEntry path = do
+        entry <- maybeToEither
+            ("Could not find " <> path <> " in DAR")
+            (ZipArchive.findEntryByPath path archive)
+        first renderPretty $
+            Archive.decodeArchive Archive.DecodeAsDependency
+            (BSL.toStrict $ ZipArchive.fromEntry entry)
+
+renderInfo :: Format -> InspectInfo -> Text
+renderInfo PlainText InspectInfo{..} = T.unlines $ concat
+  [ [ "DAR archive contains the following files:"
+    , ""
+    ]
+  , map T.pack files
+  , [ ""
+    , "DAR archive contains the following packages:"
+    , ""
+    ]
+  , map (\(pkgId, DalfInfo{..}) -> T.pack $
+             dropExtension (takeFileName dalfFilePath) <> " " <>
+             show (LF.unPackageId pkgId)
+        )
+        (HashMap.toList packages)
+  ]
+renderInfo Json info =
+    TL.toStrict (TL.toLazyText (encodePrettyToTextBuilder info))
+    <> "\n"
+
+inspectDar :: FilePath -> Format -> IO ()
+inspectDar inFile format = do
+    bytes <- B.readFile inFile
+    let dar = ZipArchive.toArchive $ BSL.fromStrict bytes
+    case collectInfo dar of
+        Left err -> do
+            hPutStrLn stderr "Failed to read dar:"
+            hPutStrLn stderr err
+            exitFailure
+        Right info -> do
+            T.putStr (renderInfo format info)
+

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -493,6 +493,27 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "inspect-dar",
+    srcs = ["src/inspect-dar.sh"],
+    args = [
+        "$(rootpath //compiler/damlc)",
+        "$(rootpath @jq_dev_env//:jq)",
+        "$(rootpath //ledger/test-common:Test-dev.dar)",
+    ],
+    data = [
+        "//compiler/damlc",
+        "//ledger/test-common:Test-dev.dar",
+        "@jq_dev_env//:jq",
+    ],
+    toolchains = [
+        "@rules_sh//sh/posix:make_variables",
+    ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 da_haskell_test(
     name = "unstable-types",
     srcs = ["src/DA/Test/UnstableTypes.hs"],

--- a/compiler/damlc/tests/src/inspect-dar.sh
+++ b/compiler/damlc/tests/src/inspect-dar.sh
@@ -1,0 +1,52 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+set -euo pipefail
+
+DAMLC=$(rlocation $TEST_WORKSPACE/$1)
+JQ=$(rlocation $TEST_WORKSPACE/$2)
+TEST_DAR=$(rlocation $TEST_WORKSPACE/$3)
+MAIN_PKG_ID=$($DAMLC inspect-dar $TEST_DAR | sed '0,/^DAR archive contains the following packages:$/d' | sed -n 's/^Test-dev-1.0.0-[^"]*"\(.*\)"$/\1/p')
+JSON_MAIN_PKG_ID=$($DAMLC inspect-dar --json $TEST_DAR | $JQ -r '.main_package_id')
+if [[ "$MAIN_PKG_ID" != "$JSON_MAIN_PKG_ID" ]]; then
+    echo "Mismatch in package ids:"
+    echo "$MAIN_PKG_ID"
+    echo "$JSON_MAIN_PKG_ID"
+    exit 1
+fi
+OUT=$($DAMLC inspect-dar --json $TEST_DAR | $JQ ".packages.\"$MAIN_PKG_ID\"")
+KEYS="$($JQ -c 'keys' <<<"$OUT")"
+if [[ "$KEYS" != '["name","path","version"]' ]]; then
+    echo "Unexpected keys:"
+    echo "$KEYS"
+    exit 1
+fi
+NAME=$($JQ -r '.name' <<<"$OUT")
+if [[ "$NAME" != "Test-dev" ]]; then
+    echo "Unexpected name:"
+    echo "$NAME"
+    exit 1
+fi
+VERSION=$($JQ -r '.version' <<<"$OUT")
+if [[ "$VERSION" != "1.0.0" ]]; then
+    echo "Unexpected version:"
+    echo "$VERSION"
+    exit 1
+fi
+PATH=$($JQ -r '.path' <<<"$OUT")
+if [[ "$PATH" != "Test-dev-1.0.0-$MAIN_PKG_ID/Test-dev-1.0.0-$MAIN_PKG_ID.dalf" ]]; then
+    echo "Unexpected path:"
+    echo "$PATH"
+    exit 1
+fi

--- a/docs/source/daml/reference/packages.rst
+++ b/docs/source/daml/reference/packages.rst
@@ -24,6 +24,87 @@ You can specify a different path for the DAML archive by using the ``-o`` flag:
 
 For details on how to upload a DAML archive to the ledger, see the :ref:`deploy documentation <deploy-ref_overview>`. The rest of this page will focus on how to import a DAML packages in other DAML projects.
 
+.. _inspecting_dars:
+
+Inspecting DARs
+***************
+
+To inspect a DAR and get information about the packages inside it, you
+can use the ``daml damlc inspect-dar`` command. This is often useful
+to find the package id of the project you just built.
+
+You can run ``damlc damlc inspect-dar /path/to/your.dar`` to get a
+human-readable listing of the files inside it and a list of packages
+and their package ids. Here is a (shortened) example output:
+
+.. code-block:: sh
+
+  $ daml damlc inspect-dar .daml/dist/create-daml-app-0.1.0.dar
+  DAR archive contains the following files:
+
+  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d.dalf
+  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15.dalf
+  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a.dalf
+  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662.dalf
+  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/data/create-daml-app-0.1.0.conf
+  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.daml
+  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hi
+  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hie
+  META-INF/MANIFEST.MF
+
+  DAR archive contains the following packages:
+
+  create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d "29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d"
+  daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662 "d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662"
+  daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15 "75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15"
+  daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a "a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a"
+
+In addition to the human-readable output, you can also get the output
+as JSON. This is easier to consume programatically and it is more
+robust to changes across SDK versions:
+
+.. code-block:: sh
+
+  $ daml damlc inspect-dar --json .daml/dist/create-daml-app-0.1.0.dar
+  {
+      "packages": {
+          "29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d": {
+              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d.dalf",
+              "name": "create-daml-app",
+              "version": "0.1.0"
+          },
+          "d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662": {
+              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662.dalf",
+              "name": null,
+              "version": null
+          },
+          "75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15": {
+              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15.dalf",
+              "name": "daml-prim",
+              "version": "0.0.0"
+          },
+          "a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a": {
+              "path": "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a.dalf",
+              "name": "daml-stdlib",
+              "version": "0.0.0"
+          }
+      },
+      "main_package_id": "29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d",
+      "files": [
+          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d.dalf",
+          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-prim-75b070729b1fbd37a618493652121b0d6f5983b787e35179e52d048db70e9f15.dalf",
+          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-0.0.0-a535cbc3657b8df953a50aaef5a4cd224574549c83ca4377e8219aadea14f21a.dalf",
+          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/daml-stdlib-DA-Internal-Template-d14e08374fc7197d6a0de468c968ae8ba3aadbf9315476fd39071831f5923662.dalf",
+          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/data/create-daml-app-0.1.0.conf",
+          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.daml",
+          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hi",
+          "create-daml-app-0.1.0-29b501bcf541a40e9f75750246874e0a35de72e00616372da435e4b69966db5d/User.hie",
+          "META-INF/MANIFEST.MF"
+      ]
+  }
+
+Note that ``name`` and ``version`` will be ``null`` for packages in DAML-LF < 1.8.
+
 Importing DAML packages
 ***********************
 

--- a/docs/source/daml/reference/packages.rst
+++ b/docs/source/daml/reference/packages.rst
@@ -33,7 +33,7 @@ To inspect a DAR and get information about the packages inside it, you
 can use the ``daml damlc inspect-dar`` command. This is often useful
 to find the package id of the project you just built.
 
-You can run ``damlc damlc inspect-dar /path/to/your.dar`` to get a
+You can run ``daml damlc inspect-dar /path/to/your.dar`` to get a
 human-readable listing of the files inside it and a list of packages
 and their package ids. Here is a (shortened) example output:
 


### PR DESCRIPTION
fixes #3117, fixes #5563

This PR adds a `--json` flag to `damlc inspect-dar` that does pretty
much what you expect. So far it mainly exposes the same information
that you already got from `inspect-dar` but it’s easy to add more as
needed.

I’ve also finally added some documentation for `inspect-dar`.

changelog_begin

- [DAML Compiler] ``damlc inspect-dar`` now has a `--json`` flag to
  produce machine-readable output. See
  https://docs.daml.com/daml/reference/packages.html#inspecting-dars
  for more information.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
