### PR TITLE
root level Pipfile to be explicit about using python 3.7

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.7"


### PR DESCRIPTION
Specify the python version 3.7 at root level to help for correct detection of python projects in the repo
