### PR TITLE
Made CacheMetrics public

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/CacheMetrics.scala
@@ -6,7 +6,7 @@ package com.daml.metrics
 import com.codahale.metrics.MetricRegistry.MetricSupplier
 import com.codahale.metrics.{Counter, Gauge, MetricRegistry, Timer}
 
-final class CacheMetrics private[metrics] (
+final class CacheMetrics(
     registry: MetricRegistry,
     prefix: MetricName,
 ) {


### PR DESCRIPTION
Summary of changes:
* Made `CacheMetrics` public so that caches defined outside of `com.daml.metrics` can be instrumented.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
