### PR TITLE
Fix vscode extension

### DIFF
--- a/compiler/daml-extension/package.json
+++ b/compiler/daml-extension/package.json
@@ -7,7 +7,7 @@
     "repository": "https://github.com/digital-asset/daml/tree/master/compiler/daml-extension",
     "icon": "images/daml-studio.png",
     "engines": {
-        "vscode": "^1.38.0"
+        "vscode": "^1.39.0"
     },
     "license": "Apache-2.0",
     "private": true,
@@ -142,14 +142,14 @@
         "fp-ts": "^2.1.1",
         "node-fetch": "^2.6.0",
         "tmp": "0.0.29",
-        "vscode-languageclient": "6.0.0-next.1",
+        "vscode-languageclient": "^6.1.3",
         "which": "1.3.1",
         "xml2js": "^0.4.22"
     },
     "devDependencies": {
         "@bazel/hide-bazel-files": "1.6.0",
         "@types/node": "12.7.11",
-        "@types/vscode": "1.38",
+        "@types/vscode": "1.39",
         "typescript": "3.6.3",
         "vsce": "1.66.0"
     }

--- a/compiler/daml-extension/yarn.lock
+++ b/compiler/daml-extension/yarn.lock
@@ -30,10 +30,10 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.29.tgz#3f188a758327375766babca50fee224aff09a13f"
   integrity sha1-PxiKdYMnN1dmurylD+4iSv8JoT8=
 
-"@types/vscode@1.38":
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.38.0.tgz#1e53953406ef662354e2e62451c3c71c9ff19a6d"
-  integrity sha512-aGo8LQ4J1YF0T9ORuCO+bhQ5sGR1MXa7VOyOdEP685se3wyQWYUExcdiDi6rvaK61KUwfzzA19JRLDrUbDl7BQ==
+"@types/vscode@1.39":
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.39.0.tgz#46c257df4833ff4c1e6806f0406a873fb79672dd"
+  integrity sha512-rlg0okXDt7NjAyHXbZ2nO1I/VY/8y9w67ltLRrOxXQ46ayvrYZavD4A6zpYrGbs2+ZOEQzcUs+QZOqcVGQIxXQ==
 
 "@types/which@1.3.1":
   version "1.3.1"
@@ -570,15 +570,15 @@ vscode-jsonrpc@^5.0.1:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
 
-vscode-languageclient@6.0.0-next.1:
-  version "6.0.0-next.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-6.0.0-next.1.tgz#deca1743afd20da092e04e40ef73cedbbd978455"
-  integrity sha512-eJ9VjLFNINArgRzLbQ11YlWry7dM93GEODkQBXTRfrSypksiO9qSGr4SHhWgxxP26p4FRSpzc/17+N+Egnnchg==
+vscode-languageclient@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-6.1.3.tgz#c979c5bb5855714a0307e998c18ca827c1b3953a"
+  integrity sha512-YciJxk08iU5LmWu7j5dUt9/1OLjokKET6rME3cI4BRpiF6HZlusm2ZwPt0MYJ0lV5y43sZsQHhyon2xBg4ZJVA==
   dependencies:
     semver "^6.3.0"
-    vscode-languageserver-protocol "^3.15.0-next.9"
+    vscode-languageserver-protocol "^3.15.3"
 
-vscode-languageserver-protocol@^3.15.0-next.9:
+vscode-languageserver-protocol@^3.15.3:
   version "3.15.3"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
   integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==


### PR DESCRIPTION
The upgrade to various nodejs libraries in
https://github.com/digital-asset/daml/commit/b03cf7b59896277e64bab88c58b5a083cd5aa6ae
seems to have gotten in an inconsistent state (what even are version
boundaries). This PR updates vscode-languageclient to the latest
version which fixes the issue. Apparently that requires a newer
version of @types/vsode as well (even 6.0.x requires that) so I had to
bump that and the engine. This does mean that we now require vscode
1.39.0. Given that this version was released in September 2019 that
seems very reasonable.

changelog_begin

- [DAML Studio] DAML Studio now requires VSCode 1.39 or newer.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
