### PR TITLE
Add a module-prefixes field to rename all modules in a pkg

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -43,7 +43,7 @@ newtype PackageId = PackageId{unPackageId :: T.Text}
 -- > ([A-Z][a-zA-Z0-9_]*)(\.[A-Z][a-zA-Z0-9_]*)*
 newtype ModuleName = ModuleName{unModuleName :: [T.Text]}
     deriving stock (Eq, Data, Generic, Ord, Show)
-    deriving newtype (Hashable, NFData)
+    deriving newtype (Hashable, NFData, ToJSON, FromJSON)
 
 -- | Name for a type synonym. Must match the regex
 --

--- a/compiler/damlc/daml-opts/BUILD.bazel
+++ b/compiler/damlc/daml-opts/BUILD.bazel
@@ -12,6 +12,7 @@ da_haskell_library(
     hackage_deps = [
         "aeson",
         "base",
+        "containers",
         "directory",
         "extra",
         "filepath",
@@ -25,6 +26,7 @@ da_haskell_library(
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",
+        "//compiler/damlc/daml-package-config",
         "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Packaging/Metadata.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Packaging/Metadata.hs
@@ -51,9 +51,10 @@ renamingToFlag unitId prefix modules =
         ModRenaming
           { modRenamingWithImplicit = False
           , modRenamings =
-            [ ( Ghc.mkModuleName (T.unpack $ LF.moduleNameString m)
-              , Ghc.mkModuleName (intercalate "." (Ghc.moduleNameString prefix : map T.unpack (LF.unModuleName m))))
+            [ ( Ghc.mkModuleName s
+              , Ghc.mkModuleName (Ghc.moduleNameString prefix ++ "." ++ s))
             | m <- modules
+            , s = T.unpack (LF.moduleNameString m)
             ]
           }
 
@@ -82,4 +83,3 @@ metadataFile projectRoot =
     fromNormalizedFilePath projectRoot </>
     projectPackageDatabase </>
     "metadata.json"
-

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Packaging/Metadata.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Packaging/Metadata.hs
@@ -9,7 +9,6 @@ module DA.Daml.Options.Packaging.Metadata
   ) where
 
 import Data.Aeson
-import Data.List
 import DA.Daml.Package.Config ()
 import Data.Map.Strict (Map)
 import qualified Data.Text as T
@@ -54,7 +53,7 @@ renamingToFlag unitId prefix modules =
             [ ( Ghc.mkModuleName s
               , Ghc.mkModuleName (Ghc.moduleNameString prefix ++ "." ++ s))
             | m <- modules
-            , s = T.unpack (LF.moduleNameString m)
+            , let s = T.unpack (LF.moduleNameString m)
             ]
           }
 

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -10,7 +10,7 @@ module DA.Daml.Options.Types
     , DlintUsage(..)
     , Haddock(..)
     , IncrementalBuild(..)
-    , InferDependantPackages(..)
+    , IgnorePackageMetadata(..)
     , PackageFlag(..)
     , ModRenaming(..)
     , PackageArg(..)
@@ -93,8 +93,11 @@ data Options = Options
     -- ^ Enable CPP, by giving filepath to the executable.
   , optIncrementalBuild :: IncrementalBuild
   -- ^ Whether to do an incremental on-disk build as opposed to keeping everything in memory.
-  , optInferDependantPackages :: InferDependantPackages
-  -- ^ Whether to infer --package flags from deps/data-deps contained in daml.yaml
+  , optIgnorePackageMetadata :: IgnorePackageMetadata
+  -- ^ Whether to ignore the package metadata generated from the daml.yaml
+  -- This is set to True when building data-dependency packages where we
+  -- have precise package flags and don’t want to use the daml.yaml from the
+  -- main package.
   , optEnableOfInterestRule :: Bool
   -- ^ Whether we should enable the of interest rule that automatically compiles all
   -- modules to DALFs or not. This is required in the IDE but we can disable it
@@ -104,7 +107,7 @@ data Options = Options
 newtype IncrementalBuild = IncrementalBuild { getIncrementalBuild :: Bool }
   deriving Show
 
-newtype InferDependantPackages = InferDependantPackages { getInferDependantPackages :: Bool }
+newtype IgnorePackageMetadata = IgnorePackageMetadata { getIgnorePackageMetadata :: Bool }
   deriving Show
 
 newtype Haddock = Haddock Bool
@@ -180,7 +183,7 @@ defaultOptions mbVersion =
         , optHaddock = Haddock False
         , optCppPath = Nothing
         , optIncrementalBuild = IncrementalBuild False
-        , optInferDependantPackages = InferDependantPackages True
+        , optIgnorePackageMetadata = IgnorePackageMetadata False
         , optEnableOfInterestRule = True
         }
 

--- a/compiler/damlc/daml-package-config/BUILD.bazel
+++ b/compiler/damlc/daml-package-config/BUILD.bazel
@@ -10,6 +10,7 @@ da_haskell_library(
     name = "daml-package-config",
     srcs = glob(["src/**/*.hs"]),
     hackage_deps = [
+        "aeson",
         "base",
         "containers",
         "ghc-lib-parser",

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -54,6 +54,7 @@ import Data.FileEmbed (embedFile)
 import qualified Data.HashSet as HashSet
 import Data.List.Extra
 import qualified Data.List.Split as Split
+import qualified Data.Map.Strict as Map
 import Data.Maybe
 import qualified Data.Text.Extended as T
 import Development.IDE.Core.API
@@ -535,7 +536,7 @@ initPackageDb opts (InitPkgDb shouldInit) =
         when isProject $ do
             projRoot <- getCurrentDirectory
             withPackageConfig defaultProjectPath $ \PackageConfigFields {..} ->
-                createProjectPackageDb (toNormalizedFilePath' projRoot) opts pSdkVersion pDependencies pDataDependencies
+                createProjectPackageDb (toNormalizedFilePath' projRoot) opts pSdkVersion pModulePrefixes pDependencies pDataDependencies
 
 execBuild :: ProjectOpts -> Options -> Maybe FilePath -> IncrementalBuild -> InitPkgDb -> Command
 execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb =
@@ -648,6 +649,7 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
                               , pDependencies = []
                               , pDataDependencies = []
                               , pSdkVersion = PackageSdkVersion SdkVersion.sdkVersion
+                              , pModulePrefixes = Map.empty
                               }
                             (toNormalizedFilePath' $ fromMaybe ifaceDir $ optIfaceDir opts)
                             dalfInput

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -69,8 +69,8 @@ import SdkVersion
 --   ledger. Based on the DAML-LF we generate dummy interface files
 --   and then remap references to those dummy packages to the original DAML-LF
 --   package id.
-createProjectPackageDb :: NormalizedFilePath -> Options -> PackageSdkVersion -> [FilePath] -> [FilePath] -> IO ()
-createProjectPackageDb projectRoot opts thisSdkVer deps dataDeps
+createProjectPackageDb :: NormalizedFilePath -> Options -> PackageSdkVersion -> MS.Map UnitId GHC.ModuleName -> [FilePath] -> [FilePath] -> IO ()
+createProjectPackageDb projectRoot opts thisSdkVer modulePrefixes deps dataDeps
   | null dataDeps && all (`elem` basePackages) deps =
     -- Initializing the package db is expensive since it requires calling GenerateStablePackages and GeneratePackageMap.
     --Therefore we only do it if we actually have a dependency.
@@ -142,6 +142,10 @@ createProjectPackageDb projectRoot opts thisSdkVer deps dataDeps
     exposedModules <- getExposedModules opts projectRoot
 
     let (depGraph, vertexToNode) = buildLfPackageGraph dalfsFromDataDependencies stablePkgs dependenciesInPkgDb
+
+
+    validatedModulePrefixes <- either exitWithError pure (prefixModules modulePrefixes (dalfsFromDependencies <> dalfsFromDataDependencies))
+
     -- Iterate over the dependency graph in topological order.
     -- We do a topological sort on the transposed graph which ensures that
     -- the packages with no dependencies come first and we
@@ -179,7 +183,7 @@ createProjectPackageDb projectRoot opts thisSdkVer deps dataDeps
             dependenciesInPkgDb
             exposedModules
 
-    writeMetadata projectRoot (PackageDbMetadata (mainUnitIds dependencyInfo))
+    writeMetadata projectRoot (PackageDbMetadata (mainUnitIds dependencyInfo) validatedModulePrefixes)
   where
     dbPath = projectPackageDatabase </> lfVersionString (optDamlLfVersion opts)
     clearPackageDb = do
@@ -244,8 +248,8 @@ generateAndInstallIfaceFiles dalf src opts workDir dbPath projectPackageDatabase
                   baseImports ++
                   depImps
             -- When compiling dummy interface files for a data-dependency,
-            -- we know all package flags so we don’t need to infer anything.
-            , optInferDependantPackages = InferDependantPackages False
+            -- we know all package flags so we don’t need to consult metadata.
+            , optIgnorePackageMetadata = IgnorePackageMetadata True
             }
 
     res <- withDamlIdeState opts loggerH diagnosticsLogger $ \ide ->
@@ -547,7 +551,7 @@ getExposedModules opts projectRoot = do
     -- do not matter and can be actively harmful since we might have picked up
     -- some from the daml.yaml if they are explicitly specified.
     opts <- pure opts
-        { optInferDependantPackages = InferDependantPackages False
+        { optIgnorePackageMetadata = IgnorePackageMetadata True
         , optPackageImports = []
         }
     hscEnv <-
@@ -650,3 +654,23 @@ decodeDalf dependenciesInPkgDb path bytes = do
 getDarsFromDependencies :: Set LF.PackageId -> [ExtractedDar] -> IO [DecodedDar]
 getDarsFromDependencies dependenciesInPkgDb depsExtracted =
     either fail pure $ mapM (decodeDar dependenciesInPkgDb) depsExtracted
+
+-- | Given the prefixes declared in daml.yaml
+-- and the list of decoded dalfs, validate that
+-- the prefixes point to packages that exist
+-- and associate them with all modules in the given package.
+-- We run this after checking for unit id collisions so we assume
+-- that the unit ids in the decoded dalfs are unique.
+prefixModules
+    :: MS.Map UnitId GHC.ModuleName
+    -> [DecodedDalf]
+    -> Either String (MS.Map UnitId (GHC.ModuleName, [LF.ModuleName]))
+prefixModules prefixes dalfs = do
+    MS.traverseWithKey f prefixes
+  where unitIdMap = MS.fromList [(decodedUnitId, decodedDalfPkg) | DecodedDalf{..} <- dalfs]
+        f unitId prefix = case MS.lookup unitId unitIdMap of
+            Nothing -> Left ("Could not find package " <> unitIdString unitId)
+            Just pkg -> Right
+                ( prefix
+                , NM.names . LF.packageModules . LF.extPackagePkg $ LF.dalfPackagePkg pkg
+                )

--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -267,7 +267,7 @@ optionsParser numProcessors enableScenarioService parsePkgName = do
     let optCoreLinting = False
     let optHaddock = Haddock False
     let optIncrementalBuild = IncrementalBuild False
-    let optInferDependantPackages = InferDependantPackages True
+    let optIgnorePackageMetadata = IgnorePackageMetadata False
     let optEnableOfInterestRule = True
     optCppPath <- optCppPath
 

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -91,7 +91,7 @@ initPackageConfig scriptDar testDar = do
         ]
     withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do
         dir <- getCurrentDirectory
-        createProjectPackageDb (toNormalizedFilePath' dir) options pSdkVersion pDependencies pDataDependencies
+        createProjectPackageDb (toNormalizedFilePath' dir) options pSdkVersion pModulePrefixes pDependencies pDataDependencies
 
 drainHandle :: Handle -> Chan String -> IO ()
 drainHandle handle chan = forever $ do

--- a/docs/source/daml/reference/packages.rst
+++ b/docs/source/daml/reference/packages.rst
@@ -232,8 +232,10 @@ This will alias the ``X`` in ``foo-1.0.0`` as ``Foo1.X``, and alias the ``X`` in
   import qualified Foo2.X
 
 It is also possible to add a prefix to all modules in a package using
-the ``module-prefixes`` field in your ``daml.yaml``. For the example
-above you can use the following:
+the ``module-prefixes`` field in your ``daml.yaml``. This is
+partiuclarly useful for upgrades where you can map all modules of
+version ``v`` of your package under ``V$v``. For the example above you
+can use the following:
 
 .. code-block:: yaml
 
@@ -243,3 +245,7 @@ above you can use the following:
 
 That will allow you to import module ``X`` from package ``foo-1.0.0``
 as ``Foo1.X`` and ``X`` from package ``-foo-2.0.0`` as ``Foo2``.
+
+You can also use more complex module prefixes, e.g., ``foo-1.0.0:
+Foo1.Bar`` which will make module ``X`` available under
+``Foo1.Bar.X``.

--- a/docs/source/daml/reference/packages.rst
+++ b/docs/source/daml/reference/packages.rst
@@ -230,3 +230,16 @@ This will alias the ``X`` in ``foo-1.0.0`` as ``Foo1.X``, and alias the ``X`` in
 
   import qualified Foo1.X
   import qualified Foo2.X
+
+It is also possible to add a prefix to all modules in a package using
+the ``module-prefixes`` field in your ``daml.yaml``. For the example
+above you can use the following:
+
+.. code-block:: yaml
+
+  module-prefixes:
+    foo-1.0.0: Foo1
+    foo-2.0.0: Foo2
+
+That will allow you to import module ``X`` from package ``foo-1.0.0``
+as ``Foo1.X`` and ``X`` from package ``-foo-2.0.0`` as ``Foo2``.

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -119,7 +119,9 @@ Here is what each field means:
 - ``version``: the project version.
 - ``exposed-modules``: the DAML modules that are exposed by this project, which can be imported in other projects.
   If this field is not specified all modules in the project are exposed.
-- ``dependencies``: the dependencies of this project.
+- ``dependencies``: library-dependencies of this project. See :doc:`/daml/reference/packages`.
+- ``data-dependencies``: Cross-SDK dependencies of this project See :doc:`/daml/reference/packages`.
+- ``module-prefixes``: Prefixes for all modules in package See :doc:`/daml/reference/packages`.
 - ``scenario-service``: settings for the scenario service
 
   - ``grpc-max-message-size``: This option controls the maximum size of gRPC messages.


### PR DESCRIPTION
This PR adds a `module-prefixes` field to `daml.yaml` a a shorthand
for specifying a `--package` flag that renames all modules in a
package to have the same prefix.

The docs are updated to describe how you can use this field and there
is a test case that makes sure it works.

fixes #4948

changelog_begin

- [DAML Compiler] You can now use the new ``module-prefixes`` field in
  ``daml.yaml`` to add a prefix to all modules from a dependency. This
  is particularly useful for handling colliding module names during
  upgrades. See
  https://docs.daml.com/daml/reference/packages.html#handling-module-name-collisions
  for more information.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
