### PR TITLE
Fix prefix for some validator metrics

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -162,14 +162,14 @@ class Metrics(val registry: MetricRegistry) {
           val fetchInputs: Timer = registry.timer(Prefix :+ "fetch_inputs")
           val validate: Timer = registry.timer(Prefix :+ "validate")
           val commit: Timer = registry.timer(Prefix :+ "commit")
-          val transformSubmission: Timer = registry.timer(prefix :+ "transform_submission")
+          val transformSubmission: Timer = registry.timer(Prefix :+ "transform_submission")
 
-          val acquireTransactionLock: Timer = registry.timer(prefix :+ "acquire_transaction_lock")
+          val acquireTransactionLock: Timer = registry.timer(Prefix :+ "acquire_transaction_lock")
           val failedToAcquireTransaction: Timer =
-            registry.timer(prefix :+ "failed_to_acquire_transaction")
-          val releaseTransactionLock: Timer = registry.timer(prefix :+ "release_transaction_lock")
+            registry.timer(Prefix :+ "failed_to_acquire_transaction")
+          val releaseTransactionLock: Timer = registry.timer(Prefix :+ "release_transaction_lock")
 
-          val stateValueCache = new CacheMetrics(registry, prefix :+ "state_value_cache")
+          val stateValueCache = new CacheMetrics(registry, Prefix :+ "state_value_cache")
 
           // The below metrics are only generated during parallel validation.
           // The counters track how many submissions we're processing in parallel.

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -158,7 +158,7 @@ class Metrics(val registry: MetricRegistry) {
         object validator {
           private val Prefix: MetricName = submission.prefix :+ "validator"
 
-          val openEnvelope: Timer = registry.timer(prefix :+ "open_envelope")
+          val openEnvelope: Timer = registry.timer(Prefix :+ "open_envelope")
           val fetchInputs: Timer = registry.timer(Prefix :+ "fetch_inputs")
           val validate: Timer = registry.timer(Prefix :+ "validate")
           val commit: Timer = registry.timer(Prefix :+ "commit")

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -156,37 +156,37 @@ class Metrics(val registry: MetricRegistry) {
         }
 
         object validator {
-          private val Prefix: MetricName = submission.prefix :+ "validator"
+          private val prefix: MetricName = submission.prefix :+ "validator"
 
-          val openEnvelope: Timer = registry.timer(Prefix :+ "open_envelope")
-          val fetchInputs: Timer = registry.timer(Prefix :+ "fetch_inputs")
-          val validate: Timer = registry.timer(Prefix :+ "validate")
-          val commit: Timer = registry.timer(Prefix :+ "commit")
-          val transformSubmission: Timer = registry.timer(Prefix :+ "transform_submission")
+          val openEnvelope: Timer = registry.timer(prefix :+ "open_envelope")
+          val fetchInputs: Timer = registry.timer(prefix :+ "fetch_inputs")
+          val validate: Timer = registry.timer(prefix :+ "validate")
+          val commit: Timer = registry.timer(prefix :+ "commit")
+          val transformSubmission: Timer = registry.timer(prefix :+ "transform_submission")
 
-          val acquireTransactionLock: Timer = registry.timer(Prefix :+ "acquire_transaction_lock")
+          val acquireTransactionLock: Timer = registry.timer(prefix :+ "acquire_transaction_lock")
           val failedToAcquireTransaction: Timer =
-            registry.timer(Prefix :+ "failed_to_acquire_transaction")
-          val releaseTransactionLock: Timer = registry.timer(Prefix :+ "release_transaction_lock")
+            registry.timer(prefix :+ "failed_to_acquire_transaction")
+          val releaseTransactionLock: Timer = registry.timer(prefix :+ "release_transaction_lock")
 
-          val stateValueCache = new CacheMetrics(registry, Prefix :+ "state_value_cache")
+          val stateValueCache = new CacheMetrics(registry, prefix :+ "state_value_cache")
 
           // The below metrics are only generated during parallel validation.
           // The counters track how many submissions we're processing in parallel.
-          val batchSizes: Histogram = registry.histogram(Prefix :+ "batch_sizes")
+          val batchSizes: Histogram = registry.histogram(prefix :+ "batch_sizes")
           val receivedBatchSubmissionBytes: Histogram =
-            registry.histogram(Prefix :+ "received_batch_submission_bytes")
+            registry.histogram(prefix :+ "received_batch_submission_bytes")
           val receivedSubmissionBytes: Histogram =
-            registry.histogram(Prefix :+ "received_submission_bytes")
+            registry.histogram(prefix :+ "received_submission_bytes")
 
-          val validateAndCommit: Timer = registry.timer(Prefix :+ "validate_and_commit")
-          val decode: Timer = registry.timer(Prefix :+ "decode")
-          val detectConflicts: Timer = registry.timer(Prefix :+ "detect_conflicts")
+          val validateAndCommit: Timer = registry.timer(prefix :+ "validate_and_commit")
+          val decode: Timer = registry.timer(prefix :+ "decode")
+          val detectConflicts: Timer = registry.timer(prefix :+ "detect_conflicts")
 
-          val decodeRunning: Counter = registry.counter(Prefix :+ "decode_running")
-          val fetchInputsRunning: Counter = registry.counter(Prefix :+ "fetch_inputs_running")
-          val validateRunning: Counter = registry.counter(Prefix :+ "validate_running")
-          val commitRunning: Counter = registry.counter(Prefix :+ "commit_running")
+          val decodeRunning: Counter = registry.counter(prefix :+ "decode_running")
+          val fetchInputsRunning: Counter = registry.counter(prefix :+ "fetch_inputs_running")
+          val validateRunning: Counter = registry.counter(prefix :+ "validate_running")
+          val commitRunning: Counter = registry.counter(prefix :+ "commit_running")
         }
       }
 


### PR DESCRIPTION
Summary of changes:
* Fixed prefix of some validator metrics.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
