### PR TITLE
Sort files when calculating CACHE_KEY

### DIFF
--- a/ci/patch_bazel_windows/compile.yml
+++ b/ci/patch_bazel_windows/compile.yml
@@ -14,7 +14,7 @@ jobs:
   - bash: |
       set -euo pipefail
 
-      CACHE_KEY="$(md5sum $(find ci/patch_bazel_windows -type f) | md5sum | awk '{print $1}')"
+      CACHE_KEY="$(find ci/patch_bazel_windows -type f -print0 | sort -z | xargs -r0 md5sum | md5sum | awk '{print $1}')"
       TARGET="patch_bazel_windows/bazel-$CACHE_KEY.zip"
       TARGET_URL="https://daml-binaries.da-ext.net/$TARGET"
 

--- a/dev-env/windows/manifests/bazel.json
+++ b/dev-env/windows/manifests/bazel.json
@@ -5,8 +5,8 @@
   "bin": "bazel.exe",
   "architecture": {
     "64bit": {
-      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-8e606d2495d967cbbf2d247269765cec.zip",
-      "hash": "9641d25c739e77932fcce51bf4756e1a51afd5cc844b1095b3cd39f24d399728"
+      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-e0c2de6ef9d4217395705f8b61fda948.zip",
+      "hash": "32fbf1f6bd585562268b1bccc38587f4efeeaec2e2989093556e983879358643"
     }
   },
   "depends": [


### PR DESCRIPTION
The order returned by `find` is unspecified and seems to have changed
for whatever reason in some cases. This changed the cache key which is
obviously not intended. It looks like the one we currently have in our
scoop manifest is the one that we get by sorting. Reversing the sort
produces the one CI currently calculates.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
