### PR TITLE
DAML REPL support static-time mode

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -310,7 +310,7 @@ cmdRepl numProcessors =
         (flag' ReplClient.ReplWallClock $ mconcat
             [ short 'w'
             , long "wall-clock-time"
-            , help "Use wall clock time (UTC)."
+            , help "Use wall clock time (UTC). (this is the default)"
             ])
         <|> (flag ReplClient.ReplWallClock ReplClient.ReplStatic $ mconcat
             [ short 's'

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -144,11 +144,15 @@ testSetTime
     -> Assertion
 testSetTime damlc scriptDar testDar ledgerPort = do
     out <- readCreateProcess cp $ unlines
-        [ "import DA.Date"
+        [ "import DA.Assert"
+        , "import DA.Date"
         , "import DA.Time"
-        , "setTime (time (date 2000 Feb 2) 0 1 2)"
+        , "expected <- pure (time (date 2000 Feb 2) 0 1 2)"
+        , "setTime expected"
+        , "actual <- getTime"
+        , "assertEq actual expected"
         ]
-    let regexString = "^daml> daml> daml> daml> Goodbye.\n$" :: String
+    let regexString = "^daml> daml> daml> daml> daml> daml> daml> daml> Goodbye.\n$" :: String
     let regex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexString
     unless (matchTest regex out) $
         assertFailure (show out <> " did not match " <> show regexString <> ".")

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -49,6 +49,12 @@ main = do
                   , mbClientAuth = Just None
                   } $ \getSandboxPort ->
                   tlsTests damlc scriptDar testDar getSandboxPort certDir
+            , withSandbox defaultSandboxConf
+                  { dars = [testDar]
+                  , mbLedgerId = Just testLedgerId
+                  , timeMode = Static
+                  } $ \getSandboxPort ->
+              staticTimeTests damlc scriptDar testDar getSandboxPort
             ]
 
 withTokenFile :: (IO FilePath -> TestTree) -> TestTree
@@ -121,4 +127,38 @@ testConnection damlc scriptDar testDar ledgerPort mbTokenFile mbCaCrt = do
                      ]
                    , [ "--access-token-file=" <> tokenFile | Just tokenFile <- [mbTokenFile] ]
                    , [ "--cacrt=" <> cacrt | Just cacrt <- [mbCaCrt] ]
+                   ]
+
+staticTimeTests :: FilePath -> FilePath -> FilePath -> IO Int -> TestTree
+staticTimeTests damlc scriptDar testDar getSandboxPort = testGroup "static-time"
+    [ testCase "setTime" $ do
+        port <- getSandboxPort
+        testSetTime damlc scriptDar testDar port
+    ]
+
+testSetTime
+    :: FilePath
+    -> FilePath
+    -> FilePath
+    -> Int
+    -> Assertion
+testSetTime damlc scriptDar testDar ledgerPort = do
+    out <- readCreateProcess cp $ unlines
+        [ "import DA.Date"
+        , "import DA.Time"
+        , "setTime (time (date 2000 Feb 2) 0 1 2)"
+        ]
+    let regexString = "^daml> daml> daml> daml> Goodbye.\n$" :: String
+    let regex = makeRegexOpts defaultCompOpt { multiline = False } defaultExecOpt regexString
+    unless (matchTest regex out) $
+        assertFailure (show out <> " did not match " <> show regexString <> ".")
+    where cp = proc damlc
+                   [ "repl"
+                   , "--static-time"
+                   , "--ledger-host=localhost"
+                   , "--ledger-port"
+                   , show ledgerPort
+                   , "--script-lib"
+                   , scriptDar
+                   , testDar
                    ]

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -62,7 +62,7 @@ main = do
     withTempFile $ \portFile ->
         withBinaryFile nullDevice WriteMode $ \devNull ->
         bracket (createSandbox portFile devNull defaultSandboxConf { dars = [testDar] }) destroySandbox $ \SandboxResource{sandboxPort} ->
-        ReplClient.withReplClient (ReplClient.Options replJar "localhost" (show sandboxPort) Nothing Nothing Nothing CreatePipe) $ \replHandle mbServiceOut processHandle ->
+        ReplClient.withReplClient (ReplClient.Options replJar "localhost" (show sandboxPort) Nothing Nothing Nothing ReplClient.ReplWallClock CreatePipe) $ \replHandle mbServiceOut processHandle ->
         -- TODO We could share some of this setup with the actual repl code in damlc.
         withTempDir $ \dir ->
         withCurrentDirectory dir $ do


### PR DESCRIPTION
Adds flags `--static-time` and `--wall-clock-time` to `daml repl` to configure the time mode. The default is `--wall-clock-time` as before.

Adds a regression test that tests whether `setTime` works in the REPL, it will only work in static time mode.
The REPL functional tests are structured in a way that does not allow to modify the sandbox flags such as time mode. I've placed the regression test next to the connection tests. If we add further tests depending on static time mode in the future then we may want to extend the functional tests to be more configurable.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
