### PR TITLE
macos nodes: add nix redirect

### DIFF
--- a/infra/macos/2-vagrant-files/init.sh
+++ b/infra/macos/2-vagrant-files/init.sh
@@ -136,7 +136,7 @@ log "Created /nix partition."
 su -l vsts <<'END'
 set -euo pipefail
 export PATH="/usr/local/bin:/usr/sbin:$PATH"
-bash <(curl https://nixos.org/nix/install)
+bash <(curl -sSfL https://nixos.org/nix/install)
 echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
 END
 


### PR DESCRIPTION
See #6400; split out as separate PR so master == reality and we can track when this is done. @nycnewman please merge this once the change is deployed.

Note: it has to be deployed before the next restart; nodes will _not_ be able to boot with the current configuration.

CHANGELOG_BEGIN
CHANGELOG_END