### PR TITLE
Don't store archived divulged contracts

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsTable.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsTable.scala
@@ -123,11 +123,35 @@ private[events] sealed abstract class ContractsTable extends PostCommitValidatio
       divulgedContracts: Iterable[DivulgedContract],
   ): RawBatches = {
 
+    /** Add divulged contracts.
+      * - If a divulged contracts is also created in the same transaction, the divulged contract will
+      *   be replaced by the regular contract through [[AccumulatingBatches.insert]].
+      * - If a divulged contract was created or divulged before, the existing contract will not be replaced by the
+      *   new divulged contract because the SQL query uses 'ON CONFLICT DO NOTHING'.
+      * - It can never happen that [[divulgedContracts]] contains archived contracts, even if the archive event is
+      *   not visible to this participant.
+      * - It can never happen that [[divulgedContracts]] contains contracts for which the create event will
+      *   appear to this participant in a future transaction.
+      * */
+    val divulgedContractsInsertions =
+      divulgedContracts.iterator
+        .map(
+          contract =>
+            contract.contractId -> new RawBatch.Contract(
+              contractId = contract.contractId,
+              templateId = contract.contractInst.template,
+              createArgument = contract.contractInst.arg,
+              createLedgerEffectiveTime = None,
+              stakeholders = Set.empty,
+              key = None,
+          ))
+        .toMap
+
     // Add the locally created contracts, ensuring that _transient_
     // contracts are not inserted in the first place
     val locallyCreatedContracts =
       transaction
-        .fold(AccumulatingBatches(Map.empty, Map.empty, Set.empty)) {
+        .fold(AccumulatingBatches(divulgedContractsInsertions, Map.empty, Set.empty)) {
           case (batches, (_, node: Create)) =>
             batches.insert(
               contractId = node.coid,
@@ -149,27 +173,7 @@ private[events] sealed abstract class ContractsTable extends PostCommitValidatio
             batches // ignore any event which is neither a create nor a consuming exercise
         }
 
-    // Divulged contracts are inserted _after_ locally created contracts to make sure they are
-    // not skipped if consumed in this transaction due to the logic that prevents the insertion
-    // of transient contracts (a divulged contract _must_ be inserted, regardless of whether it's
-    // consumed or not).
-    val divulgedContractsInsertions =
-      divulgedContracts.iterator.collect {
-        case contract if !locallyCreatedContracts.insertions.contains(contract.contractId) =>
-          contract.contractId -> new RawBatch.Contract(
-            contractId = contract.contractId,
-            templateId = contract.contractInst.template,
-            createArgument = contract.contractInst.arg,
-            createLedgerEffectiveTime = None,
-            stakeholders = Set.empty,
-            key = None,
-          )
-      }.toMap
-
-    locallyCreatedContracts
-      .copy(insertions = locallyCreatedContracts.insertions ++ divulgedContractsInsertions)
-      .prepare
-
+    locallyCreatedContracts.prepare
   }
 
   override final def lookupContractKeyGlobally(key: Key)(

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
@@ -105,6 +105,25 @@ private[dao] trait JdbcLedgerDaoContractsSpec extends LoneElement with Inside {
     }
   }
 
+  it should "not allow the retrieval of the maximum ledger time of archived divulged contracts" in {
+    val divulgedContractId = AbsoluteContractId.assertFromString(s"#divulged-${UUID.randomUUID}")
+    for {
+      // This divulges and archives a contract in the same transaction
+      (_, _) <- store(
+        divulgedContracts = Map(
+          (divulgedContractId, someContractInstance) -> Set(charlie)
+        ),
+        offsetAndTx = singleExercise(divulgedContractId)
+      )
+      failure <- ledgerDao.lookupMaximumLedgerTime(Set(divulgedContractId)).failed
+    } yield {
+      failure shouldBe an[IllegalArgumentException]
+      failure.getMessage should startWith(
+        "One or more of the following contract identifiers has been found"
+      )
+    }
+  }
+
   it should "store contracts with a transient contract in the global divulgence" in {
     store(fullyTransientWithChildren).flatMap(_ => succeed)
   }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
@@ -78,7 +78,7 @@ private[dao] trait JdbcLedgerDaoContractsSpec extends LoneElement with Inside {
         divulgedContracts = Map(
           (divulgedContractId, someContractInstance) -> Set(charlie)
         ),
-        offsetAndTx = singleExercise(divulgedContractId)
+        offsetAndTx = emptyTransaction(alice)
       )
       (_, tx) <- store(singleCreate)
       contractIds = nonTransient(tx) + divulgedContractId
@@ -97,7 +97,7 @@ private[dao] trait JdbcLedgerDaoContractsSpec extends LoneElement with Inside {
         divulgedContracts = Map(
           (divulgedContractId, someContractInstance) -> Set(charlie)
         ),
-        offsetAndTx = singleExercise(divulgedContractId)
+        offsetAndTx = emptyTransaction(alice)
       )
       result <- ledgerDao.lookupMaximumLedgerTime(Set(divulgedContractId))
     } yield {

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoContractsSpec.scala
@@ -106,7 +106,7 @@ private[dao] trait JdbcLedgerDaoContractsSpec extends LoneElement with Inside {
   }
 
   it should "not allow the retrieval of the maximum ledger time of archived divulged contracts" in {
-    val divulgedContractId = AbsoluteContractId.assertFromString(s"#divulged-${UUID.randomUUID}")
+    val divulgedContractId = ContractId.assertFromString(s"#divulged-${UUID.randomUUID}")
     for {
       // This divulges and archives a contract in the same transaction
       (_, _) <- store(


### PR DESCRIPTION
Specifically, don't keep contracts that have been divulged AND archived in the same transaction.

Even if the archival of a divulged contract might not be visible to all locally hosted parties, the ledger would reject all commands that try to use archived contracts anyway.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
