### PR TITLE
Verification tool bugfix in variable projection and substitution with…

### DIFF
--- a/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Generate.hs
+++ b/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Generate.hs
@@ -141,13 +141,7 @@ genChoice pac tem (this',this) temFs TemplateChoice{..} = do
   extVarEnv self
   extVarEnv arg
   argFs <- recTypFields (snd chcArgBinder)
-  -- Replace the argument and template fields with their record projection form.
-  let argFieldSubst = foldl concatExprSubst emptyExprSubst
-        (map (\f -> singleExprSubst (fieldName2VarName f) (EStructProj f (EVar arg))) argFs)
-      thisFieldSubst = foldl concatExprSubst emptyExprSubst
-        (map (\f -> singleExprSubst (fieldName2VarName f) (EStructProj f (EVar this))) temFs)
-      substVar = createExprSubst [(self',EVar self),(this',EVar this),(arg',EVar arg)]
-      subst = substVar `concatExprSubst` thisFieldSubst `concatExprSubst` argFieldSubst
+  let subst = createExprSubst [(self',EVar self),(this',EVar this),(arg',EVar arg)]
   extRecEnv arg argFs
   expOut <- genExpr True
     $ substituteTm subst

--- a/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Subst.hs
+++ b/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Subst.hs
@@ -7,6 +7,8 @@ module DA.Daml.LF.Verify.Subst
   , singleExprSubst
   , singleTypeSubst
   , createExprSubst
+  , emptyExprSubst
+  , concatExprSubst
   , SubstTm(..)
   , SubstTy(..)
   , InstPR(..)
@@ -19,6 +21,14 @@ import DA.Daml.LF.Ast.Type
 
 -- | Substitution of expressions for expression variables.
 type ExprSubst = Map.Map ExprVarName Expr
+
+-- | Constructs an empty substition.
+emptyExprSubst :: ExprSubst
+emptyExprSubst = Map.empty
+
+-- | Combine two substitions.
+concatExprSubst :: ExprSubst -> ExprSubst -> ExprSubst
+concatExprSubst = Map.union
 
 -- | Create an expression substitution from a single variable and expression.
 singleExprSubst :: ExprVarName
@@ -47,6 +57,14 @@ substDom :: ExprSubst
   -- ^ The substitution to analyse.
   -> [ExprVarName]
 substDom = Map.keys
+
+-- | Remove a variable from the substitution
+removeSubst :: ExprSubst
+  -- ^ The substitution to remove from.
+  -> ExprVarName
+  -- ^ The variable to remove from the substitution.
+  -> ExprSubst
+removeSubst = flip Map.delete
 
 -- | A class covering the data types to which an expression substitution can be applied.
 class SubstTm a where
@@ -83,13 +101,15 @@ instance SubstTm Expr where
     ETmApp e1 e2 -> ETmApp (substituteTm s e1) (substituteTm s e2)
     ETyApp e t -> ETyApp (substituteTm s e) t
     ETmLam (x,t) e -> if x `elem` substDom s
-      then ETmLam (x,t) e
+      then ETmLam (x,t) (substituteTm (removeSubst s x) e)
       else ETmLam (x,t) (substituteTm s e)
     ETyLam (a,k) e -> ETyLam (a,k) (substituteTm s e)
     ECase e cs -> ECase (substituteTm s e)
       $ map (\CaseAlternative{..} -> CaseAlternative altPattern (substituteTm s altExpr)) cs
-    ELet Binding{..} e -> ELet (Binding bindingBinder $ substituteTm s bindingBound)
-      (substituteTm s e)
+    ELet (Binding (var,ty) e1) e2 -> if var `elem` substDom s
+      then let s' = removeSubst s var
+           in ELet (Binding (var,ty) (substituteTm s e1)) (substituteTm s' e2)
+      else ELet (Binding (var,ty) (substituteTm s e1)) (substituteTm s e2)
     ECons t e1 e2 -> ECons t (substituteTm s e1) (substituteTm s e2)
     ESome t e -> ESome t (substituteTm s e)
     EToAny t e -> EToAny t (substituteTm s e)

--- a/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Subst.hs
+++ b/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Subst.hs
@@ -52,12 +52,6 @@ createExprSubst :: [(ExprVarName,Expr)]
   -> ExprSubst
 createExprSubst = Map.fromList
 
--- | Get the domain from an expression substitution.
-substDom :: ExprSubst
-  -- ^ The substitution to analyse.
-  -> [ExprVarName]
-substDom = Map.keys
-
 -- | Remove a variable from the substitution
 removeSubst :: ExprSubst
   -- ^ The substitution to remove from.
@@ -100,16 +94,13 @@ instance SubstTm Expr where
     EStructUpd f e1 e2 -> EStructUpd f (substituteTm s e1) (substituteTm s e2)
     ETmApp e1 e2 -> ETmApp (substituteTm s e1) (substituteTm s e2)
     ETyApp e t -> ETyApp (substituteTm s e) t
-    ETmLam (x,t) e -> if x `elem` substDom s
-      then ETmLam (x,t) (substituteTm (removeSubst s x) e)
-      else ETmLam (x,t) (substituteTm s e)
+    ETmLam (x,t) e -> let s' = removeSubst s x
+      in ETmLam (x,t) (substituteTm s' e)
     ETyLam (a,k) e -> ETyLam (a,k) (substituteTm s e)
     ECase e cs -> ECase (substituteTm s e)
       $ map (\CaseAlternative{..} -> CaseAlternative altPattern (substituteTm s altExpr)) cs
-    ELet (Binding (var,ty) e1) e2 -> if var `elem` substDom s
-      then let s' = removeSubst s var
-           in ELet (Binding (var,ty) (substituteTm s e1)) (substituteTm s' e2)
-      else ELet (Binding (var,ty) (substituteTm s e1)) (substituteTm s e2)
+    ELet (Binding (var,ty) e1) e2 -> let s' = removeSubst s var
+      in ELet (Binding (var,ty) (substituteTm s e1)) (substituteTm s' e2)
     ECons t e1 e2 -> ECons t (substituteTm s e1) (substituteTm s e2)
     ESome t e -> ESome t (substituteTm s e)
     EToAny t e -> EToAny t (substituteTm s e)


### PR DESCRIPTION
Bugfixes for the verification tool:
- Substitutions get propagated throughout let bindings, and shadowing bindings are taken into account.
- Argument and template fields (e.g. `amount`) are replaced by their projection form (e.g. `this.amount`).