### PR TITLE
use Profile.Label newtype for typechecked union instead of AnyRef

### DIFF
--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -12,7 +12,7 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repl")
 da_scala_library(
     name = "interpreter",
     srcs = glob(["src/main/**/*.scala"]),
-    scalacopts = lf_scalacopts,
+    scalacopts = lf_scalacopts + ["-Xsource:2.13"],
     tags = ["maven_coordinates=com.daml:daml-lf-interpreter:__VERSION__"],
     visibility = [
         "//compiler/repl-service:__subpackages__",

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -147,7 +147,7 @@ private[lf] final case class Compiler(
   /** Environment mapping names into stack positions */
   private var env = Env()
 
-  private val withLabel: (AnyRef, SExpr) => SExpr =
+  private val withLabel: (Profile.Label, SExpr) => SExpr =
     profiling match {
       case NoProfile => { (_, expr) =>
         expr
@@ -160,7 +160,9 @@ private[lf] final case class Compiler(
       }
     }
 
-  private def withOptLabel(optLabel: Option[AnyRef], expr: SExpr): SExpr =
+  private def withOptLabel[L: Profile.LabelModule.Allowed](
+      optLabel: Option[L with AnyRef],
+      expr: SExpr): SExpr =
     optLabel match {
       case Some(label) => withLabel(label, expr)
       case None => expr

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -266,13 +266,13 @@ private[lf] final case class Compiler(
         bf match {
           case BFoldl =>
             val ref = SEBuiltinRecursiveDefinition.FoldL
-            withLabel(ref, ref)
+            withLabel(ref.ref, ref)
           case BFoldr =>
             val ref = SEBuiltinRecursiveDefinition.FoldR
-            withLabel(ref, ref)
+            withLabel(ref.ref, ref)
           case BEqualList =>
             val ref = SEBuiltinRecursiveDefinition.EqualList
-            withLabel(ref, ref)
+            withLabel(ref.ref, ref)
           case BCoerceContractId => SEAbs.identity
           // Numeric Comparisons
           case BLessNumeric => SBLessNumeric

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -168,7 +168,7 @@ object Profile {
   }
 
   type Label = LabelModule.Module.T
-  val LabelUnset: Label = LabelModule.Unset
+  val LabelUnset: Label = LabelModule.Module(null)
 
   /** We avoid any conversions into a common label format at runtime
     * since this might skew the profile. Instead, we convert the labels to strings
@@ -176,7 +176,7 @@ object Profile {
     */
   sealed abstract class LabelModule {
     type T <: AnyRef
-    private[LabelModule] def apply(t: AnyRef): T
+    private[Profile] def apply(t: AnyRef): T
   }
 
   object LabelModule {
@@ -184,10 +184,8 @@ object Profile {
     // [[AnyRef]] for the labels.
     val Module: LabelModule = new LabelModule {
       type T = AnyRef
-      override private[LabelModule] def apply(t: T) = t
+      override def apply(t: AnyRef) = t
     }
-
-    private[Profile] def Unset: Label = Module(null)
 
     import scala.language.implicitConversions, annotation.implicitNotFound
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -35,7 +35,7 @@ final class Profile {
 
 object Profile {
   private[lf] final case class Event(val open: Boolean, val rawLabel: Label, val time: Long) {
-    def label: String = LabelModule.Allowed renderLabel rawLabel
+    def label: String = LabelModule.Allowed.renderLabel(rawLabel)
   }
 
   private def unmangleLenient(str: String): String = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -187,13 +187,12 @@ object Profile {
       override def apply(t: AnyRef) = t
     }
 
-    import scala.language.implicitConversions, annotation.implicitNotFound
+    import scala.language.implicitConversions
 
     // assumes -Xsource:2.13 in clients, which we should just do always,
     // this is in scope wherever the expected type is `Label`
     implicit def fromAllowed[T: Allowed](t: T with AnyRef): Label = Module(t)
 
-    @implicitNotFound(msg = "Values of type ${T} are not known, renderable Labels")
     final class Allowed[-T] private ()
     object Allowed {
       import com.daml.lf.speedy.SExpr._

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -9,10 +9,7 @@ import java.lang.System
 import java.nio.file.{Files, Path}
 import java.util.ArrayList
 
-/** Class for profiling information collected by Speedy. We use [[AnyRef]] for
-  * the labels to avoid any conversions into a common label format at runtime
-  * since this might skew the profile. Instead, we convert the labels to strings
-  * when we write out the profile.
+/** Class for profiling information collected by Speedy.
   */
 final class Profile {
   import Profile._
@@ -20,12 +17,12 @@ final class Profile {
   private[lf] val events: ArrayList[Event] = new ArrayList()
   var name: String = "DAML Engine profile"
 
-  def addOpenEvent(label: AnyRef) = {
+  def addOpenEvent(label: Label) = {
     val time = System.nanoTime()
     events.add(Event(true, label, time))
   }
 
-  def addCloseEvent(label: AnyRef) = {
+  def addCloseEvent(label: Label) = {
     val time = System.nanoTime()
     events.add(Event(false, label, time))
   }
@@ -37,21 +34,8 @@ final class Profile {
 }
 
 object Profile {
-  // NOTE(MH): See the documenation of [[Profile]] above for why we use
-  // [[AnyRef]] for the labels.
-  private[lf] final case class Event(val open: Boolean, val rawLabel: AnyRef, val time: Long) {
-    def label: String = {
-      import com.daml.lf.speedy.SExpr._
-      rawLabel match {
-        case null => "<null>" // NOTE(MH): We should never see this but it's no problem if we do.
-        case AnonymousClosure => "<lambda>"
-        case LfDefRef(ref) => ref.qualifiedName.toString()
-        case ChoiceDefRef(tmplRef, name) => s"exercise @${tmplRef.qualifiedName} ${name}"
-        case ref: SEBuiltinRecursiveDefinition.Reference => ref.toString().toLowerCase()
-        case str: String => str
-        case any => s"<unknown ${any}>"
-      }
-    }
+  private[lf] final case class Event(val open: Boolean, val rawLabel: Label, val time: Long) {
+    def label: String = LabelModule.Allowed renderLabel rawLabel
   }
 
   private def unmangleLenient(str: String): String = {
@@ -180,6 +164,60 @@ object Profile {
           name = profile.name,
         )
       }
+    }
+  }
+
+  type Label = LabelModule.Module.T
+  val LabelUnset: Label = LabelModule.Unset
+
+  /** We avoid any conversions into a common label format at runtime
+    * since this might skew the profile. Instead, we convert the labels to strings
+    * when we write out the profile.
+    */
+  sealed abstract class LabelModule {
+    type T <: AnyRef
+    private[LabelModule] def apply(t: AnyRef): T
+  }
+
+  object LabelModule {
+    // NOTE(MH): See the documentation of [[LabelModule]] above for why we use
+    // [[AnyRef]] for the labels.
+    val Module: LabelModule = new LabelModule {
+      type T = AnyRef
+      override private[LabelModule] def apply(t: T) = t
+    }
+
+    private[Profile] def Unset: Label = Module(null)
+
+    import scala.language.implicitConversions, annotation.implicitNotFound
+
+    // assumes -Xsource:2.13 in clients, which we should just do always,
+    // this is in scope wherever the expected type is `Label`
+    implicit def fromAllowed[T: Allowed](t: T with AnyRef): Label = Module(t)
+
+    @implicitNotFound(msg = "Values of type ${T} are not known, renderable Labels")
+    final class Allowed[-T] private ()
+    object Allowed {
+      import com.daml.lf.speedy.SExpr._
+      private[this] val allowAll = new Allowed[Any]
+      implicit val anonClosure: Allowed[AnonymousClosure.type] = allowAll
+      implicit val lfDefRef: Allowed[LfDefRef] = allowAll
+      implicit val choiceDefRef: Allowed[ChoiceDefRef] = allowAll
+      implicit val sebrdr: Allowed[SEBuiltinRecursiveDefinition.Reference] = allowAll
+      implicit val str: Allowed[String] = allowAll
+
+      // below cases must cover above set
+
+      private[Profile] def renderLabel(rawLabel: Label): String =
+        (rawLabel: AnyRef) match {
+          case null => "<null>" // NOTE(MH): We should never see this but it's no problem if we do.
+          case AnonymousClosure => "<lambda>"
+          case LfDefRef(ref) => ref.qualifiedName.toString()
+          case ChoiceDefRef(tmplRef, name) => s"exercise @${tmplRef.qualifiedName} ${name}"
+          case ref: SEBuiltinRecursiveDefinition.Reference => ref.toString().toLowerCase()
+          case str: String => str
+          case any => s"<unknown ${any}>"
+        }
     }
   }
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -210,7 +210,8 @@ object SExpr {
         sValues(i) = fvs(i).lookup(machine)
         i += 1
       }
-      machine.returnValue = SPAP(PClosure(null, body, sValues), new util.ArrayList[SValue](), arity)
+      machine.returnValue =
+        SPAP(PClosure(Profile.LabelUnset, body, sValues), new util.ArrayList[SValue](), arity)
     }
   }
 
@@ -351,7 +352,7 @@ object SExpr {
     * See [[com.daml.lf.speedy.Profile]] for an explanation why we use
     * [[AnyRef]] for the label.
     */
-  final case class SELabelClosure(label: AnyRef, expr: SExpr) extends SExpr {
+  final case class SELabelClosure(label: Profile.Label, expr: SExpr) extends SExpr {
     def execute(machine: Machine): Unit = {
       machine.pushKont(KLabelClosure(label))
       machine.ctrl = expr

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -122,10 +122,8 @@ object SValue {
     * During profiling, whenever a closure whose [[label]] has been set is
     * entered, we write an "open event" with the label and when the closure is
     * left, we write a "close event" with the same label.
-    * See [[com.daml.lf.speedy.Profile]] for an explanation why we use
-    * [[AnyRef]] for the label.
     */
-  final case class PClosure(label: AnyRef, expr: SExpr, frame: Array[SValue])
+  final case class PClosure(label: Profile.Label, expr: SExpr, frame: Array[SValue])
       extends Prim
       with SomeArrayEquals {
     override def toString: String = s"PClosure($expr, ${frame.mkString("[", ",", "]")})"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -911,7 +911,7 @@ object Speedy {
     * used during profiling. Its purpose is to attach a label to closures such
     * that entering the closure can write an "open event" with that label.
     */
-  final case class KLabelClosure(label: AnyRef) extends Kont {
+  final case class KLabelClosure(label: Profile.Label) extends Kont {
     def execute(v: SValue, machine: Machine) = {
       v match {
         case SPAP(PClosure(_, expr, closure), args, arity) =>
@@ -925,7 +925,7 @@ object Speedy {
   /** Continuation marking the exit of a closure. This is only used during
     * profiling.
     */
-  final case class KLeaveClosure(label: AnyRef) extends Kont {
+  final case class KLeaveClosure(label: Profile.Label) extends Kont {
     def execute(v: SValue, machine: Machine) = {
       machine.profile.addCloseEvent(label)
       machine.returnValue = v

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
@@ -7,6 +7,7 @@ import java.util
 
 import com.daml.lf.data.{FrontStack, Numeric, Ref, Time}
 import com.daml.lf.language.{Ast, Util => AstUtil}
+import com.daml.lf.speedy.Profile.LabelUnset
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.{SBuiltin, SExpr, SValue}
 import com.daml.lf.value.Value.ContractId
@@ -173,7 +174,7 @@ class EqualitySpec extends WordSpec with Matchers with TableDrivenPropertyChecks
 
   private val funs = List(
     lfFunction,
-    SPAP(PClosure(null, SExpr.SEVar(2), Array()), ArrayList(SValue.SValue.Unit), 2),
+    SPAP(PClosure(LabelUnset, SExpr.SEVar(2), Array()), ArrayList(SValue.SValue.Unit), 2),
   )
 
   private def nonEquatableLists(atLeast2InEquatableValues: List[SValue]) = {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -351,7 +351,7 @@ class OrderingSpec
 
   private val funs = List(
     lfFunction,
-    SPAP(PClosure(null, SExpr.SEVar(2), Array()), ArrayList(SValue.SValue.Unit), 2),
+    SPAP(PClosure(Profile.LabelUnset, SExpr.SEVar(2), Array()), ArrayList(SValue.SValue.Unit), 2),
   )
 
   private def nonEquatableLists(atLeast2InEquatableValues: List[SValue]) = {


### PR DESCRIPTION
Follow-up to https://github.com/digital-asset/daml/pull/5957#discussion_r426030726. Demonstrating its efficacy is the compiler error (×3) in 7575aece13745ffbae12d3e10bd91a8704821955 :

```scala
daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala:267: error: type mismatch;
 found   : com.daml.lf.speedy.SExpr.SEBuiltinRecursiveDefinition
 required: com.daml.lf.speedy.Profile.Label
    (which expands to)  com.daml.lf.speedy.Profile.LabelModule.Module.T
            withLabel(ref, ref)
                      ^
```

What was likely intended was to write `ref.ref` here; that is the assumption the `Event#label` rendering function makes, anyway.  Now, we type-check that the labelling matches the renderer.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
