### PR TITLE
Support multiple auth tokens in DAML Script

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -14,11 +14,14 @@ import java.util.UUID
 
 import io.grpc.netty.NettyChannelBuilder
 import scala.concurrent.{ExecutionContext, Future}
-import scalaz.\/-
+import scalaz.{\/-, Applicative, Traverse}
 import scalaz.std.either._
 import scalaz.std.list._
+import scalaz.std.option._
+import scalaz.std.map._
 import scalaz.syntax.tag._
 import scalaz.syntax.traverse._
+import scala.language.higherKinds
 import spray.json._
 import com.daml.lf.archive.Dar
 import com.daml.lf.data.FrontStack
@@ -37,8 +40,10 @@ import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.jwt.domain.Jwt
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
+import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands._
+import com.daml.ledger.client.configuration.{CommandClientConfiguration, LedgerIdRequirement}
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.LedgerClientConfiguration
 import com.google.protobuf.duration.Duration
@@ -48,7 +53,7 @@ object LfValueCodec extends ApiCodecCompressed[ContractId](false, false)
 
 case class Participant(participant: String)
 case class Party(party: String)
-case class ApiParameters(host: String, port: Int)
+case class ApiParameters(host: String, port: Int, access_token: Option[String])
 case class Participants[+T](
     default_participant: Option[T],
     participants: Map[Participant, T],
@@ -73,6 +78,24 @@ case class Participants[+T](
           case Some(t) => Right(t)
         }
     }
+}
+
+object Participants {
+  implicit val darTraverse: Traverse[Participants] = new Traverse[Participants] {
+    override def map[A, B](fa: Participants[A])(f: A => B): Participants[B] =
+      Participants[B](fa.default_participant.map(f), fa.participants.map({
+        case (k, v) => (k, f(v))
+      }), fa.party_participants)
+
+    override def traverseImpl[G[_]: Applicative, A, B](fa: Participants[A])(
+        f: A => G[B]): G[Participants[B]] = {
+      import scalaz.syntax.apply._
+      import scalaz.syntax.traverse._
+      val gb: G[Option[B]] = fa.default_participant.traverse(f)
+      val gbs: G[Map[Participant, B]] = fa.participants.traverse(f)
+      ^(gb, gbs)((b, bs) => Participants(b, bs, fa.party_participants))
+    }
+  }
 }
 
 object ParticipantsJsonProtocol extends DefaultJsonProtocol {
@@ -100,7 +123,7 @@ object ParticipantsJsonProtocol extends DefaultJsonProtocol {
         case _ => deserializationError("ContractId must be a string")
       }
     }
-  implicit val apiParametersFormat = jsonFormat2(ApiParameters)
+  implicit val apiParametersFormat = jsonFormat3(ApiParameters)
   implicit val participantsFormat = jsonFormat3(Participants[ApiParameters])
 }
 
@@ -143,10 +166,18 @@ object Script {
 object Runner {
   private def connectApiParameters(
       params: ApiParameters,
-      clientConfig: LedgerClientConfiguration,
+      applicationId: ApplicationId,
+      tlsConfig: Option[TlsConfiguration],
       maxInboundMessageSize: Int)(
       implicit ec: ExecutionContext,
       seq: ExecutionSequencerFactory): Future[GrpcLedgerClient] = {
+    val clientConfig = LedgerClientConfiguration(
+      applicationId = ApplicationId.unwrap(applicationId),
+      ledgerIdRequirement = LedgerIdRequirement.none,
+      commandClient = CommandClientConfiguration.default,
+      sslContext = tlsConfig.flatMap(_.client),
+      token = params.access_token,
+    )
     LedgerClient
       .fromBuilder(
         NettyChannelBuilder
@@ -155,12 +186,12 @@ object Runner {
         clientConfig,
       )
       .map(new GrpcLedgerClient(_))
-//    LedgerClient.singleHost(params.host, params.port, clientConfig).map(new GrpcLedgerClient(_))
   }
   // We might want to have one config per participant at some point but for now this should be sufficient.
   def connect(
       participantParams: Participants[ApiParameters],
-      clientConfig: LedgerClientConfiguration,
+      applicationId: ApplicationId,
+      tlsConfig: Option[TlsConfiguration],
       maxInboundMessageSize: Int)(
       implicit ec: ExecutionContext,
       seq: ExecutionSequencerFactory): Future[Participants[GrpcLedgerClient]] = {
@@ -169,29 +200,40 @@ object Runner {
       // Map is but it doesn’t return a Map so we have to call toMap afterwards.
       defaultClient <- Future
         .traverse(participantParams.default_participant.toList)(x =>
-          connectApiParameters(x, clientConfig, maxInboundMessageSize))
+          connectApiParameters(x, applicationId, tlsConfig, maxInboundMessageSize))
         .map(_.headOption)
       participantClients <- Future
         .traverse(participantParams.participants: Map[Participant, ApiParameters])({
-          case (k, v) => connectApiParameters(v, clientConfig, maxInboundMessageSize).map((k, _))
+          case (k, v) =>
+            connectApiParameters(v, applicationId, tlsConfig, maxInboundMessageSize).map((k, _))
         })
         .map(_.toMap)
     } yield Participants(defaultClient, participantClients, participantParams.party_participants)
   }
 
-  def jsonClients(
-      participantParams: Participants[ApiParameters],
-      token: String,
-      envIface: EnvironmentInterface)(
+  def jsonClients(participantParams: Participants[ApiParameters], envIface: EnvironmentInterface)(
       implicit ec: ExecutionContext,
       system: ActorSystem): Future[Participants[JsonLedgerClient]] = {
     def client(params: ApiParameters) = {
       val uri = Uri(params.host + ":" + params.port.toString)
-      new JsonLedgerClient(uri, Jwt(token), envIface, system)
+      params.access_token match {
+        case None =>
+          Future.failed(new RuntimeException(s"The JSON API always requires access tokens"))
+        case Some(token) =>
+          Future.successful(new JsonLedgerClient(uri, Jwt(token), envIface, system))
+      }
+
     }
-    val defClient = participantParams.default_participant.map(client(_))
-    val otherClients = participantParams.participants.map({ case (k, v) => (k, client(v)) })
-    Future { Participants(defClient, otherClients, participantParams.party_participants) }
+    for {
+      // Apparently Future.traverse is too stupid to traverse an
+      // Option so you first have to convert to a list and then convert back.
+      defClient <- Future
+        .traverse(participantParams.default_participant.toList)(client(_))
+        .map(_.headOption)
+      otherClients <- Future
+        .traverse(participantParams.participants)({ case (k, v) => client(v).map(c => (k, c)) })
+        .map(_.toMap)
+    } yield Participants(defClient, otherClients, participantParams.party_participants)
   }
 
   // Executes a DAML script

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
@@ -156,8 +156,6 @@ object RunnerConfig {
         failure("Cannot specify both --ledger-host and --participant-config")
       } else if (c.ledgerHost.isEmpty && c.participantConfig.isEmpty) {
         failure("Must specify either --ledger-host or --participant-config")
-      } else if (c.jsonApi && c.accessTokenFile.isEmpty) {
-        failure("The json-api requires an access token")
       } else {
         success
       }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -97,10 +97,10 @@ object TestMain extends StrictLogging {
               val sandboxResource = SandboxServer.owner(sandboxConfig).acquire()
               val sandboxPort =
                 Await.result(sandboxResource.asFuture.flatMap(_.portF).map(_.value), Duration.Inf)
-              (ApiParameters("localhost", sandboxPort), () => sandboxResource.release())
+              (ApiParameters("localhost", sandboxPort, None), () => sandboxResource.release())
             } else {
               (
-                ApiParameters(config.ledgerHost.get, config.ledgerPort.get),
+                ApiParameters(config.ledgerHost.get, config.ledgerPort.get, None),
                 () => Future.successful(()),
               )
             }
@@ -132,7 +132,11 @@ object TestMain extends StrictLogging {
         }
 
         val flow: Future[Boolean] = for {
-          clients <- Runner.connect(participantParams, clientConfig, config.maxInboundMessageSize)
+          clients <- Runner.connect(
+            participantParams,
+            ApplicationId("Script Test"),
+            None,
+            config.maxInboundMessageSize)
           _ <- clients.getParticipant(None) match {
             case Left(err) => throw new RuntimeException(err)
             case Right(client) =>

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -65,7 +65,9 @@ da_scala_library(
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
         "//ledger/ledger-api-common",
-        "//libs-scala/auth-utils",
+        #        "//libs-scala/auth-utils",
+        "//ledger/ledger-api-auth",
+        "//ledger-service/jwt",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_spray_spray_json_2_12",
@@ -157,42 +159,24 @@ client_server_test(
     server_files = ["$(rootpath :script-test.dar)"],
 )
 
-AUTH_TOKEN = "I_CAN_HAZ_AUTH"
-
-# This is a genrule so we can replace it by something nicer that actually generates the token
-# from some readable input so we can change it more easily.
-# For now, this corresponds to a token that has admin set to false
-# and actAs to Alice, Bob
-genrule(
-    name = "test-auth-token",
-    outs = ["test-auth-token.jwt"],
-    cmd = """
-      cat <<EOF > $(location test-auth-token.jwt)
-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsiYWRtaW4iOmZhbHNlLCJhY3RBcyI6WyJBbGljZSIsIkJvYiJdfX0.UYogXMZvmhzzjmsmKayaDsI2hGKh1T2Sz5l9h4tdgGM
-EOF
-    """,
-)
-
 client_server_test(
     name = "test_wallclock_time_authenticated",
     client = ":test_client_single_participant",
     client_args = [
         "-w",
-        "--access-token-file",
+        "--auth",
     ],
     client_files = [
-        "$(rootpath :test-auth-token.jwt)",
         "$(rootpath :script-test.dar)",
     ],
     data = [
         ":script-test.dar",
-        ":test-auth-token.jwt",
     ],
     server = "//ledger/sandbox:sandbox-binary",
     server_args = [
         "--wall-clock-time",
         "--port=0",
-        "--auth-jwt-hs256-unsafe={}".format(AUTH_TOKEN),
+        "--auth-jwt-hs256-unsafe=secret",
     ],
     server_files = ["$(rootpath :script-test.dar)"],
 )

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -229,6 +229,13 @@ jsonExpectedFailureCreateAndExercise p = submitMustFail p $ createAndExerciseCmd
 jsonAllocateParty : Text -> Script Party
 jsonAllocateParty p = allocatePartyWithHint p (PartyIdHint p)
 
+jsonMultiParty : (Party, Party) -> Script ()
+jsonMultiParty (alice, bob) = do
+  assert (alice /= bob)
+  c <- submit alice $ createCmd (TProposal alice bob)
+  submit bob (exerciseCmd c Accept)
+  pure ()
+
 -- maxInboundMessageSize
 
 template MessageSize

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipant.scala
@@ -139,12 +139,13 @@ object MultiParticipant {
         val participantParams = Participants(
           None,
           Seq(
-            (Participant("one"), ApiParameters("localhost", config.ledgerPort)),
-            (Participant("two"), ApiParameters("localhost", config.extraParticipantPort))).toMap,
+            (Participant("one"), ApiParameters("localhost", config.ledgerPort, None)),
+            (Participant("two"), ApiParameters("localhost", config.extraParticipantPort, None))
+          ).toMap,
           Map.empty
         )
 
-        val runner = new TestRunner(participantParams, dar, config.wallclockTime, None, None)
+        val runner = new TestRunner(participantParams, dar, config.wallclockTime, None)
         MultiTest(dar, runner).runTests()
         MultiPartyIdHintTest(dar, runner).runTests()
         MultiListKnownPartiesTest(dar, runner).runTests()

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -3,13 +3,12 @@
 
 package com.daml.lf.engine.script.test
 
-import java.nio.file.{Path, Paths}
 import java.io.File
 import java.time.Duration
+import scalaz.{-\/, \/-}
 import scalaz.syntax.traverse._
 import spray.json._
 
-import com.daml.auth.TokenHolder
 import com.daml.lf.archive.Dar
 import com.daml.lf.archive.DarReader
 import com.daml.lf.archive.Decode
@@ -20,15 +19,18 @@ import com.daml.lf.data.Ref.{Party => LedgerParty}
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SValue._
 import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.api.auth.{AuthServiceJWTCodec, AuthServiceJWTPayload}
 import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId}
+import com.daml.jwt.JwtSigner
+import com.daml.jwt.domain.DecodedJwt
 
-import com.daml.lf.engine.script._
+import com.daml.lf.engine.script.{Party => ScriptParty, _}
 
 case class Config(
     ledgerPort: Int,
     darPath: File,
     wallclockTime: Boolean,
-    accessTokenFile: Option[Path],
+    auth: Boolean,
     // We use the presence of a root CA as a proxy for whether to enable TLS or not.
     rootCa: Option[File],
 )
@@ -400,9 +402,9 @@ object SingleParticipant {
         c.copy(wallclockTime = true)
       }
       .text("Use wall clock time (UTC). When not provided, static time is used.")
-    opt[String]("access-token-file")
+    opt[Unit]("auth")
       .action { (f, c) =>
-        c.copy(accessTokenFile = Some(Paths.get(f)))
+        c.copy(auth = true)
       }
 
     opt[File]("cacrt")
@@ -412,8 +414,26 @@ object SingleParticipant {
 
   private val applicationId = ApplicationId("DAML Script Tests")
 
+  def getToken(parties: List[String], admin: Boolean): String = {
+    val payload = AuthServiceJWTPayload(
+      ledgerId = None,
+      participantId = None,
+      exp = None,
+      applicationId = None,
+      actAs = parties,
+      admin = admin,
+      readAs = List()
+    )
+    val header = """{"alg": "HS256", "typ": "JWT"}"""
+    val jwt = DecodedJwt[String](header, AuthServiceJWTCodec.writeToString(payload))
+    JwtSigner.HMAC256.sign(jwt, "secret") match {
+      case -\/(e) => throw new IllegalStateException(e.toString)
+      case \/-(a) => a.value
+    }
+  }
+
   def main(args: Array[String]): Unit = {
-    configParser.parse(args, Config(0, null, false, None, None)) match {
+    configParser.parse(args, Config(0, null, false, false, None)) match {
       case None =>
         sys.exit(1)
       case Some(config) =>
@@ -423,43 +443,57 @@ object SingleParticipant {
           case (pkgId, pkgArchive) => Decode.readArchivePayload(pkgId, pkgArchive)
         }
 
-        val participantParams =
-          Participants(Some(ApiParameters("localhost", config.ledgerPort)), Map.empty, Map.empty)
-
-        val tokenHolder = config.accessTokenFile.map(new TokenHolder(_))
+        val participantParams = if (config.auth) {
+          Participants(
+            None,
+            List(
+              (
+                Participant("alice"),
+                ApiParameters(
+                  "localhost",
+                  config.ledgerPort,
+                  Some(getToken(List("Alice"), false)))),
+              (
+                Participant("bob"),
+                ApiParameters("localhost", config.ledgerPort, Some(getToken(List("Bob"), false))))
+            ).toMap,
+            List(
+              (ScriptParty("Alice"), Participant("alice")),
+              (ScriptParty("Bob"), Participant("bob"))).toMap
+          )
+        } else {
+          Participants(
+            Some(ApiParameters("localhost", config.ledgerPort, None)),
+            Map.empty,
+            Map.empty)
+        }
 
         val runner =
-          new TestRunner(
-            participantParams,
-            dar,
-            config.wallclockTime,
-            tokenHolder.flatMap(_.token),
-            config.rootCa)
-        config.accessTokenFile match {
-          case None =>
-            TraceOrder(dar, runner).runTests()
-            Test0(dar, runner).runTests()
-            Test1(dar, runner).runTests()
-            Test2(dar, runner).runTests()
-            Test3(dar, runner).runTests()
-            Test4(dar, runner).runTests()
-            TestKey(dar, runner).runTests()
-            TestCreateAndExercise(dar, runner).runTests()
-            GetTime(dar, runner).runTests()
-            Sleep(dar, runner).runTests()
-            PartyIdHintTest(dar, runner).runTests()
-            ListKnownParties(dar, runner).runTests()
-            TestStack(dar, runner).runTests()
-            TestMaxInboundMessageSize(dar, runner).runTests()
-            ScriptExample(dar, runner).runTests()
-            // Keep this at the end since it changes the time and we cannot go backwards.
-            if (!config.wallclockTime) {
-              SetTime(dar, runner).runTests()
-            }
-          case Some(_) =>
-            // We can’t test much with auth since most of our tests rely on party allocation and being
-            // able to act as the corresponding party.
-            TestAuth(dar, runner).runTests()
+          new TestRunner(participantParams, dar, config.wallclockTime, config.rootCa)
+        if (!config.auth) {
+          TraceOrder(dar, runner).runTests()
+          Test0(dar, runner).runTests()
+          Test1(dar, runner).runTests()
+          Test2(dar, runner).runTests()
+          Test3(dar, runner).runTests()
+          Test4(dar, runner).runTests()
+          TestKey(dar, runner).runTests()
+          TestCreateAndExercise(dar, runner).runTests()
+          GetTime(dar, runner).runTests()
+          Sleep(dar, runner).runTests()
+          PartyIdHintTest(dar, runner).runTests()
+          ListKnownParties(dar, runner).runTests()
+          TestStack(dar, runner).runTests()
+          TestMaxInboundMessageSize(dar, runner).runTests()
+          ScriptExample(dar, runner).runTests()
+          // Keep this at the end since it changes the time and we cannot go backwards.
+          if (!config.wallclockTime) {
+            SetTime(dar, runner).runTests()
+          }
+        } else {
+          // We can’t test much with auth since most of our tests rely on party allocation and being
+          // able to act as the corresponding party.
+          TestAuth(dar, runner).runTests()
         }
     }
   }

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -12,7 +12,6 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 import scala.util.{Success, Failure}
-import scalaz.syntax.tag._
 import spray.json._
 
 import com.daml.lf.archive.Dar
@@ -22,11 +21,6 @@ import com.daml.lf.speedy.SValue
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId}
 import com.daml.ledger.api.tls.TlsConfiguration
-import com.daml.ledger.client.configuration.{
-  CommandClientConfiguration,
-  LedgerClientConfiguration,
-  LedgerIdRequirement
-}
 
 import com.daml.lf.engine.script._
 
@@ -67,19 +61,13 @@ class TestRunner(
     val participantParams: Participants[ApiParameters],
     val dar: Dar[(PackageId, Package)],
     val wallclockTime: Boolean,
-    val token: Option[String],
     val rootCa: Option[File],
 ) {
   val applicationId = ApplicationId("DAML Script Test Runner")
 
-  val clientConfig = LedgerClientConfiguration(
-    applicationId = applicationId.unwrap,
-    ledgerIdRequirement = LedgerIdRequirement.none,
-    commandClient = CommandClientConfiguration.default,
-    sslContext = rootCa.flatMap(file =>
-      TlsConfiguration.Empty.copy(trustCertCollectionFile = Some(file)).client),
-    token = token,
-  )
+  val tlsConfig =
+    rootCa.map(file => TlsConfiguration.Empty.copy(trustCertCollectionFile = Some(file)))
+
   val ttl = java.time.Duration.ofSeconds(30)
   val timeMode: ScriptTimeMode =
     if (wallclockTime) ScriptTimeMode.WallClock else ScriptTimeMode.Static
@@ -106,7 +94,7 @@ class TestRunner(
     implicit val ec: ExecutionContext = system.dispatcher
 
     val clientsF =
-      Runner.connect(participantParams, clientConfig, maxInboundMessageSize)
+      Runner.connect(participantParams, applicationId, tlsConfig, maxInboundMessageSize)
 
     val testFlow: Future[Unit] = for {
       clients <- clientsF

--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -242,6 +242,8 @@ translated to DAML script but there are a few things to keep in mind:
 #. You need to replace calls to ``getParty x`` by
    ``allocatePartyWithHint x (PartyIdHint x)``.
 
+.. daml-script-distributed
+
 Using DAML Script in Distributed Topologies
 ===========================================
 
@@ -266,12 +268,42 @@ want to allocate a party on a specific participant, you can use
 ``allocatePartyOn`` which accepts the participant name as an extra
 argument.
 
+.. daml-script-auth
+
+Running DAML Script against Authenticated Ledgers
+=================================================
+
+To run DAML Script against an authenticated ledger, you need to
+specify an access token. There are two ways of doing that:
+
+1. Specify a single access token via ``--access-token-file
+   path/to/jwt`` authenticated ledger. This token will then be used
+   for all requests so it must provide claims for all parties that you
+   use in your script.
+2. If you need multiple tokens, e.g., because you only have
+   single-party tokens you can use the ``access_token`` field in the
+   participant config specified via ``--participant-config``. The
+   section on :ref:`using DAML Script in distributed topologies
+   <daml-script-distributed>` contains an example. Note that you can
+   specify the same participant twice if you want different auth
+   tokens.
+
+If you specify both ``--access-token-file`` and
+``--participant-config``, the participant config takes precedence and
+the token from the file will be used for any participant that does not
+have a token specified in the config.
+
 .. daml-script-json-api
 
 Running DAML Script against the HTTP JSON API
 =============================================
 
-In some cases, you only have access to the :doc:`HTTP JSON API </json-api/index>` but not to the gRPC of a ledger, e.g., on `project:DABL <https://projectdabl.com>`_. For this usecase, DAML script can be run against the JSON API. Note that if you do have access to the gRPC API, running DAML script against the JSON API does not have any advantages.
+In some cases, you only have access to the :doc:`HTTP JSON API
+</json-api/index>` but not to the gRPC of a ledger, e.g., on
+`project:DABL <https://projectdabl.com>`_. For this usecase, DAML
+script can be run against the JSON API. Note that if you do have
+access to the gRPC API, running DAML script against the JSON API does
+not have any advantages.
 
 To run DAML script against the JSON API you have to pass the ``--json-api`` parameter to ``daml script``. There are a few differences and limitations compared to running DAML Script against the gRPC API:
 
@@ -281,18 +313,17 @@ To run DAML script against the JSON API you have to pass the ``--json-api`` para
 #. The JSON API only supports single-command submissions. This means
    that within a single call to ``submit`` you can only execute one
    ledger API command, e.g., one ``createCmd`` or one ``exerciseCmd``.
-#. The JSON API requires an authentication token even when it is run
-   against an unauthenticated ledger. The authentication token must be
-   a JWT token so the ``--access-token-file`` passed to
-   ``daml script`` should contain the actual JWT token.
-#. The token must contain exactly one party in ``actAs`` and/or
+#. The JSON API requires authentication tokens even when it is run
+   against an unauthenticated ledger. The section on
+   :ref:`authentication <daml-script-auth>` describes how to specify
+   the tokens.
+#. The tokens must contain exactly one party in ``actAs`` and/or
    ``readAs``. This party will be used for ``submit`` and
    ``query``. Passing a party as the argument to ``submit`` and
    ``query`` that is different from the party in the token is an
    error.
-#. Since DAML Script only accepts a single token and the party is
-   inferred from the token, this means that you can only use a single
-   party within a DAML script when running against the JSON API.
+#. If you use multiple parties within your DAML Script, you need to
+   specify one token per party.
 #. ``getTime`` will always return the Unix epoch in static time mode
    since the time service is not exposed via the JSON API.
 #. ``setTime`` is not supported and will throw a runtime error.

--- a/docs/source/daml-script/index.rst
+++ b/docs/source/daml-script/index.rst
@@ -242,7 +242,7 @@ translated to DAML script but there are a few things to keep in mind:
 #. You need to replace calls to ``getParty x`` by
    ``allocatePartyWithHint x (PartyIdHint x)``.
 
-.. daml-script-distributed
+.. _daml-script-distributed:
 
 Using DAML Script in Distributed Topologies
 ===========================================
@@ -268,7 +268,7 @@ want to allocate a party on a specific participant, you can use
 ``allocatePartyOn`` which accepts the participant name as an extra
 argument.
 
-.. daml-script-auth
+.. _daml-script-auth:
 
 Running DAML Script against Authenticated Ledgers
 =================================================
@@ -293,7 +293,7 @@ If you specify both ``--access-token-file`` and
 the token from the file will be used for any participant that does not
 have a token specified in the config.
 
-.. daml-script-json-api
+.. _daml-script-json-api:
 
 Running DAML Script against the HTTP JSON API
 =============================================

--- a/docs/source/daml-script/participants-example.json
+++ b/docs/source/daml-script/participants-example.json
@@ -1,7 +1,8 @@
 {
-    "default_participant": {"host": "localhost", "port": 6866},
+    "default_participant": {"host": "localhost", "port": 6866, "access_token": "default_jwt"},
     "participants": {
-        "one": {"host": "localhost", "port": 6865}
+        "one": {"host": "localhost", "port": 6865, "access_token": "jwt_for_alice"},
+        "two": {"host": "localhost", "port": 6865, "access_token": "jwt_for_bob"}
     },
-    "party_participants": {"alice": "one"}
+    "party_participants": {"alice": "one", "bob": "two"}
 }


### PR DESCRIPTION
This piggy backs on top of the already existing --participant-config
feature. While you can argue that it might be slightly confusing that
you have to specify the same participant twice to specify different
auth tokens, I think this actually makes sense: In an ideal
world (ignoring any performance issues) you have one participant per
party anyway and one connection per participant specified in the
config file still seems like a very reasonable model.

changelog_begin

- [DAML Script] You can now use DAML Script with multiple auth
  tokens. This is particularly useful if you are working with the JSON
  API where you can only have one party per token or with an IAM that
  only provides single-party tokens. The tokens are specified in the
  participant configuration passed via `--participant-config` in a new
  ``--access_token`` field. See
  https://docs.daml.com/daml-script/index.html#running-daml-script-against-authenticated-ledgers
  for more details.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
