### PR TITLE
remove ec from LedgerTestSuite

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
@@ -13,8 +13,8 @@ final class LedgerTestCase(
     val description: String,
     val timeoutScale: Double,
     participants: ParticipantAllocation,
-    runTestCase: Participants => Future[Unit],
+    runTestCase: ExecutionContext => Participants => Future[Unit],
 ) {
   def apply(context: LedgerTestContext)(implicit ec: ExecutionContext): Future[Unit] =
-    context.allocate(participants).flatMap(runTestCase)
+    context.allocate(participants).flatMap(p => runTestCase(ec)(p))
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
@@ -17,14 +17,12 @@ private[testtool] abstract class LedgerTestSuite(val session: LedgerSession) {
 
   final lazy val tests: Vector[LedgerTestCase] = testCaseBuffer.toVector
 
-  protected implicit final val ec: ExecutionContext = session.executionContext
-
   protected final def test(
       shortIdentifier: String,
       description: String,
       participants: ParticipantAllocation,
       timeoutScale: Double = 1.0,
-  )(testCase: Participants => Future[Unit]): Unit = {
+  )(testCase: ExecutionContext => Participants => Future[Unit]): Unit = {
     val shortIdentifierRef = Ref.LedgerString.assertFromString(shortIdentifier)
     testCaseBuffer.append(
       new LedgerTestCase(shortIdentifierRef, description, timeoutScale, participants, testCase),

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ClosedWorld.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ClosedWorld.scala
@@ -27,7 +27,7 @@ class ClosedWorld(session: LedgerSession) extends LedgerTestSuite(session) {
     "ClosedWorldObserver",
     "Cannot execute a transaction that references unallocated observer parties",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, payer)) =>
       for {
         failure <- alpha
@@ -36,5 +36,5 @@ class ClosedWorld(session: LedgerSession) extends LedgerTestSuite(session) {
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Party not known on ledger")
       }
-  }
+  })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplication.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplication.scala
@@ -15,8 +15,8 @@ import com.daml.timer.Delayed
 import com.google.protobuf.duration.Duration
 import io.grpc.Status
 
-import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite(session) {
@@ -33,7 +33,7 @@ final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite
     "CDSimpleDeduplication",
     "Deduplicate commands within the deduplication time window",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val deduplicationSeconds = 5
       val deduplicationTime = Duration.of(deduplicationSeconds.toLong, 0)
@@ -75,13 +75,13 @@ final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite
           s"There should be 3 active contracts, but received $activeContracts",
         )
       }
-  }
+  })
 
   test(
     "CDStopOnSubmissionFailure",
     "Stop deduplicating commands on submission failure",
     allocate(TwoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, alice, bob)) =>
       // Do not set the deduplication timeout.
       // The server will default to the maximum possible deduplication timeout.
@@ -97,13 +97,13 @@ final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite
         assertGrpcError(failure1, Status.Code.INVALID_ARGUMENT, "")
         assertGrpcError(failure2, Status.Code.INVALID_ARGUMENT, "")
       }
-  }
+  })
 
   test(
     "CDStopOnCompletionFailure",
     "Stop deduplicating commands on completion failure",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val key = UUID.randomUUID().toString
       val commandId = UUID.randomUUID().toString
@@ -136,13 +136,13 @@ final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite
       } yield {
         ()
       }
-  }
+  })
 
   test(
     "CDSimpleDeduplicationCommandClient",
     "Deduplicate commands within the deduplication time window using the command client",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val deduplicationSeconds = 5
       val deduplicationTime = Duration.of(deduplicationSeconds.toLong, 0)
@@ -177,13 +177,13 @@ final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite
           s"There should be 2 active contracts, but received $activeContracts",
         )
       }
-  }
+  })
 
   test(
     "CDDeduplicateSubmitter",
     "Commands with identical submitter and command identifier should be deduplicated by the submission client",
     allocate(TwoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, alice, bob)) =>
       val aliceRequest = ledger.submitRequest(alice, Dummy(alice).create.command)
       val bobRequest = ledger
@@ -218,13 +218,13 @@ final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite
           s"Only one contract was expected to be seen by $bob but ${bobContracts.length} appeared",
         )
       }
-  }
+  })
 
   test(
     "CDDeduplicateSubmitterCommandClient",
     "Commands with identical submitter and command identifier should be deduplicated by the command client",
     allocate(TwoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, alice, bob)) =>
       val aliceRequest = ledger.submitAndWaitRequest(alice, Dummy(alice).create.command)
       val bobRequest = ledger
@@ -257,6 +257,6 @@ final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite
           s"Only one contract was expected to be seen by $bob but ${bobContracts.length} appeared",
         )
       }
-  }
+  })
 
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandService.scala
@@ -25,7 +25,7 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
     "CSsubmitAndWait",
     "SubmitAndWait creates a contract of the expected template",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitAndWaitRequest(party, Dummy(party).create.command)
       for {
@@ -36,13 +36,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
         val dummyTemplateId = active.flatMap(_.templateId.toList).head
         assert(dummyTemplateId == Dummy.id.unwrap)
       }
-  }
+  })
 
   test(
     "CSsubmitAndWaitForTransactionId",
     "SubmitAndWaitForTransactionId returns a valid transaction identifier",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitAndWaitRequest(party, Dummy(party).create.command)
       for {
@@ -85,13 +85,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
         )
 
       }
-  }
+  })
 
   test(
     "CSsubmitAndWaitForTransaction",
     "SubmitAndWaitForTransaction returns a transaction",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitAndWaitRequest(party, Dummy(party).create.command)
       for {
@@ -115,13 +115,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           s"The template ID of the created-event should by ${Dummy.id.unwrap}, but was ${event.getCreated.getTemplateId}",
         )
       }
-  }
+  })
 
   test(
     "CSsubmitAndWaitForTransactionTree",
     "SubmitAndWaitForTransactionTree returns a transaction tree",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitAndWaitRequest(party, Dummy(party).create.command)
       for {
@@ -145,13 +145,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           s"The template ID of the created-event should by ${Dummy.id.unwrap}, but was ${event.getCreated.getTemplateId}",
         )
       }
-  }
+  })
 
   test(
     "CSduplicateSubmitAndWait",
     "SubmitAndWait should fail on duplicate requests",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitAndWaitRequest(party, Dummy(party).create.command)
       for {
@@ -160,13 +160,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
       } yield {
         assertGrpcError(failure, Status.Code.ALREADY_EXISTS, "")
       }
-  }
+  })
 
   test(
     "CSduplicateSubmitAndWaitForTransactionId",
     "SubmitAndWaitForTransactionId should fail on duplicate requests",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitAndWaitRequest(party, Dummy(party).create.command)
       for {
@@ -175,13 +175,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
       } yield {
         assertGrpcError(failure, Status.Code.ALREADY_EXISTS, "")
       }
-  }
+  })
 
   test(
     "CSduplicateSubmitAndWaitForTransaction",
     "SubmitAndWaitForTransaction should fail on duplicate requests",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitAndWaitRequest(party, Dummy(party).create.command)
       for {
@@ -190,13 +190,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
       } yield {
         assertGrpcError(failure, Status.Code.ALREADY_EXISTS, "")
       }
-  }
+  })
 
   test(
     "CSduplicateSubmitAndWaitForTransactionTree",
     "SubmitAndWaitForTransactionTree should fail on duplicate requests",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitAndWaitRequest(party, Dummy(party).create.command)
       for {
@@ -205,13 +205,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
       } yield {
         assertGrpcError(failure, Status.Code.ALREADY_EXISTS, "")
       }
-  }
+  })
 
   test(
     "CSsubmitAndWaitForTransactionIdInvalidLedgerId",
     "SubmitAndWaitForTransactionId should fail for invalid ledger ids",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "CSsubmitAndWaitForTransactionIdInvalidLedgerId"
       val request = ledger
@@ -225,13 +225,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           Status.Code.NOT_FOUND,
           s"Ledger ID '$invalidLedgerId' not found.",
         )
-  }
+  })
 
   test(
     "CSsubmitAndWaitForTransactionInvalidLedgerId",
     "SubmitAndWaitForTransaction should fail for invalid ledger ids",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "CSsubmitAndWaitForTransactionInvalidLedgerId"
       val request = ledger
@@ -245,13 +245,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           Status.Code.NOT_FOUND,
           s"Ledger ID '$invalidLedgerId' not found.",
         )
-  }
+  })
 
   test(
     "CSsubmitAndWaitForTransactionTreeInvalidLedgerId",
     "SubmitAndWaitForTransactionTree should fail for invalid ledger ids",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "CSsubmitAndWaitForTransactionTreeInvalidLedgerId"
       val request = ledger
@@ -265,13 +265,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           Status.Code.NOT_FOUND,
           s"Ledger ID '$invalidLedgerId' not found.",
         )
-  }
+  })
 
   test(
     "CSRefuseBadParameter",
     "The submission of a creation that contains a bad parameter label should result in an INVALID_ARGUMENT",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val createWithBadArgument = Dummy(party).create.command
         .update(_.create.createArguments.fields.foreach(_.label := "INVALID_PARAM"))
@@ -281,13 +281,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, s"Missing record label")
       }
-  }
+  })
 
   test(
     "CSReturnStackTrace",
     "A submission resulting in an interpretation error should return the stack trace",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       for {
         dummy <- ledger.create(party, Dummy(party))
@@ -299,13 +299,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           "Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:19], partial transaction: root node",
         )
       }
-  }
+  })
 
   test(
     "CSDiscloseCreateToObservers",
     "Disclose create to observers",
     allocate(TwoParties, SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, giver, observer1), Participant(beta, observer2)) =>
       val template = WithObservers(giver, Primitive.List(observer1, observer2))
       for {
@@ -333,13 +333,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           encode(template).getRecord.fields,
         )
       }
-  }
+  })
 
   test(
     "CSDiscloseExerciseToObservers",
     "Disclose exercise to observers",
     allocate(TwoParties, SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, giver, observer1), Participant(beta, observer2)) =>
       val template = WithObservers(giver, Primitive.List(observer1, observer2))
       for {
@@ -366,13 +366,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           "The observers shouls see the exercised contract",
         )
       }
-  }
+  })
 
   test(
     "CSHugeCommandSubmission",
     "The server should accept a submission with 15 commands",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val target = 15
       val commands = Vector.fill(target)(Dummy(party).create.command)
@@ -386,13 +386,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           s"Expected $target contracts to be created, got ${acs.size} instead",
         )
       }
-  }
+  })
 
   test(
     "CSCallablePayout",
     "Run CallablePayout and return the right events",
     allocate(TwoParties, SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, giver, newReceiver), Participant(beta, receiver)) =>
       for {
         callablePayout <- alpha.create(giver, CallablePayout(giver, receiver))
@@ -406,13 +406,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           encode(CallablePayout(giver, newReceiver)).getRecord.fields,
         )
       }
-  }
+  })
 
   test(
     "CSReadyForExercise",
     "It should be possible to exercise a choice on a created contract",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       for {
         factory <- ledger.create(party, DummyFactory(party))
@@ -423,68 +423,70 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
         assert(exercise.consuming, "The choice should have been consuming")
         val _ = assertLength("Two creations should have occurred", 2, createdEvents(tree))
       }
-  }
+  })
 
-  test("CSBadNumericValues", "Reject unrepresentable numeric values", allocate(SingleParty)) {
-    case Participants(Participant(ledger, party)) =>
-      // Code generation catches bad decimals early so we have to do some work to create (possibly) invalid requests
-      def rounding(numeric: String): Command =
-        DecimalRounding(party, BigDecimal("0")).create.command.update(
-          _.create.createArguments
-            .fields(1) := RecordField(value = Some(Value(Value.Sum.Numeric(numeric)))),
-        )
-      val wouldLosePrecision = "0.00000000005"
-      val positiveOutOfBounds = "10000000000000000000000000000.0000000000"
-      val negativeOutOfBounds = "-10000000000000000000000000000.0000000000"
-      for {
-        e1 <- ledger
-          .submitAndWait(ledger.submitAndWaitRequest(party, rounding(wouldLosePrecision)))
-          .failed
-        e2 <- ledger
-          .submitAndWait(ledger.submitAndWaitRequest(party, rounding(positiveOutOfBounds)))
-          .failed
-        e3 <- ledger
-          .submitAndWait(ledger.submitAndWaitRequest(party, rounding(negativeOutOfBounds)))
-          .failed
-      } yield {
-        assertGrpcError(e1, Status.Code.INVALID_ARGUMENT, "Cannot represent")
-        assertGrpcError(e2, Status.Code.INVALID_ARGUMENT, "Out-of-bounds (Numeric 10)")
-        assertGrpcError(e3, Status.Code.INVALID_ARGUMENT, "Out-of-bounds (Numeric 10)")
-      }
-  }
+  test("CSBadNumericValues", "Reject unrepresentable numeric values", allocate(SingleParty))(
+    implicit ec => {
+      case Participants(Participant(ledger, party)) =>
+        // Code generation catches bad decimals early so we have to do some work to create (possibly) invalid requests
+        def rounding(numeric: String): Command =
+          DecimalRounding(party, BigDecimal("0")).create.command.update(
+            _.create.createArguments
+              .fields(1) := RecordField(value = Some(Value(Value.Sum.Numeric(numeric)))),
+          )
+        val wouldLosePrecision = "0.00000000005"
+        val positiveOutOfBounds = "10000000000000000000000000000.0000000000"
+        val negativeOutOfBounds = "-10000000000000000000000000000.0000000000"
+        for {
+          e1 <- ledger
+            .submitAndWait(ledger.submitAndWaitRequest(party, rounding(wouldLosePrecision)))
+            .failed
+          e2 <- ledger
+            .submitAndWait(ledger.submitAndWaitRequest(party, rounding(positiveOutOfBounds)))
+            .failed
+          e3 <- ledger
+            .submitAndWait(ledger.submitAndWaitRequest(party, rounding(negativeOutOfBounds)))
+            .failed
+        } yield {
+          assertGrpcError(e1, Status.Code.INVALID_ARGUMENT, "Cannot represent")
+          assertGrpcError(e2, Status.Code.INVALID_ARGUMENT, "Out-of-bounds (Numeric 10)")
+          assertGrpcError(e3, Status.Code.INVALID_ARGUMENT, "Out-of-bounds (Numeric 10)")
+        }
+    })
 
-  test("CSCreateAndExercise", "Implement create-and-exercise correctly", allocate(SingleParty)) {
-    case Participants(Participant(ledger, party)) =>
-      val createAndExercise = Dummy(party).createAnd.exerciseDummyChoice1(party).command
-      val request = ledger.submitAndWaitRequest(party, createAndExercise)
-      for {
-        _ <- ledger.submitAndWait(request)
-        transactions <- ledger.flatTransactions(party)
-        trees <- ledger.transactionTrees(party)
-      } yield {
-        assert(
-          transactions.flatMap(_.events).isEmpty,
-          "A create-and-exercise flat transaction should show no event",
-        )
-        assertEquals(
-          "Unexpected template identifier in create event",
-          trees.flatMap(createdEvents).map(_.getTemplateId),
-          Vector(Dummy.id.unwrap),
-        )
-        val contractId = trees.flatMap(createdEvents).head.contractId
-        assertEquals(
-          "Unexpected exercise event triple (choice, contractId, consuming)",
-          trees.flatMap(exercisedEvents).map(e => (e.choice, e.contractId, e.consuming)),
-          Vector(("DummyChoice1", contractId, true)),
-        )
-      }
-  }
+  test("CSCreateAndExercise", "Implement create-and-exercise correctly", allocate(SingleParty))(
+    implicit ec => {
+      case Participants(Participant(ledger, party)) =>
+        val createAndExercise = Dummy(party).createAnd.exerciseDummyChoice1(party).command
+        val request = ledger.submitAndWaitRequest(party, createAndExercise)
+        for {
+          _ <- ledger.submitAndWait(request)
+          transactions <- ledger.flatTransactions(party)
+          trees <- ledger.transactionTrees(party)
+        } yield {
+          assert(
+            transactions.flatMap(_.events).isEmpty,
+            "A create-and-exercise flat transaction should show no event",
+          )
+          assertEquals(
+            "Unexpected template identifier in create event",
+            trees.flatMap(createdEvents).map(_.getTemplateId),
+            Vector(Dummy.id.unwrap),
+          )
+          val contractId = trees.flatMap(createdEvents).head.contractId
+          assertEquals(
+            "Unexpected exercise event triple (choice, contractId, consuming)",
+            trees.flatMap(exercisedEvents).map(e => (e.choice, e.contractId, e.consuming)),
+            Vector(("DummyChoice1", contractId, true)),
+          )
+        }
+    })
 
   test(
     "CSBadCreateAndExercise",
     "Fail create-and-exercise on bad create arguments",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val createAndExercise = Dummy(party).createAnd
         .exerciseDummyChoice1(party)
@@ -496,13 +498,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Expecting 1 field for record")
       }
-  }
+  })
 
   test(
     "CSCreateAndBadExerciseArguments",
     "Fail create-and-exercise on bad choice arguments",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val createAndExercise = Dummy(party).createAnd
         .exerciseDummyChoice1(party)
@@ -514,13 +516,13 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "mismatching type")
       }
-  }
+  })
 
   test(
     "CSCreateAndBadExerciseChoice",
     "Fail create-and-exercise on invalid choice",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val missingChoice = "DoesNotExist"
       val createAndExercise = Dummy(party).createAnd
@@ -537,6 +539,6 @@ final class CommandService(session: LedgerSession) extends LedgerTestSuite(sessi
           s"Couldn't find requested choice $missingChoice",
         )
       }
-  }
+  })
 
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletion.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletion.scala
@@ -21,7 +21,7 @@ final class CommandSubmissionCompletion(session: LedgerSession) extends LedgerTe
     "CSCCompletions",
     "Read completions correctly with a correct application identifier and reading party",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitRequest(party, Dummy(party).create.command)
       for {
@@ -35,13 +35,13 @@ final class CommandSubmissionCompletion(session: LedgerSession) extends LedgerTe
           "Wrong command identifier on completion",
         )
       }
-  }
+  })
 
   test(
     "CSCNoCompletionsWithoutRightAppId",
     "Read no completions without the correct application identifier",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitRequest(party, Dummy(party).create.command)
       for {
@@ -53,13 +53,13 @@ final class CommandSubmissionCompletion(session: LedgerSession) extends LedgerTe
       } yield {
         assert(failed == TimeoutException, "Timeout expected")
       }
-  }
+  })
 
   test(
     "CSCNoCompletionsWithoutRightParty",
     "Read no completions without the correct party",
     allocate(TwoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party, notTheSubmittingParty)) =>
       val request = ledger.submitRequest(party, Dummy(party).create.command)
       for {
@@ -68,13 +68,13 @@ final class CommandSubmissionCompletion(session: LedgerSession) extends LedgerTe
       } yield {
         assert(failed == TimeoutException, "Timeout expected")
       }
-  }
+  })
 
   test(
     "CSCRefuseBadChoice",
     "The submission of an exercise of a choice that does not exist should yield INVALID_ARGUMENT",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val badChoice = "THIS_IS_NOT_A_VALID_CHOICE"
       for {
@@ -90,13 +90,13 @@ final class CommandSubmissionCompletion(session: LedgerSession) extends LedgerTe
           s"Couldn't find requested choice $badChoice",
         )
       }
-  }
+  })
 
   test(
     "CSCSubmitWithInvalidLedgerId",
     "Submit should fail for an invalid ledger identifier",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val invalidLedgerId = "CSsubmitAndWaitInvalidLedgerId"
       val request = ledger
@@ -110,13 +110,13 @@ final class CommandSubmissionCompletion(session: LedgerSession) extends LedgerTe
           Status.Code.NOT_FOUND,
           s"Ledger ID '$invalidLedgerId' not found.",
         )
-  }
+  })
 
   test(
     "CSCDisallowEmptyTransactionsSubmission",
     "The submission of an empty command should be rejected with INVALID_ARGUMENT",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val emptyRequest = ledger.submitRequest(party)
       for {
@@ -124,13 +124,13 @@ final class CommandSubmissionCompletion(session: LedgerSession) extends LedgerTe
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Missing field: commands")
       }
-  }
+  })
 
   test(
     "CSCHandleMultiPartySubscriptions",
     "Listening for completions should support multi-party subscriptions",
     allocate(TwoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, alice, bob)) =>
       val a = UUID.randomUUID.toString
       val b = UUID.randomUUID.toString
@@ -144,6 +144,6 @@ final class CommandSubmissionCompletion(session: LedgerSession) extends LedgerTe
       } yield {
         // Nothing to do, if the two completions are found the test is passed
       }
-  }
+  })
 
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagement.scala
@@ -15,8 +15,7 @@ final class ConfigManagement(session: LedgerSession) extends LedgerTestSuite(ses
     "CMSetAndGetTimeModel",
     "It should be able to get, set and restore the time model",
     allocate(NoParties),
-  ) {
-
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       val newTimeModel = TimeModel(
         avgTransactionLatency = Some(Duration(0, 1)),
@@ -79,7 +78,7 @@ final class ConfigManagement(session: LedgerSession) extends LedgerTestSuite(ses
 
         assertGrpcError(expiredMRTFailure, Status.Code.ABORTED, "")
       }
-  }
+  })
 
   // TODO(JM): Test that sets the time model and verifies that a transaction with invalid
   // ttl/mrt won't be accepted. Can only implement once ApiSubmissionService properly

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Divulgence.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Divulgence.scala
@@ -14,7 +14,7 @@ final class Divulgence(session: LedgerSession) extends LedgerTestSuite(session) 
     "DivulgenceTx",
     "Divulged contracts should not be exposed by the transaction service",
     allocate(TwoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, alice, bob)) =>
       for {
         divulgence1 <- ledger.create(alice, Divulgence1(alice))
@@ -149,13 +149,13 @@ final class Divulgence(session: LedgerSession) extends LedgerTestSuite(session) 
           s"The creation seen by filtering for both $alice and $bob was expected to be witnessed by $alice but is instead ${firstCreationForBoth.witnessParties}",
         )
       }
-  }
+  })
 
   test(
     "DivulgenceAcs",
     "Divulged contracts should not be exposed by the active contract service",
     allocate(TwoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, alice, bob)) =>
       for {
         divulgence1 <- ledger.create(alice, Divulgence1(alice))
@@ -207,5 +207,5 @@ final class Divulgence(session: LedgerSession) extends LedgerTestSuite(session) 
           s"The witness parties of the second contract should include $alice and $bob but it is instead $divulgence2Witnesses",
         )
       }
-  }
+  })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/HealthService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/HealthService.scala
@@ -9,22 +9,24 @@ import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSui
 import io.grpc.health.v1.health.HealthCheckResponse
 
 class HealthService(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("HScheck", "The Health.Check endpoint reports everything is well", allocate(NoParties)) {
-    case Participants(Participant(ledger)) =>
-      for {
-        health <- ledger.checkHealth()
-      } yield {
-        assertEquals("HSisServing", health.status, HealthCheckResponse.ServingStatus.SERVING)
-      }
-  }
+  test("HScheck", "The Health.Check endpoint reports everything is well", allocate(NoParties))(
+    implicit ec => {
+      case Participants(Participant(ledger)) =>
+        for {
+          health <- ledger.checkHealth()
+        } yield {
+          assertEquals("HSisServing", health.status, HealthCheckResponse.ServingStatus.SERVING)
+        }
+    })
 
-  test("HSwatch", "The Health.Watch endpoint reports everything is well", allocate(NoParties)) {
-    case Participants(Participant(ledger)) =>
-      for {
-        healthSeq <- ledger.watchHealth()
-      } yield {
-        val health = assertSingleton("HScontinuesToServe", healthSeq)
-        assert(health.status == HealthCheckResponse.ServingStatus.SERVING)
-      }
-  }
+  test("HSwatch", "The Health.Watch endpoint reports everything is well", allocate(NoParties))(
+    implicit ec => {
+      case Participants(Participant(ledger)) =>
+        for {
+          healthSeq <- ledger.watchHealth()
+        } yield {
+          val health = assertSingleton("HScontinuesToServe", healthSeq)
+          assert(health.status == HealthCheckResponse.ServingStatus.SERVING)
+        }
+    })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Identity.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Identity.scala
@@ -13,10 +13,12 @@ final class Identity(session: LedgerSession) extends LedgerTestSuite(session) {
     "IdNotEmpty",
     "A ledger should return a non-empty string as its identity",
     allocate(NoParties),
-  ) {
-    case Participants(Participant(ledger)) =>
-      Future {
-        assert(ledger.ledgerId.nonEmpty, "The returned ledger identifier was empty")
-      }
+  ) { implicit ec =>
+    {
+      case Participants(Participant(ledger)) =>
+        Future {
+          assert(ledger.ledgerId.nonEmpty, "The returned ledger identifier was empty")
+        }
+    }
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationService.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationService.scala
@@ -10,32 +10,37 @@ import com.daml.ledger.test_stable.Test.Dummy
 import io.grpc.Status
 
 class LedgerConfigurationService(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("ConfigSucceeds", "Return a valid configuration for a valid request", allocate(NoParties)) {
-    case Participants(Participant(ledger)) =>
-      for {
-        config <- ledger.configuration()
-      } yield {
-        assert(
-          config.maxDeduplicationTime.isDefined,
-          "The maxDeduplicationTime field of the configuration is empty")
-      }
-  }
+  test("ConfigSucceeds", "Return a valid configuration for a valid request", allocate(NoParties))(
+    implicit ec => {
+      case Participants(Participant(ledger)) =>
+        for {
+          config <- ledger.configuration()
+        } yield {
+          assert(
+            config.maxDeduplicationTime.isDefined,
+            "The maxDeduplicationTime field of the configuration is empty")
+        }
+    })
 
-  test("ConfigLedgerId", "Return NOT_FOUND to invalid ledger identifier", allocate(NoParties)) {
-    case Participants(Participant(ledger)) =>
-      val invalidLedgerId = "THIS_IS_AN_INVALID_LEDGER_ID"
-      for {
-        failure <- ledger.configuration(overrideLedgerId = Some(invalidLedgerId)).failed
-      } yield {
-        assertGrpcError(failure, Status.Code.NOT_FOUND, s"Ledger ID '$invalidLedgerId' not found.")
-      }
-  }
+  test("ConfigLedgerId", "Return NOT_FOUND to invalid ledger identifier", allocate(NoParties))(
+    implicit ec => {
+      case Participants(Participant(ledger)) =>
+        val invalidLedgerId = "THIS_IS_AN_INVALID_LEDGER_ID"
+        for {
+          failure <- ledger.configuration(overrideLedgerId = Some(invalidLedgerId)).failed
+        } yield {
+          assertGrpcError(
+            failure,
+            Status.Code.NOT_FOUND,
+            s"Ledger ID '$invalidLedgerId' not found.")
+        }
+    })
 
   test(
     "CSLSuccessIfMaxDedplicationTimeRight",
     "Submission returns OK if deduplication time is within the accepted interval",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       // Submission using the maximum allowed deduplication time
       val request = ledger.submitRequest(party, Dummy(party).create.command)
@@ -46,13 +51,13 @@ class LedgerConfigurationService(session: LedgerSession) extends LedgerTestSuite
       } yield {
         // No assertions to make, since the command went through as expected
       }
-  }
+  })
 
   test(
     "CSLSuccessIfMaxDeduplicationTimeExceeded",
     "Submission returns OK if deduplication time is too high",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val request = ledger.submitRequest(party, Dummy(party).create.command)
       for {
@@ -66,5 +71,5 @@ class LedgerConfigurationService(session: LedgerSession) extends LedgerTestSuite
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "")
       }
-  }
+  })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LotsOfParties.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LotsOfParties.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.api.v1.transaction.Transaction
 import com.daml.ledger.client.binding.Primitive.{ContractId, Party}
 import com.daml.ledger.test_stable.Test.WithObservers
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 final class LotsOfParties(session: LedgerSession) extends LedgerTestSuite(session) {
   type Parties = Set[Party]
@@ -34,7 +34,7 @@ final class LotsOfParties(session: LedgerSession) extends LedgerTestSuite(sessio
     "Observers should see transactions in multiple single-party subscriptions",
     allocation,
     timeoutScale,
-  ) {
+  )(implicit ec => {
     case TestParticipants(t) =>
       for {
         contractId <- t.alpha.create(t.giver, WithObservers(t.giver, t.observers))
@@ -53,14 +53,14 @@ final class LotsOfParties(session: LedgerSession) extends LedgerTestSuite(sessio
           activeContractsFrom(betaTransactionsByParty),
         )
       }
-  }
+  })
 
   test(
     "LOPseeTransactionsInSingleMultiPartySubscription",
     "Observers should see transactions in a single multi-party subscription",
     allocation,
     timeoutScale,
-  ) {
+  )(implicit ec => {
     case TestParticipants(t) =>
       for {
         contractId <- t.alpha.create(t.giver, WithObservers(t.giver, t.observers))
@@ -79,14 +79,14 @@ final class LotsOfParties(session: LedgerSession) extends LedgerTestSuite(sessio
           activeContractsFrom(betaTransactions),
         )
       }
-  }
+  })
 
   test(
     "LOPseeActiveContractsInMultipleSinglePartySubscriptions",
     "Observers should see active contracts in multiple single-party subscriptions",
     allocation,
     timeoutScale,
-  ) {
+  )(implicit ec => {
     case TestParticipants(t) =>
       for {
         contractId <- t.alpha.create(t.giver, WithObservers(t.giver, t.observers))
@@ -105,14 +105,14 @@ final class LotsOfParties(session: LedgerSession) extends LedgerTestSuite(sessio
           betaContractsByParty,
         )
       }
-  }
+  })
 
   test(
     "LOPseeActiveContractsInSingleMultiPartySubscription",
     "Observers should see active contracts in a single multi-party subscription",
     allocation,
     timeoutScale,
-  ) {
+  )(implicit ec => {
     case TestParticipants(t) =>
       for {
         contractId <- t.alpha.create(t.giver, WithObservers(t.giver, t.observers))
@@ -123,12 +123,12 @@ final class LotsOfParties(session: LedgerSession) extends LedgerTestSuite(sessio
         assertWitnessesOfAMultiPartySubscription(t.alphaParties.toSet, contractId, alphaContracts)
         assertWitnessesOfAMultiPartySubscription(t.betaParties.toSet, contractId, betaContracts)
       }
-  }
+  })
 
   private def transactionsForEachParty(
       ledger: ParticipantTestContext,
       observers: Vector[Party],
-  ): Future[PartyMap[Vector[Transaction]]] = {
+  )(implicit ec: ExecutionContext): Future[PartyMap[Vector[Transaction]]] = {
     Future
       .sequence(observers.map(observer => ledger.flatTransactions(observer).map(observer -> _)))
       .map(_.toMap)
@@ -137,7 +137,7 @@ final class LotsOfParties(session: LedgerSession) extends LedgerTestSuite(sessio
   private def activeContractsForEachParty(
       ledger: ParticipantTestContext,
       observers: Vector[Party],
-  ): Future[PartyMap[Vector[CreatedEvent]]] = {
+  )(implicit ec: ExecutionContext): Future[PartyMap[Vector[CreatedEvent]]] = {
     Future
       .sequence(observers.map(observer => ledger.activeContracts(observer).map(observer -> _)))
       .map(_.toMap)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageManagement.scala
@@ -32,7 +32,7 @@ final class PackageManagement(session: LedgerSession) extends LedgerTestSuite(se
     "PackageManagementEmptyUpload",
     "An attempt at uploading an empty payload should fail",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         failure <- ledger.uploadDarFile(ByteString.EMPTY).failed
@@ -43,13 +43,13 @@ final class PackageManagement(session: LedgerSession) extends LedgerTestSuite(se
           "Invalid argument: Invalid DAR: package-upload",
         )
       }
-  }
+  })
 
   test(
     "PackageManagementLoad",
     "Concurrent uploads of the same package should be idempotent and result in the package being available for use",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       for {
         testPackage <- loadTestPackage()
@@ -77,5 +77,5 @@ final class PackageManagement(session: LedgerSession) extends LedgerTestSuite(se
           s"There should be no active package after the contract has been consumed: ${acsAfter.map(_.contractId).mkString(", ")}",
         )
       }
-  }
+  })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Packages.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Packages.scala
@@ -13,7 +13,7 @@ final class Packages(session: LedgerSession) extends LedgerTestSuite(session) {
   /** A package ID that is guaranteed to not be uploaded */
   private[this] val unknownPackageId = " "
 
-  test("PackagesList", "Listing packages should return a result", allocate(NoParties)) {
+  test("PackagesList", "Listing packages should return a result", allocate(NoParties))(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         knownPackages <- ledger.listPackages()
@@ -22,37 +22,43 @@ final class Packages(session: LedgerSession) extends LedgerTestSuite(session) {
           knownPackages.size >= 3,
           s"List of packages was expected to contain at least 3 packages, got ${knownPackages.size} instead.",
         )
-  }
+  })
 
-  test("PackagesGet", "Getting package content should return a valid result", allocate(NoParties)) {
-    case Participants(Participant(ledger)) =>
-      for {
-        somePackageId <- ledger.listPackages().map(_.headOption.getOrElse(fail("No package found")))
-        somePackage <- ledger.getPackage(somePackageId)
-      } yield {
-        assert(somePackage.hash.length > 0, s"Package $somePackageId has an empty hash.")
-        assert(
-          somePackage.hash == somePackageId,
-          s"Package $somePackageId has hash ${somePackage.hash}, expected hash to be equal to the package ID.",
-        )
-        assert(somePackage.archivePayload.size() >= 0, s"Package $somePackageId has zero size.")
-      }
-  }
+  test("PackagesGet", "Getting package content should return a valid result", allocate(NoParties))(
+    implicit ec => {
+      case Participants(Participant(ledger)) =>
+        for {
+          somePackageId <- ledger
+            .listPackages()
+            .map(_.headOption.getOrElse(fail("No package found")))
+          somePackage <- ledger.getPackage(somePackageId)
+        } yield {
+          assert(somePackage.hash.length > 0, s"Package $somePackageId has an empty hash.")
+          assert(
+            somePackage.hash == somePackageId,
+            s"Package $somePackageId has hash ${somePackage.hash}, expected hash to be equal to the package ID.",
+          )
+          assert(somePackage.archivePayload.size() >= 0, s"Package $somePackageId has zero size.")
+        }
+    })
 
   test(
     "PackagesGetUnknown",
     "Getting package content for an unknown package should fail",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         failure <- ledger.getPackage(unknownPackageId).failed
       } yield {
         assertGrpcError(failure, Status.Code.NOT_FOUND, "")
       }
-  }
+  })
 
-  test("PackagesStatus", "Getting package status should return a valid result", allocate(NoParties)) {
+  test(
+    "PackagesStatus",
+    "Getting package status should return a valid result",
+    allocate(NoParties))(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         somePackageId <- ledger.listPackages().map(_.headOption.getOrElse(fail("No package found")))
@@ -60,18 +66,18 @@ final class Packages(session: LedgerSession) extends LedgerTestSuite(session) {
       } yield {
         assert(status.isRegistered, s"Package $somePackageId is not registered.")
       }
-  }
+  })
 
   test(
     "PackagesStatusUnknown",
     "Getting package status for an unknown package should fail",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         status <- ledger.getPackageStatus(unknownPackageId)
       } yield {
         assert(status.isUnknown, s"Package $unknownPackageId is not unknown.")
       }
-  }
+  })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagement.scala
@@ -17,21 +17,21 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
     "PMNonEmptyParticipantID",
     "Asking for the participant identifier should return a non-empty string",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         participantId <- ledger.participantId()
       } yield {
         assert(participantId.nonEmpty, "The ledger returned an empty participant identifier")
       }
-  }
+  })
 
   private val pMAllocateWithHint = "PMAllocateWithHint"
   test(
     pMAllocateWithHint,
     "It should be possible to provide a hint when allocating a party",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         party <- ledger.allocateParty(
@@ -43,13 +43,13 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
           Tag.unwrap(party).nonEmpty,
           "The allocated party identifier is an empty string",
         )
-  }
+  })
 
   test(
     "PMAllocateWithoutHint",
     "It should be possible to not provide a hint when allocating a party",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         party <- ledger.allocateParty(partyIdHint = None, displayName = Some("Jebediah Kerman"))
@@ -58,14 +58,14 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
           Tag.unwrap(party).nonEmpty,
           "The allocated party identifier is an empty string",
         )
-  }
+  })
 
   private val pMAllocateWithoutDisplayName = "PMAllocateWithoutDisplayName"
   test(
     pMAllocateWithoutDisplayName,
     "It should be possible to not provide a display name when allocating a party",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         party <- ledger.allocateParty(
@@ -78,13 +78,13 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
           Tag.unwrap(party).nonEmpty,
           "The allocated party identifier is an empty string",
         )
-  }
+  })
 
   test(
     "PMAllocateDuplicateDisplayName",
     "It should be possible to allocate parties with the same display names",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         p1 <- ledger.allocateParty(partyIdHint = None, displayName = Some("Ononym McOmonymface"))
@@ -94,13 +94,13 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
         assert(Tag.unwrap(p2).nonEmpty, "The second allocated party identifier is an empty string")
         assert(p1 != p2, "The two parties have the same party identifier")
       }
-  }
+  })
 
   test(
     "PMAllocateOneHundred",
     "It should create unique party names when allocating many parties",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         parties <- ledger.allocateParties(100)
@@ -110,13 +110,13 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
           .map { case (name, count) => s"$name ($count)" }
           .mkString(", ")}")
       }
-  }
+  })
 
   test(
     "PMGetParties",
     "It should get details for multiple parties, if they exist",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         party1 <- ledger.allocateParty(
@@ -154,13 +154,13 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
           zeroPartyDetails.isEmpty,
           s"Retrieved some parties when no parties were requested: $zeroPartyDetails")
       }
-  }
+  })
 
   test(
     "PMListKnownParties",
     "It should list all known, previously-allocated parties",
     allocate(NoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger)) =>
       for {
         party1 <- ledger.allocateParty(
@@ -182,5 +182,5 @@ final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(sess
           allocatedPartyIds subsetOf knownPartyIds,
           s"The allocated party IDs $allocatedPartyIds are not a subset of $knownPartyIds.")
       }
-  }
+  })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
@@ -82,7 +82,6 @@ trait PerformanceEnvelope {
   def logger: Logger
   def envelope: Envelope
   def maxInflight: Int
-  protected implicit def ec: ExecutionContext
 
   protected def waitForParties(participants: Seq[Allocation.Participant]): Unit = {
     val (participantAlice, alice) = (participants.head.ledger, participants.head.parties.head)
@@ -112,7 +111,7 @@ trait PerformanceEnvelope {
       from: Participant,
       to: Participant,
       workflowIds: List[String],
-      payload: String): Future[(Duration, List[Duration])] = {
+      payload: String)(implicit ec: ExecutionContext): Future[(Duration, List[Duration])] = {
 
     val (participantAlice, alice) = (from.ledger, from.parties.head)
     val (participantBob, bob) = (to.ledger, to.parties.head)
@@ -201,7 +200,8 @@ trait PerformanceEnvelope {
       numPings: Int,
       queue: ConcurrentLinkedQueue[Promise[Unit]],
       inflight: AtomicInteger,
-      timings: TrieMap[String, Either[Instant, Duration]]): Future[Either[String, Unit]] = {
+      timings: TrieMap[String, Either[Instant, Duration]])(
+      implicit ec: ExecutionContext): Future[Either[String, Unit]] = {
 
     val observed = new AtomicInteger(0)
     val context = Context.ROOT.withCancellation()
@@ -283,7 +283,7 @@ trait PerformanceEnvelope {
       tracker: Promise[Either[String, Unit]],
       sender: ParticipantTestContext,
       party: P.Party,
-      offset: Option[LedgerOffset]): Unit = {
+      offset: Option[LedgerOffset])(implicit ec: ExecutionContext): Unit = {
     val context = Context.ROOT.withCancellation()
 
     context.run(
@@ -351,31 +351,32 @@ object PerformanceEnvelope {
       "perf-envelope-throughput",
       s"Verify that ledger passes the ${envelope.name} throughput envelope",
       allocate(SingleParty, SingleParty),
-    ) { participants =>
-      waitForParties(participants.participants)
+    )(implicit ec => {
+      case participants =>
+        waitForParties(participants.participants)
 
-      def runTest(num: Int, description: String): Future[(Duration, List[Duration])] =
-        sendPings(
-          from = participants.participants.head,
-          to = participants.participants(1),
-          workflowIds = (1 to num).map(x => s"$description-$x").toList,
-          payload = description)
-      for {
-        _ <- runTest(numWarmupPings, "throughput-warmup")
-        timings <- runTest(numPings, "throughput-test")
-      } yield {
-        val (elapsed, latencies) = timings
-        val throughput = numPings / elapsed.toMillis.toDouble * 1000.0
-        logger.info(
-          s"Sending of $numPings succeeded after $elapsed, yielding a throughput of ${"%.2f" format throughput}.")
-        reporter("rate", throughput)
-        logger.info(
-          s"Throughput latency stats: ${genStats(latencies.map(_.toMillis), (_, _) => ())}")
-        assert(
-          throughput >= envelope.throughput,
-          s"Observed throughput of ${"%.2f" format throughput} is below the necessary envelope level ${envelope.throughput}")
-      }
-    }
+        def runTest(num: Int, description: String): Future[(Duration, List[Duration])] =
+          sendPings(
+            from = participants.participants.head,
+            to = participants.participants(1),
+            workflowIds = (1 to num).map(x => s"$description-$x").toList,
+            payload = description)
+        for {
+          _ <- runTest(numWarmupPings, "throughput-warmup")
+          timings <- runTest(numPings, "throughput-test")
+        } yield {
+          val (elapsed, latencies) = timings
+          val throughput = numPings / elapsed.toMillis.toDouble * 1000.0
+          logger.info(
+            s"Sending of $numPings succeeded after $elapsed, yielding a throughput of ${"%.2f" format throughput}.")
+          reporter("rate", throughput)
+          logger.info(
+            s"Throughput latency stats: ${genStats(latencies.map(_.toMillis), (_, _) => ())}")
+          assert(
+            throughput >= envelope.throughput,
+            s"Observed throughput of ${"%.2f" format throughput} is below the necessary envelope level ${envelope.throughput}")
+        }
+    })
   }
 
   class LatencyTest(
@@ -394,7 +395,7 @@ object PerformanceEnvelope {
       "perf-envelope-latency",
       s"Verify that ledger passes the ${envelope.name} latency envelope",
       allocate(SingleParty, SingleParty),
-    ) { participants =>
+    )(implicit ec => { participants =>
       waitForParties(participants.participants)
 
       sendPings(
@@ -413,7 +414,7 @@ object PerformanceEnvelope {
             tailCount <= numPings * 0.1,
             s"$tailCount out of $numPings are above the latency threshold. Stats are $stats")
       }
-    }
+    })
   }
 
   private def genStats(sample: List[Long], reporter: (String, Double) => Unit): String = {
@@ -437,7 +438,7 @@ object PerformanceEnvelope {
       "perf-envelope-transaction-size",
       s"Verify that ledger passes the ${envelope.name} transaction size envelope",
       allocate(SingleParty, SingleParty),
-    ) { participants =>
+    )(implicit ec => { participants =>
       waitForParties(participants.participants)
 
       sendPings(
@@ -446,7 +447,7 @@ object PerformanceEnvelope {
         workflowIds = List("transaction-size"),
         payload = Random.alphanumeric.take(envelope.transactionSizeKb * 1024).mkString("")
       ).map(_ => ())
-    }
+    })
   }
 
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
@@ -24,7 +24,7 @@ import com.daml.ledger.test.SemanticTests._
 import io.grpc.Status
 import scalaz.Tag
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(session) {
   private[this] val onePound = Amount(BigDecimal(1), "GBP")
@@ -45,11 +45,10 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
     "SemanticDoubleSpend",
     "Cannot double spend across transactions",
     allocate(TwoParties, TwoParties),
-  ) {
+  )(implicit ec => {
     case Participants(
         Participant(alpha, payer, owner),
-        Participant(_, newOwner, leftWithNothing),
-        ) =>
+        Participant(_, newOwner, leftWithNothing)) =>
       for {
         iou <- alpha.create(payer, Iou(payer, owner, onePound))
         _ <- alpha.exercise(owner, iou.exerciseTransfer(_, newOwner))
@@ -57,13 +56,13 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
       }
-  }
+  })
 
   test(
     "SemanticDoubleSpendSameTx",
     "Cannot double spend within a transaction",
     allocate(TwoParties, TwoParties),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, payer, owner), Participant(_, newOwner1, newOwner2)) =>
       for {
         iou <- alpha.create(payer, Iou(payer, owner, onePound))
@@ -80,13 +79,13 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
           "Update failed due to fetch of an inactive contract",
         )
       }
-  }
+  })
 
   test(
     "SemanticDoubleSpendShared",
     "Different parties cannot spend the same contract",
     allocate(TwoParties, SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, payer, owner1), Participant(beta, owner2)) =>
       for {
         shared <- alpha.create(payer, SharedContract(payer, owner1, owner2))
@@ -96,7 +95,7 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
       }
-  }
+  })
 
   /*
    * Authorization
@@ -112,7 +111,7 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
     "SemanticPaintOffer",
     "Conduct the paint offer workflow successfully",
     allocate(TwoParties, SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, bank, houseOwner), Participant(beta, painter)) =>
       for {
         iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
@@ -135,13 +134,13 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
           ),
         )
       }
-  }
+  })
 
   test(
     "SemanticPaintCounterOffer",
     "Conduct the paint counter-offer worflow successfully",
     allocate(TwoParties, SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, bank, houseOwner), Participant(beta, painter)) =>
       for {
         iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
@@ -170,26 +169,26 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
           ),
         )
       }
-  }
+  })
 
   test(
     "SemanticPartialSignatories",
     "A signatory should not be able to create a contract on behalf of two parties",
     allocate(SingleParty, SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, houseOwner), Participant(_, painter)) =>
       for {
         failure <- alpha.create(houseOwner, PaintAgree(painter, houseOwner)).failed
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "requires authorizers")
       }
-  }
+  })
 
   test(
     "SemanticAcceptOnBehalf",
     "It should not be possible to exercise a choice without the consent of the controller",
     allocate(TwoParties, SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, bank, houseOwner), Participant(beta, painter)) =>
       for {
         iou <- beta.create(painter, Iou(painter, houseOwner, onePound))
@@ -198,7 +197,7 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "requires authorizers")
       }
-  }
+  })
 
   /*
    * Privacy
@@ -213,7 +212,7 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
     "Test visibility via contract fetches for the paint-offer flow",
     allocate(TwoParties, SingleParty),
     timeoutScale = 2.0,
-  ) {
+  )(implicit ec => {
     case Participants(Participant(alpha, bank, houseOwner), Participant(beta, painter)) =>
       for {
         iou <- alpha.create(bank, Iou(bank, houseOwner, onePound))
@@ -270,13 +269,13 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
           "requires one of the stakeholders",
         )
       }
-  }
+  })
 
   private def fetchIou(
       ledger: ParticipantTestContext,
       party: Primitive.Party,
       iou: Primitive.ContractId[Iou],
-  ): Future[Unit] =
+  )(implicit ec: ExecutionContext): Future[Unit] =
     for {
       fetch <- ledger.create(party, FetchIou(party, iou))
       _ <- ledger.exercise(party, fetch.exerciseFetchIou_Fetch)
@@ -286,7 +285,7 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
       ledger: ParticipantTestContext,
       party: Primitive.Party,
       paintOffer: Primitive.ContractId[PaintOffer],
-  ): Future[Unit] =
+  )(implicit ec: ExecutionContext): Future[Unit] =
     for {
       fetch <- ledger.create(party, FetchPaintOffer(party, paintOffer))
       _ <- ledger.exercise(party, fetch.exerciseFetchPaintOffer_Fetch)
@@ -296,7 +295,7 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
       ledger: ParticipantTestContext,
       party: Primitive.Party,
       agreement: Primitive.ContractId[PaintAgree],
-  ): Future[Unit] =
+  )(implicit ec: ExecutionContext): Future[Unit] =
     for {
       fetch <- ledger.create(party, FetchPaintAgree(party, agreement))
       _ <- ledger.exercise(party, fetch.exerciseFetchPaintAgree_Fetch)
@@ -306,28 +305,30 @@ final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(sessio
    * Divulgence
    */
 
-  test("SemanticDivulgence", "Respect divulgence rules", allocate(TwoParties, SingleParty)) {
-    case Participants(Participant(alpha, issuer, owner), Participant(beta, delegate)) =>
-      for {
-        token <- alpha.create(issuer, Token(issuer, owner, 1))
-        delegation <- alpha.create(owner, Delegation(owner, delegate))
+  test("SemanticDivulgence", "Respect divulgence rules", allocate(TwoParties, SingleParty))(
+    implicit ec => {
+      case Participants(Participant(alpha, issuer, owner), Participant(beta, delegate)) =>
+        for {
+          token <- alpha.create(issuer, Token(issuer, owner, 1))
+          delegation <- alpha.create(owner, Delegation(owner, delegate))
 
-        // The owner tries to divulge with a non-consuming choice, which actually doesn't work
-        noDivulgeToken <- alpha.create(owner, Delegation(owner, delegate))
-        _ <- alpha.exercise(owner, noDivulgeToken.exerciseDelegation_Wrong_Divulge_Token(_, token))
-        _ <- synchronize(alpha, beta)
-        failure <- beta
-          .exercise(delegate, delegation.exerciseDelegation_Token_Consume(_, token))
-          .failed
+          // The owner tries to divulge with a non-consuming choice, which actually doesn't work
+          noDivulgeToken <- alpha.create(owner, Delegation(owner, delegate))
+          _ <- alpha
+            .exercise(owner, noDivulgeToken.exerciseDelegation_Wrong_Divulge_Token(_, token))
+          _ <- synchronize(alpha, beta)
+          failure <- beta
+            .exercise(delegate, delegation.exerciseDelegation_Token_Consume(_, token))
+            .failed
 
-        // Successful divulgence and delegation
-        divulgeToken <- alpha.create(owner, Delegation(owner, delegate))
-        _ <- alpha.exercise(owner, divulgeToken.exerciseDelegation_Divulge_Token(_, token))
-        _ <- eventually {
-          beta.exercise(delegate, delegation.exerciseDelegation_Token_Consume(_, token))
+          // Successful divulgence and delegation
+          divulgeToken <- alpha.create(owner, Delegation(owner, delegate))
+          _ <- alpha.exercise(owner, divulgeToken.exerciseDelegation_Divulge_Token(_, token))
+          _ <- eventually {
+            beta.exercise(delegate, delegation.exerciseDelegation_Token_Consume(_, token))
+          }
+        } yield {
+          assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
         }
-      } yield {
-        assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
-      }
-  }
+    })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionScale.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionScale.scala
@@ -21,7 +21,7 @@ class TransactionScale(session: LedgerSession) extends LedgerTestSuite(session) 
     "TXLargeCommand",
     "Accept huge submissions with a large number of commands",
     allocate(SingleParty),
-  ) {
+  )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val targetNumberOfSubCommands = numberOfCommands(units = 3)
       val request = ledger.submitAndWaitRequest(
@@ -33,21 +33,22 @@ class TransactionScale(session: LedgerSession) extends LedgerTestSuite(session) 
       } yield {
         val _ = assertLength("LargeCommand", targetNumberOfSubCommands, result.events)
       }
-  }
+  })
 
-  test("TXManyCommands", "Accept many, large commands at once", allocate(SingleParty)) {
-    case Participants(Participant(ledger, party)) =>
-      val targetNumberOfCommands = numberOfCommands(units = 1)
-      val oneKbOfText = new String(Array.fill(512 /* two bytes each */ )('a'))
-      for {
-        contractIds <- Future.sequence(
-          (1 to targetNumberOfCommands).map(_ =>
-            ledger.create(party, TextContainer(party, oneKbOfText))),
-        )
-      } yield {
-        val _ = assertLength("ManyCommands", targetNumberOfCommands, contractIds)
-      }
-  }
+  test("TXManyCommands", "Accept many, large commands at once", allocate(SingleParty))(
+    implicit ec => {
+      case Participants(Participant(ledger, party)) =>
+        val targetNumberOfCommands = numberOfCommands(units = 1)
+        val oneKbOfText = new String(Array.fill(512 /* two bytes each */ )('a'))
+        for {
+          contractIds <- Future.sequence(
+            (1 to targetNumberOfCommands).map(_ =>
+              ledger.create(party, TextContainer(party, oneKbOfText))),
+          )
+        } yield {
+          val _ = assertLength("ManyCommands", targetNumberOfCommands, contractIds)
+        }
+    })
 
   private def numberOfCommands(units: Int): Int =
     (units * numberOfCommandsUnit * session.config.loadScaleFactor).toInt

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Witnesses.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/Witnesses.scala
@@ -10,7 +10,10 @@ import com.daml.ledger.test_stable.Test.{DivulgeWitnesses, Witnesses => Witnesse
 import scalaz.Tag
 
 final class Witnesses(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("RespectDisclosureRules", "The ledger should respect disclosure rules", allocate(Parties(3))) {
+  test(
+    "RespectDisclosureRules",
+    "The ledger should respect disclosure rules",
+    allocate(Parties(3)))(implicit ec => {
     case Participants(Participant(ledger, alice, bob, charlie)) =>
       for {
         // Create the Witnesses contract as Alice and get the resulting transaction as seen by all parties
@@ -97,5 +100,5 @@ final class Witnesses(session: LedgerSession) extends LedgerTestSuite(session) {
         )
 
       }
-  }
+  })
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WronglyTypedContractId.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WronglyTypedContractId.scala
@@ -13,20 +13,21 @@ import com.daml.ledger.test_stable.Test.{Delegated, Delegation, Dummy, DummyWith
 import io.grpc.Status.Code
 
 final class WronglyTypedContractId(session: LedgerSession) extends LedgerTestSuite(session) {
-  test("WTExerciseFails", "Exercising on a wrong type fails", allocate(SingleParty)) {
-    case Participants(Participant(ledger, party)) =>
-      for {
-        dummy <- ledger.create(party, Dummy(party))
-        fakeDummyWithParam = dummy.asInstanceOf[Primitive.ContractId[DummyWithParam]]
-        exerciseFailure <- ledger
-          .exercise(party, fakeDummyWithParam.exerciseDummyChoice2(_, "txt"))
-          .failed
-      } yield {
-        assertGrpcError(exerciseFailure, Code.INVALID_ARGUMENT, "wrongly typed contract id")
-      }
-  }
+  test("WTExerciseFails", "Exercising on a wrong type fails", allocate(SingleParty))(
+    implicit ec => {
+      case Participants(Participant(ledger, party)) =>
+        for {
+          dummy <- ledger.create(party, Dummy(party))
+          fakeDummyWithParam = dummy.asInstanceOf[Primitive.ContractId[DummyWithParam]]
+          exerciseFailure <- ledger
+            .exercise(party, fakeDummyWithParam.exerciseDummyChoice2(_, "txt"))
+            .failed
+        } yield {
+          assertGrpcError(exerciseFailure, Code.INVALID_ARGUMENT, "wrongly typed contract id")
+        }
+    })
 
-  test("WTFetchFails", "Fetching of the wrong type fails", allocate(TwoParties)) {
+  test("WTFetchFails", "Fetching of the wrong type fails", allocate(TwoParties))(implicit ec => {
     case Participants(Participant(ledger, owner, delegate)) =>
       for {
         dummy <- ledger.create(owner, Dummy(owner))
@@ -39,5 +40,5 @@ final class WronglyTypedContractId(session: LedgerSession) extends LedgerTestSui
       } yield {
         assertGrpcError(fetchFailure, Code.INVALID_ARGUMENT, "wrongly typed contract id")
       }
-  }
+  })
 }


### PR DESCRIPTION
`LedgerTestSuite` itself does not do anything with the `ExecutionContext`; it is only used to provide it as an "ambient" implicit throughout each test definition. Instead, with this PR, the `ExecutionContext` is explicitly passed down as an additional argument to the `runTestCase` closure.

For this not to change the behaviour of the program, we need to be confident that the `ExecutionContext` is still the same. Let's first look at how the `ExecutionContext` used to reach a test case. For any execution of the test tool, there is only one `LedgerTestSuiteRunner` created [by the main method](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala#L125-L136), on which [we call](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala#L138) the `verifyRequirementsAndRun` method. This in turn [calls](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala#L155) the `run` method after checking that the given configuration is valid, and [that](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala#L119) is where the `ExecutionContext` gets created. It is declared as implicit so it gets picked up by the [`LedgerSession`](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala#L13-L16) constructor [call](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala#L122). This (single) `LedgerSession` then [gets passed](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala#L123) to the [constructor](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala#L13) of each individual `LedgerTestSuite`, which [extracts the `ExecutionContext` from the session](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala#L20) to make it available to each individual test created in the enclosing scope of a subclass when calling the [`test`](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala#L22-L32) method.

With this PR, the `ExecutionContext` is no longer extracted from the `LedgerSession` in the `LedgerTestSuite` constructor, but is instead threaded through to the `apply` method of `LedgerTestCase` through the `run` (different signature) [call](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala#L134) for the individual test, which itself [calls](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala#L114) `start`, which then [calls](https://github.com/digital-asset/daml/blob/53bddb54d752153727ab990b50239bffb53d0ef6/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala#L60) the `apply` method of `LedgerTestCase`. Because each of these methods (`run` and `start` on `LedgerTestSuiterunner` and `apply` on `LedgerTestCase`) already expected an implicit `ExecutionContext`, no change is required on the `LedgerTestSuiteRunner` side.

A handful of helper functions in various test suites also needed to be changed to fetch the `ExecutionContext` implicitly from their calling context rather than capturing it lexically from the enclosing `LedgerTestSuite`. This is, again, the same `ExecutionContext` it used to be, but instead of getting it from the `LedgerSession` they get it from the `LedgerTestCase` closure.

This was originally part of #6314, but despite it being a pure refactoring, it is quite a large (and somewhat subtle) changeset, so I believe it is better to review/merge separately.

CHANGELOG_BEGIN
CHANGELOG_END