### PR TITLE
DAML-LF:  discriminate submitted and committed transactions

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1502,7 +1502,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
 
     "be validable in whole" in {
-      def validate(tx: Tx.Transaction, metaData: Tx.Metadata) =
+      def validate(tx: Tx.SubmittedTransaction, metaData: Tx.Metadata) =
         engine
           .validate(tx, let, participant, metaData.submissionTime, submissionSeed)
           .consume(_ => None, lookupPackage, _ => None)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -501,8 +501,6 @@ object Transaction {
   ): Either[String, CommittedTransaction] =
     tx.suffixCid(f).map(CommittedTransaction(_))
 
-  sealed trait CommandIdTag
-
   /** Errors that can happen during building transactions. */
   sealed abstract class TransactionError extends Product with Serializable
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -8,6 +8,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1._
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
+import com.daml.lf.transaction.{Transaction => Tx}
 import com.google.common.io.BaseEncoding
 import com.google.protobuf.ByteString
 
@@ -235,7 +236,7 @@ object KeyValueConsumption {
         optNodeSeeds = None,
         optByKeyNodes = None,
       ),
-      transaction = transaction,
+      transaction = Tx.CommittedTransaction(transaction),
       transactionId = hexTxId,
       recordTime = recordTime,
       divulgedContracts = List.empty

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueSubmission.scala
@@ -8,7 +8,6 @@ import com.daml.ledger.participant.state.kvutils.Conversions._
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1._
 import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.transaction.Transaction
 import com.daml.metrics.Metrics
 import com.google.protobuf.ByteString
 
@@ -32,7 +31,7 @@ class KeyValueSubmission(metrics: Metrics) {
     *
     * @deprecated Use [[KeyValueCommitting.submissionOutputs]] instead. This function will be removed in later version.
     */
-  def transactionOutputs(tx: Transaction.Transaction): List[DamlStateKey] =
+  def transactionOutputs(tx: SubmittedTransaction): List[DamlStateKey] =
     metrics.daml.kvutils.submission.conversion.transactionOutputs.time { () =>
       val effects = InputsAndEffects.computeEffects(tx)
       effects.createdContracts.map(_._1) ++ effects.consumedContracts
@@ -42,7 +41,7 @@ class KeyValueSubmission(metrics: Metrics) {
   def transactionToSubmission(
       submitterInfo: SubmitterInfo,
       meta: TransactionMeta,
-      tx: Transaction.Transaction,
+      tx: SubmittedTransaction,
   ): DamlSubmission =
     metrics.daml.kvutils.submission.conversion.transactionToSubmission.time { () =>
       val inputDamlStateFromTx = InputsAndEffects.computeInputs(tx, meta)

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -20,7 +20,7 @@ import com.daml.lf.archive.DarReader
 import com.daml.lf.crypto
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.{ImmArray, Ref}
-import com.daml.lf.transaction.{GenTransaction, Transaction}
+import com.daml.lf.transaction.{GenTransaction, Transaction => Tx}
 import com.daml.logging.LoggingContext
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
@@ -671,8 +671,8 @@ object ParticipantStateIntegrationSpecBase {
 
   private val IdleTimeout: FiniteDuration = 5.seconds
 
-  private val emptyTransaction: Transaction.Transaction =
-    GenTransaction(HashMap.empty, ImmArray.empty)
+  private val emptyTransaction: SubmittedTransaction =
+    Tx.SubmittedTransaction(GenTransaction(HashMap.empty, ImmArray.empty))
 
   private val participantId: ParticipantId = Ref.ParticipantId.assertFromString("test-participant")
   private val sourceDescription = Some("provided by test")

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -13,7 +13,7 @@ import com.daml.lf.crypto
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.Engine
-import com.daml.lf.transaction.Transaction
+import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.metrics.Metrics
 import scalaz.State
@@ -166,7 +166,7 @@ object KVTest {
       submissionSeed: crypto.Hash,
       additionalContractDataTy: String,
       cmds: Command*,
-  ): KVTest[(Transaction.Transaction, Transaction.Metadata)] =
+  ): KVTest[(SubmittedTransaction, Tx.Metadata)] =
     for {
       s <- get[KVTestState]
       (tx, meta) = engine
@@ -200,12 +200,12 @@ object KVTest {
       submitter: Party,
       submissionSeed: crypto.Hash,
       cmds: Command*,
-  ): KVTest[(Transaction.Transaction, Transaction.Metadata)] =
+  ): KVTest[(SubmittedTransaction, Tx.Metadata)] =
     runCommand(submitter, submissionSeed, defaultAdditionalContractDataTy, cmds: _*)
 
   def submitTransaction(
       submitter: Party,
-      transaction: (Transaction.Transaction, Transaction.Metadata),
+      transaction: (SubmittedTransaction, Tx.Metadata),
       submissionSeed: crypto.Hash,
       letDelta: Duration = Duration.ZERO,
       commandId: CommandId = randomLedgerString,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -16,7 +16,7 @@ import com.daml.ledger.participant.state.v1._
 import com.daml.lf.crypto
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.{ImmArray, Ref}
-import com.daml.lf.transaction.{GenTransaction, Transaction}
+import com.daml.lf.transaction.{GenTransaction, Transaction => Tx}
 import com.daml.metrics.Metrics
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
@@ -95,8 +95,8 @@ object KeyValueParticipantStateWriterSpec {
 
   private val aParty = Ref.Party.assertFromString("aParty")
 
-  private val anEmptyTransaction: Transaction.Transaction =
-    GenTransaction(HashMap.empty, ImmArray.empty)
+  private val anEmptyTransaction: Tx.SubmittedTransaction =
+    Tx.SubmittedTransaction(GenTransaction(HashMap.empty, ImmArray.empty))
 
   private val aSubmissionId: SubmissionId =
     Ref.LedgerString.assertFromString(UUID.randomUUID().toString)

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.participant.state
 
 import com.daml.lf.data.Ref
-import com.daml.lf.transaction.{GenTransaction, Transaction}
+import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.Value
 
 /** Interfaces to read from and write to an (abstract) participant state.
@@ -84,7 +84,7 @@ package object v1 {
   type SubmissionId = Ref.LedgerString
 
   /** Identifiers for nodes in a transaction. */
-  type NodeId = Transaction.NodeId
+  type NodeId = Tx.NodeId
 
   /** Identifiers for packages. */
   type PackageId = Ref.PackageId
@@ -96,15 +96,14 @@ package object v1 {
     *
     * See the Contract Id specification for more detail daml-lf/spec/contract-id.rst
     */
-  type SubmittedTransaction = Transaction.Transaction
+  type SubmittedTransaction = Tx.SubmittedTransaction
 
   /** A transaction with globally unique contract IDs.
     *
     * Used to communicate transactions that have been accepted to the ledger.
     * See the Contract Id specification for more detail daml-lf/spec/contract-id.rst
     */
-  type CommittedTransaction =
-    GenTransaction.WithTxValue[NodeId, Value.ContractId]
+  type CommittedTransaction = Tx.CommittedTransaction
 
   /** A contract instance. */
   type ContractInst =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/CommandExecutionResult.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/CommandExecutionResult.scala
@@ -4,7 +4,7 @@
 package com.daml.platform.apiserver.execution
 
 import com.daml.ledger.participant.state.v1.{SubmitterInfo, TransactionMeta}
-import com.daml.lf.transaction.Transaction
+import com.daml.lf.transaction.{Transaction => Tx}
 
 /**
   * The result of command execution.
@@ -22,6 +22,6 @@ import com.daml.lf.transaction.Transaction
 final case class CommandExecutionResult(
     submitterInfo: SubmitterInfo,
     transactionMeta: TransactionMeta,
-    transaction: Transaction.Transaction,
+    transaction: Tx.SubmittedTransaction,
     dependsOnLedgerTime: Boolean,
 )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionCommitter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionCommitter.scala
@@ -21,7 +21,7 @@ object StandardTransactionCommitter extends TransactionCommitter {
       transactionId: Ref.LedgerString,
       transaction: SubmittedTransaction
   ): CommittedTransaction =
-    transaction
+    Transaction.commitTransaction(transaction)
 }
 
 // Committer emulating Contract ID legacy scheme
@@ -41,11 +41,12 @@ object LegacyTransactionCommitter extends TransactionCommitter {
           Value.ContractId.V0(Ref.ContractIdString.assertFromString(prefix + nid.index.toString)))
         .withDefault(identity)
 
-    GenTransaction.map3(
-      identity[Transaction.NodeId],
-      contractMapping,
-      Value.VersionedValue.map1(contractMapping)
-    )(transaction)
+    Transaction.CommittedTransaction(
+      GenTransaction.map3(
+        identity[Transaction.NodeId],
+        contractMapping,
+        Value.VersionedValue.map1(contractMapping)
+      )(transaction))
 
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -27,7 +27,7 @@ import com.daml.ledger.WorkflowId
 import com.daml.lf.archive.Decode
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{PackageId, Party}
-import com.daml.lf.transaction.Node
+import com.daml.lf.transaction.{Node, Transaction => Tx}
 import com.daml.lf.value.Value.ContractId
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
@@ -556,8 +556,9 @@ private class JdbcLedgerDao(
                     transactionId = tx.transactionId,
                     ledgerEffectiveTime = tx.ledgerEffectiveTime,
                     offset = offset,
-                    transaction =
-                      tx.transaction.mapNodeId(TransactionIdWithIndex.assertFromString(_).nodeId),
+                    transaction = Tx.CommittedTransaction(
+                      tx.transaction.mapNodeId(TransactionIdWithIndex.assertFromString(_).nodeId)
+                    ),
                     divulgedContracts = Nil,
                   )
                   .write(metrics)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsTable.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsTable.scala
@@ -6,7 +6,7 @@ package com.daml.platform.store.dao.events
 import java.sql.Connection
 import java.time.Instant
 
-import com.daml.ledger.participant.state.v1.DivulgedContract
+import com.daml.ledger.participant.state.v1.{CommittedTransaction, DivulgedContract}
 import anorm.SqlParser.int
 import anorm.{BatchSql, NamedParameter, SqlStringInterpolation, ~}
 import com.daml.platform.store.Conversions._
@@ -119,7 +119,7 @@ private[events] sealed abstract class ContractsTable extends PostCommitValidatio
 
   def prepareBatchInsert(
       ledgerEffectiveTime: Instant,
-      transaction: Transaction,
+      transaction: CommittedTransaction,
       divulgedContracts: Iterable[DivulgedContract],
   ): RawBatches = {
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableInsert.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsTableInsert.scala
@@ -5,9 +5,8 @@ package com.daml.platform.store.dao.events
 
 import java.time.Instant
 import anorm.{BatchSql, NamedParameter}
-import com.daml.ledger.participant.state.v1.{Offset, SubmitterInfo}
+import com.daml.ledger.participant.state.v1.{CommittedTransaction, Offset, SubmitterInfo}
 import com.daml.ledger._
-import com.daml.lf.transaction.GenTransaction
 import com.daml.platform.store.Conversions._
 
 private[events] trait EventsTableInsert { this: EventsTable =>
@@ -159,17 +158,17 @@ private[events] trait EventsTableInsert { this: EventsTable =>
     * @throws RuntimeException If a value cannot be serialized into an array of bytes
     */
   @throws[RuntimeException]
-  def prepareBatchInsert[Nid <: NodeId](
+  def prepareBatchInsert(
       submitterInfo: Option[SubmitterInfo],
       workflowId: Option[WorkflowId],
       transactionId: TransactionId,
       ledgerEffectiveTime: Instant,
       offset: Offset,
-      transaction: GenTransaction.WithTxValue[Nid, ContractId],
-      flatWitnesses: WitnessRelation[Nid],
-      treeWitnesses: WitnessRelation[Nid],
+      transaction: CommittedTransaction,
+      flatWitnesses: WitnessRelation[NodeId],
+      treeWitnesses: WitnessRelation[NodeId],
   ): RawBatches = {
-    def event[Sp <: RawBatch.Event.Specific](nodeId: Nid, sp: Sp) =
+    def event[Sp <: RawBatch.Event.Specific](nodeId: NodeId, sp: Sp) =
       new RawBatch.Event(
         applicationId = submitterInfo.map(_.applicationId),
         workflowId = workflowId,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
@@ -19,7 +19,6 @@ package object events {
 
   import com.daml.lf.{transaction => lftx}
   private[events] type NodeId = lftx.Transaction.NodeId
-  private[events] type Transaction = lftx.GenTransaction.WithTxValue[NodeId, ContractId]
   private[events] type Node = lftx.Node.GenNode.WithTxValue[NodeId, ContractId]
   private[events] type Create = lftx.Node.NodeCreate.WithTxValue[ContractId]
   private[events] type Exercise = lftx.Node.NodeExercises.WithTxValue[NodeId, ContractId]

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -17,7 +17,7 @@ import com.daml.lf.archive.DarReader
 import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.transaction.Node._
-import com.daml.lf.transaction.{GenTransaction, Node}
+import com.daml.lf.transaction.{GenTransaction, Node, Transaction => Tx}
 import com.daml.lf.value.Value.{
   ContractId,
   ContractInst,
@@ -441,7 +441,9 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         submitterInfo = submitterInfo,
         workflowId = entry.workflowId,
         transactionId = entry.transactionId,
-        transaction = entry.transaction.mapNodeId(TransactionIdWithIndex.assertFromString(_).nodeId),
+        transaction = Tx.CommittedTransaction(
+          entry.transaction.mapNodeId(TransactionIdWithIndex.assertFromString(_).nodeId)
+        ),
         recordTime = entry.recordedAt,
         ledgerEffectiveTime = entry.ledgerEffectiveTime,
         offset = offset,

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/events/TransactionBuilder.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/events/TransactionBuilder.scala
@@ -5,6 +5,7 @@ package com.daml.platform.store.dao.events
 
 import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Ref.{ChoiceName, Name}
+import com.daml.lf.transaction.{GenTransaction, Transaction => Tx}
 
 import scala.collection.immutable.HashMap
 import scala.util.control.NonFatal
@@ -40,8 +41,8 @@ final class TransactionBuilder {
     nodeId
   }
 
-  def build(): Transaction = ids.synchronized {
-    Transaction(nodes.result(), roots.result())
+  def build(): Tx.Transaction = ids.synchronized {
+    GenTransaction(nodes.result(), roots.result())
   }
 
 }
@@ -149,13 +150,13 @@ object TransactionBuilder {
       result = if (found) Some(contract.coid) else None
     )
 
-  def just(node: Node, nodes: Node*): Transaction = {
+  def just(node: Node, nodes: Node*): Tx.CommittedTransaction = {
     val builder = new TransactionBuilder
     val _ = builder.add(node)
     for (node <- nodes) {
       val _ = builder.add(node)
     }
-    builder.build()
+    Tx.CommittedTransaction(builder.build())
   }
 
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -27,7 +27,7 @@ import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.participant.state.v1._
 import com.daml.lf.crypto
 import com.daml.lf.data.{ImmArray, Ref, Time}
-import com.daml.lf.transaction.{GenTransaction, Transaction}
+import com.daml.lf.transaction.{GenTransaction, Transaction => Tx}
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.platform.sandbox.stores.ledger.TransactionTimeModelComplianceIT._
 import com.daml.platform.sandbox.{LedgerResource, MetricsAround}
@@ -95,8 +95,8 @@ class TransactionTimeModelComplianceIT
   }
 
   private[this] def publishTxAt(ledger: Ledger, ledgerTime: Instant, commandId: String) = {
-    val dummyTransaction: Transaction.Transaction =
-      GenTransaction(HashMap.empty, ImmArray.empty)
+    val dummyTransaction =
+      Tx.SubmittedTransaction(GenTransaction(HashMap.empty[Tx.NodeId, Tx.Node], ImmArray.empty))
 
     val submitterInfo = SubmitterInfo(
       submitter = Ref.Party.assertFromString("submitter"),


### PR DESCRIPTION
The [new contract ID scheme ](https://github.com/digital-asset/daml/blob/master/daml-lf/spec/contract-id.rst) leaves the ledger implementation free to suffix the fresh contract IDs as its convenience before committing the transaction. 

This PR makes this possibility explicitly by distinguish `SubmittedTransaction`  (where fresh contract IDs are not suffix) from `CommittedTransaction` (where contract IDs have been suffixed). 

Note that kv-utils does not suffix Contract IDs, but making the distinction explicit is very helpful for other ledger implementations like canton or daml-on-corda.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
