### PR TITLE
api test tool: remove dead code

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.api.testtool.infrastructure
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation.{ParticipantAllocation, Participants}
-import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite._
 import com.daml.lf.data.Ref
 
 import scala.collection.mutable.ListBuffer
@@ -28,16 +27,4 @@ private[testtool] abstract class LedgerTestSuite(val session: LedgerSession) {
       new LedgerTestCase(shortIdentifierRef, description, timeoutScale, participants, testCase),
     )
   }
-
-  protected final def skip(reason: String): Future[Unit] = Future.failed(SkipTestException(reason))
-
-  protected final def skipIf(reason: String)(p: => Boolean): Future[Unit] =
-    if (p)
-      skip(reason)
-    else
-      Future.successful(())
-}
-
-private[testtool] object LedgerTestSuite {
-  final case class SkipTestException(message: String) extends RuntimeException(message)
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
@@ -9,7 +9,6 @@ import java.util.{Timer, TimerTask}
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
-import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite.SkipTestException
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuiteRunner._
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessionManager
 import org.slf4j.LoggerFactory
@@ -83,8 +82,6 @@ final class LedgerTestSuiteRunner(
     startedTest
       .map[Either[Result.Failure, Result.Success]](duration => Right(Result.Succeeded(duration)))
       .recover[Either[Result.Failure, Result.Success]] {
-        case SkipTestException(reason) =>
-          Right(Result.Skipped(reason))
         case _: TimeoutException =>
           Left(Result.TimedOut)
         case failure: AssertionError =>


### PR DESCRIPTION
This is extracted from #6314, but actually has nothing to do with it. This is removing two functions that are never called, as well as a type that is never constructed (and the one pattern match on it).

CHANGELOG_BEGIN
CHANGELOG_END