### PR TITLE
add --no-out-link to dev-env

### DIFF
--- a/dev-env/lib/dade-common
+++ b/dev-env/lib/dade-common
@@ -57,7 +57,7 @@ dadeBaseHash() {
 
 # List tools defined in dade
 dadeListTools() {
-    cat $(nix-build $DADE_BASE_ROOT/nix -A dade.tools-list)
+    cat $(nix-build --no-out-link $DADE_BASE_ROOT/nix -A dade.tools-list)
 }
 
 # dadeGetOutput get output of a target
@@ -108,7 +108,7 @@ buildTool() {
     errcho "Building tools.${attr}${forced}..."
     # Allow to fail, so we can capture outpath and to capture the exit code too.
     set +e
-    outpath=$(nix-build "${DADE_BASE_ROOT}/nix/default.nix" -A tools.$attr -Q -o "${target}")
+    outpath=$(nix-build --no-out-link "${DADE_BASE_ROOT}/nix/default.nix" -A tools.$attr -Q -o "${target}")
     local dade_build_exit_code=$?
     set -e
     if [[ "$dade_build_exit_code" != "0" ]]; then


### PR DESCRIPTION
Without this flag, `nix-build` will create a `result` symlink after every invocation, appending a number to disambiguate. This means we end up with loads of `result-xyz` folders after a while, despite never incoking nix-build manually. This PR should fix that.

CHANGELOG_BEGIN
CHANGELOG_END