### PR TITLE
Add data-dependencies compatibility tests

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -13,6 +13,11 @@ load(
     "daml_trigger_dar",
     "daml_trigger_test",
 )
+load(
+    "//bazel_tools/data_dependencies:data_dependencies.bzl",
+    "data_dependencies_coins",
+    "data_dependencies_upgrade",
+)
 load("//bazel_tools:versions.bzl", "versions")
 load("//sandbox-migration:util.bzl", "migration_test")
 load("//:versions.bzl", "platform_versions", "sdk_versions", "stable_versions")
@@ -115,3 +120,22 @@ migration_test(
     tags = ["exclusive"],
     versions = platform_versions,
 ) if not is_windows else None
+
+[
+    data_dependencies_coins(
+        sdk_version = sdk_version,
+    )
+    for sdk_version in sdk_versions
+]
+
+[
+    data_dependencies_upgrade(
+        new_sdk_version = new_sdk_version,
+        old_sdk_version = old_sdk_version,
+    )
+    for old_sdk_version in sdk_versions
+    for new_sdk_version in sdk_versions
+    # Tests that we can build a package with a newer SDK version that has
+    # data-dependencies on packages built with an older SDK version.
+    if versions.is_at_least(old_sdk_version, new_sdk_version)
+]

--- a/compatibility/bazel_tools/data_dependencies/BUILD.bazel
+++ b/compatibility/bazel_tools/data_dependencies/BUILD.bazel
@@ -1,0 +1,4 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+exports_files(glob(["example/**"]))

--- a/compatibility/bazel_tools/data_dependencies/data_dependencies.bzl
+++ b/compatibility/bazel_tools/data_dependencies/data_dependencies.bzl
@@ -1,0 +1,104 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bazel_tools:versions.bzl", "version_to_name")
+
+def _build_dar(
+        name,
+        package_name,
+        srcs,
+        data_dependencies,
+        sdk_version):
+    daml = "@daml-sdk-{sdk_version}//:daml".format(
+        sdk_version = sdk_version,
+    )
+    native.genrule(
+        name = name,
+        srcs = srcs + data_dependencies,
+        outs = ["%s.dar" % name],
+        tools = [daml],
+        cmd = """\
+set -euo pipefail
+TMP_DIR=$$(mktemp -d)
+cleanup() {{ rm -rf $$TMP_DIR; }}
+trap cleanup EXIT
+mkdir -p $$TMP_DIR/src $$TMP_DIR/dep
+for src in {srcs}; do
+  cp -L $$src $$TMP_DIR/src
+done
+DATA_DEPS=
+for dep in {data_dependencies}; do
+  cp -L $$dep $$TMP_DIR/dep
+  DATA_DEPS="$$DATA_DEPS\n  - dep/$$(basename $$dep)"
+done
+cat <<EOF >$$TMP_DIR/daml.yaml
+sdk-version: {sdk_version}
+name: {name}
+source: src
+version: 0.0.1
+dependencies:
+  - daml-prim
+  - daml-script
+data-dependencies:$$DATA_DEPS
+EOF
+$(location {daml}) build --project-root=$$TMP_DIR -o $$PWD/$(OUTS)
+""".format(
+            daml = daml,
+            name = package_name,
+            data_dependencies = " ".join([
+                "$(location %s)" % dep
+                for dep in data_dependencies
+            ]),
+            sdk_version = sdk_version,
+            srcs = " ".join([
+                "$(locations %s)" % src
+                for src in srcs
+            ]),
+        ),
+    )
+
+def data_dependencies_coins(sdk_version):
+    """Build the coin1 and coin2 packages with the given SDK version.
+    """
+    _build_dar(
+        name = "data-dependencies-coin1-{sdk_version}".format(
+            sdk_version = sdk_version,
+        ),
+        package_name = "data-dependencies-coin1",
+        srcs = ["//bazel_tools/data_dependencies:example/CoinV1.daml"],
+        data_dependencies = [],
+        sdk_version = sdk_version,
+    )
+    _build_dar(
+        name = "data-dependencies-coin2-{sdk_version}".format(
+            sdk_version = sdk_version,
+        ),
+        package_name = "data-dependencies-coin2",
+        srcs = ["//bazel_tools/data_dependencies:example/CoinV2.daml"],
+        data_dependencies = [],
+        sdk_version = sdk_version,
+    )
+
+def data_dependencies_upgrade(old_sdk_version, new_sdk_version):
+    """Build the coin-upgrade package using the new SDK version.
+
+    The package will have data-dependencies on the coin1 and coin2 package
+    built with the old SDK version.
+    """
+    _build_dar(
+        name = "data-dependencies-upgrade-old-{old_sdk_version}-new-{new_sdk_version}".format(
+            old_sdk_version = old_sdk_version,
+            new_sdk_version = new_sdk_version,
+        ),
+        package_name = "data-dependencies-upgrade",
+        srcs = ["//bazel_tools/data_dependencies:example/UpgradeFromCoinV1.daml"],
+        data_dependencies = [
+            "data-dependencies-coin1-{sdk_version}".format(
+                sdk_version = old_sdk_version,
+            ),
+            "data-dependencies-coin2-{sdk_version}".format(
+                sdk_version = old_sdk_version,
+            ),
+        ],
+        sdk_version = new_sdk_version,
+    )

--- a/compatibility/bazel_tools/data_dependencies/example/CoinV1.daml
+++ b/compatibility/bazel_tools/data_dependencies/example/CoinV1.daml
@@ -1,0 +1,24 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- COIN_BEGIN
+module CoinV1 where
+
+template Coin
+  with
+    issuer : Party
+    owner : Party
+  where
+    signatory issuer, owner
+-- COIN_END
+
+template CoinProposal
+  with
+    issuer : Party
+    owner : Party
+  where
+    signatory issuer
+    observer owner
+    choice CoinProposal_Accept : ContractId Coin
+      controller owner
+      do create Coin with ..

--- a/compatibility/bazel_tools/data_dependencies/example/CoinV2.daml
+++ b/compatibility/bazel_tools/data_dependencies/example/CoinV2.daml
@@ -1,0 +1,14 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- COIN_AMOUNT_BEGIN
+module CoinV2 where
+
+template CoinWithAmount
+  with
+    issuer : Party
+    owner : Party
+    amount : Int
+  where
+    signatory issuer, owner
+-- COIN_AMOUNT_END

--- a/compatibility/bazel_tools/data_dependencies/example/UpgradeFromCoinV1.daml
+++ b/compatibility/bazel_tools/data_dependencies/example/UpgradeFromCoinV1.daml
@@ -1,0 +1,46 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- UPGRADE_MODULE_BEGIN
+module UpgradeFromCoinV1 where
+import CoinV2
+import CoinV1
+-- UPGRADE_MODULE_END
+
+-- UPGRADE_PROPOSAL_BEGIN
+template UpgradeCoinProposal
+  with
+    issuer : Party
+    owner : Party
+  where
+    signatory issuer
+    observer owner
+    key (issuer, owner) : (Party, Party)
+    maintainer key._1
+    choice Accept : ContractId UpgradeCoinAgreement
+      controller owner
+      do create UpgradeCoinAgreement with ..
+-- UPGRADE_PROPOSAL_END
+
+-- UPGRADE_AGREEMENT_BEGIN
+template UpgradeCoinAgreement
+  with
+    issuer : Party
+    owner : Party
+  where
+    signatory issuer, owner
+    key (issuer, owner) : (Party, Party)
+    maintainer key._1
+    nonconsuming choice Upgrade : ContractId CoinWithAmount
+      with
+        coinId : ContractId Coin
+      controller issuer
+      do coin <- fetch coinId
+         assert (coin.issuer == issuer)
+         assert (coin.owner == owner)
+         archive coinId
+         create CoinWithAmount with
+           issuer = coin.issuer
+           owner = coin.owner
+           amount = 1
+-- UPGRADE_AGREEMENT_END


### PR DESCRIPTION
Closes #6257 

Takes the coin upgrade example from the documentation as an example for `data-dependencies`.
Builds the coin packages with an older SDK version and builds the upgrade package with a newer SDK version depending on the coin packages as data-dependencies to test that we can compile a package with data-dependencies built with an older SDK.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
