### PR TITLE
Include sadbonx-classic in compatibility tests

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -34,6 +34,7 @@ config_setting(
     sh_binary(
         name = "sandbox-with-postgres-{}".format(version),
         srcs = ["@//bazel_tools:sandbox-with-postgres.sh"],
+        args = ["sandbox"],
         data = [
             "@//bazel_tools/client_server/with-postgres:with-postgres-exe",
             "@daml-sdk-{}//:daml".format(version),

--- a/compatibility/README.md
+++ b/compatibility/README.md
@@ -28,11 +28,12 @@ release.
 #### Cross-version compatibility between ledger-api-test-tool
 
 We test that the `ledger-api-test-tool` of a given version passes
-against Sandbox next of another version. We test all possible version
-combinations here to ensure forwards and backwards compatibility. The
-`ledger-api-test-tool` includes a DAR built using a compiler from
-the same SDK version so this also ensures that sandbox can load a DAR from
-a different SDK version.
+against Sandbox next and classic of another version. We test all
+possible version combinations here to ensure forwards and backwards
+compatibility. The `ledger-api-test-tool` includes a DAR built using a
+compiler from the same SDK version so this also ensures that sandbox
+can load a DAR from a different SDK version. We test both in-memory
+backends and postgresql backends.
 
 Since all our JVM ledger clients use the same client libraries we
 consider the `ledger-api-test-tool` to be a good proxy and if things

--- a/compatibility/bazel_tools/sandbox-with-postgres.sh
+++ b/compatibility/bazel_tools/sandbox-with-postgres.sh
@@ -23,4 +23,4 @@ if [ -z "$WITH_POSTGRES" ]; then
     echo "Faild to find with-postgres wrapper"
     exit 1
 fi
-$WITH_POSTGRES $(rlocation daml-sdk-$version/daml) sandbox $extra_args
+$WITH_POSTGRES $(rlocation daml-sdk-$version/daml) $extra_args


### PR DESCRIPTION
Given that sadbonx-classic came back from the dead my initial
reasoning that we don’t have to include it since it will be gone soon
anyway is obsolete. Therefore, this PR adds both the in-memory and
postgresql variant to the ledger-api-test-tool tests. For other tests,
I did not yet create variants for sadbonx-classic. Not sure how
important that is, we can always add it later.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
