### PR TITLE
Put initialization failures through retries too

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -399,11 +399,8 @@ object Server {
               case Right(()) => Behaviors.same
             }
           case TriggerInitializationFailure(runningTrigger, cause) =>
-            // The trigger has failed to start. Send the runner a stop
-            // message. There's no point in it remaining alive since
-            // its child actor is stopped and won't be restarted.
+            // The trigger has failed to start.
             server.logTriggerStatus(runningTrigger, "stopped: initialization failure")
-            runningTrigger.runner ! TriggerRunner.Stop
             // No need to update the running triggers tables since
             // this trigger never made it there.
             Behaviors.same

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -37,19 +37,12 @@ class TriggerRunner(
 
   import TriggerRunner.{Message, Stop}
 
-  // Spawn a trigger runner impl. Supervise it. If it fails to start
-  // its runner, send it a stop message (the server will later send us
-  // a stop message in due course in this case so this actor will get
-  // garbage collected too). If it something bad happens when the
-  // trigger is running, try to restart it up to 3 times.
+  // Spawn a trigger runner impl. Supervise it.
   private val child =
     ctx.spawn(
       Behaviors
-        .supervise(
-          Behaviors
-            .supervise(TriggerRunnerImpl(ctx.self, config))
-            .onFailure[InitializationException](stop))
-        .onFailure[RuntimeException](
+        .supervise(TriggerRunnerImpl(ctx.self, config))
+        .onFailure(
           restart.withLimit(config.maxFailureNumberOfRetries, config.failureRetryTimeRange)),
       name
     )

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -10,6 +10,7 @@ import com.daml.ledger.api.refinements.ApiTypes.Party
 import io.grpc.netty.NettyChannelBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 import scalaz.syntax.tag._
 import com.daml.lf.CompiledPackages
@@ -137,9 +138,10 @@ object TriggerRunnerImpl {
                   // Report the failure to the server.
                   config.server ! TriggerInitializationFailure(runningTrigger, cause.toString)
                   // Tell our monitor there's been a failure. The
-                  // monitor's supervisor strategy will respond to this by
-                  // writing the exception to the log and stopping this
-                  // actor.
+                  // monitor's supervisor strategy will respond to
+                  // this by writing the exception to the log and
+                  // attempting to restart this actor up to some
+                  // number of times.
                   throw new InitializationException("Couldn't start: " + cause.toString)
               }
             }


### PR DESCRIPTION
We used to stop triggers that had an initialization failure. That wasn't a great idea. Now they too get retries before we give up. Re-enables the test disabled by PR https://github.com/digital-asset/daml/pull/6228.