### PR TITLE
Engine: Centralize the place where value version is inferred.

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -28,7 +28,7 @@ final class Conversions(
   // We need the mapping for converting error message so we manually add it here.
   private val ptxCoidToNodeId = machine.ptx.nodes
     .collect {
-      case (nodeId, node @ N.NodeCreate(_, _, _, _, _, _)) =>
+      case (nodeId, node: N.NodeCreate[V.ContractId, _]) =>
         node.coid -> ledger.ptxNodeId(nodeId)
     }
 
@@ -585,7 +585,7 @@ final class Conversions(
 
   }
 
-  private def convertVersionnedValue(value: V.VersionedValue[V.ContractId]): Value =
+  private def convertVersionedValue(value: V.VersionedValue[V.ContractId]): Value =
     convertValue(value.value)
 
   def convertValue(value: V[V.ContractId]): Value = {

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -471,7 +471,7 @@ final class Conversions(
         lbk.optLocation.foreach(loc => builder.setLocation(convertLocation(loc)))
         val lbkBuilder = Node.LookupByKey.newBuilder
           .setTemplateId(convertIdentifier(lbk.templateId))
-          .setKeyWithMaintainers(convertKeyWithMaintainers(convertVersionnedValue, lbk.key))
+          .setKeyWithMaintainers(convertKeyWithMaintainers(convertVersionedValue, lbk.key))
         lbk.result.foreach(cid => lbkBuilder.setContractId(coidToNodeId(cid)))
         builder.setLookupByKey(lbkBuilder)
 
@@ -500,7 +500,7 @@ final class Conversions(
       .setNodeId(NodeId.newBuilder.setId(nodeId.index.toString).build)
     // FIXME(JM): consumedBy, parent, ...
     node match {
-      case create @ N.NodeCreate(_, _, _, _, _, _) =>
+      case create: N.NodeCreate[V.ContractId, Val] =>
         val createBuilder =
           Node.Create.newBuilder
             .setContractInstance(
@@ -515,7 +515,7 @@ final class Conversions(
           createBuilder.setKeyWithMaintainers(convertKeyWithMaintainers(convertValue, key)))
         create.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setCreate(createBuilder.build)
-      case fetch @ N.NodeFetch(_, _, _, _, _, _, _) =>
+      case fetch: N.NodeFetch[V.ContractId, Val] =>
         builder.setFetch(
           Node.Fetch.newBuilder
             .setContractId(coidToNodeId(fetch.coid))
@@ -524,7 +524,7 @@ final class Conversions(
             .addAllStakeholders(fetch.stakeholders.map(convertParty).asJava)
             .build,
         )
-      case ex @ N.NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _) =>
+      case ex: N.NodeExercises[V.NodeId, V.ContractId, Val] =>
         ex.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setExercise(
           Node.Exercise.newBuilder
@@ -545,7 +545,7 @@ final class Conversions(
             .build,
         )
 
-      case lookup @ N.NodeLookupByKey(_, _, _, _) =>
+      case lookup: N.NodeLookupByKey[V.ContractId, Val] =>
         lookup.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setLookupByKey({
           val builder = Node.LookupByKey.newBuilder

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -28,7 +28,7 @@ final class Conversions(
   // We need the mapping for converting error message so we manually add it here.
   private val ptxCoidToNodeId = machine.ptx.nodes
     .collect {
-      case (nodeId, node: N.NodeCreate.WithTxValue[V.ContractId]) =>
+      case (nodeId, node @ N.NodeCreate(_, _, _, _, _, _)) =>
         node.coid -> ledger.ptxNodeId(nodeId)
     }
 
@@ -96,7 +96,7 @@ final class Conversions(
         builder.setTemplatePrecondViolated(
           uepvBuilder
             .setTemplateId(convertIdentifier(tid))
-            .setArg(convertValue(arg.value))
+            .setArg(convertValue(arg))
             .build,
         )
       case SError.DamlELocalContractNotActive(coid, tid, consumedBy) =>
@@ -374,7 +374,7 @@ final class Conversions(
 
   def convertPartialTransaction(ptx: SPartialTransaction): PartialTransaction = {
     val builder = PartialTransaction.newBuilder
-      .addAllNodes(ptx.nodes.map(Function.tupled(convertTxNode)).asJava)
+      .addAllNodes(ptx.nodes.map(convertNode(convertValue(_), _)).asJava)
       .addAllRoots(
         ptx.context.children.toImmArray.toSeq.sortBy(_.index).map(convertTxNodeId).asJava,
       )
@@ -385,7 +385,7 @@ final class Conversions(
         val ecBuilder = ExerciseContext.newBuilder
           .setTargetId(mkContractRef(ctx.targetId, ctx.templateId))
           .setChoiceId(ctx.choiceId)
-          .setChosenValue(convertValue(ctx.chosenValue.value))
+          .setChosenValue(convertValue(ctx.chosenValue))
         ctx.optLocation.map(loc => ecBuilder.setExerciseLocation(convertLocation(loc)))
         builder.setExerciseContext(ecBuilder.build)
     }
@@ -471,7 +471,7 @@ final class Conversions(
         lbk.optLocation.foreach(loc => builder.setLocation(convertLocation(loc)))
         val lbkBuilder = Node.LookupByKey.newBuilder
           .setTemplateId(convertIdentifier(lbk.templateId))
-          .setKeyWithMaintainers(convertKeyWithMaintainers(lbk.key))
+          .setKeyWithMaintainers(convertKeyWithMaintainers(convertVersionnedValue, lbk.key))
         lbk.result.foreach(cid => lbkBuilder.setContractId(coidToNodeId(cid)))
         builder.setLookupByKey(lbkBuilder)
 
@@ -479,38 +479,43 @@ final class Conversions(
     builder.build
   }
 
-  def convertKeyWithMaintainers(
-      key: N.KeyWithMaintainers[V.VersionedValue[V.ContractId]],
+  def convertKeyWithMaintainers[Val](
+      convertValue: Val => Value,
+      key: N.KeyWithMaintainers[Val],
   ): KeyWithMaintainers = {
     KeyWithMaintainers
       .newBuilder()
-      .setKey(convertValue(key.key.value))
+      .setKey(convertValue(key.key))
       .addAllMaintainers(key.maintainers.map(convertParty).asJava)
       .build()
   }
 
-  def convertTxNode( /*ptx: Tx.PartialTransaction, */ nodeId: Tx.NodeId, node: Tx.Node): Node = {
+  def convertNode[Val](
+      convertValue: Val => Value,
+      nodeWithId: (Tx.NodeId, N.GenNode[V.NodeId, V.ContractId, Val]),
+  ): Node = {
+    val (nodeId, node) = nodeWithId
     val builder = Node.newBuilder
     builder
       .setNodeId(NodeId.newBuilder.setId(nodeId.index.toString).build)
     // FIXME(JM): consumedBy, parent, ...
     node match {
-      case create: N.NodeCreate.WithTxValue[V.ContractId] =>
+      case create @ N.NodeCreate(_, _, _, _, _, _) =>
         val createBuilder =
           Node.Create.newBuilder
             .setContractInstance(
               ContractInstance.newBuilder
                 .setTemplateId(convertIdentifier(create.coinst.template))
-                .setValue(convertValue(create.coinst.arg.value))
+                .setValue(convertValue(create.coinst.arg))
                 .build,
             )
             .addAllSignatories(create.signatories.map(convertParty).asJava)
             .addAllStakeholders(create.stakeholders.map(convertParty).asJava)
         create.key.foreach(key =>
-          createBuilder.setKeyWithMaintainers(convertKeyWithMaintainers(key)))
+          createBuilder.setKeyWithMaintainers(convertKeyWithMaintainers(convertValue, key)))
         create.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setCreate(createBuilder.build)
-      case fetch: N.NodeFetch.WithTxValue[V.ContractId] =>
+      case fetch @ N.NodeFetch(_, _, _, _, _, _, _) =>
         builder.setFetch(
           Node.Fetch.newBuilder
             .setContractId(coidToNodeId(fetch.coid))
@@ -519,7 +524,7 @@ final class Conversions(
             .addAllStakeholders(fetch.stakeholders.map(convertParty).asJava)
             .build,
         )
-      case ex: N.NodeExercises.WithTxValue[Tx.NodeId, V.ContractId] =>
+      case ex @ N.NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _) =>
         ex.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setExercise(
           Node.Exercise.newBuilder
@@ -528,7 +533,7 @@ final class Conversions(
             .setChoiceId(ex.choiceId)
             .setConsuming(ex.consuming)
             .addAllActingParties(ex.actingParties.map(convertParty).asJava)
-            .setChosenValue(convertValue(ex.chosenValue.value))
+            .setChosenValue(convertValue(ex.chosenValue))
             .addAllSignatories(ex.signatories.map(convertParty).asJava)
             .addAllStakeholders(ex.stakeholders.map(convertParty).asJava)
             .addAllChildren(
@@ -540,11 +545,11 @@ final class Conversions(
             .build,
         )
 
-      case lookup: N.NodeLookupByKey.WithTxValue[V.ContractId] =>
+      case lookup @ N.NodeLookupByKey(_, _, _, _) =>
         lookup.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setLookupByKey({
           val builder = Node.LookupByKey.newBuilder
-            .setKeyWithMaintainers(convertKeyWithMaintainers(lookup.key))
+            .setKeyWithMaintainers(convertKeyWithMaintainers(convertValue, lookup.key))
           lookup.result.foreach(cid => builder.setContractId(coidToNodeId(cid)))
           builder.build
         })
@@ -579,6 +584,9 @@ final class Conversions(
       .build
 
   }
+
+  private def convertVersionnedValue(value: V.VersionedValue[V.ContractId]): Value =
+    convertValue(value.value)
 
   def convertValue(value: V[V.ContractId]): Value = {
     val builder = Value.newBuilder

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -349,7 +349,7 @@ final class Engine {
       }
     }
 
-    machine.ptx.finish match {
+    machine.ptx.finish(machine.supportedValueVersions) match {
       case Left(p) =>
         ResultError(Error(s"Interpretation error: ended with partial result: $p"))
       case Right(t) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -75,16 +75,16 @@ object Pretty {
   // A minimal pretty-print of an update transaction node, without recursing into child nodes..
   def prettyPartialTransactionNode(node: PartialTransaction.Node): Doc =
     node match {
-      case create @ NodeCreate(_, _, _, _, _, _) =>
+      case create: NodeCreate[Value.ContractId, Value[Value.ContractId]] =>
         "create" &: prettyContractInst(create.coinst)
-      case fetch @ NodeFetch(_, _, _, _, _, _, _) =>
+      case fetch: NodeFetch[Value.ContractId, Value[Value.ContractId]] =>
         "fetch" &: prettyContractId(fetch.coid)
-      case ex @ NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _) =>
+      case ex: NodeExercises[Value.NodeId, Value.ContractId, Value[Value.ContractId]] =>
         intercalate(text(", "), ex.actingParties.map(p => text(p))) &
           text("exercises") & text(ex.choiceId) + char(':') + prettyIdentifier(ex.templateId) &
           text("on") & prettyContractId(ex.targetCoid) /
           text("with") & prettyValue(false)(ex.chosenValue)
-      case lbk @ NodeLookupByKey(_, _, _, _) =>
+      case lbk: NodeLookupByKey[Value.ContractId, Value[Value.ContractId]] =>
         text("lookup by key") & prettyIdentifier(lbk.templateId) /
           text("key") & prettyKeyWithMaintainers(lbk.key) /
           (lbk.result match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -6,8 +6,8 @@ package com.daml.lf.speedy
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
 import com.daml.lf.transaction.Node.GlobalKey
-import com.daml.lf.transaction.Transaction
-import com.daml.lf.transaction.Transaction.Transaction
+import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.value.Value
 import com.daml.lf.types.Ledger
 import com.daml.lf.value.Value.ContractId
 
@@ -48,7 +48,7 @@ object SError {
   final case class DamlETemplatePreconditionViolated(
       templateId: TypeConName,
       optLocation: Option[Location],
-      arg: Transaction.Value[ContractId],
+      arg: Value[ContractId],
   ) extends SErrorDamlException
 
   /** A fetch or an exercise on a transaction-local contract that has already
@@ -56,7 +56,7 @@ object SError {
   final case class DamlELocalContractNotActive(
       coid: ContractId,
       templateId: TypeConName,
-      consumedBy: Transaction.NodeId,
+      consumedBy: Tx.NodeId,
   ) extends SErrorDamlException
 
   /** Error during an operation on the update transaction. */
@@ -111,7 +111,7 @@ object SError {
   final case class ScenarioErrorCommitError(commitError: Ledger.CommitError) extends SErrorScenario
 
   /** The transaction produced by the update expression in a 'mustFailAt' succeeded. */
-  final case class ScenarioErrorMustFailSucceeded(tx: Transaction) extends SErrorScenario
+  final case class ScenarioErrorMustFailSucceeded(tx: Tx.Transaction) extends SErrorScenario
 
   /** Invalid party name supplied to 'getParty'. */
   final case class ScenarioErrorInvalidPartyName(name: String, msg: String) extends SErrorScenario

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueVersion.scala
@@ -37,6 +37,13 @@ object ValueVersions
   def assignVersion[Cid](
       v0: Value[Cid],
       supportedVersions: VersionRange[ValueVersion] = DefaultSupportedVersions,
+  ): Either[String, ValueVersion] =
+    assignVersion(v0, supportedVersions.min, supportedVersions.max)
+
+  def assignVersion[Cid](
+      v0: Value[Cid],
+      minVersion: ValueVersion,
+      maxVersion: ValueVersion,
   ): Either[String, ValueVersion] = {
     import VersionTimeline.{maxVersion => maxVV}
     import VersionTimeline.Implicits._
@@ -84,8 +91,8 @@ object ValueVersions
       }
     }
 
-    go(supportedVersions.min, FrontStack(v0)) match {
-      case Right(inferredVersion) if supportedVersions.max precedes inferredVersion =>
+    go(minVersion, FrontStack(v0)) match {
+      case Right(inferredVersion) if maxVersion precedes inferredVersion =>
         Left(s"inferred version $inferredVersion is not supported")
       case res =>
         res


### PR DESCRIPTION
We move inference of value versions in a single place (when finalizing the `PartialTransacion`)
In an upcoming PR, we will infer the transaction version in the same place. 

This PR advances the state of #5164

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
