### PR TITLE
Trigger service: Increase server binding timeout

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -448,7 +448,11 @@ object Server {
 }
 
 object ServiceMain {
-  // This is mainly intended for tests
+
+  // Timeout for serving binding
+  implicit val timeout: Timeout = 30.seconds
+
+  // Used by the test fixture
   def startServer(
       host: String,
       port: Int,
@@ -477,8 +481,6 @@ object ServiceMain {
         "TriggerService"
       )
 
-    // timeout chosen at random, change freely if you see issues
-    implicit val timeout: Timeout = 15.seconds
     implicit val scheduler: Scheduler = system.scheduler
     implicit val ec: ExecutionContext = system.executionContext
 
@@ -519,8 +521,7 @@ object ServiceMain {
             ),
             "TriggerService"
           )
-        // Timeout chosen at random, change freely if you see issues.
-        implicit val timeout: Timeout = 15.seconds
+
         implicit val scheduler: Scheduler = system.scheduler
         implicit val ec: ExecutionContext = system.executionContext
 


### PR DESCRIPTION
To avoid timeouts in CI. Also factor out the implicit val one level
so it is used by both tests and main method.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
