### PR TITLE
Increment Windows cache URL

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -49,6 +49,8 @@ function bazel() {
 # which is a workaround for this problem.
 bazel shutdown
 
+bazel clean --expunge
+
 # Prefetch nodejs_dev_env to avoid permission denied errors on external/nodejs_dev_env/nodejs_dev_env/node.exe
 # It isn’t clear where exactly those errors are coming from.
 bazel fetch @nodejs_dev_env//...

--- a/ci/configure-bazel.sh
+++ b/ci/configure-bazel.sh
@@ -74,7 +74,7 @@ if is_windows; then
   SUFFIX="${SUFFIX:0:3}"
   echo "Platform suffix: $SUFFIX"
   # We include an extra version at the end that we can bump manually.
-  CACHE_SUFFIX="$SUFFIX-v2"
+  CACHE_SUFFIX="$SUFFIX-v3"
   CACHE_URL="$CACHE_URL/$CACHE_SUFFIX"
   echo "build:windows-ci --remote_http_cache=https://bazel-cache.da-ext.net/$CACHE_SUFFIX" >> .bazelrc.local
 fi

--- a/compatibility/build-release-artifacts-windows.ps1
+++ b/compatibility/build-release-artifacts-windows.ps1
@@ -37,6 +37,7 @@ function bazel() {
 
 
 bazel shutdown
+bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build `
   `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution_windows.log `

--- a/compatibility/test-windows.ps1
+++ b/compatibility/test-windows.ps1
@@ -45,6 +45,7 @@ cd compatibility
 cp ../.bazelrc .bazelrc
 
 bazel shutdown
+bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build //...
 bazel shutdown


### PR DESCRIPTION
We've seen a series of failures of the form
```
ERROR: D:/a/1/s/daml-assistant/integration-tests/BUILD.bazel:162:1: output 'daml-assistant/integration-tests/create-daml-app-tests.exe' was not created
ERROR: D:/a/1/s/daml-assistant/integration-tests/BUILD.bazel:162:1: not all outputs were created or valid
```
across multiple machines. We suspect cache poisoning as the cause. This
increments the cache URL to effectively clear the cache.

See https://github.com/digital-asset/daml/issues/6262

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
