### PR TITLE
Close FileInputStream in UniversalArchiveReader

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/UniversalArchiveReader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/UniversalArchiveReader.scala
@@ -34,7 +34,9 @@ class UniversalArchiveReader[A](
   /** Reads a DAR from a File. */
   def readFile(file: File): Try[Dar[A]] =
     supportedFileType(file).flatMap {
-      case DarFile => readDarStream(file.getName, new ZipInputStream(new FileInputStream(file)))
+      case DarFile =>
+        bracket(Try(new FileInputStream(file)))(inputStream => Try(inputStream.close()))
+          .flatMap(inputStream => readDarStream(file.getName, new ZipInputStream(inputStream)))
       case DalfFile => readDalfStream(new FileInputStream(file))
     }
 


### PR DESCRIPTION
Unless I am missing something calling `close` on the `ZipInputStream`
does not close the underlying `FileInputStream` and we need to close
that separately.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
