### PR TITLE
damlc: Run simplifier on templates as well

### DIFF
--- a/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Generate.hs
+++ b/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Generate.hs
@@ -141,9 +141,10 @@ genChoice pac tem (this',this) temFs TemplateChoice{..} = do
   extVarEnv self
   extVarEnv arg
   argFs <- recTypFields (snd chcArgBinder)
+  let subst = createExprSubst [(self',EVar self),(this',EVar this),(arg',EVar arg)]
   extRecEnv arg argFs
   expOut <- genExpr True
-    $ substituteTm (createExprSubst [(self',EVar self),(this',EVar this),(arg',EVar arg)])
+    $ substituteTm subst
     $ instPRSelf pac chcUpdate
   let out = if chcConsuming
         then addArchiveUpd tem fields expOut

--- a/compiler/damlc/tests/daml-test-files/SimplifyAppliedLambda.daml
+++ b/compiler/damlc/tests/daml-test-files/SimplifyAppliedLambda.daml
@@ -4,7 +4,9 @@
 -- Check that immediately applied lambdas get rewritten into a expressions
 -- without lambdas.
 
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["f"]) | .expr | has("abs")
 -- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["f"]) | isempty(.expr.abs.body | .. | .abs? | values)
+-- @QUERY-LF [.modules[] | .templates[] | select(lf::get_template_name($pkg) == ["Arithmetic"]) | .choices[]] | length == 2 and all(isempty(.update | .. | .abs? | values))
 module SimplifyAppliedLambda where
 
 f: Int -> Int -> Int
@@ -12,3 +14,15 @@ f x y = g (h x) y
   where
     g x y = x+y
     h x = 2*x
+
+template Arithmetic with
+    owner: Party
+  where
+    signatory owner
+
+    choice Add: Int with
+        x: Int
+        y: Int
+      controller owner
+      do
+        pure $ (\a b -> a+b) x y


### PR DESCRIPTION
Currently, the simplifier only runs on top-level value definitions.
However, there's no good reason for not running it on all expressions
within templates as well.

This does not significantly improve the `CollectAuthority` benchmark,
but there's not much code in the templates.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6286)
<!-- Reviewable:end -->
