### PR TITLE
restore terraform to working state

### DIFF
--- a/infra/macos/2-vagrant-files/init.sh
+++ b/infra/macos/2-vagrant-files/init.sh
@@ -136,7 +136,7 @@ log "Created /nix partition."
 su -l vsts <<'END'
 set -euo pipefail
 export PATH="/usr/local/bin:/usr/sbin:$PATH"
-bash <(curl -sSfL https://nixos.org/nix/install)
+bash <(curl https://nixos.org/nix/install)
 echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
 END
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -11,13 +11,11 @@ terraform {
 provider "google" {
   project = "da-dev-gcp-daml-language"
   region  = "us-east4"
-  version = "3.5"
 }
 
 provider "google-beta" {
   project = "da-dev-gcp-daml-language"
   region  = "us-east4"
-  version = "3.5"
 }
 
 provider "secret" {

--- a/infra/vsts_agent_linux_startup.sh
+++ b/infra/vsts_agent_linux_startup.sh
@@ -146,7 +146,7 @@ chown --recursive root:root /home/vsts/agent/{*.sh,bin,externals}
 
 # This needs to run inside of a user with sudo access
 echo "vsts ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/nix_installation
-su --command "sh <(curl -sSfL https://nixos.org/nix/install) --daemon" --login vsts
+su --command "sh <(curl https://nixos.org/nix/install) --daemon" --login vsts
 rm /etc/sudoers.d/nix_installation
 
 # Note: the "hydra.da-int.net" string is now part of the name of the key for


### PR DESCRIPTION
It looks like some nix update has broken our current Terraform setup. The Google provider plugin has changed its reported version to 0.0.0; poking at my local nix store seems to indicate we actually get 3.15, but :shrug:.

This PR also reverts the infra part of #6400 so we get back to master == reality.

CHANGELOG_BEGIN
CHANGELOG_END