### PR TITLE
Test trigger won't start when ledger connection not viable

### DIFF
--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -68,7 +68,6 @@ object TriggerServiceFixture {
     val toxiProxyProc = Process(Seq(toxiProxyExe, "--port", toxiProxyPort.value.toString)).run()
     RetryStrategy.constant(attempts = 3, waitTime = 2.seconds) { (_, _) =>
       for {
-        _ <- Future(println("Waiting for Toxiproxy..."))
         channel <- Future(new Socket(host, toxiProxyPort.value))
       } yield (channel.close())
     }


### PR DESCRIPTION
Add a test that checks that when a trigger can't be initialized, it does not make its way to the running triggers table.