### PR TITLE
Handle contract key failures due to visiblity in scenarios

### DIFF
--- a/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
+++ b/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
@@ -1,0 +1,17 @@
+-- @ERROR Attempt to fetch, lookup or exercise a key associated with a contract
+module ContractKeyNotVisible where
+
+template Foo
+  with
+    p : Party
+  where
+    signatory p
+    key p : Party
+    maintainer key
+
+aScenario = scenario do
+  alice <- getParty "Alice"
+  bob <- getParty "Bob"
+  bobFooId <- submit bob do create Foo with p = bob
+  _ <- submit alice $ fetchByKey @Foo bob
+  pure ()

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -270,6 +270,21 @@ prettyScenarioErrorError (Just err) =  do
         , label_ "Disclosed to:"
             $ prettyParties scenarioError_ContractNotVisibleObservers
         ]
+    ScenarioErrorErrorScenarioContractKeyNotVisible ScenarioError_ContractKeyNotVisible{..} ->
+      pure $ vcat
+        [ "Attempt to fetch, lookup or exercise a key associated with a contract not visible to the committer."
+        , label_ "Contract: "
+            $ prettyMay "<missing contract>"
+                (prettyContractRef world)
+                scenarioError_ContractKeyNotVisibleContractRef
+        , label_ "Key: "
+            $ prettyMay "<missing key>"
+                (prettyValue' False 0 world)
+                scenarioError_ContractKeyNotVisibleKey
+        , label_ "Committer:" $ prettyMay "<missing party>" prettyParty scenarioError_ContractKeyNotVisibleCommitter
+        , label_ "Disclosed to:"
+            $ prettyParties scenarioError_ContractKeyNotVisibleObservers
+        ]
 
 partyDifference :: V.Vector Party -> V.Vector Party -> Doc SyntaxClass
 partyDifference with without =

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -170,6 +170,13 @@ message ScenarioError {
     repeated Party observers = 3;
   }
 
+  message ContractKeyNotVisible {
+    ContractRef contract_ref = 1;
+    Value key = 2;
+    Party committer = 3;
+    repeated Party observers = 4;
+  }
+
   message ContractNotEffective {
     ContractRef contract_ref = 1;
     sfixed64 effective_at = 2;
@@ -225,6 +232,7 @@ message ScenarioError {
     CommitError scenario_commit_error = 19;
     Empty scenario_mustfail_succeeded = 20;
     string scenario_invalid_party_name = 21;
+    ContractKeyNotVisible scenario_contract_key_not_visible = 22;
   }
 }
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -131,6 +131,16 @@ final class Conversions(
             .build,
         )
 
+      case SError.ScenarioErrorContractKeyNotVisible(coid, gk, committer, observers) =>
+        builder.setScenarioContractKeyNotVisible(
+          ScenarioError.ContractKeyNotVisible.newBuilder
+            .setContractRef(mkContractRef(coid, gk.templateId))
+            .setKey(convertValue(gk.key))
+            .setCommitter(convertParty(committer))
+            .addAllObservers(observers.map(convertParty).asJava)
+            .build,
+        )
+
       case SError.ScenarioErrorCommitError(commitError) =>
         builder.setScenarioCommitError(
           convertCommitError(commitError),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -113,6 +113,17 @@ object Pretty {
           comma + space,
           observers.map(prettyParty),
         ) + char('.')
+      case ScenarioErrorContractKeyNotVisible(coid, gk, committer, observers) =>
+        text("due to the failure to fetch the contract") & prettyContractId(coid) &
+          char('(') + (prettyIdentifier(gk.templateId)) + text(") associated with key ") +
+            prettyValue(false)(gk.key) &
+          text("The contract had not been disclosed to the committer") & prettyParty(committer) + char(
+          '.',
+        ) /
+          text("The contract had been disclosed to:") & intercalate(
+          comma + space,
+          observers.map(prettyParty),
+        ) + char('.')
       case ScenarioErrorCommitError(CommitError.FailedAuthorizations(fas)) =>
         (text("due to failed authorizations:") / prettyFailedAuthorizations(fas)).nested(4)
       case ScenarioErrorCommitError(CommitError.UniqueKeyViolation(gk)) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -5,6 +5,7 @@ package com.daml.lf.speedy
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
+import com.daml.lf.transaction.Node.GlobalKey
 import com.daml.lf.transaction.Transaction
 import com.daml.lf.transaction.Transaction.Transaction
 import com.daml.lf.types.Ledger
@@ -92,6 +93,16 @@ object SError {
   final case class ScenarioErrorContractNotVisible(
       coid: ContractId,
       templateId: Identifier,
+      committer: Party,
+      observers: Set[Party],
+  ) extends SErrorScenario
+
+  /** A fetchByKey or lookupByKey was being made against a key
+    * for which the contract exists but has not
+    * been disclosed to 'committer'. */
+  final case class ScenarioErrorContractKeyNotVisible(
+      coid: ContractId,
+      key: GlobalKey,
       committer: Party,
       observers: Set[Party],
   ) extends SErrorScenario

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -212,7 +212,7 @@ final case class ScenarioRunner(
             if (stakeholders.contains(committer))
               cb(SKeyLookupResult.Found(acoid))
             else if (!cb(SKeyLookupResult.NotVisible))
-              throw SErrorCrash(s"key of contract $acoid not visible, but we found it!")
+              missingWith(ScenarioErrorContractKeyNotVisible(acoid, gk, committer, stakeholders))
             ()
           case LookupContractNotFound(coid) =>
             missingWith(SErrorCrash(s"contract $coid not found, but we found its key!"))
@@ -220,9 +220,9 @@ final case class ScenarioRunner(
             missingWith(SErrorCrash(s"contract $acoid not effective, but we found its key!"))
           case LookupContractNotActive(_, _, _) =>
             missingWith(SErrorCrash(s"contract $acoid not active, but we found its key!"))
-          case LookupContractNotVisible(_, _, _) =>
+          case LookupContractNotVisible(coid, tid, observers) =>
             if (!cb(SKeyLookupResult.NotVisible))
-              throw SErrorCrash(s"contract $acoid not visible, but we found its key!")
+              missingWith(ScenarioErrorContractKeyNotVisible(coid, gk, committer, observers))
         }
     }
   }


### PR DESCRIPTION
Previously, we just crashed the scenario service instead of throwing a
proper scenario error. This meant that you had to look at the
debugging output to figure out what is going wrong. This is both a
shitty UX and also inconsistent with how we handle this for fetch and
exercise on contract ids that are not visible. This PR adds a new
error type that matches the one for invisible contract ids.

changelog_begin

- [DAML Studio] Fetches and exercises of contract keys associated with
  contracts not visible to the submitter are now handled properly
  instead of showing a low-level error.

changelog_end

fixes #5903

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
