### PR TITLE
Track runfile dependencies of SDK assistant

### DIFF
--- a/compatibility/bazel_tools/daml_sdk.bzl
+++ b/compatibility/bazel_tools/daml_sdk.bzl
@@ -128,7 +128,7 @@ sh_binary(
 cc_binary(
   name = "daml",
   srcs = ["daml.cc"],
-  data = [":sdk/bin/daml"],
+  data = [":sdk/bin/daml"] + glob(["sdk/sdk/{version}/**"]),
   deps = ["@bazel_tools//tools/cpp/runfiles:runfiles"],
 )
 # Needed to provide the same set of DARs to the ledger that
@@ -138,7 +138,7 @@ filegroup(
     srcs = glob(["extracted-test-tool/ledger/test-common/**"]),
 )
 exports_files(["daml-types.tgz", "daml-ledger.tgz", "daml-react.tgz", "create_daml_app.patch"])
-""",
+""".format(version = ctx.attr.version),
     )
     return None
 


### PR DESCRIPTION
The `//:migration-stable` test-cases had issues with cached test results not being invalidated after an update of the HEAD SDK. This was due to the SDK distribution files being undeclared dependencies of the `daml` binary. This change adds the SDK distribution files to the `data` attribute of the generated `daml` `cc_binary` to ensure that changes are noticed by Bazel and cached test-cases invalidated.

The resulting runfiles tree for `daml` (and targets with `data` dependencies on `daml`) includes a symlink per file in the SDK release. At the time of commit this amounts to ~9MiB of symlinks for one SDK version (0.0.0 in particular).

I have verified that this resolves the issue of wrongly cached test results with the following steps:
- Revert https://github.com/digital-asset/daml/pull/6461 on top of master and observe that the `compatibility-linux` CI step passes even though `//:migration-stable` should be broken.
- Revert #6461 on top of this PR and observe that `//:migration-stable` fails in `compatibility-linux` as expected.


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
