### PR TITLE
Display why a party knows about a contract in table view

### DIFF
--- a/compiler/daml-extension/src/webview.css
+++ b/compiler/daml-extension/src/webview.css
@@ -40,4 +40,23 @@ div.observer {
   transform: rotate(180deg);
   white-space: nowrap;
 }
-
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 5em;
+  background-color: var(--vscode-editor-foreground);
+  color: var(--vscode-editor-background);
+  text-align: center;
+  border-radius: 4px;
+  padding: 4px 4px;
+  position: absolute;
+  z-index: 1;
+  top: -4px;
+  left: 105%;
+}
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -1206,7 +1206,7 @@ scenarioTests mbScenarioService = Tasty.testGroup "Scenario tests"
         let vr = VRScenario f "test"
         setOpenVirtualResources [vr]
         -- TODO(MH): Matching on HTML via regular expressions has a high
-        -- chance of becoming a maintenance nightmare.
+        -- chance of becoming a maintenance nightmare. Fina a better way.
         expectVirtualResourceRegex vr $ T.intercalate ".*"
             [ "<h1>TableView:Iou</h1>"
             , "<table"
@@ -1214,7 +1214,7 @@ scenarioTests mbScenarioService = Tasty.testGroup "Scenario tests"
             , "<tr"
             , "<td", "tooltip", ">S<", "tooltiptext", ">Signatory<", "</td>"
             , "<td", "tooltip", ">O<", "tooltiptext", ">Observer<", "</td>"
-            , "<td", "tooltip", ">-<", "tooltiptext", ">Invisible<", "</td>"
+            , "<td", "tooltip", ">-</div></td>"
             , "</tr"
             , "<tr"
             , "<td", "tooltip", ">S<", "tooltiptext", ">Signatory<", "</td>"

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -1171,6 +1171,59 @@ scenarioTests mbScenarioService = Tasty.testGroup "Scenario tests"
             , quote "foo", lineBreak
             , quote "bar"
             ]
+    , testCase' "Table view displays signatory + observer + disclosed/divulged" $ do
+        f <- makeFile "TableView.daml" $ T.unlines
+          [ "module TableView where"
+
+          , "template IouIssuer with"
+          , "    regulator: Party"
+          , "    issuer: Party"
+          , "  where"
+          , "    signatory regulator"
+          , "    observer issuer"
+          , "    nonconsuming choice Issue: ContractId Iou with"
+          , "        owner: Party"
+          , "      controller issuer"
+          , "      do create Iou with issuer; owner"
+
+          , "template Iou with"
+          , "    issuer: Party"
+          , "    owner: Party"
+          , "  where"
+          , "    signatory issuer"
+          , "    observer owner"
+
+          , "test = scenario do"
+          , "  regulator <- getParty \"Regulator\""
+          , "  issuer <- getParty \"Issuer\""
+          , "  owner <- getParty \"Owner\""
+          , "  iouIssuerCid <- submit regulator do create IouIssuer with regulator; issuer"
+          , "  submit issuer do exercise iouIssuerCid Issue with owner"
+          , "  submit issuer do create Iou with issuer; owner"
+          , "  pure ()"
+          ]
+        setFilesOfInterest [f]
+        let vr = VRScenario f "test"
+        setOpenVirtualResources [vr]
+        -- TODO(MH): Matching on HTML via regular expressions has a high
+        -- chance of becoming a maintenance nightmare.
+        expectVirtualResourceRegex vr $ T.intercalate ".*"
+            [ "<h1>TableView:Iou</h1>"
+            , "<table"
+            , "<tr", "Issuer", "Owner", "Regulator", "</tr>"
+            , "<tr"
+            , "<td", "tooltip", ">S<", "tooltiptext", ">Signatory<", "</td>"
+            , "<td", "tooltip", ">O<", "tooltiptext", ">Observer<", "</td>"
+            , "<td", "tooltip", ">-<", "tooltiptext", ">Invisible<", "</td>"
+            , "</tr"
+            , "<tr"
+            , "<td", "tooltip", ">S<", "tooltiptext", ">Signatory<", "</td>"
+            , "<td", "tooltip", ">O<", "tooltiptext", ">Observer<", "</td>"
+            , "<td", "tooltip", ">D<", "tooltiptext", ">Disclosed/\x200B\&Divulged<", "</td>"
+            , "</tr>"
+            , "</table>"
+            , "<h1>TableView:IouIssuer</h1>"
+            ]
     ]
     where
         testCase' = testCase mbScenarioService

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -828,10 +828,10 @@ renderRow :: LF.World -> S.Set T.Text -> NodeInfo -> (H.Html, H.Html)
 renderRow world parties NodeInfo{..} =
     let (ths, tds) = renderValue world [] niValue
         header = H.tr $ mconcat
-            [ foldMap (H.th . (H.div H.! A.class_ "observer") . H.text) parties
-            , H.th "id"
+            [ H.th "id"
             , H.th "status"
             , ths
+            , foldMap (H.th . (H.div H.! A.class_ "observer") . H.text) parties
             ]
         viewStatus party =
             let (label, mbHint)
@@ -845,10 +845,10 @@ renderRow world parties NodeInfo{..} =
                 whenJust mbHint $ \hint -> H.span H.! A.class_ "tooltiptext" $ H.text hint
         active = if niActive then "active" else "archived"
         row = H.tr H.! A.class_ (H.textValue active) $ mconcat
-            [ foldMap viewStatus parties
-            , H.td (H.text $ renderPlain $ prettyNodeId niNodeId)
+            [ H.td (H.text $ renderPlain $ prettyNodeId niNodeId)
             , H.td (H.text active)
             , tds
+            , foldMap viewStatus parties
             ]
     in (header, row)
 

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -14,7 +14,7 @@ module DA.Daml.LF.PrettyScenario
   , ModuleRef
   ) where
 
-import           Control.Monad
+import           Control.Monad.Extra
 import           Control.Monad.Reader
 import           Control.Monad.Trans.Except
 import qualified DA.Daml.LF.Ast             as LF
@@ -834,15 +834,15 @@ renderRow world parties NodeInfo{..} =
             , ths
             ]
         viewStatus party =
-            let (label, hint)
-                    | party `S.member` niSignatories = ("S", "Signatory")
-                    | party `S.member` niStakeholders = ("O", "Observer")
-                    | party `S.member` niWitnesses = ("D", "Disclosed/\x200B\&Divulged")  -- The charater after the "/" is a zero-width space.
-                    | otherwise = ("-", "Invisible")
+            let (label, mbHint)
+                    | party `S.member` niSignatories = ("S", Just "Signatory")
+                    | party `S.member` niStakeholders = ("O", Just "Observer")
+                    | party `S.member` niWitnesses = ("D", Just "Disclosed/\x200B\&Divulged")  -- The charater after the "/" is a zero-width space.
+                    | otherwise = ("-", Nothing)
             in
             H.td H.! A.class_ "disclosure" $ H.div H.! A.class_ "tooltip" $ do
                 H.text label
-                H.span H.! A.class_ "tooltiptext" $ H.text hint
+                whenJust mbHint $ \hint -> H.span H.! A.class_ "tooltiptext" $ H.text hint
         active = if niActive then "active" else "archived"
         row = H.tr H.! A.class_ (H.textValue active) $ mconcat
             [ foldMap viewStatus parties

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -833,14 +833,19 @@ renderRow world parties NodeInfo{..} =
             , H.th "status"
             , ths
             ]
-        viewStatus party
-            | party `S.member` niSignatories = "S"  -- "S" for signatory.
-            | party `S.member` niStakeholders = "O"  -- "O" for observer.
-            | party `S.member` niWitnesses = "D"  -- "D" for disclosed/divulged.
-            | otherwise = "-"
+        viewStatus party =
+            let (label, hint)
+                    | party `S.member` niSignatories = ("S", "Signatory")
+                    | party `S.member` niStakeholders = ("O", "Observer")
+                    | party `S.member` niWitnesses = ("D", "Disclosed/\x200B\&Divulged")  -- The charater after the "/" is a zero-width space.
+                    | otherwise = ("-", "Invisible")
+            in
+            H.td H.! A.class_ "disclosure" $ H.div H.! A.class_ "tooltip" $ do
+                H.text label
+                H.span H.! A.class_ "tooltiptext" $ H.text hint
         active = if niActive then "active" else "archived"
         row = H.tr H.! A.class_ (H.textValue active) $ mconcat
-            [ foldMap ((H.td H.! A.class_ "disclosure") . H.text . viewStatus) parties
+            [ foldMap viewStatus parties
             , H.td (H.text $ renderPlain $ prettyNodeId niNodeId)
             , H.td (H.text active)
             , tds


### PR DESCRIPTION
When displaying scenario results in table view in DAML Studio, we now
indicate _why_ a party knows about the existence of a contract:
- `S` means the party is a signatory.
- `O` means the party is an observer.
- `D` means the party has learned about the contract via disclosure or
  divulgence.

With the information we get from the scenario service there is no
straightforward way of distinguishing between disclosed (you
witnessed the `create`) and divulged (you witnessed a `fetch`)
contracts. Fortunately, both words start with a "D" and we're fine. :)

This addresses the first point of
https://github.com/digital-asset/daml/issues/6412 for the table view.

CHANGELOG_BEGIN
* [DAML Studio]
  When displaying scenario results in table view in DAML Studio, we now
  indicate _why_ a party knows about the existence of a contract:
  - `S` means the party is a signatory.
  - `O` means the party is an observer.
  - `D` means the party has learned about the contract via disclosure or
    divulgence.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6475)
<!-- Reviewable:end -->
