### PR TITLE
Save the expression in the CollectAuthority benchmark

### DIFF
--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -35,8 +35,8 @@ class CollectAuthorityState {
   @Param(Array("CollectAuthority:test"))
   private var scenario: String = _
 
-  var machine: Machine = _
-  var the_sexpr: SExpr = _
+  var machine: Machine = null
+  var the_sexpr: SExpr = null
 
   @Setup(Level.Trial)
   def init(): Unit = {
@@ -53,6 +53,7 @@ class CollectAuthorityState {
     val expr = EVal(Identifier(packages.main._1, QualifiedName.assertFromString(scenario)))
 
     machine = Machine.fromScenarioExpr(compiledPackages, seeding(), expr)
+    the_sexpr = machine.ctrl
 
     // fill the caches!
     setup()
@@ -76,7 +77,7 @@ class CollectAuthorityState {
         case SResultScenarioCommit(_, _, _, callback) => callback(cachedCommit(step))
         case SResultNeedContract(_, _, _, _, callback) => callback(cachedContract(step))
         case SResultFinalValue(v) => finalValue = v
-        case r => crash("bench run: unexpected result from speedy")
+        case r => crash(s"bench run: unexpected result from speedy: ${r}")
       }
     }
   }
@@ -128,7 +129,7 @@ class CollectAuthorityState {
         case SResultFinalValue(v) =>
           finalValue = v
         case r =>
-          crash("setup run: unexpected result from speedy")
+          crash(s"setup run: unexpected result from speedy: ${r}")
       }
     }
   }


### PR DESCRIPTION
During some refactoring we forgot to save the initial expression to
evaluate for the machine during benchmarking. This PR fixes the issue.
It also make the error messages a bit more descriptive so that we can
actually debug this.

A test to make sure issues like this one don't get through CI again is
worked on by @garyverhaegen-da in a separate PR.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6454)
<!-- Reviewable:end -->
