### PR TITLE
Add the stdlib anchor table as a bazel target.

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -258,6 +258,7 @@ genrule(
         ":daml-base-rst-template",
     ],
     outs = [
+        "daml-base-anchors.json",
         "daml-base-rst.tar.gz",
         "daml-base-hoogle.txt",
     ],
@@ -273,6 +274,7 @@ genrule(
             --hoogle-template=$(location :daml-base-hoogle-template) \
             --base-url=https://docs.daml.com/daml/stdlib \
             --output-hoogle=$(location :daml-base-hoogle.txt) \
+            --output-anchor=$(location :daml-base-anchors.json) \
             $(location :daml-stdlib.json) $(location :daml-prim.json)
         tar c daml-base-rst \
             --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \


### PR DESCRIPTION
This PR adds a new bazel target `//compiler/damlc:daml-base-anchors.json` which is the anchor table for the standard library generated by damldocs.

Part of #6039

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
