### PR TITLE
Speedy ANF

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -72,6 +72,17 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        "end": "1.3.0-snapshot.20200617.4484.0.7e0a6848",
+        "platform_ranges": [
+            {
+                "start": "0.0.0",  # fixme on next release
+                "exclusions": [
+                    "CommandServiceIT",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -12,6 +12,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.engine.script._
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{Ast, LanguageVersion}
+import com.daml.lf.speedy.AExpr
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.{Compiler, SValue, SExpr, SError}
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
@@ -190,7 +191,7 @@ class ReplService(
     mat: Materializer)
     extends ReplServiceGrpc.ReplServiceImplBase {
   var packages: Map[PackageId, Package] = Map.empty
-  var compiledDefinitions: Map[SDefinitionRef, SExpr] = Map.empty
+  var compiledDefinitions: Map[SDefinitionRef, AExpr] = Map.empty
   var results: Seq[SValue] = Seq()
   implicit val ec_ = ec
   implicit val esf_ = esf

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -15,7 +15,7 @@ import com.daml.lf.speedy.Compiler
 import com.daml.lf.speedy.ScenarioRunner
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.Speedy
-import com.daml.lf.speedy.SExpr
+import com.daml.lf.speedy.AExpr
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SExpr.{LfDefRef, SDefinitionRef}
 import com.daml.lf.transaction.TransactionVersions
@@ -54,10 +54,10 @@ class Context(val contextId: Context.ContextId) {
   val homePackageId: PackageId = PackageId.assertFromString("-homePackageId-")
 
   private var extPackages: Map[PackageId, Ast.Package] = HashMap.empty
-  private var extDefns: Map[SDefinitionRef, SExpr] = HashMap.empty
+  private var extDefns: Map[SDefinitionRef, AExpr] = HashMap.empty
   private var modules: Map[ModuleName, Ast.Module] = HashMap.empty
-  private var modDefns: Map[ModuleName, Map[SDefinitionRef, SExpr]] = HashMap.empty
-  private var defns: Map[SDefinitionRef, SExpr] = HashMap.empty
+  private var modDefns: Map[ModuleName, Map[SDefinitionRef, AExpr]] = HashMap.empty
+  private var defns: Map[SDefinitionRef, AExpr] = HashMap.empty
 
   def loadedModules(): Iterable[ModuleName] = modules.keys
   def loadedPackages(): Iterable[PackageId] = extPackages.keys
@@ -150,7 +150,7 @@ class Context(val contextId: Context.ContextId) {
     for {
       defn <- defns.get(LfDefRef(identifier))
     } yield
-      Speedy.Machine.fromScenarioSExpr(
+      Speedy.Machine.fromScenarioAExpr(
         compiledPackages,
         txSeeding,
         defn,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -18,14 +18,14 @@ import scala.collection.concurrent.{Map => ConcurrentMap}
 final class ConcurrentCompiledPackages extends MutableCompiledPackages {
   private[this] val _packages: ConcurrentMap[PackageId, Package] =
     new ConcurrentHashMap().asScala
-  private[this] val _defns: ConcurrentHashMap[speedy.SExpr.SDefinitionRef, speedy.SExpr] =
+  private[this] val _defns: ConcurrentHashMap[speedy.SExpr.SDefinitionRef, speedy.AExpr] =
     new ConcurrentHashMap()
   private[this] val _packageDeps: ConcurrentHashMap[PackageId, Set[PackageId]] =
     new ConcurrentHashMap()
   private[this] var _profilingMode: speedy.Compiler.ProfilingMode = speedy.Compiler.NoProfile
 
   def getPackage(pId: PackageId): Option[Package] = _packages.get(pId)
-  def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
+  def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.AExpr] =
     Option(_defns.get(dref))
 
   def stackTraceMode = speedy.Compiler.FullStackTrace

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -8,7 +8,7 @@ import com.daml.lf.command._
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.{PackageId, ParticipantId, Party}
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.{InitialSeeding, Pretty, SExpr}
+import com.daml.lf.speedy.{InitialSeeding, Pretty}
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{TransactionVersions, Transaction => Tx}
@@ -275,8 +275,7 @@ final class Engine(config: Engine.Config) {
         compiledPackages = compiledPackages,
         submissionTime = submissionTime,
         initialSeeding = seeding,
-        expr = SExpr
-          .SEApp(compiledPackages.compiler.unsafeCompile(commands), Array(SExpr.SEValue.Token)),
+        anf = Machine.makeApplyToToken(compiledPackages.compiler.unsafeCompile(commands)),
         globalCids = globalCids,
         committers = submitters,
         supportedValueVersions = config.allowedOutputValueVersions,

--- a/daml-lf/interpreter/perf/BUILD.bazel
+++ b/daml-lf/interpreter/perf/BUILD.bazel
@@ -32,6 +32,8 @@ da_scala_binary(
     data = [
         ":Examples.dar",
         ":Examples.dar.pp",
+        ":JsonParser.dar",
+        ":JsonParser.dar.pp",
     ],
     main_class = "com.daml.lf.speedy.explore.ExploreDar",
     runtime_deps = [

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -30,8 +30,8 @@ object PlaySpeedy {
 
     names.foreach { name =>
       val (expected, expr) = examples(name)
-      val converted = compiler.unsafeClosureConvert(expr)
-      val machine = Speedy.Machine.fromPureSExpr(noPackages, converted)
+      val anf = compiler.unsafeClosureConvert(expr)
+      val machine = Speedy.Machine.fromPureAExpr(noPackages, anf)
       runMachine(name, machine, expected)
     }
   }
@@ -84,7 +84,7 @@ object PlaySpeedy {
     }
   }
 
-  final case class MachineProblem(s: String) extends RuntimeException(s, null, false, false)
+  final case class MachineProblem(s: String) extends RuntimeException(s)
 
   def examples: Map[String, (Int, SExpr)] = {
 
@@ -97,6 +97,8 @@ object PlaySpeedy {
 
     def subtract2(x: SExpr, y: SExpr): SExpr = SEApp(SEBuiltin(SBSubInt64), Array(x, y))
     val subtract = SEAbs(2, subtract2(SEVar(2), SEVar(1)))
+
+    val identity = SEAbs(1, SEVar(1))
 
     def twice2(f: SExpr, x: SExpr): SExpr = SEApp(f, Array(SEApp(f, Array(x))))
     val twice = SEAbs(2, twice2(SEVar(2), SEVar(1)))
@@ -117,6 +119,10 @@ object PlaySpeedy {
         "subF", //88-55
         33,
         SEApp(subtract, Array(num(88), num(55)))),
+      (
+        "id-id", // id id 77
+        77,
+        SEApp(identity, Array(identity, num(77)))),
       (
         "thrice", // thrice (\x -> x - 1) 0
         -3,

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -30,7 +30,7 @@ object PlaySpeedy {
 
     names.foreach { name =>
       val (expected, expr) = examples(name)
-      val anf = compiler.unsafeClosureConvert(expr)
+      val anf = compiler.unsafeCompilationPipeline(expr)
       val machine = Speedy.Machine.fromPureAExpr(noPackages, anf)
       runMachine(name, machine, expected)
     }

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -30,6 +30,7 @@ object PlaySpeedy {
   }
 
   def parseArgs(args0: List[String]): Config = {
+    var moduleName: String = "Examples"
     var funcName: String = "triangle"
     var argValue: Long = 10
     var stacktracing: Compiler.StackTraceMode = Compiler.NoStackTrace
@@ -43,15 +44,19 @@ object PlaySpeedy {
       case "--stacktracing" :: args =>
         stacktracing = Compiler.FullStackTrace
         loop(args)
+      case "--base" :: x :: args =>
+        moduleName = x
+        loop(args)
       case x :: args =>
         funcName = x
         loop(args)
     }
     loop(args0)
-    Config(funcName, argValue, stacktracing)
+    Config(moduleName, funcName, argValue, stacktracing)
   }
 
   final case class Config(
+      moduleName: String,
       funcName: String,
       argValue: Long,
       stacktracing: Compiler.StackTraceMode,
@@ -60,8 +65,8 @@ object PlaySpeedy {
   def main(args0: List[String]) = {
 
     println("Start...")
-    val base = "Examples"
     val config = parseArgs(args0)
+    val base = config.moduleName
     val dar = s"daml-lf/interpreter/perf/${base}.dar"
     val darFile = new File(rlocation(dar))
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
@@ -6,18 +6,18 @@ package com.daml.lf
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.language.Ast.Package
 import com.daml.lf.speedy.SExpr.SDefinitionRef
-import com.daml.lf.speedy.{Compiler, SExpr}
+import com.daml.lf.speedy.{Compiler, AExpr}
 
 /** Trait to abstract over a collection holding onto DAML-LF package definitions + the
   * compiled speedy expressions.
   */
 trait CompiledPackages {
   def getPackage(pkgId: PackageId): Option[Package]
-  def getDefinition(dref: SDefinitionRef): Option[SExpr]
+  def getDefinition(dref: SDefinitionRef): Option[AExpr]
 
   def packages: PartialFunction[PackageId, Package] = Function.unlift(this.getPackage)
   def packageIds: Set[PackageId]
-  def definitions: PartialFunction[SDefinitionRef, SExpr] =
+  def definitions: PartialFunction[SDefinitionRef, AExpr] =
     Function.unlift(this.getDefinition)
 
   def stackTraceMode: Compiler.StackTraceMode
@@ -28,13 +28,13 @@ trait CompiledPackages {
 
 final class PureCompiledPackages private (
     packages: Map[PackageId, Package],
-    defns: Map[SDefinitionRef, SExpr],
+    defns: Map[SDefinitionRef, AExpr],
     stacktracing: Compiler.StackTraceMode,
     profiling: Compiler.ProfilingMode,
 ) extends CompiledPackages {
   override def packageIds: Set[PackageId] = packages.keySet
   override def getPackage(pkgId: PackageId): Option[Package] = packages.get(pkgId)
-  override def getDefinition(dref: SDefinitionRef): Option[SExpr] = defns.get(dref)
+  override def getDefinition(dref: SDefinitionRef): Option[AExpr] = defns.get(dref)
   override def stackTraceMode = stacktracing
   override def profilingMode = profiling
 }
@@ -46,7 +46,7 @@ object PureCompiledPackages {
     */
   private[lf] def apply(
       packages: Map[PackageId, Package],
-      defns: Map[SDefinitionRef, SExpr],
+      defns: Map[SDefinitionRef, AExpr],
       stacktracing: Compiler.StackTraceMode,
       profiling: Compiler.ProfilingMode
   ): PureCompiledPackages =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/AExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/AExpr.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+
+/**
+  * The even more simplified AST for the speedy interpreter, following ANF transformation.
+  */
+final case class AExpr(wrapped: SExpr) extends Serializable {}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/AExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/AExpr.scala
@@ -6,4 +6,4 @@ package com.daml.lf.speedy
 /**
   * The even more simplified AST for the speedy interpreter, following ANF transformation.
   */
-final case class AExpr(wrapped: SExpr) extends Serializable {}
+final case class AExpr(wrapped: SExpr) extends Serializable

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -1,0 +1,339 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+
+/**
+  Transformation to ANF based AST for the speedy interpreter.
+
+  "ANF" stands for A-normal form.
+  In essence it means that sub-expressions of most expression nodes are in atomic-form.
+  The one exception is the let-expression.
+
+  Atomic mean: a variable reference (ELoc), a (literal) value, or a builtin.
+  This is captured by any speedy-expression which `extends SExprAtomic`.
+
+  TODO: <EXAMPLE HERE>
+
+  The reason we convert to ANF is to improve the efficiency of speedy execution: the
+  execution engine can take advantage of the atomic assumption, and often removes
+  additional execution steps - in particular the pushing of continuations to allow
+  execution to continue after a compound expression is reduced to a value.
+
+  The speedy machine now expects that it will never have to execute a non-ANF expression,
+  crashing at runtime if one is encountered.  In particular we must ensure that the
+  expression forms: SEAppGeneral and SECase are removed, and replaced by the simpler
+  SEAppAtomic and SECaseAtomic (plus SELet as required).
+
+  */
+import com.daml.lf.speedy.SExpr._
+
+import scala.annotation.tailrec
+
+object Anf {
+
+  /*** Entry point for the ANF transformation phase */
+  def flattenToAnf(exp: SExpr): AExpr = {
+    val depth = DepthA(0)
+    val env = initEnv
+    flattenExp(depth, env, exp, flattenedExpression => Land(flattenedExpression)).bounce
+  }
+
+  /**
+    The transformation code is implemented using a continuation-passing style of
+    translation (which is quite common for translation to ANF). In general, naming nested
+    compound expressions requires turning an expression kind of inside out, lifting the
+    introduced let-expression up to the the nearest enclosing abstraction or case-branch.
+
+    For speedy, the ANF pass occurs after translation to De Brujin and closure conversions,
+    which adds the additional complication of re-indexing the variable indexes. This is
+    achieved by tracking the old and new depth & the mapping between them. See the types:
+    DepthE, DepthA and Env.
+
+    There is also the issue of avoiding stack-overflow during compilation, which is
+    managed by the using of a Trampoline[T] type.
+    */
+  case class CompilationError(error: String) extends RuntimeException(error)
+
+  /** `DepthE` tracks the stack-depth of the original expression being traversed */
+  case class DepthE(n: Int)
+
+  /** `DepthA` tracks the stack-depth of the ANF expression being constructed */
+  case class DepthA(n: Int)
+
+  /** `Env` contains the mapping from old to new depth, as well as the old-depth as these
+    * components always travel together */
+  case class Env(absMap: Map[DepthE, DepthA], oldDepth: DepthE)
+
+  val initEnv = Env(absMap = Map.empty, oldDepth = DepthE(0))
+
+  def trackBindings(depth: DepthA, env: Env, n: Int): Env = {
+    if (n == 0) {
+      env
+    } else {
+      val extra = (0 to n - 1).map(i => (DepthE(env.oldDepth.n + i), DepthA(depth.n + i)))
+      Env(absMap = env.absMap ++ extra, oldDepth = DepthE(env.oldDepth.n + n))
+    }
+  }
+
+  // TODO: reference something here about trampolines
+  sealed abstract class Trampoline[T] {
+    @tailrec
+    final def bounce: T = this match {
+      case Land(x) => x
+      case Bounce(continue) => continue().bounce
+    }
+  }
+
+  final case class Land[T](x: T) extends Trampoline[T]
+  final case class Bounce[T](continue: () => Trampoline[T]) extends Trampoline[T]
+
+  /** `Res` is the final, fully transformed ANF expression, returned by the continuations. */
+  type Res = Trampoline[AExpr]
+
+  /** `K[T]` is the continuation type which must be passed to the core transformation
+    functions, i,e, `transformExp`.
+
+    Notice how the DepthA is threaded through the continuation.
+    */
+  type K[T] = ((DepthA, T) => Res)
+
+  /** During conversion we need to deal with bindings which are made/found at a given
+    absolute stack depth. These are represented using `AbsBinding`.
+
+    Note the contrast with the expression form `ELocS` which indicates a relative offset
+    from the top of the stack. This relative-position is used in both the original
+    expression which we traverse AND the new ANF expression we are constructing.
+    */
+  case class AbsBinding(abs: DepthA)
+
+  def makeAbsoluteB(env: Env, rel: Int): AbsBinding = {
+    val oldAbs = DepthE(env.oldDepth.n - rel)
+    env.absMap.get(oldAbs) match {
+      case None => throw CompilationError(s"makeAbsoluteB(env=$env,rel=$rel)")
+      case Some(abs) => AbsBinding(abs)
+    }
+  }
+
+  def makeRelativeB(depth: DepthA, binding: AbsBinding): Int = {
+    (depth.n - binding.abs.n)
+  }
+
+  type AbsAtom = Either[SExprAtomic, AbsBinding]
+
+  def makeAbsoluteA(env: Env, atom: SExprAtomic): AbsAtom = atom match {
+    case SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case x => Left(x)
+  }
+
+  def makeRelativeA(depth: DepthA)(atom: AbsAtom): SExprAtomic = atom match {
+    case Left(x: SELocS) => throw CompilationError(s"makeRelativeA: unexpected: $x")
+    case Left(atom) => atom
+    case Right(binding) => SELocS(makeRelativeB(depth, binding))
+  }
+
+  def relocateA(depth: DepthA, env: Env)(atom: SExprAtomic): SExprAtomic = {
+    makeRelativeA(depth)(makeAbsoluteA(env, atom))
+  }
+
+  type AbsLoc = Either[SELoc, AbsBinding]
+
+  def makeAbsoluteL(env: Env, loc: SELoc): AbsLoc = loc match {
+    case SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case x: SELocA => Left(x)
+    case x: SELocF => Left(x)
+  }
+
+  def makeRelativeL(depth: DepthA)(loc: AbsLoc): SELoc = loc match {
+    case Left(x: SELocS) => throw CompilationError(s"makeRelativeL: unexpected: $x")
+    case Left(loc) => loc
+    case Right(binding) => SELocS(makeRelativeB(depth, binding))
+  }
+
+  def relocateL(depth: DepthA, env: Env)(loc: SELoc): SELoc = {
+    makeRelativeL(depth)(makeAbsoluteL(env, loc))
+  }
+
+  def flattenExp(depth: DepthA, env: Env, exp: SExpr, k: (AExpr => Trampoline[AExpr])): Res = {
+    Bounce(() => k(transformExp(depth, env, exp, { case (_, sexpr) => Land(AExpr(sexpr)) }).bounce))
+  }
+
+  def transformLet1(depth: DepthA, env: Env, rhs: SExpr, body: SExpr, k: K[SExpr]): Res = {
+    flattenExp(
+      depth,
+      env,
+      rhs, { rhs1 =>
+        val depth1 = DepthA(depth.n + 1)
+        val env1 = trackBindings(depth, env, 1)
+        flattenExp(depth1, env1, body, { body1 =>
+          k(depth, SELet1(rhs1.wrapped, body1.wrapped))
+        })
+      }
+    )
+  }
+
+  /*def transformLet1(depth: DepthA, env: Env, rhs: SExpr, body: SExpr, k: K[SExpr]): Res = {
+    // This is a better transform, but sadly it can blow the stack for deeply nested lets.
+    transformExp(depth, env, rhs, {
+      case (depth, rhs) =>
+        val depth1 = DepthA(depth.n + 1)
+        val env1 = trackBindings(depth, env, 1)
+        val body1 = transformExp(depth1, env1, body, k).bounce
+        Land(SELet1(rhs, body1))
+    })
+  }*/
+
+  def flattenAlts(depth: DepthA, env: Env, alts: Array[SCaseAlt]): Array[SCaseAlt] = {
+    alts.map {
+      case SCaseAlt(pat, body0) =>
+        val n = patternNArgs(pat)
+        val env1 = trackBindings(depth, env, n)
+        SCaseAlt(pat, flattenExp(DepthA(depth.n + n), env1, body0, body => {
+          Land(body)
+        }).bounce.wrapped)
+    }
+  }
+
+  def patternNArgs(pat: SCasePat): Int = pat match {
+    case _: SCPEnum | _: SCPPrimCon | SCPNil | SCPDefault | SCPNone => 0
+    case _: SCPVariant | SCPSome => 1
+    case SCPCons => 2
+  }
+
+  /** `transformExp` is the function at the heart of the ANF transformation.  You can read
+    it's type as saying: "Caller, give me a general expression `exp`, (& depth/env info),
+    and a continuation function `k` which says what you want to do with the transformed
+    expression. Then I will do the transform, and call `k` with it. I reserve the right to
+    wrap further expression-AST around the expression returned by `k`.
+    See: `atomizeExp` for a instance where this wrapping occurs.
+    */
+  def transformExp(depth: DepthA, env: Env, exp: SExpr, k: K[SExpr]): Res =
+    Bounce(() =>
+      exp match {
+        case atom: SExprAtomic => k(depth, relocateA(depth, env)(atom))
+        case x: SEVal => k(depth, x)
+        case x: SEImportValue => k(depth, x)
+
+        // (NC) I'm not entirely happy with how the following code is formatted, but
+        // scalafmt wont have it any other way.
+        case SEAppGeneral(func, args) =>
+          atomizeExp(
+            depth,
+            env,
+            func, {
+              case (depth, func) =>
+                atomizeExps(
+                  depth,
+                  env,
+                  args.toList, {
+                    case (depth, args) =>
+                      val func1 = makeRelativeA(depth)(func)
+                      val args1 = args.map(makeRelativeA(depth))
+                      k(depth, SEAppAtomic(func1, args1.toArray))
+                  }
+                )
+            }
+          )
+        case SEMakeClo(fvs0, arity, body0) =>
+          val fvs = fvs0.map(relocateL(depth, env))
+          val body = flattenToAnf(body0).wrapped
+          k(depth, SEMakeClo(fvs, arity, body))
+
+        case SECase(scrut, alts0) =>
+          atomizeExp(depth, env, scrut, {
+            case (depth, scrut) =>
+              val scrut1 = makeRelativeA(depth)(scrut)
+              val alts = flattenAlts(depth, env, alts0)
+              k(depth, SECaseAtomic(scrut1, alts))
+          })
+
+        case SELet(rhss, body) =>
+          val expanded = expandMultiLet(rhss.toList, body)
+          transformExp(depth, env, expanded, k)
+
+        case SELet1General(rhs, body) =>
+          transformLet1(depth, env, rhs, body, k)
+
+        case SECatch(body0, handler0, fin0) =>
+          flattenExp(
+            depth,
+            env,
+            body0,
+            body => {
+              flattenExp(depth, env, handler0, handler => {
+                flattenExp(depth, env, fin0, fin => {
+                  k(depth, SECatch(body.wrapped, handler.wrapped, fin.wrapped))
+                })
+              })
+            }
+          )
+
+        case SELocation(loc, body) =>
+          transformExp(depth, env, body, {
+            case (depth, body) =>
+              k(depth, SELocation(loc, body))
+          })
+
+        case SELabelClosure(label, exp) =>
+          transformExp(depth, env, exp, {
+            case (depth, exp) =>
+              k(depth, SELabelClosure(label, exp))
+          })
+
+        case x: SEAbs => throw CompilationError(s"flatten: unexpected: $x")
+        case x: SEWronglyTypeContractId => throw CompilationError(s"flatten: unexpected: $x")
+        case x: SEVar => throw CompilationError(s"flatten: unexpected: $x")
+
+        case x: SEAppAtomicGeneral => throw CompilationError(s"flatten: unexpected: $x")
+        case x: SEAppAtomicSaturatedBuiltin => throw CompilationError(s"flatten: unexpected: $x")
+        case x: SELet1Builtin => throw CompilationError(s"flatten: unexpected: $x")
+        case x: SECaseAtomic => throw CompilationError(s"flatten: unexpected: $x")
+
+    })
+
+  def atomizeExps(depth: DepthA, env: Env, exps: List[SExpr], k: K[List[AbsAtom]]): Res =
+    exps match {
+      case Nil => k(depth, Nil)
+      case exp :: exps =>
+        Bounce(() =>
+          atomizeExp(depth, env, exp, {
+            case (depth, atom) =>
+              atomizeExps(depth, env, exps, {
+                case (depth, atoms) =>
+                  Bounce(() => k(depth, atom :: atoms))
+              })
+          }))
+    }
+
+  def atomizeExp(depth: DepthA, env: Env, exp: SExpr, k: K[AbsAtom]): Res = {
+    exp match {
+      case ea: SExprAtomic => k(depth, makeAbsoluteA(env, ea))
+      case _ =>
+        transformExp(
+          depth,
+          env,
+          exp, {
+            case (depth, anf) =>
+              val atom = Right(AbsBinding(depth))
+              // Here we call `k' with a newly introduced variable:
+              val body = k(DepthA(depth.n + 1), atom).bounce.wrapped
+              // Here we wrap the result of `k` with an enclosing let expression:
+              Land(AExpr(SELet1(anf, body)))
+          }
+        )
+    }
+  }
+
+  def expandMultiLet(rhss: List[SExpr], body: SExpr): SExpr = {
+    //loop over rhss in reverse order
+    @tailrec
+    def loop(acc: SExpr, xs: List[SExpr]): SExpr = {
+      xs match {
+        case Nil => acc
+        case rhs :: xs => loop(SELet1General(rhs, acc), xs)
+      }
+    }
+    loop(body, rhss.reverse)
+  }
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -168,17 +168,6 @@ object Anf {
     )
   }
 
-  /*def transformLet1(depth: DepthA, env: Env, rhs: SExpr, body: SExpr, k: K[SExpr]): Res = {
-    // This is a better transform, but sadly it can blow the stack for deeply nested lets.
-    transformExp(depth, env, rhs, {
-      case (depth, rhs) =>
-        val depth1 = DepthA(depth.n + 1)
-        val env1 = trackBindings(depth, env, 1)
-        val body1 = transformExp(depth1, env1, body, k).bounce
-        Land(SELet1(rhs, body1))
-    })
-  }*/
-
   def flattenAlts(depth: DepthA, env: Env, alts: Array[SCaseAlt]): Array[SCaseAlt] = {
     alts.map {
       case SCaseAlt(pat, body0) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -31,7 +31,8 @@ import com.daml.lf.speedy.Compiler.CompilationError
 
 import scala.annotation.tailrec
 
-private[speedy] object Anf {
+//TODO: make this object private[speedy] when use of flattenToAnf is removed from daml-script
+object Anf {
 
   /*** Entry point for the ANF transformation phase */
   def flattenToAnf(exp: SExpr): AExpr = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -72,12 +72,8 @@ object Anf {
   val initEnv = Env(absMap = Map.empty, oldDepth = DepthE(0))
 
   def trackBindings(depth: DepthA, env: Env, n: Int): Env = {
-    if (n == 0) {
-      env
-    } else {
-      val extra = (0 to n - 1).map(i => (env.oldDepth.incr(i), depth.incr(i)))
-      Env(absMap = env.absMap ++ extra, oldDepth = env.oldDepth.incr(n))
-    }
+    val extra = (0 to n - 1).map(i => (env.oldDepth.incr(i), depth.incr(i)))
+    Env(absMap = env.absMap ++ extra, oldDepth = env.oldDepth.incr(n))
   }
 
   // TODO: reference something here about trampolines

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -100,9 +100,9 @@ object Anf {
 
   /** During conversion we need to deal with bindings which are made/found at a given
     absolute stack depth. These are represented using `AbsBinding`. An absolute stack
-    depth is the offset from the bottom of the stack, which is empty when a function is
-    entered. We call it absolute because an offset doesn't change as new bindings are
-    pushed onto the stack.
+    depth is the offset from the depth of the stack when the function is entered. We call
+    it absolute because an offset doesn't change as new bindings are pushed onto the
+    stack.
 
     Note the contrast with the expression form `ELocS` which contains a relative offset
     from the end of the stack. This relative-position is used in both the original

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -213,8 +213,6 @@ object Anf {
         case x: SEVal => k(depth, x)
         case x: SEImportValue => k(depth, x)
 
-        // (NC) I'm not entirely happy with how the following code is formatted, but
-        // scalafmt wont have it any other way.
         case SEAppGeneral(func, args) =>
           atomizeExp(
             depth,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -99,11 +99,15 @@ object Anf {
   type K[T] = ((DepthA, T) => Res)
 
   /** During conversion we need to deal with bindings which are made/found at a given
-    absolute stack depth. These are represented using `AbsBinding`.
+    absolute stack depth. These are represented using `AbsBinding`. An absolute stack
+    depth is the offset from the bottom of the stack, which is empty when a function is
+    entered. We call it absolute because an offset doesn't change as new bindings are
+    pushed onto the stack.
 
-    Note the contrast with the expression form `ELocS` which indicates a relative offset
-    from the top of the stack. This relative-position is used in both the original
-    expression which we traverse AND the new ANF expression we are constructing.
+    Note the contrast with the expression form `ELocS` which contains a relative offset
+    from the end of the stack. This relative-position is used in both the original
+    expression which we traverse AND the new ANF expression we are constructing. The
+    relative-offset to a binding varies as new bindings are pushed on the stack.
     */
   case class AbsBinding(abs: DepthA)
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -24,8 +24,11 @@ object Classify { // classify the machine state w.r.t what step occurs next
       var ebuiltin: Int = 0,
       var eval: Int = 0,
       var elocation: Int = 0,
-      var elet: Int = 0,
-      var ecase: Int = 0,
+      var eletG: Int = 0,
+      var elet1: Int = 0,
+      var eletB: Int = 0,
+      var ecaseE: Int = 0,
+      var ecaseA: Int = 0,
       var erecdef: Int = 0,
       var ecatch: Int = 0,
       var eimportvalue: Int = 0,
@@ -39,7 +42,6 @@ object Classify { // classify the machine state w.r.t what step occurs next
       var kpushto: Int = 0,
       var kcacheval: Int = 0,
       var klocation: Int = 0,
-      var kmatch: Int = 0,
       var kcatch: Int = 0,
   ) {
     def steps = ctrlExpr + ctrlValue
@@ -57,8 +59,11 @@ object Classify { // classify the machine state w.r.t what step occurs next
         ("- ebuiltin", ebuiltin),
         ("- eval", eval),
         ("- elocation", elocation),
-        ("- elet", elet),
-        ("- ecase", ecase),
+        ("- eletG", eletG),
+        ("- elet1", elet1),
+        ("- eletB", eletB),
+        ("- ecaseE", ecaseE),
+        ("- ecaseA", ecaseA),
         ("- erecdef", erecdef),
         ("- ecatch", ecatch),
         ("- eimportvalue", eimportvalue),
@@ -71,7 +76,6 @@ object Classify { // classify the machine state w.r.t what step occurs next
         ("- kpushto", kpushto),
         ("- kcacheval", kcacheval),
         ("- klocation", klocation),
-        ("- kmatch", kmatch),
         ("- kcatch", kcatch),
       ).map { case (tag, n) => s"$tag : $n" }.mkString("\n")
     }
@@ -85,7 +89,9 @@ object Classify { // classify the machine state w.r.t what step occurs next
       classifyKont(kont, counts)
     } else {
       counts.ctrlExpr += 1
-      classifyExpr(machine.ctrl, counts)
+      if (machine.ctrl != null) {
+        classifyExpr(machine.ctrl, counts)
+      }
     }
   }
 
@@ -98,14 +104,17 @@ object Classify { // classify the machine state w.r.t what step occurs next
       case _: SELocA => counts.evarA += 1
       case _: SELocF => counts.evarF += 1
       case _: SEAppGeneral => counts.eappE += 1
-      case _: SEAppAtomicFun => counts.eappA += 1
-      case _: SEAppSaturatedBuiltinFun => counts.eappB += 1
+      case _: SEAppAtomicGeneral => counts.eappA += 1
+      case _: SEAppAtomicSaturatedBuiltin => counts.eappB += 1
       case _: SEMakeClo => counts.eclose += 1
       case _: SEBuiltin => counts.ebuiltin += 1
       case _: SEVal => counts.eval += 1
       case _: SELocation => counts.elocation += 1
-      case _: SELet => counts.elet += 1
-      case _: SECase => counts.ecase += 1
+      case _: SELet => counts.eletG += 1
+      case _: SELet1General => counts.elet1 += 1
+      case _: SELet1Builtin => counts.eletB += 1
+      case _: SECase => counts.ecaseE += 1
+      case _: SECaseAtomic => counts.ecaseA += 1
       case _: SEBuiltinRecursiveDefinition => counts.erecdef += 1
       case _: SECatch => counts.ecatch += 1
       case _: SELabelClosure => ()
@@ -124,7 +133,6 @@ object Classify { // classify the machine state w.r.t what step occurs next
       case _: KPushTo => counts.kpushto += 1
       case _: KCacheVal => counts.kcacheval += 1
       case _: KLocation => counts.klocation += 1
-      case _: KMatch => counts.kmatch += 1
       case _: KCatch => counts.kcatch += 1
       case _: KLabelClosure => ()
       case _: KLeaveClosure => ()

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -1243,7 +1243,6 @@ private[lf] final case class Compiler(
     }
 
     def goBody(maxS: Int, maxA: Int, maxF: Int): SExpr => Unit = {
-      //println(s"goBody, maxS=$maxS")
       def goLoc(loc: SELoc) = loc match {
         case SELocS(i) =>
           if (i < 1 || i > maxS)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -956,8 +956,8 @@ private[lf] final case class Compiler(
                 SEVar(2)
             }
           )
-        }
-      )
+        },
+      ),
     )
 
   // ELet(a, ELet(b, body)) => ([a, b], body)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -184,7 +184,7 @@ private[lf] final case class Compiler(
 
   @throws[PackageNotFound]
   @throws[CompilationError]
-  def unsafeClosureConvert(sexpr: SExpr): AExpr =
+  def unsafeCompilationPipeline(sexpr: SExpr): AExpr =
     validate(compilationPipeline(None, sexpr))
 
   // Run the compilation pipeline phases:

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -472,10 +472,11 @@ object Pretty {
       (pat & text("=>") + lineOrSpace + prettySExpr(newIndex)(alt.body)).nested(2)
     }
 
-    def prettySELoc(loc: SELoc): Doc = loc match {
-      case SELocS(i) => char('S') + str(i)
-      case SELocA(i) => char('A') + str(i)
-      case SELocF(i) => char('F') + str(i)
+    def prettySELoc(index: Int)(loc: SELoc): Doc = loc match {
+      case SELocS(i) =>
+        text("S[") + str(i) + text("=abs:") + str(index - i) + text("]") // show absolute stack position, 0..
+      case SELocA(i) => text("A") + str(i)
+      case SELocF(i) => text("F") + str(i)
     }
 
     def prettySExpr(index: Int)(e: SExpr): Doc =
@@ -490,6 +491,7 @@ object Pretty {
             case other => str(other)
           }
 
+        case SECaseAtomic(scrut, alts) => prettySExpr(index)(SECase(scrut, alts))
         case SECase(scrut, alts) =>
           (text("case") & prettySExpr(index)(scrut) & text("of") +
             line +
@@ -519,16 +521,16 @@ object Pretty {
             case SBGetTime => text("$getTime")
             case _ => str(x)
           }
+        case SEAppAtomicGeneral(fun, args) =>
+          val prefix = prettySExpr(index)(fun) + char('(')
+          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
+            .tightBracketBy(prefix, char(')'))
+        case SEAppAtomicSaturatedBuiltin(builtin, args) =>
+          val prefix = prettySExpr(index)(SEBuiltin(builtin)) + char('(')
+          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
+            .tightBracketBy(prefix, char(')'))
         case SEAppGeneral(fun, args) =>
           val prefix = prettySExpr(index)(fun) + char('(')
-          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
-            .tightBracketBy(prefix, char(')'))
-        case SEAppAtomicFun(fun, args) =>
-          val prefix = prettySExpr(index)(fun) + char('(')
-          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
-            .tightBracketBy(prefix, char(')'))
-        case SEAppSaturatedBuiltinFun(builtin, args) =>
-          val prefix = prettySExpr(index)(SEBuiltin(builtin)) + char('(')
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))
         case SEAbs(n, body) =>
@@ -547,12 +549,12 @@ object Pretty {
 
         case SEMakeClo(fv, n, body) =>
           val prefix = char('[') +
-            intercalate(space, fv.map(prettySELoc)) + char(']') + text("(\\") +
-            intercalate(space, (index to n + index - 1).map((v: Int) => str(v))) &
+            intercalate(space, fv.map(prettySELoc(index))) + char(']') + text("(\\") +
+            intercalate(space, (0 to n - 1).map((v: Int) => text("A") + str(v))) &
             text("-> ")
-          prettySExpr(index + n)(body).tightBracketBy(prefix, char(')'))
+          prettySExpr(0)(body).tightBracketBy(prefix, char(')'))
 
-        case loc: SELoc => prettySELoc(loc)
+        case loc: SELoc => prettySELoc(index)(loc)
 
         case SELet(bounds, body) =>
           // let [a, b, c] in X
@@ -561,6 +563,12 @@ object Pretty {
               str(index + n) & char('=') & prettySExpr(index + n)(x)
           })).tightBracketBy(text("let ["), char(']')) +
             lineOrSpace + text("in") & prettySExpr(index + bounds.length)(body)
+
+        case SELet1General(rhs, body) =>
+          prettySExpr(index)(SELet(Array(rhs), body))
+
+        case SELet1Builtin(builtin, args, body) =>
+          prettySExpr(index)(SELet1General(SEAppAtomicSaturatedBuiltin(builtin, args), body))
 
         case x: SEBuiltinRecursiveDefinition => str(x)
         case x: SEImportValue => str(x)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -35,7 +35,7 @@ import scala.collection.immutable.TreeSet
   The vast majority of the builtins are nevery hungry, and so they extend `SBuiltin`
   There are 7 hungry builtins which extend `SBuiltinMaybeHungry`
   */
-/** Speedy builtin functions */
+/** Speedy builtin functions that may raise `SpeedyHungry` exceptions. */
 sealed abstract class SBuiltinMaybeHungry(val arity: Int) {
   // Helper for constructing expressions applying this builtin.
   // E.g. SBCons(SEVar(1), SEVar(2))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -24,8 +24,19 @@ import com.daml.lf.transaction.Node.{GlobalKey, KeyWithMaintainers}
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeSet
 
+/**
+  Speedy builtins are stratified into two layers:
+  Parent: `SBuiltinMaybeHungry`, child: `SBuiltin` (which are never hungry).
+  Hungry means, may throw SpeedyHungry.
+
+  Non-hungry builtins can be treated specially because their evaluation is immediate.
+  This fact is used by the execution of the ANF expression form: `SELet1Builtin`.
+
+  The vast majority of the builtins are nevery hungry, and so they extend `SBuiltin`
+  There are 7 hungry builtins which extend `SBuiltinMaybeHungry`
+  */
 /** Speedy builtin functions */
-sealed abstract class SBuiltin(val arity: Int) {
+sealed abstract class SBuiltinMaybeHungry(val arity: Int) {
   // Helper for constructing expressions applying this builtin.
   // E.g. SBCons(SEVar(1), SEVar(2))
   def apply(args: SExpr*): SExpr =
@@ -36,7 +47,14 @@ sealed abstract class SBuiltin(val arity: Int) {
   def execute(args: util.ArrayList[SValue], machine: Machine): Unit
 }
 
+sealed abstract class SBuiltin(val arity1: Int) extends SBuiltinMaybeHungry(arity1) {
+  // TODO: define evaluate, and convert all subclasses to this simpler form
+  // def evaluate(args: util.ArrayList[SValue]): SValue
+  // Then execute can be defined in terms of evaluate. Like how it is done in `SExprAtomic`.
+}
+
 object SBuiltin {
+
   //
   // Arithmetic
   //
@@ -866,7 +884,7 @@ object SBuiltin {
     *    -> Token
     *    -> a
     */
-  final case class SBUFetch(templateId: TypeConName) extends SBuiltin(2) {
+  final case class SBUFetch(templateId: TypeConName) extends SBuiltinMaybeHungry(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       checkToken(args.get(1))
       val coid = args.get(0) match {
@@ -949,7 +967,7 @@ object SBuiltin {
     *   -> Token
     *   -> Maybe (ContractId T)
     */
-  final case class SBULookupKey(templateId: TypeConName) extends SBuiltin(2) {
+  final case class SBULookupKey(templateId: TypeConName) extends SBuiltinMaybeHungry(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       checkToken(args.get(1))
       val keyWithMaintainers =
@@ -1025,7 +1043,7 @@ object SBuiltin {
     *   -> Token
     *   -> ContractId T
     */
-  final case class SBUFetchKey(templateId: TypeConName) extends SBuiltin(2) {
+  final case class SBUFetchKey(templateId: TypeConName) extends SBuiltinMaybeHungry(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       checkToken(args.get(1))
       val keyWithMaintainers = extractKeyWithMaintainers(args.get(0))
@@ -1061,7 +1079,7 @@ object SBuiltin {
   }
 
   /** $getTime :: Token -> Timestamp */
-  final case object SBGetTime extends SBuiltin(1) {
+  final case object SBGetTime extends SBuiltinMaybeHungry(1) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       checkToken(args.get(0))
       // $ugettime :: Token -> Timestamp
@@ -1084,7 +1102,7 @@ object SBuiltin {
   }
 
   /** $endCommit[mustFail?] :: result -> Token -> () */
-  final case class SBSEndCommit(mustFail: Boolean) extends SBuiltin(2) {
+  final case class SBSEndCommit(mustFail: Boolean) extends SBuiltinMaybeHungry(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       checkToken(args.get(1))
       if (mustFail) executeMustFail(args, machine)
@@ -1153,7 +1171,7 @@ object SBuiltin {
   }
 
   /** $pass :: Int64 -> Token -> Timestamp */
-  final case object SBSPass extends SBuiltin(2) {
+  final case object SBSPass extends SBuiltinMaybeHungry(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       checkToken(args.get(1))
       val relTime = args.get(0) match {
@@ -1171,7 +1189,7 @@ object SBuiltin {
   }
 
   /** $getParty :: Text -> Token -> Party */
-  final case object SBSGetParty extends SBuiltin(2) {
+  final case object SBSGetParty extends SBuiltinMaybeHungry(2) {
     def execute(args: util.ArrayList[SValue], machine: Machine): Unit = {
       checkToken(args.get(1))
       args.get(0) match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -109,8 +109,6 @@ object SExpr {
   /** Function application: General case: 'fun' and 'args' are any kind of expression */
   final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
-      //machine.pushKont(KArg(args, machine.frame, machine.actuals, machine.env.size))
-      //machine.ctrl = fun
       // We never encounter a general application node when executing on the speedy machine
       // This is because all speedy expression must have been converted to ANF form
       // The wrapper type `AExpr` helps ensure this restrction is adhered to.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -64,16 +64,8 @@ sealed trait SValue {
         V.ValueGenMap(ImmArray(values.map { case (k, v) => k.toValue -> v.toValue }))
       case SContractId(coid) =>
         V.ValueContractId(coid)
-      case SAny(_, _) =>
-        throw SErrorCrash("SValue.toValue: unexpected SAny")
-      case STypeRep(_) =>
-        throw SErrorCrash("SValue.toValue: unexpected STypeRep")
-      case STNat(_) =>
-        throw SErrorCrash("SValue.toValue: unexpected STNat")
-      case _: SPAP =>
-        throw SErrorCrash("SValue.toValue: unexpected SPAP")
-      case SToken =>
-        throw SErrorCrash("SValue.toValue: unexpected SToken")
+      case _: SAny | _: STypeRep | _: STNat | _: SPAP | SToken =>
+        throw SErrorCrash(s"SValue.toValue: unexpected $this")
     }
 
   def mapContractId(f: V.ContractId => V.ContractId): SValue =
@@ -113,7 +105,7 @@ object SValue {
 
   /** "Primitives" that can be applied. */
   sealed trait Prim
-  final case class PBuiltin(b: SBuiltin) extends Prim
+  final case class PBuiltin(b: SBuiltinMaybeHungry) extends Prim
 
   /** A closure consisting of an expression together with the values the
     * expression is closing over.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -64,8 +64,16 @@ sealed trait SValue {
         V.ValueGenMap(ImmArray(values.map { case (k, v) => k.toValue -> v.toValue }))
       case SContractId(coid) =>
         V.ValueContractId(coid)
-      case _: SAny | _: STypeRep | _: STNat | _: SPAP | SToken =>
-        throw SErrorCrash(s"SValue.toValue: unexpected $this")
+      case SAny(_, _) =>
+        throw SErrorCrash("SValue.toValue: unexpected SAny")
+      case STypeRep(_) =>
+        throw SErrorCrash("SValue.toValue: unexpected STypeRep")
+      case STNat(_) =>
+        throw SErrorCrash("SValue.toValue: unexpected STNat")
+      case _: SPAP =>
+        throw SErrorCrash("SValue.toValue: unexpected SPAP")
+      case SToken =>
+        throw SErrorCrash("SValue.toValue: unexpected SToken")
     }
 
   def mapContractId(f: V.ContractId => V.ContractId): SValue =

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -411,8 +411,8 @@ object Repl {
     defs.get(idToRef(state, args(0))) match {
       case None =>
         println("Error: definition '" + args(0) + "' not found. Try :list."); usage
-      case Some(expr) =>
-        println(Pretty.SExpr.prettySExpr(0)(expr).render(80))
+      case Some(anf) =>
+        println(Pretty.SExpr.prettySExpr(0)(anf.wrapped).render(80))
     }
   }
 

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -10,6 +10,7 @@ import com.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.daml.lf.data.Ref.{Identifier, Party, QualifiedName}
 import com.daml.lf.data.Time
 import com.daml.lf.language.Ast.EVal
+import com.daml.lf.speedy.AExpr
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.Transaction.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
@@ -38,7 +39,7 @@ class CollectAuthorityState {
   private var scenario: String = _
 
   var machine: Machine = null
-  var the_sexpr: SExpr = null
+  var the_anf: AExpr = null
 
   @Setup(Level.Trial)
   def init(): Unit = {
@@ -61,7 +62,7 @@ class CollectAuthorityState {
       ValueVersions.SupportedDevVersions,
       TransactionVersions.SupportedDevVersions,
     )
-    the_sexpr = machine.ctrl
+    the_anf = AExpr(machine.ctrl)
 
     // fill the caches!
     setup()
@@ -75,7 +76,7 @@ class CollectAuthorityState {
 
   // This is function that we benchmark
   def run(): Unit = {
-    machine.setExpressionToEvaluate(the_sexpr)
+    machine.setExpressionToEvaluate(the_anf)
     var step = 0
     var finalValue: SValue = null
     while (finalValue == null) {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -31,7 +31,8 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.iface.EnvironmentInterface
 import com.daml.lf.iface.reader.InterfaceReader
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.{Compiler, Pretty, SExpr, SValue, Speedy}
+import com.daml.lf.speedy.{Compiler, Pretty, AExpr, SExpr, SValue, Speedy}
+import com.daml.lf.speedy.Anf.flattenToAnf
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
@@ -303,13 +304,13 @@ class Runner(
   // This is a type error but Speedy doesn’t care about the types and the only thing we do
   // with the result is convert it to ledger values/record so this is safe.
   private val extendedCompiledPackages = {
-    val fromLedgerValue: PartialFunction[SDefinitionRef, SExpr] = {
+    val fromLedgerValue: PartialFunction[SDefinitionRef, AExpr] = {
       case LfDefRef(id) if id == script.scriptIds.damlScript("fromLedgerValue") =>
-        SEMakeClo(Array(), 1, SELocA(0))
+        AExpr(SEMakeClo(Array(), 1, SELocA(0)))
     }
     new CompiledPackages {
       def getPackage(pkgId: PackageId): Option[Package] = compiledPackages.getPackage(pkgId)
-      def getDefinition(dref: SDefinitionRef): Option[SExpr] =
+      def getDefinition(dref: SDefinitionRef): Option[AExpr] =
         fromLedgerValue.andThen(Some(_)).applyOrElse(dref, compiledPackages.getDefinition)
       override def packages = compiledPackages.packages
       def packageIds = compiledPackages.packageIds
@@ -351,7 +352,7 @@ class Runner(
       }
 
     def run(expr: SExpr): Future[SValue] = {
-      machine.setExpressionToEvaluate(expr)
+      machine.setExpressionToEvaluate(flattenToAnf(expr))
       stepToValue()
         .fold(Future.failed, Future.successful)
         .flatMap {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -356,7 +356,7 @@ case class ScriptExample(dar: Dar[(PackageId, Package)], runner: TestRunner) {
 
 case class TraceOrder(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:traceOrder"))
-  def traceMsg(msg: String) = s"""[DA.Internal.Prelude:540]: "$msg""""
+  def traceMsg(msg: String) = s"""[GHC.Base:52]: "$msg""""
   def runTests(): Unit = {
     runner.genericTest(
       "traceOrder",


### PR DESCRIPTION
ANF transformation in Speedy.

The idea behind this PR is to transform speedy expressions into a simpler form where all non-atomic sub-expressions are made explicit by the introduction of let-forms. In particular, for the function-application form. These simpler forms allow the execution engine to take advantage of the atomic assumption, and often removes many additional execution steps. In particular the pushing of continuations to allow execution to continue after a compound expression has been reduced to a value.


The performance is increase by around x1.15. Here are the raw figures for the CollectAuthority benchmark, run 6x, interleaving between the master branch and this branch.

```
anf:     64.538 ±(99.9%) 0.442 ms/op [Average]
master:  75.250 ±(99.9%) 0.444 ms/op [Average]
anf:     64.160 ±(99.9%) 0.674 ms/op [Average]
master:  73.407 ±(99.9%) 0.850 ms/op [Average]
anf:     63.549 ±(99.9%) 0.753 ms/op [Average]
master:  73.293 ±(99.9%) 0.500 ms/op [Average]
```

This PR relates to issue #6198 

changelog_begin
changelog_end
