### PR TITLE
caching: Wait for the cache to evict some values in tests.

### DIFF
--- a/ledger/caching/src/test/lib/scala/com/daml/caching/CacheBehaviorSpecBase.scala
+++ b/ledger/caching/src/test/lib/scala/com/daml/caching/CacheBehaviorSpecBase.scala
@@ -3,11 +3,9 @@
 
 package com.daml.caching
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{Matchers, WordSpecLike}
 
-abstract class CacheBehaviorSpecBase(name: String) extends WordSpec with Matchers {
-  protected def newCache(): Cache[Integer, String]
-
+trait CacheBehaviorSpecBase extends CacheSpecBase with WordSpecLike with Matchers {
   name should {
     "compute the correct results" in {
       val cache = newCache()

--- a/ledger/caching/src/test/lib/scala/com/daml/caching/CacheCachingSpecBase.scala
+++ b/ledger/caching/src/test/lib/scala/com/daml/caching/CacheCachingSpecBase.scala
@@ -5,16 +5,11 @@ package com.daml.caching
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.scalatest.WordSpec
+import org.scalatest.{Matchers, WordSpecLike}
 
-class NoCacheSpec extends WordSpec with CacheBehaviorSpecBase {
-  override protected lazy val name: String = "a non-existent cache"
-
-  override protected def newCache(): Cache[Integer, String] =
-    Cache.none
-
-  "a non-existent cache" should {
-    "compute every time" in {
+trait CacheCachingSpecBase extends CacheSpecBase with WordSpecLike with Matchers {
+  name should {
+    "compute once, and cache" in {
       val cache = newCache()
       val counter = new AtomicInteger(0)
 
@@ -28,22 +23,27 @@ class NoCacheSpec extends WordSpec with CacheBehaviorSpecBase {
       cache.get(1, compute)
       cache.get(2, compute)
 
-      counter.get() should be(4)
+      counter.get() should be(2)
     }
 
-    "always return `None` on `getIfPresent`" in {
-      val cache = Cache.none[Integer, String]
+    "return `None` on `getIfPresent` if the value is not present" in {
+      val cache = newCache()
 
       cache.getIfPresent(7) should be(None)
+    }
+
+    "return the value on `getIfPresent` if the value is present" in {
+      val cache = newCache()
+
       cache.get(7, _.toString) should be("7")
-      cache.getIfPresent(7) should be(None)
+      cache.getIfPresent(7) should be(Some("7"))
     }
 
-    "do nothing on `put`" in {
-      val cache = Cache.none[Integer, String]
+    "`put` values" in {
+      val cache = newCache()
 
       cache.put(7, "7")
-      cache.getIfPresent(7) should be(None)
+      cache.getIfPresent(7) should be(Some("7"))
 
       val counter = new AtomicInteger(0)
 
@@ -53,7 +53,7 @@ class NoCacheSpec extends WordSpec with CacheBehaviorSpecBase {
       }
 
       cache.get(7, compute) should be("7")
-      counter.get() should be(1)
+      counter.get() should be(0)
     }
   }
 }

--- a/ledger/caching/src/test/lib/scala/com/daml/caching/CacheEvictionSpecBase.scala
+++ b/ledger/caching/src/test/lib/scala/com/daml/caching/CacheEvictionSpecBase.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.caching
+
+import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Second, Span}
+
+import scala.util.Random
+
+trait CacheEvictionSpecBase
+    extends CacheBehaviorSpecBase
+    with WordSpecLike
+    with Matchers
+    with Eventually {
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(scaled(Span(1, Second)))
+
+  protected def newLargeCache(): Cache[Integer, String]
+
+  name should {
+    "evict values eventually, once the limit has been reached" in {
+      val cache = newLargeCache()
+      val values = Iterator.continually[Integer](Random.nextInt).take(1000).toSet.toVector
+
+      values.foreach { value =>
+        cache.get(value, _.toString)
+      }
+
+      // The cache may not evict straight away. We should keep trying.
+      eventually {
+        val cachedValues = values.map(cache.getIfPresent).filter(_.isDefined)
+        // It may evict more than expected, and it might grow past the bounds again before we check.
+        cachedValues.length should (be > 16 and be < 500)
+      }
+    }
+  }
+}

--- a/ledger/caching/src/test/lib/scala/com/daml/caching/CacheSpecBase.scala
+++ b/ledger/caching/src/test/lib/scala/com/daml/caching/CacheSpecBase.scala
@@ -3,55 +3,8 @@
 
 package com.daml.caching
 
-import java.util.concurrent.atomic.AtomicInteger
+trait CacheSpecBase {
+  protected def name: String
 
-abstract class CacheSpecBase(name: String) extends CacheBehaviorSpecBase(name) {
-  name should {
-    "compute once, and cache" in {
-      val cache = newCache()
-      val counter = new AtomicInteger(0)
-
-      def compute(value: Integer): String = {
-        counter.incrementAndGet()
-        value.toString
-      }
-
-      cache.get(1, compute)
-      cache.get(1, compute)
-      cache.get(1, compute)
-      cache.get(2, compute)
-
-      counter.get() should be(2)
-    }
-
-    "return `None` on `getIfPresent` if the value is not present" in {
-      val cache = newCache()
-
-      cache.getIfPresent(7) should be(None)
-    }
-
-    "return the value on `getIfPresent` if the value is present" in {
-      val cache = newCache()
-
-      cache.get(7, _.toString) should be("7")
-      cache.getIfPresent(7) should be(Some("7"))
-    }
-
-    "`put` values" in {
-      val cache = newCache()
-
-      cache.put(7, "7")
-      cache.getIfPresent(7) should be(Some("7"))
-
-      val counter = new AtomicInteger(0)
-
-      def compute(value: Integer): String = {
-        counter.incrementAndGet()
-        value.toString
-      }
-
-      cache.get(7, compute) should be("7")
-      counter.get() should be(0)
-    }
-  }
+  protected def newCache(): Cache[Integer, String]
 }

--- a/ledger/caching/src/test/suite/scala/com/daml/caching/SizedCacheSpec.scala
+++ b/ledger/caching/src/test/suite/scala/com/daml/caching/SizedCacheSpec.scala
@@ -3,24 +3,33 @@
 
 package com.daml.caching
 
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Second, Span}
+
 import scala.util.Random
 
-class SizedCacheSpec extends CacheSpecBase("a sized cache") {
+class SizedCacheSpec extends CacheSpecBase("a sized cache") with Eventually {
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(scaled(Span(1, Second)))
+
   override protected def newCache(): Cache[Integer, String] =
     SizedCache.from[Integer, String](SizedCache.Configuration(maximumSize = 16))
 
   "a sized cache" should {
     "evict values eventually, once the size limit has been reached" in {
       val cache =
-        SizedCache.from[Integer, String](SizedCache.Configuration(maximumSize = 256))
+        SizedCache.from[Integer, String](SizedCache.Configuration(maximumSize = 128))
       val values = Iterator.continually[Integer](Random.nextInt).take(1000).toSet.toVector
 
       values.foreach { value =>
         cache.get(value, _.toString)
       }
-      val cachedValues = values.map(cache.getIfPresent).filter(_.isDefined)
 
-      cachedValues.length should (be > 16 and be < 500)
+      // The cache may not evict straight away. We should keep trying.
+      eventually {
+        val cachedValues = values.map(cache.getIfPresent).filter(_.isDefined)
+        // It may evict more than expected, and it might grow past the bounds again before we check.
+        cachedValues.length should (be > 16 and be < 500)
+      }
     }
   }
 }

--- a/ledger/caching/src/test/suite/scala/com/daml/caching/WeightedCacheSpec.scala
+++ b/ledger/caching/src/test/suite/scala/com/daml/caching/WeightedCacheSpec.scala
@@ -3,36 +3,21 @@
 
 package com.daml.caching
 
-import org.scalatest.concurrent.Eventually
-import org.scalatest.time.{Second, Span}
+import org.scalatest.WordSpec
 
-import scala.util.Random
-
-class WeightedCacheSpec extends CacheSpecBase("a weighted cache") with Eventually {
-  private implicit val `Int Weight`: Weight[Integer] = (_: Integer) => 1
-  private implicit val `String Weight`: Weight[String] = _.length.toLong
-
-  override implicit def patienceConfig: PatienceConfig = PatienceConfig(scaled(Span(1, Second)))
+class WeightedCacheSpec
+    extends WordSpec
+    with CacheBehaviorSpecBase
+    with CacheCachingSpecBase
+    with CacheEvictionSpecBase {
+  override protected lazy val name: String = "a weighted cache"
 
   override protected def newCache(): Cache[Integer, String] =
     WeightedCache.from[Integer, String](WeightedCache.Configuration(maximumWeight = 16))
 
-  "a weighted cache" should {
-    "evict values eventually, once the weight limit has been reached" in {
-      val cache =
-        WeightedCache.from[Integer, String](WeightedCache.Configuration(maximumWeight = 256))
-      val values = Iterator.continually[Integer](Random.nextInt).take(1000).toSet.toVector
+  override protected def newLargeCache(): Cache[Integer, String] =
+    WeightedCache.from[Integer, String](WeightedCache.Configuration(maximumWeight = 256))
 
-      values.foreach { value =>
-        cache.get(value, _.toString)
-      }
-
-      // The cache may not evict straight away. We should keep trying.
-      eventually {
-        val cachedValues = values.map(cache.getIfPresent).filter(_.isDefined)
-        // It may evict more than expected, and it might grow past the bounds again before we check.
-        cachedValues.length should (be > 16 and be < 500)
-      }
-    }
-  }
+  private implicit val `Int Weight`: Weight[Integer] = (_: Integer) => 1
+  private implicit val `String Weight`: Weight[String] = _.length.toLong
 }


### PR DESCRIPTION
Windows, especially, might not do it the first time. Not sure why; caching is weird.

Also decreases the size of the size-based cache used for testing evictions, which should help trigger it more readily.

The relevant change is in `CacheEvictionSpecBase`. Alternatively, you can look at the first commit, which is the fix, and then the second, which removes some duplication.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
