### PR TITLE
Trigger service: Write packages to database if we have one

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -176,7 +176,7 @@ object Server {
     initialDar foreach { dar =>
       server.addDar(dar) match {
         case Left(err) =>
-          ctx.log.error("Failed to add provided DAR.\n" ++ err)
+          ctx.log.error("Failed to upload provided DAR.\n" ++ err)
           sys.exit(1)
         case Right(()) =>
       }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/InMemoryTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/InMemoryTriggerDao.scala
@@ -34,6 +34,7 @@ class InMemoryTriggerDao extends RunningTriggerDao {
     Right(triggersByParty.getOrElse(credentials, Set()).toVector.sorted)
   }
 
+  // This is only possible when running with persistence. For in-memory mode we do nothing.
   override def persistPackages(dar: Dar[(PackageId, DamlLf.ArchivePayload)]): Either[String, Unit] =
     Right(())
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/InMemoryTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/InMemoryTriggerDao.scala
@@ -5,6 +5,9 @@ package com.daml.lf.engine.trigger.dao
 
 import java.util.UUID
 
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.lf.archive.Dar
+import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.trigger.{RunningTrigger, UserCredentials}
 
 class InMemoryTriggerDao extends RunningTriggerDao {
@@ -30,6 +33,9 @@ class InMemoryTriggerDao extends RunningTriggerDao {
   override def listRunningTriggers(credentials: UserCredentials): Either[String, Vector[UUID]] = {
     Right(triggersByParty.getOrElse(credentials, Set()).toVector.sorted)
   }
+
+  override def persistPackages(dar: Dar[(PackageId, DamlLf.ArchivePayload)]): Either[String, Unit] =
+    Right(())
 }
 
 object InMemoryTriggerDao {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/RunningTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/RunningTriggerDao.scala
@@ -5,10 +5,14 @@ package com.daml.lf.engine.trigger.dao
 
 import java.util.UUID
 
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.lf.archive.Dar
+import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.trigger.{RunningTrigger, UserCredentials}
 
 trait RunningTriggerDao {
   def addRunningTrigger(t: RunningTrigger): Either[String, Unit]
   def removeRunningTrigger(triggerInstance: UUID): Either[String, Boolean]
   def listRunningTriggers(credentials: UserCredentials): Either[String, Vector[UUID]]
+  def persistPackages(dar: Dar[(PackageId, DamlLf.ArchivePayload)]): Either[String, Unit]
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -211,6 +211,16 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
       Future(succeed)
     }
 
+  it should "allow repeated uploads of the same packages" in
+    withTriggerService(Some(dar)) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+      for {
+        resp <- uploadDar(uri, darPath) // same dar as in initialization
+        _ <- parseResult(resp)
+        resp <- uploadDar(uri, darPath) // same dar again
+        _ <- parseResult(resp)
+      } yield succeed
+    }
+
   it should "fail to start non-existent trigger" in withTriggerService(Some(dar)) {
     (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
       val expectedError = StatusCodes.UnprocessableEntity


### PR DESCRIPTION
This is needed to recover state after the service shuts down or crashes.
We add a method to the RunningTriggerDao to persistPackages. This only
does something in the case of a DbTriggerDao. In any case the Server
keeps a package map in memory as it's required to construct a trigger runner.
Uploads of existing packages is considered harmless.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
