### PR TITLE
Improve errors from the option parser in daml2js

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -30,6 +30,7 @@ import Data.Maybe
 import Data.Bifoldable
 import Options.Applicative
 import System.Directory
+import System.Environment
 import System.FilePath hiding ((<.>))
 import System.Process
 import System.Exit
@@ -119,8 +120,8 @@ mergePackageMap ps = foldM merge Map.empty ps
 
 -- Write packages for all the DALFs in all the DARs.
 main :: IO ()
-main = do
-    opts@Options{..} <- execParser optionsParserInfo
+main = withProgName "daml codegen js" $ do
+    opts@Options{..} <- customExecParser (prefs showHelpOnError) optionsParserInfo
     sdkVersionOrErr <- DATypes.parseVersion . T.pack . fromMaybe "0.0.0" <$> getSdkVersionMaybe
     sdkVersion <- case sdkVersionOrErr of
           Left _ -> fail "Invalid SDK version"


### PR DESCRIPTION
fixes #6353
fixes #6352

This fixes the program name to refer to `daml codegen js` and changes
the behavior to show help if the parser fails. Putting things together
running `daml codegen js` without arguments now looks as follows:

```
Missing: DAR-FILES -o DIR

Usage: daml codegen js DAR-FILES -o DIR [-s SCOPE]
  Generate TypeScript bindings from a DAR

Available options:
  DAR-FILES                DAR files to generate TypeScript bindings for
  -o DIR                   Output directory for the generated packages
  -s SCOPE                 The NPM scope name for the generated packages;
                           defaults to daml.js
  -h,--help                Show this help text
```

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
