### PR TITLE
exit on failed benchmark

### DIFF
--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -5,6 +5,7 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_benchmark_jmh",
     "da_scala_library",
+    "da_scala_test",
     "da_scala_test_suite",
     "lf_scalacopts",
 )
@@ -66,4 +67,14 @@ da_scala_benchmark_jmh(
         "//daml-lf/transaction",
         "@maven//:com_google_protobuf_protobuf_java",
     ],
+)
+
+da_scala_test(
+    name = "scenario-perf-test",
+    args = [
+        "-f",
+        "0",
+    ],
+    main_class = "org.openjdk.jmh.Main",
+    deps = [":scenario-perf"],
 )

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -133,6 +133,9 @@ class CollectAuthorityState {
     }
   }
 
-  def crash(reason: String) =
-    throw new RuntimeException(s"CollectAuthority: $reason")
+  def crash(reason: String) = {
+    System.err.println("Benchmark failed: " + reason)
+    System.exit(1)
+  }
+
 }


### PR DESCRIPTION
At the moment, JMH seems happy to just swallow exceptions and consider the benchmark done, which makes it produce inaccurate speed results and lets errors slip through to master. This makes unexpected errors in the benchmark a hard stop.

This is not a complete solution: ideally there would be a way to just tell jmh to abort on uncaught exceptions. However, I don't seem to be able to find any relevant documentation on how to do that.

CHANGELOG_BEGIN
CHANGELOG_END