### PR TITLE
Factor out generic types from migration tests

### DIFF
--- a/compatibility/sandbox-migration/runner/Migration/Types.hs
+++ b/compatibility/sandbox-migration/runner/Migration/Types.hs
@@ -48,6 +48,7 @@ data Tuple2 a b = Tuple2
 
 instance (A.FromJSON a, A.FromJSON b) => A.FromJSON (Tuple2 a b)
 
+-- | Since this is only for testing, we omit the package id for convenience.
 data TemplateId = TemplateId
   { moduleName :: !String
   , entityName :: !String


### PR DESCRIPTION
This PR factors out `Event` and `Transaction` so we can reuse them for
different tests. To make that work we simply remove the type parameter
from ContractId which didn’t help much anyway and store the undecoded
JSON value in the constructors. The use sites are basically unchanged
thanks to pattern synonyms which match the old constructors.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
