### PR TITLE
Consistently display stakeholders for key visibility errors

### DIFF
--- a/compiler/damlc/tests/daml-test-files/KeyNotVisibleStakeholders.daml
+++ b/compiler/damlc/tests/daml-test-files/KeyNotVisibleStakeholders.daml
@@ -1,0 +1,98 @@
+-- @INFO Reduce duplication
+-- @INFO Reduce duplication
+-- @INFO Reduce duplication
+-- @ERROR Stakeholders: 's'
+-- @ERROR Stakeholders: 's'
+-- @ERROR Stakeholders: 's'
+-- @ERROR Stakeholders: 's'
+
+-- We make this a separate test since it’s annoying to assert
+-- which scenario an error message belongs to
+-- and here we sidestep this by having the same error for all tests.
+module KeyNotVisibleStakeholders where
+
+template Keyed
+  with
+    sig : Party
+  where
+    signatory sig
+
+    key sig : Party
+    maintainer key
+
+template Divulger
+  with
+    divulgee : Party
+    sig : Party
+  where
+    signatory divulgee
+
+    controller sig can
+      nonconsuming DivulgeKeyed
+        : Keyed
+        with
+          keyedCid : ContractId Keyed
+        do
+          fetch keyedCid
+
+template Delegation
+  with
+    sig : Party
+    divulgee : Party
+  where
+    signatory sig
+    observer divulgee
+
+    choice FetchKeyed
+      : (ContractId Keyed, Keyed)
+      controller divulgee
+      do
+        fetchByKey @Keyed sig
+
+    choice LookupKeyed
+      : (ContractId Keyed, Keyed)
+      controller divulgee
+      do
+        fetchByKey @Keyed sig
+
+divulgeeFetch = scenario do
+  sig <- getParty "s" -- Signatory
+  divulgee <- getParty "d" -- Divulgee
+  keyedCid <- submit sig do create Keyed with ..
+  divulgercid <- submit divulgee do create Divulger with ..
+  submit sig do exercise divulgercid DivulgeKeyed with ..
+  submit divulgee do
+    _ <- createAndExercise (Delegation sig divulgee) FetchKeyed
+    pure ()
+
+divulgeeLookup = scenario do
+  sig <- getParty "s" -- Signatory
+  divulgee <- getParty "d" -- Divulgee
+  keyedCid <- submit sig do create Keyed with ..
+  divulgercid <- submit divulgee do create Divulger with ..
+  submit sig do exercise divulgercid DivulgeKeyed with ..
+  submit divulgee do
+    _ <- createAndExercise (Delegation sig divulgee) FetchKeyed
+    pure ()
+
+blindFetch = scenario do
+  sig <- getParty "s" -- Signatory
+  divulgee <- getParty "d" -- Divulgee
+  blind <- getParty "b" -- Blind
+  keyedCid <- submit sig do create Keyed with ..
+  divulgercid <- submit divulgee do create Divulger with ..
+  submit sig do exercise divulgercid DivulgeKeyed with ..
+  submit blind do
+    _ <- createAndExercise (Delegation sig blind) LookupKeyed
+    pure ()
+
+blindLookup = scenario do
+  sig <- getParty "s" -- Signatory
+  divulgee <- getParty "d" -- Divulgee
+  blind <- getParty "b" -- Blind
+  keyedCid <- submit sig do create Keyed with ..
+  divulgercid <- submit divulgee do create Divulger with ..
+  submit sig do exercise divulgercid DivulgeKeyed with ..
+  submit blind do
+    _ <- createAndExercise (Delegation sig blind) LookupKeyed
+    pure ()

--- a/compiler/damlc/tests/daml-test-files/KeyNotVisibleStakeholders.daml
+++ b/compiler/damlc/tests/daml-test-files/KeyNotVisibleStakeholders.daml
@@ -1,6 +1,3 @@
--- @INFO Reduce duplication
--- @INFO Reduce duplication
--- @INFO Reduce duplication
 -- @ERROR Stakeholders: 's'
 -- @ERROR Stakeholders: 's'
 -- @ERROR Stakeholders: 's'

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -282,8 +282,8 @@ prettyScenarioErrorError (Just err) =  do
                 (prettyValue' False 0 world)
                 scenarioError_ContractKeyNotVisibleKey
         , label_ "Committer:" $ prettyMay "<missing party>" prettyParty scenarioError_ContractKeyNotVisibleCommitter
-        , label_ "Disclosed to:"
-            $ prettyParties scenarioError_ContractKeyNotVisibleObservers
+        , label_ "Stakeholders:"
+            $ prettyParties scenarioError_ContractKeyNotVisibleStakeholders
         ]
 
 partyDifference :: V.Vector Party -> V.Vector Party -> Doc SyntaxClass

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -174,7 +174,7 @@ message ScenarioError {
     ContractRef contract_ref = 1;
     Value key = 2;
     Party committer = 3;
-    repeated Party observers = 4;
+    repeated Party stakeholders = 4;
   }
 
   message ContractNotEffective {

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -131,13 +131,13 @@ final class Conversions(
             .build,
         )
 
-      case SError.ScenarioErrorContractKeyNotVisible(coid, gk, committer, observers) =>
+      case SError.ScenarioErrorContractKeyNotVisible(coid, gk, committer, stakeholders) =>
         builder.setScenarioContractKeyNotVisible(
           proto.ScenarioError.ContractKeyNotVisible.newBuilder
             .setContractRef(mkContractRef(coid, gk.templateId))
             .setKey(convertValue(gk.key))
             .setCommitter(convertParty(committer))
-            .addAllObservers(observers.map(convertParty).asJava)
+            .addAllStakeholders(stakeholders.map(convertParty).asJava)
             .build,
         )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -218,6 +218,7 @@ object ScenarioLedger {
       coid: ContractId,
       templateId: Identifier,
       observers: Set[Party],
+      stakeholders: Set[Party],
   ) extends LookupResult
 
   sealed trait CommitError
@@ -608,6 +609,7 @@ case class ScenarioLedger(
                 coid,
                 create.coinst.template,
                 info.observingSince.keys.toSet,
+                create.stakeholders,
               )
             else
               LookupOk(coid, create.coinst, create.stakeholders)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -115,16 +115,16 @@ object Pretty {
           comma + space,
           observers.map(prettyParty),
         ) + char('.')
-      case ScenarioErrorContractKeyNotVisible(coid, gk, committer, observers) =>
+      case ScenarioErrorContractKeyNotVisible(coid, gk, committer, stakeholders) =>
         text("due to the failure to fetch the contract") & prettyContractId(coid) &
           char('(') + (prettyIdentifier(gk.templateId)) + text(") associated with key ") +
             prettyValue(false)(gk.key) &
           text("The contract had not been disclosed to the committer") & prettyParty(committer) + char(
           '.',
         ) /
-          text("The contract had been disclosed to:") & intercalate(
+          text("Stakeholders:") & intercalate(
           comma + space,
-          observers.map(prettyParty),
+          stakeholders.map(prettyParty),
         ) + char('.')
       case ScenarioErrorCommitError(ScenarioLedger.CommitError.FailedAuthorizations(fas)) =>
         (text("due to failed authorizations:") / prettyFailedAuthorizations(fas)).nested(4)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -105,7 +105,7 @@ object SError {
       coid: ContractId,
       key: GlobalKey,
       committer: Party,
-      observers: Set[Party],
+      stakeholders: Set[Party],
   ) extends SErrorScenario
 
   /** The commit of the transaction failed due to authorization errors. */

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -184,7 +184,7 @@ final case class ScenarioRunner(
       case ScenarioLedger.LookupContractNotActive(coid, tid, consumedBy) =>
         missingWith(ScenarioErrorContractNotActive(coid, tid, consumedBy))
 
-      case ScenarioLedger.LookupContractNotVisible(coid, tid, observers, _) =>
+      case ScenarioLedger.LookupContractNotVisible(coid, tid, observers, stakeholders@_) =>
         missingWith(ScenarioErrorContractNotVisible(coid, tid, committer, observers))
     }
   }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -184,7 +184,7 @@ final case class ScenarioRunner(
       case ScenarioLedger.LookupContractNotActive(coid, tid, consumedBy) =>
         missingWith(ScenarioErrorContractNotActive(coid, tid, consumedBy))
 
-      case ScenarioLedger.LookupContractNotVisible(coid, tid, observers, stakeholders@_) =>
+      case ScenarioLedger.LookupContractNotVisible(coid, tid, observers, stakeholders @ _) =>
         missingWith(ScenarioErrorContractNotVisible(coid, tid, committer, observers))
     }
   }
@@ -227,7 +227,7 @@ final case class ScenarioRunner(
             missingWith(SErrorCrash(s"contract $acoid not effective, but we found its key!"))
           case ScenarioLedger.LookupContractNotActive(_, _, _) =>
             missingWith(SErrorCrash(s"contract $acoid not active, but we found its key!"))
-          case ScenarioLedger.LookupContractNotVisible(coid, tid, observers@_, stakeholders) =>
+          case ScenarioLedger.LookupContractNotVisible(coid, tid, observers @ _, stakeholders) =>
             notVisibleWith(ScenarioErrorContractKeyNotVisible(coid, gk, committer, stakeholders))
         }
     }

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -184,7 +184,7 @@ final case class ScenarioRunner(
       case ScenarioLedger.LookupContractNotActive(coid, tid, consumedBy) =>
         missingWith(ScenarioErrorContractNotActive(coid, tid, consumedBy))
 
-      case ScenarioLedger.LookupContractNotVisible(coid, tid, observers) =>
+      case ScenarioLedger.LookupContractNotVisible(coid, tid, observers, _) =>
         missingWith(ScenarioErrorContractNotVisible(coid, tid, committer, observers))
     }
   }
@@ -227,8 +227,8 @@ final case class ScenarioRunner(
             missingWith(SErrorCrash(s"contract $acoid not effective, but we found its key!"))
           case ScenarioLedger.LookupContractNotActive(_, _, _) =>
             missingWith(SErrorCrash(s"contract $acoid not active, but we found its key!"))
-          case ScenarioLedger.LookupContractNotVisible(coid, tid, observers) =>
-            notVisibleWith(ScenarioErrorContractKeyNotVisible(coid, gk, committer, observers))
+          case ScenarioLedger.LookupContractNotVisible(coid, tid, observers@_, stakeholders) =>
+            notVisibleWith(ScenarioErrorContractKeyNotVisible(coid, gk, committer, stakeholders))
         }
     }
   }


### PR DESCRIPTION
fixes #6404

As pointed out by Bernhard in #6404, the previous behavior was pretty
weird. If the committer was only a divulgee, we only displayed
stakeholders. If the committer was neither a stakeholder nor a
divulgee, we displayed stakeholders + parties the contract has been
divulged to. Given that only stakeholders can do lookups it makes much
more sense to display them consistently which is what this PR
achieves. I’ve also renamed “disclosed to” to “stakeholders” to make
it very explicit what is shown there.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
