### PR TITLE
More detailed store transaction metrics

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/DatabaseMetrics.scala
@@ -5,23 +5,14 @@ package com.daml.metrics
 
 import com.codahale.metrics.{MetricRegistry, Timer}
 
-final class DatabaseMetrics private[metrics] (
+class DatabaseMetrics private[metrics] (
     registry: MetricRegistry,
     prefix: MetricName,
     val name: String,
 ) {
+  val dbPrefix = prefix :+ name
 
-  val waitTimer: Timer = registry.timer(prefix :+ name :+ "wait")
-  val executionTimer: Timer = registry.timer(prefix :+ name :+ "exec")
-  val translationTimer: Timer = registry.timer(prefix :+ name :+ "translation")
-
-}
-
-object DatabaseMetrics {
-
-  private[metrics] def apply(registry: MetricRegistry, prefix: MetricName)(
-      name: String,
-  ): DatabaseMetrics =
-    new DatabaseMetrics(registry, prefix, name)
-
+  val waitTimer: Timer = registry.timer(dbPrefix :+ "wait")
+  val executionTimer: Timer = registry.timer(dbPrefix :+ "exec")
+  val translationTimer: Timer = registry.timer(dbPrefix :+ "translation")
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -313,28 +313,28 @@ class Metrics(val registry: MetricRegistry) {
         val stopDeduplicatingCommand: Timer =
           registry.timer(prefix :+ "stop_deduplicating_command")
 
-        private val createDatabaseMetrics: String => DatabaseMetrics =
+        private val createDbMetrics: String => DatabaseMetrics =
           new DatabaseMetrics(registry, prefix, _)
 
-        private val overall = createDatabaseMetrics("all")
+        private val overall = createDbMetrics("all")
         val waitAll: Timer = overall.waitTimer
         val execAll: Timer = overall.executionTimer
 
-        val getCompletions: DatabaseMetrics = createDatabaseMetrics("get_completions")
-        val getLedgerId: DatabaseMetrics = createDatabaseMetrics("get_ledger_id")
-        val getLedgerEnd: DatabaseMetrics = createDatabaseMetrics("get_ledger_end")
-        val getInitialLedgerEnd: DatabaseMetrics = createDatabaseMetrics("get_initial_ledger_end")
-        val initializeLedgerParameters: DatabaseMetrics = createDatabaseMetrics(
+        val getCompletions: DatabaseMetrics = createDbMetrics("get_completions")
+        val getLedgerId: DatabaseMetrics = createDbMetrics("get_ledger_id")
+        val getLedgerEnd: DatabaseMetrics = createDbMetrics("get_ledger_end")
+        val getInitialLedgerEnd: DatabaseMetrics = createDbMetrics("get_initial_ledger_end")
+        val initializeLedgerParameters: DatabaseMetrics = createDbMetrics(
           "initialize_ledger_parameters")
-        val lookupConfiguration: DatabaseMetrics = createDatabaseMetrics("lookup_configuration")
-        val loadConfigurationEntries: DatabaseMetrics = createDatabaseMetrics(
+        val lookupConfiguration: DatabaseMetrics = createDbMetrics("lookup_configuration")
+        val loadConfigurationEntries: DatabaseMetrics = createDbMetrics(
           "load_configuration_entries")
-        val storeConfigurationEntryDao: DatabaseMetrics = createDatabaseMetrics(
+        val storeConfigurationEntryDbMetrics: DatabaseMetrics = createDbMetrics(
           "store_configuration_entry") // FIXME Base name conflicts with storeConfigurationEntry
-        val storePartyEntryDao
-          : DatabaseMetrics = createDatabaseMetrics("store_party_entry") // FIXME Base name conflicts with storePartyEntry
-        val loadPartyEntries: DatabaseMetrics = createDatabaseMetrics("load_party_entries")
-        object storeTransactionDao
+        val storePartyEntryDbMetrics
+          : DatabaseMetrics = createDbMetrics("store_party_entry") // FIXME Base name conflicts with storePartyEntry
+        val loadPartyEntries: DatabaseMetrics = createDbMetrics("load_party_entries")
+        object storeTransactionDbMetrics
             extends DatabaseMetrics(registry, prefix, "store_ledger_entry") {
           // outside of SQL transaction
           val prepareBatches = registry.timer(dbPrefix :+ "prepare_batches")
@@ -352,36 +352,36 @@ class Metrics(val registry: MetricRegistry) {
           val insertCompletion = registry.timer(dbPrefix :+ "insert_completion")
           val updateLedgerEnd = registry.timer(dbPrefix :+ "update_ledger_end")
         }
-        val storeRejectionDao
-          : DatabaseMetrics = createDatabaseMetrics("store_rejection") // FIXME Base name conflicts with storeRejection
-        val storeInitialStateFromScenario: DatabaseMetrics = createDatabaseMetrics(
+        val storeRejectionDbMetrics
+          : DatabaseMetrics = createDbMetrics("store_rejection") // FIXME Base name conflicts with storeRejection
+        val storeInitialStateFromScenario: DatabaseMetrics = createDbMetrics(
           "store_initial_state_from_scenario")
-        val loadParties: DatabaseMetrics = createDatabaseMetrics("load_parties")
-        val loadAllParties: DatabaseMetrics = createDatabaseMetrics("load_all_parties")
-        val loadPackages: DatabaseMetrics = createDatabaseMetrics("load_packages")
-        val loadArchive: DatabaseMetrics = createDatabaseMetrics("load_archive")
-        val storePackageEntryDao
-          : DatabaseMetrics = createDatabaseMetrics("store_package_entry") // FIXME Base name conflicts with storePackageEntry
-        val loadPackageEntries: DatabaseMetrics = createDatabaseMetrics("load_package_entries")
-        val deduplicateCommandDao
-          : DatabaseMetrics = createDatabaseMetrics("deduplicate_command") // FIXME Base name conflicts with deduplicateCommand
-        val removeExpiredDeduplicationDataDao: DatabaseMetrics = createDatabaseMetrics(
+        val loadParties: DatabaseMetrics = createDbMetrics("load_parties")
+        val loadAllParties: DatabaseMetrics = createDbMetrics("load_all_parties")
+        val loadPackages: DatabaseMetrics = createDbMetrics("load_packages")
+        val loadArchive: DatabaseMetrics = createDbMetrics("load_archive")
+        val storePackageEntryDbMetrics
+          : DatabaseMetrics = createDbMetrics("store_package_entry") // FIXME Base name conflicts with storePackageEntry
+        val loadPackageEntries: DatabaseMetrics = createDbMetrics("load_package_entries")
+        val deduplicateCommandDbMetrics
+          : DatabaseMetrics = createDbMetrics("deduplicate_command") // FIXME Base name conflicts with deduplicateCommand
+        val removeExpiredDeduplicationDataDbMetrics: DatabaseMetrics = createDbMetrics(
           "remove_expired_deduplication_data") // FIXME Base name conflicts with removeExpiredDeduplicationData
-        val stopDeduplicatingCommandDao: DatabaseMetrics = createDatabaseMetrics(
+        val stopDeduplicatingCommandDbMetrics: DatabaseMetrics = createDbMetrics(
           "stop_deduplicating_command") // FIXME Base name conflicts with stopDeduplicatingCommand
-        val truncateAllTables: DatabaseMetrics = createDatabaseMetrics("truncate_all_tables")
-        val lookupActiveContractDao: DatabaseMetrics = createDatabaseMetrics(
+        val truncateAllTables: DatabaseMetrics = createDbMetrics("truncate_all_tables")
+        val lookupActiveContractDbMetrics: DatabaseMetrics = createDbMetrics(
           "lookup_active_contract") // FIXME Base name conflicts with lookupActiveContract
-        val lookupContractByKey: DatabaseMetrics = createDatabaseMetrics("lookup_contract_by_key")
-        val lookupMaximumLedgerTimeDao: DatabaseMetrics = createDatabaseMetrics(
+        val lookupContractByKey: DatabaseMetrics = createDbMetrics("lookup_contract_by_key")
+        val lookupMaximumLedgerTimeDbMetrics: DatabaseMetrics = createDbMetrics(
           "lookup_maximum_ledger_time") // FIXME Base name conflicts with lookupActiveContract
-        val getFlatTransactions: DatabaseMetrics = createDatabaseMetrics("get_flat_transactions")
-        val lookupFlatTransactionById: DatabaseMetrics = createDatabaseMetrics(
+        val getFlatTransactions: DatabaseMetrics = createDbMetrics("get_flat_transactions")
+        val lookupFlatTransactionById: DatabaseMetrics = createDbMetrics(
           "lookup_flat_transaction_by_id")
-        val getTransactionTrees: DatabaseMetrics = createDatabaseMetrics("get_transaction_trees")
-        val lookupTransactionTreeById: DatabaseMetrics = createDatabaseMetrics(
+        val getTransactionTrees: DatabaseMetrics = createDbMetrics("get_transaction_trees")
+        val lookupTransactionTreeById: DatabaseMetrics = createDbMetrics(
           "lookup_transaction_tree_by_id")
-        val getActiveContracts: DatabaseMetrics = createDatabaseMetrics("get_active_contracts")
+        val getActiveContracts: DatabaseMetrics = createDbMetrics("get_active_contracts")
 
         object translation {
           val prefix: MetricName = db.prefix :+ "translation"

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/ContractsReader.scala
@@ -40,7 +40,7 @@ private[dao] sealed abstract class ContractsReader(
       contractId: ContractId,
   ): Future[Option[Contract]] =
     dispatcher
-      .executeSql(metrics.daml.index.db.lookupActiveContractDao) { implicit connection =>
+      .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
         SQL"select participant_contracts.contract_id, template_id, create_argument from #$contractsTable where contract_witness = $submitter and participant_contracts.contract_id = $contractId"
           .as(contractRowParser.singleOpt)
       }
@@ -50,7 +50,8 @@ private[dao] sealed abstract class ContractsReader(
             contractId = contractId,
             templateId = templateId,
             createArgument = createArgument,
-            deserializationTimer = metrics.daml.index.db.lookupActiveContractDao.translationTimer,
+            deserializationTimer =
+              metrics.daml.index.db.lookupActiveContractDbMetrics.translationTimer,
           )
       })
 
@@ -64,7 +65,7 @@ private[dao] sealed abstract class ContractsReader(
 
   override def lookupMaximumLedgerTime(ids: Set[ContractId]): Future[Option[Instant]] =
     dispatcher
-      .executeSql(metrics.daml.index.db.lookupMaximumLedgerTimeDao) { implicit connection =>
+      .executeSql(metrics.daml.index.db.lookupMaximumLedgerTimeDbMetrics) { implicit connection =>
         committedContracts.lookupMaximumLedgerTime(ids)
       }
       .map(_.get)


### PR DESCRIPTION
The 1st commit adds the additional metrics.
The 2nd commit renames the metric values from `abcXyzDao` to `abcXyzDbMetrics`.

Considering that the event witness tables will be merged into the `participant_events` table soon, I didn't add the metrics for those.

CHANGELOG_BEGIN
[DAML Ledger Integration Kit] Add additional metrics for storing transactions. The overall time is measured by ``daml.index.db.store_ledger_entry``.
- Timer ``daml.index.db.store_ledger_entry.prepare_batches``: measures the time for preparing batch insert/delete statements
- Timer ``daml.index.db.store_ledger_entry.events_batch``: measures the time for inserting events
- Timer ``daml.index.db.store_ledger_entry.delete_contract_witnesses_batch``:  measures the time for deleting contract witnesses
- Timer ``daml.index.db.store_ledger_entry.delete_contracts_batch``: measures the time for deleting contracts
- Timer ``daml.index.db.store_ledger_entry.insert_contracts_batch``: measures the time for inserting contracts
- Timer ``daml.index.db.store_ledger_entry.insert_contract_witnesses_batch``: measures the time for inserting contract witnesses
- Timer ``daml.index.db.store_ledger_entry.insert_completion``: measures the time for inserting the completion
- Timer ``daml.index.db.store_ledger_entry.update_ledger_end``: measures the time for updating the ledger end
[Sandbox Classic] Added Timer ``daml.index.db.store_ledger_entry.commit_validation``: measure the time for commit validation in Sandbox Classic

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
