### PR TITLE
Only force the result of GeneratePackageMap to WHNF

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -188,7 +188,7 @@ runRepl opts mainDar replClient ideState = do
     Right Dalfs{..} <- readDalfs . Zip.toArchive <$> BSL.readFile mainDar
     (_, pkg) <- either (fail . show) pure (LFArchive.decodeArchive LFArchive.DecodeAsMain (BSL.toStrict mainDalf))
     let moduleNames = map LF.moduleName (NM.elems (LF.packageModules pkg))
-    Just pkgs <- runAction ideState (use GeneratePackageMap "Dummy.daml")
+    Just (PackageMap pkgs) <- runAction ideState (use GeneratePackageMap "Dummy.daml")
     Just stablePkgs <- runAction ideState (use GenerateStablePackages "Dummy.daml")
     for_ (topologicalSort (toList pkgs <> toList stablePkgs)) $ \pkg -> do
         r <- ReplClient.loadPackage replClient (LF.dalfPackageBytes pkg)

--- a/compiler/damlc/daml-rule-types/src/Development/IDE/Core/RuleTypes/Daml.hs
+++ b/compiler/damlc/daml-rule-types/src/Development/IDE/Core/RuleTypes/Daml.hs
@@ -62,7 +62,14 @@ instance Show GeneratePackageMapFun where show _ = "GeneratePackageMapFun"
 instance NFData GeneratePackageMapFun where rnf !_ = ()
 -- | This matches how GhcSessionIO is handled in ghcide.
 type instance RuleResult GeneratePackageMapIO = GeneratePackageMapFun
-type instance RuleResult GeneratePackageMap = Map UnitId LF.DalfPackage
+
+-- | We only want to force this to WHNF not to NF since that is way too slow,
+-- repeated for each file and unnecessary since decoding forces it.
+newtype PackageMap = PackageMap { getPackageMap :: Map UnitId LF.DalfPackage }
+  deriving Show
+instance NFData PackageMap where
+    rnf = rwhnf
+type instance RuleResult GeneratePackageMap = PackageMap
 type instance RuleResult GenerateStablePackages = Map (UnitId, LF.ModuleName) LF.DalfPackage
 
 data DamlGhcSession = DamlGhcSession (Maybe NormalizedFilePath)

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -103,7 +103,7 @@ createProjectPackageDb projectRoot opts thisSdkVer modulePrefixes deps dataDeps
     mbRes <- withDamlIdeState opts loggerH diagnosticsLogger $ \ide -> runActionSync ide $ runMaybeT $
         (,) <$> useNoFileE GenerateStablePackages
             <*> useE GeneratePackageMap projectRoot
-    (stablePkgs, dependenciesInPkgDb) <- maybe (fail "Failed to generate package info") pure mbRes
+    (stablePkgs, PackageMap dependenciesInPkgDb) <- maybe (fail "Failed to generate package info") pure mbRes
     let stablePkgIds :: Set LF.PackageId
         stablePkgIds = Set.fromList $ map LF.dalfPackageId $ MS.elems stablePkgs
     let dependenciesInPkgDbIds =


### PR DESCRIPTION
This rule is repeated for every file. While we cache the computation,
we still forced it to NF which is super slow. On my (realworld)
testcase, this is a speedup of > 1.7x, cuts allocations to 1/3 and max
residency also goes down to 1/3.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
