### PR TITLE
remove javadoc_dev_env

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -564,25 +564,6 @@ nixpkgs_package(
     repositories = dev_env_nix_repos,
 )
 
-# This will not be needed after merge of the PR to bazel adding proper javadoc filegroups:
-# https://github.com/bazelbuild/bazel/pull/7898
-# `@javadoc_dev_env//:javadoc` could be then replaced with `@local_jdk//:javadoc` and the below removed
-dev_env_tool(
-    name = "javadoc_dev_env",
-    nix_include = ["bin/javadoc"],
-    nix_label = "@jdk_nix",
-    nix_paths = ["bin/javadoc"],
-    tools = ["javadoc"],
-    win_include = [
-        "bin",
-        "include",
-        "jre",
-        "lib",
-    ],
-    win_paths = ["bin/javadoc.exe"],
-    win_tool = "java-openjdk-8u201",
-)
-
 # This only makes sense on Windows so we just put dummy values in the nix fields.
 dev_env_tool(
     name = "makensis_dev_env",


### PR DESCRIPTION
The comment on it says it should be replaced by `local_jdk//:javadoc` once [a patch](https://github.com/bazelbuild/bazel/pull/7898) is merged into Bazel. Not only has that patch been merged, but I could not find any reference to `javadoc_dev_env` to replace.

CHANGELOG_BEGIN
CHANGELOG_END