### PR TITLE
reduce default concurrency of api-test-tool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,6 +115,12 @@ jobs:
           is_release: variables.is_release
       - bash: |
           set -euo pipefail
+          eval "$(dev-env/bin/dade-assist)"
+          bazel test -t- --runs_per_test=50 //ledger/sandbox:conformance-test-static-time-h2database
+          sed -i 's/concurrentTestRuns = 1,/concurrentTestRuns = Runtime.getRuntime.availableProcessors(),/' ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+          bazel test -t- --runs_per_test=50 //ledger/sandbox:conformance-test-static-time-h2database
+      - bash: |
+          set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bazel build //release:release
           ./bazel-bin/release/release --release-dir "$(mktemp -d)"
@@ -150,6 +156,12 @@ jobs:
           release_tag: $(release_tag)
           name: macos
           is_release: variables.is_release
+      - bash: |
+          set -euo pipefail
+          eval "$(dev-env/bin/dade-assist)"
+          bazel test -t- --runs_per_test=50 //ledger/sandbox:conformance-test-static-time-h2database
+          sed -i 's/concurrentTestRuns = 1,/concurrentTestRuns = Runtime.getRuntime.availableProcessors(),/' ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+          bazel test -t- --runs_per_test=50 //ledger/sandbox:conformance-test-static-time-h2database
       - template: ci/tell-slack-failed.yml
         parameters:
           trigger_sha: '$(trigger_sha)'

--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -153,6 +153,9 @@ Use the command line option ``--verbose`` to print full stack traces on failures
 Concurrent test runs
 ====================
 
-To minimize parallelized runs of tests, ``--concurrent-test-runs`` can be set to 1 or 2.
-The default value is the number of processors available.
+To parallelize test runs, ``--concurrent-test-runs`` can be set. The default
+value is 1. Note that in general the rate at which tests can be processed
+depends more on the ledger than on this number, and the API Test Tool does not
+currently handle backpressure. In other words, if the test tool is going faster
+than the ledger, the test tool will fail.
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -104,8 +104,10 @@ object Cli {
     opt[Int](name = "concurrent-test-runs")
       .optional()
       .action((v, c) => c.copy(concurrentTestRuns = v))
-      .text("""Number of tests to run concurrently. Defaults to the number of available
-              |processors.""".stripMargin)
+      .text("""Number of tests to run concurrently. Defaults to 1. Note that,
+              |in general, the bottleneck is the ledger, not the test suite,
+              |and if the ledger cannot keep up, the test tool will fail.
+              |""".stripMargin)
 
     opt[Unit]("verbose")
       .abbr("v")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -37,7 +37,7 @@ object Config {
     verbose = false,
     timeoutScaleFactor = 1.0,
     loadScaleFactor = 1.0,
-    concurrentTestRuns = Runtime.getRuntime.availableProcessors(),
+    concurrentTestRuns = 1,
     extract = false,
     tlsConfig = None,
     excluded = Set.empty,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Random, Try}
 
 object LedgerTestSuiteRunner {
   private val DefaultTimeout = 30.seconds
@@ -128,7 +128,7 @@ final class LedgerTestSuiteRunner(
     val tests = suites
       .flatMap(suite => suite.tests.map(suite -> _))
       .zipWithIndex
-    Source(tests)
+    Source(Random.shuffle(tests))
       .mapAsyncUnordered(concurrentTestRuns) {
         case ((suite, test), index) =>
           run(test, suite.session).map(testResult => (suite, test, testResult) -> index)


### PR DESCRIPTION
This PR makes two small (?) changes to the Ledger API Test Tool. First, it realizes the original intention that tests should run in a randomized order, by explicily shuffling the list of tests (after selection through include/exclude etc.). The existing implementation relies on the ordering of `Map#values`, which, while not obviously connected to either insertion order or sort order on the keys, is nonetheless deterministic and hence results in all our tests always running in the same order (for the same selection).

Second, because shuffling the tests results in a very flaky build, this PR reduces the default concurrency from "as many threads as there are CPU cores on this machine" to 1. On my machine this reduces the performance of `//ledger/sandbox:conformance-test-static-time-h2database` from running in about 30 seconds to running in about 55 seconds, so this is definitely not negligible. However, trying to run with concurrency 2 on my machine yields a failure rate of about 20%, whereas setting concurrency to 1 succeeded 40 times in a row.

I believe the underlying issue is that, after the test tool has been implemented, the ledger API has been enhanced to support backpressure. This is, in general, a good thing, but the test tool has apparently not been updated to take it into account (say, with appropriate retry strategies). Implementing that would be better than limiting concurrency, but it would also be significantly more effort for me.

CHANGELOG_BEGIN
- [Ledger API Test Tool] Change default concurrency from "number of cores" to 1. You can still set explicit concurrency settings with ``--concurrent-test-runs INT``.
CHANGELOG_END