### PR TITLE
backport #6197

### DIFF
--- a/docs/source/deploy/index.rst
+++ b/docs/source/deploy/index.rst
@@ -54,8 +54,8 @@ The following table lists open source DAML integrations.
      - `Blockchain Technology Partners <https://blockchaintp.com/>`__
      - `Github Repo <https://github.com/blockchaintp/daml-on-sawtooth>`__
    * - `Hyperledger Fabric <https://www.hyperledger.org/projects/fabric>`__
-     - `Hacera <https://hacera.com/>`__
-     - `Github Repo <https://github.com/hacera/daml-on-fabric>`__
+     - `Digital Asset <https://digitalasset.com/>`__
+     - `Github Repo <https://github.com/digital-asset/daml-on-fabric>`__
    * - `PostgreSQL <https://www.postgresql.org/>`__
      - `Digital Asset <https://digitalasset.com/>`__
      - `DAML Sandbox Docs <https://docs.daml.com/tools/sandbox.html>`__


### PR DESCRIPTION
This backports #6197 so the change goes into the docs for the 1.2.0 release.

CHANGELOG_BEGIN
CHANGELOG_END