### PR TITLE
Speedy: refactor Machine builders

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -139,19 +139,15 @@ class Context(val contextId: Context.ContextId) {
   }
 
   // We use a fix Hash and fix time to seed the contract id, so we get reproducible run.
-  private val txSeeding =
-    crypto.Hash.hashPrivateKey(s"scenario-service")
+  private val txSeeding = crypto.Hash.hashPrivateKey(s"scenario-service")
 
   private def buildMachine(identifier: Identifier): Option[Speedy.Machine] = {
     val defns = this.defns
+    val compiledPackages =
+      PureCompiledPackages(allPackages, defns, Compiler.FullStackTrace, Compiler.NoProfile)
     for {
       defn <- defns.get(LfDefRef(identifier))
-    } yield
-      Speedy.Machine.buildForScenario(
-        PureCompiledPackages(allPackages, defns, Compiler.FullStackTrace, Compiler.NoProfile),
-        txSeeding,
-        defn,
-      )
+    } yield Speedy.Machine.buildForScenario(compiledPackages, txSeeding, defn)
   }
 
   def interpretScenario(

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -139,25 +139,19 @@ class Context(val contextId: Context.ContextId) {
   }
 
   // We use a fix Hash and fix time to seed the contract id, so we get reproducible run.
-  private val submissionTime =
-    data.Time.Timestamp.MinValue
-  private val initialSeeding =
-    speedy.InitialSeeding.TransactionSeed(crypto.Hash.hashPrivateKey(s"scenario-service"))
+  private val txSeeding =
+    crypto.Hash.hashPrivateKey(s"scenario-service")
 
   private def buildMachine(identifier: Identifier): Option[Speedy.Machine] = {
     val defns = this.defns
     for {
       defn <- defns.get(LfDefRef(identifier))
     } yield
-      Speedy.Machine
-        .build(
-          sexpr = defn,
-          compiledPackages =
-            PureCompiledPackages(allPackages, defns, Compiler.FullStackTrace, Compiler.NoProfile),
-          submissionTime,
-          initialSeeding,
-          Set.empty,
-        )
+      Speedy.Machine.buildForScenario(
+        PureCompiledPackages(allPackages, defns, Compiler.FullStackTrace, Compiler.NoProfile),
+        txSeeding,
+        defn,
+      )
   }
 
   def interpretScenario(

--- a/daml-lf/interpreter/perf/BUILD.bazel
+++ b/daml-lf/interpreter/perf/BUILD.bazel
@@ -23,7 +23,6 @@ da_scala_binary(
         "//daml-lf/data",
         "//daml-lf/interpreter",
         "//daml-lf/language",
-        "//daml-lf/transaction",
     ],
 )
 

--- a/daml-lf/interpreter/perf/BUILD.bazel
+++ b/daml-lf/interpreter/perf/BUILD.bazel
@@ -44,7 +44,6 @@ da_scala_binary(
         "//daml-lf/data",
         "//daml-lf/interpreter",
         "//daml-lf/language",
-        "//daml-lf/transaction",
         "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
@@ -70,7 +69,6 @@ da_scala_binary(
         "//daml-lf/data",
         "//daml-lf/interpreter",
         "//daml-lf/language",
-        "//daml-lf/transaction",
         "@maven//:com_google_protobuf_protobuf_java",
     ],
 )
@@ -101,7 +99,6 @@ da_scala_binary(
         "//daml-lf/data",
         "//daml-lf/interpreter",
         "//daml-lf/language",
-        "//daml-lf/transaction",
         "@maven//:com_google_protobuf_protobuf_java",
     ],
 )

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -5,7 +5,6 @@ package com.daml.lf
 package speedy
 package explore
 
-import com.daml.lf.data._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SResult._
@@ -32,7 +31,7 @@ object PlaySpeedy {
     names.foreach { name =>
       val (expected, expr) = examples(name)
       val converted = compiler.unsafeClosureConvert(expr)
-      val machine = makeMachine(converted)
+      val machine = Speedy.Machine.fromExpr(noPackages, converted)
       runMachine(name, machine, expected)
     }
   }
@@ -62,20 +61,8 @@ object PlaySpeedy {
     Config(names)
   }
 
-  private val seeding = InitialSeeding.TransactionSeed(crypto.Hash.hashPrivateKey("SpeedyExplore"))
-
-  def makeMachine(sexpr: SExpr): Machine = {
-    val compiledPackages: CompiledPackages =
-      PureCompiledPackages(Map.empty, Compiler.NoStackTrace, Compiler.NoProfile).right.get
-    Machine(
-      compiledPackages = compiledPackages,
-      submissionTime = Time.Timestamp.now(),
-      initialSeeding = seeding,
-      expr = sexpr,
-      globalCids = Set.empty,
-      committers = Set.empty
-    )
-  }
+  private val noPackages =
+    data.assertRight(PureCompiledPackages(Map.empty, Compiler.NoStackTrace, Compiler.NoProfile))
 
   def runMachine(name: String, machine: Machine, expected: Int): Unit = {
 

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -62,17 +62,18 @@ object PlaySpeedy {
     Config(names)
   }
 
-  private val txSeed = crypto.Hash.hashPrivateKey("SpeedyExplore")
+  private val seeding = InitialSeeding.TransactionSeed(crypto.Hash.hashPrivateKey("SpeedyExplore"))
 
   def makeMachine(sexpr: SExpr): Machine = {
     val compiledPackages: CompiledPackages =
       PureCompiledPackages(Map.empty, Compiler.NoStackTrace, Compiler.NoProfile).right.get
-    Machine.fromSExpr(
-      sexpr,
-      compiledPackages,
-      Time.Timestamp.now(),
-      InitialSeeding.TransactionSeed(txSeed),
-      Set.empty,
+    Machine(
+      compiledPackages = compiledPackages,
+      submissionTime = Time.Timestamp.now(),
+      initialSeeding = seeding,
+      expr = sexpr,
+      globalCids = Set.empty,
+      committers = Set.empty
     )
   }
 

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -90,12 +90,13 @@ object PlaySpeedy {
         val arg = SEValue(SInt64(config.argValue))
         SEApp(func, Array(arg))
       }
-      Machine.fromSExpr(
-        expr,
-        compiledPackages,
-        Time.Timestamp.now(),
-        InitialSeeding.TransactionSeed(txSeed),
-        Set.empty,
+      Machine(
+        compiledPackages = compiledPackages,
+        submissionTime = Time.Timestamp.now(),
+        initialSeeding = seeding,
+        expr = expr,
+        globalCids = Set.empty,
+        committers = Set.empty,
       )
     }
 
@@ -110,7 +111,7 @@ object PlaySpeedy {
     println(s"Final-value: $result")
   }
 
-  private val txSeed = crypto.Hash.hashPrivateKey("ExploreDar")
+  private val seeding = InitialSeeding.TransactionSeed(crypto.Hash.hashPrivateKey("ExploreDar"))
 
   final case class MachineProblem(s: String) extends RuntimeException(s, null, false, false)
 

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -103,8 +103,6 @@ object PlaySpeedy {
     println(s"Final-value: $result")
   }
 
-  private val seeding = InitialSeeding.TransactionSeed(crypto.Hash.hashPrivateKey("ExploreDar"))
-
   final case class MachineProblem(s: String) extends RuntimeException(s, null, false, false)
 
 }

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -8,7 +8,6 @@ package explore
 import com.daml.bazeltools.BazelRunfiles.{rlocation}
 import com.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.daml.lf.data.Ref.{DefinitionRef, Identifier, QualifiedName}
-import com.daml.lf.data.Time
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
@@ -90,14 +89,7 @@ object PlaySpeedy {
         val arg = SEValue(SInt64(config.argValue))
         SEApp(func, Array(arg))
       }
-      Machine(
-        compiledPackages = compiledPackages,
-        submissionTime = Time.Timestamp.now(),
-        initialSeeding = seeding,
-        expr = expr,
-        globalCids = Set.empty,
-        committers = Set.empty,
-      )
+      Machine.fromExpr(compiledPackages, expr)
     }
 
     val result: SValue = {

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -48,6 +48,4 @@ object LoadDarFunction extends App {
     function
   }
 
-  private[this] val seeding = InitialSeeding.TransactionSeed(crypto.Hash.hashPrivateKey("KEY"))
-
 }

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -7,7 +7,6 @@ package explore
 
 import com.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.daml.lf.data.Ref.{DefinitionRef, Identifier, QualifiedName}
-import com.daml.lf.data.Time
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
@@ -38,14 +37,7 @@ object LoadDarFunction extends App {
         val arg = SEValue(SInt64(argValue))
         SEApp(func, Array(arg))
       }
-      val machine = Machine(
-        compiledPackages = compiledPackages,
-        submissionTime = Time.Timestamp.now(),
-        initialSeeding = seeding,
-        expr = expr,
-        globalCids = Set.empty,
-        committers = Set.empty
-      )
+      val machine = Machine.fromExpr(compiledPackages, expr)
 
       machine.run() match {
         case SResultFinalValue(SInt64(result)) => result

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -38,15 +38,15 @@ object LoadDarFunction extends App {
         val arg = SEValue(SInt64(argValue))
         SEApp(func, Array(arg))
       }
-      val machine: Machine = {
-        Machine.fromSExpr(
-          expr,
-          compiledPackages,
-          Time.Timestamp.now(),
-          InitialSeeding.TransactionSeed(crypto.Hash.hashPrivateKey("KEY")),
-          Set.empty,
-        )
-      }
+      val machine = Machine(
+        compiledPackages = compiledPackages,
+        submissionTime = Time.Timestamp.now(),
+        initialSeeding = seeding,
+        expr = expr,
+        globalCids = Set.empty,
+        committers = Set.empty
+      )
+
       machine.run() match {
         case SResultFinalValue(SInt64(result)) => result
         case res => throw new RuntimeException(s"Unexpected result from machine $res")
@@ -55,5 +55,7 @@ object LoadDarFunction extends App {
 
     function
   }
+
+  private[this] val seeding = InitialSeeding.TransactionSeed(crypto.Hash.hashPrivateKey("KEY"))
 
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -91,9 +91,13 @@ object Speedy {
   type Actuals = util.ArrayList[SValue]
 
   /** The speedy CEK machine. */
-  final case class Machine(
+  final class Machine(
       /* Value versions that the machine can output */
-      supportedValueVersions: VersionRange[value.ValueVersion],
+      val supportedValueVersions: VersionRange[value.ValueVersion],
+      /* Whether the current submission is validating the transaction, or interpreting
+       * it. If this is false, the committers must be a singleton set.
+       */
+      val validating: Boolean,
       /* The control is what the machine should be evaluating. If this is not
        * null, then `returnValue` must be null.
        */
@@ -120,12 +124,8 @@ object Speedy {
       var committers: Set[Party],
       /* Commit location, if a scenario commit is in progress. */
       var commitLocation: Option[Location],
-      /* Whether the current submission is validating the transaction, or interpreting
-       * it. If this is false, the committers must be a singleton set.
-       */
-      var validating: Boolean,
       /* The trace log. */
-      traceLog: TraceLog,
+      val traceLog: TraceLog,
       /* Compiled packages (DAML-LF ast + compiled speedy expressions). */
       var compiledPackages: CompiledPackages,
       /* Flag to trace usage of get_time builtins */
@@ -139,8 +139,8 @@ object Speedy {
       /* Used when enableInstrumentation is true */
       var track: Instrumentation,
       /* Profile of the run when the packages haven been compiled with profiling enabled. */
-      var profile: Profile
-  ) extends SomeArrayEquals {
+      var profile: Profile,
+  ) {
 
     /* kont manipulation... */
 
@@ -515,15 +515,21 @@ object Speedy {
 
     private val damlTraceLog = LoggerFactory.getLogger("daml.tracelog")
 
-    private def initial(
+    def apply(
         compiledPackages: CompiledPackages,
         submissionTime: Time.Timestamp,
         initialSeeding: InitialSeeding,
-        globalCids: Set[V.ContractId]
-    ) =
-      Machine(
-        supportedValueVersions = value.ValueVersions.DefaultSupportedVersions,
-        ctrl = null,
+        expr: SExpr,
+        globalCids: Set[V.ContractId],
+        committers: Set[Party],
+        supportedValueVersions: VersionRange[value.ValueVersion] =
+          value.ValueVersions.DefaultSupportedVersions,
+        validating: Boolean = false,
+    ): Machine =
+      new Machine(
+        supportedValueVersions = supportedValueVersions,
+        validating = validating,
+        ctrl = expr,
         returnValue = null,
         frame = null,
         actuals = null,
@@ -531,11 +537,10 @@ object Speedy {
         kontStack = initialKontStack(),
         lastLocation = None,
         ptx = PartialTransaction.initial(submissionTime, initialSeeding),
-        committers = Set.empty,
+        committers = committers,
         commitLocation = None,
         traceLog = TraceLog(damlTraceLog, 100),
         compiledPackages = compiledPackages,
-        validating = false,
         dependsOnTime = false,
         localContracts = Map.empty,
         globalDiscriminators = globalCids.collect {
@@ -546,73 +551,29 @@ object Speedy {
         profile = new Profile(),
       )
 
-    def newBuilder(
+    def buildForScenario(
         compiledPackages: CompiledPackages,
-        submissionTime: Time.Timestamp,
-        submissionSeed: crypto.Hash,
-    ): Either[SError, Expr => Machine] = {
-      val compiler = compiledPackages.compiler
-      Right(
-        (expr: Expr) =>
-          fromSExpr(
-            SEApp(compiler.unsafeCompile(expr), Array(SEValue.Token)),
-            compiledPackages,
-            submissionTime,
-            InitialSeeding.TransactionSeed(submissionSeed),
-            Set.empty
-        ))
-    }
+        seed: crypto.Hash,
+        expr: SExpr,
+    ): Machine = Machine(
+      compiledPackages,
+      Time.Timestamp.MinValue,
+      InitialSeeding.TransactionSeed(seed),
+      SEApp(expr, Array(SEValue.Token)),
+      Set.empty,
+      Set.empty,
+    )
 
-    def build(
-        sexpr: SExpr,
+    def buildForScenario(
         compiledPackages: CompiledPackages,
-        submissionTime: Time.Timestamp,
-        seeds: InitialSeeding,
-        globalCids: Set[V.ContractId],
-    ): Machine =
-      fromSExpr(
-        SEApp(sexpr, Array(SEValue.Token)),
-        compiledPackages,
-        submissionTime,
-        seeds,
-        globalCids
-      )
-
-    // Used from repl.
-    def fromExpr(
+        seed: crypto.Hash,
         expr: Expr,
-        compiledPackages: CompiledPackages,
-        scenario: Boolean,
-        submissionTime: Time.Timestamp,
-        initialSeeding: InitialSeeding,
-    ): Machine = {
-      val compiler = compiledPackages.compiler
-      val sexpr =
-        if (scenario)
-          SEApp(compiler.unsafeCompile(expr), Array(SEValue.Token))
-        else
-          compiler.unsafeCompile(expr)
-
-      fromSExpr(
-        sexpr,
-        compiledPackages,
-        submissionTime,
-        initialSeeding,
-        Set.empty,
-      )
-    }
-
-    // Construct a machine from an SExpr. This is useful when you don’t have
-    // an update expression and build’s behavior of applying the expression to
-    // a token is not appropriate.
-    def fromSExpr(
-        sexpr: SExpr,
-        compiledPackages: CompiledPackages,
-        submissionTime: Time.Timestamp,
-        seeding: InitialSeeding,
-        globalCids: Set[V.ContractId],
     ): Machine =
-      initial(compiledPackages, submissionTime, seeding, globalCids).copy(ctrl = sexpr)
+      buildForScenario(
+        compiledPackages,
+        seed,
+        compiledPackages.compiler.unsafeCompile(expr)
+      )
   }
 
   // Environment

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -580,7 +580,7 @@ object Speedy {
         scenario = compiledPackages.compiler.unsafeCompile(scenario)
       )
 
-    // Construct a machine from evaluating an expression that is neither an update nor a scenario expression.
+    // Construct a machine for evaluating an expression that is neither an update nor a scenario expression.
     def fromExpr(
         compiledPackages: CompiledPackages,
         expr: SExpr,
@@ -596,7 +596,7 @@ object Speedy {
 
     @throws[PackageNotFound]
     @throws[CompilationError]
-    // Construct a machine from evaluating an expression that is neither an update nor a scenario expression.
+    // Construct a machine for evaluating an expression that is neither an update nor a scenario expression.
     def fromExpr(
         compiledPackages: CompiledPackages,
         expr: Expr,

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -5,7 +5,7 @@ package com.daml.lf.speedy
 
 import com.daml.lf.PureCompiledPackages
 import com.daml.lf.data.Ref._
-import com.daml.lf.data.{FrontStack, ImmArray, Numeric, Ref, Time}
+import com.daml.lf.data.{FrontStack, ImmArray, Numeric, Ref}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.LanguageVersion
 import com.daml.lf.language.Util._
@@ -27,14 +27,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
   private val noPackages: PureCompiledPackages = PureCompiledPackages(Map.empty).right.get
 
   private def runExpr(e: Expr): SValue = {
-    val machine = Speedy.Machine(
-      compiledPackages = noPackages,
-      submissionTime = Time.Timestamp.now(),
-      initialSeeding = InitialSeeding.NoSeed,
-      noPackages.compiler.unsafeCompile(e),
-      Set.empty,
-      Set.empty
-    )
+    val machine = Speedy.Machine.fromExpr(noPackages, e)
     machine.run() match {
       case SResultFinalValue(v) => v
       case res => throw new RuntimeException(s"Got unexpected interpretation result $res")
@@ -140,14 +133,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
       )
     var machine: Speedy.Machine = null
     "compile" in {
-      machine = Speedy.Machine(
-        noPackages,
-        Time.Timestamp.now(),
-        InitialSeeding.NoSeed,
-        list,
-        Set.empty,
-        Set.empty
-      )
+      machine = Speedy.Machine.fromExpr(noPackages, list)
     }
     "interpret" in {
       val value = machine.run() match {
@@ -240,14 +226,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
     ).right.get
 
     "succeeds" in {
-      val machine = Speedy.Machine(
-        compiledPackages = pkgs1,
-        submissionTime = Time.Timestamp.now(),
-        initialSeeding = InitialSeeding.NoSeed,
-        expr = SEVal(LfDefRef(ref)),
-        globalCids = Set.empty,
-        committers = Set.empty
-      )
+      val machine = Speedy.Machine.fromExpr(pkgs1, SEVal(LfDefRef(ref)))
       val result = machine.run()
       result match {
         case SResultNeedPackage(pkgId, cb) =>
@@ -262,14 +241,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
     }
 
     "crashes without definition" in {
-      val machine = Speedy.Machine(
-        compiledPackages = pkgs1,
-        submissionTime = Time.Timestamp.now(),
-        initialSeeding = InitialSeeding.NoSeed,
-        expr = SEVal(LfDefRef(ref)),
-        globalCids = Set.empty,
-        committers = Set.empty
-      )
+      val machine = Speedy.Machine.fromExpr(pkgs1, SEVal(LfDefRef(ref)))
       val result = machine.run()
       result match {
         case SResultNeedPackage(pkgId, cb) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -5,7 +5,7 @@ package com.daml.lf.speedy
 
 import com.daml.lf.PureCompiledPackages
 import com.daml.lf.data.Ref._
-import com.daml.lf.data.{ImmArray, Numeric, Ref, Time}
+import com.daml.lf.data.{ImmArray, Numeric, Ref}
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.LanguageVersion
 import com.daml.lf.language.Util._

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1447,14 +1447,7 @@ object SBuiltinTest {
     PureCompiledPackages(Map(defaultParserParameters.defaultPackageId -> pkg)).right.get
 
   private def eval(e: Expr): Either[SError, SValue] = {
-    val machine = Speedy.Machine(
-      compiledPackages = compiledPackages,
-      submissionTime = Time.Timestamp.now(),
-      initialSeeding = InitialSeeding.NoSeed,
-      expr = compiledPackages.compiler.unsafeCompile(e),
-      globalCids = Set.empty,
-      committers = Set.empty,
-    )
+    val machine = Speedy.Machine.fromExpr(compiledPackages, e)
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {
       val value = machine.run() match {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1447,12 +1447,13 @@ object SBuiltinTest {
     PureCompiledPackages(Map(defaultParserParameters.defaultPackageId -> pkg)).right.get
 
   private def eval(e: Expr): Either[SError, SValue] = {
-    val machine = Speedy.Machine.fromExpr(
-      expr = e,
+    val machine = Speedy.Machine(
       compiledPackages = compiledPackages,
-      scenario = false,
       submissionTime = Time.Timestamp.now(),
       initialSeeding = InitialSeeding.NoSeed,
+      expr = compiledPackages.compiler.unsafeCompile(e),
+      globalCids = Set.empty,
+      committers = Set.empty,
     )
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -305,18 +305,8 @@ class SpeedyTest extends WordSpec with Matchers {
 
 object SpeedyTest {
 
-  private[this] def build(e: Expr, packages: PureCompiledPackages) =
-    Speedy.Machine(
-      compiledPackages = packages,
-      submissionTime = Time.Timestamp.now(),
-      initialSeeding = InitialSeeding.NoSeed,
-      expr = packages.compiler.unsafeCompile(e),
-      globalCids = Set.empty,
-      committers = Set.empty
-    )
-
   private def eval(e: Expr, packages: PureCompiledPackages): Either[SError, SValue] = {
-    val machine = build(e, packages)
+    val machine = Speedy.Machine.fromExpr(packages, e)
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {
       val value = machine.run() match {
@@ -332,7 +322,7 @@ object SpeedyTest {
 
   private def profile(e: Expr): java.util.ArrayList[Profile.Event] = {
     val packages = PureCompiledPackages(Map.empty, profiling = Compiler.FullProfile).right.get
-    val machine = build(e, packages)
+    val machine = Speedy.Machine.fromExpr(packages, e)
     machine.run()
     machine.profile.events
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -8,7 +8,7 @@ import java.util
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.PureCompiledPackages
-import com.daml.lf.data.{FrontStack, Ref, Time}
+import com.daml.lf.data.{FrontStack, Ref}
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SError.SError

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -502,13 +502,14 @@ class OrderingSpec
     new util.ArrayList[X](as.asJava)
 
   private val txSeed = crypto.Hash.hashPrivateKey("SBuiltinTest")
-  private def initMachine(expr: SExpr) = Speedy.Machine fromSExpr (
-    sexpr = expr,
+  private def initMachine(expr: SExpr) = Speedy.Machine(
     compiledPackages =
       PureCompiledPackages(Map.empty, Map.empty, Compiler.FullStackTrace, Compiler.NoProfile),
     submissionTime = Time.Timestamp.now(),
-    seeding = InitialSeeding.TransactionSeed(txSeed),
+    initialSeeding = InitialSeeding.TransactionSeed(txSeed),
+    expr = expr,
     globalCids = Set.empty,
+    committers = Set.empty
   )
 
   private def translatePrimValue(v: Value[Value.ContractId]) = {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -6,13 +6,12 @@ package svalue
 
 import java.util
 
-import com.daml.lf.crypto
 import com.daml.lf.data.{FrontStack, ImmArray, Numeric, Ref, Time}
 import com.daml.lf.language.{Ast, Util => AstUtil}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SExpr.SEImportValue
-import com.daml.lf.speedy.{SBuiltin, SExpr, SValue}
+import com.daml.lf.speedy.SValue
 import com.daml.lf.value.Value
 import com.daml.lf.value.TypedValueGenerators.genAddend
 import com.daml.lf.value.ValueGenerators.{cidV0Gen, comparableCoidsGen}
@@ -501,19 +500,11 @@ class OrderingSpec
   private def ArrayList[X](as: X*): util.ArrayList[X] =
     new util.ArrayList[X](as.asJava)
 
-  private val txSeed = crypto.Hash.hashPrivateKey("SBuiltinTest")
-  private def initMachine(expr: SExpr) = Speedy.Machine(
-    compiledPackages =
-      PureCompiledPackages(Map.empty, Map.empty, Compiler.FullStackTrace, Compiler.NoProfile),
-    submissionTime = Time.Timestamp.now(),
-    initialSeeding = InitialSeeding.TransactionSeed(txSeed),
-    expr = expr,
-    globalCids = Set.empty,
-    committers = Set.empty
-  )
+  private val noPackages =
+    PureCompiledPackages(Map.empty, Map.empty, Compiler.FullStackTrace, Compiler.NoProfile)
 
   private def translatePrimValue(v: Value[Value.ContractId]) = {
-    val machine = initMachine(SEImportValue(v))
+    val machine = Speedy.Machine.fromExpr(noPackages, SEImportValue(v))
     machine.run() match {
       case SResultFinalValue(value) => value
       case _ => throw new Error(s"error while translating value $v")

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -14,7 +14,7 @@ import com.daml.lf.speedy.Pretty._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.scenario.ScenarioLedger
-import com.daml.lf.speedy.SExpr.LfDefRef
+import com.daml.lf.speedy.SExpr.{LfDefRef, SEApp, SEValue}
 import com.daml.lf.validation.Validation
 import com.daml.lf.testing.parser
 import com.daml.lf.language.LanguageVersion
@@ -172,16 +172,15 @@ object Repl {
   case class ScenarioRunnerHelper(
       packages: Map[PackageId, Package],
       profiling: Compiler.ProfilingMode) {
-    private val build = Speedy.Machine
-      .newBuilder(
-        PureCompiledPackages(packages, Compiler.FullStackTrace, profiling).right.get,
-        Time.Timestamp.MinValue,
-        nextSeed())
-      .fold(err => sys.error(err.toString), identity)
+    val compiledPackages =
+      PureCompiledPackages(packages, Compiler.FullStackTrace, profiling).right.get
+    private val seed = nextSeed()
+
     def run(expr: Expr): (
         Speedy.Machine,
         Either[(SError, ScenarioLedger), (Double, Int, ScenarioLedger, SValue)]) = {
-      val machine = build(expr)
+      val machine =
+        Speedy.Machine.buildForScenario(compiledPackages, seed, expr)
       (machine, ScenarioRunner(machine).run())
     }
   }
@@ -419,13 +418,15 @@ object Repl {
           case Some(DValue(_, _, body, _)) =>
             val expr = argExprs.foldLeft(body)((e, arg) => EApp(e, arg))
 
+            val compiledPackages = PureCompiledPackages(state.packages).right.get
             val machine =
-              Speedy.Machine.fromExpr(
-                expr = expr,
-                compiledPackages = PureCompiledPackages(state.packages).right.get,
-                scenario = false,
+              Speedy.Machine(
+                compiledPackages = compiledPackages,
                 submissionTime = Time.Timestamp.now(),
                 initialSeeding = InitialSeeding.NoSeed,
+                expr = SEApp(compiledPackages.compiler.unsafeCompile(expr), Array(SEValue.Token)),
+                globalCids = Set.empty,
+                committers = Set.empty
               )
             val startTime = System.nanoTime()
             val valueOpt = machine.run match {

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -14,7 +14,7 @@ import com.daml.lf.speedy.Pretty._
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.scenario.ScenarioLedger
-import com.daml.lf.speedy.SExpr.{LfDefRef, SEApp, SEValue}
+import com.daml.lf.speedy.SExpr.LfDefRef
 import com.daml.lf.validation.Validation
 import com.daml.lf.testing.parser
 import com.daml.lf.language.LanguageVersion
@@ -419,15 +419,7 @@ object Repl {
             val expr = argExprs.foldLeft(body)((e, arg) => EApp(e, arg))
 
             val compiledPackages = PureCompiledPackages(state.packages).right.get
-            val machine =
-              Speedy.Machine(
-                compiledPackages = compiledPackages,
-                submissionTime = Time.Timestamp.now(),
-                initialSeeding = InitialSeeding.NoSeed,
-                expr = SEApp(compiledPackages.compiler.unsafeCompile(expr), Array(SEValue.Token)),
-                globalCids = Set.empty,
-                committers = Set.empty
-              )
+            val machine = Speedy.Machine.fromExpr(compiledPackages, expr)
             val startTime = System.nanoTime()
             val valueOpt = machine.run match {
               case SResultError(err) =>

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -57,12 +57,13 @@ class CollectAuthorityState {
     // This is the expression which we insert into the machine each time we run()
     the_sexpr = SEApp(compiler.unsafeCompile(expr), Array(SEValue.Token))
 
-    machine = Machine.fromSExpr(
-      sexpr = the_sexpr,
+    machine = Machine(
       compiledPackages = compiledPackages,
       submissionTime = Time.Timestamp.MinValue,
-      seeding = InitialSeeding.TransactionSeed(seeding()),
-      globalCids = Set.empty
+      initialSeeding = InitialSeeding.TransactionSeed(seeding()),
+      expr = the_sexpr,
+      globalCids = Set.empty,
+      committers = Set.empty
     )
 
     // fill the caches!

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -4,7 +4,7 @@
 package com.daml.lf
 package speedy
 
-import com.daml.lf.data.{Ref, Time}
+import com.daml.lf.data.Ref
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast.ScenarioGetParty
 import org.scalatest._
@@ -14,14 +14,14 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
 
   "ScenarioRunner" can {
     "mangle party names correctly" in {
-      val e = Ast.EScenario(ScenarioGetParty(Ast.EPrimLit(Ast.PLText(("foo-bar")))))
-      val m = Speedy.Machine.fromExpr(
-        expr = e,
-        compiledPackages = PureCompiledPackages(Map.empty).right.get,
-        scenario = true,
-        submissionTime = Time.Timestamp.now(),
-        initialSeeding =
-          InitialSeeding.TransactionSeed(crypto.Hash.hashPrivateKey("ScenarioRunnerTest")),
+      val compiledPackages = PureCompiledPackages(Map.empty).right.get
+      val e = compiledPackages.compiler.unsafeCompile(
+        Ast.EScenario(ScenarioGetParty(Ast.EPrimLit(Ast.PLText(("foo-bar")))))
+      )
+      val m = Speedy.Machine.buildForScenario(
+        compiledPackages = compiledPackages,
+        seed = crypto.Hash.hashPrivateKey("ScenarioRunnerTest"),
+        expr = e
       )
       val sr = ScenarioRunner(m, _ + "-XXX")
       sr.run() match {

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -15,14 +15,9 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
   "ScenarioRunner" can {
     "mangle party names correctly" in {
       val compiledPackages = PureCompiledPackages(Map.empty).right.get
-      val e = compiledPackages.compiler.unsafeCompile(
-        Ast.EScenario(ScenarioGetParty(Ast.EPrimLit(Ast.PLText(("foo-bar")))))
-      )
-      val m = Speedy.Machine.buildForScenario(
-        compiledPackages = compiledPackages,
-        seed = crypto.Hash.hashPrivateKey("ScenarioRunnerTest"),
-        expr = e
-      )
+      val e = Ast.EScenario(ScenarioGetParty(Ast.EPrimLit(Ast.PLText(("foo-bar")))))
+      val txSeed = crypto.Hash.hashPrivateKey("ScenarioRunnerTest")
+      val m = Speedy.Machine.buildForScenario(compiledPackages, txSeed, e)
       val sr = ScenarioRunner(m, _ + "-XXX")
       sr.run() match {
         case Right((_, _, _, value)) =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -20,14 +20,13 @@ import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.{InitialSeeding, Pretty, SExpr, SValue, Speedy}
+import com.daml.lf.speedy.{Pretty, SExpr, SValue, Speedy}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.lf.CompiledPackages
 import com.daml.ledger.api.v1.value
-import com.daml.lf.data.Time
 
 // Helper to create identifiers pointing to the DAML.Script module
 case class ScriptIds(val scriptPackageId: PackageId) {
@@ -217,14 +216,7 @@ object Converter {
         Array(SELocA(0), SELocA(1))),
     )
     val machine =
-      Speedy.Machine(
-        compiledPackages = compiledPackages,
-        submissionTime = Time.Timestamp.now(),
-        initialSeeding = InitialSeeding.NoSeed,
-        expr = SEApp(SEValue(fun), Array(extractStruct)),
-        globalCids = Set.empty,
-        committers = Set.empty,
-      )
+      Speedy.Machine.fromExpr(compiledPackages, SEApp(SEValue(fun), Array(extractStruct)))
     machine.run() match {
       case SResultFinalValue(v) =>
         v match {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -217,12 +217,13 @@ object Converter {
         Array(SELocA(0), SELocA(1))),
     )
     val machine =
-      Speedy.Machine.fromSExpr(
-        sexpr = SEApp(SEValue(fun), Array(extractStruct)),
+      Speedy.Machine(
         compiledPackages = compiledPackages,
         submissionTime = Time.Timestamp.now(),
-        seeding = InitialSeeding.NoSeed,
-        Set.empty,
+        initialSeeding = InitialSeeding.NoSeed,
+        expr = SEApp(SEValue(fun), Array(extractStruct)),
+        globalCids = Set.empty,
+        committers = Set.empty,
       )
     machine.run() match {
       case SResultFinalValue(v) =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -26,7 +26,7 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.iface.EnvironmentInterface
 import com.daml.lf.iface.reader.InterfaceReader
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.{Compiler, InitialSeeding, Pretty, SExpr, SValue, Speedy}
+import com.daml.lf.speedy.{Compiler, Pretty, SExpr, SValue, Speedy}
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
@@ -303,15 +303,7 @@ class Runner(
       implicit ec: ExecutionContext,
       mat: Materializer): Future[SValue] = {
     var clients = initialClients
-    val machine =
-      Speedy.Machine(
-        compiledPackages = extendedCompiledPackages,
-        submissionTime = Timestamp.now(),
-        initialSeeding = InitialSeeding.NoSeed,
-        expr = script.expr,
-        globalCids = Set.empty,
-        committers = Set.empty,
-      )
+    val machine = Speedy.Machine.fromExpr(extendedCompiledPackages, script.expr)
 
     def stepToValue(): Either[RuntimeException, SValue] =
       machine.run() match {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -304,12 +304,13 @@ class Runner(
       mat: Materializer): Future[SValue] = {
     var clients = initialClients
     val machine =
-      Speedy.Machine.fromSExpr(
-        sexpr = script.expr,
+      Speedy.Machine(
         compiledPackages = extendedCompiledPackages,
         submissionTime = Timestamp.now(),
-        seeding = InitialSeeding.NoSeed,
-        Set.empty,
+        initialSeeding = InitialSeeding.NoSeed,
+        expr = script.expr,
+        globalCids = Set.empty,
+        committers = Set.empty,
       )
 
     def stepToValue(): Either[RuntimeException, SValue] =


### PR DESCRIPTION
In this PR we make clean-up the constructor for the speedy Machine.
    
* We remove the `case`  keyword since `Machine` is a stateful class,
* We replace the pre-existing builders with
      + one generic builder `Machine.apply`,
      + simple scenario specific builder,
      + simple non-scenario specific builder,
    

CHANGELOG_BEGIN
CHANGELOG_END


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
