### PR TITLE
Replay transaction

### DIFF
--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -44,13 +44,8 @@ da_scala_binary(
         "@maven//:ch_qos_logback_logback_classic",
     ],
     deps = [
-        "//daml-lf/archive:daml_lf_archive_reader",
-        "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
         "//daml-lf/engine",
-        "//daml-lf/language",
-        "//daml-lf/transaction",
-        "//daml-lf/transaction:transaction_java_proto",
         "//ledger/ledger-on-memory",
         "//ledger/metrics",
         "//ledger/participant-state",
@@ -61,7 +56,6 @@ da_scala_binary(
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_dropwizard_metrics_metrics_core",
-        "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )
 

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -3,7 +3,9 @@
 
 load(
     "//bazel_tools:scala.bzl",
+    "da_scala_benchmark_jmh",
     "da_scala_binary",
+    "lf_scalacopts",
 )
 
 da_scala_binary(
@@ -42,8 +44,13 @@ da_scala_binary(
         "@maven//:ch_qos_logback_logback_classic",
     ],
     deps = [
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
         "//daml-lf/engine",
+        "//daml-lf/language",
+        "//daml-lf/transaction",
+        "//daml-lf/transaction:transaction_java_proto",
         "//ledger/ledger-on-memory",
         "//ledger/metrics",
         "//ledger/participant-state",
@@ -54,5 +61,27 @@ da_scala_binary(
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_dropwizard_metrics_metrics_core",
+        "@maven//:org_scalaz_scalaz_core_2_12",
+    ],
+)
+
+da_scala_benchmark_jmh(
+    name = "replay",
+    srcs = glob(["src/test/scala/**/Replay.scala"]),
+    max_heap_size = "4g",
+    scalacopts = lf_scalacopts,
+    deps = [
+        "//daml-lf/archive:daml_lf_archive_reader",
+        "//daml-lf/archive:daml_lf_dev_archive_java_proto",
+        "//daml-lf/data",
+        "//daml-lf/engine",
+        "//daml-lf/language",
+        "//daml-lf/transaction",
+        "//daml-lf/transaction:transaction_java_proto",
+        "//ledger/participant-state",
+        "//ledger/participant-state/kvutils",
+        "//ledger/participant-state/kvutils:daml_kvutils_java_proto",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/Replay.scala
@@ -1,0 +1,225 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.test
+
+import java.io.DataInputStream
+import java.lang.System.err.println
+import java.nio.file.{Files, Path, Paths}
+import java.util.concurrent.TimeUnit
+
+import com.daml.ledger.participant.state.kvutils.Conversions._
+import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.SubmissionInfo
+import com.daml.ledger.participant.state.kvutils.export.Serialization
+import com.daml.ledger.participant.state.kvutils.{Envelope, DamlKvutils => Proto}
+import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.lf.archive.{Decode, UniversalArchiveReader}
+import com.daml.lf.data._
+import com.daml.lf.engine.Engine
+import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.{Node, Transaction => Tx, TransactionCoder => TxCoder}
+import com.daml.lf.value.Value.ContractId
+import com.daml.lf.value.{Value, ValueCoder => ValCoder}
+import com.daml.lf.{crypto, data}
+import com.google.protobuf.ByteString
+import org.openjdk.jmh.annotations._
+
+import scala.collection.JavaConverters._
+
+case class TxEntry(
+    tx: Tx.SubmittedTransaction,
+    participantId: ParticipantId,
+    ledgerTime: Time.Timestamp,
+    submissionTime: Time.Timestamp,
+    submissionSeed: crypto.Hash,
+)
+
+case class BenchMarkSate(
+    name: String,
+    transaction: TxEntry,
+    contracts: ContractId => Option[Tx.ContractInst[ContractId]],
+    contractKeys: GlobalKey => Option[ContractId],
+)
+
+@State(Scope.Benchmark)
+class Replay {
+
+  @Param(Array())
+  var choiceName: String = _
+
+  @Param(Array())
+  var darFile: String = _
+
+  @Param(Array())
+  var ledgerFile: String = _
+
+  private var engineDarFile: Option[String] = None
+  private var engine: Engine = _
+  private var benchmarksFile: Option[String] = None
+  private var benchmarks: Map[String, BenchMarkSate] = _
+  private var benchmark: BenchMarkSate = _
+
+  @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  def bench() = {
+    engine
+      .replay(
+        benchmark.transaction.tx,
+        benchmark.transaction.ledgerTime,
+        benchmark.transaction.participantId,
+        benchmark.transaction.submissionTime,
+        benchmark.transaction.submissionSeed,
+      )
+      .consume(benchmark.contracts, _ => Replay.unexpectedError, benchmark.contractKeys)
+  }
+
+  @Setup(Level.Trial)
+  def init() = {
+    if (!engineDarFile.contains(darFile)) {
+      engine = Replay.loadDar(Paths.get(darFile))
+      engineDarFile = Some(darFile)
+    }
+    if (!benchmarksFile.contains(ledgerFile)) {
+      benchmarks = Replay.loadBenchmarks(Paths.get(ledgerFile))
+      benchmarksFile = Some(ledgerFile)
+    }
+
+    benchmark = benchmarks(choiceName)
+    // before running the bench, we validate the transaction first to be sure everything is fine.
+    val r = engine
+      .validate(
+        benchmark.transaction.tx,
+        benchmark.transaction.ledgerTime,
+        benchmark.transaction.participantId,
+        benchmark.transaction.submissionTime,
+        benchmark.transaction.submissionSeed,
+      )
+      .consume(benchmark.contracts, _ => Replay.unexpectedError, benchmark.contractKeys)
+    assert(r.isRight)
+  }
+
+}
+
+object Replay {
+
+  private def unexpectedError = sys.error("Unexpected Error")
+
+  def loadDar(darFile: Path): Engine = {
+    println(s"%%% loading dar file $darFile ...")
+    lazy val dar = UniversalArchiveReader().readFile(darFile.toFile).get
+    lazy val packages = dar.all.map {
+      case (pkgId, pkgArchive) => Decode.readArchivePayloadAndVersion(pkgId, pkgArchive)._1
+    }.toMap
+    val engine = new Engine(Engine.DevConfig)
+    val r = engine
+      .preloadPackage(dar.main._1, packages(dar.main._1))
+      .consume(_ => unexpectedError, packages.get, _ => unexpectedError)
+      .left
+      .map(_.msg)
+    data.assertRight(r)
+    engine
+  }
+
+  private def exportEntries(file: Path): Stream[SubmissionInfo] = {
+    val ledgerExportStream = new DataInputStream(Files.newInputStream(file))
+
+    def go: Stream[SubmissionInfo] =
+      if (ledgerExportStream.available() > 0)
+        Serialization.readEntry(ledgerExportStream)._1 #:: go
+      else {
+        ledgerExportStream.close()
+        Stream.empty
+      }
+
+    go
+  }
+
+  private def decodeSubmission(participantId: ParticipantId, submission: Proto.DamlSubmission) = {
+    if (submission.getPayloadCase == Proto.DamlSubmission.PayloadCase.TRANSACTION_ENTRY) {
+      val entry = submission.getTransactionEntry
+      val tx = TxCoder
+        .decodeTransaction(
+          TxCoder.NidDecoder,
+          ValCoder.CidDecoder,
+          submission.getTransactionEntry.getTransaction)
+        .fold(err => sys.error(err.toString), Tx.SubmittedTransaction(_))
+      Stream(
+        TxEntry(
+          tx = tx,
+          participantId = participantId,
+          ledgerTime = parseTimestamp(entry.getLedgerEffectiveTime),
+          submissionTime = parseTimestamp(entry.getSubmissionTime),
+          submissionSeed = parseHash(entry.getSubmissionSeed)
+        ))
+    } else
+      Stream.empty
+  }
+
+  private def decodeEnvelope(participantId: ParticipantId, envelope: ByteString): Stream[TxEntry] =
+    assertRight(Envelope.open(envelope)) match {
+      case Envelope.SubmissionMessage(submission) =>
+        decodeSubmission(participantId, submission)
+      case Envelope.SubmissionBatchMessage(batch) =>
+        batch.getSubmissionsList.asScala.toStream
+          .map(_.getSubmission)
+          .flatMap(decodeEnvelope(participantId, _))
+      case Envelope.LogEntryMessage(_) | Envelope.StateValueMessage(_) =>
+        Stream.empty
+    }
+
+  private def decodeSubmissionInfo(submissionInfo: SubmissionInfo) =
+    decodeEnvelope(submissionInfo.participantId, submissionInfo.submissionEnvelope)
+
+  def loadBenchmarks(dumpFile: Path): Map[String, BenchMarkSate] = {
+    println(s"%%% load ledger export file  $dumpFile...")
+    val transactions = exportEntries(dumpFile).flatMap(decodeSubmissionInfo)
+    if (transactions.isEmpty) sys.error("no transaction find")
+
+    val createsNodes: Seq[Node.NodeCreate[ContractId, Tx.Value[ContractId]]] =
+      transactions.flatMap(entry =>
+        entry.tx.nodes.values.collect {
+          case create: Node.NodeCreate[ContractId, Tx.Value[ContractId]] =>
+            create
+      })
+
+    val allContracts: Map[ContractId, Value.ContractInst[Tx.Value[ContractId]]] =
+      createsNodes.map(node => node.coid -> node.coinst).toMap
+
+    val allContractsWithKey = createsNodes.flatMap { node =>
+      node.key.toList.map(
+        key =>
+          node.coid -> Node.GlobalKey(
+            node.coinst.template,
+            key.key.value.assertNoCid(key => s"found cid in key $key")))
+    }.toMap
+
+    val benchmarks = transactions.flatMap { entry =>
+      entry.tx.roots.map(entry.tx.nodes) match {
+        case ImmArray(exe: Node.NodeExercises[_, ContractId, Tx.Value[ContractId]]) =>
+          val inputContracts = entry.tx.inputContracts
+          List(
+            BenchMarkSate(
+              name = exe.templateId.qualifiedName.toString + ":" + exe.choiceId,
+              transaction = entry,
+              contracts = allContracts.filterKeys(inputContracts).get,
+              contractKeys = inputContracts.iterator
+                .flatMap(cid => allContractsWithKey.get(cid).toList.map(_ -> cid))
+                .toMap
+                .get
+            ))
+        case _ =>
+          List.empty
+      }
+    }
+
+    benchmarks.groupBy(_.name).flatMap {
+      case (key, Seq(test)) =>
+        println(s"%%% found 1 exercise for $key")
+        List(key -> test)
+      case (key, tests) =>
+        println(s"%%% found ${tests.length} exercises for $key. IGNORED")
+        List.empty
+    }
+
+  }
+
+}

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/Replay.scala
@@ -34,7 +34,7 @@ final case class TxEntry(
     submissionSeed: crypto.Hash,
 )
 
-final case class BenchMarkSate(
+final case class BenchMarkState(
     name: String,
     transaction: TxEntry,
     contracts: ContractId => Option[Tx.ContractInst[ContractId]],
@@ -56,8 +56,8 @@ class Replay {
   private var engineDarFile: Option[String] = None
   private var engine: Engine = _
   private var benchmarksFile: Option[String] = None
-  private var benchmarks: Map[String, BenchMarkSate] = _
-  private var benchmark: BenchMarkSate = _
+  private var benchmarks: Map[String, BenchMarkState] = _
+  private var benchmark: BenchMarkState = _
 
   @Benchmark @BenchmarkMode(Array(Mode.AverageTime)) @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def bench(): Unit = {
@@ -170,7 +170,7 @@ object Replay {
   private def decodeSubmissionInfo(submissionInfo: SubmissionInfo) =
     decodeEnvelope(submissionInfo.participantId, submissionInfo.submissionEnvelope)
 
-  private def loadBenchmarks(dumpFile: Path): Map[String, BenchMarkSate] = {
+  private def loadBenchmarks(dumpFile: Path): Map[String, BenchMarkState] = {
     println(s"%%% load ledger export file  $dumpFile...")
     val transactions = exportEntries(dumpFile).flatMap(decodeSubmissionInfo)
     if (transactions.isEmpty) sys.error("no transaction find")
@@ -198,7 +198,7 @@ object Replay {
         case ImmArray(exe: Node.NodeExercises.WithTxValue[_, ContractId]) =>
           val inputContracts = entry.tx.inputContracts
           List(
-            BenchMarkSate(
+            BenchMarkState(
               name = exe.templateId.qualifiedName.toString + ":" + exe.choiceId,
               transaction = entry,
               contracts = allContracts.filterKeys(inputContracts).get,


### PR DESCRIPTION
JMH benchmark  that replay transactions from a ledger export. 

usage: 
```
 bazel run //ledger/participant-state/kvutils/tools:replay -- -p ledgerFile=ledger.export -p darFile=fle.dar -p choiceName="ModuleName1:TemplateName1:ChoiceName1","ModuleName2:TemplateName2:ChoiceName2"
```
Currently the replay support only transaction with single exercise root node, other transaction are ignored.
If a same choice is exercise is repeated in the ledger dump, the case is also ignored. 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
