### PR TITLE
Fix variable in daily slack notifications

### DIFF
--- a/ci/daily_tell_slack.yml
+++ b/ci/daily_tell_slack.yml
@@ -16,7 +16,7 @@ steps:
         MESSAGE=${{ parameters['success-message'] }}
     fi
     PAYLOAD="{\"text\":\"$MESSAGE\n\"}"
-    if [ "$(variables['Build.SourceBranchName'])" = "master" ]; then
+    if [ "$(Build.SourceBranchName)" = "master" ]; then
         curl -XPOST \
              -i \
              -H 'Content-type: application/json' \


### PR DESCRIPTION
Currently the report fails with variables[Build.SourceBranchName]:
command not found which is obviously not what we want (it’s mixing up
the syntax in Azure’s yaml config and Bash). Looking at the
code in the tell-slack-failed.yml, this one does seem to work but I
haven’t tested this so :crossed-fingers:.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
