### PR TITLE
Drop 'Batched' infix from all ledger-on-memory class names

### DIFF
--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -63,7 +63,7 @@ object Main {
         logCtx: LoggingContext,
     ): ResourceOwner[KeyValueLedger] = {
       val metrics = createMetrics(participantConfig, config)
-      new InMemoryBatchedLedgerReaderWriter.Owner(
+      new InMemoryLedgerReaderWriter.Owner(
         initialLedgerId = config.ledgerId,
         config.extra.batchingLedgerWriterConfig,
         participantId = participantConfig.participantId,

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -31,7 +31,7 @@ import com.daml.resources.{Resource, ResourceOwner}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 
-final class InMemoryBatchedLedgerReaderWriter(
+final class InMemoryLedgerReaderWriter(
     override val participantId: ParticipantId,
     override val ledgerId: LedgerId,
     dispatcher: Dispatcher[Index],
@@ -61,7 +61,7 @@ final class InMemoryBatchedLedgerReaderWriter(
   private val ledgerStateAccess = new InMemoryLedgerStateAccess(state, metrics)
 }
 
-object InMemoryBatchedLedgerReaderWriter {
+object InMemoryLedgerReaderWriter {
   val DefaultTimeProvider: TimeProvider = TimeProvider.UTC
 
   final class SingleParticipantOwner(
@@ -131,7 +131,7 @@ object InMemoryBatchedLedgerReaderWriter {
           validator,
           stateValueCache)
       val readerWriter =
-        new InMemoryBatchedLedgerReaderWriter(
+        new InMemoryLedgerReaderWriter(
           participantId,
           ledgerId,
           dispatcher,

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
@@ -17,7 +17,7 @@ import com.daml.resources.ResourceOwner
 
 import scala.concurrent.duration._
 
-abstract class InMemoryBatchedLedgerReaderWriterIntegrationSpecBase(enableBatching: Boolean)
+abstract class InMemoryLedgerReaderWriterIntegrationSpecBase(enableBatching: Boolean)
     extends ParticipantStateIntegrationSpecBase(
       s"In-memory ledger/participant with parallel validation ${if (enableBatching) "enabled"
       else "disabled"}") {
@@ -44,7 +44,7 @@ abstract class InMemoryBatchedLedgerReaderWriterIntegrationSpecBase(enableBatchi
       testId: String,
       metrics: Metrics,
   )(implicit logCtx: LoggingContext): ResourceOwner[ParticipantState] =
-    new InMemoryBatchedLedgerReaderWriter.SingleParticipantOwner(
+    new InMemoryLedgerReaderWriter.SingleParticipantOwner(
       ledgerId,
       batchingLedgerWriterConfig,
       participantId,
@@ -53,5 +53,5 @@ abstract class InMemoryBatchedLedgerReaderWriterIntegrationSpecBase(enableBatchi
     ).map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter, metrics))
 }
 
-class InMemoryBatchedLedgerReaderWriterIntegrationSpec
-    extends InMemoryBatchedLedgerReaderWriterIntegrationSpecBase(enableBatching = true)
+class InMemoryLedgerReaderWriterIntegrationSpec
+    extends InMemoryLedgerReaderWriterIntegrationSpecBase(enableBatching = true)

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterSpec.scala
@@ -18,7 +18,7 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class InMemoryBatchedLedgerReaderWriterSpec
+class InMemoryLedgerReaderWriterSpec
     extends AsyncWordSpec
     with AkkaBeforeAndAfterAll
     with Matchers
@@ -35,7 +35,7 @@ class InMemoryBatchedLedgerReaderWriterSpec
           any[LedgerStateOperations[Index]])(any[ExecutionContext]()))
         .thenReturn(
           Future.successful(SubmissionResult.InternalError("Validation failed with an exception")))
-      val instance = new InMemoryBatchedLedgerReaderWriter(
+      val instance = new InMemoryLedgerReaderWriter(
         Ref.ParticipantId.assertFromString("participant ID"),
         "ledger ID",
         mockDispatcher,

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/NonBatchedInMemoryLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/NonBatchedInMemoryLedgerReaderWriterIntegrationSpec.scala
@@ -3,5 +3,5 @@
 
 package com.daml.ledger.on.memory
 
-class InMemoryNonBatchedLedgerReaderWriterIntegrationSpec
-    extends InMemoryBatchedLedgerReaderWriterIntegrationSpecBase(enableBatching = false) {}
+class NonBatchedInMemoryLedgerReaderWriterIntegrationSpec
+    extends InMemoryLedgerReaderWriterIntegrationSpecBase(enableBatching = false) {}

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.Source
 import ch.qos.logback.classic.Level
 import com.codahale.metrics.MetricRegistry
 import com.daml.caching.Cache
-import com.daml.ledger.on.memory.InMemoryBatchedLedgerReaderWriter
+import com.daml.ledger.on.memory.InMemoryLedgerReaderWriter
 import com.daml.ledger.participant.state.kvutils.api.{
   BatchingLedgerWriterConfig,
   KeyValueParticipantState
@@ -238,7 +238,7 @@ object RecoveringIndexerIntegrationSpec {
         logCtx: LoggingContext
     ): ResourceOwner[ParticipantState] = {
       val metrics = new Metrics(new MetricRegistry)
-      new InMemoryBatchedLedgerReaderWriter.SingleParticipantOwner(
+      new InMemoryLedgerReaderWriter.SingleParticipantOwner(
         ledgerId,
         BatchingLedgerWriterConfig.reasonableDefault,
         participantId,


### PR DESCRIPTION
Summary of changes:
* Removed `Batched` infix from all class names related to `ledger-on-memory`.
* Renamed integration test with batching disabled to `NonBatchedInMemoryLedgerReaderWriteIntegrationSpec`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
