### PR TITLE
fix fatjar versions

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -92,6 +92,8 @@ steps:
       bazel build //ledger-service/http-json:http-json-binary_deploy.jar
       cp bazel-bin/ledger-service/http-json/http-json-binary_deploy.jar $(Build.StagingDirectory)/$JSON_API
       echo "##vso[task.setvariable variable=json-api;isOutput=true]$JSON_API"
+    env:
+      DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
     name: publish
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),


### PR DESCRIPTION
Version is taken from the env var (or defaulted to 0.0.0) at build-time. Since those two packages are not build by default by Bazel, we need to add the env var to the Bash step where they do get explicitly built.

Fixes #6090.

CHANGELOG_BEGIN
- sandbox and http-api fatjars will now display correct version number.
CHANGELOG_END