### PR TITLE
add blackduck scan to run on master

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -1,3 +1,5 @@
+# root Pipfile needed to identify that all python projects in this repo should be scanned as 3.7, and to give pypi url to use
+
 [[source]]
 name = "pypi"
 url = "https://pypi.org/simple"

--- a/Pipfile
+++ b/Pipfile
@@ -1,4 +1,4 @@
-# root Pipfile needed to identify that all python projects in this repo should be scanned as 3.7, and to give pypi url to use
+# root Pipfile needed to identify that all python projects in this repo should be scanned as 3.7 for blackduck, and to give pypi url to use
 
 [[source]]
 name = "pypi"

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -40,18 +40,18 @@ steps:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-      ci-build digitalasset_daml local-bh \
+      ci-build digitalasset_daml master \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.npm.include.dev.dependencies=true \
       --detect.yarn.prod.only=false \
       --detect.excluded.detector.types=NUGET \
-      --detect.tools=DETECTOR,BAZEL,SIGNATURE_SCAN,BINARY_SCAN,DOCKER \
+      --detect.tools=DETECTOR,BAZEL,DOCKER \
       --detect.bazel.target=//... \
       --detect.excluded.detector.types=MAVEN,GO_MOD \
       --detect.excluded.detector.types=SBT \
       --detect.bazel.dependency.type=maven_install \
       --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/ \
-      --detect.report.timeout=1360
+      --detect.report.timeout=480
     displayName: 'Blackduck Scan'
 
     env:

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -39,17 +39,35 @@ steps:
   - bash: |
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
-      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
       ci-build digitalasset_daml master \
       --logging.level.com.synopsys.integration=DEBUG \
-      --detect.npm.include.dev.dependencies=true \
-      --detect.yarn.prod.only=false \
+      --detect.tools=BAZEL \
+      --detect.bazel.target=//... \
+      --detect.bazel.dependency.type=haskell_cabal_library
+    displayName: 'Blackduck Haskell Scan'
+
+    env:
+      BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
+
+  - bash: |
+      set -euo pipefail
+      eval "$(./dev-env/bin/dade-assist)"
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
+      ci-build digitalasset_daml master \
+      --logging.level.com.synopsys.integration=DEBUG \
+      --detect.npm.include.dev.dependencies=false \
+      --detect.excluded.detector.types=NUGET \
+      --detect.yarn.prod.only=true \
       --detect.python.python3=true \
       --detect.tools=DETECTOR,BAZEL,DOCKER \
       --detect.bazel.target=//... \
       --detect.bazel.dependency.type=maven_install \
-      --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/ \
-      --detect.report.timeout=360
+      --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,/Users/brianhealey/g/daml/language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
+      --detect.cleanup=false \
+      --detect.cleanup.bdio.files=false \
+      --detect.report.timeout=360  
+
     displayName: 'Blackduck Scan'
 
     env:

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -37,13 +37,13 @@ steps:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
 
   - bash: |
-      set -euo pipefail
-      eval "$(./dev-env/bin/dade-assist)"
-      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml local-bh --logging.level.com.synopsys.integration=DEBUG --detect.npm.include.dev.dependencies=true --detect.yarn.prod.only=false --detect.excluded.detector.types=NUGET --detect.tools=DETECTOR,BAZEL,SIGNATURE_SCAN,BINARY_SCAN,DOCKER --detect.bazel.target=//... --detect.excluded.detector.types=MAVEN --detect.excluded.detector.types=SBT --detect.bazel.dependency.type=maven_install --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/daml-ledger
-      displayName: 'Blackduck Scan'
+    set -euo pipefail
+    eval "$(./dev-env/bin/dade-assist)"
+    bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml local-bh --logging.level.com.synopsys.integration=DEBUG --detect.npm.include.dev.dependencies=true --detect.yarn.prod.only=false --detect.excluded.detector.types=NUGET --detect.tools=DETECTOR,BAZEL,SIGNATURE_SCAN,BINARY_SCAN,DOCKER --detect.bazel.target=//... --detect.excluded.detector.types=MAVEN --detect.excluded.detector.types=SBT --detect.bazel.dependency.type=maven_install --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/daml-ledger
+    displayName: 'Blackduck Scan'
       
-      env:
-        BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)      
+    env:
+      BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)      
 
   - task: PublishBuildArtifacts@1
     condition: failed()

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -36,6 +36,15 @@ steps:
     env:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
 
+  - bash: |
+      set -euo pipefail
+      eval "$(./dev-env/bin/dade-assist)"
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml local-bh --logging.level.com.synopsys.integration=DEBUG --detect.npm.include.dev.dependencies=true --detect.yarn.prod.only=false --detect.excluded.detector.types=NUGET --detect.tools=DETECTOR,BAZEL,SIGNATURE_SCAN,BINARY_SCAN,DOCKER --detect.bazel.target=//... --detect.excluded.detector.types=MAVEN --detect.excluded.detector.types=SBT --detect.bazel.dependency.type=maven_install --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/daml-ledger
+      displayName: 'Blackduck Scan'
+      
+      env:
+        BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)      
+
   - task: PublishBuildArtifacts@1
     condition: failed()
     displayName: 'Publish the bazel test logs'

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -67,8 +67,9 @@ steps:
       --detect.bazel.dependency.type=maven_install \
       --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,/Users/brianhealey/g/daml/language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
       --detect.cleanup=false \
-      --detect.cleanup.bdio.files=false \
-      --detect.report.timeout=360  
+      --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
+      --detect.cleanup.bdio.files=true \
+      --detect.report.timeout=1050
     displayName: 'Blackduck Scan'
     condition: eq('${{parameters.name}}', 'linux')
 

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -44,7 +44,9 @@ steps:
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.tools=BAZEL \
       --detect.bazel.target=//... \
-      --detect.bazel.dependency.type=haskell_cabal_library
+      --detect.bazel.dependency.type=haskell_cabal_library \
+      --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
+      --detect.report.timeout=1050
     displayName: 'Blackduck Haskell Scan'
     condition: eq('${{parameters.name}}', 'linux')
 

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -45,7 +45,6 @@ steps:
       --detect.tools=BAZEL \
       --detect.bazel.target=//... \
       --detect.bazel.dependency.type=haskell_cabal_library \
-      --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
       --detect.notices.report=true \      
       --detect.report.timeout=1500
     displayName: 'Blackduck Haskell Scan'
@@ -70,8 +69,7 @@ steps:
       --detect.bazel.dependency.type=maven_install \
       --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,/Users/brianhealey/g/daml/language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
       --detect.cleanup=false \
-      --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
-      --detect.notices.report=true \      
+      --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \  
       --detect.cleanup.bdio.files=true \
       --detect.report.timeout=4500
     displayName: 'Blackduck Scan'

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -44,11 +44,9 @@ steps:
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.npm.include.dev.dependencies=true \
       --detect.yarn.prod.only=false \
-      --detect.excluded.detector.types=NUGET \
+      --detect.python.python3=true \
       --detect.tools=DETECTOR,BAZEL,DOCKER \
       --detect.bazel.target=//... \
-      --detect.excluded.detector.types=MAVEN,GO_MOD \
-      --detect.excluded.detector.types=SBT \
       --detect.bazel.dependency.type=maven_install \
       --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/ \
       --detect.report.timeout=360

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -39,15 +39,14 @@ steps:
   - bash: |
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
-      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/9389c116807f2db7611930a4c9fb5dbf07cce70e/synopsys-detect) \
       ci-build digitalasset_daml $(Build.SourceBranchName) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.tools=BAZEL \
       --detect.bazel.target=//... \
       --detect.bazel.dependency.type=haskell_cabal_library
     displayName: 'Blackduck Haskell Scan'
-    condition: and(eq(variables['Build.SourceBranchName'], 'master'),
-                   eq('${{parameters.name}}', 'linux'))
+    condition: eq('${{parameters.name}}', 'linux')
 
     env:
       BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
@@ -55,7 +54,7 @@ steps:
   - bash: |
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
-      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/9389c116807f2db7611930a4c9fb5dbf07cce70e/synopsys-detect) \
       ci-build digitalasset_daml $(Build.SourceBranchName) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.npm.include.dev.dependencies=false \
@@ -71,8 +70,7 @@ steps:
       --detect.cleanup.bdio.files=false \
       --detect.report.timeout=360  
     displayName: 'Blackduck Scan'
-    condition: and(eq(variables['Build.SourceBranchName'], 'master'),
-                   eq('${{parameters.name}}', 'linux'))
+    condition: eq('${{parameters.name}}', 'linux')
 
     env:
       BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -51,7 +51,7 @@ steps:
       --detect.excluded.detector.types=SBT \
       --detect.bazel.dependency.type=maven_install \
       --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/ \
-      --detect.report.timeout=480
+      --detect.report.timeout=360
     displayName: 'Blackduck Scan'
 
     env:

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -71,7 +71,7 @@ steps:
       --detect.cleanup=false \
       --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
       --detect.cleanup.bdio.files=true \
-      --detect.report.timeout=1050
+      --detect.report.timeout=1500
     displayName: 'Blackduck Scan'
     condition: eq('${{parameters.name}}', 'linux')
 

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -46,7 +46,7 @@ steps:
       --detect.bazel.target=//... \
       --detect.bazel.dependency.type=haskell_cabal_library
     displayName: 'Blackduck Haskell Scan'
-    condition: eq(variables['Build.SourceBranchName'], 'enable-blackduck'),
+    condition: and(eq(variables['Build.SourceBranchName'], 'enable-blackduck'),
                 eq('${{parameters.name}}', 'linux'))
 
     env:
@@ -71,8 +71,8 @@ steps:
       --detect.cleanup.bdio.files=false \
       --detect.report.timeout=360  
     displayName: 'Blackduck Scan'
-    condition: eq(variables['Build.SourceBranchName'], 'enable-blackduck'),
-                eq('${{parameters.name}}', 'linux'))    
+    condition: and(eq(variables['Build.SourceBranchName'], 'enable-blackduck'),
+                eq('${{parameters.name}}', 'linux'))
 
     env:
       BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -40,13 +40,14 @@ steps:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/9389c116807f2db7611930a4c9fb5dbf07cce70e/synopsys-detect) \
-      ci-build digitalasset_daml $(System.PullRequest.SourceBranch) \
+      ci-build digital-asset_daml $(System.PullRequest.SourceBranch) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.tools=BAZEL \
       --detect.bazel.target=//... \
       --detect.bazel.dependency.type=haskell_cabal_library \
       --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
-      --detect.report.timeout=1000
+      --detect.notices.report=true \      
+      --detect.report.timeout=1500
     displayName: 'Blackduck Haskell Scan'
     condition: eq('${{parameters.name}}', 'linux')
 
@@ -57,7 +58,7 @@ steps:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/9389c116807f2db7611930a4c9fb5dbf07cce70e/synopsys-detect) \
-      ci-build digitalasset_daml $(System.PullRequest.SourceBranch) \
+      ci-build digital-asset_daml $(System.PullRequest.SourceBranch) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.npm.include.dev.dependencies=false \
       --detect.excluded.detector.types=NUGET \
@@ -70,8 +71,9 @@ steps:
       --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,/Users/brianhealey/g/daml/language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
       --detect.cleanup=false \
       --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
+      --detect.notices.report=true \      
       --detect.cleanup.bdio.files=true \
-      --detect.report.timeout=1500
+      --detect.report.timeout=4500
     displayName: 'Blackduck Scan'
     condition: eq('${{parameters.name}}', 'linux')
 

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -40,7 +40,7 @@ steps:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
-      ci-build digitalasset_daml master \
+      ci-build digitalasset_daml enable-blackduck \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.tools=BAZEL \
       --detect.bazel.target=//... \
@@ -54,11 +54,11 @@ steps:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
-      ci-build digitalasset_daml master \
+      ci-build digitalasset_daml enable-blackduck \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.npm.include.dev.dependencies=false \
       --detect.excluded.detector.types=NUGET \
-      --detect.excluded.detector.types=NUGET \
+      --detect.excluded.detector.types=GO_MOD \
       --detect.yarn.prod.only=true \
       --detect.python.python3=true \
       --detect.tools=DETECTOR,BAZEL,DOCKER \
@@ -73,6 +73,24 @@ steps:
 
     env:
       BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
+
+  # - bash: |
+  #     set -euo pipefail
+  #     eval "$(./dev-env/bin/dade-assist)"
+  #     bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
+  #     ci-build digitalasset_daml enable-blackduck \
+  #     --logging.level.com.synopsys.integration=DEBUG \
+  #     --detect.tools=SIGNATURE_SCAN,BINARY_SCAN \
+  #     --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,/Users/brianhealey/g/daml/language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
+  #     --detect.cleanup=false \
+  #     --detect.cleanup.bdio.files=false \
+  #     --detect.report.timeout=360  
+
+  #   displayName: 'Blackduck Binary Scan'
+
+  #   env:
+  #     BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
+
 
   - task: PublishBuildArtifacts@1
     condition: failed()

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -46,7 +46,7 @@ steps:
       --detect.bazel.target=//... \
       --detect.bazel.dependency.type=haskell_cabal_library \
       --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
-      --detect.report.timeout=1050
+      --detect.report.timeout=1000
     displayName: 'Blackduck Haskell Scan'
     condition: eq('${{parameters.name}}', 'linux')
 

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -46,6 +46,8 @@ steps:
       --detect.bazel.target=//... \
       --detect.bazel.dependency.type=haskell_cabal_library
     displayName: 'Blackduck Haskell Scan'
+    condition: eq(variables['Build.SourceBranchName'], 'enable-blackduck'),
+                eq('${{parameters.name}}', 'linux'))
 
     env:
       BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
@@ -68,28 +70,12 @@ steps:
       --detect.cleanup=false \
       --detect.cleanup.bdio.files=false \
       --detect.report.timeout=360  
-
     displayName: 'Blackduck Scan'
+    condition: eq(variables['Build.SourceBranchName'], 'enable-blackduck'),
+                eq('${{parameters.name}}', 'linux'))    
 
     env:
       BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
-
-  # - bash: |
-  #     set -euo pipefail
-  #     eval "$(./dev-env/bin/dade-assist)"
-  #     bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
-  #     ci-build digitalasset_daml enable-blackduck \
-  #     --logging.level.com.synopsys.integration=DEBUG \
-  #     --detect.tools=SIGNATURE_SCAN,BINARY_SCAN \
-  #     --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,/Users/brianhealey/g/daml/language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
-  #     --detect.cleanup=false \
-  #     --detect.cleanup.bdio.files=false \
-  #     --detect.report.timeout=360  
-
-  #   displayName: 'Blackduck Binary Scan'
-
-  #   env:
-  #     BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
 
 
   - task: PublishBuildArtifacts@1

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -45,7 +45,7 @@ steps:
       --detect.tools=BAZEL \
       --detect.bazel.target=//... \
       --detect.bazel.dependency.type=haskell_cabal_library \
-      --detect.notices.report=true \      
+      --detect.notices.report=true \
       --detect.report.timeout=1500
     displayName: 'Blackduck Haskell Scan'
     condition: eq('${{parameters.name}}', 'linux')
@@ -69,7 +69,7 @@ steps:
       --detect.bazel.dependency.type=maven_install \
       --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,/Users/brianhealey/g/daml/language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
       --detect.cleanup=false \
-      --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \  
+      --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
       --detect.cleanup.bdio.files=true \
       --detect.report.timeout=4500
     displayName: 'Blackduck Scan'

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -50,7 +50,8 @@ steps:
       --detect.excluded.detector.types=MAVEN,GO_MOD \
       --detect.excluded.detector.types=SBT \
       --detect.bazel.dependency.type=maven_install \
-      --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/
+      --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/ \
+      --detect.report.timeout=1360
     displayName: 'Blackduck Scan'
 
     env:

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -40,7 +40,7 @@ steps:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/9389c116807f2db7611930a4c9fb5dbf07cce70e/synopsys-detect) \
-      ci-build digitalasset_daml $(Build.SourceBranchName) \
+      ci-build digitalasset_daml $(System.PullRequest.SourceBranch) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.tools=BAZEL \
       --detect.bazel.target=//... \
@@ -55,7 +55,7 @@ steps:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/9389c116807f2db7611930a4c9fb5dbf07cce70e/synopsys-detect) \
-      ci-build digitalasset_daml $(Build.SourceBranchName) \
+      ci-build digitalasset_daml $(System.PullRequest.SourceBranch) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.npm.include.dev.dependencies=false \
       --detect.excluded.detector.types=NUGET \

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -58,6 +58,7 @@ steps:
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.npm.include.dev.dependencies=false \
       --detect.excluded.detector.types=NUGET \
+      --detect.excluded.detector.types=NUGET \
       --detect.yarn.prod.only=true \
       --detect.python.python3=true \
       --detect.tools=DETECTOR,BAZEL,DOCKER \

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -39,7 +39,18 @@ steps:
   - bash: |
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
-      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml local-bh --logging.level.com.synopsys.integration=DEBUG --detect.npm.include.dev.dependencies=true --detect.yarn.prod.only=false --detect.excluded.detector.types=NUGET --detect.tools=DETECTOR,BAZEL,SIGNATURE_SCAN,BINARY_SCAN,DOCKER --detect.bazel.target=//... --detect.excluded.detector.types=MAVEN --detect.excluded.detector.types=SBT --detect.bazel.dependency.type=maven_install --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/daml-ledger
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
+      ci-build digitalasset_daml local-bh \
+      --logging.level.com.synopsys.integration=DEBUG \
+      --detect.npm.include.dev.dependencies=true \
+      --detect.yarn.prod.only=false \
+      --detect.excluded.detector.types=NUGET \
+      --detect.tools=DETECTOR,BAZEL,SIGNATURE_SCAN,BINARY_SCAN,DOCKER \
+      --detect.bazel.target=//... \
+      --detect.excluded.detector.types=MAVEN,GO_MOD \
+      --detect.excluded.detector.types=SBT \
+      --detect.bazel.dependency.type=maven_install \
+      --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/
     displayName: 'Blackduck Scan'
 
     env:

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -40,7 +40,7 @@ steps:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
-      ci-build digitalasset_daml enable-blackduck \
+      ci-build digitalasset_daml $(Build.SourceBranchName) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.tools=BAZEL \
       --detect.bazel.target=//... \
@@ -56,7 +56,7 @@ steps:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
       bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/detect-haskell-snapshot/synopsys-detect) \
-      ci-build digitalasset_daml enable-blackduck \
+      ci-build digitalasset_daml $(Build.SourceBranchName) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.npm.include.dev.dependencies=false \
       --detect.excluded.detector.types=NUGET \

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -46,8 +46,8 @@ steps:
       --detect.bazel.target=//... \
       --detect.bazel.dependency.type=haskell_cabal_library
     displayName: 'Blackduck Haskell Scan'
-    condition: and(eq(variables['Build.SourceBranchName'], 'enable-blackduck'),
-                eq('${{parameters.name}}', 'linux'))
+    condition: and(eq(variables['Build.SourceBranchName'], 'master'),
+                   eq('${{parameters.name}}', 'linux'))
 
     env:
       BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
@@ -71,8 +71,8 @@ steps:
       --detect.cleanup.bdio.files=false \
       --detect.report.timeout=360  
     displayName: 'Blackduck Scan'
-    condition: and(eq(variables['Build.SourceBranchName'], 'enable-blackduck'),
-                eq('${{parameters.name}}', 'linux'))
+    condition: and(eq(variables['Build.SourceBranchName'], 'master'),
+                   eq('${{parameters.name}}', 'linux'))
 
     env:
       BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -37,13 +37,13 @@ steps:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
 
   - bash: |
-    set -euo pipefail
-    eval "$(./dev-env/bin/dade-assist)"
-    bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml local-bh --logging.level.com.synopsys.integration=DEBUG --detect.npm.include.dev.dependencies=true --detect.yarn.prod.only=false --detect.excluded.detector.types=NUGET --detect.tools=DETECTOR,BAZEL,SIGNATURE_SCAN,BINARY_SCAN,DOCKER --detect.bazel.target=//... --detect.excluded.detector.types=MAVEN --detect.excluded.detector.types=SBT --detect.bazel.dependency.type=maven_install --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/daml-ledger
+      set -euo pipefail
+      eval "$(./dev-env/bin/dade-assist)"
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) ci-build digitalasset_daml local-bh --logging.level.com.synopsys.integration=DEBUG --detect.npm.include.dev.dependencies=true --detect.yarn.prod.only=false --detect.excluded.detector.types=NUGET --detect.tools=DETECTOR,BAZEL,SIGNATURE_SCAN,BINARY_SCAN,DOCKER --detect.bazel.target=//... --detect.excluded.detector.types=MAVEN --detect.excluded.detector.types=SBT --detect.bazel.dependency.type=maven_install --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts/daml-types,language-support/ts/daml-react,language-support/ts/daml-ledger
     displayName: 'Blackduck Scan'
-      
+
     env:
-      BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)      
+      BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
 
   - task: PublishBuildArtifacts@1
     condition: failed()

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -39,7 +39,7 @@ steps:
   - bash: |
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
-      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/9389c116807f2db7611930a4c9fb5dbf07cce70e/synopsys-detect) \
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/834b480fc52cf36592fe7aea3955f2a17fa37802/synopsys-detect) \
       ci-build digital-asset_daml $(System.PullRequest.SourceBranch) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.tools=BAZEL \
@@ -56,7 +56,7 @@ steps:
   - bash: |
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
-      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/9389c116807f2db7611930a4c9fb5dbf07cce70e/synopsys-detect) \
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/834b480fc52cf36592fe7aea3955f2a17fa37802/synopsys-detect) \
       ci-build digital-asset_daml $(System.PullRequest.SourceBranch) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.npm.include.dev.dependencies=false \

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -39,7 +39,7 @@ steps:
   - bash: |
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
-      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/834b480fc52cf36592fe7aea3955f2a17fa37802/synopsys-detect) \
+      bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
       ci-build digital-asset_daml $(System.PullRequest.SourceBranch) \
       --logging.level.com.synopsys.integration=DEBUG \
       --detect.tools=BAZEL \

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -196,3 +196,65 @@ jobs:
         env:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
       - template: ../daily_tell_slack.yml
+
+  - job: blackduck_scan
+    timeoutInMinutes: 1200
+    pool:
+      name: linux-pool
+      demands: assignment -equals default
+    steps:
+      - checkout: self
+      - bash: ci/dev-env-install.sh
+        displayName: 'Build/Install the Developer Environment'
+      - bash: ci/configure-bazel.sh
+        displayName: 'Configure Bazel'
+        env:
+          IS_FORK: $(System.PullRequest.IsFork)
+          # to upload to the bazel cache
+          GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)        
+      - template: ../bash-lib.yml
+        parameters:
+          var_name: bash_lib
+      - bash: ./build.sh "_$(uname)"
+        displayName: 'Build'
+        env:
+          DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
+      - bash: |
+          set -euo pipefail
+          eval "$(./dev-env/bin/dade-assist)"
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
+          ci-build digital-asset_daml $(System.PullRequest.SourceBranch) \
+          --logging.level.com.synopsys.integration=DEBUG \
+          --detect.tools=BAZEL \
+          --detect.bazel.target=//... \
+          --detect.bazel.dependency.type=haskell_cabal_library \
+          --detect.notices.report=true \
+          --detect.report.timeout=1500
+        displayName: 'Blackduck Haskell Scan'
+        condition: eq('${{parameters.name}}', 'linux')
+        env:
+          BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
+      - bash: |
+          set -euo pipefail
+          eval "$(./dev-env/bin/dade-assist)"
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/834b480fc52cf36592fe7aea3955f2a17fa37802/synopsys-detect) \
+          ci-build digital-asset_daml $(System.PullRequest.SourceBranch) \
+          --logging.level.com.synopsys.integration=DEBUG \
+          --detect.npm.include.dev.dependencies=false \
+          --detect.excluded.detector.types=NUGET \
+          --detect.excluded.detector.types=GO_MOD \
+          --detect.yarn.prod.only=true \
+          --detect.python.python3=true \
+          --detect.tools=DETECTOR,BAZEL,DOCKER \
+          --detect.bazel.target=//... \
+          --detect.bazel.dependency.type=maven_install \
+          --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,/Users/brianhealey/g/daml/language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
+          --detect.cleanup=false \
+          --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
+          --detect.cleanup.bdio.files=true \
+          --detect.report.timeout=4500
+        displayName: 'Blackduck Scan'
+        condition: eq('${{parameters.name}}', 'linux')
+        env:
+          BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
+      - template: ../daily_tell_slack.yml

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -24,6 +24,7 @@ schedules:
 
 jobs:
   - job: compatibility_ts_libs
+    condition: false
     timeoutInMinutes: 60
     pool:
       name: linux-pool
@@ -34,6 +35,7 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility
+    condition: false  
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     strategy:
@@ -53,6 +55,7 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility_windows
+    condition: false  
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     pool:
@@ -69,6 +72,7 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: perf_speedy
+    condition: false  
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -117,6 +121,7 @@ jobs:
           success-message: '$(cat $(Build.StagingDirectory)/perf-results.json | jq . | jq -sR ''"perf for ''"$COMMIT_LINK"'':```\(.)```"'')'
 
   - job: perf_http_json
+    condition: false  
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -175,6 +180,7 @@ jobs:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
 
   - job: check_releases
+    condition: false  
     timeoutInMinutes: 240
     pool:
       name: linux-pool

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -223,8 +223,6 @@ jobs:
           var_name: bash_lib
       - bash: ./build.sh "_$(uname)"
         displayName: 'Build'
-        env:
-          DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
@@ -237,7 +235,6 @@ jobs:
           --detect.notices.report=true \
           --detect.report.timeout=1500
         displayName: 'Blackduck Haskell Scan'
-        condition: eq('${{parameters.name}}', 'linux')
         env:
           BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
       - bash: |
@@ -260,7 +257,6 @@ jobs:
           --detect.cleanup.bdio.files=true \
           --detect.report.timeout=4500
         displayName: 'Blackduck Scan'
-        condition: eq('${{parameters.name}}', 'linux')
         env:
           BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
       - template: ../daily_tell_slack.yml


### PR DESCRIPTION
THIS PR
- Enable blackduck scan to run only on linux
- Include bazel haskell library scan with current snapshot verison of hub detect
- bazel jvm and npm and all other build tool scans runs as a second round but to the same version and project


TODO (follow-on PRs)
- Daily binary/signature scan -- time consuming and takes hours so only need to run daily or weekly as a cron job #6420 
- Enable GO_MOD scanning (need to know location of GO exe on CI) #6419 
