### PR TITLE
Include rules_haskell revision in platform suffix

### DIFF
--- a/ci/configure-bazel.sh
+++ b/ci/configure-bazel.sh
@@ -68,7 +68,7 @@ if is_windows; then
   # To avoid exceeding the maximum path limit on Windows we limit the suffix to
   # three characters.
   echo "Working directory: $PWD"
-  SUFFIX="$(echo $PWD $RULES_HASKELL_REV | md5sum)"
+  SUFFIX="$(echo $PWD $RULES_HASKELL_REV | openssl dgst -md5 -binary | openssl enc -base64)"
   SUFFIX="${SUFFIX:0:3}"
   echo "Platform suffix: $SUFFIX"
   echo "build --platform_suffix=-$SUFFIX" >> .bazelrc.local

--- a/ci/configure-bazel.sh
+++ b/ci/configure-bazel.sh
@@ -40,6 +40,10 @@ cd "$(dirname "$0")"/..
 
 step "configuring bazel"
 
+# We include the rules_haskell revision in the suffix since
+# it sometimes breaks Windows due to the lack of sandboxing.
+RULES_HASKELL_REV="$(sed -n 's/rules_haskell_version = "\(.*\)"$/\1/p' deps.bzl)"
+
 if [ ! -z "${BAZEL_CONFIG_DIR:-}" ]; then
     cd "$BAZEL_CONFIG_DIR"
 fi
@@ -64,8 +68,8 @@ if is_windows; then
   # To avoid exceeding the maximum path limit on Windows we limit the suffix to
   # three characters.
   echo "Working directory: $PWD"
-  SUFFIX="$(echo $PWD | md5sum)"
-  SUFFIX="${SUFFIX:0:2}"
+  SUFFIX="$(echo $PWD $RULES_HASKELL_REV | md5sum)"
+  SUFFIX="${SUFFIX:0:3}"
   echo "Platform suffix: $SUFFIX"
   echo "build --platform_suffix=-$SUFFIX" >> .bazelrc.local
 fi


### PR DESCRIPTION
Hopefully this makes CI a bit less of a dumpsterfire. I’ve also
followed the comment and made the suffix actually 3 characters long
instead of 2 since that makes me worry less about collisions and
should hopefully still be short enough to not hit MAX_PATH.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
