### PR TITLE
Special case atomic expressions in the functional-position of application

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -17,7 +17,8 @@ object Classify { // classify the machine state w.r.t what step occurs next
       var evarS: Int = 0,
       var evarA: Int = 0,
       var evarF: Int = 0,
-      var eapp: Int = 0,
+      var eappE: Int = 0,
+      var eappA: Int = 0,
       var eclose: Int = 0,
       var ebuiltin: Int = 0,
       var eval: Int = 0,
@@ -48,7 +49,8 @@ object Classify { // classify the machine state w.r.t what step occurs next
         ("- evarS", evarS),
         ("- evarA", evarA),
         ("- evarF", evarF),
-        ("- eapp", eapp),
+        ("- eappE", eappE),
+        ("- eappA", eappA),
         ("- eclose", eclose),
         ("- ebuiltin", ebuiltin),
         ("- eval", eval),
@@ -93,7 +95,8 @@ object Classify { // classify the machine state w.r.t what step occurs next
       case _: SELocS => counts.evarS += 1
       case _: SELocA => counts.evarA += 1
       case _: SELocF => counts.evarF += 1
-      case _: SEApp => counts.eapp += 1
+      case _: SEAppE => counts.eappE += 1
+      case _: SEAppA => counts.eappA += 1
       case _: SEMakeClo => counts.eclose += 1
       case _: SEBuiltin => counts.ebuiltin += 1
       case _: SEVal => counts.eval += 1

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -1045,7 +1045,12 @@ private[lf] final case class Compiler(
       case x: SEMakeClo =>
         throw CompilationError(s"closureConvert: unexpected SEMakeClo: $x")
 
-      case SEApp(fun, args) =>
+      case SEAppE(fun, args) =>
+        val newFun = closureConvert(remaps, fun)
+        val newArgs = args.map(closureConvert(remaps, _))
+        SEApp(newFun, newArgs)
+
+      case SEAppA(fun, args) =>
         val newFun = closureConvert(remaps, fun)
         val newArgs = args.map(closureConvert(remaps, _))
         SEApp(newFun, newArgs)
@@ -1128,7 +1133,10 @@ private[lf] final case class Compiler(
         case _: SEBuiltinRecursiveDefinition => ()
         case SELocation(_, body) =>
           go(body)
-        case SEApp(fun, args) =>
+        case SEAppE(fun, args) =>
+          go(fun)
+          args.foreach(go)
+        case SEAppA(fun, args) =>
           go(fun)
           args.foreach(go)
         case SEAbs(n, body) =>
@@ -1214,7 +1222,10 @@ private[lf] final case class Compiler(
         case _: SEBuiltin => ()
         case _: SEBuiltinRecursiveDefinition => ()
         case SEValue(v) => goV(v)
-        case SEApp(fun, args) =>
+        case SEAppE(fun, args) =>
+          go(fun)
+          args.foreach(go)
+        case SEAppA(fun, args) =>
           go(fun)
           args.foreach(go)
         case x: SEVar =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -497,7 +497,11 @@ object Pretty {
             case SBGetTime => text("$getTime")
             case _ => str(x)
           }
-        case SEApp(fun, args) =>
+        case SEAppE(fun, args) =>
+          val prefix = prettySExpr(index)(fun) + char('(')
+          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
+            .tightBracketBy(prefix, char(')'))
+        case SEAppA(fun, args) =>
           val prefix = prettySExpr(index)(fun) + char('(')
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -61,7 +61,8 @@ object PrettyLightweight { // lightweight pretty printer for CEK machine states
     case SEValue(v) => pp(v)
     case SEVar(n) => s"D#$n" //dont expect these at runtime
     case loc: SELoc => pp(loc)
-    case SEApp(func, args) => s"@(${pp(func)},${commas(args.map(pp))})"
+    case SEAppE(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
+    case SEAppA(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
     case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(pp))}]\\$arity.${pp(body)}"
     case SEBuiltin(b) => s"$b"
     case SEVal(ref) => s"${pp(ref)}"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -18,7 +18,6 @@ import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SBuiltin._
-import java.util.ArrayList
 
 /** The speedy expression:
   * - de Bruijn indexed.
@@ -91,18 +90,18 @@ object SExpr {
       /* special case for nullary record constructors */
       b match {
         case SBRecCon(id, fields) if b.arity == 0 =>
-          SRecord(id, fields, new ArrayList())
+          SRecord(id, fields, new util.ArrayList())
         case _ =>
-          SPAP(PBuiltin(b), new util.ArrayList[SValue](), b.arity)
+          SPAP(PBuiltin(b), new util.ArrayList(), b.arity)
       }
     }
     def execute(machine: Machine): Unit = {
       /* special case for nullary record constructors */
       machine.returnValue = b match {
         case SBRecCon(id, fields) if b.arity == 0 =>
-          SRecord(id, fields, new ArrayList())
+          SRecord(id, fields, new util.ArrayList())
         case _ =>
-          SPAP(PBuiltin(b), new util.ArrayList[SValue](), b.arity)
+          SPAP(PBuiltin(b), new util.ArrayList(), b.arity)
       }
     }
   }
@@ -138,8 +137,8 @@ object SExpr {
 
   object SEApp {
     def apply(fun: SExpr, args: Array[SExpr]): SExpr = {
-      (optimizeAtomicApps, fun) match {
-        case (true, vfun: SExprAtomic) => SEAppA(vfun, args)
+      fun match {
+        case vfun: SExprAtomic if optimizeAtomicApps => SEAppA(vfun, args)
         case _ => SEAppE(fun, args)
       }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -268,6 +268,8 @@ object Speedy {
       ctrl = expr
       kontStack = initialKontStack()
       env = emptyEnv
+      steps = 0
+      track = Instrumentation()
     }
 
     /** Run a machine until we get a result: either a final-value or a request for data, with a callback */
@@ -650,61 +652,65 @@ object Speedy {
   }
 
   /** The function has been evaluated to a value, now start evaluating the arguments. */
+  def executeApplication(machine: Machine, vfun: SValue, newArgs: Array[SExpr]): Unit = {
+    vfun match {
+      case SPAP(prim, actualsSoFar, arity) =>
+        val missing = arity - actualsSoFar.size
+        val newArgsLimit = Math.min(missing, newArgs.length)
+
+        val actuals = new util.ArrayList[SValue](actualsSoFar.size + newArgsLimit)
+        actuals.addAll(actualsSoFar)
+
+        val othersLength = newArgs.length - missing
+
+        // Not enough arguments. Push a continuation to construct the PAP.
+        if (othersLength < 0) {
+          machine.pushKont(KPap(prim, actuals, arity))
+        } else {
+          // Too many arguments: Push a continuation to re-apply the over-applied args.
+          if (othersLength > 0) {
+            val others = new Array[SExpr](othersLength)
+            System.arraycopy(newArgs, missing, others, 0, othersLength)
+            machine.pushKont(KArg(others, machine.frame, machine.actuals, machine.env.size))
+          }
+          // Now the correct number of arguments is ensured. What kind of prim do we have?
+          prim match {
+            case PClosure(label, body, frame) =>
+              // Maybe push a continuation for the profiler
+              if (label != null) {
+                machine.profile.addOpenEvent(label)
+                machine.pushKont(KLeaveClosure(label))
+              }
+              // Push a continuation to execute the function body when the arguments have been evaluated
+              machine.pushKont(KFun(body, frame, actuals))
+
+            case PBuiltin(builtin) =>
+              // Push a continuation to execute the builtin when the arguments have been evaluated
+              machine.pushKont(KBuiltin(builtin, actuals))
+          }
+        }
+
+        // Start evaluating the arguments.
+        var i = 1
+        while (i < newArgsLimit) {
+          val arg = newArgs(newArgsLimit - i)
+          machine.pushKont(KPushTo(actuals, arg, machine.frame, machine.actuals, machine.env.size))
+          i = i + 1
+        }
+        machine.ctrl = newArgs(0)
+
+      case _ =>
+        crash(s"Applying non-PAP: $vfun")
+    }
+  }
+
+  /** The function has been evaluated to a value. Now restore the environment and execute the application */
   final case class KArg(newArgs: Array[SExpr], frame: Frame, actuals: Actuals, envSize: Int)
       extends Kont
       with SomeArrayEquals {
-    def execute(v: SValue, machine: Machine) = {
+    def execute(vfun: SValue, machine: Machine) = {
       machine.restoreEnv(frame, actuals, envSize)
-      v match {
-        case SPAP(prim, actualsSoFar, arity) =>
-          val missing = arity - actualsSoFar.size
-          val newArgsLimit = Math.min(missing, newArgs.length)
-
-          val actuals = new util.ArrayList[SValue](actualsSoFar.size + newArgsLimit)
-          actuals.addAll(actualsSoFar)
-
-          val othersLength = newArgs.length - missing
-
-          // Not enough arguments. Push a continuation to construct the PAP.
-          if (othersLength < 0) {
-            machine.pushKont(KPap(prim, actuals, arity))
-          } else {
-            // Too many arguments: Push a continuation to re-apply the over-applied args.
-            if (othersLength > 0) {
-              val others = new Array[SExpr](othersLength)
-              System.arraycopy(newArgs, missing, others, 0, othersLength)
-              machine.pushKont(KArg(others, machine.frame, machine.actuals, machine.env.size))
-            }
-            // Now the correct number of arguments is ensured. What kind of prim do we have?
-            prim match {
-              case PClosure(label, body, frame) =>
-                // Maybe push a continuation for the profiler
-                if (label != null) {
-                  machine.profile.addOpenEvent(label)
-                  machine.pushKont(KLeaveClosure(label))
-                }
-                // Push a continuation to execute the function body when the arguments have been evaluated
-                machine.pushKont(KFun(body, frame, actuals))
-
-              case PBuiltin(builtin) =>
-                // Push a continuation to execute the builtin when the arguments have been evaluated
-                machine.pushKont(KBuiltin(builtin, actuals))
-            }
-          }
-
-          // Start evaluating the arguments.
-          var i = 1
-          while (i < newArgsLimit) {
-            val arg = newArgs(newArgsLimit - i)
-            machine.pushKont(
-              KPushTo(actuals, arg, machine.frame, machine.actuals, machine.env.size))
-            i = i + 1
-          }
-          machine.ctrl = newArgs(0)
-
-        case _ =>
-          crash(s"Applying non-PAP: $v")
-      }
+      executeApplication(machine, vfun, newArgs)
     }
   }
 


### PR DESCRIPTION
We regard builtins, values and variables as atomic. The special case detection is done at compile time; at run time, the atomic case avoids one push/pop on the continuation stack.

For the bench example, about 2/3 of the applications performed at run-time, fall into the special case, leading to an overall reduction in about 15% of the steps taken by the Speedy CEK machine.

This PR gives a 3% to 4% performance improvement.

In a following PR, we can further special case builtins.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
