### PR TITLE
remove LedgerSession from LedgerTestSuite constructor

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -6,39 +6,35 @@ package com.daml.ledger.api.testtool
 import java.nio.file.Path
 
 import com.daml.ledger.api.testtool
-import com.daml.ledger.api.testtool.infrastructure.{
-  BenchmarkReporter,
-  LedgerSession,
-  LedgerTestSuite
-}
+import com.daml.ledger.api.testtool.infrastructure.{BenchmarkReporter, LedgerTestSuite}
 import com.daml.ledger.api.testtool.tests._
 import org.slf4j.LoggerFactory
 
 object Tests {
-  type Tests = Map[String, LedgerSession => LedgerTestSuite]
+  type Tests = Map[String, LedgerTestSuite]
 
   /**
     * These tests are safe to be run concurrently and are
     * always run by default, unless otherwise specified.
     */
   val default: Tests = Map(
-    "ActiveContractsServiceIT" -> (new ActiveContractsServiceIT(_)),
-    "CommandServiceIT" -> (new CommandServiceIT(_)),
-    "CommandSubmissionCompletionIT" -> (new CommandSubmissionCompletionIT(_)),
-    "CommandDeduplicationIT" -> (new CommandDeduplicationIT(_)),
-    "ContractKeysIT" -> (new ContractKeysIT(_)),
-    "DivulgenceIT" -> (new DivulgenceIT(_)),
-    "HealthServiceIT" -> (new HealthServiceIT(_)),
-    "IdentityIT" -> (new IdentityIT(_)),
-    "LedgerConfigurationServiceIT" -> (new LedgerConfigurationServiceIT(_)),
-    "PackageManagementServiceIT" -> (new PackageManagementServiceIT(_)),
-    "PackageServiceIT" -> (new PackageServiceIT(_)),
-    "PartyManagementServiceIT" -> (new PartyManagementServiceIT(_)),
-    "SemanticTests" -> (new SemanticTests(_)),
-    "TransactionServiceIT" -> (new TransactionServiceIT(_)),
-    "WitnessesIT" -> (new WitnessesIT(_)),
-    "WronglyTypedContractIdIT" -> (new WronglyTypedContractIdIT(_)),
-    "ClosedWorldIT" -> (new ClosedWorldIT(_)),
+    "ActiveContractsServiceIT" -> new ActiveContractsServiceIT,
+    "CommandServiceIT" -> new CommandServiceIT,
+    "CommandSubmissionCompletionIT" -> new CommandSubmissionCompletionIT,
+    "CommandDeduplicationIT" -> new CommandDeduplicationIT,
+    "ContractKeysIT" -> new ContractKeysIT,
+    "DivulgenceIT" -> new DivulgenceIT,
+    "HealthServiceIT" -> new HealthServiceIT,
+    "IdentityIT" -> new IdentityIT,
+    "LedgerConfigurationServiceIT" -> new LedgerConfigurationServiceIT,
+    "PackageManagementServiceIT" -> new PackageManagementServiceIT,
+    "PackageServiceIT" -> new PackageServiceIT,
+    "PartyManagementServiceIT" -> new PartyManagementServiceIT,
+    "SemanticTests" -> new SemanticTests,
+    "TransactionServiceIT" -> new TransactionServiceIT,
+    "WitnessesIT" -> new WitnessesIT,
+    "WronglyTypedContractIdIT" -> new WronglyTypedContractIdIT,
+    "ClosedWorldIT" -> new ClosedWorldIT,
   )
 
   /**
@@ -48,13 +44,13 @@ object Tests {
     *
     * These are consequently not run unless otherwise specified.
     */
-  val optional: Tests = Map(
-    "ConfigManagementServiceIT" -> (new ConfigManagementServiceIT(_)),
-    "LotsOfPartiesIT" -> (new LotsOfPartiesIT(_)),
-    "TransactionScaleIT" -> (new TransactionScaleIT(_)),
+  def optional(config: Config): Tests = Map(
+    "ConfigManagementServiceIT" -> new ConfigManagementServiceIT,
+    "LotsOfPartiesIT" -> new LotsOfPartiesIT,
+    "TransactionScaleIT" -> new TransactionScaleIT(config.loadScaleFactor),
   )
 
-  val all: Tests = default ++ optional
+  def all(config: Config): Tests = default ++ optional(config)
 
   /**
     * These are performance envelope tests that also provide benchmarks and are always run
@@ -75,20 +71,20 @@ object Tests {
         val latencyKey: String = performanceEnvelopeLatencyTestKey(envelope)
         val transactionSizeKey: String = performanceEnvelopeTransactionSizeTestKey(envelope)
         List(
-          throughputKey -> (new testtool.tests.PerformanceEnvelope.ThroughputTest(
+          throughputKey -> new testtool.tests.PerformanceEnvelope.ThroughputTest(
             logger = LoggerFactory.getLogger(throughputKey),
             envelope = envelope,
             reporter = reporter,
-          )(_)),
-          latencyKey -> (new testtool.tests.PerformanceEnvelope.LatencyTest(
+          ),
+          latencyKey -> new testtool.tests.PerformanceEnvelope.LatencyTest(
             logger = LoggerFactory.getLogger(latencyKey),
             envelope = envelope,
             reporter = reporter,
-          )(_)),
-          transactionSizeKey -> (new testtool.tests.PerformanceEnvelope.TransactionSizeScaleTest(
+          ),
+          transactionSizeKey -> new testtool.tests.PerformanceEnvelope.TransactionSizeScaleTest(
             logger = LoggerFactory.getLogger(transactionSizeKey),
             envelope = envelope,
-          )(_)),
+          ),
         )
       }
     }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
@@ -9,7 +9,7 @@ import com.daml.lf.data.Ref
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}
 
-private[testtool] abstract class LedgerTestSuite(val session: LedgerSession) {
+private[testtool] abstract class LedgerTestSuite {
   val name: String = getClass.getSimpleName
 
   private val testCaseBuffer: ListBuffer[LedgerTestCase] = ListBuffer()

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuiteRunner.scala
@@ -34,7 +34,7 @@ object LedgerTestSuiteRunner {
 
 final class LedgerTestSuiteRunner(
     config: LedgerSessionConfiguration,
-    suiteConstructors: Vector[LedgerSession => LedgerTestSuite],
+    suites: Vector[LedgerTestSuite],
     identifierSuffix: String,
     suiteTimeoutScale: Double,
     concurrentTestRuns: Int,
@@ -103,7 +103,7 @@ final class LedgerTestSuiteRunner(
       result: Either[Result.Failure, Result.Success])(
       implicit ec: ExecutionContext,
   ): LedgerTestSummary =
-    LedgerTestSummary(suite.name, test.description, suite.session.config, result)
+    LedgerTestSummary(suite.name, test.description, config, result)
 
   private def run(test: LedgerTestCase, session: LedgerSession)(
       implicit ec: ExecutionContext,
@@ -117,7 +117,6 @@ final class LedgerTestSuiteRunner(
 
     val participantSessionManager = new ParticipantSessionManager
     val ledgerSession = new LedgerSession(config, participantSessionManager)
-    val suites = suiteConstructors.map(constructor => constructor(ledgerSession))
     val testCount = suites.map(_.tests.size).sum
 
     logger.info(s"Running $testCount tests, ${math.min(testCount, concurrentTestRuns)} at a time.")
@@ -128,7 +127,7 @@ final class LedgerTestSuiteRunner(
     Source(tests)
       .mapAsyncUnordered(concurrentTestRuns) {
         case ((suite, test), index) =>
-          run(test, suite.session).map(testResult => (suite, test, testResult) -> index)
+          run(test, ledgerSession).map(testResult => (suite, test, testResult) -> index)
       }
       .map {
         case ((suite, test, testResult), index) => summarize(suite, test, testResult) -> index

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ActiveContractsServiceIT.scala
@@ -5,14 +5,14 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.daml.ledger.api.v1.event.Event.Event.Created
 import com.daml.ledger.api.v1.event.{CreatedEvent, Event}
 import com.daml.ledger.client.binding.Primitive.{Party, TemplateId}
+import com.daml.ledger.test_stable.Test.Divulgence2._
 import com.daml.ledger.test_stable.Test.Dummy._
 import com.daml.ledger.test_stable.Test.Witnesses._
-import com.daml.ledger.test_stable.Test.Divulgence2._
 import com.daml.ledger.test_stable.Test.{
   Divulgence1,
   Divulgence2,
@@ -26,7 +26,7 @@ import scalaz.syntax.tag._
 
 import scala.concurrent.ExecutionContext
 
-class ActiveContractsServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+class ActiveContractsServiceIT extends LedgerTestSuite {
   test(
     "ACSinvalidLedgerId",
     "The ActiveContractService should fail for requests with an invalid ledger identifier",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ClosedWorldIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ClosedWorldIT.scala
@@ -10,12 +10,12 @@ import com.daml.ledger.api.testtool.infrastructure.Allocation.{
   allocate
 }
 import com.daml.ledger.api.testtool.infrastructure.Assertions.assertGrpcError
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.client.binding
 import com.daml.ledger.test.SemanticTests.{Amount, Iou}
 import io.grpc.Status
 
-class ClosedWorldIT(session: LedgerSession) extends LedgerTestSuite(session) {
+class ClosedWorldIT extends LedgerTestSuite {
 
   private[this] val onePound = Amount(BigDecimal(1), "GBP")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions.assertGrpcError
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.test_stable.DA.Types.Tuple2
 import com.daml.ledger.test_stable.Test.TextKeyOperations._
 import com.daml.ledger.test_stable.Test._
@@ -19,7 +19,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-final class CommandDeduplicationIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class CommandDeduplicationIT extends LedgerTestSuite {
 
   /** A deduplicated submission can either
     * succeed (if the participant knows that the original submission has succeeded),

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
@@ -5,9 +5,9 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.daml.ledger.api.v1.commands.Command
 import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.client.binding.Primitive
@@ -20,7 +20,7 @@ import com.daml.ledger.test_stable.Test.{Dummy, _}
 import io.grpc.Status
 import scalaz.syntax.tag._
 
-final class CommandServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class CommandServiceIT extends LedgerTestSuite {
   test(
     "CSsubmitAndWait",
     "SubmitAndWait creates a contract of the expected template",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.test_stable.Test.Dummy
 import com.daml.ledger.test_stable.Test.Dummy._
 import com.daml.platform.testing.{TimeoutException, WithTimeout}
@@ -15,7 +15,7 @@ import io.grpc.Status
 
 import scala.concurrent.duration.DurationInt
 
-final class CommandSubmissionCompletionIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class CommandSubmissionCompletionIT extends LedgerTestSuite {
 
   test(
     "CSCCompletions",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagementServiceIT.scala
@@ -5,12 +5,12 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.v1.admin.config_management_service.TimeModel
 import com.google.protobuf.duration.Duration
 import io.grpc.Status
 
-final class ConfigManagementServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class ConfigManagementServiceIT extends LedgerTestSuite {
   test(
     "CMSetAndGetTimeModel",
     "It should be able to get, set and restore the time model",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
@@ -8,9 +8,9 @@ import java.util.UUID
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.test_stable.DA.Types.Tuple2
 import com.daml.ledger.test_stable.Test.Delegated._
@@ -22,7 +22,7 @@ import com.daml.ledger.test_stable.Test._
 import io.grpc.Status
 import scalaz.Tag
 
-final class ContractKeysIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class ContractKeysIT extends LedgerTestSuite {
   test(
     "CKFetchOrLookup",
     "Divulged contracts cannot be fetched or looked up by key by non-stakeholders",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/DivulgenceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/DivulgenceIT.scala
@@ -4,12 +4,12 @@
 package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.test_stable.Test.Divulgence2._
 import com.daml.ledger.test_stable.Test.{Divulgence1, Divulgence2}
 import scalaz.Tag
 
-final class DivulgenceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class DivulgenceIT extends LedgerTestSuite {
   test(
     "DivulgenceTx",
     "Divulged contracts should not be exposed by the transaction service",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/HealthServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/HealthServiceIT.scala
@@ -5,10 +5,10 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import io.grpc.health.v1.health.HealthCheckResponse
 
-class HealthServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+class HealthServiceIT extends LedgerTestSuite {
   test("HScheck", "The Health.Check endpoint reports everything is well", allocate(NoParties))(
     implicit ec => {
       case Participants(Participant(ledger)) =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/IdentityIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/IdentityIT.scala
@@ -4,11 +4,11 @@
 package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 
 import scala.concurrent.Future
 
-final class IdentityIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class IdentityIT extends LedgerTestSuite {
   test(
     "IdNotEmpty",
     "A ledger should return a non-empty string as its identity",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LedgerConfigurationServiceIT.scala
@@ -5,11 +5,11 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.test_stable.Test.Dummy
 import io.grpc.Status
 
-class LedgerConfigurationServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+class LedgerConfigurationServiceIT extends LedgerTestSuite {
   test("ConfigSucceeds", "Return a valid configuration for a valid request", allocate(NoParties))(
     implicit ec => {
       case Participants(Participant(ledger)) =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LotsOfPartiesIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LotsOfPartiesIT.scala
@@ -5,9 +5,9 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.daml.ledger.api.v1.event.CreatedEvent
 import com.daml.ledger.api.v1.transaction.Transaction
 import com.daml.ledger.client.binding.Primitive.{ContractId, Party}
@@ -15,7 +15,7 @@ import com.daml.ledger.test_stable.Test.WithObservers
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class LotsOfPartiesIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class LotsOfPartiesIT extends LedgerTestSuite {
   type Parties = Set[Party]
   type PartyMap[T] = Map[Party, T]
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageManagementServiceIT.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.packagemanagementtest.PackageManagementTest.PackageManagementTestTemplate
 import com.daml.ledger.packagemanagementtest.PackageManagementTest.PackageManagementTestTemplate._
 import com.google.protobuf.ByteString
@@ -13,7 +13,7 @@ import io.grpc.Status
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class PackageManagementServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class PackageManagementServiceIT extends LedgerTestSuite {
   private[this] val testPackageResourcePath =
     "/ledger/ledger-api-test-tool/PackageManagementTest.dar"
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PackageServiceIT.scala
@@ -5,10 +5,10 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import io.grpc.Status
 
-final class PackageServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class PackageServiceIT extends LedgerTestSuite {
 
   /** A package ID that is guaranteed to not be uploaded */
   private[this] val unknownPackageId = " "

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PartyManagementServiceIT.scala
@@ -4,15 +4,15 @@
 package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
-import com.daml.lf.data.Ref
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.v1.admin.party_management_service.PartyDetails
 import com.daml.ledger.client.binding
+import com.daml.lf.data.Ref
 import scalaz.Tag
 
 import scala.util.Random
 
-final class PartyManagementServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class PartyManagementServiceIT extends LedgerTestSuite {
   test(
     "PMNonEmptyParticipantID",
     "Asking for the participant identifier should return a non-empty string",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
@@ -9,33 +9,28 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
-import com.daml.ledger.api.testtool.infrastructure.{
-  Allocation,
-  Assertions,
-  LedgerSession,
-  LedgerTestSuite
-}
+import com.daml.ledger.api.testtool.infrastructure.{Allocation, Assertions, LedgerTestSuite}
 import com.daml.ledger.api.v1.command_completion_service.{
   CompletionEndRequest,
   CompletionStreamRequest,
   CompletionStreamResponse
 }
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
-import com.daml.ledger.client.binding.{Primitive => P}
 import com.daml.ledger.api.v1.commands.{Command, Commands}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.transaction.Transaction
 import com.daml.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
 import com.daml.ledger.api.v1.transaction_service.{GetTransactionsRequest, GetTransactionsResponse}
-import io.grpc.{Context, Status}
+import com.daml.ledger.client.binding.{Primitive => P}
+import com.daml.ledger.test.performance.{PingPong => PingPongModule}
 import io.grpc.stub.StreamObserver
+import io.grpc.{Context, Status}
+import org.slf4j.Logger
 import scalaz.syntax.tag._
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future, Promise, blocking}
 import scala.util.{Failure, Random, Success, Try}
-import com.daml.ledger.test.performance.{PingPong => PingPongModule}
-import org.slf4j.Logger
 
 sealed trait Envelope {
   val name: String
@@ -343,8 +338,8 @@ object PerformanceEnvelope {
       val numPings: Int = 200,
       val maxInflight: Int = 40,
       val numWarmupPings: Int = 40,
-      reporter: (String, Double) => Unit)(session: LedgerSession)
-      extends LedgerTestSuite(session)
+      reporter: (String, Double) => Unit)
+      extends LedgerTestSuite
       with PerformanceEnvelope {
 
     test(
@@ -384,8 +379,8 @@ object PerformanceEnvelope {
       val envelope: Envelope,
       val numPings: Int = 20,
       val numWarmupPings: Int = 10,
-      reporter: (String, Double) => Unit)(session: LedgerSession)
-      extends LedgerTestSuite(session)
+      reporter: (String, Double) => Unit)
+      extends LedgerTestSuite
       with PerformanceEnvelope {
 
     val maxInflight = 1 // will only be one
@@ -428,8 +423,8 @@ object PerformanceEnvelope {
     s"Sample size of ${sample.length}: avg=${"%.0f" format avg} ms, median=$med ms, stdev=${"%.0f" format stddev} ms"
   }
 
-  class TransactionSizeScaleTest(val logger: Logger, val envelope: Envelope)(session: LedgerSession)
-      extends LedgerTestSuite(session)
+  class TransactionSizeScaleTest(val logger: Logger, val envelope: Envelope)
+      extends LedgerTestSuite
       with PerformanceEnvelope {
 
     val maxInflight = 10

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
@@ -6,10 +6,10 @@ package com.daml.ledger.api.testtool.tests
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.test.SemanticTests.Delegation._
@@ -26,7 +26,7 @@ import scalaz.Tag
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class SemanticTests(session: LedgerSession) extends LedgerTestSuite(session) {
+final class SemanticTests extends LedgerTestSuite {
   private[this] val onePound = Amount(BigDecimal(1), "GBP")
   private[this] val twoPounds = Amount(BigDecimal(2), "GBP")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionScaleIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionScaleIT.scala
@@ -5,13 +5,13 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
+import com.daml.ledger.api.testtool.tests.TransactionScaleIT.numberOfCommandsUnit
 import com.daml.ledger.test_stable.Test.{Dummy, TextContainer}
-import TransactionScaleIT.numberOfCommandsUnit
 
 import scala.concurrent.Future
 
-class TransactionScaleIT(session: LedgerSession) extends LedgerTestSuite(session) {
+class TransactionScaleIT(loadScaleFactor: Double) extends LedgerTestSuite {
   require(
     numberOfCommands(units = 1) > 0,
     s"The load scale factor must be at least ${1.0 / numberOfCommandsUnit}",
@@ -51,7 +51,7 @@ class TransactionScaleIT(session: LedgerSession) extends LedgerTestSuite(session
     })
 
   private def numberOfCommands(units: Int): Int =
-    (units * numberOfCommandsUnit * session.config.loadScaleFactor).toInt
+    (units * numberOfCommandsUnit * loadScaleFactor).toInt
 
 }
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionServiceIT.scala
@@ -6,9 +6,9 @@ package com.daml.ledger.api.testtool.tests
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
 import com.daml.ledger.api.testtool.infrastructure.TransactionHelpers._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
 import com.daml.ledger.api.testtool.tests.TransactionServiceIT.{
   comparableTransactionTrees,
   comparableTransactions
@@ -38,7 +38,7 @@ import scalaz.Tag
 import scala.collection.mutable
 import scala.concurrent.Future
 
-class TransactionServiceIT(session: LedgerSession) extends LedgerTestSuite(session) {
+class TransactionServiceIT extends LedgerTestSuite {
   test(
     "TXBeginToBegin",
     "An empty stream should be served when getting transactions from and to the beginning of the ledger",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WitnessesIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WitnessesIT.scala
@@ -3,13 +3,13 @@
 package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.test_stable.Test.DivulgeWitnesses._
 import com.daml.ledger.test_stable.Test.Witnesses._
 import com.daml.ledger.test_stable.Test.{DivulgeWitnesses, Witnesses => WitnessesTemplate}
 import scalaz.Tag
 
-final class WitnessesIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class WitnessesIT extends LedgerTestSuite {
   test(
     "RespectDisclosureRules",
     "The ledger should respect disclosure rules",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WronglyTypedContractIdIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/WronglyTypedContractIdIT.scala
@@ -5,14 +5,14 @@ package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
-import com.daml.ledger.api.testtool.infrastructure.{LedgerSession, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.client.binding.Primitive
 import com.daml.ledger.test_stable.Test.Delegation._
 import com.daml.ledger.test_stable.Test.DummyWithParam._
 import com.daml.ledger.test_stable.Test.{Delegated, Delegation, Dummy, DummyWithParam}
 import io.grpc.Status.Code
 
-final class WronglyTypedContractIdIT(session: LedgerSession) extends LedgerTestSuite(session) {
+final class WronglyTypedContractIdIT extends LedgerTestSuite {
   test("WTExerciseFails", "Exercising on a wrong type fails", allocate(SingleParty))(
     implicit ec => {
       case Participants(Participant(ledger, party)) =>


### PR DESCRIPTION
This is another refactoring extracted from #6314. This is removing the `LedgerSession` argument from `LedgerTestSuite`. The goal of this change is to remove the closures from the `Tests.Tests` type, so it becomes a plain map of name to test suite, rather than a map of name to function-that-returns-a-test-suite.

In context, this is another step towards removing the name duplication that occurs in the `Tests.default` and `Tests.optional` maps. I have separated this step from the one that actually removes the duplication because removing the duplication in #6314 was done by turning the maps into seqs, thereby changing the order in which tests are run, which caused the flakiness issues I've been investigating over the past week.

This commit does not yet change the order in which tests are run and is therefore safe from that perspective. It's still a true refactoring.

It's a fairly simple one at that as `LedgerTestSuite` itself never uses the session, and there was only one subclass that did. The subclass, `TransactionScaleIT`, only used it to get at one config parameter. In this PR, that config parameter is instead passed down directly to the `Tests.default` method.

The other use of the `session` attribute was to extract it from the test suite in order to pass it to the `run` method of `LedgerTestSuiteRunner`. This was done right after creating the test suites and giving them that same session, so we're now skipping that round trip and just giving the session directly to `run`.

CHANGELOG_BEGIN
CHANGELOG_END