### PR TITLE
Collect active contract lookup time per execution

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -36,7 +36,15 @@ class Metrics(val registry: MetricRegistry) {
       val prefix: MetricName = daml.prefix :+ "execution"
 
       val lookupActiveContract: Timer = registry.timer(prefix :+ "lookup_active_contract")
+      val lookupActiveContractPerExecution: Timer =
+        registry.timer(prefix :+ "lookup_active_contract_per_execution")
+      val lookupActiveContractCountPerExecution: Histogram =
+        registry.histogram(prefix :+ "lookup_active_contract_count_per_execution")
       val lookupContractKey: Timer = registry.timer(prefix :+ "lookup_contract_key")
+      val lookupContractKeyPerExecution: Timer =
+        registry.timer(prefix :+ "lookup_contract_key_per_execution")
+      val lookupContractKeyCountPerExecution: Histogram =
+        registry.histogram(prefix :+ "lookup_contract_key_count_per_execution")
       val getLfPackage: Timer = registry.timer(prefix :+ "get_lf_package")
       val retry: Meter = registry.meter(prefix :+ "retry")
       val total: Timer = registry.timer(prefix :+ "total")


### PR DESCRIPTION
CHANGELOG_BEGIN
[DAML Ledger Integration Kit]: Added 4 new metrics for more detailed execution time statistics:
- Timer ``daml.execution.lookup_active_contract_per_execution``: measures the accumulated time spent for looking up active contracts per execution
- Histogram ``daml.execution.lookup_active_contract_count_per_execution``: measures the number of active contract lookups per execution
- Timer ``daml.execution.lookup_contract_key_per_execution``: measures the accumulated time spent for looking up contract keys per execution
- Histogram ``daml.execution.lookup_contract_key_count_per_execution``: measures the number of contract key lookups per execution
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
