### PR TITLE
DAML profiler: Evaluate arguments before open event

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -17,7 +17,7 @@ import java.util.ArrayList
 final class Profile {
   import Profile._
   private val start: Long = System.nanoTime()
-  private val events: ArrayList[Event] = new ArrayList()
+  private[lf] val events: ArrayList[Event] = new ArrayList()
   var name: String = "DAML Engine profile"
 
   def addOpenEvent(label: AnyRef) = {
@@ -39,7 +39,7 @@ final class Profile {
 object Profile {
   // NOTE(MH): See the documenation of [[Profile]] above for why we use
   // [[AnyRef]] for the labels.
-  private final case class Event(val open: Boolean, val rawLabel: AnyRef, val time: Long) {
+  private[lf] final case class Event(val open: Boolean, val rawLabel: AnyRef, val time: Long) {
     def label: String = {
       import com.daml.lf.speedy.SExpr._
       rawLabel match {


### PR DESCRIPTION
This PR fixes a bug where the profiler wrote open events for functions
_before_ evaluating their arguments. However, in a call-by-value
language such as DAML, arguments are evaluated before entering a
function and the profiler should reflect that.

This PR also adds a regression test.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6234)
<!-- Reviewable:end -->
