### PR TITLE
Speed-up create-daml-app compat tests

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -3,7 +3,7 @@
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@os_info//:os_info.bzl", "is_windows")
-load("//bazel_tools:testing.bzl", "sdk_platform_test")
+load("//bazel_tools:testing.bzl", "create_daml_app_codegen", "create_daml_app_dar", "sdk_platform_test")
 load(
     "//bazel_tools/daml_script:daml_script.bzl",
     "daml_script_dar",
@@ -11,6 +11,7 @@ load(
 )
 load("//sandbox-migration:util.bzl", "migration_test")
 load("//:versions.bzl", "platform_versions", "sdk_versions", "stable_versions")
+load("@daml//bazel_tools:haskell.bzl", "da_haskell_binary")
 
 config_setting(
     name = "ghci_data",
@@ -30,6 +31,14 @@ config_setting(
         deps = ["@bazel_tools//tools/bash/runfiles"],
     )
     for version in platform_versions
+]
+
+[
+    [
+        create_daml_app_dar(sdk_version),
+        create_daml_app_codegen(sdk_version),
+    ]
+    for sdk_version in sdk_versions
 ]
 
 [

--- a/compatibility/bazel_tools/create-daml-app/BUILD.bazel
+++ b/compatibility/bazel_tools/create-daml-app/BUILD.bazel
@@ -37,6 +37,25 @@ da_haskell_binary(
     ],
 )
 
+da_haskell_binary(
+    name = "run-with-yarn",
+    srcs = ["RunWithYarn.hs"],
+    data = [
+        "@nodejs//:yarn",
+    ],
+    hackage_deps = [
+        "base",
+        "directory",
+        "filepath",
+        "extra",
+        "process",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@rules_haskell//tools/runfiles",
+    ],
+)
+
 exports_files(
     [
         "testDeps.json",

--- a/compatibility/bazel_tools/create-daml-app/RunWithYarn.hs
+++ b/compatibility/bazel_tools/create-daml-app/RunWithYarn.hs
@@ -1,0 +1,44 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main (main) where
+
+import Data.List
+import System.Environment.Blank
+import System.FilePath
+import System.Info.Extra
+import System.IO.Extra
+import System.Process
+import qualified Bazel.Runfiles
+
+main :: IO ()
+main = withTempDir $ \yarnCache -> do
+    setEnv "YARN_CACHE_FOLDER" yarnCache True
+    (dir : args) <- getArgs
+    runfiles <- Bazel.Runfiles.create
+    let yarn | isWindows = Bazel.Runfiles.rlocation runfiles $ "nodejs_windows_amd64" </> "bin" </> "yarn.cmd"
+          | isMac = Bazel.Runfiles.rlocation runfiles $ "nodejs_darwin_amd64" </> "bin" </> "yarn"
+          | otherwise = Bazel.Runfiles.rlocation runfiles $ "nodejs_linux_amd64" </> "bin" </> "yarn"
+    sp <- getSearchPath
+    -- For reasons unbeknown to me setting PATH in the Bash script results in
+    -- yarn pointing to hash/execroot/compatibility/external/nodejs_windows_amd64/bin/yarn.cmd.
+    -- While this file exists just fine, this results in the error
+    -- `The system cannot find the path specified.` for reasons nobody understands.
+    -- Adding it to the runfiles of this binary and locating it here
+    -- points to hash/external/nodejs_windows_amd64/bin/yarn.cmd.
+    -- This works just fine.
+    setEnv "PATH" (intercalate [searchPathSeparator] (takeDirectory yarn : sp)) True
+    -- We write out the yarn workspace file here since it makes it much easier to
+    -- get the paths right on Windows.
+    writeFileUTF8 (dir </> "package.json") $ unlines
+      [ "{"
+      , "  \"private\": true,"
+      , "  \"workspaces\": [\"daml.js\"],"
+      , "  \"resolutions\": {"
+      , "     \"@daml/types\": " <> show ("file:" <> dir  </> "daml-types") <> ","
+      , "     \"@daml/ledger\": " <> show ("file:" <> dir  </> "daml-ledger")
+      , "  }"
+      , "}"
+      ]
+    callCommand (unwords args)
+

--- a/compatibility/bazel_tools/create-daml-app/index.test.ts
+++ b/compatibility/bazel_tools/create-daml-app/index.test.ts
@@ -23,7 +23,7 @@ import { User } from "@daml.js/create-daml-app";
 import { computeCredentials } from "./Credentials";
 import semver from "semver";
 
-const DAR_PATH = ".daml/dist/create-daml-app-0.1.0.dar";
+const DAR_PATH = process.env.DAR_PATH;
 const SANDBOX_LEDGER_ID = "create-daml-app-sandbox";
 const SANDBOX_PORT_FILE_NAME = "sandbox.port";
 const JSON_API_PORT_FILE_NAME = "json-api.port";
@@ -140,7 +140,7 @@ beforeAll(async () => {
   const extraJsonApiOptions = semver.gte(
     process.env.JSON_API_VERSION,
     "1.1.0-snapshot.20200430.4057.0.681c862d"
-  )
+  ) || process.env.JSON_API_VERSION === "0.0.0"
     ? ["--allow-insecure-tokens"]
     : [];
   jsonApi = spawn(

--- a/compatibility/bazel_tools/create_daml_app_test.sh
+++ b/compatibility/bazel_tools/create_daml_app_test.sh
@@ -13,6 +13,12 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 # --- end runfiles.bash initialization v2 ---
 set -euo pipefail
 
+canonicalize_rlocation() {
+    # Bazel will add a . at the beginning of locations in the root package
+    # which breaks rlocation.
+    rlocation $(realpath -L -s -m --relative-to=$PWD $TEST_WORKSPACE/$1)
+}
+
 RUNNER="$(rlocation "$TEST_WORKSPACE/$1")"
 DAML="$(rlocation "$TEST_WORKSPACE/$2")"
 # These things are only used in the jest tests so rather
@@ -26,12 +32,12 @@ DAML_TYPES="$(rlocation "$TEST_WORKSPACE/$7")"
 DAML_LEDGER="$(rlocation "$TEST_WORKSPACE/$8")"
 DAML_REACT="$(rlocation "$TEST_WORKSPACE/$9")"
 MESSAGING_PATCH="$(rlocation "$TEST_WORKSPACE/${10}")"
-# Adding yarn to path here seems tempting but ends up in a mess
-# due to unix/windows paths so we only do that in the Haskell code.
 YARN="$(rlocation "$TEST_WORKSPACE/${11}")"
 PATCH="$(rlocation "$TEST_WORKSPACE/${12}")"
 TEST_DEPS="$(rlocation "$TEST_WORKSPACE/${13}")"
 TEST_TS="$(rlocation "$TEST_WORKSPACE/${14}")"
+CODEGEN_OUTPUT="$(canonicalize_rlocation "${15}")"
+export DAR_PATH="$(canonicalize_rlocation "${16}")"
 
 "$RUNNER" \
   --daml "$DAML" \
@@ -43,3 +49,4 @@ TEST_TS="$(rlocation "$TEST_WORKSPACE/${14}")"
   --patch "$PATCH" \
   --test-deps "$TEST_DEPS" \
   --test-ts "$TEST_TS" \
+  --codegen "$CODEGEN_OUTPUT" \


### PR DESCRIPTION
Previously we ran `daml codegen js` and `daml build` in the tests and
we also ran it twice. While this makes sense for the SDK integration
tests, it doesn’t really make sense for the compatibility tests. These
are SDK-only features so they don’t actually test compatibility. These
steps are super slow and running them in the tests also means that we
run them a quadratic number of times.

This PR moves the `daml build` and the `daml codegen js` step to
separate genrules. In the actual test, the only expensive steps are to
run `yarn install` and the actual jest tests. In principle, we could
probably try to factor out the `yarn install` step as well but I’m a
bit scared of coyping around node_modules so I’ll not attempt to do
that for now.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
