### PR TITLE
Integrate time service into DAML Script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -22,6 +22,7 @@ module Daml.Script
   , exerciseByKeyCmd
   , createAndExerciseCmd
   , getTime
+  , setTime
   , sleep
   ) where
 
@@ -83,6 +84,7 @@ data ScriptF a
   | AllocParty (AllocateParty a)
   | ListKnownParties (ListKnownPartiesPayload a)
   | GetTime (Time -> a)
+  | SetTime (SetTimePayload a)
   | Sleep (SleepRec a)
   deriving Functor
 
@@ -96,6 +98,22 @@ data QueryACS a = QueryACS
 -- that are visible to the given party.
 query : forall t. Template t => Party -> Script [(ContractId t, t)]
 query p = lift $ Free $ Query (QueryACS p (templateTypeRep @t) (pure . map (\(cid, tpl) -> (coerceContractId cid, fromSome $ fromAnyTemplate tpl))))
+
+data SetTimePayload a = SetTimePayload
+  with
+    time : Time
+    continue : () -> a
+  deriving Functor
+
+-- | Set the time via the time service.
+--
+-- This is only supported in static time mode when running over the gRPC API.
+--
+-- Note that the time service does not support going backwards in time.
+setTime : Time -> Script ()
+setTime time = lift $ Free $ SetTime $ SetTimePayload with
+  time
+  continue = pure
 
 data AllocateParty a = AllocateParty
   { displayName : Text
@@ -184,7 +202,10 @@ data PartyDetails = PartyDetails
     isLocal : Bool -- ^ True if party is hosted by the backing participant.
   deriving (Eq, Ord, Show)
 
--- | In wallclock mode, this is UTC time. In static time mode, this is the UNIX epoch.
+-- | In wallclock mode, this is UTC time. In static time mode, this will
+-- query the ledger time service for the current time when running over
+-- gRPC. When running over the JSON API, it will always
+-- return the Unix epoch.
 instance HasTime Script where
   getTime = lift $ Free (GetTime pure)
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -13,6 +13,7 @@ import scala.concurrent.Future
 import scalaz.{-\/, \/-}
 import spray.json._
 import com.daml.lf.data.Ref._
+import com.daml.lf.data.Time
 import com.daml.lf.iface
 import com.daml.lf.iface.EnvironmentInterface
 import com.daml.lf.iface.reader.InterfaceReader
@@ -371,6 +372,12 @@ object Converter {
     v match {
       case p @ SParty(_) => Right(p)
       case _ => Left(s"Expected SParty but got $v")
+    }
+
+  def toTimestamp(v: SValue): Either[String, Time.Timestamp] =
+    v match {
+      case STimestamp(t) => Right(t)
+      case _ => Left(s"Expected STimestamp but got $v")
     }
 
   // Helper to construct a record

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -13,6 +13,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import io.grpc.{Status, StatusRuntimeException}
+import java.time.{Clock, Instant}
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Failure}
@@ -23,8 +24,12 @@ import scalaz.syntax.tag._
 import scalaz.syntax.traverse._
 import spray.json._
 
+import com.daml.api.util.TimestampConversion
+import com.daml.grpc.adapter.ExecutionSequencerFactory
+import com.daml.grpc.adapter.client.akka.ClientAdapter
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Ref
+import com.daml.lf.data.Time
 import com.daml.lf.iface.{EnvironmentInterface, InterfaceType}
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SValue._
@@ -37,6 +42,8 @@ import com.daml.ledger.api.domain.PartyDetails
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands._
+import com.daml.ledger.api.v1.testing.time_service.{GetTimeRequest, SetTimeRequest, TimeServiceGrpc}
+import com.daml.ledger.api.v1.testing.time_service.TimeServiceGrpc.TimeServiceStub
 import com.daml.ledger.api.v1.transaction.TreeEvent
 import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, TransactionFilter}
 import com.daml.ledger.api.validation.ValueValidator
@@ -45,6 +52,15 @@ import com.daml.platform.participant.util.LfEngineToApi.{
   lfValueToApiRecord,
   lfValueToApiValue,
   toApiIdentifier
+}
+
+// We have our own type for time modes since TimeProviderType
+// allows for more stuff that doesn’t make sense in DAML Script.
+sealed trait ScriptTimeMode
+
+object ScriptTimeMode {
+  final case object Static extends ScriptTimeMode
+  final case object WallClock extends ScriptTimeMode
 }
 
 object ScriptLedgerClient {
@@ -104,6 +120,15 @@ trait ScriptLedgerClient {
       implicit ec: ExecutionContext,
       mat: Materializer): Future[List[PartyDetails]]
 
+  def getStaticTime()(
+      implicit ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer): Future[Time.Timestamp]
+
+  def setStaticTime(time: Time.Timestamp)(
+      implicit ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer): Future[Unit]
 }
 
 class GrpcLedgerClient(val grpcClient: LedgerClient) extends ScriptLedgerClient {
@@ -186,6 +211,37 @@ class GrpcLedgerClient(val grpcClient: LedgerClient) extends ScriptLedgerClient 
   override def listKnownParties()(implicit ec: ExecutionContext, mat: Materializer) = {
     grpcClient.partyManagementClient
       .listKnownParties()
+  }
+
+  private val utcClock = Clock.systemUTC()
+
+  override def getStaticTime()(
+      implicit ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer): Future[Time.Timestamp] = {
+    val timeService: TimeServiceStub = TimeServiceGrpc.stub(grpcClient.channel)
+    for {
+      resp <- ClientAdapter
+        .serverStreaming(GetTimeRequest(grpcClient.ledgerId.unwrap), timeService.getTime)
+        .runWith(Sink.head)
+    } yield Time.Timestamp.assertFromInstant(TimestampConversion.toInstant(resp.getCurrentTime))
+  }
+
+  override def setStaticTime(time: Time.Timestamp)(
+      implicit ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer): Future[Unit] = {
+    val timeService: TimeServiceStub = TimeServiceGrpc.stub(grpcClient.channel)
+    for {
+      oldTime <- ClientAdapter
+        .serverStreaming(GetTimeRequest(grpcClient.ledgerId.unwrap), timeService.getTime)
+        .runWith(Sink.head)
+      _ <- timeService.setTime(
+        SetTimeRequest(
+          grpcClient.ledgerId.unwrap,
+          oldTime.currentTime,
+          Some(TimestampConversion.fromInstant(time.toInstant))))
+    } yield ()
   }
 
   private def toCommand(command: ScriptLedgerClient.Command): Either[String, Command] =
@@ -363,6 +419,23 @@ class JsonLedgerClient(
     Future.failed(
       new RuntimeException(
         s"listKnownParties is not supported when running DAML Script over the JSON API"))
+  }
+
+  override def getStaticTime()(
+      implicit ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer): Future[Time.Timestamp] = {
+    // There is no time service in the JSON API so we default to the Unix epoch.
+    Future { Time.Timestamp.assertFromInstant(Instant.EPOCH) }
+  }
+
+  override def setStaticTime(time: Time.Timestamp)(
+      implicit ec: ExecutionContext,
+      esf: ExecutionSequencerFactory,
+      mat: Materializer): Future[Unit] = {
+    // No time service in the JSON API
+    Future.failed(
+      new RuntimeException("setTime is not supported when running DAML Script over the JSON API."))
   }
 
   // Check that the party in the token matches the given party.

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
@@ -9,7 +9,6 @@ import java.time.Duration
 import scala.util.Try
 
 import com.daml.ledger.api.tls.TlsConfiguration
-import com.daml.platform.services.time.TimeProviderType
 
 case class RunnerConfig(
     darPath: File,
@@ -18,7 +17,7 @@ case class RunnerConfig(
     ledgerPort: Option[Int],
     participantConfig: Option[File],
     // optional so we can detect if both --static-time and --wall-clock-time are passed.
-    timeProviderType: Option[TimeProviderType],
+    timeMode: Option[ScriptTimeMode],
     commandTtl: Duration,
     inputFile: Option[File],
     outputFile: Option[File],
@@ -30,7 +29,7 @@ case class RunnerConfig(
 
 object RunnerConfig {
 
-  val DefaultTimeProviderType: TimeProviderType = TimeProviderType.WallClock
+  val DefaultTimeMode: ScriptTimeMode = ScriptTimeMode.WallClock
   val DefaultMaxInboundMessageSize: Int = 4194304
 
   private def validatePath(path: String, message: String): Either[String, Unit] = {
@@ -68,13 +67,13 @@ object RunnerConfig {
 
     opt[Unit]('w', "wall-clock-time")
       .action { (_, c) =>
-        setTimeProviderType(c, TimeProviderType.WallClock)
+        setTimeMode(c, ScriptTimeMode.WallClock)
       }
       .text("Use wall clock time (UTC).")
 
     opt[Unit]('s', "static-time")
       .action { (_, c) =>
-        setTimeProviderType(c, TimeProviderType.Static)
+        setTimeMode(c, ScriptTimeMode.Static)
       }
       .text("Use static time.")
 
@@ -166,15 +165,15 @@ object RunnerConfig {
 
   }
 
-  private def setTimeProviderType(
+  private def setTimeMode(
       config: RunnerConfig,
-      timeProviderType: TimeProviderType,
+      timeMode: ScriptTimeMode,
   ): RunnerConfig = {
-    if (config.timeProviderType.exists(_ != timeProviderType)) {
+    if (config.timeMode.exists(_ != timeMode)) {
       throw new IllegalStateException(
         "Static time mode (`-s`/`--static-time`) and wall-clock time mode (`-w`/`--wall-clock-time`) are mutually exclusive. The time mode must be unambiguous.")
     }
-    config.copy(timeProviderType = Some(timeProviderType))
+    config.copy(timeMode = Some(timeMode))
   }
 
   def parse(args: Array[String]): Option[RunnerConfig] =
@@ -186,7 +185,7 @@ object RunnerConfig {
         ledgerHost = None,
         ledgerPort = None,
         participantConfig = None,
-        timeProviderType = None,
+        timeMode = None,
         commandTtl = Duration.ofSeconds(30L),
         inputFile = None,
         outputFile = None,

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestConfig.scala
@@ -6,14 +6,12 @@ package com.daml.lf.engine.script
 import java.io.File
 import java.time.Duration
 
-import com.daml.platform.services.time.TimeProviderType
-
 case class TestConfig(
     darPath: File,
     ledgerHost: Option[String],
     ledgerPort: Option[Int],
     participantConfig: Option[File],
-    timeProviderType: TimeProviderType,
+    timeMode: ScriptTimeMode,
     commandTtl: Duration,
     maxInboundMessageSize: Int,
 )
@@ -44,7 +42,7 @@ object TestConfig {
 
     opt[Unit]('w', "wall-clock-time")
       .action { (t, c) =>
-        c.copy(timeProviderType = TimeProviderType.WallClock)
+        c.copy(timeMode = ScriptTimeMode.WallClock)
       }
       .text("Use wall clock time (UTC). When not provided, static time is used.")
 
@@ -80,7 +78,7 @@ object TestConfig {
         ledgerHost = None,
         ledgerPort = None,
         participantConfig = None,
-        timeProviderType = TimeProviderType.Static,
+        timeMode = ScriptTimeMode.Static,
         commandTtl = Duration.ofSeconds(30L),
         maxInboundMessageSize = RunnerConfig.DefaultMaxInboundMessageSize,
       )

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -49,7 +49,8 @@ ScriptTest:test3 SUCCESS
 ScriptTest:test4 SUCCESS
 ScriptTest:testCreateAndExercise SUCCESS
 ScriptTest:testKey SUCCESS
-ScriptTest:time SUCCESS
+ScriptTest:testGetTime SUCCESS
+ScriptTest:testSetTime SUCCESS
 ScriptTest:traceOrder SUCCESS
 ScriptTest:partyIdHintTest SUCCESS
 ScriptTest:sleepTest SUCCESS

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -7,6 +7,7 @@ module ScriptTest where
 
 import DA.Action
 import DA.Assert
+import DA.Date
 import DA.Foldable hiding (length)
 import DA.List
 import DA.Time
@@ -150,8 +151,8 @@ testStack = do
   results <- submit p $ replicateA 1000 (createCmd (C p 42))
   assert (length results == 1000)
 
-time : Script (Time, Time)
-time = do
+testGetTime : Script (Time, Time)
+testGetTime = do
   t1 <- getTime
   t2 <- getTime
   assert (t1 <= t2)
@@ -250,3 +251,9 @@ testMaxInboundMessageSize : Script () = do
   b <- submit p do createCmd (MessageSize p)
   submit p do exerciseCmd b CreateN with n = 50000
   return ()
+
+testSetTime : Script (Time, Time) = do
+  t0 <- getTime
+  setTime (time (date 2000 Feb 2) 0 1 2)
+  t1 <- getTime
+  pure (t0, t1)

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -15,12 +15,17 @@ import scalaz.{-\/, \/-}
 import scalaz.syntax.traverse._
 import spray.json._
 
-import com.daml.api.util.TimeProvider
 import com.daml.bazeltools.BazelRunfiles._
 import com.daml.lf.archive.DarReader
 import com.daml.lf.archive.Decode
 import com.daml.lf.data.Ref._
-import com.daml.lf.engine.script.{ApiParameters, Participants, Runner, ScriptLedgerClient}
+import com.daml.lf.engine.script.{
+  ApiParameters,
+  Participants,
+  Runner,
+  ScriptLedgerClient,
+  ScriptTimeMode
+}
 import com.daml.lf.iface.EnvironmentInterface
 import com.daml.lf.iface.reader.InterfaceReader
 import com.daml.lf.speedy.SError._
@@ -170,7 +175,7 @@ final class JsonApiIt
       inputValue,
       clients,
       ApplicationId(MockMessages.applicationId),
-      TimeProvider.UTC)
+      ScriptTimeMode.WallClock)
   }
 
   "DAML Script over JSON API" can {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -14,6 +14,7 @@ import com.daml.lf.archive.Dar
 import com.daml.lf.archive.DarReader
 import com.daml.lf.archive.Decode
 import com.daml.lf.data.{FrontStack, FrontStackCons, Numeric}
+import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Ref.{Party => LedgerParty}
 import com.daml.lf.language.Ast._
@@ -182,11 +183,11 @@ case class TestCreateAndExercise(dar: Dar[(PackageId, Package)], runner: TestRun
   }
 }
 
-case class Time(dar: Dar[(PackageId, Package)], runner: TestRunner) {
-  val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:time"))
+case class GetTime(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:testGetTime"))
   def runTests() = {
     runner.genericTest(
-      "Time",
+      "getTime",
       scriptId,
       None,
       result =>
@@ -200,6 +201,30 @@ case class Time(dar: Dar[(PackageId, Package)], runner: TestRunner) {
               else Right(())
             } yield r
           case v => Left(s"Expected SUnit but got $v")
+      }
+    )
+  }
+}
+
+case class SetTime(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:testSetTime"))
+  def runTests() = {
+    runner.genericTest(
+      "tTime",
+      scriptId,
+      None,
+      result =>
+        result match {
+          case SRecord(_, _, vals) if vals.size == 2 =>
+            for {
+              t0 <- TestRunner.assertSTimestamp(vals.get(0))
+              t1 <- TestRunner.assertSTimestamp(vals.get(1))
+              _ <- TestRunner
+                .assertEqual(t0, Timestamp.assertFromString("1970-01-01T00:00:00Z"), "t0")
+              _ <- TestRunner
+                .assertEqual(t1, Timestamp.assertFromString("2000-02-02T00:01:02Z"), "t1")
+            } yield ()
+          case v => Left(s"Expected Tuple2 but got $v")
       }
     )
   }
@@ -420,13 +445,17 @@ object SingleParticipant {
             Test4(dar, runner).runTests()
             TestKey(dar, runner).runTests()
             TestCreateAndExercise(dar, runner).runTests()
-            Time(dar, runner).runTests()
+            GetTime(dar, runner).runTests()
             Sleep(dar, runner).runTests()
             PartyIdHintTest(dar, runner).runTests()
             ListKnownParties(dar, runner).runTests()
             TestStack(dar, runner).runTests()
             TestMaxInboundMessageSize(dar, runner).runTests()
             ScriptExample(dar, runner).runTests()
+            // Keep this at the end since it changes the time and we cannot go backwards.
+            if (!config.wallclockTime) {
+              SetTime(dar, runner).runTests()
+            }
           case Some(_) =>
             // We can’t test much with auth since most of our tests rely on party allocation and being
             // able to act as the corresponding party.

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -8,7 +8,6 @@ import akka.stream._
 import ch.qos.logback.core.AppenderBase
 import ch.qos.logback.classic.spi.ILoggingEvent
 import java.io.File
-import java.time.Instant
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
@@ -16,7 +15,6 @@ import scala.util.{Success, Failure}
 import scalaz.syntax.tag._
 import spray.json._
 
-import com.daml.api.util.TimeProvider
 import com.daml.lf.archive.Dar
 import com.daml.lf.data.Ref._
 import com.daml.lf.language.Ast._
@@ -83,8 +81,8 @@ class TestRunner(
     token = token,
   )
   val ttl = java.time.Duration.ofSeconds(30)
-  val timeProvider: TimeProvider =
-    if (wallclockTime) TimeProvider.UTC else TimeProvider.Constant(Instant.EPOCH)
+  val timeMode: ScriptTimeMode =
+    if (wallclockTime) ScriptTimeMode.WallClock else ScriptTimeMode.Static
 
   def genericTest[A](
       // test name
@@ -112,7 +110,7 @@ class TestRunner(
 
     val testFlow: Future[Unit] = for {
       clients <- clientsF
-      result <- Runner.run(dar, scriptId, inputValue, clients, applicationId, timeProvider)
+      result <- Runner.run(dar, scriptId, inputValue, clients, applicationId, timeMode)
       _ <- expectedLog match {
         case None => Future.unit
         case Some(expectedLogs) =>

--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -293,3 +293,6 @@ To run DAML script against the JSON API you have to pass the ``--json-api`` para
 #. Since DAML Script only accepts a single token and the party is
    inferred from the token, this means that you can only use a single
    party within a DAML script when running against the JSON API.
+#. ``getTime`` will always return the Unix epoch in static time mode
+   since the time service is not exposed via the JSON API.
+#. ``setTime`` is not supported and will throw a runtime error.


### PR DESCRIPTION
This integrates the time service into DAML script thereby covering the
main piece of scenarios that was missing from DAML script.

This PR does two things (they are very related and doing them together
makes it much easier to test):

1. It “fixes” `getTime` to return the ledger time in static mode by
   querying the ledger time service instead of defaulting to the Unix
   epoch which is pretty useless and I would consider the old behavior
   a bug. We keep the old behavior via the JSON API since there is no
   time service.

2. It adds `setTime` to set the ledger time via the time service. This
   is only supported in static time mode (sadbonx and other ledgers do
   not expose the time service in wallclock mode because changing time
   makes it not wallclock) or via the JSON API (no time service).

fixes #6220

changelog_begin

- [DAML Script] DAML Script’s `getTime` now correctly handles time
  changes in static time mode and returns the current time by querying
  the time service rather than defaulting to the Unix epoch. Note that
  when run via the JSON API, it still returns the Unix epoch.

- [DAML Script] Add `setTime` to DAML Script which sets the ledger
  time via the ledger API time service. Note that this is only
  supported when running over gRPC in static time mode.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
