### PR TITLE
Do not expect a specific location in ledger-api-test-tool

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -38,26 +38,33 @@ object Assertions extends DiffExtensions {
   /** Match the given exception against a status code and a regex for the expected message.
       Succeeds if the exception is a GrpcException with the expected code and
       the regex matches some part of the message or there is no message and the pattern is
-      empty.
+      None.
     */
-  def assertGrpcError(t: Throwable, expectedCode: Status.Code, pattern: Pattern): Unit =
-    t match {
-      case GrpcException(GrpcStatus(`expectedCode`, Some(msg)), _) =>
+  def assertGrpcError(t: Throwable, expectedCode: Status.Code, optPattern: Option[Pattern]): Unit =
+    (t, optPattern) match {
+      case (GrpcException(GrpcStatus(`expectedCode`, Some(msg)), _), Some(pattern)) =>
         if (pattern.matcher(msg).find()) {
           ()
         } else {
           fail(s"Error message did not contain [$pattern], but was [$msg].")
         }
-      case GrpcException(GrpcStatus(`expectedCode`, None), _) if pattern.toString.isEmpty =>
+      // None both represents pattern that we do not care about as well as
+      // exceptions that have no message.
+      case (GrpcException(GrpcStatus(`expectedCode`, Some(msg)), _), None) => ()
+      case (GrpcException(GrpcStatus(`expectedCode`, None), _), None) =>
         ()
-      case GrpcException(GrpcStatus(code, _), _) =>
+      case (GrpcException(GrpcStatus(code, _), _), _) =>
         fail(s"Expected code [$expectedCode], but got [$code].")
-      case NonFatal(e) =>
+      case (NonFatal(e), _) =>
         fail("Exception is neither a StatusRuntimeException nor a StatusException", e)
     }
 
   /** non-regex overload for assertGrpcError which just does a substring check.
     */
-  def assertGrpcError(t: Throwable, expectedCode: Status.Code, pattern: String): Unit =
-    assertGrpcError(t, expectedCode, Pattern.compile(Pattern.quote(pattern)))
+  def assertGrpcError(t: Throwable, expectedCode: Status.Code, pattern: String): Unit = {
+    assertGrpcError(
+      t,
+      expectedCode,
+      if (pattern.isEmpty) None else Some(Pattern.compile(Pattern.quote(pattern))))
+  }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
@@ -297,7 +297,8 @@ final class CommandServiceIT extends LedgerTestSuite {
         assertGrpcError(
           failure,
           Status.Code.INVALID_ARGUMENT,
-          Pattern.compile("Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed\\. Details: Last location: \\[[^\\]]*\\], partial transaction: root node"),
+          Some(Pattern.compile(
+            "Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed\\. Details: Last location: \\[[^\\]]*\\], partial transaction: root node")),
         )
       }
   })

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
@@ -17,6 +17,7 @@ import com.daml.ledger.test_stable.Test.Dummy._
 import com.daml.ledger.test_stable.Test.DummyFactory._
 import com.daml.ledger.test_stable.Test.WithObservers._
 import com.daml.ledger.test_stable.Test.{Dummy, _}
+import java.util.regex.Pattern
 import io.grpc.Status
 import scalaz.syntax.tag._
 
@@ -296,7 +297,7 @@ final class CommandServiceIT extends LedgerTestSuite {
         assertGrpcError(
           failure,
           Status.Code.INVALID_ARGUMENT,
-          "Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed. Details: Last location: [DA.Internal.Assert:19], partial transaction: root node",
+          Pattern.compile("Command interpretation error in LF-DAMLe: Interpretation error: Error: User abort: Assertion failed\\. Details: Last location: \\[[^\\]]*\\], partial transaction: root node"),
         )
       }
   })


### PR DESCRIPTION
This broke running the ledger-api-test-tool against older ledgers
since the behavior of Speedy has changed slightly.

This PR changes `assertGrpcError` to accept a regex and uses that to
match for a wildcard in place of a specific location. I’ve gone
through the existing calls and added appropriate levels of escaping.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
