### PR TITLE
Fix waitForSelector calls in create-daml-app-tests

### DIFF
--- a/compatibility/bazel_tools/create-daml-app/index.test.ts
+++ b/compatibility/bazel_tools/create-daml-app/index.test.ts
@@ -307,7 +307,9 @@ test("log in as three different users and start following each other", async () 
 
   // Add Party 3 as well and check both are in the list.
   await follow(page1, party3);
-  await page1.waitForSelector(".test-select-following");
+  await page1.waitForFunction(
+    () => document.querySelectorAll(".test-select-following").length == 2
+  );
   const followingList11 = await page1.$$eval(
     ".test-select-following",
     (following) => following.map((e) => e.innerHTML)
@@ -344,7 +346,9 @@ test("log in as three different users and start following each other", async () 
   await follow(page2, party3);
 
   // Check the following list is updated correctly.
-  await page2.waitForSelector(".test-select-following");
+  await page2.waitForFunction(
+    () => document.querySelectorAll(".test-select-following").length == 2
+  );
   const followingList2 = await page2.$$eval(
     ".test-select-following",
     (following) => following.map((e) => e.innerHTML)

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -234,7 +234,9 @@ test('log in as three different users and start following each other', async () 
 
    // Add Party 3 as well and check both are in the list.
    await follow(page1, party3);
-   await page1.waitForSelector('.test-select-following');
+   await page1.waitForFunction(
+    () => document.querySelectorAll(".test-select-following").length == 2
+   );
    const followingList11 = await page1.$$eval('.test-select-following', following => following.map(e => e.innerHTML));
    expect(followingList11).toHaveLength(2);
    expect(followingList11).toContain(party2);
@@ -266,7 +268,9 @@ test('log in as three different users and start following each other', async () 
   await follow(page2, party3);
 
   // Check the following list is updated correctly.
-  await page2.waitForSelector('.test-select-following');
+  await page2.waitForFunction(
+    () => document.querySelectorAll(".test-select-following").length == 2
+  );
   const followingList2 = await page2.$$eval('.test-select-following', following => following.map(e => e.innerHTML));
   expect(followingList2).toHaveLength(2);
   expect(followingList2).toContain(party1);


### PR DESCRIPTION
`waitForSelector` returns immediately if the selector is already
present (which is documented). This means that the waitForSelector
after the second follow isn’t doing anything since we already waited
for after the first follow. `waitForFunction` seemed like the simplest
solution and doesn’t require patching the HTML which is a bit finnicky
in the compat tests.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
