### PR TITLE
fix error message on daily compat failure

### DIFF
--- a/ci/daily_tell_slack.yml
+++ b/ci/daily_tell_slack.yml
@@ -11,7 +11,7 @@ steps:
     COMMIT_TITLE=$(git log --pretty=format:%s -n1)
     COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$COMMIT_TITLE>"
     if [ "$(Agent.JobStatus)" != "Succeeded" ]; then
-        MESSAGE=":fire: :fire: <!here> :fire: :fire:\n$(Agent.JobName) *FAILED*: $COMMIT_LINK\n:fire: :fire:"
+        MESSAGE="\":fire: :fire: <!here> :fire: :fire:\n$(Agent.JobName) *FAILED*: $COMMIT_LINK\n:fire: :fire:\""
     else
         MESSAGE="${{ parameters['success-message'] }}"
     fi


### PR DESCRIPTION
When I changed the quoting for the success case as part of #6267, I forgot to update the error case, so now we don't get well-formed JSON for errors.

CHANGELOG_BEGIN
CHANGELOG_END