### PR TITLE
Trigger service: create role for service in database initialization

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -94,9 +94,7 @@ object DbUser {
     "Contains comma-separated key-value pairs. Where:\n" +
       s"${indent}user -- user name for database user to create with permissions to read and write tables,\n" +
       s"${indent}password -- password of database user to be created,\n" +
-      s"${indent}Example: " + helpString(
-      "service",
-      "servicepass")
+      s"${indent}Example: " + helpString("service", "servicepass")
 
   private def helpString(user: String, password: String): String =
     s"""\"user=$user,password=$password\""""
@@ -150,8 +148,7 @@ object ServiceConfig {
       .text("TTL in seconds used for commands emitted by the trigger. Defaults to 30s.")
 
     opt[Map[String, String]]("jdbc")
-      .action((x, c) =>
-        c.copy(jdbcConfig = Some(JdbcConfig.create(x).fold(sys.error, identity))))
+      .action((x, c) => c.copy(jdbcConfig = Some(JdbcConfig.create(x).fold(sys.error, identity))))
       .optional()
       .valueName(JdbcConfig.usage)
       .text("JDBC configuration parameters. If omitted the service runs without a database.")
@@ -161,7 +158,8 @@ object ServiceConfig {
       .text("Initialize database and terminate.")
       .children(
         opt[Map[String, String]]("service-db-user")
-          .action((x, c) => c.copy(serviceDbUser = Some(DbUser.create(x).fold(sys.error, identity))))
+          .action(
+            (x, c) => c.copy(serviceDbUser = Some(DbUser.create(x).fold(sys.error, identity))))
           .valueName(DbUser.usage)
           .text("Database user to be created with permissions to read and write to tables.")
       )

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
@@ -55,7 +55,19 @@ object TriggerDao {
           package bytea not null
         )
       """
+    val createServiceRole: Fragment = sql"""
+        create role service login password 'servicepass'
+      """
+    val grantRunningTriggersAccess: Fragment = sql"""
+        grant select, insert, delete on table running_triggers to service
+      """
+    val grantDalfAccess: Fragment = sql"""
+        grant select, insert on table dalfs to service
+      """
     (createTriggerTable.update.run
-      *> createDalfTable.update.run).void
+      *> createDalfTable.update.run
+      *> createServiceRole.update.run
+      *> grantRunningTriggersAccess.update.run
+      *> grantDalfAccess.update.run).void
   }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -169,8 +169,9 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
   it should "initialize database" in {
     connectToPostgresqlServer()
     createNewDatabase()
-    val testJdbcConfig = JdbcConfig(postgresDatabase.url, "operator", "password")
-    assert(ServiceMain.initDatabase(testJdbcConfig).isRight)
+    val jdbcConfig = JdbcConfig(postgresDatabase.url, "operator", "operatorpass")
+    val serviceUser = DbUser(user = "service", password = "servicepass")
+    assert(ServiceMain.initDatabase(jdbcConfig, serviceUser).isRight)
     dropDatabase()
     succeed
   }


### PR DESCRIPTION
In database initialization, the client passes in the username and password of a role they'd like to create for the trigger service. The new role is granted appropriate read and write permissions to the two tables. This would then be used in subsequent runs of the service (after initialization). This way, the client does not need to know details of the database tables we use and permission a user for the service themselves. They also don't need to resort to using the same role used for initialization (the "operator"), which has very liberal permissions.

Looking for feedback on the approach. This is still a draft as the username and password strings need to be validated, and it's not rigorously tested. To test this properly we'd need to connect to the database as the service user, which I think we may as well do by implementing connection to the database during regular service execution.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
