### PR TITLE
Interleave migration tests

### DIFF
--- a/compatibility/sandbox-migration/runner/Migration/Runner.hs
+++ b/compatibility/sandbox-migration/runner/Migration/Runner.hs
@@ -57,11 +57,6 @@ main = do
     let step = Bazel.Runfiles.rlocation
             runfiles
             ("compatibility" </> "sandbox-migration" </> "migration-step")
-    runTest "propose-accept" modelDar platformAssistants (ProposeAccept.test step modelDar)
-    runTest "key-transfer" modelDar platformAssistants (KeyTransfer.test step modelDar)
-
-runTest :: forall s r. String -> FilePath -> [FilePath] -> Test s r -> IO ()
-runTest testName modelDar platformAssistants Test{..} =
     withPostgres $ \jdbcUrl -> do
         initialPlatform : _ <- pure platformAssistants
         hPutStrLn stderr "--> Uploading model DAR"
@@ -71,18 +66,23 @@ runTest testName modelDar platformAssistants Test{..} =
                 , "upload-dar", modelDar
                 , "--host=localhost", "--port=" <> show p
                 ]
+        runTest jdbcUrl platformAssistants
+            (ProposeAccept.test step modelDar `interleave` KeyTransfer.test step modelDar)
+
+runTest :: forall s r. T.Text -> [FilePath] -> Test s r -> IO ()
+runTest jdbcUrl platformAssistants Test{..} = do
         hPutStrLn stderr "<-- Uploaded model DAR"
         foldM_ (step jdbcUrl) initialState platformAssistants
             where step :: T.Text -> s -> FilePath -> IO s
                   step jdbcUrl state assistant = do
                       let version = takeFileName (takeDirectory assistant)
-                      hPutStrLn stderr ("--> Testing: " <> testName <> "; SDK version: " <> version)
+                      hPutStrLn stderr ("--> Testing: " <> "SDK version: " <> version)
                       r <- withSandbox assistant jdbcUrl $ \port ->
                            executeStep (SdkVersion version) "localhost" port state
                       case validateStep (SdkVersion version) state r of
                           Left err -> fail err
                           Right state' -> do
-                              hPutStrLn stderr ("<-- Tested: " <> testName <> "; SDK version: " <> version)
+                              hPutStrLn stderr ("<-- Tested: SDK version: " <> version)
                               pure state'
 
 withSandbox :: FilePath -> T.Text -> (Int -> IO a) -> IO a


### PR DESCRIPTION
Currently we run all migration tests on a separate postgres
instance. This PR changes this to interleave the steps so that we can
run all tests on a single postgres instance.

We do get slightly worse errors for now but the assertion failures
should be informative enough that I don’t think assigning them to the
test that caused them is an issue (and if it is we can just change the
error message).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
