### PR TITLE
Don't update running triggers until we know the trigger is running

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -14,8 +14,6 @@ import akka.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 
-import scala.concurrent.duration._
-
 class InitializationException(s: String) extends Exception(s) {}
 
 object TriggerRunner {
@@ -52,7 +50,7 @@ class TriggerRunner(
             .supervise(TriggerRunnerImpl(ctx.self, config))
             .onFailure[InitializationException](stop))
         .onFailure[RuntimeException](
-          restart.withLimit(maxNrOfRetries = 3, withinTimeRange = 10.seconds)),
+          restart.withLimit(config.maxFailureNumberOfRetries, config.failureRetryTimeRange)),
       name
     )
 

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -3,6 +3,7 @@
 
 package com.daml.lf.engine.trigger
 
+import akka.actor.typed.{ActorRef}
 import akka.actor.typed.{Behavior, PostStop}
 import akka.actor.typed.PostStop
 import akka.actor.typed.PreRestart
@@ -24,9 +25,15 @@ import com.daml.ledger.client.configuration.{
   LedgerClientConfiguration,
   LedgerIdRequirement
 }
+import com.daml.jwt.domain.Jwt
+
+import java.util.UUID
 
 object TriggerRunnerImpl {
   case class Config(
+      server: ActorRef[Server.Message],
+      triggerId: UUID, // trigger id
+      jwt: Jwt, // trigger token
       compiledPackages: CompiledPackages,
       trigger: Trigger,
       ledgerConfig: LedgerConfig,
@@ -35,17 +42,25 @@ object TriggerRunnerImpl {
   )
 
   import TriggerRunner.{Message, Stop}
-  final case class Failed(error: Throwable) extends Message
-  final case class QueryACSFailed(cause: Throwable) extends Message
-  final case class QueriedACS(runner: Runner, acs: Seq[CreatedEvent], offset: LedgerOffset)
+  final private case class Failed(error: Throwable) extends Message
+  final private case class QueryACSFailed(cause: Throwable) extends Message
+  final private case class QueriedACS(runner: Runner, acs: Seq[CreatedEvent], offset: LedgerOffset)
       extends Message
+  import Server.{
+    TriggerStarting,
+    TriggerStarted,
+    TriggerInitializationFailure,
+    TriggerRuntimeFailure
+  }
 
-  def apply(config: Config)(
+  def apply(parent: ActorRef[Message], config: Config)(
       implicit esf: ExecutionSequencerFactory,
       mat: Materializer): Behavior[Message] =
     Behaviors.setup { ctx =>
-      implicit val ec: ExecutionContext = ctx.executionContext
       val name = ctx.self.path.name
+      implicit val ec: ExecutionContext = ctx.executionContext
+      // Report to the server that this trigger is starting.
+      config.server ! TriggerStarting(config.triggerId, config.jwt, parent)
       ctx.log.info(s"Trigger ${name} is starting")
       val appId = ApplicationId(name)
       val clientConfig = LedgerClientConfiguration(
@@ -62,16 +77,46 @@ object TriggerRunnerImpl {
         Behaviors.receiveMessagePartial[Message] {
           case QueryACSFailed(cause) =>
             if (wasStopped) {
-              // Never mind that it failed - we were asked to stop
-              // anyway.
-              Behaviors.stopped;
+              // Report the failure to the server.
+              config.server ! TriggerInitializationFailure(
+                config.triggerId,
+                config.jwt,
+                parent,
+                cause.toString)
+              // Tell our monitor there's been a failure. The
+              // monitor's supervision strategy will respond to this
+              // by writing the exception to the log and stopping this
+              // actor.
+              throw new InitializationException("User stopped")
             } else {
-              throw new RuntimeException("ACS query failed", cause)
+              // Report the failure to the server.
+              config.server ! TriggerInitializationFailure(
+                config.triggerId,
+                config.jwt,
+                parent,
+                cause.toString)
+              // Tell our monitor there's been a failure. The
+              // monitor's supervisor strategy will respond to this by
+              // writing the exception to the log and stopping this
+              // actor.
+              throw new InitializationException("Couldn't start: " + cause.toString)
             }
           case QueriedACS(runner, acs, offset) =>
             if (wasStopped) {
-              Behaviors.stopped;
+              // Report that we won't be going on to the server.
+              config.server ! TriggerInitializationFailure(
+                config.triggerId,
+                config.jwt,
+                parent,
+                "User stopped")
+              // Tell our monitor there's been a failure. The
+              // monitor's supervisor strategy will respond to this
+              // writing the exception to the log and stopping this
+              // actor.
+              throw new InitializationException("User stopped")
             } else {
+              // The trigger is a future that we only expect to
+              // complete if something goes wrong.
               val (killSwitch, trigger) = runner.runWithACS(
                 acs,
                 offset,
@@ -83,9 +128,14 @@ object TriggerRunnerImpl {
               // is sent to a now terminated actor. We should fix this
               // somehow™.
               ctx.pipeToSelf(trigger) {
-                case Success(_) => Failed(new RuntimeException("Trigger exited unexpectedly"))
-                case Failure(cause) => Failed(cause)
+                case Success(_) =>
+                  Failed(new RuntimeException("Trigger exited unexpectedly"))
+                case Failure(cause) =>
+                  Failed(cause)
               }
+              // Report to the server that this trigger is entering
+              // the running state.
+              config.server ! TriggerStarted(config.triggerId, config.jwt, parent)
               running(killSwitch)
             }
           case Stop =>
@@ -94,28 +144,46 @@ object TriggerRunnerImpl {
             queryingACS(wasStopped = true)
         }
 
-      // Trigger loop is started, wait until we should stop.
+      // The trigger loop is running. The only thing to do now is wait
+      // to be told to stop or respond to failures.
       def running(killSwitch: KillSwitch) =
         Behaviors
           .receiveMessagePartial[Message] {
             case Stop =>
+              // Don't think about trying to send the server a message
+              // here. It won't receive it (I found out the hard way).
               Behaviors.stopped
             case Failed(cause) =>
-              // In the event 'runWithACS' completes it's because the
-              // stream is broken. Throw an exception allowing our
-              // supervisor to restart us.
+              // Report the failure to the server.
+              config.server ! TriggerRuntimeFailure(
+                config.triggerId,
+                config.jwt,
+                parent,
+                cause.toString)
+              // Tell our monitor there's been a failure. The
+              // monitor's supervisor strategy will respond to this by
+              // writing the exception to the log and attempting to
+              // restart this actor up to some number of times.
               throw new RuntimeException(cause)
           }
           .receiveSignal {
             case (_, PostStop) =>
+              // Don't think about trying to send the server a message
+              // here. It won't receive it (many Bothans died to bring
+              // us this information).
               ctx.log.info(s"Trigger ${name} is stopping")
               killSwitch.shutdown
               Behaviors.stopped
             case (_, PreRestart) =>
+              // No need to send any messages here. The server has
+              // already been informed of the earlier failure and in
+              // the process of being restarted, will be informed of
+              // the start along the way.
               ctx.log.info(s"Trigger ${name} is being restarted")
               Behaviors.same
           }
 
+      // The ACS query is a future.
       val acsQuery: Future[QueriedACS] = for {
         client <- LedgerClient
           .fromBuilder(
@@ -133,11 +201,13 @@ object TriggerRunnerImpl {
           config.party.unwrap)
         (acs, offset) <- runner.queryACS()
       } yield QueriedACS(runner, acs, offset)
-
+      // Arrange for the completion status to be piped into a message
+      // to this actor.
       ctx.pipeToSelf(acsQuery) {
         case Success(msg) => msg
         case Failure(cause) => QueryACSFailed(cause)
       }
+
       queryingACS(wasStopped = false)
     }
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -28,16 +28,19 @@ import com.daml.ledger.client.configuration.{
 import com.daml.jwt.domain.Jwt
 
 import java.util.UUID
+import java.time.Duration
 
 object TriggerRunnerImpl {
   case class Config(
       server: ActorRef[Server.Message],
-      triggerId: UUID, // trigger id
-      jwt: Jwt, // trigger token
+      triggerId: UUID,
+      jwt: Jwt,
       compiledPackages: CompiledPackages,
       trigger: Trigger,
       ledgerConfig: LedgerConfig,
       maxInboundMessageSize: Int,
+      maxFailureNumberOfRetries: Int,
+      failureRetryTimeRange: Duration,
       party: Party,
   )
 
@@ -183,7 +186,6 @@ object TriggerRunnerImpl {
               Behaviors.same
           }
 
-      // The ACS query is a future.
       val acsQuery: Future[QueriedACS] = for {
         client <- LedgerClient
           .fromBuilder(

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -191,13 +191,6 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
   }
 
   it should "start a trigger after uploading it" in withHttpService(None) { (uri: Uri, client) =>
-    def chk() = {
-      for {
-            resp <- listTriggers(uri, "Alice")
-            result <- parseTriggerIds(resp)
-          } yield result
-    }
-
     for {
       resp <- uploadDar(uri, darPath)
       JsObject(fields) <- parseResult(resp)
@@ -205,13 +198,15 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
       _ <- mainPackageId should not be empty
       resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Alice")
       triggerId <- parseTriggerId(resp)
-      _ <- Future { eventually {
+      _ <- Future {
+        eventually {
           val r = Await.result(for {
             resp <- listTriggers(uri, "Alice")
             result <- parseTriggerIds(resp)
           } yield result, Duration.Inf)
-          assert (r == Vector(triggerId))
-      }}
+          assert(r == Vector(triggerId))
+        }
+      }
       resp <- stopTrigger(uri, triggerId, "Alice")
       stoppedTriggerId <- parseTriggerId(resp)
       _ <- stoppedTriggerId should equal(triggerId)
@@ -227,59 +222,71 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
         // start trigger for Alice
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Alice")
         aliceTrigger <- parseTriggerId(resp)
-        _ <- Future { eventually {
-          val r = Await.result(for {
-            resp <- listTriggers(uri, "Alice")
-            result <- parseTriggerIds(resp)
-          } yield result, Duration.Inf)
-          assert (r == Vector(aliceTrigger))
-        }}
+        _ <- Future {
+          eventually {
+            val r = Await.result(for {
+              resp <- listTriggers(uri, "Alice")
+              result <- parseTriggerIds(resp)
+            } yield result, Duration.Inf)
+            assert(r == Vector(aliceTrigger))
+          }
+        }
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Bob")
         bobTrigger1 <- parseTriggerId(resp)
-        _ <- Future { eventually {
-          val r = Await.result(for {
-            resp <- listTriggers(uri, "Bob")
-            result <- parseTriggerIds(resp)
-          } yield result, Duration.Inf)
-          assert (r == Vector(bobTrigger1))
-        }}
+        _ <- Future {
+          eventually {
+            val r = Await.result(for {
+              resp <- listTriggers(uri, "Bob")
+              result <- parseTriggerIds(resp)
+            } yield result, Duration.Inf)
+            assert(r == Vector(bobTrigger1))
+          }
+        }
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Bob")
         bobTrigger2 <- parseTriggerId(resp)
-        _ <- Future { eventually {
-          val r = Await.result(for {
-            resp <- listTriggers(uri, "Bob")
-            result <- parseTriggerIds(resp)
-          } yield result, Duration.Inf)
-          assert (r == Vector(bobTrigger1, bobTrigger2))
-        }}
+        _ <- Future {
+          eventually {
+            val r = Await.result(for {
+              resp <- listTriggers(uri, "Bob")
+              result <- parseTriggerIds(resp)
+            } yield result, Duration.Inf)
+            assert(r == Vector(bobTrigger1, bobTrigger2))
+          }
+        }
         resp <- stopTrigger(uri, aliceTrigger, "Alice")
         _ <- assert(resp.status.isSuccess)
-        _ <- Future { eventually {
-          val r = Await.result(for {
-            resp <- listTriggers(uri, "Alice")
-            result <- parseTriggerIds(resp)
-          } yield result, Duration.Inf)
-          assert (r == Vector())
-        }}
-        _ <- Future { eventually {
-          val r = Await.result(for {
-            resp <- listTriggers(uri, "Bob")
-            result <- parseTriggerIds(resp)
-          } yield result, Duration.Inf)
-          assert (r == Vector(bobTrigger1, bobTrigger2))
-        }}
+        _ <- Future {
+          eventually {
+            val r = Await.result(for {
+              resp <- listTriggers(uri, "Alice")
+              result <- parseTriggerIds(resp)
+            } yield result, Duration.Inf)
+            assert(r == Vector())
+          }
+        }
+        _ <- Future {
+          eventually {
+            val r = Await.result(for {
+              resp <- listTriggers(uri, "Bob")
+              result <- parseTriggerIds(resp)
+            } yield result, Duration.Inf)
+            assert(r == Vector(bobTrigger1, bobTrigger2))
+          }
+        }
         // Stop Bob's triggers
         resp <- stopTrigger(uri, bobTrigger1, "Bob")
         _ <- assert(resp.status.isSuccess)
         resp <- stopTrigger(uri, bobTrigger2, "Bob")
         _ <- assert(resp.status.isSuccess)
-        _ <- Future { eventually {
-          val r = Await.result(for {
-            resp <- listTriggers(uri, "Bob")
-            result <- parseTriggerIds(resp)
-          } yield result, Duration.Inf)
-          assert (r == Vector())
-        }}
+        _ <- Future {
+          eventually {
+            val r = Await.result(for {
+              resp <- listTriggers(uri, "Bob")
+              result <- parseTriggerIds(resp)
+            } yield result, Duration.Inf)
+            assert(r == Vector())
+          }
+        }
       } yield succeed
   }
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -68,7 +68,10 @@ object TriggerServiceFixture {
         0,
         ledgerConfig,
         ServiceConfig.DefaultMaxInboundMessageSize,
-        dar)
+        ServiceConfig.DefaultMaxFailureNumberOfRetries,
+        ServiceConfig.DefaultFailureRetryTimeRange,
+        dar
+      )
     } yield service
 
     val fa: Future[A] = for {


### PR DESCRIPTION
The night is long and full of terrors. The focus of this PR is state management of the running trigger tables and error handling.

(1) The error handling strategy has been improved:
- Trigger initialization failures are now disambiguated from running trigger failures and handled separately;
- Trigger initialization failures result in the actor being stopped;
- Trigger runtime failures result in failing triggers being restarted up to some 3 times.

(2) A trigger runner/server protocol has been established so that runners can report status back to the server:
- This mechanism is used to keep the running trigger tables grounded in reality;
- In a follow up PR I believe it will be possible to keep a trigger status table that details the current status or indeed, history of a trigger ("starting", "running", "failed initialization", "failed at runtime", etc.)
