### PR TITLE
Improve error reporting when running DAML Script over the JSON API

### DIFF
--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -47,6 +47,39 @@ EOF
     visibility = ["//visibility:public"],
 )
 
+# A variant of script-test that has not been uploaded to the ledger
+# to test missing template ids. We only care that this has a different package id.
+genrule(
+    name = "script-test-no-ledger",
+    srcs =
+        glob(["**/*.daml"]) + [
+            "//daml-script/daml:daml-script.dar",
+            "//docs:source/daml-script/template-root/src/ScriptExample.daml",
+        ],
+    outs = ["script-test-no-ledger.dar"],
+    cmd = """
+      set -eou pipefail
+      TMP_DIR=$$(mktemp -d)
+      mkdir -p $$TMP_DIR/daml
+      cp -L $(location :daml/ScriptTest.daml) $$TMP_DIR/daml
+      cp -L $(location //daml-script/daml:daml-script.dar) $$TMP_DIR/
+      cat << EOF > $$TMP_DIR/daml.yaml
+sdk-version: {sdk}
+name: script-test-no-ledger
+source: daml
+version: 0.0.2
+dependencies:
+  - daml-stdlib
+  - daml-prim
+  - daml-script.dar
+EOF
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR -o $$PWD/$(location script-test-no-ledger.dar)
+      rm -rf $$TMP_DIR
+    """.format(sdk = sdk_version),
+    tools = ["//compiler/damlc"],
+    visibility = ["//visibility:public"],
+)
+
 da_scala_library(
     name = "test-lib",
     srcs = glob(
@@ -95,7 +128,10 @@ da_scala_test_suite(
     srcs = [
         "src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala",
     ],
-    data = [":script-test.dar"],
+    data = [
+        ":script-test.dar",
+        ":script-test-no-ledger.dar",
+    ],
     resources = glob(["src/main/resources/**/*"]),
     deps = [
         ":test-lib",

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -236,6 +236,11 @@ jsonMultiParty (alice, bob) = do
   submit bob (exerciseCmd c Accept)
   pure ()
 
+jsonMissingTemplateId : Party -> Script Int
+jsonMissingTemplateId p = do
+  cid <- submit p (createCmd $ TProposal p p)
+  snd <$> submit p (exerciseCmd cid Accept)
+
 -- maxInboundMessageSize
 
 template MessageSize


### PR DESCRIPTION
It is pretty easy to hit this, e.g., when your templates haven’t been
uploaded to the ledger. Just printing the response doesn’t actually
include the response body which means that you don’t see the actual
error so it’s pretty useless. This PR changes that by printing the
status code and the response body.

All the rest is just test setup to be able to submit a script with a
template that has not been uploaded to the ledger.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
