### PR TITLE
granular test selection: compat matrix update

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -61,7 +61,7 @@ excluded_test_tool_tests = [
         ],
     },
     {
-        "start": "0.0.0",  # FIXME: change to first snapshot after 4484
+        "start": "1.3.0-snapshot.20200623.4546.0.4f68cfc4",
         "platform_ranges": [
             {
                 "end": "1.0.1-snapshot.20200417.3908.1.722bac90",


### PR DESCRIPTION
This PR updates the lower bound of the api test tool required to use the granular test selection feature to the first snapshot that includes it (as opposed to the floating 0.0.0).

CHANGELOG_BEGIN
CHANGELOG_END