### PR TITLE
Expose the DAML profiler in Sandbox Classic

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -21,13 +21,17 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
     new ConcurrentHashMap()
   private[this] val _packageDeps: ConcurrentHashMap[PackageId, Set[PackageId]] =
     new ConcurrentHashMap()
+  private[this] var _profilingMode: speedy.Compiler.ProfilingMode = speedy.Compiler.NoProfile
 
   def getPackage(pId: PackageId): Option[Package] = Option(_packages.get(pId))
   def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
     Option(_defns.get(dref))
 
   def stackTraceMode = speedy.Compiler.FullStackTrace
-  def profilingMode = speedy.Compiler.NoProfile
+  def profilingMode = _profilingMode
+  def profilingMode_=(profilingMode: speedy.Compiler.ProfilingMode) = {
+    _profilingMode = profilingMode
+  }
 
   /** Might ask for a package if the package you're trying to add references it.
     *

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -5,6 +5,7 @@ package com.daml.lf
 package speedy
 
 import java.lang.System
+import java.nio.file.Path
 import java.util.ArrayList
 
 /** Class for profiling information collected by Speedy. We use [[AnyRef]] for
@@ -28,9 +29,9 @@ final class Profile {
     events.add(Event(false, label, time))
   }
 
-  def writeSpeedscopeJson(filename: String) = {
+  def writeSpeedscopeJson(path: Path) = {
     val fileJson = SpeedscopeJson.FileJson.fromProfile(this)
-    fileJson.write(filename)
+    fileJson.write(path)
   }
 }
 
@@ -89,9 +90,9 @@ object Profile {
         exporter: String,
         name: String,
     ) {
-      def write(filename: String): Unit = {
+      def write(path: Path): Unit = {
         import JsonProtocol.fileFormat
-        val writer = new BufferedWriter(new FileWriter(filename))
+        val writer = new BufferedWriter(new FileWriter(path.toFile()))
         writer.write(this.toJson.compactPrint)
         writer.close()
       }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -36,8 +36,6 @@ object Main extends App {
   val out = new PrintStream(System.out, true, "UTF-8")
   System.setOut(out)
 
-  case class ProfileArgs(scenarioId: String, inputFile: String, outputFile: String)
-
   def usage(): Unit = {
     println(
       """
@@ -82,7 +80,7 @@ object Main extends App {
       case List("test", id, file) =>
         if (!Repl.test(allowDev, id, file)._1) System.exit(1)
       case List("profile", scenarioId, inputFile, outputFile) =>
-        if (!Repl.profile(allowDev, scenarioId, inputFile, outputFile)._1) System.exit(1)
+        if (!Repl.profile(allowDev, scenarioId, inputFile, Paths.get(outputFile))._1) System.exit(1)
       case List("validate", file) =>
         if (!Repl.validate(allowDev, file)._1) System.exit(1)
       case List(possibleFile) =>
@@ -142,7 +140,7 @@ object Repl {
       allowDev: Boolean,
       scenarioId: String,
       inputFile: String,
-      outputFile: String,
+      outputFile: Path,
   ): (Boolean, State) =
     load(inputFile, Compiler.FullProfile) fMap cmdValidate fMap (state =>
       cmdProfile(state, scenarioId, outputFile))
@@ -531,7 +529,7 @@ object Repl {
     (failures == 0, state)
   }
 
-  def cmdProfile(state: State, scenarioId: String, outputFile: String): (Boolean, State) = {
+  def cmdProfile(state: State, scenarioId: String, outputFile: Path): (Boolean, State) = {
     buildExpr(state, Seq(scenarioId))
       .map { expr =>
         println("Warming up JVM for 10s...")

--- a/ledger/sandbox/README.md
+++ b/ledger/sandbox/README.md
@@ -54,3 +54,35 @@ You can enable debug logging in Sandbox with `sandbox-log-level` system property
 Or when started from Bazel with:
 
     $ bazel run //ledger/sandbox:sandbox-binary -- --log-level=DEBUG $PWD/bazel-bin/ledger/sandbox/Test.dar
+
+# Profiling
+
+You can enable profiling in Sandbox by passing a directory where the profiling
+information should be written via the `--profile-dir` flag, e.g.
+```shell
+$ bazel run //ledger/sandbox:sandbox-binary -- --profile-dir=/write/profiles/here/ ...
+```
+
+**DISCLAIMER**: Profiling is not intended to be used in production setups since
+it slows down DAML execution significantly and writes a lot of profiling
+information to disk.
+
+For every command submitted to the Sandbox, a JSON file named like
+`<submission time>-<command description>-<seed>.json` is written to the
+directory specified via `--profile-dir`. In this file name,
+`<command description>` is a string of the form `create:TemplateName` or
+`exercise:TemplateName:ChoiceName`.
+
+These JSON files can be viewed using the
+[speedscope](https://www.speedscope.app/) flamegraph visualizer. The easiest
+way to install speedscope is to run
+```shell
+$ npm install -g speedscope
+```
+See the [Offline usage](https://github.com/jlfwong/speedscope#usage) section of
+its documentation for alternatives.
+
+Once speedscope is installed, a specific profile can be viewed via
+```shell
+$ speedscope /path/to/profile.json
+```

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -287,6 +287,12 @@ object Cli {
           )
         )
 
+      opt[File]("profile-dir")
+        .hidden()
+        .optional()
+        .action((dir, config) => config.copy(profileDir = Some(dir.toPath)))
+        .text("Enable profiling and write the profiles into the given directory.")
+
       help("help").text("Print the usage text")
 
       checkConfig(c => {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -42,6 +42,7 @@ final case class SandboxConfig(
     metricsReportingInterval: Duration,
     eventsPageSize: Int,
     lfValueTranslationCacheConfiguration: caching.Configuration,
+    profileDir: Option[Path],
 )
 
 object SandboxConfig {
@@ -78,6 +79,7 @@ object SandboxConfig {
       metricsReportingInterval = Duration.ofSeconds(10),
       eventsPageSize = DefaultEventsPageSize,
       lfValueTranslationCacheConfiguration = DefaultLfValueTranslationCacheConfiguration,
+      profileDir = None,
     )
 
   lazy val default: SandboxConfig =


### PR DESCRIPTION
This PR adds an option `--profile-dir` to Sandbox Classic which takes
a directory as its argument. When this option is used, all command
submissions to the Sandbox are run in profiling more and the resulting
profiling information is written to the directory specified via
`--profile-dir`. See `/ledger/sandbox/README.md#Profiling` for further
details on this.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6151)
<!-- Reviewable:end -->
