### PR TITLE
Handle another potential initialization failure case

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -117,6 +117,8 @@ genrule(
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
       cp -L $(location :test-model/TestTrigger.daml) $$TMP_DIR/daml
+      cp -L $(location :test-model/ErrorTrigger.daml) $$TMP_DIR/daml
+      cp -L $(location :test-model/LowLevelErrorTrigger.daml) $$TMP_DIR/daml
       cp -L $(location //triggers/daml:daml-trigger.dar) $$TMP_DIR/
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}

--- a/triggers/service/test-model/ErrorTrigger.daml
+++ b/triggers/service/test-model/ErrorTrigger.daml
@@ -1,0 +1,21 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module ErrorTrigger where
+
+import DA.Action
+import DA.Foldable
+import DA.Next.Map (Map)
+import Daml.Trigger
+
+trigger : Trigger ()
+trigger = Trigger with
+  initialize = \_ -> ()
+  updateState = \_ _ _ -> ()
+  rule = triggerRule
+  registeredTemplates = AllInDar
+  heartbeat = None
+
+triggerRule : Party -> ACS -> Time -> Map CommandId [Command] -> () -> TriggerA ()
+triggerRule _ _ _ _ _ = error "Intentional error"

--- a/triggers/service/test-model/LowLevelErrorTrigger.daml
+++ b/triggers/service/test-model/LowLevelErrorTrigger.daml
@@ -1,0 +1,21 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+module LowLevelErrorTrigger where
+
+import DA.Time
+import Daml.Trigger.LowLevel
+
+trigger : Trigger Int
+trigger = Trigger
+  { initialState = \party _ _ -> (0, [])
+  , update = \_ msg count ->
+      case msg of
+        _ -> if count == 5
+             then
+               error "Intentional error"
+             else (count + 1, [])
+  , registeredTemplates = AllInDar
+  , heartbeat = Some (convertMicrosecondsToRelTime 1)
+  }


### PR DESCRIPTION
- `runWithACS` can throw in the construction of its `Flow`. Handle that as an initialization failure.
- test for the above
- test for the case where execution fails for real.