### PR TITLE
Trigger service: streamline running tests with and without the database

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -122,7 +122,7 @@ class Server(dar: Option[Dar[(PackageId, Package)]], triggerDao: Option[TriggerD
   }
 
   private def listRunningTriggers(jwt: Jwt): Either[String, Vector[UUID]] = {
-    triggerDao match {
+    val triggerInstances = triggerDao match {
       case None =>
         Right(triggersByToken.getOrElse(jwt, Set()).toVector)
       case Some(dao) =>
@@ -132,6 +132,9 @@ class Server(dar: Option[Dar[(PackageId, Package)]], triggerDao: Option[TriggerD
           case Success(triggerInstances) => Right(triggerInstances)
         }
     }
+    // Note(RJR): We sort UUIDs here using Java's comparison of UUIDs.
+    // We do not rely on the Postgres ordering which is different.
+    triggerInstances.map(_.sorted)
   }
 
   private def logTriggerStatus(t: RunningTrigger, msg: String): Unit = {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -186,7 +186,6 @@ object Server {
       dar: Option[Dar[(PackageId, Package)]],
       jdbcConfig: Option[JdbcConfig],
   ): Behavior[Message] = Behaviors.setup { ctx =>
-
     val triggerDao = jdbcConfig.map(TriggerDao(_)(ctx.system.executionContext))
     val server = new Server(dar, triggerDao)
 

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -531,6 +531,15 @@ object ServiceMain {
     }
   }
 
+  def destroyDatabase(c: JdbcConfig)(implicit ec: ExecutionContext): Either[String, Unit] = {
+    val triggerDao = TriggerDao(c)(ec)
+    val transaction = triggerDao.transact(TriggerDao.destroy)
+    Try(transaction.unsafeRunSync()) match {
+      case Failure(err) => Left(err.toString)
+      case Success(()) => Right(())
+    }
+  }
+
   def main(args: Array[String]): Unit = {
     ServiceConfig.parse(args) match {
       case None => sys.exit(1)

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerDao.scala
@@ -72,6 +72,15 @@ object TriggerDao {
       *> createPartyIndex.update.run).void
   }
 
+  // Drop all tables and other objects associated with the database.
+  // Only used between tests for now.
+  def destroy: ConnectionIO[Unit] = {
+    val dropTriggerTable: Fragment = sql"drop table running_triggers"
+    val dropDalfTable: Fragment = sql"drop table dalfs"
+    (dropTriggerTable.update.run
+      *> dropDalfTable.update.run).void
+  }
+
   def addRunningTrigger(t: RunningTrigger): ConnectionIO[Unit] = {
     val partyToken = t.jwt.value
     val fullTriggerName = t.triggerName.toString

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -80,10 +80,10 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
       .fold(e => fail(s"cannot sign a JWT: ${e.shows}"), identity)
   }
 
-  protected def headersWithAuth(party: String) = authorizationHeader(jwt(party))
-
-  protected def authorizationHeader(token: Jwt): List[Authorization] =
+  protected def headersWithAuth(party: String): List[Authorization] = {
+    val token = jwt(party)
     List(Authorization(OAuth2BearerToken(token.value)))
+  }
 
   def withHttpService[A](
       triggerDar: Option[Dar[(PackageId, Package)]],

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -53,7 +53,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
   val testPkgId = dar.main._1
 
   // Lazy because the postgresDatabase is only available once the tests start
-  private lazy val testJdbcConfig = JdbcConfig(postgresDatabase.url, "operator", "password")
+  private lazy val jdbcConfig = JdbcConfig(postgresDatabase.url, "operator", "password")
 
   def submitCmd(client: LedgerClient, party: String, cmd: Command) = {
     val req = SubmitAndWaitRequest(
@@ -88,28 +88,27 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
     List(Authorization(OAuth2BearerToken(token.value)))
   }
 
-  def withTriggerService[A](
-      triggerDar: Option[Dar[(PackageId, Package)]],
-      jdbcConfig: JdbcConfig)
-  : ((Uri, LedgerClient, Proxy) => Future[A]) => Future[Assertion] =
-    TriggerServiceFixture
-      .withTriggerServiceAndDb[A](testId, darPath, triggerDar, jdbcConfig)
-
   def withHttpService[A](
-      triggerDar: Option[Dar[(PackageId, Package)]],
-      jdbcConfig: Option[JdbcConfig] = None)
+      triggerDar: Option[Dar[(PackageId, Package)]])
     : ((Uri, LedgerClient, Proxy) => Future[A]) => Future[A] =
     TriggerServiceFixture
-      .withTriggerService[A](testId, List(darPath), triggerDar, jdbcConfig)
+      .withTriggerService[A](testId, List(darPath), triggerDar, None)
 
-  def startTrigger(uri: Uri, id: String, party: String): Future[HttpResponse] = {
+  def withTriggerServiceAndDb[A](dar: Option[Dar[(PackageId, Package)]])
+  : ((Uri, LedgerClient, Proxy) => Future[A]) => Future[Assertion] =
+    testFn => for {
+      _ <- TriggerServiceFixture.withTriggerService(testId, List(darPath), dar, None)(testFn)
+      _ <- TriggerServiceFixture.withTriggerService(testId, List(darPath), dar, Some(jdbcConfig))(testFn)
+    } yield succeed
+
+  def startTrigger(uri: Uri, triggerName: String, party: String): Future[HttpResponse] = {
     val req = HttpRequest(
       method = HttpMethods.POST,
       uri = uri.withPath(Uri.Path("/v1/start")),
       headers = headersWithAuth(party),
       entity = HttpEntity(
         ContentTypes.`application/json`,
-        s"""{"triggerName": "$id"}"""
+        s"""{"triggerName": "$triggerName"}"""
       )
     )
     Http().singleRequest(req)
@@ -124,7 +123,8 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
     Http().singleRequest(req)
   }
 
-  def triggerStatus(uri: Uri, id: String): Future[HttpResponse] = {
+  def triggerStatus(uri: Uri, triggerInstance: UUID): Future[HttpResponse] = {
+    val id = triggerInstance.toString
     val req = HttpRequest(
       method = HttpMethods.GET,
       uri = uri.withPath(Uri.Path(s"/v1/status/$id")),
@@ -132,10 +132,11 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
     Http().singleRequest(req)
   }
 
-  def stopTrigger(uri: Uri, id: String, party: String): Future[HttpResponse] = {
+  def stopTrigger(uri: Uri, triggerInstance: UUID, party: String): Future[HttpResponse] = {
+    val id = triggerInstance.toString
     val req = HttpRequest(
       method = HttpMethods.DELETE,
-      headers = headersWithAuth(s"${party}"),
+      headers = headersWithAuth(party),
       uri = uri.withPath(Uri.Path(s"/v1/stop/$id")),
     )
     Http().singleRequest(req)
@@ -170,19 +171,19 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
     } yield result
   }
 
-  def parseTriggerId(resp: HttpResponse): Future[String] = {
+  def parseTriggerId(resp: HttpResponse): Future[UUID] = {
     for {
       JsObject(fields) <- parseResult(resp)
       Some(JsString(triggerId)) = fields.get("triggerId")
-    } yield triggerId
+    } yield UUID.fromString(triggerId)
   }
 
-  def parseTriggerIds(resp: HttpResponse): Future[Vector[String]] = {
+  def parseTriggerIds(resp: HttpResponse): Future[Vector[UUID]] = {
     for {
       JsObject(fields) <- parseResult(resp)
       Some(JsArray(ids)) = fields.get("triggerIds")
       triggerIds = ids map {
-        case JsString(id) => id
+        case JsString(id) => UUID.fromString(id)
         case _ => fail("""Non-string element of "triggerIds" field""")
       }
     } yield triggerIds
@@ -191,7 +192,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
   def assertTriggerIds(
       uri: Uri,
       party: String,
-      pred: (Vector[String]) => Boolean): Future[Assertion] = {
+      pred: Vector[UUID] => Boolean): Future[Assertion] = {
     eventually {
       val actualTriggerIds = Await.result(for {
         resp <- listTriggers(uri, party)
@@ -214,25 +215,25 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
 
   def assertTriggerStatus(
       uri: Uri,
-      id: String,
+      triggerInstance: UUID,
       pred: (Vector[String]) => Boolean): Future[Assertion] = {
     eventually {
       val actualTriggerStatus = Await.result(for {
-        resp <- triggerStatus(uri, id)
+        resp <- triggerStatus(uri, triggerInstance)
         result <- parseTriggerStatus(resp)
       } yield result, Duration.Inf)
       assert(pred(actualTriggerStatus))
     }
   }
 
-  it should "set up server with database" in
-    withHttpService(Some(dar), Some(testJdbcConfig)) {
+  it should "start up and shut down server" in
+    withTriggerServiceAndDb(Some(dar)) {
       (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
         Future(succeed)
     }
 
-  it should "add running triggers to the database" in
-    withTriggerService(Some(dar), testJdbcConfig) {
+  it should "add running triggers" in
+    withTriggerServiceAndDb(Some(dar)) {
       (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
         for {
           // Initially no triggers started for Alice
@@ -244,12 +245,11 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
           // Do the same for a second trigger.
           resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Alice")
           trigger2 <- parseTriggerId(resp)
-          expected = Vector(trigger1, trigger2).sorted
-          _ <- assertTriggerIds(uri, "Alice", _ == expected)
+          _ <- assertTriggerIds(uri, "Alice", _ == Vector(trigger1, trigger2).sorted)
         } yield succeed
       }
 
-  it should "fail to start non-existent trigger" in withHttpService(Some(dar)) {
+  it should "fail to start non-existent trigger" in withTriggerServiceAndDb(Some(dar)) {
     (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
       val expectedError = StatusCodes.UnprocessableEntity
       for {
@@ -297,12 +297,12 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
         // Start another trigger for Bob.
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", "Bob")
         bobTrigger2 <- parseTriggerId(resp)
-        _ <- assertTriggerIds(uri, "Bob", _ == Vector(bobTrigger1, bobTrigger2))
+        _ <- assertTriggerIds(uri, "Bob", _ == Vector(bobTrigger1, bobTrigger2).sorted)
         // Stop Alice's trigger.
         resp <- stopTrigger(uri, aliceTrigger, "Alice")
         _ <- assert(resp.status.isSuccess)
         _ <- assertTriggerIds(uri, "Alice", _.isEmpty)
-        _ <- assertTriggerIds(uri, "Bob", _ == Vector(bobTrigger1, bobTrigger2))
+        _ <- assertTriggerIds(uri, "Bob", _ == Vector(bobTrigger1, bobTrigger2).sorted)
         // Stop Bob's triggers.
         resp <- stopTrigger(uri, bobTrigger1, "Bob")
         _ <- assert(resp.status.isSuccess)
@@ -352,7 +352,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
       } yield succeed
   }
 
-  it should "fail to start a trigger if a ledger client can't be obtained" in withHttpService(
+  it should "fail to start a trigger if a ledger client can't be obtained" in withTriggerServiceAndDb(
     Some(dar)) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
     // Disable the proxy. This means that the service won't be able to
     // get a ledger connection.
@@ -514,15 +514,20 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
 
   it should "stopping a trigger that can't parse as a UUID gives a 404 response" in withHttpService(
     None) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    val uuid: String = "No More Mr Nice Guy"
+    val req = HttpRequest(
+      method = HttpMethods.DELETE,
+      uri = uri.withPath(Uri.Path(s"/v1/stop/$uuid")),
+    )
     for {
-      resp <- stopTrigger(uri, "No More Mr Nice Guy", "Alice")
+      resp <- Http().singleRequest(req)
       _ <- assert(resp.status.isFailure() && resp.status.intValue() == 404)
     } yield succeed
   }
 
   it should "stopping an unknown trigger gives an error response" in withHttpService(None) {
     (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
-      val uuid: String = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+      val uuid = UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff")
       for {
         resp <- stopTrigger(uri, uuid, "Alice")
         _ <- assert(resp.status.isFailure() && resp.status.intValue() == 404)

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -36,10 +36,10 @@ import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, Tra
 import com.daml.ledger.client.LedgerClient
 import com.daml.jwt.JwtSigner
 import com.daml.jwt.domain.{DecodedJwt, Jwt}
-import com.daml.testing.postgresql.PostgresAroundSuite
+import com.daml.testing.postgresql.PostgresAroundAll
 import eu.rekawek.toxiproxy._
 
-class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with PostgresAroundSuite {
+class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with PostgresAroundAll {
 
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(15, Seconds)), interval = scaled(Span(1, Seconds)))
@@ -216,18 +216,13 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
   }
 
   it should "initialize database" in {
-    connectToPostgresqlServer()
-    createNewDatabase()
     val testJdbcConfig = JdbcConfig(postgresDatabase.url, "operator", "password")
     assert(ServiceMain.initDatabase(testJdbcConfig).isRight)
-    dropDatabase()
-    disconnectFromPostgresqlServer()
+    assert(ServiceMain.destroyDatabase(testJdbcConfig).isRight)
     succeed
   }
 
   it should "add running triggers to the database" in {
-    connectToPostgresqlServer()
-    createNewDatabase()
     val testJdbcConfig = JdbcConfig(postgresDatabase.url, "operator", "password")
     assert(ServiceMain.initDatabase(testJdbcConfig).isRight)
     Await.result(
@@ -249,8 +244,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
       },
       Duration.Inf
     )
-    dropDatabase()
-    disconnectFromPostgresqlServer()
+    assert(ServiceMain.destroyDatabase(testJdbcConfig).isRight)
     succeed
   }
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/ServiceTest.scala
@@ -216,15 +216,16 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
   }
 
   it should "initialize database" in {
-    val testJdbcConfig = JdbcConfig(postgresDatabase.url, "operator", "password")
-    assert(ServiceMain.initDatabase(testJdbcConfig).isRight)
-    assert(ServiceMain.destroyDatabase(testJdbcConfig).isRight)
+    val dao = TriggerDao(JdbcConfig(postgresDatabase.url, "operator", "password"))
+    assert(ServiceMain.initDatabase(dao).isRight)
+    assert(ServiceMain.destroyDatabase(dao).isRight)
     succeed
   }
 
   it should "add running triggers to the database" in {
     val testJdbcConfig = JdbcConfig(postgresDatabase.url, "operator", "password")
-    assert(ServiceMain.initDatabase(testJdbcConfig).isRight)
+    val dao = TriggerDao(testJdbcConfig)
+    assert(ServiceMain.initDatabase(dao).isRight)
     Await.result(
       withHttpService(Some(dar), Some(testJdbcConfig)) {
         (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
@@ -244,7 +245,7 @@ class ServiceTest extends AsyncFlatSpec with Eventually with Matchers with Postg
       },
       Duration.Inf
     )
-    assert(ServiceMain.destroyDatabase(testJdbcConfig).isRight)
+    assert(ServiceMain.destroyDatabase(dao).isRight)
     succeed
   }
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -35,7 +35,6 @@ import scala.sys.process.Process
 import java.net.{InetAddress, ServerSocket, Socket}
 
 import eu.rekawek.toxiproxy._
-import org.scalatest.Assertion
 
 object TriggerServiceFixture {
 
@@ -50,20 +49,6 @@ object TriggerServiceFixture {
       socket.close()
     }
   }
-
-  def withTriggerServiceAndDb[A](
-      testName: String,
-      darPath: File,
-      dar: Option[Dar[(PackageId, Package)]],
-      jdbcConfig: JdbcConfig,
-    )(testFn: (Uri, LedgerClient, Proxy) => Future[A])(
-      implicit asys: ActorSystem,
-      mat: Materializer,
-      aesf: ExecutionSequencerFactory,
-      ec: ExecutionContext): Future[Assertion] = for {
-        _ <- withTriggerService(testName ++ " (no database)", List(darPath), dar, None)(testFn)
-        _ <- withTriggerService(testName ++ " (with database)", List(darPath), dar, Some(jdbcConfig))(testFn)
-      } yield succeed
 
   def withTriggerService[A](
       testName: String,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -19,7 +19,11 @@ import com.daml.ledger.api.auth.AuthService
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.client.LedgerClient
-import com.daml.ledger.client.configuration.{CommandClientConfiguration, LedgerClientConfiguration, LedgerIdRequirement}
+import com.daml.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement
+}
 import com.daml.platform.common.LedgerIdMode
 import com.daml.platform.sandbox.SandboxServer
 import com.daml.platform.sandbox.config.SandboxConfig
@@ -141,9 +145,9 @@ object TriggerServiceFixture {
       ledgerF.foreach(_._1.close())
       toxiProxyProc.destroy()
       triggerDao.map(dao =>
-        ServiceMain.destroyDatabase(dao).getOrElse {
-          err: String => fail("Failed to remove database objects: " ++ err.toString)
-        })
+        ServiceMain.destroyDatabase(dao).getOrElse { err: String =>
+          fail("Failed to remove database objects: " ++ err.toString)
+      })
     }
 
     fa

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -31,6 +31,7 @@ import com.daml.platform.services.time.TimeProviderType
 import com.daml.ports.Port
 import com.daml.bazeltools.BazelRunfiles
 import com.daml.timer.RetryStrategy
+import org.scalatest.Assertions.fail
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.sys.process.Process
@@ -95,6 +96,15 @@ object TriggerServiceFixture {
       client <- LedgerClient.singleHost(host.getHostName(), ledgerPort, clientConfig(applicationId))
     } yield client
 
+    val triggerDao: Option[TriggerDao] =
+      jdbcConfig.map(c => {
+        val dao = TriggerDao(c)
+        ServiceMain.initDatabase(dao) match {
+          case Left(err) => fail("Failed to initialize database: " ++ err.toString)
+          case Right(()) => dao
+        }
+      })
+
     // Configure the service with the ledger's *proxy* port.
     val serviceF: Future[(ServerBinding, TypedActorSystem[Server.Message])] = for {
       (_, _, ledgerProxyPort, _) <- ledgerF
@@ -118,7 +128,7 @@ object TriggerServiceFixture {
     // For adding toxics.
     val ledgerProxyF: Future[Proxy] = for {
       (_, _, _, ledgerProxy) <- ledgerF
-    } yield ledgerProxy // Not used yet.
+    } yield ledgerProxy
 
     val fa: Future[A] = for {
       client <- clientF
@@ -132,6 +142,10 @@ object TriggerServiceFixture {
       serviceF.foreach({ case (_, system) => system ! Server.Stop })
       ledgerF.foreach(_._1.close())
       toxiProxyProc.destroy()
+      triggerDao.map(dao =>
+        ServiceMain.destroyDatabase(dao).getOrElse {
+          err: String => fail("Failed to remove database objects: " ++ err.toString)
+        })
     }
 
     fa


### PR DESCRIPTION
This adds a function `withTriggerServiceAndDb` which runs a test twice, once with and once without a database, and succeeds if both succeed. This will be useful for reusing test logic with both backends and making sure behaviour is consistent. I have used this function where possible, but it won't work for everything until `stop` is implemented on the DB side.

I'm open to feedback on how this new function runs the two tests, as at the moment it squashes them into one making it hard to tell whether it failed with or without the database. I would ideally like to create two distinct tests with different descriptions but I didn't immediately see how to abstract over the `it should` syntax.

This feature required a few changes in the process, mainly:
- Use `PostgresAroundAll` to connect/disconnect to the database before and after all tests run
- Add a `destroy` method to the `TriggerDao` to reset the database between tests
- Use the TriggerDao in the `withTriggerService` functions to initialize / clean up the database at the start / end of each test
- Sort trigger instances from `list` using Scala's sort, not relying on Postgres' ordering of UUIDs. This also means we need to use UUIDs for trigger instances in the tests and sort nonempty vectors in expected results.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
