### PR TITLE
Trigger service: split up Server companion object

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -50,7 +50,9 @@ class TriggerRunner(
             .onFailure[InitializationHalted](stop)
         )
         .onFailure(
-          restart.withLimit(config.maxFailureNumberOfRetries, config.failureRetryTimeRange)),
+          restart.withLimit(
+            config.runnerConfig.maxFailureNumberOfRetries,
+            config.runnerConfig.failureRetryTimeRange)),
       name
     )
 


### PR DESCRIPTION
The Server object and especially the apply method is extremely big and
hard to follow. There are a great many functions nested within the apply
method. This PR attempt to organize things, mostly by moving local
functions into methods of the Server class. I think this makes things
easier to follow and is more conventional.

Note that with this change I added some implicit parameters to the
Server constructor, which I think makes sense for these kinds of values
(contexts, sequencer factory, etc.) I also moved the Message trait to
the top level, but we will probably it its own file, following this PR.
There are a few other shallow tweaks that I made along the way.

Open to feedback on the high level structuring, as I'm not super
familiar with idiomatic design in Scala. Let me know if I can help with
your reviewing as the PR might be hard to follow.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
