### PR TITLE
Include the transaction service in sandbox migration tests

### DIFF
--- a/compatibility/sandbox-migration/BUILD
+++ b/compatibility/sandbox-migration/BUILD
@@ -55,6 +55,7 @@ da_scala_binary(
         "@maven//:com_thesamet_scalapb_scalapb_runtime_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:io_grpc_grpc_api",
         "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/compatibility/sandbox-migration/SandboxMigrationRunner.hs
+++ b/compatibility/sandbox-migration/SandboxMigrationRunner.hs
@@ -69,16 +69,16 @@ main = do
                 , "--host=localhost", "--port=" <> show p
                 ]
         hPutStrLn stderr "<-- Uploaded model DAR"
-        void $ foldlM (testVersion step modelDar jdbcUrl) [] platformAssistants
+        void $ foldlM (testVersion step modelDar jdbcUrl) ([], []) platformAssistants
 
 testVersion
     :: FilePath
     -> FilePath
     -> T.Text
-    -> [Tuple2 (ContractId T) T]
+    -> ([Tuple2 (ContractId T) T], [Transaction])
     -> FilePath
-    -> IO [Tuple2 (ContractId T) T]
-testVersion step modelDar jdbcUrl prevTs assistant = do
+    -> IO ([Tuple2 (ContractId T) T], [Transaction])
+testVersion step modelDar jdbcUrl (prevTs, prevTransactions) assistant = do
     let note = takeFileName (takeDirectory assistant)
     hPutStrLn stderr ("--> Testing " <> note)
     withSandbox assistant jdbcUrl $ \port ->
@@ -112,8 +112,39 @@ testVersion step modelDar jdbcUrl prevTs assistant = do
                 unless (t == expected) $
                     fail ("Expected " <> show expected <> " but got " <> show t)
             _ -> fail ("Expected 1 new T contract but got: " <> show addedTs)
+        -- verify that the stream before and after the migration are the same.
+        unless (prevTransactions == oldTransactions) $
+            fail $ "Transaction stream changed after migration "
+                <> show (prevTransactions, oldTransactions)
+        -- verify that we created the right number of new transactions.
+        unless (length newTransactions == length oldTransactions + 5) $
+            fail $ "Expected 3 new transactions but got "
+                <> show (length newTransactions - length oldTransactions)
+        let (newStart, newEnd) = splitAt (length oldTransactions) newTransactions
+        -- verify that the new stream is identical to the old if we cut off the new transactions.
+        unless (newStart == oldTransactions) $
+            fail $ "New transaction stream does not contain old transactions "
+                <> show (oldTransactions, newStart)
+        -- verify that the new transactions are what we expect.
+        validateNewTransactions (map events newEnd)
         hPutStrLn stderr ("<-- Tested " <> note)
-        pure newTs
+        pure (newTs, newTransactions)
+
+validateNewTransactions :: [[Event]] -> IO ()
+validateNewTransactions
+  [ [CreatedTProposal prop1 _]
+  , [CreatedTProposal prop2 _]
+  , [ArchivedTProposal prop1',CreatedT t1 _]
+  , [ArchivedTProposal prop2',CreatedT _t2 _]
+  , [ArchivedT t1']
+  ] = do
+    checkArchive prop1 prop1'
+    checkArchive prop2 prop2'
+    checkArchive t1 t1'
+  where
+    checkArchive cid cid' = unless (cid == cid') $
+      fail ("Expected " <> show cid <> " to be archived but got " <> show cid')
+validateNewTransactions events = fail ("Unexpected events: " <> show events)
 
 testProposer :: Party
 testProposer = Party "proposer"
@@ -143,7 +174,7 @@ data TProposal = TProposal
   { proposer :: Party
   , accepter :: Party
   , note :: T.Text
-  } deriving (Generic, Show)
+  } deriving (Generic, Show, Eq)
 
 instance A.FromJSON TProposal
 
@@ -154,11 +185,42 @@ data Tuple2 a b = Tuple2
 
 instance (A.FromJSON a, A.FromJSON b) => A.FromJSON (Tuple2 a b)
 
+data Event
+  = CreatedT (ContractId T) T
+  | ArchivedT (ContractId T)
+  | CreatedTProposal (ContractId TProposal) TProposal
+  | ArchivedTProposal (ContractId TProposal)
+  deriving (Eq, Show)
+
+instance A.FromJSON Event where
+    parseJSON = A.withObject "Event" $ \o -> do
+        ty <- o A..: "type"
+        tpl <- o A..: "template"
+        case ty of
+            "created" -> case tpl of
+                "Model:T" -> CreatedT <$> o A..: "cid" <*> o A..: "argument"
+                "Model:TProposal" -> CreatedTProposal <$> o A..: "cid" <*> o A..: "argument"
+                _ -> fail ("Invalid template: " <> tpl)
+            "archived" -> case tpl of
+                "Model:T" -> ArchivedT <$> o A..: "cid"
+                "Model:TProposal" -> ArchivedTProposal <$> o A..: "cid"
+                _ -> fail ("Invalid template: " <> tpl)
+            _ -> fail ("Invalid type: " <> ty)
+
+data Transaction = Transaction
+  { transactionId :: T.Text
+  , events :: [Event]
+  } deriving (Generic, Eq, Show)
+
+instance A.FromJSON Transaction
+
 data Result = Result
   { oldTProposals :: [Tuple2 (ContractId TProposal) TProposal]
   , newTProposals :: [Tuple2 (ContractId TProposal) TProposal]
   , oldTs :: [Tuple2 (ContractId T) T]
   , newTs :: [Tuple2 (ContractId T) T]
+  , oldTransactions :: [Transaction]
+  , newTransactions :: [Transaction]
   } deriving Generic
 
 instance A.FromJSON Result


### PR DESCRIPTION
This PR extends the existing sandbox migration tests with a query to
the transaction service before and after running each step and
corresponding validations for that in the migration runner.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
