### PR TITLE
Strengthen unused * testing

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -284,9 +284,21 @@ xFlagsSet options =
 wOptsSet :: [ WarningFlag ]
 wOptsSet =
   [ Opt_WarnUnusedImports
+-- Can enable when we are on GHC >= 8.10 (we should, after all we
+-- upstreamed it :) ).
 --  , Opt_WarnPrepositiveQualifiedModule
   , Opt_WarnOverlappingPatterns
   , Opt_WarnIncompletePatterns
+-- Confirmed that nothing in template desugaring prevents us from
+-- enabling these.
+  -- , Opt_WarnUnusedMatches
+  -- , Opt_WarnUnusedForalls
+  -- , Opt_WarnUnusedPatternBinds
+  -- , Opt_WarnUnusedTopBinds
+  -- , Opt_WarnUnusedTypePatterns
+-- Template desugaring in the presence of local binds will currently
+-- trigger this.
+  -- , Opt_WarnUnusedLocalBinds
   ]
 
 -- | Warning options set for DAML compilation, which become errors.

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Template/Functions.daml
@@ -202,7 +202,7 @@ exerciseByKey k c = do
     exercise cid c
 
 -- | Create a contract and exercise the choice on the newly created contract.
-createAndExercise : forall t k c r. (HasCreate t, HasExercise t c r) => t -> c -> Update r
+createAndExercise : forall t c r. (HasCreate t, HasExercise t c r) => t -> c -> Update r
 createAndExercise t c = do
     cid <- create t
     exercise cid c

--- a/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
+++ b/compiler/damlc/tests/daml-test-files/ContractKeyNotVisible.daml
@@ -78,7 +78,7 @@ divulgeeLookup = scenario do
 blindLookup = scenario do
   sig <- getParty "s" -- Signatory
   blind <- getParty "b" -- Blind
-  keyedCid <- submit sig do create Keyed with ..
+  _ <- submit sig do create Keyed with ..
   -- Blind party can't do positive lookup with maintainer authority.
   submit blind do
     mcid <- createAndExercise (Delegation sig blind) LookupKeyed

--- a/compiler/damlc/tests/daml-test-files/ExportList.daml
+++ b/compiler/damlc/tests/daml-test-files/ExportList.daml
@@ -1,4 +1,5 @@
-
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its
+-- affiliates. All rights reserved.
 module ExportList
     ( function1
     , Data1

--- a/compiler/damlc/tests/daml-test-files/TyConAppCoercion.daml
+++ b/compiler/damlc/tests/daml-test-files/TyConAppCoercion.daml
@@ -1,5 +1,6 @@
-
-module TyConAppCoercion () where
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its
+-- affiliates. All rights reserved.
+module TyConAppCoercion (X(..)) where
 
 class MyClass a where
   f1 : Optional a -> a

--- a/compiler/damlc/tests/daml-test-files/UnusedMatchTests.daml
+++ b/compiler/damlc/tests/daml-test-files/UnusedMatchTests.daml
@@ -1,13 +1,20 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its
 -- affiliates. All rights reserved.
 
--- @WARN range=12:2-12:3; Defined but not used
+-- @WARN range=19:2-19:3; Defined but not used
 
 {-# OPTIONS_GHC -Wunused-matches #-}
+{-# OPTIONS_GHC -Wunused-foralls #-}
+{-# OPTIONS_GHC -Wunused-imports #-}
+{-# OPTIONS_GHC -Wunused-pattern-binds #-}
+{-# OPTIONS_GHC -Wunused-top-binds #-}
+{-# OPTIONS_GHC -Wunused-type-patterns #-}
+-- We know this will fail and why.
+--   {-# OPTIONS_GHC -Wunused-local-binds #-}
 module UnusedMatchTests where
 
--- It should be OK to enable -Wunused-matches and not get warnings
--- from template desugared code.
+-- It should be OK to enable -Wunused-* and not get warnings from
+-- template desugared code.
 
 f x = 12 -- Defined but not used 'x'; prove unsed match detection.
 


### PR DESCRIPTION
More tests to confirm template desugaring does not trigger `unused-*` warnings. Some small fixes to eliminate such warnings from our tests and standard library where it's meaningful to do so. Some documentation of the state of play in the form of comments in `Options.hs`.