### PR TITLE
rs-grpc-bridge: If the execution sequencer pool is closed, fail fast.

### DIFF
--- a/ledger-api/rs-grpc-bridge/src/main/java/com/daml/grpc/adapter/SingleThreadExecutionSequencer.java
+++ b/ledger-api/rs-grpc-bridge/src/main/java/com/daml/grpc/adapter/SingleThreadExecutionSequencer.java
@@ -3,17 +3,16 @@
 
 package com.daml.grpc.adapter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Ensures serial execution and thread safety of Runnables by using a single thread underneath.
  */
-public class SingleThreadExecutionSequencer implements ExecutionSequencer{
+public class SingleThreadExecutionSequencer implements ExecutionSequencer {
 
     private static final Logger logger = LoggerFactory.getLogger(SingleThreadExecutionSequencer.class);
 
@@ -24,7 +23,8 @@ public class SingleThreadExecutionSequencer implements ExecutionSequencer{
             Thread thread = new Thread(runnable);
             thread.setName(name);
             thread.setDaemon(true);
-            thread.setUncaughtExceptionHandler((t, e) -> logger.error("Unhandled exception in SingleThreadExecutionSequencer.", e));
+            thread.setUncaughtExceptionHandler((t, e) ->
+                    logger.error("Unhandled exception in SingleThreadExecutionSequencer.", e));
             return thread;
         });
     }


### PR DESCRIPTION
On closing the SingleThreadExecutionSequencerPool, all sequencers in the pool are set to null (presumably to encourage garbage collection). However, you can still ask for the next executor, which will then return `null`, causing all manner of problems down the line.

This change forces the failure early, making it easier to debug, by checking whether the pool is closed and if so, throwing an `IllegalStateException`.

We see these null pointer exceptions in the `BotTest` test logs from time to time.

### Changelog

- **[RxJava Bindings]** We now fail faster, with a more meaningful error, when RxJava flows continue running after shutting down the client.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
