### PR TITLE
declare http-json Streaming API as stable

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -25,6 +25,11 @@ complicating concerns, including but not limited to:
 For these and other features, use :doc:`the Ledger API </app-dev/ledger-api>`
 instead.
 
+We welcome feedback about the JSON API on `our issue tracker
+<https://github.com/digital-asset/daml/issues/new?milestone=HTTP+JSON+API+Maintenance>`_
+`on our forum <https://discuss.daml.com>`_, or `on Slack
+<https://slack.daml.com>`_.
+
 .. toctree::
    :hidden:
 
@@ -1176,18 +1181,6 @@ HTTP Response with Error
 Streaming API
 *************
 
-**WARNING:** the WebSocket endpoints described below are in alpha,
-so are *subject to breaking changes*, including all
-request and response elements demonstrated below or otherwise
-implemented by the API.  We welcome feedback about the API on `our issue
-tracker
-<https://github.com/digital-asset/daml/issues/new?milestone=HTTP+JSON+API+Maintenance>`_
-or `on our forum <https://discuss.daml.com>`_ or `on Slack <https://slack.daml.com>`_.
-
-Please keep in mind that the presence of **/v1** prefix in the the
-WebSocket URLs does not mean that the endpoint interfaces are
-stabilized.
-
 Two subprotocols must be passed with every request, as described in
 `Passing token with WebSockets <#passing-token-with-websockets>`__.
 
@@ -1254,8 +1247,6 @@ Contracts Query Stream
 - URL: ``/v1/stream/query``
 - Scheme: ``ws``
 - Protocol: ``WebSocket``
-
-*Endpoint is in alpha as described above.*
 
 List currently active contracts that match a given query, with
 continuous updates.
@@ -1420,8 +1411,6 @@ Fetch by Key Contracts Stream
 - URL: ``/v1/stream/fetch``
 - Scheme: ``ws``
 - Protocol: ``WebSocket``
-
-*Endpoint is in alpha as described above.*
 
 List currently active contracts that match one of the given ``{templateId, key}`` pairs, with continuous updates.
 


### PR DESCRIPTION
```rst
CHANGELOG_BEGIN
- [JSON API] The WebSocket endpoints ``/v1/stream/query`` and ``/v1/stream/fetch`` are now
  stable; these endpoints in SDK v1.0.0 are fully compatible with this first officially
  stable version.
  See `issue #6152 <https://github.com/digital-asset/daml/pull/6152>`_.
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
