### PR TITLE
Check application identifier when authorizing a Ledger API call

### DIFF
--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
@@ -75,9 +75,10 @@ class AuthServiceJWT(verifier: JwtVerifierBase) extends AuthService {
 
     Claims(
       claims = claims.toList,
-      expiration = payload.exp,
       ledgerId = payload.ledgerId,
       participantId = payload.participantId,
+      applicationId = payload.applicationId,
+      expiration = payload.exp,
     )
   }
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
@@ -19,38 +19,39 @@ final class Authorizer(now: () => Instant, ledgerId: String, participantId: Stri
 
   /** Validates all properties of claims that do not depend on the request,
     * such as expiration time or ledger ID. */
-  private def validClaims(claims: Claims): Boolean =
-    claims.notExpired(now()) && claims.validForLedger(ledgerId) && claims.validForParticipant(
-      participantId)
+  private def valid(claims: Claims): Boolean =
+    claims.notExpired(now()) &&
+      claims.validForLedger(ledgerId) &&
+      claims.validForParticipant(participantId)
 
   def requirePublicClaimsOnStream[Req, Res](
       call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
-    wrapStream(c => validClaims(c) && c.isPublic, call)
+    authorize(call) { claims =>
+      valid(claims) && claims.isPublic
+    }
 
   def requirePublicClaims[Req, Res](call: Req => Future[Res]): Req => Future[Res] =
-    wrapSingleCall(c => validClaims(c) && c.isPublic, call)
-
-  def requireAdminClaimsOnStream[Req, Res](
-      call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
-    wrapStream(c => validClaims(c) && c.isAdmin, call)
+    authorize(call) { claims =>
+      valid(claims) && claims.isPublic
+    }
 
   def requireAdminClaims[Req, Res](call: Req => Future[Res]): Req => Future[Res] =
-    wrapSingleCall(c => validClaims(c) && c.isAdmin, call)
-
-  def requireNotExpiredOnStream[Req, Res](
-      call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
-    wrapStream(validClaims, call)
-
-  def requireNotExpired[Req, Res](call: Req => Future[Res]): Req => Future[Res] =
-    wrapSingleCall(validClaims, call)
+    authorize(call) { claims =>
+      valid(claims) && claims.isAdmin
+    }
 
   /** Wraps a streaming call to verify whether some Claims authorize to read as all parties
     * of the given set. Authorization is always granted for an empty collection of parties.
     */
   def requireReadClaimsForAllPartiesOnStream[Req, Res](
       parties: Iterable[String],
+      applicationId: Option[String],
       call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
-    wrapStream(c => validClaims(c) && parties.forall(p => c.canReadAs(p)), call)
+    authorize(call) { claims =>
+      valid(claims) &&
+      parties.forall(p => claims.canReadAs(p)) &&
+      applicationId.forall(id => claims.applicationId.forall(_ == id))
+    }
 
   /** Wraps a single call to verify whether some Claims authorize to read as all parties
     * of the given set. Authorization is always granted for an empty collection of parties.
@@ -58,39 +59,23 @@ final class Authorizer(now: () => Instant, ledgerId: String, participantId: Stri
   def requireReadClaimsForAllParties[Req, Res](
       parties: Iterable[String],
       call: Req => Future[Res]): Req => Future[Res] =
-    wrapSingleCall(c => validClaims(c) && parties.forall(p => c.canReadAs(p)), call)
-
-  /** Wraps a single call to verify whether some Claims authorize to act as all parties
-    * of the given set. Authorization is always granted for an empty collection of parties.
-    */
-  def requireActClaimsForAllParties[Req, Res](
-      parties: Iterable[String],
-      call: Req => Future[Res]): Req => Future[Res] =
-    wrapSingleCall(c => validClaims(c) && parties.forall(p => c.canActAs(p)), call)
-
-  /** Checks whether the current Claims authorize to read as the given party, if any.
-    * Note: A missing party does NOT result in an authorization error.
-    */
-  def requireReadClaimsForPartyOnStream[Req, Res](
-      party: Option[String],
-      call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
-    requireReadClaimsForAllPartiesOnStream(party.toList, call)
-
-  /** Checks whether the current Claims authorize to read as the given party, if any.
-    * Note: A missing party does NOT result in an authorization error.
-    */
-  def requireReadClaimsForParty[Req, Res](
-      party: Option[String],
-      call: Req => Future[Res]): Req => Future[Res] =
-    requireReadClaimsForAllParties(party.toList, call)
+    authorize(call) { claims =>
+      valid(claims) &&
+      parties.forall(p => claims.canReadAs(p))
+    }
 
   /** Checks whether the current Claims authorize to act as the given party, if any.
-    * Note: A missing party does NOT result in an authorization error.
+    * Note: A missing party or applicationId does NOT result in an authorization error.
     */
   def requireActClaimsForParty[Req, Res](
       party: Option[String],
+      applicationId: Option[String],
       call: Req => Future[Res]): Req => Future[Res] =
-    requireActClaimsForAllParties(party.toList, call)
+    authorize(call) { claims =>
+      valid(claims) &&
+      party.forall(p => claims.canActAs(p)) &&
+      applicationId.forall(id => claims.applicationId.forall(_ == id))
+    }
 
   /** Checks whether the current Claims authorize to read data for all parties mentioned in the given transaction filter */
   def requireReadClaimsForTransactionFilterOnStream[Req, Res](
@@ -98,14 +83,7 @@ final class Authorizer(now: () => Instant, ledgerId: String, participantId: Stri
       call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
     requireReadClaimsForAllPartiesOnStream(
       filter.map(_.filtersByParty).fold(Set.empty[String])(_.keySet),
-      call)
-
-  /** Checks whether the current Claims authorize to read data for all parties mentioned in the given transaction filter */
-  def requireReadClaimsForTransactionFilter[Req, Res](
-      filter: Option[TransactionFilter],
-      call: Req => Future[Res]): Req => Future[Res] =
-    requireReadClaimsForAllParties(
-      filter.map(_.filtersByParty).fold(Set.empty[String])(_.keySet),
+      applicationId = None,
       call)
 
   private def assertServerCall[A](observer: StreamObserver[A]): ServerCallStreamObserver[A] =
@@ -120,9 +98,9 @@ final class Authorizer(now: () => Instant, ledgerId: String, participantId: Stri
   private def ongoingAuthorization[Res](scso: ServerCallStreamObserver[Res], claims: Claims) =
     new OngoingAuthorizationObserver[Res](scso, claims, _.notExpired(now()), permissionDenied())
 
-  private def wrapStream[Req, Res](
+  private def authorize[Req, Res](call: (Req, ServerCallStreamObserver[Res]) => Unit)(
       authorized: Claims => Boolean,
-      call: (Req, ServerCallStreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
+  ): (Req, StreamObserver[Res]) => Unit =
     (request, observer) => {
       val scso = assertServerCall(observer)
       AuthorizationInterceptor
@@ -142,9 +120,9 @@ final class Authorizer(now: () => Instant, ledgerId: String, participantId: Stri
         )
     }
 
-  private def wrapSingleCall[Req, Res](
+  private def authorize[Req, Res](call: Req => Future[Res])(
       authorized: Claims => Boolean,
-      call: Req => Future[Res]): Req => Future[Res] =
+  ): Req => Future[Res] =
     request =>
       AuthorizationInterceptor
         .extractClaimsFromContext()

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
@@ -49,8 +49,8 @@ final class Authorizer(now: () => Instant, ledgerId: String, participantId: Stri
       call: (Req, StreamObserver[Res]) => Unit): (Req, StreamObserver[Res]) => Unit =
     authorize(call) { claims =>
       valid(claims) &&
-      parties.forall(p => claims.canReadAs(p)) &&
-      applicationId.forall(id => claims.applicationId.forall(_ == id))
+      parties.forall(claims.canReadAs) &&
+      applicationId.forall(claims.validForApplication)
     }
 
   /** Wraps a single call to verify whether some Claims authorize to read as all parties
@@ -61,7 +61,7 @@ final class Authorizer(now: () => Instant, ledgerId: String, participantId: Stri
       call: Req => Future[Res]): Req => Future[Res] =
     authorize(call) { claims =>
       valid(claims) &&
-      parties.forall(p => claims.canReadAs(p))
+      parties.forall(claims.canReadAs)
     }
 
   /** Checks whether the current Claims authorize to act as the given party, if any.
@@ -73,8 +73,8 @@ final class Authorizer(now: () => Instant, ledgerId: String, participantId: Stri
       call: Req => Future[Res]): Req => Future[Res] =
     authorize(call) { claims =>
       valid(claims) &&
-      party.forall(p => claims.canActAs(p)) &&
-      applicationId.forall(id => claims.applicationId.forall(_ == id))
+      party.forall(claims.canActAs) &&
+      applicationId.forall(claims.validForApplication)
     }
 
   /** Checks whether the current Claims authorize to read data for all parties mentioned in the given transaction filter */

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
@@ -75,14 +75,16 @@ final case class ClaimReadAsParty(name: Ref.Party) extends Claim
   * +-------------------------------------+----------------------------+------------------------------------------+
   *
   * @param claims         List of [[Claim]]s describing the authorization this object describes.
-  * @param ledgerId       If set, the claims will only be valid on the given ledger.
-  * @param participantId  If set, the claims will only be valid on the given participant.
+  * @param ledgerId       If set, the claims will only be valid on the given ledger identifier.
+  * @param participantId  If set, the claims will only be valid on the given participant identifier.
+  * @param applicationId  If set, the claims will only be valid on the given application identifier.
   * @param expiration     If set, the claims will cease to be valid at the given time.
   */
 final case class Claims(
     claims: Seq[Claim],
     ledgerId: Option[String] = None,
     participantId: Option[String] = None,
+    applicationId: Option[String] = None,
     expiration: Option[Instant] = None,
 ) {
   def validForLedger(id: String): Boolean =
@@ -91,7 +93,10 @@ final case class Claims(
   def validForParticipant(id: String): Boolean =
     participantId.forall(_ == id)
 
-  /** Returns false if the expiration timestamp exists and is greather than or equal to the current time */
+  def validForApplication(id: String): Boolean =
+    applicationId.forall(_ == id)
+
+  /** Returns false if the expiration timestamp exists and is greater than or equal to the current time */
   def notExpired(now: Instant): Boolean =
     expiration.forall(now.isBefore)
 
@@ -126,13 +131,16 @@ final case class Claims(
 object Claims {
 
   /** A set of [[Claims]] that does not have any authorization */
-  val empty = Claims(List.empty[Claim], expiration = None, ledgerId = None, participantId = None)
+  val empty: Claims = Claims(
+    claims = List.empty[Claim],
+    ledgerId = None,
+    participantId = None,
+    applicationId = None,
+    expiration = None,
+  )
 
   /** A set of [[Claims]] that has all possible authorizations */
-  val wildcard = Claims(
-    List[Claim](ClaimPublic, ClaimAdmin, ClaimActAsAnyParty),
-    expiration = None,
-    ledgerId = None,
-    participantId = None)
+  val wildcard: Claims =
+    empty.copy(claims = List[Claim](ClaimPublic, ClaimAdmin, ClaimActAsAnyParty))
 
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandCompletionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandCompletionServiceAuthorization.scala
@@ -27,9 +27,11 @@ final class CommandCompletionServiceAuthorization(
   override def completionStream(
       request: CompletionStreamRequest,
       responseObserver: StreamObserver[CompletionStreamResponse]): Unit =
-    authorizer.requireReadClaimsForAllPartiesOnStream(request.parties, service.completionStream)(
-      request,
-      responseObserver)
+    authorizer.requireReadClaimsForAllPartiesOnStream(
+      parties = request.parties,
+      applicationId = Some(request.applicationId),
+      call = service.completionStream,
+    )(request, responseObserver)
 
   override def bindService(): ServerServiceDefinition =
     CommandCompletionServiceGrpc.bindService(this, DirectExecutionContext)

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
@@ -25,26 +25,35 @@ final class CommandServiceAuthorization(
     with GrpcApiService {
 
   override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] =
-    authorizer.requireActClaimsForParty(request.commands.map(_.party), service.submitAndWait)(
-      request)
+    authorizer.requireActClaimsForParty(
+      party = request.commands.map(_.party),
+      applicationId = request.commands.map(_.applicationId),
+      call = service.submitAndWait,
+    )(request)
 
   override def submitAndWaitForTransaction(
       request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionResponse] =
     authorizer.requireActClaimsForParty(
-      request.commands.map(_.party),
-      service.submitAndWaitForTransaction)(request)
+      party = request.commands.map(_.party),
+      applicationId = request.commands.map(_.applicationId),
+      call = service.submitAndWaitForTransaction,
+    )(request)
 
   override def submitAndWaitForTransactionId(
       request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionIdResponse] =
     authorizer.requireActClaimsForParty(
-      request.commands.map(_.party),
-      service.submitAndWaitForTransactionId)(request)
+      party = request.commands.map(_.party),
+      applicationId = request.commands.map(_.applicationId),
+      call = submitAndWaitForTransactionId,
+    )(request)
 
   override def submitAndWaitForTransactionTree(
       request: SubmitAndWaitRequest): Future[SubmitAndWaitForTransactionTreeResponse] =
     authorizer.requireActClaimsForParty(
-      request.commands.map(_.party),
-      service.submitAndWaitForTransactionTree)(request)
+      party = request.commands.map(_.party),
+      applicationId = request.commands.map(_.applicationId),
+      call = service.submitAndWaitForTransactionTree,
+    )(request)
 
   override def bindService(): ServerServiceDefinition =
     CommandServiceGrpc.bindService(this, DirectExecutionContext)

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
@@ -44,7 +44,7 @@ final class CommandServiceAuthorization(
     authorizer.requireActClaimsForParty(
       party = request.commands.map(_.party),
       applicationId = request.commands.map(_.applicationId),
-      call = submitAndWaitForTransactionId,
+      call = service.submitAndWaitForTransactionId,
     )(request)
 
   override def submitAndWaitForTransactionTree(

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandSubmissionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandSubmissionServiceAuthorization.scala
@@ -22,7 +22,11 @@ final class CommandSubmissionServiceAuthorization(
     with GrpcApiService {
 
   override def submit(request: SubmitRequest): Future[Empty] =
-    authorizer.requireActClaimsForParty(request.commands.map(_.party), service.submit)(request)
+    authorizer.requireActClaimsForParty(
+      party = request.commands.map(_.party),
+      applicationId = request.commands.map(_.applicationId),
+      call = service.submit,
+    )(request)
 
   override def bindService(): ServerServiceDefinition =
     CommandSubmissionServiceGrpc.bindService(this, DirectExecutionContext)

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
@@ -34,4 +34,7 @@ trait ReadWriteServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
   it should "deny calls with a random participant ID" in {
     expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomParticipantId))
   }
+  it should "deny calls with a random application ID" in {
+    expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomApplicationId))
+  }
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ReadWriteServiceCallAuthTests.scala
@@ -34,6 +34,9 @@ trait ReadWriteServiceCallAuthTests extends ServiceCallWithMainActorAuthTests {
   it should "deny calls with a random participant ID" in {
     expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomParticipantId))
   }
+  it should "allow calls with the correct application ID" in {
+    expectSuccess(serviceCallWithToken(canActAsMainActorActualApplicationId))
+  }
   it should "deny calls with a random application ID" in {
     expectPermissionDenied(serviceCallWithToken(canActAsMainActorRandomApplicationId))
   }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
@@ -46,6 +46,8 @@ trait ServiceCallWithMainActorAuthTests extends ServiceCallAuthTests {
     Option(toHeader(forParticipantId("sandbox-participant", readOnlyToken(mainActor))))
   protected val canReadAsMainActorRandomParticipantId =
     Option(toHeader(forParticipantId(UUID.randomUUID.toString, readOnlyToken(mainActor))))
+  protected val canReadAsMainActorActualApplicationId =
+    Option(toHeader(forApplicationId(serviceCallName, readOnlyToken(mainActor))))
   protected val canReadAsMainActorRandomApplicationId =
     Option(toHeader(forApplicationId(UUID.randomUUID.toString, readOnlyToken(mainActor))))
 
@@ -58,6 +60,8 @@ trait ServiceCallWithMainActorAuthTests extends ServiceCallAuthTests {
     Option(toHeader(forParticipantId("sandbox-participant", readWriteToken(mainActor))))
   protected val canActAsMainActorRandomParticipantId =
     Option(toHeader(forParticipantId(UUID.randomUUID.toString, readWriteToken(mainActor))))
+  protected val canActAsMainActorActualApplicationId =
+    Option(toHeader(forApplicationId(serviceCallName, readWriteToken(mainActor))))
   protected val canActAsMainActorRandomApplicationId =
     Option(toHeader(forApplicationId(UUID.randomUUID.toString, readWriteToken(mainActor))))
 

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
@@ -46,6 +46,8 @@ trait ServiceCallWithMainActorAuthTests extends ServiceCallAuthTests {
     Option(toHeader(forParticipantId("sandbox-participant", readOnlyToken(mainActor))))
   protected val canReadAsMainActorRandomParticipantId =
     Option(toHeader(forParticipantId(UUID.randomUUID.toString, readOnlyToken(mainActor))))
+  protected val canReadAsMainActorRandomApplicationId =
+    Option(toHeader(forApplicationId(UUID.randomUUID.toString, readOnlyToken(mainActor))))
 
   // Note: lazy val, because the ledger ID is only known after the sandbox start
   protected lazy val canActAsMainActorActualLedgerId =
@@ -56,5 +58,7 @@ trait ServiceCallWithMainActorAuthTests extends ServiceCallAuthTests {
     Option(toHeader(forParticipantId("sandbox-participant", readWriteToken(mainActor))))
   protected val canActAsMainActorRandomParticipantId =
     Option(toHeader(forParticipantId(UUID.randomUUID.toString, readWriteToken(mainActor))))
+  protected val canActAsMainActorRandomApplicationId =
+    Option(toHeader(forApplicationId(UUID.randomUUID.toString, readWriteToken(mainActor))))
 
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/auth/CompletionStreamAuthIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/auth/CompletionStreamAuthIT.scala
@@ -28,4 +28,12 @@ final class CompletionStreamAuthIT
       observer =>
         stub(CommandCompletionServiceGrpc.stub(channel), token).completionStream(request, observer)
 
+  // The completion stream is the one read-only endpoint where the application
+  // identifier has to be checked. Hence, we didn't put this test in a shared
+  // trait to no have to have to override the result for the transaction service
+  // authorization tests.
+  it should "deny calls with a random application ID" in {
+    expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomApplicationId))
+  }
+
 }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/auth/CompletionStreamAuthIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/auth/CompletionStreamAuthIT.scala
@@ -32,6 +32,11 @@ final class CompletionStreamAuthIT
   // identifier is part of the request. Hence, we didn't put this test in a shared
   // trait to no have to have to override the result for the transaction service
   // authorization tests.
+
+  it should "allow calls with the correct application ID" in {
+    expectSuccess(serviceCallWithToken(canReadAsMainActorActualApplicationId))
+  }
+
   it should "deny calls with a random application ID" in {
     expectPermissionDenied(serviceCallWithToken(canReadAsMainActorRandomApplicationId))
   }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/auth/CompletionStreamAuthIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/auth/CompletionStreamAuthIT.scala
@@ -29,7 +29,7 @@ final class CompletionStreamAuthIT
         stub(CommandCompletionServiceGrpc.stub(channel), token).completionStream(request, observer)
 
   // The completion stream is the one read-only endpoint where the application
-  // identifier has to be checked. Hence, we didn't put this test in a shared
+  // identifier is part of the request. Hence, we didn't put this test in a shared
   // trait to no have to have to override the result for the transaction service
   // authorization tests.
   it should "deny calls with a random application ID" in {


### PR DESCRIPTION
Fixes #4409

changelog_begin
[Ledger API] Bugfix: the application identifier in a request is checked against
the authorization token. See https://github.com/digital-asset/daml/issues/4409.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
