### PR TITLE
Improve error message for unsuccessful key lookups

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -329,7 +329,7 @@ final class Engine {
                   if (cb(SKeyLookupResult(result)))
                     interpretLoop(machine, time)
                   else
-                    ResultError(Error(s"dependency error: couldn't find key $gk"))
+                    ResultError(Error(s"dependency error: couldn't find key ${gk.key}"))
             )
           )
 


### PR DESCRIPTION
This should work as all implementations of `Value` are `case class`es (unlike `GlobalKey`).

changelog_begin
[Runtime] Improved error messages on unsuccessful key lookups
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
