### PR TITLE
Add listKnownParties to DAML Script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -9,10 +9,13 @@ module Daml.Script
   , query
   , PartyIdHint (..)
   , ParticipantName (..)
+  , PartyDetails(..)
   , allocateParty
   , allocatePartyWithHint
   , allocatePartyOn
   , allocatePartyWithHintOn
+  , listKnownParties
+  , listKnownPartiesOn
   , Commands
   , createCmd
   , exerciseCmd
@@ -78,6 +81,7 @@ data ScriptF a
   = Submit (SubmitCmd a)
   | Query (QueryACS a)
   | AllocParty (AllocateParty a)
+  | ListKnownParties (ListKnownPartiesPayload a)
   | GetTime (Time -> a)
   | Sleep (SleepRec a)
   deriving Functor
@@ -98,6 +102,11 @@ data AllocateParty a = AllocateParty
   , idHint : Text
   , participant : Optional Text
   , continue : Party -> a
+  } deriving Functor
+
+data ListKnownPartiesPayload a = ListKnownPartiesPayload
+  { participant : Optional Text
+  , continue : [PartyDetails] -> a
   } deriving Functor
 
 data SleepRec a = SleepRec
@@ -150,6 +159,30 @@ allocatePartyWithHintOn displayName (PartyIdHint idHint) (ParticipantName partic
   , participant = Some participant
   , continue = pure
   }
+
+-- | List the parties known to the default participant.
+listKnownParties : Script [PartyDetails]
+listKnownParties =
+  lift $ Free $ ListKnownParties $ ListKnownPartiesPayload
+    { participant = None
+    , continue = pure
+    }
+
+-- | List the parties known to the given participant.
+listKnownPartiesOn : ParticipantName -> Script [PartyDetails]
+listKnownPartiesOn (ParticipantName participant) =
+  lift $ Free $ ListKnownParties $ ListKnownPartiesPayload
+    { participant = Some participant
+    , continue = pure
+    }
+
+-- | The party details returned by the party management service.
+data PartyDetails = PartyDetails
+  with
+    party : Party -- ^ Party id
+    displayName : Optional Text -- ^ Optional display name
+    isLocal : Bool -- ^ True if party is hosted by the backing participant.
+  deriving (Eq, Ord, Show)
 
 -- | In wallclock mode, this is UTC time. In static time mode, this is the UNIX epoch.
 instance HasTime Script where

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -26,6 +26,7 @@ import com.daml.lf.speedy.SValue._
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.lf.CompiledPackages
+import com.daml.ledger.api.domain.PartyDetails
 import com.daml.ledger.api.v1.value
 import com.daml.lf.data.Time
 
@@ -423,6 +424,16 @@ object Converter {
         scriptIds.damlScript("SubmitFailure"),
         ("status", SInt64(status.getCode.value.asInstanceOf[Long])),
         ("description", SText(status.getDescription))
+      ))
+  }
+
+  def fromPartyDetails(scriptIds: ScriptIds, details: PartyDetails): Either[String, SValue] = {
+    Right(
+      record(
+        scriptIds.damlScript("PartyDetails"),
+        ("party", SParty(details.party)),
+        ("displayName", SOptional(details.displayName.map(SText))),
+        ("isLocal", SBool(details.isLocal))
       ))
   }
 

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -37,10 +37,12 @@ if [[ $TEST_RESULT = 0 ]]; then
 fi
 
 EXPECTED="$($SORT <<'EOF'
+MultiTest:listKnownPartiesTest SUCCESS
 MultiTest:multiTest SUCCESS
 MultiTest:partyIdHintTest SUCCESS
 ScriptExample:test SUCCESS
 ScriptTest:failingTest FAILURE (com.daml.lf.speedy.SError$DamlEUserError)
+ScriptTest:listKnownPartiesTest SUCCESS
 ScriptTest:test0 SUCCESS
 ScriptTest:test1 SUCCESS
 ScriptTest:test3 SUCCESS

--- a/daml-script/test/daml/MultiTest.daml
+++ b/daml-script/test/daml/MultiTest.daml
@@ -5,6 +5,7 @@
 
 module MultiTest where
 
+import DA.List
 import Daml.Script
 
 template T
@@ -39,3 +40,13 @@ partyIdHintTest = do
   alice <- allocatePartyWithHintOn "alice" (PartyIdHint "alice") (ParticipantName "one")
   bob <- allocatePartyWithHintOn "bob" (PartyIdHint "bob") (ParticipantName "two")
   pure (alice, bob)
+
+listKnownPartiesTest : Script ([PartyDetails], [PartyDetails])
+listKnownPartiesTest = do
+  parties1 <- listKnownPartiesOn (ParticipantName "one")
+  parties2 <- listKnownPartiesOn (ParticipantName "two")
+  p1 <- allocatePartyOn "p1" (ParticipantName "one")
+  p2 <- allocatePartyOn "p2" (ParticipantName "two")
+  parties1' <- listKnownPartiesOn (ParticipantName "one")
+  parties2' <- listKnownPartiesOn (ParticipantName "two")
+  pure (parties1' \\ parties1, parties2' \\ parties2)

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -8,6 +8,7 @@ module ScriptTest where
 import DA.Action
 import DA.Assert
 import DA.Foldable hiding (length)
+import DA.List
 import DA.Time
 import Daml.Script
 
@@ -170,6 +171,15 @@ partyIdHintTest = do
   carol <- allocatePartyWithHint "carol" (PartyIdHint "carol")
   dan <- allocatePartyWithHint "dan" (PartyIdHint "dan")
   pure (carol, dan)
+
+listKnownPartiesTest : Script ([PartyDetails], Party)
+listKnownPartiesTest = do
+  before <- listKnownParties
+  p <- allocateParty "myparty"
+  after <- listKnownParties
+  let new = after \\ before
+  new === [PartyDetails p (Some "myparty") True]
+  pure (new, p)
 
 auth : (Party, Party) -> Script ()
 auth (alice, bob) = do


### PR DESCRIPTION
This is particularly useful if you want easy access to a party that
has already been allocated since partyFromText is bad.

For now this is not supported in the JSON API. It should be possible
to add it but I consider it fairly low priority so omitting for now.

changelog_begin

- [DAML Script] Add ``listKnownParties`` and ``listKnownPartiesOn`` to
  query the corresponding ListKnownParties endpoint in the party
  management service.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
