### PR TITLE
remove jo from dev-env

### DIFF
--- a/dev-env/bin/jo
+++ b/dev-env/bin/jo
@@ -1,1 +1,0 @@
-../lib/dade-exec-nix-tool

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -192,7 +192,6 @@ in rec {
     grpcurl = pkgs.grpcurl;
 
     # String mangling tooling.
-    jo   = pkgs.jo;
     jq   = bazel_dependencies.jq;
     gawk = bazel_dependencies.gawk;
     sed = pkgs.gnused;


### PR DESCRIPTION
It doesn't seem to be used anywhere. Obviously `git grep jo` returns a lot of results, so I may have missed something in the noise, but I did a reasonable effort to look through them.

CHANGELOG_BEGIN
CHANGELOG_END