### PR TITLE
Fix race in doctest integration tests

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DamlDocTestIntegration.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDocTestIntegration.hs
@@ -31,7 +31,11 @@ tests damlcPath = testGroup "doctest integration tests"
                   , "add : Int -> Int -> Int"
                   , "add x y = 0"
                   ]
-              (exit, stdout, stderr) <- readProcessWithExitCode damlcPath ["doctest", f] ""
+              -- NOTE (MK) We need to change the working directory
+              -- since the generated files end up in .daml/generated which
+              -- is otherwise identical between the two tests.
+              (exit, stdout, stderr) <-
+                  readCreateProcessWithExitCode (docTestProc tmpDir f) ""
               assertBool ("error in: " <> stderr) ("expected 0 == 2" `isInfixOf` stderr)
               stdout @?= ""
               assertEqual "exit code" (ExitFailure 1) exit
@@ -47,8 +51,10 @@ tests damlcPath = testGroup "doctest integration tests"
                   , "add : Int -> Int -> Int"
                   , "add x y = x + y"
                   ]
-              (exit, stdout, stderr) <- readProcessWithExitCode damlcPath ["doctest", f] ""
+              (exit, stdout, stderr) <-
+                  readCreateProcessWithExitCode (docTestProc tmpDir f) ""
               stdout @?= ""
               stderr @?= ""
               assertEqual "exit code" ExitSuccess exit
     ]
+  where docTestProc dir f = (proc damlcPath ["doctest", f]) { cwd = Just dir }


### PR DESCRIPTION
Doctests generate a temporary file in .daml/generated. This works fine
as long as you only run one instance at the same time. However, those
tests here run in parallel and they run in the same working directory
even though we create a temporary directory for the source file. This
means that occasionally (very rarely, I still haven’t managed to
reproduce it locally) the two tests overwrote each other’s file and
you end up with a mess.

There are two solutions here:

1. Disable parallel tests.
2. Remove the working directory as global state and instead use tmpDir
   as the working directory.

Nobody likes global state so I went with 2.

I ran 500 iterations of this test on CI on all 3 platforms and got not
a single failure so I’m reasonably confident this fixes the issue.

changelog_begin
changelog_end