### PR TITLE
remove envsubst from dev-env

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ export POSTGRESQL_PASSWORD=''
 function start_postgresql() {
   mkdir -p "$POSTGRESQL_DATA_DIR"
   bazel run -- @postgresql_dev_env//:initdb --auth=trust --encoding=UNICODE --locale=en_US.UTF-8 --username="$POSTGRESQL_USERNAME" "$POSTGRESQL_DATA_DIR"
-  envsubst -no-unset -i ci/postgresql.conf -o "$POSTGRESQL_DATA_DIR/postgresql.conf"
+  eval "echo \"$(cat ci/postgresql.conf)\"" > "$POSTGRESQL_DATA_DIR/postgresql.conf"
   bazel run -- @postgresql_dev_env//:pg_ctl -w --pgdata="$POSTGRESQL_DATA_DIR" --log="$POSTGRESQL_LOG_FILE" start || {
     if [[ -f "$POSTGRESQL_LOG_FILE" ]]; then
       echo >&2 'PostgreSQL logs:'

--- a/dev-env/bin/envsubst
+++ b/dev-env/bin/envsubst
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-bin-tool

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -203,7 +203,6 @@ in rec {
     xmlstarlet = pkgs.xmlstarlet;
     grep = pkgs.gnugrep;
     bc = pkgs.bc;
-    envsubst = pkgs.envsubst;
 
     # Cryptography tooling
     gnupg = pkgs.gnupg;


### PR DESCRIPTION
It should not be an issue, but I know of at least 4 people for whom having envsubst in dev-env causes their local git to get confused and spit out many lines of warning on each invocation. This also seems to make git much slower.

Given that we're only using envsubst in this one place, I think it may be worth replacing.

CHANGELOG_BEGIN
CHANGELOG_END