### PR TITLE
Add CLI option for ledger time skew

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -301,9 +301,14 @@ object Cli {
 
       opt[Long]("max-ledger-time-skew")
         .optional()
-        .action((value, config) =>
-          config.copy(ledgerConfig = config.ledgerConfig.copy(initialConfiguration = config.ledgerConfig.initialConfiguration.copy(timeModel = config.ledgerConfig.initialConfiguration.timeModel.copy(minSkew = Duration.ofSeconds(value), maxSkew = Duration.ofSeconds(value))))))
-        .text(s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${TimeModel.reasonableDefault.minSkew.getSeconds}.")
+        .action((value, config) => {
+          val timeModel = config.ledgerConfig.initialConfiguration.timeModel
+            .copy(minSkew = Duration.ofSeconds(value), maxSkew = Duration.ofSeconds(value))
+          val ledgerConfig = config.ledgerConfig.initialConfiguration.copy(timeModel = timeModel)
+          config.copy(ledgerConfig = config.ledgerConfig.copy(initialConfiguration = ledgerConfig))
+        })
+        .text(
+          s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${TimeModel.reasonableDefault.minSkew.getSeconds}.")
 
       help("help").text("Print the usage text")
 


### PR DESCRIPTION
This PR makes it possible to change the initial ledger time model through the sandbox classic CLI.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
