### PR TITLE
Verification tool bugfix for PR#6101

### DIFF
--- a/compiler/daml-lf-verify/tests/DA/Daml/LF/Verify/Tests.hs
+++ b/compiler/daml-lf-verify/tests/DA/Daml/LF/Verify/Tests.hs
@@ -16,11 +16,10 @@ import DA.Bazel.Runfiles
 
 mainTest :: IO ()
 mainTest = defaultMain $ testGroup "DA.Daml.LF.Verify"
-  [ -- quickstartTests, -- TODO: reinstate
+  [ quickstartTests,
     conditionalTests
   ]
 
-{-
 quickstartTests :: TestTree
 quickstartTests = testGroup "Quickstart"
   [ testCase "Iou_Split" $ do
@@ -40,7 +39,6 @@ quickstartTests = testGroup "Quickstart"
       assertEqual "Verification failed for Iou_Merge - amount"
         Success result
   ]
--}
 
 conditionalTests :: TestTree
 conditionalTests = testGroup "Conditionals"


### PR DESCRIPTION
Bugfix for the verification tool, in order to fix failing test in PR#6101:
- Forward value references would not be inlined (and evaluated) in create updates.