### PR TITLE
Prefix IDE include paths with project root

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -556,7 +556,7 @@ damlGhcSessionRule opts@Options{..} = do
             _ -> pure []
         optPackageImports <- pure $ map mkPackageFlag base ++ extraPkgFlags ++ optPackageImports
         env <- liftIO $ runGhcFast $ do
-            setupDamlGHC opts
+            setupDamlGHC mbProjectRoot opts
             GHC.getSession
         pkg <- liftIO $ generatePackageState optDamlLfVersion mbProjectRoot optPackageDbs optPackageImports
         dflags <- liftIO $ checkDFlags opts $ setPackageDynFlags pkg $ hsc_dflags env

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -754,11 +754,11 @@ includePathTests damlc = testGroup "include-path"
               ]
           withCurrentDirectory dir $
             runSessionWithConfig conf (damlc <> " ide --scenarios=yes") fullCaps' dir $ do
-              _docB <- openDoc ("src2/B.daml") "daml"
+              _docB <- openDoc "src2/B.daml" "daml"
               -- If we get a scenario result, we managed to build a DALF which
               -- is what we really want to check here.
               expectDiagnostics [ ("src2/B.daml", [(DsError, (3,0), "Assertion failed")]) ]
-              _docRoot <- openDoc ("src1/Root.daml") "daml"
+              _docRoot <- openDoc "src1/Root.daml" "daml"
               expectDiagnostics [ ("src1/Root.daml", [(DsError, (3,0), "Assertion failed")]) ]
     ]
 


### PR DESCRIPTION
As described in #6174, `--include` is broken pretty badly in the IDE
atm. LSP works based on absolute file paths so if you have a relative
include dir you run into two issues:

1. You end up with two GHC sessions e.g, one for `/multidir` and one
   for `.`. That results in fun type errors like “Couldn’t match expected
   type `Text` with actual type `Text`”.
2. The same file can end up being represented twice. Apart from being
   horribly inefficient, this breaks as soon as we try to build a DALF
   since the function for constructing that (correctly) explodes when
   there are two files with the same module name.

This change does not break `daml build` since the project root is
relative there.

fixes #6174

changelog_begin

- [DAML Studio] Fix an issue where use of the `--include` option
  resulted in various confusing type errors. See
  https://github.com/digital-asset/daml/issues/6174

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
