### PR TITLE
ledger-api-client: More backwards-compatibility.

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerIdRequirement.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerIdRequirement.scala
@@ -4,20 +4,26 @@
 package com.daml.ledger.client.configuration
 
 /**
-  * @param ledgerId The ID of the target ledger. If defined, the client will only communicate with ledgers that have the
-  *                 expected LedgerId. Note that this setting only affects the binding process, when the ledger ID
-  *                 on the server is checked.
+  * @param optionalLedgerId The ID of the target ledger. If defined, the client will only
+  *                         communicate with ledgers that have the expected LedgerId.
+  *                         Note that this setting only affects the binding process, when the ledger
+  *                         ID on the server is checked.
   */
-final case class LedgerIdRequirement(ledgerId: Option[String]) {
+final case class LedgerIdRequirement(optionalLedgerId: Option[String]) {
+  @deprecated("This function will return `Option[String]` in a future release.", "1.3.0")
+  def ledgerId: String = optionalLedgerId.get
+
+  def enabled: Boolean = optionalLedgerId.isDefined
+
   def isAccepted(checkedLedgerId: String): Boolean =
-    ledgerId.fold(true)(checkedLedgerId.equals)
+    optionalLedgerId.fold(true)(checkedLedgerId.equals)
 
   def copy(ledgerId: Option[String]): LedgerIdRequirement =
-    LedgerIdRequirement(ledgerId = ledgerId)
+    LedgerIdRequirement(optionalLedgerId = ledgerId)
 
   @deprecated("Use Option-based copy", "1.3.0")
   def copy(ledgerId: String): LedgerIdRequirement =
-    LedgerIdRequirement(this.ledgerId.map(_ => ledgerId))
+    LedgerIdRequirement(this.optionalLedgerId.map(_ => ledgerId))
 }
 
 object LedgerIdRequirement {

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/identity/LedgerIdentityClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/identity/LedgerIdentityClient.scala
@@ -25,7 +25,7 @@ final class LedgerIdentityClient(service: LedgerIdentityServiceStub) {
       val requirement = ledgerIdRequirement
       require(
         requirement.isAccepted(ledgerId),
-        s"Required Ledger ID ${requirement.ledgerId} does not match received Ledger ID $ledgerId"
+        s"Required Ledger ID ${requirement.optionalLedgerId.get} does not match received Ledger ID $ledgerId"
       )
       LedgerId(ledgerId)
     }


### PR DESCRIPTION
Let's not break others' code until they've had a chance to migrate. This changes `LedgerIdRequirement` so that properties don't change types, and adds `@deprecated` where necessary.

There is one behavior change: `ledgerId` used to return whatever string was passed in (typically `""`) if the requirement was not enabled. It now throws an exception.

In the future, we will change the type of `ledgerId` to be `Option[String]`, and make `optionalLedgerId` an alias for that property.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
