### PR TITLE
Yarn install workaround for noobs

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -66,7 +66,7 @@ In order to connect the UI code to this DAML, we need to run a code generation s
 Now, changing to the ``ui`` folder, use Yarn to install the project dependencies::
 
     cd ui
-    yarn install
+    yarn install --force --frozen-lockfile
 
 This step may take a couple of moments (it's worth it!).
 You should see ``success Saved lockfile.`` in the output if everything worked as expected.


### PR DESCRIPTION
Noobs had a problem running `yarn install` second time around when they've changed the code. Simply put they would way too often (almost always) forget to include ` --force --frozen-lockfile` when calling `yarn install`. This would be a very simple workaround that woould lead to them being aware from the very first step that there's the ` --force --frozen-lockfile` parameter that needs to be called. 

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
