### PR TITLE
Fix handling of non-visibile contract keys in scenario runner

### DIFF
--- a/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
+++ b/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
@@ -1,5 +1,9 @@
 -- @ERROR Attempt to fetch, lookup or exercise a key associated with a contract
+-- @ERROR Attempt to fetch, lookup or exercise a key associated with a contract
+-- @ERROR Attempt to fetch, lookup or exercise a key associated with a contract
 module ContractKeyNotVisible where
+
+import DA.Optional
 
 template Foo
   with
@@ -15,3 +19,68 @@ aScenario = scenario do
   bobFooId <- submit bob do create Foo with p = bob
   _ <- submit alice $ fetchByKey @Foo bob
   pure ()
+
+template Keyed
+  with
+    sig : Party
+  where
+    signatory sig
+
+    key sig : Party
+    maintainer key
+
+template Divulger
+  with
+    divulgee : Party
+    sig : Party
+  where
+    signatory divulgee
+
+    controller sig can
+      nonconsuming DivulgeKeyed
+        : Keyed
+        with
+          keyedCid : ContractId Keyed
+        do
+          fetch keyedCid
+
+template Delegation
+  with
+    sig : Party
+    divulgee : Party
+  where
+    signatory sig
+    observer divulgee
+
+    choice LookupKeyed
+      : Optional (ContractId Keyed)
+      controller divulgee
+      do
+        lookupByKey @Keyed sig
+
+divulgeeLookup = scenario do
+  sig <- getParty "s" -- Signatory
+  divulgee <- getParty "d" -- Divulgee
+  keyedCid <- submit sig do create Keyed with ..
+  divulgercid <- submit divulgee do create Divulger with ..
+  submit sig do exercise divulgercid DivulgeKeyed with ..
+  -- Divulgee can't do positive lookup with maintainer authority.
+  -- Note that the lookup returns `None` so the assertion passes.
+  -- If the assertion is changed to `isSome`, the assertion fails,
+  -- which means the error message changes. The reason is that the
+  -- assertion is checked at interpretation time, before the lookup
+  -- is checked at validation time.
+  submit divulgee do
+    mcid <- createAndExercise (Delegation sig divulgee) LookupKeyed
+    assert (isNone mcid)
+    pure ()
+
+blindLookup = scenario do
+  sig <- getParty "s" -- Signatory
+  blind <- getParty "b" -- Blind
+  keyedCid <- submit sig do create Keyed with ..
+  -- Blind party can't do positive lookup with maintainer authority.
+  submit blind do
+    mcid <- createAndExercise (Delegation sig blind) LookupKeyed
+    assert (isNone mcid)
+    pure ()


### PR DESCRIPTION
fixes #6403

I am not entirely sure why I thought that using `missingWith` makes
sense here but it clearly doesn’t make sense and resulted in a pretty
bad bug where a transaction both succeeded via `submit` as well as
failed via `submitMustFail` which is clearly the wrong thing to do.

This PR fixes this issue and introduces a `notVisibleWith` function
that does the right thing. I’ve also added some comments and an extra
assertion to clarify things a bit.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
