### PR TITLE
Enable caching of immutable state values only

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -14,16 +14,18 @@ import com.daml.ledger.participant.state.kvutils.api.{
   LedgerWriter
 }
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
-import com.daml.ledger.validator.{
+import com.daml.ledger.validator.caching.{
   CachingCommitStrategy,
   CachingDamlLedgerStateReader,
+  QueryableReadSet
+}
+import com.daml.ledger.validator.{
   CommitStrategy,
   DamlLedgerStateReader,
   DefaultStateKeySerializationStrategy,
   LedgerStateOperations,
   LedgerStateReader,
   LogAppendingCommitStrategy,
-  QueryableReadSet,
   StateKeySerializationStrategy
 }
 import com.daml.lf.engine.Engine

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -15,6 +15,7 @@ import com.daml.ledger.participant.state.kvutils.api.{
 }
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.caching.{
+  CacheUpdatePolicy,
   CachingCommitStrategy,
   CachingDamlLedgerStateReader,
   QueryableReadSet
@@ -98,11 +99,13 @@ object BatchedSubmissionValidatorFactory {
   def cachingReaderAndCommitStrategyFrom[LogResult](
       ledgerStateOperations: LedgerStateOperations[LogResult],
       stateCache: Cache[DamlStateKey, DamlStateValue],
+      cacheUpdatePolicy: CacheUpdatePolicy,
       keySerializationStrategy: StateKeySerializationStrategy = DefaultStateKeySerializationStrategy)(
       implicit executionContext: ExecutionContext)
     : (DamlLedgerStateReader with QueryableReadSet, CommitStrategy[LogResult]) = {
     val ledgerStateReader = new CachingDamlLedgerStateReader(
       stateCache,
+      cacheUpdatePolicy.shouldCacheOnRead,
       keySerializationStrategy,
       DamlLedgerStateReader.from(
         new LedgerStateReaderAdapter[LogResult](ledgerStateOperations),
@@ -110,29 +113,31 @@ object BatchedSubmissionValidatorFactory {
     )
     val commitStrategy = new CachingCommitStrategy(
       stateCache,
+      cacheUpdatePolicy.shouldCacheOnWrite,
       new LogAppendingCommitStrategy[LogResult](ledgerStateOperations, keySerializationStrategy))
     (ledgerStateReader, commitStrategy)
   }
 
-  case class WriteThroughCachingComponents[LogResult](
+  case class CachingEnabledComponents[LogResult](
       ledgerStateReader: DamlLedgerStateReader with QueryableReadSet,
       commitStrategy: CommitStrategy[LogResult],
       batchValidator: BatchedSubmissionValidator[LogResult])
 
-  def componentsForWriteThroughCaching[LogResult](
+  def componentsEnabledForCaching[LogResult](
       params: BatchedSubmissionValidatorParameters,
       ledgerStateOperations: LedgerStateOperations[LogResult],
       stateCache: Cache[DamlStateKey, DamlStateValue],
+      cacheUpdatePolicy: CacheUpdatePolicy,
       metrics: Metrics,
       engine: Engine
-  )(implicit executionContext: ExecutionContext): WriteThroughCachingComponents[LogResult] = {
+  )(implicit executionContext: ExecutionContext): CachingEnabledComponents[LogResult] = {
     val (ledgerStateReader, commitStrategy) =
-      cachingReaderAndCommitStrategyFrom(ledgerStateOperations, stateCache)
+      cachingReaderAndCommitStrategyFrom(ledgerStateOperations, stateCache, cacheUpdatePolicy)
     val batchValidator = BatchedSubmissionValidator[LogResult](
       params,
       engine,
       metrics
     )
-    WriteThroughCachingComponents(ledgerStateReader, commitStrategy, batchValidator)
+    CachingEnabledComponents(ledgerStateReader, commitStrategy, batchValidator)
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/AlwaysCacheUpdatePolicy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/AlwaysCacheUpdatePolicy.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.validator.caching
 import com.daml.ledger.participant.state.kvutils.DamlKvutils
 
 /**
-  * Cache write policy that enables write-through caching, i.e., allows caching of all committed keys
+  * Cache update policy that enables write-through caching, i.e., allows caching of all committed keys
   * and allows caching all read keys.
   * This policy should be used for ledgers that guarantee serializability of transactions.
   */

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/AlwaysCacheUpdatePolicy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/AlwaysCacheUpdatePolicy.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.caching
+import com.daml.ledger.participant.state.kvutils.DamlKvutils
+
+/**
+  * Cache write policy that enables write-through caching, i.e., allows caching of all committed keys
+  * and allows caching all read keys.
+  * This policy should be used for ledgers that guarantee serializability of transactions.
+  */
+object AlwaysCacheUpdatePolicy extends CacheUpdatePolicy {
+  override def shouldCacheOnWrite(key: DamlKvutils.DamlStateKey): Boolean = true
+
+  override def shouldCacheOnRead(key: DamlKvutils.DamlStateKey): Boolean = true
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CacheUpdatePolicy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CacheUpdatePolicy.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.caching
+
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+
+trait CacheUpdatePolicy {
+  def shouldCacheOnWrite(key: DamlStateKey): Boolean
+
+  def shouldCacheOnRead(key: DamlStateKey): Boolean
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
@@ -1,12 +1,13 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.validator
+package com.daml.ledger.validator.caching
 
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.ledger.validator.CommitStrategy
 
 import scala.concurrent.Future
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
@@ -9,11 +9,12 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, Daml
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.CommitStrategy
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class CachingCommitStrategy[Result](
     cache: Cache[DamlStateKey, DamlStateValue],
-    delegate: CommitStrategy[Result])
+    shouldCache: DamlStateKey => Boolean,
+    delegate: CommitStrategy[Result])(implicit executionContext: ExecutionContext)
     extends CommitStrategy[Result] {
   override def commit(
       participantId: ParticipantId,
@@ -21,8 +22,19 @@ class CachingCommitStrategy[Result](
       entryId: DamlKvutils.DamlLogEntryId,
       entry: DamlKvutils.DamlLogEntry,
       inputState: Map[DamlStateKey, Option[DamlStateValue]],
-      outputState: Map[DamlStateKey, DamlStateValue]): Future[Result] = {
-    outputState.foreach { case (key, value) => cache.put(key, value) }
-    delegate.commit(participantId, correlationId, entryId, entry, inputState, outputState)
-  }
+      outputState: Map[DamlStateKey, DamlStateValue]): Future[Result] =
+    for {
+      _ <- Future {
+        outputState.view.filter { case (key, _) => shouldCache(key) }.foreach {
+          case (key, value) => cache.put(key, value)
+        }
+      }
+      result <- delegate.commit(
+        participantId,
+        correlationId,
+        entryId,
+        entry,
+        inputState,
+        outputState)
+    } yield result
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingDamlLedgerStateReader.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingDamlLedgerStateReader.scala
@@ -1,11 +1,17 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.validator
+package com.daml.ledger.validator.caching
 
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.validator.LedgerStateOperations.Key
+import com.daml.ledger.validator.{
+  DamlLedgerStateReader,
+  LedgerStateReader,
+  RawToDamlLedgerStateReaderAdapter,
+  StateKeySerializationStrategy
+}
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingDamlLedgerStateReader.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingDamlLedgerStateReader.scala
@@ -30,6 +30,7 @@ trait QueryableReadSet {
   */
 class CachingDamlLedgerStateReader(
     val cache: Cache[DamlStateKey, DamlStateValue],
+    shouldCache: DamlStateKey => Boolean,
     keySerializationStrategy: StateKeySerializationStrategy,
     delegate: DamlLedgerStateReader)(implicit executionContext: ExecutionContext)
     extends DamlLedgerStateReader
@@ -54,7 +55,7 @@ class CachingDamlLedgerStateReader(
         .map { readStateValues =>
           val readValues = keysToRead.zip(readStateValues).toMap
           readValues.collect {
-            case (key, Some(value)) => cache.put(key, value)
+            case (key, Some(value)) if shouldCache(key) => cache.put(key, value)
           }
           val all = cachedValues ++ readValues
           keys.map(all(_))
@@ -70,11 +71,13 @@ class CachingDamlLedgerStateReader(
 object CachingDamlLedgerStateReader {
   private[validator] def apply(
       cache: Cache[DamlStateKey, DamlStateValue],
+      cachingPolicy: CacheUpdatePolicy,
       ledgerStateOperations: LedgerStateReader,
       keySerializationStrategy: StateKeySerializationStrategy)(
       implicit executionContext: ExecutionContext): CachingDamlLedgerStateReader = {
     new CachingDamlLedgerStateReader(
       cache,
+      cachingPolicy.shouldCacheOnRead,
       keySerializationStrategy,
       new RawToDamlLedgerStateReaderAdapter(ledgerStateOperations, keySerializationStrategy))
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicy.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.validator.caching
 import com.daml.ledger.participant.state.kvutils.DamlKvutils
 
 /**
-  * Cache write policy that allows writing to-be-committed packages back to the cache and read
+  * Cache update policy that allows writing to-be-committed packages back to the cache and read
   * immutable values such as packages and party allocations from the ledger.
   * This policy should be used for ledgers with multiple committers.
   * In case a commit fails and hence does not get persisted e.g. because of a conflicting write set

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicy.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.caching
+import com.daml.ledger.participant.state.kvutils.DamlKvutils
+
+/**
+  * Cache write policy that allows writing to-be-committed packages back to the cache and read
+  * immutable values such as packages and party allocations from the ledger.
+  * This policy should be used for ledgers with multiple committers.
+  * In case a commit fails and hence does not get persisted e.g. because of a conflicting write set
+  * with another commit, this policy ensures that we don't need to invalidate items in the cache.
+  * Specifically, packages are content-addressed hence may be cached without consistency issues,
+  * whereas party allocations must be only cached once they are available on the ledger.
+  */
+object ImmutablesOnlyCacheUpdatePolicy extends CacheUpdatePolicy {
+  override def shouldCacheOnWrite(key: DamlKvutils.DamlStateKey): Boolean =
+    key.getPackageId.nonEmpty
+
+  override def shouldCacheOnRead(key: DamlKvutils.DamlStateKey): Boolean =
+    key.getPackageId.nonEmpty || key.getParty.nonEmpty
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/TestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/TestHelper.scala
@@ -4,12 +4,17 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlCommandDedupKey,
+  DamlContractKey,
   DamlLogEntry,
   DamlLogEntryId,
   DamlPartyAllocationEntry,
-  DamlSubmission
+  DamlStateKey,
+  DamlSubmission,
+  DamlSubmissionDedupKey
 }
 import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.lf.value.ValueOuterClass
 import com.google.protobuf.ByteString
 
 private[validator] object TestHelper {
@@ -22,6 +27,24 @@ private[validator] object TestHelper {
       .setPartyAllocationEntry(
         DamlPartyAllocationEntry.newBuilder().setParty("aParty").setParticipantId(aParticipantId))
       .build()
+
+  lazy val allDamlStateKeyTypes: Seq[DamlStateKey] = Seq(
+    DamlStateKey.newBuilder
+      .setPackageId("a package ID"),
+    DamlStateKey.newBuilder
+      .setContractId("a contract ID"),
+    DamlStateKey.newBuilder
+      .setCommandDedup(DamlCommandDedupKey.newBuilder.setCommandId("an ID")),
+    DamlStateKey.newBuilder
+      .setParty("a party"),
+    DamlStateKey.newBuilder
+      .setContractKey(
+        DamlContractKey.newBuilder.setTemplateId(
+          ValueOuterClass.Identifier.newBuilder.addName("a name"))),
+    DamlStateKey.newBuilder.setConfiguration(com.google.protobuf.Empty.getDefaultInstance),
+    DamlStateKey.newBuilder.setSubmissionDedup(
+      DamlSubmissionDedupKey.newBuilder.setSubmissionId("a submission ID"))
+  ).map(_.build)
 
   lazy val anInvalidEnvelope: ByteString = ByteString.copyFromUtf8("invalid data")
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/AlwaysCacheUpdatePolicySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/AlwaysCacheUpdatePolicySpec.scala
@@ -4,20 +4,21 @@
 package com.daml.ledger.validator.caching
 
 import com.daml.ledger.validator.TestHelper
-import com.daml.ledger.validator.caching.AlwaysCacheUpdatePolicy._
 import org.scalatest.{Matchers, WordSpec}
 
 class AlwaysCacheUpdatePolicySpec extends WordSpec with Matchers {
+  private val policy = AlwaysCacheUpdatePolicy
+
   "cache update policy" should {
     "allow caching of all types of keys" in {
       for (stateKey <- TestHelper.allDamlStateKeyTypes) {
-        shouldCacheOnWrite(stateKey) shouldBe true
+        policy.shouldCacheOnWrite(stateKey) shouldBe true
       }
     }
 
     "allow caching of all read values" in {
       for (stateKey <- TestHelper.allDamlStateKeyTypes) {
-        shouldCacheOnRead(stateKey) shouldBe true
+        policy.shouldCacheOnRead(stateKey) shouldBe true
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/AlwaysCacheUpdatePolicySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/AlwaysCacheUpdatePolicySpec.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.caching
+
+import com.daml.ledger.validator.TestHelper
+import com.daml.ledger.validator.caching.AlwaysCacheUpdatePolicy._
+import org.scalatest.{Matchers, WordSpec}
+
+class AlwaysCacheUpdatePolicySpec extends WordSpec with Matchers {
+  "cache update policy" should {
+    "allow caching of all types of keys" in {
+      for (stateKey <- TestHelper.allDamlStateKeyTypes) {
+        shouldCacheOnWrite(stateKey) shouldBe true
+      }
+    }
+
+    "allow caching of all read values" in {
+      for (stateKey <- TestHelper.allDamlStateKeyTypes) {
+        shouldCacheOnRead(stateKey) shouldBe true
+      }
+    }
+  }
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingCommitStrategySpec.scala
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.caching
+
+import com.daml.caching.{Cache, Configuration}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlLogEntry,
+  DamlLogEntryId,
+  DamlStateKey,
+  DamlStateValue
+}
+import com.daml.ledger.participant.state.kvutils.caching.`Message Weight`
+import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.ledger.validator.CommitStrategy
+import com.daml.ledger.validator.TestHelper._
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{AsyncWordSpec, Matchers}
+
+import scala.concurrent.Future
+
+class CachingCommitStrategySpec extends AsyncWordSpec with Matchers with MockitoSugar {
+  "commit" should {
+    "update cache with output state upon commit if policy allows" in {
+      val cache = newCache()
+      val instance = createInstance(cache, shouldCache = true)
+      val expectedKey = DamlStateKey.newBuilder.setContractId("a contract ID").build
+      val outputState = Map(expectedKey -> DamlStateValue.getDefaultInstance)
+
+      instance
+        .commit(aParticipantId, "correlation ID", aLogEntryId(), aLogEntry, Map.empty, outputState)
+        .map { _ =>
+          cache.getIfPresent(expectedKey) shouldBe defined
+        }
+    }
+
+    "not update cache with output state upon commit if policy does not allow" in {
+      val cache = newCache()
+      val instance = createInstance(cache, shouldCache = false)
+      val expectedKey = DamlStateKey.newBuilder.setContractId("a contract ID").build
+      val outputState = Map(expectedKey -> DamlStateValue.getDefaultInstance)
+
+      instance
+        .commit(aParticipantId, "correlation ID", aLogEntryId(), aLogEntry, Map.empty, outputState)
+        .map { _ =>
+          cache.getIfPresent(expectedKey) should not be defined
+        }
+    }
+  }
+
+  private def newCache(): Cache[DamlStateKey, DamlStateValue] =
+    Cache.from[DamlStateKey, DamlStateValue](Configuration(1024))
+
+  private def createInstance(
+      cache: Cache[DamlStateKey, DamlStateValue],
+      shouldCache: Boolean): CachingCommitStrategy[Unit] = {
+    val mockCommitStrategy = mock[CommitStrategy[Unit]]
+    when(
+      mockCommitStrategy.commit(
+        any[ParticipantId](),
+        anyString(),
+        any[DamlLogEntryId](),
+        any[DamlLogEntry](),
+        any[Map[DamlStateKey, Option[DamlStateValue]]](),
+        any[Map[DamlStateKey, DamlStateValue]]()
+      ))
+      .thenReturn(Future.unit)
+    new CachingCommitStrategy[Unit](cache, _ => shouldCache, mockCommitStrategy)
+  }
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingDamlLedgerStateReaderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingDamlLedgerStateReaderSpec.scala
@@ -1,11 +1,12 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.validator
+package com.daml.ledger.validator.caching
 
 import com.daml.caching.{Cache, Configuration}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.caching.`Message Weight`
+import com.daml.ledger.validator.{DamlLedgerStateReader, DefaultStateKeySerializationStrategy}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicySpec.scala
@@ -5,29 +5,30 @@ package com.daml.ledger.validator.caching
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
 import com.daml.ledger.validator.TestHelper
-import com.daml.ledger.validator.caching.ImmutablesOnlyCacheUpdatePolicy._
 import org.scalatest.{Matchers, WordSpec}
 
 class ImmutablesOnlyCacheUpdatePolicySpec extends WordSpec with Matchers {
+  private val policy = ImmutablesOnlyCacheUpdatePolicy
+
   "cache update policy" should {
     "allow write-through caching of packages" in {
-      shouldCacheOnWrite(aPackageKey) shouldBe true
+      policy.shouldCacheOnWrite(aPackageKey) shouldBe true
     }
 
     "not allow write-through caching of non-packages" in {
       for (stateKey <- nonPackageKeyTypes) {
-        shouldCacheOnWrite(stateKey) shouldBe false
+        policy.shouldCacheOnWrite(stateKey) shouldBe false
       }
     }
 
     "allow caching of read packages or parties" in {
-      shouldCacheOnRead(aPackageKey) shouldBe true
-      shouldCacheOnRead(aPartyKey) shouldBe true
+      policy.shouldCacheOnRead(aPackageKey) shouldBe true
+      policy.shouldCacheOnRead(aPartyKey) shouldBe true
     }
 
     "not allow caching of read mutable values" in {
       for (stateKey <- nonPackageKeyTypes if stateKey.getParty.isEmpty) {
-        shouldCacheOnRead(stateKey) shouldBe false
+        policy.shouldCacheOnRead(stateKey) shouldBe false
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/ImmutablesOnlyCacheUpdatePolicySpec.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.caching
+
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.validator.TestHelper
+import com.daml.ledger.validator.caching.ImmutablesOnlyCacheUpdatePolicy._
+import org.scalatest.{Matchers, WordSpec}
+
+class ImmutablesOnlyCacheUpdatePolicySpec extends WordSpec with Matchers {
+  "cache update policy" should {
+    "allow write-through caching of packages" in {
+      shouldCacheOnWrite(aPackageKey) shouldBe true
+    }
+
+    "not allow write-through caching of non-packages" in {
+      for (stateKey <- nonPackageKeyTypes) {
+        shouldCacheOnWrite(stateKey) shouldBe false
+      }
+    }
+
+    "allow caching of read packages or parties" in {
+      shouldCacheOnRead(aPackageKey) shouldBe true
+      shouldCacheOnRead(aPartyKey) shouldBe true
+    }
+
+    "not allow caching of read mutable values" in {
+      for (stateKey <- nonPackageKeyTypes if stateKey.getParty.isEmpty) {
+        shouldCacheOnRead(stateKey) shouldBe false
+      }
+    }
+  }
+
+  private val aPackageKey: DamlStateKey = DamlStateKey.newBuilder
+    .setPackageId("a package ID")
+    .build
+
+  private val aPartyKey: DamlStateKey = DamlStateKey.newBuilder
+    .setParty("a party")
+    .build
+
+  private val nonPackageKeyTypes: Seq[DamlStateKey] =
+    TestHelper.allDamlStateKeyTypes.filter(_.getPackageId.isEmpty)
+}


### PR DESCRIPTION
Summary of changes:
* Introduced `CacheUpdatePolicy` that determines what keys should be written to the cache when.
* Switched `ledger-on-memory` to use `ImmutablesOnlyUpdatePolicy` by default.
* Moved all `Caching*` classes from `validator` to `validator.caching` package.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
