### PR TITLE
@daml/react: Initialize loading indicators of hooks with true

### DIFF
--- a/language-support/ts/daml-react/hooks.ts
+++ b/language-support/ts/daml-react/hooks.ts
@@ -71,7 +71,7 @@ export function useQuery<T extends object, K, I extends string>(template: Templa
 export function useQuery<T extends object, K, I extends string>(template: Template<T, K, I>): QueryResult<T, K, I>
 export function useQuery<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory?: () => Query<T>, queryDeps?: readonly unknown[]): QueryResult<T, K, I> {
   const state = useDamlState();
-  const [result, setResult] = useState<QueryResult<T, K, I>>({contracts: [], loading: false});
+  const [result, setResult] = useState<QueryResult<T, K, I>>({contracts: [], loading: true});
   useEffect(() => {
     setResult({contracts: [], loading: true});
     const query = queryFactory ? queryFactory() : undefined;
@@ -115,7 +115,7 @@ export type FetchResult<T extends object, K, I extends string> = {
  */
 export function useFetchByKey<T extends object, K, I extends string>(template: Template<T, K, I>, keyFactory: () => K, keyDeps: readonly unknown[]): FetchResult<T, K, I> {
   const state = useDamlState();
-  const [result, setResult] = useState<FetchResult<T, K, I>>({contract: null, loading: false});
+  const [result, setResult] = useState<FetchResult<T, K, I>>({contract: null, loading: true});
   useEffect(() => {
     const key = keyFactory();
     setResult({contract: null, loading: true});
@@ -147,7 +147,7 @@ export function useFetchByKey<T extends object, K, I extends string>(template: T
 export function useStreamQuery<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory: () => Query<T>, queryDeps: readonly unknown[]): QueryResult<T, K, I>
 export function useStreamQuery<T extends object, K, I extends string>(template: Template<T, K, I>): QueryResult<T, K, I>
 export function useStreamQuery<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory?: () => Query<T>, queryDeps?: readonly unknown[]): QueryResult<T, K, I> {
-  const [result, setResult] = useState<QueryResult<T, K, I>>({contracts: [], loading: false});
+  const [result, setResult] = useState<QueryResult<T, K, I>>({contracts: [], loading: true});
   const state = useDamlState();
   useEffect(() => {
     setResult({contracts: [], loading: true});
@@ -183,7 +183,7 @@ export function useStreamQuery<T extends object, K, I extends string>(template: 
  * @return The matching (unique) contract.
  */
 export function useStreamFetchByKey<T extends object, K, I extends string>(template: Template<T, K, I>, keyFactory: () => K, keyDeps: readonly unknown[]): FetchResult<T, K, I> {
-  const [result, setResult] = useState<FetchResult<T, K, I>>({contract: null, loading: false});
+  const [result, setResult] = useState<FetchResult<T, K, I>>({contract: null, loading: true});
   const state = useDamlState();
   useEffect(() => {
     setResult({contract: null, loading: true});


### PR DESCRIPTION
Having them set to `false` when they will immediately bet set to `true`
does not make too much sense. This allows for simplifying uses of
`useFetchByKey` where the key is know to always be present since you
can now operate under the assumption that the contract is never `null`
when the loading indicator is `false`.

This fixes #6171.

CHANGELOG_BEGIN
- @daml/react: Initialize the loading indicators of ``useQuery``,
  ``useFetchByKey`` and their streaming variants with ``true``. This
  removes a glitch where the loading indicator was ``false`` for a very
  brief moment when components using these hooks were mounted although
  no data had been loaded yet. Code using these hooks does not need to
  adapted in response to this change.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6196)
<!-- Reviewable:end -->
