### PR TITLE
add find to dev-env

### DIFF
--- a/dev-env/bin/find
+++ b/dev-env/bin/find
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Meant to be linked to from `dev-env/bin`, symlink should be named after the
+# tool. Execute a Nix tool from a derivation that creates a `result` directory.
+
+DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
+execTool findutils out find "$@"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -186,6 +186,7 @@ in rec {
     # System tools
     shellcheck = pkgs.shellcheck;
     curl = bazel_dependencies.curl;
+    findutils = pkgs.findutils;
 
     patch = pkgs.patch;
     wget = pkgs.wget;
@@ -256,7 +257,6 @@ in rec {
     cheat = pkgs.cheat;
     coreutils = pkgs.coreutils;
     dockerd = pkgs.docker;
-    findutils = pkgs.findutils;
     ftop = pkgs.ftop;
     gcc7 = pkgs.gcc7;
     glibc = pkgs.glibc;


### PR DESCRIPTION
The issues underlying #6173 prompted me to look into which `find` version we had in dev-env, and I was surprised to notice we had none. We already have `findutils` in our nix configuration, however, so this is just adding the symlink.

Note that, on my machine at least, switching from the macOS-provided one to the dev-env one does not change the result order for the hash calculation in `ci/patch_bazel_windows`, so this would likely not have helped for #6173. Still, we use `find` in many places in our scripts so I think it's worth having there.

CHANGELOG_BEGIN
CHANGELOG_END