### PR TITLE
Support external anchors

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -79,6 +79,7 @@ package_app(
     name = "damlc-dist",
     binary = ":damlc",
     resources = [
+        ":daml-base-anchors.json",
         ":ghc-pkg-dist",
         "//compiler/damlc/daml-ide-core:dlint.yaml",
         "//compiler/damlc/pkg-db",

--- a/compiler/damlc/daml-doc/BUILD.bazel
+++ b/compiler/damlc/daml-doc/BUILD.bazel
@@ -59,6 +59,7 @@ da_haskell_library(
         "aeson-pretty",
         "base",
         "bytestring",
+        "containers",
         "directory",
         "extra",
         "filepath",

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render.hs
@@ -53,6 +53,7 @@ renderDocs ro@RenderOptions{..} mods = do
                 Html -> (renderMd, GFM.commonmarkToHtml [GFM.optUnsafe] [GFM.extTable])
         templateText = fromMaybe (defaultTemplate ro_format) ro_template
         renderMap = Map.fromList [(md_name mod, renderModule mod) | mod <- mods]
+        externalAnchors = ro_externalAnchors
 
     template <- compileTemplate "template" templateText
 
@@ -62,12 +63,12 @@ renderDocs ro@RenderOptions{..} mods = do
                 . T.encodeUtf8
                 . renderTemplate ro template
                 . postProcessing
-                . renderPage formatter
+                . renderPage formatter externalAnchors
                 $ fold renderMap
 
         RenderToFolder path -> do
             let
-                (outputIndex, outputMap) = renderFolder formatter renderMap
+                (outputIndex, outputMap) = renderFolder formatter externalAnchors renderMap
                 extension =
                     case ro_format of
                         Markdown -> "md"

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Monoid.hs
@@ -76,6 +76,8 @@ data RenderEnv = RenderEnv
         -- ^ anchors defined in the same file
     , re_globalAnchors :: Map.Map Anchor FilePath
         -- ^ anchors defined in the same folder
+    , re_externalAnchors :: Map.Map Anchor String
+        -- ^ anchors defined externally
     }
 
 -- | Location of an anchor relative to the output being rendered. An anchor
@@ -96,8 +98,7 @@ anchorHyperlink anchorLoc (Anchor anchor) =
     case anchorLoc of
         SameFile -> "#" <> anchor
         SameFolder fileName -> T.concat [T.pack fileName, "#", anchor]
-        External uri -> T.pack . show $
-            uri { URI.uriFragment = "#" <> T.unpack anchor }
+        External uri -> T.pack . show $ uri
 
 -- | Find the location of an anchor by reference, if possible.
 lookupReference ::
@@ -107,21 +108,8 @@ lookupReference ::
 lookupReference RenderEnv{..} ref = asum
     [ SameFile <$ guard (Set.member (referenceAnchor ref) re_localAnchors)
     , SameFolder <$> Map.lookup (referenceAnchor ref) re_globalAnchors
-    , External <$> (packageURI =<< referencePackage ref)
+    , External <$> (URI.parseURI =<< Map.lookup (referenceAnchor ref) re_externalAnchors)
     ]
-
--- | Map package names to URLs. In the future this should be configurable
--- but for now we are hardcoding the standard library packages which are
--- documented on docs.daml.com
-packageURI :: Packagename -> Maybe URI.URI
-packageURI (Packagename "daml-prim") = Just damlBaseURI
-packageURI (Packagename "daml-stdlib") = Just damlBaseURI
-packageURI _ = Nothing
-
-damlBaseURI :: URI.URI
-damlBaseURI = fromJust $ URI.parseURI "https://docs.daml.com/daml/stdlib/index.html"
-    -- TODO (sofia): Make this configurable, and don't include index.html,
-    -- need a way to supply (or recreate) anchor list.
 
 type RenderFormatter = RenderEnv -> RenderOut -> [T.Text]
 
@@ -138,23 +126,26 @@ getRenderAnchors = \case
     RenderDocs _ -> Set.empty
     RenderIndex _ -> Set.empty
 
-renderPage :: RenderFormatter -> RenderOut -> T.Text
-renderPage formatter output =
+renderPage :: RenderFormatter -> Map.Map Anchor String -> RenderOut -> T.Text
+renderPage formatter externalAnchors output =
     T.unlines (formatter renderEnv output)
-  where
-    renderEnv = RenderEnv
-        { re_separateModules = False
-        , re_localAnchors = getRenderAnchors output
-        , re_globalAnchors = Map.empty
-        }
+    where
+        renderEnv = RenderEnv
+          { re_separateModules = False
+          , re_localAnchors = getRenderAnchors output
+          , re_globalAnchors = Map.empty
+          , re_externalAnchors = externalAnchors
+          }
 
 -- | Render a folder of modules.
 renderFolder ::
     RenderFormatter
+    -> Map.Map Anchor String
     -> Map.Map Modulename RenderOut
     -> (T.Text, Map.Map Modulename T.Text)
-renderFolder formatter fileMap =
+renderFolder formatter externalAnchors fileMap =
     let moduleAnchors = Map.map getRenderAnchors fileMap
+        re_externalAnchors = externalAnchors
         re_separateModules = True
         re_globalAnchors = Map.fromList
             [ (anchor, moduleNameToFileName moduleName <.> "html")

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Types.hs
@@ -6,9 +6,8 @@ module DA.Daml.Doc.Render.Types
     ( module DA.Daml.Doc.Render.Types
     ) where
 
-import DA.Daml.Doc.Types -- for Anchor
+import DA.Daml.Doc.Types -- for Anchor, AnchorMap
 import qualified Data.Text as T
-import qualified Data.Map.Strict as Map
 
 data RenderFormat = Rst | Markdown | Html
     deriving (Eq, Show, Read, Enum, Bounded)
@@ -30,5 +29,5 @@ data RenderOptions = RenderOptions
     , ro_baseURL :: Maybe T.Text -- ^ base URL for generated documentation
     , ro_hooglePath :: Maybe FilePath -- ^ path to output hoogle database
     , ro_anchorPath :: Maybe FilePath -- ^ path to output anchor table
-    , ro_externalAnchors :: Map.Map Anchor String -- ^ external input anchor table
+    , ro_externalAnchors :: AnchorMap -- ^ external input anchor table
     }

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Render/Types.hs
@@ -6,7 +6,9 @@ module DA.Daml.Doc.Render.Types
     ( module DA.Daml.Doc.Render.Types
     ) where
 
+import DA.Daml.Doc.Types -- for Anchor
 import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
 
 data RenderFormat = Rst | Markdown | Html
     deriving (Eq, Show, Read, Enum, Bounded)
@@ -28,4 +30,5 @@ data RenderOptions = RenderOptions
     , ro_baseURL :: Maybe T.Text -- ^ base URL for generated documentation
     , ro_hooglePath :: Maybe FilePath -- ^ path to output hoogle database
     , ro_anchorPath :: Maybe FilePath -- ^ path to output anchor table
+    , ro_externalAnchors :: Map.Map Anchor String -- ^ external input anchor table
     }

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -13,6 +13,7 @@ import qualified Data.Text as T
 import Data.Hashable
 import GHC.Generics
 import Data.String
+import qualified Data.HashMap.Strict as HMS
 
 -- | Doc text type, presumably Markdown format.
 newtype DocText = DocText { unDocText :: Text }
@@ -81,6 +82,10 @@ data Reference = Reference
 -- | Anchors are URL-safe (and RST-safe!) ids into the docs.
 newtype Anchor = Anchor { unAnchor :: Text }
     deriving newtype (Eq, Ord, Show, ToJSON, ToJSONKey, FromJSON, FromJSONKey, IsString, Hashable)
+
+-- | A database of anchors to URL strings.
+newtype AnchorMap = AnchorMap { unAnchorMap :: HMS.HashMap Anchor String }
+    deriving newtype (Eq, Ord, Show, FromJSON)
 
 ------------------------------------------------------------
 -- | Documentation data for a module

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Types.hs
@@ -80,7 +80,7 @@ data Reference = Reference
 
 -- | Anchors are URL-safe (and RST-safe!) ids into the docs.
 newtype Anchor = Anchor { unAnchor :: Text }
-    deriving newtype (Eq, Ord, Show, ToJSON, ToJSONKey, FromJSON, IsString, Hashable)
+    deriving newtype (Eq, Ord, Show, ToJSON, ToJSONKey, FromJSON, FromJSONKey, IsString, Hashable)
 
 ------------------------------------------------------------
 -- | Documentation data for a module

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
@@ -11,13 +11,12 @@ import           DA.Daml.Doc.Render
 import           Control.Monad.Except
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-import qualified Data.Map.Strict as Map
 
 import qualified Test.Tasty.Extended as Tasty
 import           Test.Tasty.HUnit
 
 
-mkTestTree :: Map.Map Anchor String -> IO Tasty.TestTree
+mkTestTree :: AnchorMap -> IO Tasty.TestTree
 mkTestTree externalAnchors = do
   pure $ Tasty.testGroup "DA.Daml.Doc.Render"
     [ Tasty.testGroup "RST Rendering" $
@@ -299,7 +298,7 @@ mkExpectMD anchor name descr templates classes adts fcts
       , ""]
   ]
 
-renderTest :: RenderFormat -> Map.Map Anchor String -> (String, ModuleDoc) -> T.Text -> Tasty.TestTree
+renderTest :: RenderFormat -> AnchorMap -> (String, ModuleDoc) -> T.Text -> Tasty.TestTree
 renderTest format externalAnchors (name, input) expected =
   testCase name $ do
   let

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Render/Tests.hs
@@ -11,19 +11,19 @@ import           DA.Daml.Doc.Render
 import           Control.Monad.Except
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import qualified Data.Map.Strict as Map
 
 import qualified Test.Tasty.Extended as Tasty
 import           Test.Tasty.HUnit
 
 
-
-mkTestTree :: IO Tasty.TestTree
-mkTestTree = do
+mkTestTree :: Map.Map Anchor String -> IO Tasty.TestTree
+mkTestTree externalAnchors = do
   pure $ Tasty.testGroup "DA.Daml.Doc.Render"
     [ Tasty.testGroup "RST Rendering" $
-      zipWith (renderTest Rst) cases expectRst
+      zipWith (renderTest Rst externalAnchors) cases expectRst
     , Tasty.testGroup "Markdown Rendering" $
-      zipWith (renderTest Markdown) cases expectMarkdown
+      zipWith (renderTest Markdown externalAnchors) cases expectMarkdown
     ]
 
 
@@ -299,13 +299,13 @@ mkExpectMD anchor name descr templates classes adts fcts
       , ""]
   ]
 
-renderTest :: RenderFormat -> (String, ModuleDoc) -> T.Text -> Tasty.TestTree
-renderTest format (name, input) expected =
+renderTest :: RenderFormat -> Map.Map Anchor String -> (String, ModuleDoc) -> T.Text -> Tasty.TestTree
+renderTest format externalAnchors (name, input) expected =
   testCase name $ do
   let
     renderer = case format of
-                 Rst -> renderPage renderRst . renderModule
-                 Markdown -> renderPage renderMd . renderModule
+                 Rst -> renderPage renderRst externalAnchors . renderModule
+                 Markdown -> renderPage renderMd externalAnchors . renderModule
                  Html -> error "HTML testing not supported (use Markdown)"
     output = T.strip $ renderer input
     expect = T.strip expected

--- a/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
+++ b/compiler/damlc/daml-doc/test/DA/Daml/Doc/Tests.hs
@@ -6,8 +6,8 @@
 module DA.Daml.Doc.Tests(mkTestTree)
   where
 
-import           DA.Bazel.Runfiles
-import           DA.Daml.Options.Types
+import DA.Bazel.Runfiles
+import DA.Daml.Options.Types
 
 import DA.Daml.Doc.Extract
 import DA.Daml.Doc.Render
@@ -28,7 +28,6 @@ import qualified Data.Text.IO as T
 import qualified Data.Text.Extended as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
-import qualified Data.Map.Strict as Map
 import           System.Directory
 import           System.FilePath
 import           System.IO.Extra
@@ -37,7 +36,7 @@ import           Test.Tasty.Golden
 import           Test.Tasty.HUnit
 import Data.Maybe
 
-mkTestTree :: Map.Map Anchor String -> IO Tasty.TestTree
+mkTestTree :: AnchorMap -> IO Tasty.TestTree
 mkTestTree externalAnchors = do
 
   testDir <- locateRunfiles $ mainWorkspace </> "compiler/damlc/tests/daml-test-files"
@@ -286,7 +285,7 @@ runDamldoc testfile importPathM = do
 -- | For the given file <name>.daml (assumed), this test checks if any
 -- <name>.EXPECTED.<suffix> exists, and produces output according to <suffix>
 -- for all files found.
-fileTest :: Map.Map Anchor FilePath -> FilePath -> IO [Tasty.TestTree]
+fileTest :: AnchorMap -> FilePath -> IO [Tasty.TestTree]
 fileTest externalAnchors damlFile = do
 
   damlFileAbs <- makeAbsolute damlFile

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -46,6 +46,7 @@ documentation numProcessors = Damldoc
     <*> optBaseURL
     <*> optHooglePath
     <*> optAnchorPath
+    <*> optExternalAnchorPath
     <*> argMainFiles
   where
     optInputFormat :: Parser InputFormat
@@ -91,6 +92,13 @@ documentation numProcessors = Damldoc
             $ metavar "PATH"
             <> help "Path to output anchor table."
             <> long "output-anchor"
+
+    optExternalAnchorPath :: Parser (Maybe FilePath)
+    optExternalAnchorPath =
+        optional . option str
+            $ metavar "PATH"
+            <> help "Path to input anchor table (for external anchors)."
+            <> long "input-anchor"
 
     optTemplate :: Parser (Maybe FilePath)
     optTemplate =
@@ -243,6 +251,7 @@ data CmdArgs = Damldoc
     , cBaseURL :: Maybe T.Text
     , cHooglePath :: Maybe FilePath
     , cAnchorPath :: Maybe FilePath
+    , cExternalAnchorPath :: Maybe FilePath
     , cMainFiles :: [FilePath]
     } deriving (Show)
 
@@ -270,6 +279,7 @@ exec Damldoc{..} = do
         , do_baseURL = cBaseURL
         , do_hooglePath = cHooglePath
         , do_anchorPath = cAnchorPath
+        , do_externalAnchorPath = cExternalAnchorPath
         }
 
   where

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -119,11 +119,14 @@ da_haskell_test(
     srcs = ["src/DA/Test/DamlDoc.hs"],
     data = [
         ":daml-test-files",
+        "//compiler/damlc:daml-base-anchors.json",
         "//compiler/damlc/pkg-db",
         "//compiler/damlc/stable-packages",
     ],
     hackage_deps = [
         "base",
+        "containers",
+        "filepath",
         "tasty-hunit",
         "text",
     ],
@@ -132,7 +135,9 @@ da_haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/damlc:damlc-lib",
+        "//compiler/damlc/daml-doc",
         "//compiler/damlc/daml-doc:daml-doc-testing",
+        "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.md
@@ -13,4 +13,4 @@ not present in the class itself.
 > 
 > <a name="function-constrainedclassmethod-bar-13431"></a>[bar](#function-constrainedclassmethod-bar-13431)
 > 
-> > : [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) t =\> t -\> t
+> > : [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) t =\> t -\> t

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.EXPECTED.rst
@@ -21,4 +21,4 @@ Typeclasses
   .. _function-constrainedclassmethod-bar-13431:
   
   `bar <function-constrainedclassmethod-bar-13431_>`_
-    \: `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ t \=\> t \-\> t
+    \: `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ t \=\> t \-\> t

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.md
@@ -4,38 +4,38 @@
 
 <a name="type-constrainttuples-eq2-31733"></a>**type** [Eq2](#type-constrainttuples-eq2-31733) a b
 
-> = ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b)
+> = ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) b)
 
 <a name="type-constrainttuples-eq3-75180"></a>**type** [Eq3](#type-constrainttuples-eq3-75180) a b c
 
-> = ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) c)
+> = ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) c)
 
 <a name="type-constrainttuples-eq4-2935"></a>**type** [Eq4](#type-constrainttuples-eq4-2935) a b c d
 
-> = ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) d)
+> = ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) d)
 
 ## Functions
 
 <a name="function-constrainttuples-eq2-12289"></a>[eq2](#function-constrainttuples-eq2-12289)
 
-> : [Eq2](#type-constrainttuples-eq2-31733) a b =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
+> : [Eq2](#type-constrainttuples-eq2-31733) a b =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq2tick-62955"></a>[eq2'](#function-constrainttuples-eq2tick-62955)
 
-> : ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b) =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
+> : ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) b) =\> a -\> a -\> b -\> b -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq3-55736"></a>[eq3](#function-constrainttuples-eq3-55736)
 
-> : [Eq3](#type-constrainttuples-eq3-75180) a b c =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
+> : [Eq3](#type-constrainttuples-eq3-75180) a b c =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq3tick-75648"></a>[eq3'](#function-constrainttuples-eq3tick-75648)
 
-> : ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) c) =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
+> : ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) c) =\> a -\> a -\> b -\> b -\> c -\> c -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq4-56779"></a>[eq4](#function-constrainttuples-eq4-56779)
 
-> : [Eq4](#type-constrainttuples-eq4-2935) a b c d =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
+> : [Eq4](#type-constrainttuples-eq4-2935) a b c d =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654)
 
 <a name="function-constrainttuples-eq4tick-50089"></a>[eq4'](#function-constrainttuples-eq4tick-50089)
 
-> : ([Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) d) =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654)
+> : ([Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) a, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) b, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) c, [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) d) =\> a -\> a -\> b -\> b -\> c -\> c -\> d -\> d -\> [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654)

--- a/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ConstraintTuples.EXPECTED.rst
@@ -9,17 +9,17 @@ Data Types
 .. _type-constrainttuples-eq2-31733:
 
 **type** `Eq2 <type-constrainttuples-eq2-31733_>`_ a b
-  \= (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b)
+  \= (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ b)
 
 .. _type-constrainttuples-eq3-75180:
 
 **type** `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c
-  \= (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ c)
+  \= (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ c)
 
 .. _type-constrainttuples-eq4-2935:
 
 **type** `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d
-  \= (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ d)
+  \= (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ d)
 
 Functions
 ^^^^^^^^^
@@ -27,29 +27,29 @@ Functions
 .. _function-constrainttuples-eq2-12289:
 
 `eq2 <function-constrainttuples-eq2-12289_>`_
-  \: `Eq2 <type-constrainttuples-eq2-31733_>`_ a b \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
+  \: `Eq2 <type-constrainttuples-eq2-31733_>`_ a b \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq2tick-62955:
 
 `eq2' <function-constrainttuples-eq2tick-62955_>`_
-  \: (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b) \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
+  \: (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ b) \=\> a \-\> a \-\> b \-\> b \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq3-55736:
 
 `eq3 <function-constrainttuples-eq3-55736_>`_
-  \: `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
+  \: `Eq3 <type-constrainttuples-eq3-75180_>`_ a b c \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq3tick-75648:
 
 `eq3' <function-constrainttuples-eq3tick-75648_>`_
-  \: (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ c) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
+  \: (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ c) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq4-56779:
 
 `eq4 <function-constrainttuples-eq4-56779_>`_
-  \: `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
+  \: `Eq4 <type-constrainttuples-eq4-2935_>`_ a b c d \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654>`_
 
 .. _function-constrainttuples-eq4tick-50089:
 
 `eq4' <function-constrainttuples-eq4tick-50089_>`_
-  \: (`Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ d) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
+  \: (`Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ a, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ b, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ c, `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ d) \=\> a \-\> a \-\> b \-\> b \-\> c \-\> c \-\> d \-\> d \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654>`_

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.md
@@ -18,15 +18,15 @@
 > 
 > > : (a -\> b -\> b) -\> b -\> t a -\> b
 
-<a name="class-defaultmethods-traversablex-59027"></a>**class** ([Functor](https://docs.daml.com/daml/stdlib/index.html#class-ghc-base-functor-73448) t, [FoldableX](#class-defaultmethods-foldablex-48748) t) =\> [TraversableX](#class-defaultmethods-traversablex-59027) t **where**
+<a name="class-defaultmethods-traversablex-59027"></a>**class** ([Functor](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-base-functor-73448) t, [FoldableX](#class-defaultmethods-foldablex-48748) t) =\> [TraversableX](#class-defaultmethods-traversablex-59027) t **where**
 
 > <a name="function-defaultmethods-traversex-21140"></a>[traverseX](#function-defaultmethods-traversex-21140)
 > 
-> > : Applicative m =\> (a -\> m b) -\> t a -\> m (t b)
+> > : [Applicative](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-43914) m =\> (a -\> m b) -\> t a -\> m (t b)
 > 
 > <a name="function-defaultmethods-sequencex-86855"></a>[sequenceX](#function-defaultmethods-sequencex-86855)
 > 
-> > : Applicative m =\> t (m a) -\> m (t a)
+> > : [Applicative](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-43914) m =\> t (m a) -\> m (t a)
 
 <a name="class-defaultmethods-id-77721"></a>**class** [Id](#class-defaultmethods-id-77721) a **where**
 
@@ -34,7 +34,7 @@
 > 
 > > : a -\> a
 > 
-> **instance** [Id](#class-defaultmethods-id-77721) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> **instance** [Id](#class-defaultmethods-id-77721) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 <a name="class-defaultmethods-myshow-63359"></a>**class** [MyShow](#class-defaultmethods-myshow-63359) t **where**
 
@@ -42,12 +42,12 @@
 > 
 > <a name="function-defaultmethods-myshow-41356"></a>[myShow](#function-defaultmethods-myshow-41356)
 > 
-> > : t -\> [Text](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703)
+> > : t -\> [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-57703)
 > > 
 > > Doc for method.
 > 
 > **default** myShow
 > 
-> > : [Show](https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447) t =\> t -\> [Text](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703)
+> > : [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-56447) t =\> t -\> [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-57703)
 > > 
 > > Doc for default.

--- a/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/DefaultMethods.EXPECTED.rst
@@ -31,17 +31,17 @@ Typeclasses
 
 .. _class-defaultmethods-traversablex-59027:
 
-**class** (`Functor <https://docs.daml.com/daml/stdlib/index.html#class-ghc-base-functor-73448>`_ t, `FoldableX <class-defaultmethods-foldablex-48748_>`_ t) \=\> `TraversableX <class-defaultmethods-traversablex-59027_>`_ t **where**
+**class** (`Functor <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-base-functor-73448>`_ t, `FoldableX <class-defaultmethods-foldablex-48748_>`_ t) \=\> `TraversableX <class-defaultmethods-traversablex-59027_>`_ t **where**
 
   .. _function-defaultmethods-traversex-21140:
   
   `traverseX <function-defaultmethods-traversex-21140_>`_
-    \: Applicative m \=\> (a \-\> m b) \-\> t a \-\> m (t b)
+    \: `Applicative <https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-43914>`_ m \=\> (a \-\> m b) \-\> t a \-\> m (t b)
   
   .. _function-defaultmethods-sequencex-86855:
   
   `sequenceX <function-defaultmethods-sequencex-86855_>`_
-    \: Applicative m \=\> t (m a) \-\> m (t a)
+    \: `Applicative <https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-prelude-applicative-43914>`_ m \=\> t (m a) \-\> m (t a)
 
 .. _class-defaultmethods-id-77721:
 
@@ -52,7 +52,7 @@ Typeclasses
   `id <function-defaultmethods-id-57162_>`_
     \: a \-\> a
   
-  **instance** `Id <class-defaultmethods-id-77721_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  **instance** `Id <class-defaultmethods-id-77721_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 .. _class-defaultmethods-myshow-63359:
 
@@ -63,12 +63,12 @@ Typeclasses
   .. _function-defaultmethods-myshow-41356:
   
   `myShow <function-defaultmethods-myshow-41356_>`_
-    \: t \-\> `Text <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703>`_
+    \: t \-\> `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-57703>`_
     
     Doc for method\.
   
   **default** myShow
   
-    \: `Show <https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447>`_ t \=\> t \-\> `Text <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703>`_
+    \: `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-56447>`_ t \=\> t \-\> `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-57703>`_
     
     Doc for default\.

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.md
@@ -22,10 +22,10 @@
 > <a name="constr-deriving-disjunction-94592"></a>[Disjunction](#constr-deriving-disjunction-94592) \[[Formula](#type-deriving-formula-84903) t\]
 > 
 > 
-> **instance** [Functor](https://docs.daml.com/daml/stdlib/index.html#class-ghc-base-functor-73448) [Formula](#type-deriving-formula-84903)
+> **instance** [Functor](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-base-functor-73448) [Formula](#type-deriving-formula-84903)
 > 
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) t =\> [Eq](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216) ([Formula](#type-deriving-formula-84903) t)
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) t =\> [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216) ([Formula](#type-deriving-formula-84903) t)
 > 
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-ord-70960) t =\> [Ord](https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-ord-70960) ([Formula](#type-deriving-formula-84903) t)
+> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-70960) t =\> [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-70960) ([Formula](#type-deriving-formula-84903) t)
 > 
-> **instance** [Show](https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447) t =\> [Show](https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447) ([Formula](#type-deriving-formula-84903) t)
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-56447) t =\> [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-56447) ([Formula](#type-deriving-formula-84903) t)

--- a/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Deriving.EXPECTED.rst
@@ -40,10 +40,10 @@ Data Types
   `Disjunction <constr-deriving-disjunction-94592_>`_ \[`Formula <type-deriving-formula-84903_>`_ t\]
   
   
-  **instance** `Functor <https://docs.daml.com/daml/stdlib/index.html#class-ghc-base-functor-73448>`_ `Formula <type-deriving-formula-84903_>`_
+  **instance** `Functor <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-base-functor-73448>`_ `Formula <type-deriving-formula-84903_>`_
   
-  **instance** `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ t \=\> `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ t \=\> `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** `Ord <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-ord-70960>`_ t \=\> `Ord <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-ord-70960>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Ord <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-70960>`_ t \=\> `Ord <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-70960>`_ (`Formula <type-deriving-formula-84903_>`_ t)
   
-  **instance** `Show <https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447>`_ t \=\> `Show <https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447>`_ (`Formula <type-deriving-formula-84903_>`_ t)
+  **instance** `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-56447>`_ t \=\> `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-56447>`_ (`Formula <type-deriving-formula-84903_>`_ t)

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.md
@@ -4,10 +4,10 @@
 
 <a name="type-exportlist-template0-22237"></a>**template** [Template0](#type-exportlist-template0-22237)
 
-> | Field    | Type     | Description |
-> | :------- | :------- | :---------- |
-> | tfield0  | Party    |  |
-> | tfield0' | Party    |  |
+> | Field                                                                                   | Type                                                                                    | Description |
+> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+> | tfield0                                                                                 | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
+> | tfield0'                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
 > 
 > * **Choice Archive**
 >   
@@ -19,10 +19,10 @@
 
 <a name="type-exportlist-template1-34256"></a>**template** [Template1](#type-exportlist-template1-34256)
 
-> | Field    | Type     | Description |
-> | :------- | :------- | :---------- |
-> | tfield1  | Party    |  |
-> | tfield1' | Party    |  |
+> | Field                                                                                   | Type                                                                                    | Description |
+> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+> | tfield1                                                                                 | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
+> | tfield1'                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
 > 
 > * **Choice Archive**
 >   
@@ -34,10 +34,10 @@
 
 <a name="type-exportlist-template2-3915"></a>**template** [Template2](#type-exportlist-template2-3915)
 
-> | Field    | Type     | Description |
-> | :------- | :------- | :---------- |
-> | tfield2  | Party    |  |
-> | tfield2' | Party    |  |
+> | Field                                                                                   | Type                                                                                    | Description |
+> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+> | tfield2                                                                                 | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
+> | tfield2'                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
 > 
 > * **Choice Archive**
 >   
@@ -49,10 +49,10 @@
 
 <a name="type-exportlist-template3-57838"></a>**template** [Template3](#type-exportlist-template3-57838)
 
-> | Field    | Type     | Description |
-> | :------- | :------- | :---------- |
-> | tfield3  | Party    |  |
-> | tfield3' | Party    |  |
+> | Field                                                                                   | Type                                                                                    | Description |
+> | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+> | tfield3                                                                                 | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
+> | tfield3'                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
 > 
 > * **Choice Archive**
 >   
@@ -90,11 +90,11 @@
 
 <a name="type-exportlist-data1-25282"></a>**data** [Data1](#type-exportlist-data1-25282)
 
-> **instance** HasField "field1" [Data1](#type-exportlist-data1-25282) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480) "field1" [Data1](#type-exportlist-data1-25282) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data2-68729"></a>**data** [Data2](#type-exportlist-data2-68729)
 
-> **instance** HasField "field2" [Data2](#type-exportlist-data2-68729) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480) "field2" [Data2](#type-exportlist-data2-68729) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data3-43604"></a>**data** [Data3](#type-exportlist-data3-43604)
 
@@ -102,37 +102,37 @@
 > 
 > > (no fields)
 > 
-> **instance** HasField "field3" [Data3](#type-exportlist-data3-43604) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480) "field3" [Data3](#type-exportlist-data3-43604) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data4-87051"></a>**data** [Data4](#type-exportlist-data4-87051)
 
-> **instance** HasField "field4" [Data4](#type-exportlist-data4-87051) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480) "field4" [Data4](#type-exportlist-data4-87051) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data5-40974"></a>**data** [Data5](#type-exportlist-data5-40974)
 
 > <a name="constr-exportlist-constr5-35310"></a>[Constr5](#constr-exportlist-constr5-35310)
 > 
-> > | Field                                                                        | Type                                                                         | Description |
-> > | :--------------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :---------- |
-> > | field5                                                                       | [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) |  |
+> > | Field                                                                          | Type                                                                           | Description |
+> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+> > | field5                                                                         | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728) |  |
 > 
-> **instance** HasField "field5" [Data5](#type-exportlist-data5-40974) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480) "field5" [Data5](#type-exportlist-data5-40974) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 <a name="type-exportlist-data6-26325"></a>**data** [Data6](#type-exportlist-data6-26325)
 
 > <a name="constr-exportlist-constr6-63065"></a>[Constr6](#constr-exportlist-constr6-63065)
 > 
-> > | Field                                                                        | Type                                                                         | Description |
-> > | :--------------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :---------- |
-> > | field6                                                                       | [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) |  |
+> > | Field                                                                          | Type                                                                           | Description |
+> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+> > | field6                                                                         | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728) |  |
 > 
 > <a name="constr-exportlist-constr6tick-67971"></a>[Constr6'](#constr-exportlist-constr6tick-67971)
 > 
 > 
-> **instance** HasField "field6" [Data6](#type-exportlist-data6-26325) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480) "field6" [Data6](#type-exportlist-data6-26325) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 ## Functions
 
 <a name="function-exportlist-function1-77714"></a>[function1](#function-exportlist-function1-77714)
 
-> : [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> : [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)

--- a/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/ExportList.EXPECTED.rst
@@ -18,10 +18,10 @@ Templates
        - Type
        - Description
      * - tfield0
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
      * - tfield0'
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
   
   + **Choice Archive**
@@ -42,10 +42,10 @@ Templates
        - Type
        - Description
      * - tfield1
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
      * - tfield1'
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
   
   + **Choice Archive**
@@ -66,10 +66,10 @@ Templates
        - Type
        - Description
      * - tfield2
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
      * - tfield2'
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
   
   + **Choice Archive**
@@ -90,10 +90,10 @@ Templates
        - Type
        - Description
      * - tfield3
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
      * - tfield3'
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
   
   + **Choice Archive**
@@ -145,13 +145,13 @@ Data Types
 
 **data** `Data1 <type-exportlist-data1-25282_>`_
 
-  **instance** HasField \"field1\" `Data1 <type-exportlist-data1-25282_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480>`_ \"field1\" `Data1 <type-exportlist-data1-25282_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data2-68729:
 
 **data** `Data2 <type-exportlist-data2-68729_>`_
 
-  **instance** HasField \"field2\" `Data2 <type-exportlist-data2-68729_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480>`_ \"field2\" `Data2 <type-exportlist-data2-68729_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data3-43604:
 
@@ -162,13 +162,13 @@ Data Types
   `Constr3 <constr-exportlist-constr3-90820_>`_
   
   
-  **instance** HasField \"field3\" `Data3 <type-exportlist-data3-43604_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480>`_ \"field3\" `Data3 <type-exportlist-data3-43604_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data4-87051:
 
 **data** `Data4 <type-exportlist-data4-87051_>`_
 
-  **instance** HasField \"field4\" `Data4 <type-exportlist-data4-87051_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480>`_ \"field4\" `Data4 <type-exportlist-data4-87051_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data5-40974:
 
@@ -186,10 +186,10 @@ Data Types
          - Type
          - Description
        * - field5
-         - `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
          - 
   
-  **instance** HasField \"field5\" `Data5 <type-exportlist-data5-40974_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480>`_ \"field5\" `Data5 <type-exportlist-data5-40974_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 .. _type-exportlist-data6-26325:
 
@@ -207,7 +207,7 @@ Data Types
          - Type
          - Description
        * - field6
-         - `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
          - 
   
   .. _constr-exportlist-constr6tick-67971:
@@ -215,7 +215,7 @@ Data Types
   `Constr6' <constr-exportlist-constr6tick-67971_>`_
   
   
-  **instance** HasField \"field6\" `Data6 <type-exportlist-data6-26325_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480>`_ \"field6\" `Data6 <type-exportlist-data6-26325_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 Functions
 ^^^^^^^^^
@@ -223,4 +223,4 @@ Functions
 .. _function-exportlist-function1-77714:
 
 `function1 <function-exportlist-function1-77714_>`_
-  \: `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  \: `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.md
@@ -4,13 +4,13 @@
 
 <a name="type-iou12-iou-45923"></a>**template** [Iou](#type-iou12-iou-45923)
 
-> | Field                                                                                | Type                                                                                 | Description |
-> | :----------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :---------- |
-> | issuer                                                                               | Party                                                                                |  |
-> | owner                                                                                | Party                                                                                |  |
-> | currency                                                                             | [Text](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703)       | only 3-letter symbols are allowed |
-> | amount                                                                               | [Decimal](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-decimal-54602) | must be positive |
-> | regulators                                                                           | \[Party\]                                                                            | `regulators` may observe any use of the `Iou` |
+> | Field                                                                                       | Type                                                                                        | Description |
+> | :------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------ | :---------- |
+> | issuer                                                                                      | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311)     |  |
+> | owner                                                                                       | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311)     |  |
+> | currency                                                                                    | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-57703)            | only 3-letter symbols are allowed |
+> | amount                                                                                      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-54602)      | must be positive |
+> | regulators                                                                                  | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311)\] | `regulators` may observe any use of the `Iou` |
 > 
 > * **Choice Archive**
 >   
@@ -24,32 +24,32 @@
 >   
 >   merges two "compatible" `Iou`s
 >   
->   | Field                                   | Type                                    | Description |
->   | :-------------------------------------- | :-------------------------------------- | :---------- |
->   | otherCid                                | ContractId [Iou](#type-iou12-iou-45923) | Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original `Iou`. |
+>   | Field                                                                                                                          | Type                                                                                                                           | Description |
+>   | :----------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------- | :---------- |
+>   | otherCid                                                                                                                       | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-47171) [Iou](#type-iou12-iou-45923) | Must have same owner, issuer, and currency. The regulators may differ, and are taken from the original `Iou`. |
 > 
 > * **Choice Split**
 >   
 >   splits into two `Iou`s with
 >   smaller amounts
 >   
->   | Field                                                                                | Type                                                                                 | Description |
->   | :----------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- | :---------- |
->   | splitAmount                                                                          | [Decimal](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-decimal-54602) | must be between zero and original amount |
+>   | Field                                                                                  | Type                                                                                   | Description |
+>   | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- | :---------- |
+>   | splitAmount                                                                            | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-54602) | must be between zero and original amount |
 > 
 > * **Choice Transfer**
 >   
 >   changes the owner
 >   
->   | Field    | Type     | Description |
->   | :------- | :------- | :---------- |
->   | newOwner | Party    |  |
+>   | Field                                                                                   | Type                                                                                    | Description |
+>   | :-------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :---------- |
+>   | newOwner                                                                                | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311) |  |
 
 ## Functions
 
 <a name="function-iou12-main-35518"></a>[main](#function-iou12-main-35518)
 
-> : Scenario ()
+> : [Scenario](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-scenario-45418) ()
 > 
 > A single test scenario covering all functionality that `Iou` implements.
 > This description contains [a link](http://example.com), some bogus <inline html>,

--- a/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Iou12.EXPECTED.rst
@@ -18,19 +18,19 @@ Templates
        - Type
        - Description
      * - issuer
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
      * - owner
-       - Party
+       - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
        - 
      * - currency
-       - `Text <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-text-57703>`_
+       - `Text <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-57703>`_
        - only 3\-letter symbols are allowed
      * - amount
-       - `Decimal <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-decimal-54602>`_
+       - `Decimal <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-54602>`_
        - must be positive
      * - regulators
-       - \[Party\]
+       - \[`Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_\]
        - ``regulators`` may observe any use of the ``Iou``
   
   + **Choice Archive**
@@ -51,7 +51,7 @@ Templates
          - Type
          - Description
        * - otherCid
-         - ContractId `Iou <type-iou12-iou-45923_>`_
+         - `ContractId <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-47171>`_ `Iou <type-iou12-iou-45923_>`_
          - Must have same owner, issuer, and currency\. The regulators may differ, and are taken from the original ``Iou``\.
   
   + **Choice Split**
@@ -67,7 +67,7 @@ Templates
          - Type
          - Description
        * - splitAmount
-         - `Decimal <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-decimal-54602>`_
+         - `Decimal <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-54602>`_
          - must be between zero and original amount
   
   + **Choice Transfer**
@@ -82,7 +82,7 @@ Templates
          - Type
          - Description
        * - newOwner
-         - Party
+         - `Party <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-50311>`_
          - 
 
 Functions
@@ -91,7 +91,7 @@ Functions
 .. _function-iou12-main-35518:
 
 `main <function-iou12-main-35518_>`_
-  \: Scenario ()
+  \: `Scenario <https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-scenario-45418>`_ ()
   
   A single test scenario covering all functionality that ``Iou`` implements\.
   This description contains a link(http://example.com), some bogus \<inline html\>,

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.md
@@ -6,21 +6,21 @@
 
 > <a name="constr-newtype-nat-99832"></a>[Nat](#constr-newtype-nat-99832)
 > 
-> > | Field                                                                        | Type                                                                         | Description |
-> > | :--------------------------------------------------------------------------- | :--------------------------------------------------------------------------- | :---------- |
-> > | unNat                                                                        | [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) |  |
+> > | Field                                                                          | Type                                                                           | Description |
+> > | :----------------------------------------------------------------------------- | :----------------------------------------------------------------------------- | :---------- |
+> > | unNat                                                                          | [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728) |  |
 > 
-> **instance** HasField "unNat" [Nat](#type-newtype-nat-61947) [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> **instance** [HasField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480) "unNat" [Nat](#type-newtype-nat-61947) [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 ## Functions
 
 <a name="function-newtype-mknat-8513"></a>[mkNat](#function-newtype-mknat-8513)
 
-> : [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
+> : [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
 
 <a name="function-newtype-unsafemknat-96593"></a>[unsafeMkNat](#function-newtype-unsafemknat-96593)
 
-> : [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
+> : [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728) -\> [Nat](#type-newtype-nat-61947)
 
 <a name="function-newtype-zero0-10450"></a>[zero0](#function-newtype-zero0-10450)
 
@@ -32,12 +32,12 @@
 
 <a name="function-newtype-unnat1-26452"></a>[unNat1](#function-newtype-unnat1-26452)
 
-> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 <a name="function-newtype-unnat2-96339"></a>[unNat2](#function-newtype-unnat2-96339)
 
-> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)
 
 <a name="function-newtype-unnat3-97654"></a>[unNat3](#function-newtype-unnat3-97654)
 
-> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728)
+> : [Nat](#type-newtype-nat-61947) -\> [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728)

--- a/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/Newtype.EXPECTED.rst
@@ -22,10 +22,10 @@ Data Types
          - Type
          - Description
        * - unNat
-         - `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+         - `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
          - 
   
-  **instance** HasField \"unNat\" `Nat <type-newtype-nat-61947_>`_ `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  **instance** `HasField <https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-hasfield-39480>`_ \"unNat\" `Nat <type-newtype-nat-61947_>`_ `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 Functions
 ^^^^^^^^^
@@ -33,12 +33,12 @@ Functions
 .. _function-newtype-mknat-8513:
 
 `mkNat <function-newtype-mknat-8513_>`_
-  \: `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
+  \: `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-unsafemknat-96593:
 
 `unsafeMkNat <function-newtype-unsafemknat-96593_>`_
-  \: `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
+  \: `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_ \-\> `Nat <type-newtype-nat-61947_>`_
 
 .. _function-newtype-zero0-10450:
 
@@ -53,14 +53,14 @@ Functions
 .. _function-newtype-unnat1-26452:
 
 `unNat1 <function-newtype-unnat1-26452_>`_
-  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat2-96339:
 
 `unNat2 <function-newtype-unnat2-96339_>`_
-  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_
 
 .. _function-newtype-unnat3-97654:
 
 `unNat3 <function-newtype-unnat3-97654_>`_
-  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-int-68728>`_
+  \: `Nat <type-newtype-nat-61947_>`_ \-\> `Int <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-68728>`_

--- a/compiler/damlc/tests/daml-test-files/SingleConEnum.EXPECTED.rst
+++ b/compiler/damlc/tests/daml-test-files/SingleConEnum.EXPECTED.rst
@@ -15,9 +15,9 @@ Data Types
   `Red <constr-singleconenum-red-70275_>`_
   
   
-  **instance** `Eq <https://docs.daml.com/daml/stdlib/index.html#class-ghc-classes-eq-21216>`_ `Color <type-singleconenum-color-33374_>`_
+  **instance** `Eq <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-21216>`_ `Color <type-singleconenum-color-33374_>`_
   
-  **instance** `Show <https://docs.daml.com/daml/stdlib/index.html#class-ghc-show-show-56447>`_ `Color <type-singleconenum-color-33374_>`_
+  **instance** `Show <https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-56447>`_ `Color <type-singleconenum-color-33374_>`_
 
 Functions
 ^^^^^^^^^
@@ -30,4 +30,4 @@ Functions
 .. _function-singleconenum-isred-76570:
 
 `isRed <function-singleconenum-isred-76570_>`_
-  \: `Color <type-singleconenum-color-33374_>`_ \-\> `Bool <https://docs.daml.com/daml/stdlib/index.html#type-ghc-types-bool-8654>`_
+  \: `Color <type-singleconenum-color-33374_>`_ \-\> `Bool <https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-8654>`_

--- a/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
@@ -5,32 +5,22 @@
 module DA.Test.DamlDoc (main) where
 
 import DA.Daml.Doc.Driver (loadExternalAnchors)
-import qualified DA.Daml.Doc.Types as Damldoc
+import DA.Daml.Doc.Types
 import qualified DA.Daml.Doc.Tests as Damldoc
 import qualified DA.Daml.Doc.Render.Tests as Render
-
-import qualified Data.Map.Strict as Map
 import qualified Test.Tasty.Extended as Tasty
 import System.Environment.Blank
 import System.FilePath
-import System.IO
-import System.Exit
-
 import DA.Bazel.Runfiles
 
 main :: IO ()
 main = do
     setEnv "TASTY_NUM_THREADS" "1" True
     externalAnchorsPath <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "daml-base-anchors.json")
-    externalAnchors <- loadExternalAnchors (Just externalAnchorsPath)
-    case externalAnchors of
-      Right anchors -> 
-        Tasty.deterministicMain =<< allTests anchors
-      Left err -> do
-        hPutStr stderr err
-        exitFailure
+    anchors <- loadExternalAnchors (Just externalAnchorsPath)
+    Tasty.deterministicMain =<< allTests anchors
 
-allTests :: Map.Map Damldoc.Anchor FilePath -> IO Tasty.TestTree
+allTests :: AnchorMap -> IO Tasty.TestTree
 allTests externalAnchors = Tasty.testGroup "All DAML GHC tests using Tasty" <$> sequence
   [ Damldoc.mkTestTree externalAnchors
   , Render.mkTestTree externalAnchors

--- a/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
+++ b/compiler/damlc/tests/src/DA/Test/DamlDoc.hs
@@ -4,19 +4,34 @@
 
 module DA.Test.DamlDoc (main) where
 
+import DA.Daml.Doc.Driver (loadExternalAnchors)
+import qualified DA.Daml.Doc.Types as Damldoc
 import qualified DA.Daml.Doc.Tests as Damldoc
 import qualified DA.Daml.Doc.Render.Tests as Render
 
+import qualified Data.Map.Strict as Map
 import qualified Test.Tasty.Extended as Tasty
 import System.Environment.Blank
+import System.FilePath
+import System.IO
+import System.Exit
+
+import DA.Bazel.Runfiles
 
 main :: IO ()
 main = do
     setEnv "TASTY_NUM_THREADS" "1" True
-    Tasty.deterministicMain =<< allTests
+    externalAnchorsPath <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "daml-base-anchors.json")
+    externalAnchors <- loadExternalAnchors (Just externalAnchorsPath)
+    case externalAnchors of
+      Right anchors -> 
+        Tasty.deterministicMain =<< allTests anchors
+      Left err -> do
+        hPutStr stderr err
+        exitFailure
 
-allTests :: IO Tasty.TestTree
-allTests = Tasty.testGroup "All DAML GHC tests using Tasty" <$> sequence
-  [ Damldoc.mkTestTree
-  , Render.mkTestTree
+allTests :: Map.Map Damldoc.Anchor FilePath -> IO Tasty.TestTree
+allTests externalAnchors = Tasty.testGroup "All DAML GHC tests using Tasty" <$> sequence
+  [ Damldoc.mkTestTree externalAnchors
+  , Render.mkTestTree externalAnchors
   ]


### PR DESCRIPTION
For external anchors, satisfy URIs by consulting an external anchors database.

- Add `--input-anchor` argument to `daml docs` command;
  - We may wish to enhance this feature by assuming a default value based on an SDK environment variable in its absence;
- Update unit tests to use `daml-base-anchors.json` as the external anchors database.

changelog_begin
- `daml docs` now supports an (optional) argument `--input-anchor` specifying the
path to a database of external anchors

changelog_end
