### PR TITLE
release: Faster release process locally.

### DIFF
--- a/release/src/Maven.hs
+++ b/release/src/Maven.hs
@@ -1,0 +1,78 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Maven (generateAggregatePom) where
+
+import qualified Control.Exception.Safe as E
+import qualified Data.Maybe as Maybe
+import qualified Data.Text as T
+import Data.Text (Text)
+import Path
+
+import Util
+import Types
+
+aggregatePomStart :: Text
+aggregatePomStart =
+    T.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">"
+        , "  <modelVersion>4.0.0</modelVersion>"
+        , "    <groupId>com.daml</groupId>"
+        , "    <artifactId>aggregate</artifactId>"
+        , "    <version>0.0.0</version>"
+        , "    <packaging>pom</packaging>"
+        , "    <build>"
+        , "        <plugins>"
+        , "            <plugin>"
+        , "                <groupId>org.apache.maven.plugins</groupId>"
+        , "                <artifactId>maven-install-plugin</artifactId>"
+        , "                <version>3.0.0-M1</version>"
+        , "                <executions>"
+        ]
+
+aggregatePomEnd :: Text
+aggregatePomEnd =
+    T.unlines
+        [ "                </executions>"
+        , "            </plugin>"
+        , "        </plugins>"
+        , "    </build>"
+        , "</project>"
+        ]
+
+generateAggregatePom :: E.MonadThrow m => BazelLocations -> [Artifact PomData] -> m Text
+generateAggregatePom BazelLocations{bazelBin} artifacts = do
+    executions <- T.concat <$> mapM execution (filter (isJar . artReleaseType) artifacts)
+    return (aggregatePomStart <> executions <> aggregatePomEnd)
+    where
+    execution :: E.MonadThrow m => Artifact PomData -> m Text
+    execution artifact = do
+        let (directoryText, name) = splitBazelTarget (artTarget artifact)
+        directory <- parseRelDir (T.unpack directoryText)
+        let prefix = bazelBin </> directory
+        mainArtifactFile <- mainArtifactPath name artifact
+        pomFile <- pomFilePath name
+        javadocFile <- javadocJarPath artifact
+        sourcesFile <- sourceJarPath artifact
+        let configuration =
+                map (\(name, value) -> (name, pathToText (prefix </> value))) $
+                    Maybe.catMaybes
+                        [ Just ("pomFile", pomFile)
+                        , Just ("file", mainArtifactFile)
+                        , ("javadoc", ) <$> javadocFile
+                        , ("sources", ) <$> sourcesFile
+                        ]
+        return $ T.unlines $
+            [ "                    <execution>"
+            , "                        <id>" <> pomArtifactId (artMetadata artifact) <> "</id>"
+            , "                        <phase>initialize</phase>"
+            , "                        <goals>"
+            , "                            <goal>install-file</goal>"
+            , "                        </goals>"
+            , "                        <configuration>"
+            ] ++
+            map (\(name, value) -> "                            <" <> name <> ">" <> value <> "</" <> name <> ">") configuration ++
+            [ "                        </configuration>"
+            , "                    </execution>"
+            ]


### PR DESCRIPTION
I've been running `daml-sdk-head` a lot lately, and it's really slow, even when there's not much to do since last time. This has been pretty painful.

This PR makes some changes to the release script for maximum speed.

First of all, it computes missing dependencies by using one Bazel query, not many. It only runs multiple queries if the first query finds a missing dependency. This means that in the positive case, it'll be pretty fast.

Secondly, it publishes all JARs to the local Maven repository at once. This is way, way faster than running `mvn install:install-file` in a loop.

It works by creating a POM that instructs the `install:install-file` plugin command to install the JARs in roughly the same way as before, and then running `mvn initialize` once.

These two steps now run in about 5 seconds each. On my machine, re-running `daml-sdk-head` when nothing has changed now takes around 1 minute, where previously it would take about 5–10 minutes.

We may be able to apply the same logic to the upload, potentially saving time there too, but I'm not sure how that works and it's much harder to test locally.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
