### PR TITLE
Introduce CLI option for input buffer size

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -266,14 +266,19 @@ object Cli {
         .optional()
         .action((value, config) =>
           config.copy(commandConfig = config.commandConfig.copy(maxCommandsInFlight = value)))
-        .text("The maximum number of unconfirmed commands in flight in CommandService.")
+        .text("Maximum number of submitted commands waiting for completion for each party (only applied when using the CommandService). Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 256.")
 
       opt[Int]("max-parallel-submissions")
         .optional()
         .action((value, config) =>
           config.copy(commandConfig = config.commandConfig.copy(maxParallelSubmissions = value)))
-        .text(
-          "The maximum number of parallel command submissions. Only applicable to sandbox-classic.")
+        .text("Maximum number of successfully interpreted commands waiting to be sequenced (applied only when running sandbox-classic). The threshold is shared across all parties, overflowing it will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512.")
+
+      opt[Int]("input-buffer-size")
+        .optional()
+        .action((value, config) =>
+          config.copy(commandConfig = config.commandConfig.copy(inputBufferSize = value)))
+        .text("The maximum number of commands waiting to be submitted for each party. Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512.")
 
       opt[Long]("max-lf-value-translation-cache-entries")
         .optional()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -272,7 +272,7 @@ object Cli {
         .optional()
         .action((value, config) =>
           config.copy(commandConfig = config.commandConfig.copy(maxParallelSubmissions = value)))
-        .text("Maximum number of successfully interpreted commands waiting to be sequenced (applied only when running sandbox-classic). The threshold is shared across all parties, overflowing it will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512.")
+        .text("Maximum number of successfully interpreted commands waiting to be sequenced (applied only when running sandbox-classic). The threshold is shared across all parties. Overflowing it will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512.")
 
       opt[Int]("input-buffer-size")
         .optional()


### PR DESCRIPTION
Also improves CLI help text for other back-pressure related options.

changelog_begin
[Sandbox] Allow to configure --input-buffer-size, which allows to tune the number of commands waiting to be submitted before the Sandbox applies back-pressure, run daml sandbox --help for more info.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
