### PR TITLE
Fix contains check in ConcurrentCompiledPackages

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -10,20 +10,21 @@ import com.daml.lf.engine.ConcurrentCompiledPackages.AddPackageState
 import com.daml.lf.language.Ast.Package
 import com.daml.lf.speedy
 import scala.collection.JavaConverters._
+import scala.collection.concurrent.{Map => ConcurrentMap}
 
 /** Thread-safe class that can be used when you need to maintain a shared, mutable collection of
   * packages.
   */
 final class ConcurrentCompiledPackages extends MutableCompiledPackages {
-  private[this] val _packages: ConcurrentHashMap[PackageId, Package] =
-    new ConcurrentHashMap()
+  private[this] val _packages: ConcurrentMap[PackageId, Package] =
+    new ConcurrentHashMap().asScala
   private[this] val _defns: ConcurrentHashMap[speedy.SExpr.SDefinitionRef, speedy.SExpr] =
     new ConcurrentHashMap()
   private[this] val _packageDeps: ConcurrentHashMap[PackageId, Set[PackageId]] =
     new ConcurrentHashMap()
   private[this] var _profilingMode: speedy.Compiler.ProfilingMode = speedy.Compiler.NoProfile
 
-  def getPackage(pId: PackageId): Option[Package] = Option(_packages.get(pId))
+  def getPackage(pId: PackageId): Option[Package] = _packages.get(pId)
   def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
     Option(_defns.get(dref))
 
@@ -55,7 +56,7 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
         val pkgId: PackageId = toCompile.head
         toCompile = toCompile.tail
 
-        if (!_packages.containsKey(pkgId)) {
+        if (!_packages.contains(pkgId)) {
 
           val pkg = state.packages.get(pkgId) match {
             case None => return ResultError(Error(s"Could not find package $pkgId"))
@@ -64,7 +65,7 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
 
           // Load dependencies of this package and transitively its dependencies.
           for (dependency <- pkg.directDeps) {
-            if (!_packages.containsKey(dependency) && !state.seenDependencies.contains(dependency)) {
+            if (!_packages.contains(dependency) && !state.seenDependencies.contains(dependency)) {
               return ResultNeedPackage(
                 dependency, {
                   case None => ResultError(Error(s"Could not find package $dependency"))
@@ -83,27 +84,28 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
           // map using 'computeIfAbsent' which will ensure we only compile the
           // package once. Other concurrent calls to add this package will block
           // waiting for the first one to finish.
-          _packages.computeIfAbsent(
-            pkgId, { _ =>
-              // Compile the speedy definitions for this package.
-              val defns =
-                speedy
-                  .Compiler(packages orElse state.packages, stackTraceMode, profilingMode)
-                  .unsafeCompilePackage(pkgId)
-              defns.foreach {
-                case (defnId, defn) => _defns.put(defnId, defn)
-              }
-              // Compute the transitive dependencies of the new package. Since we are adding
-              // packages in dependency order we can just union the dependencies of the
-              // direct dependencies to get the complete transitive dependencies.
-              val deps = pkg.directDeps.foldLeft(pkg.directDeps) {
-                case (deps, dependency) =>
-                  deps union _packageDeps.get(dependency)
-              }
-              _packageDeps.put(pkgId, deps)
-              pkg
+          if (!_packages.contains(pkgId)) {
+            // Compile the speedy definitions for this package.
+            val defns =
+              speedy
+                .Compiler(packages orElse state.packages, stackTraceMode, profilingMode)
+                .unsafeCompilePackage(pkgId)
+            defns.foreach {
+              case (defnId, defn) => _defns.put(defnId, defn)
             }
-          )
+            // Compute the transitive dependencies of the new package. Since we are adding
+            // packages in dependency order we can just union the dependencies of the
+            // direct dependencies to get the complete transitive dependencies.
+            val deps = pkg.directDeps.foldLeft(pkg.directDeps) {
+              case (deps, dependency) =>
+                deps union _packageDeps.get(dependency)
+            }
+            _packageDeps.put(pkgId, deps)
+            _packages.put(
+              pkgId,
+              pkg
+            )
+          }
         }
       }
 
@@ -117,7 +119,7 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
   }
 
   override def packageIds: Set[PackageId] =
-    _packages.keySet.asScala.toSet
+    _packages.keySet.toSet
 
   def getPackageDependencies(pkgId: PackageId): Option[Set[PackageId]] =
     Option(_packageDeps.get(pkgId))

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -55,7 +55,7 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
         val pkgId: PackageId = toCompile.head
         toCompile = toCompile.tail
 
-        if (!_packages.contains(pkgId)) {
+        if (!_packages.containsKey(pkgId)) {
 
           val pkg = state.packages.get(pkgId) match {
             case None => return ResultError(Error(s"Could not find package $pkgId"))
@@ -64,7 +64,7 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
 
           // Load dependencies of this package and transitively its dependencies.
           for (dependency <- pkg.directDeps) {
-            if (!_packages.contains(dependency) && !state.seenDependencies.contains(dependency)) {
+            if (!_packages.containsKey(dependency) && !state.seenDependencies.contains(dependency)) {
               return ResultNeedPackage(
                 dependency, {
                   case None => ResultError(Error(s"Could not find package $dependency"))


### PR DESCRIPTION
`contains` searches for a _value_ not a _key_. We have a package id
here in both cases which is clearly a key.

I am not exactly clear on what exactly happens if you hit this bug. I
believe it’s just a performance issue so probably hard to write a test
for.

I did take a brief look at whether we can make this
typesafe (`contains` accept an `Object` which is how this typechecks)
and apparently calling `asScala` and then using
`scala.collection.concurrent.Map` should work but I don’t know if this
has performance implications or if there is another reason why we
didn’t do this. Happy to make the change if someone tells me this is
the right thing to do.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
