### PR TITLE
increase nix cache retention time

### DIFF
--- a/infra/nix_cache.tf
+++ b/infra/nix_cache.tf
@@ -16,7 +16,7 @@ module "nix_cache" {
   project              = "${local.project}"
   region               = "${local.region}"
   ssl_certificate      = "${local.ssl_certificate}"
-  cache_retention_days = 60
+  cache_retention_days = 360
 }
 
 // allow rw access for CI writer (see writer.tf)


### PR DESCRIPTION
The nix cache is currently only 3.5GB, and GHC takes a long time to build, so I think the convenience vs. cost tradeoff is in favour of keeping things for a bit longer.

CHANGELOG_BEGIN
CHANGELOG_END