### PR TITLE
Modify the cache URL instead of relying on platform_suffix

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,6 @@
 # flag: --noremote_accept_cached
 build:darwin --remote_http_cache=https://bazel-cache.da-ext.net
 build:linux --remote_http_cache=https://bazel-cache.da-ext.net
-build:windows-ci --remote_http_cache=https://bazel-cache.da-ext.net/v1
 build --remote_upload_local_results=false
 # Enable the disk cache in addition to the http cache.
 build:linux --disk_cache=.bazel-cache/disk

--- a/build.ps1
+++ b/build.ps1
@@ -49,6 +49,8 @@ function bazel() {
 # which is a workaround for this problem.
 bazel shutdown
 
+bazel clean --expunge
+
 # Prefetch nodejs_dev_env to avoid permission denied errors on external/nodejs_dev_env/nodejs_dev_env/node.exe
 # It isn’t clear where exactly those errors are coming from.
 bazel fetch @nodejs_dev_env//...

--- a/ci/configure-bazel.sh
+++ b/ci/configure-bazel.sh
@@ -51,7 +51,6 @@ fi
 CACHE_URL="https://storage.googleapis.com/daml-bazel-cache"
 
 if is_windows; then
-  CACHE_URL="$CACHE_URL/v1"
   echo "build --config windows" > .bazelrc.local
   echo "build --config windows-ci" >> .bazelrc.local
 
@@ -74,7 +73,10 @@ if is_windows; then
   SUFFIX="$(echo $PWD $RULES_HASKELL_REV | openssl dgst -md5 -binary | openssl enc -base64)"
   SUFFIX="${SUFFIX:0:3}"
   echo "Platform suffix: $SUFFIX"
-  echo "build --platform_suffix=-$SUFFIX" >> .bazelrc.local
+  # We include an extra version at the end that we can bump manually.
+  CACHE_SUFFIX="$SUFFIX-v1"
+  CACHE_URL="$CACHE_URL/$CACHE_SUFFIX"
+  echo "build:windows-ci --remote_http_cache=https://bazel-cache.da-ext.net/$CACHE_SUFFIX" >> .bazelrc.local
 fi
 
 # sets up write access to the shared remote cache if the branch is not a fork

--- a/compatibility/build-release-artifacts-windows.ps1
+++ b/compatibility/build-release-artifacts-windows.ps1
@@ -37,6 +37,7 @@ function bazel() {
 
 
 bazel shutdown
+bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build `
   `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution_windows.log `

--- a/compatibility/test-windows.ps1
+++ b/compatibility/test-windows.ps1
@@ -45,6 +45,7 @@ cd compatibility
 cp ../.bazelrc .bazelrc
 
 bazel shutdown
+bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build //...
 bazel shutdown


### PR DESCRIPTION
For some reason, platform_suffix doesn’t seem to provide enough
isolation to fix the “undeclared inclusion” errors even though it does
fix the issues for me locally.

This PR tries to address the problem by switching from
`platform_suffix` to modifying the actual URL of the cache.

To avoid leaking stuff from the local cache, I’ve added a clean
--expunge for now. We should be able to remove this once nodes have
been reset tomorrow. It will slow down nodes but that is clearly
better than having everything fail.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
