### PR TITLE
Allocate parties in test-tool compat tests

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -313,14 +313,12 @@ def sdk_platform_test(sdk_version, platform_version):
         client = ledger_api_test_tool,
         client_args = [
             "localhost:6865",
-            "--open-world",
-            "--exclude=ClosedWorldIT",
         ] + exclusions,
         data = [dar_files],
         runner = "@//bazel_tools/client_server:runner",
         runner_args = ["6865"],
         server = sandbox,
-        server_args = sandbox_args,
+        server_args = sandbox_args + ["--implicit-party-allocation=false"],
         server_files = ["$(rootpaths {dar_files})".format(
             dar_files = dar_files,
         )],
@@ -332,7 +330,6 @@ def sdk_platform_test(sdk_version, platform_version):
         client = ledger_api_test_tool,
         client_args = [
             "localhost:6865",
-            "--open-world",
             "--exclude=ClosedWorldIT",
         ] + exclusions,
         data = [dar_files],
@@ -351,14 +348,13 @@ def sdk_platform_test(sdk_version, platform_version):
         client = ledger_api_test_tool,
         client_args = [
             "localhost:6865",
-            "--open-world",
-            "--exclude=ClosedWorldIT",
+            "--implicit-party-allocation=false",
         ] + exclusions,
         data = [dar_files],
         runner = "@//bazel_tools/client_server:runner",
         runner_args = ["6865"],
         server = ":sandbox-with-postgres-{}".format(platform_version),
-        server_args = [platform_version] + sandbox_args,
+        server_args = [platform_version] + sandbox_args + ["--implicit-party-allocation=false"],
         server_files = ["$(rootpaths {dar_files})".format(
             dar_files = dar_files,
         )],
@@ -370,7 +366,6 @@ def sdk_platform_test(sdk_version, platform_version):
         client = ledger_api_test_tool,
         client_args = [
             "localhost:6865",
-            "--open-world",
             "--exclude=ClosedWorldIT",
         ] + exclusions,
         data = [dar_files],

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -348,7 +348,6 @@ def sdk_platform_test(sdk_version, platform_version):
         client = ledger_api_test_tool,
         client_args = [
             "localhost:6865",
-            "--implicit-party-allocation=false",
         ] + exclusions,
         data = [dar_files],
         runner = "@//bazel_tools/client_server:runner",


### PR DESCRIPTION
Compatibility is really something you care about in a production
setup. Implicit party allocation is a development feature and not
available on most ledgers. Therefore, this PR switches the tests over
to allocate parties explicitly. For sandbox-next we also disable the
implicit party allocation feature completely which allows us to
include the ClosedWorldIT test. Sadbonx-classic does not allow
disabling it atm.

In principle, we could run in both configurations but I don’t think
the additional costs (we have hundreds of those tests and this would
double the number) are worth it due to the same reasons that I’ve
given at the beginning for why explicit allocation is more important.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
