### PR TITLE
damlc: Avoid immediately invoked closures

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -377,9 +377,12 @@ simplifyExpr world = fst . cata go
       -- if `xi` is not free in `ej` for any `i < j`
       --
       -- This rule is achieved by combining the rules for `(λx. e1) e2` and
-      -- `(let x = e1 in e1) e3`, if `x` is not free in `e3`, repeatedly.
+      -- `(let x = e1 in e2) e3` repeatedly.
 
       -- (λx. e1) e2    ==>    let x = e2 in e1
+      --
+      -- NOTE(MH): This also works when `x` is free in `e2` since let-bindings
+      -- are _not_ recursive.
       ETmAppF (ETmLam (x, t) e1, s0) (e2, s2) ->
         go $ ELetF (BindingF (x, t) (e2, s2)) (e1, s1)
         where

--- a/compiler/damlc/tests/daml-test-files/SimplifyAppliedLambda.daml
+++ b/compiler/damlc/tests/daml-test-files/SimplifyAppliedLambda.daml
@@ -1,0 +1,14 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Check that immediately applied lambdas get rewritten into a expressions
+-- without lambdas.
+
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["f"]) | isempty(.expr.abs.body | .. | .abs? | values)
+module SimplifyAppliedLambda where
+
+f: Int -> Int -> Int
+f x y = g (h x) y
+  where
+    g x y = x+y
+    h x = 2*x


### PR DESCRIPTION
We add rules to the simplifier which rewrite expressions of the form
```
(\x1 ... xn -> E) A1 ... An
```
into
```
let x1 = A1 in ... let xn = An in E
```
provided that `xi` is not free in `Aj` for any `i < j`.

In cases where `E` is _not_ a lambda, this rewriting is beneficial
since it removes a costly closure allocation and the immediate entering
of the closure. If `E` is a closure itself, this rewriting is not
detrimental since the only difference it makes is that the values for
`A1, ..., An` end up in the list of captured variables rather than in
the list of already applied variables.

Even though users might not write expressions like the one we're
simplifying here themselves, various desugarings produce them
nevertheless. A common pattern is to define multiple auxiliary
functions that a only used once in a where cluase. For instance, with
the help these new rewriting rules the function
```haskell
f: Int -> Int -> Int
f x y = g (h x) y
  where
    g x y = x+y
    h x = 2*x
```
gets translated to
```
def f : Int64 -> Int64 -> Int64 =
  \(x : Int64) (y : Int64).
    let x2 : Int64 =
          let x2 : Int64 = x
          in MUL_INT64 2 x2
        y2 : Int64 = y
    in ADD_INT64 x2 y2
```
Without the simplification, `g` and `h` would each allocate a closure:
```
def f : Int64 -> Int64 -> Int64 =
  \(x : Int64) (y : Int64).
    (\(x2 : Int64) (y2 : Int64). ADD_INT64 x2 y2)
      ((\(x2 : Int64). MUL_INT64 2 x2) x)
      y
```

The `collect-authority` benchmarck is sped up by 1.03x by this change.
This is not a huge improvement but the change is simple enough to
merge it nevertheless.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6274)
<!-- Reviewable:end -->
