### PR TITLE
fix docs cron not ignoring release-notes

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -197,7 +197,7 @@ build_docs_folder path versions current = do
             shell_ $ "aws s3 sync s3://docs-daml-com/ " <> path
         exists dir = Directory.doesDirectoryExist dir
         checksums path = do
-            let cmd = "cd " <> path <> "; sed -i ':support/release-notes.html:d' checksum; sha256sum -c checksum"
+            let cmd = "cd " <> path <> "; sed -i '/support\\/release-notes.html/d' checksum; sha256sum -c checksum"
             (code, _, _) <- shell_exit_code cmd
             case code of
                 Exit.ExitSuccess -> return True


### PR DESCRIPTION
The docs cron is supposed to ignore the release-notes.html page when checking whether a docs folder is corrupted, because we manually override it. However, that currently doesn't work, either because the `sed` version we are using does not support changing the delimiters, or because no version of `sed` does and I just imagined it.

CHANGELOG_BEGIN
CHANGELOG_END