### PR TITLE
shorten Windows CI username

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -17,7 +17,7 @@ $ARTIFACT_DIRS = if ("$env:BUILD_ARTIFACTSTAGINGDIRECTORY") { $env:BUILD_ARTIFAC
 # If a previous build was forcefully terminated, then stack's lock file might
 # not have been cleaned up properly leading to errors of the form
 #
-#   user error (hTryLock: lock already exists: C:\Users\VssAdministrator\AppData\Roaming\stack\pantry\hackage\hackage-security-lock)
+#   user error (hTryLock: lock already exists: C:\Users\u\AppData\Roaming\stack\pantry\hackage\hackage-security-lock)
 #
 # The package cache might be corrupted and just removing the lock might lead to
 # errors as below, so we just nuke the entire stack cache.

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -107,7 +107,7 @@ $partition | Set-Content C:\diskpart.txt
 & diskpart /s C:\diskpart.txt 2>&1 | %{ "$_" }
 
 # Create a temporary and random password for the VSTS user, forget about it once this script has finished running
-$Username = "VssAdministrator"
+$Username = "u"
 $Account = "$env:COMPUTERNAME\$Username"
 Add-Type -AssemblyName System.Web
 $Password = [System.Web.Security.Membership]::GeneratePassword(24, 0)


### PR DESCRIPTION
Keeping CI working on Windows involves a constant fight against MAX_PATH, which is a very short 260 characters. As the username appears in some paths, sometimes multiple times, we can save a few precious characters by having it shorter.

CHANGELOG_BEGIN
CHANGELOG_END