### PR TITLE
rename test suites to match their names

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -22,23 +22,23 @@ object Tests {
     * always run by default, unless otherwise specified.
     */
   val default: Tests = Map(
-    "ActiveContractsServiceIT" -> (new ActiveContractsService(_)),
-    "CommandServiceIT" -> (new CommandService(_)),
-    "CommandSubmissionCompletionIT" -> (new CommandSubmissionCompletion(_)),
-    "CommandDeduplicationIT" -> (new CommandDeduplication(_)),
-    "ContractKeysIT" -> (new ContractKeys(_)),
-    "DivulgenceIT" -> (new Divulgence(_)),
-    "HealthServiceIT" -> (new HealthService(_)),
-    "IdentityIT" -> (new Identity(_)),
-    "LedgerConfigurationServiceIT" -> (new LedgerConfigurationService(_)),
-    "PackageManagementServiceIT" -> (new PackageManagement(_)),
-    "PackageServiceIT" -> (new Packages(_)),
-    "PartyManagementServiceIT" -> (new PartyManagement(_)),
+    "ActiveContractsServiceIT" -> (new ActiveContractsServiceIT(_)),
+    "CommandServiceIT" -> (new CommandServiceIT(_)),
+    "CommandSubmissionCompletionIT" -> (new CommandSubmissionCompletionIT(_)),
+    "CommandDeduplicationIT" -> (new CommandDeduplicationIT(_)),
+    "ContractKeysIT" -> (new ContractKeysIT(_)),
+    "DivulgenceIT" -> (new DivulgenceIT(_)),
+    "HealthServiceIT" -> (new HealthServiceIT(_)),
+    "IdentityIT" -> (new IdentityIT(_)),
+    "LedgerConfigurationServiceIT" -> (new LedgerConfigurationServiceIT(_)),
+    "PackageManagementServiceIT" -> (new PackageManagementServiceIT(_)),
+    "PackageServiceIT" -> (new PackageServiceIT(_)),
+    "PartyManagementServiceIT" -> (new PartyManagementServiceIT(_)),
     "SemanticTests" -> (new SemanticTests(_)),
-    "TransactionServiceIT" -> (new TransactionService(_)),
-    "WitnessesIT" -> (new Witnesses(_)),
-    "WronglyTypedContractIdIT" -> (new WronglyTypedContractId(_)),
-    "ClosedWorldIT" -> (new ClosedWorld(_)),
+    "TransactionServiceIT" -> (new TransactionServiceIT(_)),
+    "WitnessesIT" -> (new WitnessesIT(_)),
+    "WronglyTypedContractIdIT" -> (new WronglyTypedContractIdIT(_)),
+    "ClosedWorldIT" -> (new ClosedWorldIT(_)),
   )
 
   /**
@@ -49,9 +49,9 @@ object Tests {
     * These are consequently not run unless otherwise specified.
     */
   val optional: Tests = Map(
-    "ConfigManagementServiceIT" -> (new ConfigManagement(_)),
-    "LotsOfPartiesIT" -> (new LotsOfParties(_)),
-    "TransactionScaleIT" -> (new TransactionScale(_)),
+    "ConfigManagementServiceIT" -> (new ConfigManagementServiceIT(_)),
+    "LotsOfPartiesIT" -> (new LotsOfPartiesIT(_)),
+    "TransactionScaleIT" -> (new TransactionScaleIT(_)),
   )
 
   val all: Tests = default ++ optional

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ActiveContractsServiceIT.scala
@@ -26,7 +26,7 @@ import scalaz.syntax.tag._
 
 import scala.concurrent.ExecutionContext
 
-class ActiveContractsService(session: LedgerSession) extends LedgerTestSuite(session) {
+class ActiveContractsServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "ACSinvalidLedgerId",
     "The ActiveContractService should fail for requests with an invalid ledger identifier",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ClosedWorldIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ClosedWorldIT.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.client.binding
 import com.daml.ledger.test.SemanticTests.{Amount, Iou}
 import io.grpc.Status
 
-class ClosedWorld(session: LedgerSession) extends LedgerTestSuite(session) {
+class ClosedWorldIT(session: LedgerSession) extends LedgerTestSuite(session) {
 
   private[this] val onePound = Amount(BigDecimal(1), "GBP")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-final class CommandDeduplication(session: LedgerSession) extends LedgerTestSuite(session) {
+final class CommandDeduplicationIT(session: LedgerSession) extends LedgerTestSuite(session) {
 
   /** A deduplicated submission can either
     * succeed (if the participant knows that the original submission has succeeded),

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
@@ -20,7 +20,7 @@ import com.daml.ledger.test_stable.Test.{Dummy, _}
 import io.grpc.Status
 import scalaz.syntax.tag._
 
-final class CommandService(session: LedgerSession) extends LedgerTestSuite(session) {
+final class CommandServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "CSsubmitAndWait",
     "SubmitAndWait creates a contract of the expected template",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
@@ -15,7 +15,7 @@ import io.grpc.Status
 
 import scala.concurrent.duration.DurationInt
 
-final class CommandSubmissionCompletion(session: LedgerSession) extends LedgerTestSuite(session) {
+final class CommandSubmissionCompletionIT(session: LedgerSession) extends LedgerTestSuite(session) {
 
   test(
     "CSCCompletions",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagementServiceIT.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.api.v1.admin.config_management_service.TimeModel
 import com.google.protobuf.duration.Duration
 import io.grpc.Status
 
-final class ConfigManagement(session: LedgerSession) extends LedgerTestSuite(session) {
+final class ConfigManagementServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "CMSetAndGetTimeModel",
     "It should be able to get, set and restore the time model",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
@@ -22,7 +22,7 @@ import com.daml.ledger.test_stable.Test._
 import io.grpc.Status
 import scalaz.Tag
 
-final class ContractKeys(session: LedgerSession) extends LedgerTestSuite(session) {
+final class ContractKeysIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "CKFetchOrLookup",
     "Divulged contracts cannot be fetched or looked up by key by non-stakeholders",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/DivulgenceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/DivulgenceIT.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.test_stable.Test.Divulgence2._
 import com.daml.ledger.test_stable.Test.{Divulgence1, Divulgence2}
 import scalaz.Tag
 
-final class Divulgence(session: LedgerSession) extends LedgerTestSuite(session) {
+final class DivulgenceIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "DivulgenceTx",
     "Divulged contracts should not be exposed by the transaction service",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/HealthServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/HealthServiceIT.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import io.grpc.health.v1.health.HealthCheckResponse
 
-class HealthService(session: LedgerSession) extends LedgerTestSuite(session) {
+class HealthServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test("HScheck", "The Health.Check endpoint reports everything is well", allocate(NoParties))(
     implicit ec => {
       case Participants(Participant(ledger)) =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/IdentityIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/IdentityIT.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSui
 
 import scala.concurrent.Future
 
-final class Identity(session: LedgerSession) extends LedgerTestSuite(session) {
+final class IdentityIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "IdNotEmpty",
     "A ledger should return a non-empty string as its identity",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationServiceIT.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSui
 import com.daml.ledger.test_stable.Test.Dummy
 import io.grpc.Status
 
-class LedgerConfigurationService(session: LedgerSession) extends LedgerTestSuite(session) {
+class LedgerConfigurationServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test("ConfigSucceeds", "Return a valid configuration for a valid request", allocate(NoParties))(
     implicit ec => {
       case Participants(Participant(ledger)) =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LotsOfPartiesIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LotsOfPartiesIT.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.test_stable.Test.WithObservers
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class LotsOfParties(session: LedgerSession) extends LedgerTestSuite(session) {
+final class LotsOfPartiesIT(session: LedgerSession) extends LedgerTestSuite(session) {
   type Parties = Set[Party]
   type PartyMap[T] = Map[Party, T]
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageManagementServiceIT.scala
@@ -13,7 +13,7 @@ import io.grpc.Status
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class PackageManagement(session: LedgerSession) extends LedgerTestSuite(session) {
+final class PackageManagementServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
   private[this] val testPackageResourcePath =
     "/ledger/ledger-api-test-tool/PackageManagementTest.dar"
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageServiceIT.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import io.grpc.Status
 
-final class Packages(session: LedgerSession) extends LedgerTestSuite(session) {
+final class PackageServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
 
   /** A package ID that is guaranteed to not be uploaded */
   private[this] val unknownPackageId = " "

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagementServiceIT.scala
@@ -12,7 +12,7 @@ import scalaz.Tag
 
 import scala.util.Random
 
-final class PartyManagement(session: LedgerSession) extends LedgerTestSuite(session) {
+final class PartyManagementServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "PMNonEmptyParticipantID",
     "Asking for the participant identifier should return a non-empty string",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionScaleIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionScaleIT.scala
@@ -7,11 +7,11 @@ import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.daml.ledger.test_stable.Test.{Dummy, TextContainer}
-import TransactionScale.numberOfCommandsUnit
+import TransactionScaleIT.numberOfCommandsUnit
 
 import scala.concurrent.Future
 
-class TransactionScale(session: LedgerSession) extends LedgerTestSuite(session) {
+class TransactionScaleIT(session: LedgerSession) extends LedgerTestSuite(session) {
   require(
     numberOfCommands(units = 1) > 0,
     s"The load scale factor must be at least ${1.0 / numberOfCommandsUnit}",
@@ -55,6 +55,6 @@ class TransactionScale(session: LedgerSession) extends LedgerTestSuite(session) 
 
 }
 
-object TransactionScale {
+object TransactionScaleIT {
   private val numberOfCommandsUnit = 500
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionServiceIT.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
-import com.daml.ledger.api.testtool.tests.TransactionService.{
+import com.daml.ledger.api.testtool.tests.TransactionServiceIT.{
   comparableTransactionTrees,
   comparableTransactions
 }
@@ -38,7 +38,7 @@ import scalaz.Tag
 import scala.collection.mutable
 import scala.concurrent.Future
 
-class TransactionService(session: LedgerSession) extends LedgerTestSuite(session) {
+class TransactionServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "TXBeginToBegin",
     "An empty stream should be served when getting transactions from and to the beginning of the ledger",
@@ -1599,7 +1599,7 @@ class TransactionService(session: LedgerSession) extends LedgerTestSuite(session
   })
 }
 
-object TransactionService {
+object TransactionServiceIT {
 
   // Strip command id and offset to yield a transaction comparable across participant
   // Furthermore, makes sure that the order is not relevant for witness parties

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WitnessesIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WitnessesIT.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.test_stable.Test.Witnesses._
 import com.daml.ledger.test_stable.Test.{DivulgeWitnesses, Witnesses => WitnessesTemplate}
 import scalaz.Tag
 
-final class Witnesses(session: LedgerSession) extends LedgerTestSuite(session) {
+final class WitnessesIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test(
     "RespectDisclosureRules",
     "The ledger should respect disclosure rules",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WronglyTypedContractIdIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WronglyTypedContractIdIT.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.test_stable.Test.DummyWithParam._
 import com.daml.ledger.test_stable.Test.{Delegated, Delegation, Dummy, DummyWithParam}
 import io.grpc.Status.Code
 
-final class WronglyTypedContractId(session: LedgerSession) extends LedgerTestSuite(session) {
+final class WronglyTypedContractIdIT(session: LedgerSession) extends LedgerTestSuite(session) {
   test("WTExerciseFails", "Exercising on a wrong type fails", allocate(SingleParty))(
     implicit ec => {
       case Participants(Participant(ledger, party)) =>


### PR DESCRIPTION
This is extracted from #6314. This is a simple renaming of a few classes. The goal here is to have the `LedgerTestSuite#name` match the key currently used in the `Tests.default` and `Tests.optional` maps so that we can eventually remove that duplication (after the `LedgerSession` argument is removed so we can actually construct the `LedgerTestSuite` objects and ask them their name).

Note that `LedgerTestSuite#name` is [already defined][0] as:

```
  val name: String = getClass.getSimpleName
```

In the context of #6314, this is useful to align the existing behaviour of `--include` with the desired future behaviour of `--exclude`, so we can use the same names in both. Alternatives could be to remove the `LedgerTestSuite#name` method and thread the key `String`s through to the individual tests somehow, or make the `name` field a constructor argument rather than reconstruct it based on the class name. This approach of using the class name is the cleanest I could think of.

CHANGELOG_BEGIN
CHANGELOG_END

[0]: https://github.com/digital-asset/daml/blob/d01715bf2f0380fd83f073ef1698d3c1b5fd35fe/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala#L14