### PR TITLE
create-daml-app: Restore test for messaging feature

### DIFF
--- a/compatibility/bazel_tools/create-daml-app/index.test.ts
+++ b/compatibility/bazel_tools/create-daml-app/index.test.ts
@@ -433,7 +433,7 @@ const sendMessage = async (page: Page, receiver: string, content: string) => {
   const item = `${dropdown} > .menu > .item`;
 
   // Click the dropdown and then wait for the choices to appear.
-  await page.waitForSelector(dropdown);
+  await page.waitForSelector(dropdown, {timeout: 60_000});
   await page.click(dropdown);
   await page.waitForSelector(item);
 

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -345,7 +345,8 @@ const sendMessage = async (page: Page, receiver: string, content: string) => {
   const dropdown = '.test-select-message-receiver > .dropdown';
   const item = `${dropdown} > .menu > .item`;
 
-  // After clicking the dropdown, we need to wait for the choices to appear.
+  // Click the dropdown and then wait for the choices to appear.
+  await page.waitForSelector(dropdown);
   await page.click(dropdown);
   await page.waitForSelector(item);
 
@@ -375,10 +376,12 @@ const sendMessage = async (page: Page, receiver: string, content: string) => {
 // class in the message item itself to get an accurate count.
 // Waiting on other selectors (e.g. on the Send button not loading, or the
 // message list instead of the items) doesn't seem to be effective.
-const countMessagesNotZero = async (page: Page) => {
-  await page.waitForSelector('.test-select-message-item');
-  const messages = await page.$$('.test-select-message-item');
-  return messages.length;
+const countMessagesNotZero = async (page: Page, expected: number) => {
+  await page.waitForFunction(
+    expected => document.querySelectorAll('.test-select-message-item').length === expected,
+    {},
+    expected
+  );
 }
 
 test('send messages between users', async () => {
@@ -407,8 +410,8 @@ test('send messages between users', async () => {
   // Both Party 1 and 2 should see the messages.
   // Note: It's not obvious how to test that the message list is empty for Party
   // 0 as even when we get a message we need to wait a bit for it to render.
-  expect(await countMessagesNotZero(page1)).toEqual(2);
-  expect(await countMessagesNotZero(page2)).toEqual(2);
+  await countMessagesNotZero(page1, 2);
+  await countMessagesNotZero(page2, 2);
 
   // As Party 2, follow Party 1 and log out.
   // We will test that a message is received even when logged out.
@@ -422,10 +425,10 @@ test('send messages between users', async () => {
   await login(page2, party2);
 
   // Now both Party 1 and 2 can see all the messages.
-  expect(await countMessagesNotZero(page1)).toEqual(3);
-  expect(await countMessagesNotZero(page2)).toEqual(3);
+  await countMessagesNotZero(page1, 3);
+  await countMessagesNotZero(page2, 3);
 
   await page0.close();
   await page1.close();
   await page2.close();
-}, 40_000);
+}, 60_000);

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -346,7 +346,7 @@ const sendMessage = async (page: Page, receiver: string, content: string) => {
   const item = `${dropdown} > .menu > .item`;
 
   // Click the dropdown and then wait for the choices to appear.
-  await page.waitForSelector(dropdown);
+  await page.waitForSelector(dropdown, {timeout: 60_000});
   await page.click(dropdown);
   await page.waitForSelector(item);
 

--- a/templates/create-daml-app-test-resources/index.test.ts
+++ b/templates/create-daml-app-test-resources/index.test.ts
@@ -335,3 +335,97 @@ test('error when adding a user that you are already following', async () => {
 
   await page.close();
 });
+
+// Send a message to the given user.
+// NOTE: There must be at least one user available in the dropdown,
+// otherwise the function hangs waiting for the selector to match.
+// Throws an exception if the given user does not appear in the dropdown menu.
+const sendMessage = async (page: Page, receiver: string, content: string) => {
+  // Selectors for the dropdown and the items inside it.
+  const dropdown = '.test-select-message-receiver > .dropdown';
+  const item = `${dropdown} > .menu > .item`;
+
+  // After clicking the dropdown, we need to wait for the choices to appear.
+  await page.click(dropdown);
+  await page.waitForSelector(item);
+
+  // Select the dropdown items and extract their names.
+  const receivers = await page.$$(item);
+  const names = await Promise.all(receivers.map(e => e.$eval('.text', name => name.innerHTML)));
+
+  // Find which item corresponds to the given user and click it.
+  const receiverIndex = names.indexOf(receiver);
+  if (receiverIndex < 0) {
+    throw Error(`sendMessage: '${receiver}' does not appear in the dropdown menu`);
+  }
+  await receivers[receiverIndex].click();
+
+  // Type the message into the text input.
+  const messageInput = await page.waitForSelector('.test-select-message-content');
+  await messageInput.click();
+  await messageInput.type(content);
+
+  // Click send and wait for the request to complete.
+  await page.click('.test-select-message-send-button');
+  await page.waitForSelector('.test-select-message-send-button:not(.loading)');
+}
+
+// Count the number of messages on the page, assuming there is *at least one*.
+// The restriction against zero messages is because we need to wait on the
+// class in the message item itself to get an accurate count.
+// Waiting on other selectors (e.g. on the Send button not loading, or the
+// message list instead of the items) doesn't seem to be effective.
+const countMessagesNotZero = async (page: Page) => {
+  await page.waitForSelector('.test-select-message-item');
+  const messages = await page.$$('.test-select-message-item');
+  return messages.length;
+}
+
+test('send messages between users', async () => {
+  const party0 = getParty();
+  const party1 = getParty();
+  const party2 = getParty();
+
+  const page0 = await newUiPage();
+  await login(page0, party0);
+
+  const page1 = await newUiPage();
+  await login(page1, party1);
+
+  const page2 = await newUiPage();
+  await login(page2, party2);
+
+  // Party 0 and 1 both follow Party 2.
+  await follow(page0, party2);
+  await follow(page1, party2);
+
+  // Party 2 has two choices of whom to message.
+  // Party 2 sends two messages to Party 1.
+  await sendMessage(page2, party1, `Hey ${party1}!`);
+  await sendMessage(page2, party1, `What's up?`);
+
+  // Both Party 1 and 2 should see the messages.
+  // Note: It's not obvious how to test that the message list is empty for Party
+  // 0 as even when we get a message we need to wait a bit for it to render.
+  expect(await countMessagesNotZero(page1)).toEqual(2);
+  expect(await countMessagesNotZero(page2)).toEqual(2);
+
+  // As Party 2, follow Party 1 and log out.
+  // We will test that a message is received even when logged out.
+  await follow(page2, party1);
+  await logout(page2);
+
+  // Party 1 can now send Party 2 a message.
+  await sendMessage(page1, party2, `Hey ${party2}!`);
+
+  // Log back in as Party 2.
+  await login(page2, party2);
+
+  // Now both Party 1 and 2 can see all the messages.
+  expect(await countMessagesNotZero(page1)).toEqual(3);
+  expect(await countMessagesNotZero(page2)).toEqual(3);
+
+  await page0.close();
+  await page1.close();
+  await page2.close();
+}, 40_000);


### PR DESCRIPTION
This restores the Puppeteer tests for direct messaging which was
part of the direct-messaging branch of the old create-daml-app repo
but got forgotten (by me) in the migration.

The test code is also included in the Testing Your App documentation but
is just pasted there for reference so I haven't added explanation for it
in this PR.

changelog_begin
[Getting Started Guide] Add end-to-end tests for the messaging feature.
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
