### PR TITLE
Trigger service: read packages from database on startup

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -35,7 +35,6 @@ import com.daml.lf.engine.trigger.Response._
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.platform.services.time.TimeProviderType
-import scalaz.syntax.traverse._
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -73,14 +72,13 @@ class Server(triggerDao: RunningTriggerDao) {
   private var triggerLog: Map[UUID, Vector[(LocalDateTime, String)]] = Map.empty
 
   // We keep the compiled packages in memory as it is required to construct a trigger Runner.
-  // When running with a persistent store we also write packages to it so we can recover our state
-  // after the service shuts down or crashes.
+  // When running with a persistent store we also write the encoded packages so we can recover
+  // our state after the service shuts down or crashes.
   val compiledPackages: MutableCompiledPackages = ConcurrentCompiledPackages()
 
-  private def addPackagesInMemory(encodedDar: Dar[(PackageId, DamlLf.ArchivePayload)]): Unit = {
-    // Decode the dar for the in-memory store.
-    val dar = encodedDar.map((Decode.readArchivePayload _).tupled)
-    val darMap = dar.all.toMap
+  private def addPackagesInMemory(pkgs: List[(PackageId, DamlLf.ArchivePayload)]): Unit = {
+    // We store decoded packages in memory
+    val pkgMap = pkgs.map((Decode.readArchivePayload _).tupled).toMap
 
     // `addPackage` returns a ResultNeedPackage if a dependency is not yet uploaded.
     // So we need to use the entire `darMap` to complete each call to `addPackage`.
@@ -90,12 +88,12 @@ class Server(triggerDao: RunningTriggerDao) {
     def complete(r: Result[Unit]): Unit = r match {
       case ResultDone(()) => ()
       case ResultNeedPackage(dep, resume) =>
-        complete(resume(darMap.get(dep)))
+        complete(resume(pkgMap.get(dep)))
       case _ =>
         throw new RuntimeException(s"Unexpected engine result $r from attempt to add package.")
     }
 
-    darMap foreach {
+    pkgMap foreach {
       case (pkgId, pkg) => complete(compiledPackages.addPackage(pkgId, pkg))
     }
   }
@@ -103,7 +101,7 @@ class Server(triggerDao: RunningTriggerDao) {
   // Add a dar to compiledPackages (in memory) and to persistent storage if using it.
   // Uploads of packages that already exist are considered harmless and are ignored.
   private def addDar(encodedDar: Dar[(PackageId, DamlLf.ArchivePayload)]): Either[String, Unit] = {
-    addPackagesInMemory(encodedDar)
+    addPackagesInMemory(encodedDar.all)
     triggerDao.persistPackages(encodedDar)
   }
 
@@ -153,7 +151,6 @@ object Server {
       initDb: Boolean,
       noSecretKey: Boolean,
   ): Behavior[Message] = Behaviors.setup { ctx =>
-
     val key: SecretKey =
       sys.env.get("TRIGGER_SERVICE_SECRET_KEY") match {
         case Some(key) => SecretKey(key)
@@ -188,10 +185,16 @@ object Server {
           (dao, new Server(dao))
         case (false, Some(c)) =>
           val dao = DbTriggerDao(c)
-          val server = new Server(dao)
-//          server.recover
-//          ctx.log.info("Successfully recovered state from database.")
-          (dao, server)
+          dao.readPackages match {
+            case Left(err) =>
+              ctx.log.error(err)
+              sys.exit(1)
+            case Right(pkgs) =>
+              val server = new Server(dao)
+              server.addPackagesInMemory(pkgs)
+              ctx.log.info("Successfully recovered packages from database.")
+              (dao, server)
+          }
       }
 
     initialDar foreach { dar =>

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
@@ -165,7 +165,7 @@ class DbTriggerDao(xa: Connection.T) extends RunningTriggerDao {
 
   def readPackages: Either[String, List[(PackageId, DamlLf.ArchivePayload)]] = {
     import cats.implicits._ // needed for traverse
-    run(selectPackages).flatMap(
+    run(selectPackages, "Failed to read packages from database").flatMap(
       _.traverse[({ type E[A] = Either[String, A] })#E, (PackageId, DamlLf.ArchivePayload)](
         (parsePackage _).tupled)
     )

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
@@ -158,13 +158,13 @@ class DbTriggerDao(xa: Connection.T) extends RunningTriggerDao {
   // Write packages to the `dalfs` table so we can recover state after a shutdown.
   override def persistPackages(
       dar: Dar[(PackageId, DamlLf.ArchivePayload)]): Either[String, Unit] = {
-    import cats.implicits._
+    import cats.implicits._ // needed for traverse
     val insertAll = dar.all.traverse_((insertPackage _).tupled)
     run(insertAll)
   }
 
   def readPackages: Either[String, List[(PackageId, DamlLf.ArchivePayload)]] = {
-    import cats.implicits._ // needed to find traverse
+    import cats.implicits._ // needed for traverse
     run(selectPackages).flatMap(
       _.traverse[({ type E[A] = Either[String, A] })#E, (PackageId, DamlLf.ArchivePayload)](
         (parsePackage _).tupled)

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -46,11 +46,11 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(15, Seconds)), interval = scaled(Span(1, Seconds)))
 
-  private val darPath = requiredResource("triggers/service/test-model.dar")
+  protected val darPath = requiredResource("triggers/service/test-model.dar")
 
   // Encoded dar used in service initialization
-  private val dar = DarReader().readArchiveFromFile(darPath).get
-  private val testPkgId = dar.main._1
+  protected val dar = DarReader().readArchiveFromFile(darPath).get
+  protected val testPkgId = dar.main._1
 
   private def submitCmd(client: LedgerClient, party: String, cmd: Command) = {
     val req = SubmitAndWaitRequest(
@@ -70,9 +70,9 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   implicit val esf: ExecutionSequencerFactory = new AkkaExecutionSequencerPool(testId)(system)
   implicit val ec: ExecutionContext = system.dispatcher
 
-  private case class User(userName: String, password: String)
-  private val alice = User("Alice", "&alC2l3SDS*V")
-  private val bob = User("Bob", "7GR8G@InIO&v")
+  protected case class User(userName: String, password: String)
+  protected val alice = User("Alice", "&alC2l3SDS*V")
+  protected val bob = User("Bob", "7GR8G@InIO&v")
 
   protected def headersWithAuth(user: User): List[Authorization] = {
     user match {
@@ -534,4 +534,23 @@ class TriggerServiceTestWithDb
     }
     super.afterEach()
   }
+
+  it should "recover packages after shutdown" in (for {
+    _ <- withTriggerService(None) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+      for {
+        resp <- uploadDar(uri, darPath)
+        _ <- parseResult(resp)
+      } yield succeed
+    }
+    // Once service is shutdown, start a new one and try to use the previously uploaded dar
+    _ <- withTriggerService(None) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+      for {
+        // start trigger defined in previously uploaded dar
+        resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
+        triggerId <- parseTriggerId(resp)
+        _ <- assertTriggerIds(uri, alice, _ == Vector(triggerId))
+      } yield succeed
+    }
+  } yield succeed)
+
 }


### PR DESCRIPTION
This uses the packages written to the database to recover after a shutdown. This PR does not restart running triggers, only loads the packages into memory. There is a simple test that you can start a trigger uploaded before the service was shutdown. More tests to come once I implement trigger restarting.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
