### PR TITLE
Support version ranges in test tool exclusions

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -6,7 +6,7 @@ load(
     "client_server_test",
 )
 load("@os_info//:os_info.bzl", "is_windows")
-load("//bazel_tools:versions.bzl", "version_to_name")
+load("//bazel_tools:versions.bzl", "cmp_version", "version_to_name")
 load("//:versions.bzl", "latest_stable_version")
 
 # Indexed first by test tool version and then by sandbox version.
@@ -14,269 +14,166 @@ load("//:versions.bzl", "latest_stable_version")
 # is sadly quite coarse. See
 # https://discuss.daml.com/t/can-i-disable-individual-tests-in-the-ledger-api-test-tool/226
 # for details.
+# PRs that resulted in exclusions:
+# - ContractKeysIT:
+#   - https://github.com/digital-asset/daml/pull/5608
+# - ContractKeysSubmitterIsMaintainerIT:
+#   - https://github.com/digital-asset/daml/pull/5611
 excluded_test_tool_tests = {
-    "1.0.0": {
-        "1.1.0-snapshot.20200430.4057.0.681c862d": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200506.4107.0.7e448d81": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "0.0.0": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1-snapshot.20200424.3917.0.16093690": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.1": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.2.0-snapshot.20200513.4172.0.021f4af3": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-    },
-    "1.0.1-snapshot.20200417.3908.1.722bac90": {
-        "0.0.0": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1-snapshot.20200424.3917.0.16093690": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200430.4057.0.681c862d": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200506.4107.0.7e448d81": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.1": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.2.0-snapshot.20200513.4172.0.021f4af3": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-    },
-    "1.0.1-snapshot.20200424.3917.0.16093690": {
-        "1.0.0": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1-snapshot.20200417.3908.1.722bac90": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200422.3991.0.6391ee9f": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200430.4057.0.681c862d": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-        "1.1.0-snapshot.20200506.4107.0.7e448d81": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-        "1.1.1": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-        "1.2.0-snapshot.20200513.4172.0.021f4af3": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-        "0.0.0": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-    },
-    "1.0.1": {
-        "1.0.0": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1-snapshot.20200417.3908.1.722bac90": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200422.3991.0.6391ee9f": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200430.4057.0.681c862d": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-        "1.1.0-snapshot.20200506.4107.0.7e448d81": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-        "1.1.1": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-        "1.2.0-snapshot.20200513.4172.0.021f4af3": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-        "0.0.0": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-        ],
-    },
-    "1.1.0-snapshot.20200422.3991.0.6391ee9f": {
-        "1.0.1-snapshot.20200424.3917.0.16093690": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200430.4057.0.681c862d": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200506.4107.0.7e448d81": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.1": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.2.0-snapshot.20200513.4172.0.021f4af3": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "0.0.0": [
-            # This restriction has been removed in https://github.com/digital-asset/daml/pull/5611.
-            "ContractKeysSubmitterIsMaintainerIT",
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-    },
-    "1.1.0-snapshot.20200430.4057.0.681c862d": {
-        "1.0.0": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1-snapshot.20200417.3908.1.722bac90": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200422.3991.0.6391ee9f": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-    },
-    "1.1.0-snapshot.20200506.4107.0.7e448d81": {
-        "1.0.0": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1-snapshot.20200417.3908.1.722bac90": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200422.3991.0.6391ee9f": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-    },
-    "1.1.1": {
-        "1.0.0": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1-snapshot.20200417.3908.1.722bac90": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200422.3991.0.6391ee9f": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-    },
-    "1.2.0-snapshot.20200513.4172.0.021f4af3": {
-        "1.0.0": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1-snapshot.20200417.3908.1.722bac90": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200422.3991.0.6391ee9f": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-    },
-    "0.0.0": {
-        "1.0.0": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.0.1-snapshot.20200417.3908.1.722bac90": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-        "1.1.0-snapshot.20200422.3991.0.6391ee9f": [
-            # Fix for https://github.com/digital-asset/daml/issues/5562
-            "ContractKeysIT",
-        ],
-    },
+    "1.0.0": [
+        {
+            "start": "1.0.1-snapshot.20200424.3917.0.16093690",
+            "end": "1.0.1",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200430.4057.0.681c862d",
+            "exclusions": ["ContractKeysIT", "ContractKeysSubmitterIsMaintainerIT"],
+        },
+    ],
+    "1.0.1-snapshot.20200417.3908.1.722bac90": [
+        {
+            "start": "1.0.1-snapshot.20200424.3917.0.16093690",
+            "end": "1.0.1",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200430.4057.0.681c862d",
+            "exclusions": ["ContractKeysIT", "ContractKeysSubmitterIsMaintainerIT"],
+        },
+    ],
+    "1.0.1-snapshot.20200424.3917.0.16093690": [
+        {
+            "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "end": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200430.4057.0.681c862d",
+            "exclusions": ["ContractKeysSubmitterIsMaintainerIT"],
+        },
+    ],
+    "1.0.1": [
+        {
+            "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "end": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200430.4057.0.681c862d",
+            "exclusions": ["ContractKeysSubmitterIsMaintainerIT"],
+        },
+    ],
+    "1.1.0-snapshot.20200422.3991.0.6391ee9f": [
+        {
+            "start": "1.0.1-snapshot.20200424.3917.0.16093690",
+            "end": "1.0.1",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200430.4057.0.681c862d",
+            "exclusions": ["ContractKeysIT", "ContractKeysSubmitterIsMaintainerIT"],
+        },
+    ],
+    "1.1.0-snapshot.20200430.4057.0.681c862d": [
+        {
+            "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "end": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "exclusions": ["ContractKeysIT"],
+        },
+    ],
+    "1.1.0-snapshot.20200506.4107.0.7e448d81": [
+        {
+            "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "end": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "exclusions": ["ContractKeysIT"],
+        },
+    ],
+    "1.1.1": [
+        {
+            "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "end": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "exclusions": ["ContractKeysIT"],
+        },
+    ],
+    "1.2.0-snapshot.20200513.4172.0.021f4af3": [
+        {
+            "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "end": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "exclusions": ["ContractKeysIT"],
+        },
+    ],
+    "1.2.0-snapshot.20200520.4224.0.2af134ca": [
+        {
+            "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "end": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "exclusions": ["ContractKeysIT"],
+        },
+    ],
+    "1.2.0-snapshot.20200520.4228.0.595f1e27": [
+        {
+            "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "end": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "exclusions": ["ContractKeysIT"],
+        },
+    ],
+    "0.0.0": [
+        {
+            "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
+            "exclusions": ["ContractKeysIT"],
+        },
+        {
+            "start": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "end": "1.1.0-snapshot.20200422.3991.0.6391ee9f",
+            "exclusions": ["ContractKeysIT"],
+        },
+    ],
 }
 
 def get_excluded_tests(test_tool_version, sandbox_version):
-    return excluded_test_tool_tests.get(test_tool_version, default = {}).get(sandbox_version, default = [])
+    exclusion_ranges = excluded_test_tool_tests.get(test_tool_version, default = [])
+    exclusions = []
+    for range in exclusion_ranges:
+        start = range.get("start")
+        end = range.get("end")
+        if start and sandbox_version != "0.0.0" and cmp_version(sandbox_version, start) < 0:
+            continue
+        if end and (cmp_version(sandbox_version, end) > 0 or sandbox_version == "0.0.0"):
+            continue
+        exclusions += range["exclusions"]
+    return exclusions
 
 def extra_tags(sdk_version, platform_version):
     if sorted([sdk_version, platform_version]) == sorted(["0.0.0", latest_stable_version]):

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -6,7 +6,7 @@ load(
     "client_server_test",
 )
 load("@os_info//:os_info.bzl", "is_windows")
-load("//bazel_tools:versions.bzl", "versions", "version_to_name")
+load("//bazel_tools:versions.bzl", "version_to_name", "versions")
 load("//:versions.bzl", "latest_stable_version")
 
 # Indexed first by test tool version and then a list of ranges

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -6,10 +6,11 @@ load(
     "client_server_test",
 )
 load("@os_info//:os_info.bzl", "is_windows")
-load("//bazel_tools:versions.bzl", "cmp_version", "version_to_name")
+load("//bazel_tools:versions.bzl", "versions", "version_to_name")
 load("//:versions.bzl", "latest_stable_version")
 
-# Indexed first by test tool version and then by sandbox version.
+# Indexed first by test tool version and then a list of ranges
+# of sandbox versions and their corresponding exclusions.
 # Note that at this point the granularity for disabling tests
 # is sadly quite coarse. See
 # https://discuss.daml.com/t/can-i-disable-individual-tests-in-the-ledger-api-test-tool/226
@@ -168,9 +169,9 @@ def get_excluded_tests(test_tool_version, sandbox_version):
     for range in exclusion_ranges:
         start = range.get("start")
         end = range.get("end")
-        if start and sandbox_version != "0.0.0" and cmp_version(sandbox_version, start) < 0:
+        if start and not versions.is_at_least(sandbox_version, start):
             continue
-        if end and (cmp_version(sandbox_version, end) > 0 or sandbox_version == "0.0.0"):
+        if end and not versions.is_at_most(sandbox_version, end):
             continue
         exclusions += range["exclusions"]
     return exclusions

--- a/compatibility/bazel_tools/versions.bzl
+++ b/compatibility/bazel_tools/versions.bzl
@@ -96,12 +96,12 @@ def _cmp_version(version1, version2):
     """
 
     # Handle special-cases for 0.0.0 which is always the latest.
-    if version1 == '0.0.0' and version2 == '0.0.0':
-      return 0
-    elif version1 == '0.0.0':
-      return 1
-    elif version2 == '0.0.0':
-      return -1
+    if version1 == "0.0.0" and version2 == "0.0.0":
+        return 0
+    elif version1 == "0.0.0":
+        return 1
+    elif version2 == "0.0.0":
+        return -1
 
     # No version is 0.0.0 so use a proper semver comparison.
     # Note that the comparisons in skylib ignore the prerelease
@@ -134,10 +134,10 @@ def _cmp_version(version1, version2):
         return _cmp(len(a), len(b))
 
 def _is_at_least(version1, version2):
-  return _cmp_version(version1, version2) >= 0
+    return _cmp_version(version1, version2) >= 0
 
 def _is_at_most(version1, version2):
-  return _cmp_version(version1, version2) <= 0
+    return _cmp_version(version1, version2) <= 0
 
 versions = struct(
     is_at_most = _is_at_most,

--- a/compatibility/bazel_tools/versions.bzl
+++ b/compatibility/bazel_tools/versions.bzl
@@ -90,10 +90,23 @@ def _cmp_prerelease_part(part1, part2):
     else:
         return _cmp(part1, part2)
 
-def cmp_version(version1, version2):
+def _cmp_version(version1, version2):
     """Semver comparison of version1 and version2.
     Returns 1 if version1 > version2, 0 if version1 == version2 and -1 if version1 < version2.
     """
+
+    # Handle special-cases for 0.0.0 which is always the latest.
+    if version1 == '0.0.0' and version2 == '0.0.0':
+      return 0
+    elif version1 == '0.0.0':
+      return 1
+    elif version2 == '0.0.0':
+      return -1
+
+    # No version is 0.0.0 so use a proper semver comparison.
+    # Note that the comparisons in skylib ignore the prerelease
+    # so they aren’t suitable if we have one.
+
     (core1, prerelease1, _) = _semver_components(version1)
     (core2, prerelease2, _) = _semver_components(version2)
     core1_parsed = _bazel_versions.parse(core1)
@@ -119,3 +132,14 @@ def cmp_version(version1, version2):
             if cmp_result != 0:
                 return cmp_result
         return _cmp(len(a), len(b))
+
+def _is_at_least(version1, version2):
+  return _cmp_version(version1, version2) >= 0
+
+def _is_at_most(version1, version2):
+  return _cmp_version(version1, version2) <= 0
+
+versions = struct(
+    is_at_most = _is_at_most,
+    is_at_least = _is_at_least,
+)

--- a/compatibility/bazel_tools/versions.bzl
+++ b/compatibility/bazel_tools/versions.bzl
@@ -71,3 +71,51 @@ def version_to_name(version):
         name = version
 
     return name
+
+def _cmp(a, b):
+    if a == b:
+        return 0
+    elif a > b:
+        return 1
+    else:
+        return -1
+
+def _cmp_prerelease_part(part1, part2):
+    if part1.isdigit() and part2.isdigit():
+        return _cmp(int(part1), int(part2))
+    elif part1.isdigit():
+        return False
+    elif part2.isdigit():
+        return True
+    else:
+        return _cmp(part1, part2)
+
+def cmp_version(version1, version2):
+    """Semver comparison of version1 and version2.
+    Returns 1 if version1 > version2, 0 if version1 == version2 and -1 if version1 < version2.
+    """
+    (core1, prerelease1, _) = _semver_components(version1)
+    (core2, prerelease2, _) = _semver_components(version2)
+    core1_parsed = _bazel_versions.parse(core1)
+    core2_parsed = _bazel_versions.parse(core2)
+
+    # First compare (major, minor, patch) triples
+    if core1_parsed > core2_parsed:
+        return 1
+    elif core1_parsed < core2_parsed:
+        return -1
+    elif not prerelease1 and not prerelease2:
+        return 0
+    elif not prerelease1:
+        return 1
+    elif not prerelease2:
+        return -1
+    else:
+        # Finally compare the prerelease.
+        parts1 = prerelease1.split(".")
+        parts2 = prerelease2.split(".")
+        for a, b in zip(parts1, parts2):
+            cmp_result = _cmp_prerelease_part(a, b)
+            if cmp_result != 0:
+                return cmp_result
+        return _cmp(len(a), len(b))

--- a/compatibility/versions.bzl
+++ b/compatibility/versions.bzl
@@ -12,6 +12,8 @@ sdk_versions = [
     "1.1.0-snapshot.20200506.4107.0.7e448d81",
     "1.1.1",
     "1.2.0-snapshot.20200513.4172.0.021f4af3",
+    "1.2.0-snapshot.20200520.4224.0.2af134ca",
+    "1.2.0-snapshot.20200520.4228.0.595f1e27",
     "0.0.0",
 ]
 platform_versions = [
@@ -24,6 +26,8 @@ platform_versions = [
     "1.1.0-snapshot.20200506.4107.0.7e448d81",
     "1.1.1",
     "1.2.0-snapshot.20200513.4172.0.021f4af3",
+    "1.2.0-snapshot.20200520.4224.0.2af134ca",
+    "1.2.0-snapshot.20200520.4228.0.595f1e27",
     "0.0.0",
 ]
 stable_versions = [
@@ -118,6 +122,26 @@ version_sha256s = {
         "daml_types": "5bc76ae50297af0587ec26d380bed46fd9ba90316000bdb7d0907c0db60171e5",
         "daml_ledger": "6ca843d878a510910f4be34c61e0ad0b8f7a6d4646175334caecdda4f5a297d7",
         "daml_react": "0fc2cd41c8f0205f07e18e066a2d7f89cbcb03ef46825f241e2ec1efa6cd0778",
+        "create_daml_app_patch": "b187d446443209288c165cf34247307275b497e015a5d953805297c05279d856",
+    },
+    "1.2.0-snapshot.20200520.4224.0.2af134ca": {
+        "linux": "611a14502dc9db690310b13b282dc869bb6b4926954715e990e797fe99747586",
+        "macos": "e5f23672acb0bc8347e27b79b573b4b12c5eebd575b7b5ed83b7ee47247cc717",
+        "windows": "6a87a34e76add64caab98422d16fb229a6f34aa3c9b460893148e0498ebe6792",
+        "test_tool": "672848dbee588c9086c5cd7320bfd03bdc95233a49a97d198f1b863cb8bf7100",
+        "daml_types": "96baeea080cee765bedab95245fec39f8570e6e5c390cd2c3907f2ecf1b0d6b3",
+        "daml_ledger": "5a3c85c50af261664dfc12f706b93c3fec4e73450811a4432abe438b362cdd4e",
+        "daml_react": "b03a91cb4d9302adde0bd941fb8b107462eb9aa5c9f1a87ca71e8243542d5af8",
+        "create_daml_app_patch": "b187d446443209288c165cf34247307275b497e015a5d953805297c05279d856",
+    },
+    "1.2.0-snapshot.20200520.4228.0.595f1e27": {
+        "linux": "8c8e423608a341ee98e40c2f7c7b129ae4674e93fe8b74bf476180444ac9bd6f",
+        "macos": "6c621bc1dd9fbffa073118c0a255f7c9f2cabc06e5f9c281bb07b216c866c13c",
+        "windows": "6aaebe7a12013391dc784d9cbcacb554fb998cf0c078ca18bb4059ff3358b87c",
+        "test_tool": "30b8d46b1e05000c169cd63c2e6002d129ca78e0648e0d2cb4c15ef6cafb406b",
+        "daml_types": "62c1a8bd81a751ce5c6b7fcd30b61fcf01c8fe27929172f0d939431f14ff371f",
+        "daml_ledger": "181b4a763c35da8e7241e36ace05f9b37fe48f88b570e645bbe2dab7cf6c0a63",
+        "daml_react": "029895aee31e4af3d995471af52466879163786659b20852bbb145d7a4063a13",
         "create_daml_app_patch": "b187d446443209288c165cf34247307275b497e015a5d953805297c05279d856",
     },
 }


### PR DESCRIPTION
This cleans up the map of exclusions for the ledger-api-test-tool part
of the compat tests. For now, you can only use ranges for the inner
map. In principle we could also add it to the outer map but I’ll leave
that for a separate PR.

I’ve also run the script to update versions so this includes the
latest two snapshots.

fixes #5851

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
