### PR TITLE
Improve CollectAuthority perf benchmark

### DIFF
--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -63,9 +63,7 @@ da_scala_benchmark_jmh(
         "//daml-lf/data",
         "//daml-lf/interpreter",
         "//daml-lf/language",
-        "//daml-lf/scenario-interpreter",
         "//daml-lf/transaction",
         "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:org_typelevel_paiges_core_2_12",
     ],
 )

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -7,23 +7,38 @@ package perf
 
 import com.daml.bazeltools.BazelRunfiles._
 import com.daml.lf.archive.{Decode, UniversalArchiveReader}
-import com.daml.lf.data._
-import com.daml.lf.data.Ref._
-import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.Pretty._
+import com.daml.lf.data.Ref.{Identifier, QualifiedName, Party}
+import com.daml.lf.data.Time
+import com.daml.lf.language.Ast.EVal
+import com.daml.lf.speedy.SResult._
+import com.daml.lf.transaction.Transaction.Value
+import com.daml.lf.types.Ledger
+import com.daml.lf.types.Ledger._
+import com.daml.lf.value.Value.{ContractId, ContractInst}
+import com.daml.lf.speedy.SExpr.{SEApp, SEValue}
+import com.daml.lf.speedy.Speedy.Machine
+
 import java.io.File
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 
+class CollectAuthority {
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  def bench(state: CollectAuthorityState): Unit = {
+    state.run()
+  }
+}
+
 @State(Scope.Benchmark)
 class CollectAuthorityState {
-  private var buildMachine: Expr => Speedy.Machine = null
-  private var expr: Expr = null
 
   @Param(Array("//daml-lf/scenario-interpreter/CollectAuthority.dar"))
   private var dar: String = _
   @Param(Array("CollectAuthority:test"))
   private var scenario: String = _
+
+  var machine: Machine = _
+  var the_sexpr: SExpr = _
 
   @Setup(Level.Trial)
   def init(): Unit = {
@@ -36,31 +51,97 @@ class CollectAuthorityState {
 
     // NOTE(MH): We use a static seed to get reproducible runs.
     val seeding = crypto.Hash.secureRandom(crypto.Hash.hashPrivateKey("scenario-perf"))
-    buildMachine = Speedy.Machine
-      .newBuilder(
-        PureCompiledPackages(packagesMap, stacktracing).right.get,
-        Time.Timestamp.MinValue,
-        seeding(),
-      )
-      .fold(err => sys.error(err.toString), identity)
-    expr = EVal(Identifier(packages.main._1, QualifiedName.assertFromString(scenario)))
-    // NOTE(MH): We run the machine once to initialize all data that is shared
-    // between runs.
-    val steps1 = run()
+    val compiledPackages = PureCompiledPackages(packagesMap, stacktracing).right.get
+    val compiler = compiledPackages.compiler
+    val expr = EVal(Identifier(packages.main._1, QualifiedName.assertFromString(scenario)))
+
+    // This is the expression which we insert into the machine each time we run()
+    the_sexpr = SEApp(compiler.unsafeCompile(expr), Array(SEValue.Token))
+
+    machine = Machine.fromSExpr(
+      sexpr = the_sexpr,
+      compiledPackages = compiledPackages,
+      submissionTime = Time.Timestamp.MinValue,
+      seeding = InitialSeeding.TransactionSeed(seeding()),
+      globalCids = Set.empty
+    )
+
+    // fill the caches!
+    setup()
   }
 
-  def run(): Int = {
-    val machine = buildMachine(expr)
-    ScenarioRunner(machine).run() match {
-      case Left((err, _)) => sys.error(prettyError(err, machine.ptx).render(80))
-      case Right((_, steps, _, _)) => steps
+  // Caches for Party creation & Ledger interaction performed during the setup run.
+  // The maps are indexed by step number.
+  private var cachedParty: Map[Int, Party] = Map()
+  private var cachedCommit: Map[Int, SValue] = Map()
+  private var cachedContract: Map[Int, ContractInst[Value[ContractId]]] = Map()
+
+  // This is function that we benchmark
+  def run(): Unit = {
+    machine.setExpressionToEvaluate(the_sexpr)
+    var step = 0
+    var finalValue: SValue = null
+    while (finalValue == null) {
+      step += 1
+      machine.run() match {
+        case SResultScenarioGetParty(_, callback) => callback(cachedParty(step))
+        case SResultScenarioCommit(_, _, _, callback) => callback(cachedCommit(step))
+        case SResultNeedContract(_, _, _, _, callback) => callback(cachedContract(step))
+        case SResultFinalValue(v) => finalValue = v
+        case r => crash("bench run: unexpected result from speedy")
+      }
     }
   }
-}
 
-class CollectAuthority {
-  @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def bench(state: CollectAuthorityState): Int = {
-    state.run()
+  // This is the initial setup run (not benchmarked), where we cache the results of
+  // interacting with the ledger, so they can be reused during the benchmark runs.
+
+  def setup(): Unit = {
+    var ledger: Ledger = Ledger.initialLedger(Time.Timestamp.Epoch)
+    var step = 0
+    var finalValue: SValue = null
+    while (finalValue == null) {
+      step += 1
+      machine.run() match {
+        case SResultScenarioGetParty(partyText, callback) =>
+          Party.fromString(partyText) match {
+            case Right(res) =>
+              cachedParty = cachedParty + (step -> res)
+              callback(res)
+            case Left(msg) =>
+              crash(s"Party.fromString failed: $msg")
+          }
+        case SResultScenarioCommit(value, tx, committers, callback) =>
+          Ledger.commitTransaction(
+            committers.head,
+            ledger.currentTime,
+            machine.commitLocation,
+            tx,
+            ledger
+          ) match {
+            case Left(fas) => crash(s"commitTransaction failed: $fas")
+            case Right(result) =>
+              ledger = result.newLedger
+              cachedCommit = cachedCommit + (step -> value)
+              callback(value)
+          }
+        case SResultNeedContract(acoid, _, committers, _, callback) =>
+          val effectiveAt = ledger.currentTime
+          ledger.lookupGlobalContract(ParticipantView(committers.head), effectiveAt, acoid) match {
+            case LookupOk(_, result) =>
+              cachedContract = cachedContract + (step -> result)
+              callback(result)
+            case x =>
+              crash(s"lookupGlobalContract failed: $x")
+          }
+        case SResultFinalValue(v) =>
+          finalValue = v
+        case r =>
+          crash("setup run: unexpected result from speedy")
+      }
+    }
   }
+
+  def crash(reason: String) =
+    throw new RuntimeException(s"CollectAuthority: $reason")
 }


### PR DESCRIPTION
The aim of the `CollectAuthority` benchmark is to track performance improvements made to the
DAML compiler & the speedy interpreter. Unfortunately the benchmark was spending at least
20% of the time being benchmarked outside of the speedy machine execution code, and
instead interacting with the ledger. We would like to minimize this as much as possible.

The solution is to cache the responses from the ledger made during the `setup()`, and
replay them during the benchmark `run()`s.  To perform the caching, we no longer make use
of the scenario-interpreter, but instead have our own simplified runner, specialized for
this benchmark, and managing the cache.

Using the cache speeds up the benchmark by a factor of about x1.25 (Which is the origin of
the claim above about 20% outside of speedy execution).

    Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
      95.188 ±(99.9%) 0.410 ms/op [Average]
      (min, avg, max) = (94.177, 95.188, 95.890), stdev = 0.472
      CI (99.9%): [94.779, 95.598] (assumes normal distribution)

    Result "com.daml.lf.speedy.perf.CollectAuthority.bench":
      75.881 ±(99.9%) 0.288 ms/op [Average]
      (min, avg, max) = (75.077, 75.881, 76.491), stdev = 0.332
      CI (99.9%): [75.593, 76.169] (assumes normal distribution)

Because of how we run perf benchmark on CI -- by running the benchmark for now vs. some
fixed time in the past -- it ought to be fine to change the benchmark like this, although
we might need some help from Gary!

As well as improving the focus of this benchmark going forwards, we should also gain a
retrospective improvement on the speedup work already committed, since they will no longer
we dragged down by time which is outside of our control.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
