### PR TITLE
Make runner for migration tests more generic

### DIFF
--- a/compatibility/sandbox-migration/BUILD
+++ b/compatibility/sandbox-migration/BUILD
@@ -62,7 +62,7 @@ da_scala_binary(
 
 da_haskell_binary(
     name = "sandbox-migration-runner",
-    srcs = ["SandboxMigrationRunner.hs"],
+    srcs = glob(["runner/**/*.hs"]),
     data = [
         ":migration-step",
         "@daml-sdk-0.0.0//:daml",
@@ -74,10 +74,12 @@ da_haskell_binary(
         "filepath",
         "lens",
         "lens-aeson",
+        "mtl",
         "optparse-applicative",
         "process",
         "text",
     ],
+    main_function = "Migration.Runner.main",
     visibility = ["//visibility:public"],
     deps = [
         "//bazel_tools/client_server/with-postgres",

--- a/compatibility/sandbox-migration/runner/Migration/Runner.hs
+++ b/compatibility/sandbox-migration/runner/Migration/Runner.hs
@@ -1,0 +1,96 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Migration.Runner (main) where
+
+-- This test runs through the following steps:
+-- 1. Start postgres
+-- 2. Start the oldest version of sandbox.
+-- 3. Upload a DAR using the same SDK version.
+-- 4. Stop sandbox.
+-- 5. In a loop over all versions:
+--    1. Start sandbox of the given version.
+--    2. Run a custom scala binary for querying and creating new contracts.
+--    3. Stop sandbox.
+-- 6. Stop postgres.
+
+import Control.Exception
+import Control.Monad
+import qualified Data.Text as T
+import Options.Applicative
+import Sandbox
+    ( createSandbox
+    , defaultSandboxConf
+    , destroySandbox
+    , nullDevice
+    , sandboxPort
+    , SandboxConfig(..)
+    )
+import System.Environment.Blank
+import System.FilePath
+import System.IO.Extra
+import System.Process
+import WithPostgres (withPostgres)
+import qualified Bazel.Runfiles
+
+import qualified Migration.ProposeAccept as ProposeAccept
+import Migration.Types
+
+data Options = Options
+  { modelDar :: FilePath
+  , platformAssistants :: [FilePath]
+  -- ^ Ordered list of assistant binaries that will be used to run sandbox.
+  -- We run through migrations in the order of the list
+  }
+
+optsParser :: Parser Options
+optsParser = Options
+    <$> strOption (long "model-dar")
+    <*> many (strArgument mempty)
+
+main :: IO ()
+main = do
+    -- Limit sandbox and model-step memory.
+    setEnv "_JAVA_OPTIONS" "-Xms128m -Xmx1g" True
+    Options{..} <- execParser (info optsParser fullDesc)
+    runfiles <- Bazel.Runfiles.create
+    let step = Bazel.Runfiles.rlocation
+            runfiles
+            ("compatibility" </> "sandbox-migration" </> "migration-step")
+    withPostgres $ \jdbcUrl -> do
+        initialPlatform : _ <- pure platformAssistants
+        hPutStrLn stderr "--> Uploading model DAR"
+        withSandbox initialPlatform jdbcUrl $ \p ->
+            callProcess initialPlatform
+                [ "ledger"
+                , "upload-dar", modelDar
+                , "--host=localhost", "--port=" <> show p
+                ]
+        hPutStrLn stderr "<-- Uploaded model DAR"
+        runTest jdbcUrl platformAssistants (ProposeAccept.test step modelDar)
+
+runTest :: forall s r. T.Text -> [FilePath] -> Test s r -> IO ()
+runTest jdbcUrl platformAssistants Test{..} = foldM_ step initialState platformAssistants
+  where step :: s -> FilePath -> IO s
+        step state assistant = do
+            let version = takeFileName (takeDirectory assistant)
+            hPutStrLn stderr ("--> Testing " <> version)
+            r <- withSandbox assistant jdbcUrl $ \port ->
+              executeStep (SdkVersion version) "localhost" port state
+            case validateStep (SdkVersion version) state r of
+                Left err -> fail err
+                Right state' -> do
+                    hPutStrLn stderr ("<-- Tested " <> version)
+                    pure state'
+
+withSandbox :: FilePath -> T.Text -> (Int -> IO a) -> IO a
+withSandbox assistant jdbcUrl f =
+    withBinaryFile nullDevice ReadWriteMode $ \handle ->
+    withTempFile $ \portFile ->
+    bracket (createSandbox portFile handle sandboxConfig) destroySandbox $ \resource ->
+      f (sandboxPort resource)
+  where
+    sandboxConfig = defaultSandboxConf
+        { sandboxBinary = assistant
+        , sandboxArgs = ["sandbox-classic", "--jdbcurl=" <> T.unpack jdbcUrl]
+        }

--- a/compatibility/sandbox-migration/runner/Migration/Types.hs
+++ b/compatibility/sandbox-migration/runner/Migration/Types.hs
@@ -1,0 +1,21 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Migration.Types
+  ( Test(..)
+  , SdkVersion(..)
+  ) where
+
+data Test s r = Test
+  { executeStep :: SdkVersion -> String -> Int -> s -> IO r
+  -- ^ Execute a step given SDK version, the host and port
+  -- and current state and produce a result.
+  , validateStep :: SdkVersion -> s -> r -> Either String s
+  -- ^ Validate the result of a step given the SDK version and current state
+  -- and produce either an error or a new state.
+  , initialState :: s
+  -- ^ The initial state to start with.
+  }
+
+newtype SdkVersion = SdkVersion { getSdkVersion :: String }
+


### PR DESCRIPTION
This factors out the parts of the migration runner that are specific
to the current test so we can easily add new tests.

Currently the postgres instance and the model DAR are shared. It’s
easy to separate that and have them be per test. I don’t have strong
feelings on what the right approach here.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
