### PR TITLE
release: Faster release process locally.

### DIFF
--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -145,7 +145,7 @@ main = do
               pomPath <- (releaseDir </>) <$> parseRelFile "pom.xml"
               liftIO $ T.IO.writeFile (toFilePath pomPath) pom
               exitCode <- liftIO $ withCreateProcess ((proc "mvn" ["initialize"]) { cwd = Just (toFilePath releaseDir) }) $ \_ _ _ mvnHandle ->
-                  liftIO $ waitForProcess mvnHandle
+                  waitForProcess mvnHandle
               unless (exitCode == ExitSuccess) $ do
                   $logError "Failed to install JARs locally."
                   liftIO exitFailure

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -85,12 +85,13 @@ main = do
           internalDeps <- bazelQueryDeps ("set(" <> T.unpack (T.intercalate " " targets) <> ")")
           -- check if a dependency is not already a maven target from artifacts.yaml
           let missingDeps = filter (`Set.notMember` allMavenTargets) internalDeps
-          -- if there's a missing artifact, find out what depends on it by querying each artifact
-          -- separately, one by one (this is slow, so we don't do it unless we have to)
           if null missingDeps
               then
                   return []
               else do
+                  -- if there's a missing artifact, find out what depends on it by querying each
+                  -- artifact separately, one by one, so that the error message is more useful
+                  -- (this is slow, so we don't do it unless we have to)
                   maybeMissingDeps <- forM nonDeployJars $ \a -> do
                       internalDeps <- bazelQueryDeps (T.unpack (getBazelTarget (artTarget a)))
                       let missingDeps = filter (`Set.notMember` allMavenTargets) internalDeps

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -110,15 +110,15 @@ main = do
       mvnUploadArtifacts <- concatMapM mavenArtifactCoords mvnArtifacts
       validateMavenArtifacts releaseDir mvnUploadArtifacts
 
-      -- npm packages we want to publish.
+      -- NPM packages we want to publish
       let npmPackages =
               [ "//language-support/ts/daml-types"
               , "//language-support/ts/daml-ledger"
               , "//language-support/ts/daml-react"
               ]
-      -- make sure the npm packages can be build.
-      $logDebug "Building language-support typescript packages"
-      forM_ npmPackages $ \rule -> liftIO $ callCommand $ "bazel build " <> rule
+      -- make sure the NPM packages can be built
+      $logInfo "Building language-support TypeScript packages"
+      liftIO $ callProcess "bazel" $ ["build"] ++ npmPackages
 
       if  | getPerformUpload optsPerformUpload -> do
               $logInfo "Uploading to Maven Central"

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -77,10 +77,6 @@ main = do
               liftIO $ lines <$> readCreateProcess (proc "bazel" ["query", query]) ""
 
           -- run a Bazel query to find all internal Java and Scala library dependencies
-          -- We exclude the scenario service and the script service to avoid a false dependency on
-          -- Scala files originating from genrules that use damlc. This is a bit hacky but given
-          -- that it’s fairly unlikely to accidentally introduce a dependency on the scenario
-          -- service it doesn’t seem worth fixing properly.
           let targets = map (getBazelTarget . artTarget) nonDeployJars
           internalDeps <- bazelQueryDeps ("set(" <> T.unpack (T.intercalate " " targets) <> ")")
           -- check if a dependency is not already a maven target from artifacts.yaml

--- a/release/src/Maven.hs
+++ b/release/src/Maven.hs
@@ -12,35 +12,6 @@ import Path
 import Util
 import Types
 
-aggregatePomStart :: Text
-aggregatePomStart =
-    T.unlines
-        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        , "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">"
-        , "  <modelVersion>4.0.0</modelVersion>"
-        , "    <groupId>com.daml</groupId>"
-        , "    <artifactId>aggregate</artifactId>"
-        , "    <version>0.0.0</version>"
-        , "    <packaging>pom</packaging>"
-        , "    <build>"
-        , "        <plugins>"
-        , "            <plugin>"
-        , "                <groupId>org.apache.maven.plugins</groupId>"
-        , "                <artifactId>maven-install-plugin</artifactId>"
-        , "                <version>3.0.0-M1</version>"
-        , "                <executions>"
-        ]
-
-aggregatePomEnd :: Text
-aggregatePomEnd =
-    T.unlines
-        [ "                </executions>"
-        , "            </plugin>"
-        , "        </plugins>"
-        , "    </build>"
-        , "</project>"
-        ]
-
 generateAggregatePom :: E.MonadThrow m => BazelLocations -> [Artifact PomData] -> m Text
 generateAggregatePom BazelLocations{bazelBin} artifacts = do
     executions <- T.concat <$> mapM execution (filter (isJar . artReleaseType) artifacts)
@@ -63,16 +34,44 @@ generateAggregatePom BazelLocations{bazelBin} artifacts = do
                         , ("javadoc", ) <$> javadocFile
                         , ("sources", ) <$> sourcesFile
                         ]
-        return $ T.unlines $
-            [ "                    <execution>"
-            , "                        <id>" <> pomArtifactId (artMetadata artifact) <> "</id>"
-            , "                        <phase>initialize</phase>"
-            , "                        <goals>"
-            , "                            <goal>install-file</goal>"
-            , "                        </goals>"
-            , "                        <configuration>"
+        return $ T.unlines $ map ("                    " <>) $
+            [ "<execution>"
+            , "    <id>" <> pomArtifactId (artMetadata artifact) <> "</id>"
+            , "    <phase>initialize</phase>"
+            , "    <goals>"
+            , "        <goal>install-file</goal>"
+            , "    </goals>"
+            , "    <configuration>"
             ] ++
-            map (\(name, value) -> "                            <" <> name <> ">" <> value <> "</" <> name <> ">") configuration ++
-            [ "                        </configuration>"
-            , "                    </execution>"
+            map (\(name, value) -> "        <" <> name <> ">" <> value <> "</" <> name <> ">") configuration ++
+            [ "    </configuration>"
+            , "</execution>"
             ]
+    aggregatePomStart :: Text
+    aggregatePomStart =
+        T.unlines
+            [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            , "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">"
+            , "  <modelVersion>4.0.0</modelVersion>"
+            , "    <groupId>com.daml</groupId>"
+            , "    <artifactId>aggregate</artifactId>"
+            , "    <version>0.0.0</version>"
+            , "    <packaging>pom</packaging>"
+            , "    <build>"
+            , "        <plugins>"
+            , "            <plugin>"
+            , "                <groupId>org.apache.maven.plugins</groupId>"
+            , "                <artifactId>maven-install-plugin</artifactId>"
+            , "                <version>3.0.0-M1</version>"
+            , "                <executions>"
+            ]
+    aggregatePomEnd :: Text
+    aggregatePomEnd =
+        T.unlines
+            [ "                </executions>"
+            , "            </plugin>"
+            , "        </plugins>"
+            , "    </build>"
+            , "</project>"
+            ]
+

--- a/release/src/Maven.hs
+++ b/release/src/Maven.hs
@@ -1,0 +1,78 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Maven (generateAggregatePom) where
+
+import qualified Control.Exception.Safe as E
+import qualified Data.Maybe as Maybe
+import qualified Data.Text as T
+import Data.Text (Text)
+import Path
+
+import Util
+import Types
+
+aggregatePomStart :: Text
+aggregatePomStart =
+    T.unlines
+        [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        , "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">"
+        , "  <modelVersion>4.0.0</modelVersion>"
+        , "    <groupId>com.daml</groupId>"
+        , "    <artifactId>aggregate</artifactId>"
+        , "    <version>0.0.0</version>"
+        , "    <packaging>pom</packaging>"
+        , "    <build>"
+        , "        <plugins>"
+        , "            <plugin>"
+        , "                <groupId>org.apache.maven.plugins</groupId>"
+        , "                <artifactId>maven-install-plugin</artifactId>"
+        , "                <version>3.0.0-M1</version>"
+        , "                <executions>"
+        ]
+
+aggregatePomEnd :: Text
+aggregatePomEnd =
+    T.unlines
+        [ "                </executions>"
+        , "            </plugin>"
+        , "        </plugins>"
+        , "    </build>"
+        , "</project>"
+        ]
+
+generateAggregatePom :: E.MonadThrow m => BazelLocations -> [Artifact PomData] -> m Text
+generateAggregatePom BazelLocations{bazelBin} artifacts = do
+    executions <- T.concat <$> mapM execution (filter (isJar . artReleaseType) artifacts)
+    return (aggregatePomStart <> executions <> aggregatePomEnd)
+    where
+    execution :: E.MonadThrow m => Artifact PomData -> m Text
+    execution artifact = do
+        let (directoryText, name) = splitBazelTarget (artTarget artifact)
+        directory <- parseRelDir (T.unpack directoryText)
+        let prefix = bazelBin </> directory
+        mainArtifactFile <- mainArtifactPath name artifact
+        pomFile <- pomFilePath name
+        javadocFile <- javadocJarPath artifact
+        sourcesFile <- sourceJarPath artifact
+        let configuration =
+                map (\(name, value) -> (name, pathToText (prefix </> value))) $
+                    Maybe.catMaybes
+                        [ Just ("pomFile", pomFile)
+                        , Just ("file", mainArtifactFile)
+                        , ("javadoc", ) <$> javadocFile
+                        , ("sources", ) <$> sourcesFile
+                        ]
+        return $ T.unlines $
+            [ "                    <execution>"
+            , "                        <id>" <> pomArtifactId (artMetadata artifact) <> "</id>"
+            , "                        <phase>initialize</phase>"
+            , "                        <goals>"
+            , "                            <goal>install-file</goal>"
+            , "                        </goals>"
+            , "                        <configuration>"
+            ] ++
+            map (\(name, value) -> "                            <" <> name <> ">" <> value <> "</" <> name <> ">") configuration ++
+            [ "                        </configuration>"
+            , "                    </execution>"
+            ]

--- a/release/src/Upload.hs
+++ b/release/src/Upload.hs
@@ -1,12 +1,11 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DuplicateRecordFields #-}
 
 module Upload (
-    validateMavenArtifacts,
     uploadToMavenCentral,
     mavenConfigFromEnv,
 ) where
@@ -34,25 +33,13 @@ import           Network.HTTP.Client.TLS (mkManagerSettings, tlsManagerSettings)
 import           Network.HTTP.Simple (setRequestBasicAuth, setRequestBodyFile, setRequestBodyLBS, setRequestHeader, setRequestMethod, setRequestPath)
 import           Network.HTTP.Types.Status
 import           Path
-import Path.IO
 import           System.Environment
 import           System.IO.Temp
-import System.Exit
 
 import Types
 import Util
 
--- | Validate that the Maven artifacts to be uploaded are present.
-validateMavenArtifacts :: MonadCI m => Path Abs Dir -> [(MavenCoords, Path Rel File)] -> m ()
-validateMavenArtifacts releaseDir arts =
-    forM_ arts $ \(_, file) -> do
-        exists <- doesFileExist (releaseDir </> file)
-        unless exists $ do
-            $logError $ T.pack $ show file <> " is required for publishing to Maven"
-            liftIO exitFailure
-
-
--- 
+--
 -- Upload the artifacts to Maven Central
 --
 -- The artifacts are first uploaded to a staging repository on the Sonatype Open Source Repository Hosting platform


### PR DESCRIPTION
I've been running `daml-sdk-head` a lot lately, and it's really slow, even when there's not much to do since last time. This has been pretty painful.

This PR makes some changes to the release script for maximum speed.

First of all, it computes missing dependencies by using one Bazel query, not many. It only runs multiple queries if the first query finds a missing dependency. This means that in the positive case, it'll be pretty fast.

Secondly, it builds the NPM targets all at once, not one at a time. Bazel is slow to initialize, so this makes it faster.

Thirdly, it publishes all JARs to the local Maven repository at once. This is way, way faster than running `mvn install:install-file` in a loop.

It works by creating a POM that instructs the `install:install-file` plugin command to install the JARs in roughly the same way as before, and then running `mvn initialize` once.

These three steps now run in about 5 seconds each. On my machine, re-running `daml-sdk-head` when nothing has changed now takes around 1 minute, where previously it would take about 5–10 minutes.

We may be able to apply the same logic to the upload, potentially saving time there too, but I'm not sure how that works and it's much harder to test locally.

This pull request is an update of #6276, which I broke somehow.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
