### PR TITLE
language: remove self-referencing links from docs

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -439,6 +439,11 @@ genrule(
         tar -xzf ../$(location //language-support/ts/daml-react:docs) --strip-components 1 -C html/app-dev/bindings-ts/daml-react/
         tar -xzf ../$(location //language-support/ts/daml-ledger:docs) --strip-components 1 -C html/app-dev/bindings-ts/daml-ledger/
         tar -xzf ../$(location //language-support/ts/daml-types:docs) --strip-components 1 -C html/app-dev/bindings-ts/daml-types/
+        # The generated docs of the typescript libraries are published at two places: The npm
+        # registry and on docs.daml.com. The docs at the npm registry contain a link pointing
+        # to docs.daml.com. We remove it for the version published at docs.daml.com as it would be
+        # pointing to itself.
+        sed -i -e 's,^.*\(Comprehensive documentation\|<h2>Documentation</h2>\|0.0.0-SDKVERSION\).*$$,,' html/app-dev/bindings-ts/*/index.html
 
         # Get the daml cheat sheet
         mkdir -p html/cheat-sheet


### PR DESCRIPTION
This drops the `Documentation` section from the generated typescript library
docs on docs.daml.com, because it contains a link that points to itself.

### Pull Request Checklist


- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
