### PR TITLE
sandbox: Inject the dispatcher into the BaseLedger.

### DIFF
--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -32,6 +32,7 @@ da_scala_library(
         "//ledger/ledger-api-health",
         "//ledger/metrics",
         "//libs-scala/direct-execution-context",
+        "//libs-scala/resources",
         "@maven//:com_github_ghik_silencer_lib_2_12_11",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/Dispatcher.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/Dispatcher.scala
@@ -44,7 +44,7 @@ object Dispatcher {
   def apply[Index: Ordering](
       name: String,
       zeroIndex: Index,
-      headAtInitialization: Index
+      headAtInitialization: Index,
   ): Dispatcher[Index] =
     new DispatcherImpl[Index](name: String, zeroIndex, headAtInitialization)
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/Dispatcher.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/Dispatcher.scala
@@ -5,6 +5,7 @@ package com.daml.platform.akkastreams.dispatcher
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import com.daml.resources.ResourceOwner
 
 /**
   * A fanout signaller, representing a stream of external updates,
@@ -43,6 +44,15 @@ object Dispatcher {
   def apply[Index: Ordering](
       name: String,
       zeroIndex: Index,
-      headAtInitialization: Index): Dispatcher[Index] =
+      headAtInitialization: Index
+  ): Dispatcher[Index] =
     new DispatcherImpl[Index](name: String, zeroIndex, headAtInitialization)
+
+  def owner[Index: Ordering](
+      name: String,
+      zeroIndex: Index,
+      headAtInitialization: Index,
+  ): ResourceOwner[Dispatcher[Index]] =
+    ResourceOwner.forCloseable(() => apply(name, zeroIndex, headAtInitialization))
+
 }

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/package.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/package.scala
@@ -12,11 +12,9 @@ package object memory {
   private[memory] val StartIndex: Index = 0
 
   private[memory] def dispatcherOwner: ResourceOwner[Dispatcher[Index]] =
-    ResourceOwner.forCloseable(
-      () =>
-        Dispatcher(
-          "in-memory-key-value-participant-state",
-          zeroIndex = StartIndex,
-          headAtInitialization = StartIndex,
-      ))
+    Dispatcher.owner(
+      name = "in-memory-key-value-participant-state",
+      zeroIndex = StartIndex,
+      headAtInitialization = StartIndex,
+    )
 }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -139,7 +139,7 @@ object SqlLedgerReaderWriter {
           if (resetOnStartup) uninitializedDatabase.migrateAndReset()
           else Future.successful(uninitializedDatabase.migrate()))
         ledgerId <- Resource.fromFuture(updateOrRetrieveLedgerId(initialLedgerId, database))
-        dispatcher <- ResourceOwner.forFutureCloseable(() => newDispatcher(database)).acquire()
+        dispatcher <- new DispatcherOwner(database).acquire()
       } yield
         new SqlLedgerReaderWriter(
           ledgerId,
@@ -177,13 +177,26 @@ object SqlLedgerReaderWriter {
           })
     }
 
-  private def newDispatcher(database: Database)(
-      implicit executionContext: ExecutionContext,
-      logCtx: LoggingContext,
-  ): Future[Dispatcher[Index]] =
-    database
-      .inReadTransaction("read_head") { queries =>
-        Future.fromTry(queries.selectLatestLogEntryId().map(_.map(_ + 1).getOrElse(StartIndex)))
-      }
-      .map(head => Dispatcher("sql-participant-state", StartIndex, head))
+  private final class DispatcherOwner(database: Database)(implicit logCtx: LoggingContext)
+      extends ResourceOwner[Dispatcher[Index]] {
+    override def acquire()(
+        implicit executionContext: ExecutionContext
+    ): Resource[Dispatcher[Index]] =
+      for {
+        head <- Resource.fromFuture(
+          database
+            .inReadTransaction("read_head") { queries =>
+              Future.fromTry(
+                queries.selectLatestLogEntryId().map(_.map(_ + 1).getOrElse(StartIndex)))
+            })
+        dispatcher <- Dispatcher
+          .owner(
+            name = "sql-participant-state",
+            zeroIndex = StartIndex,
+            headAtInitialization = head,
+          )
+          .acquire()
+      } yield dispatcher
+  }
+
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -58,7 +58,10 @@ object ReadOnlySqlLedger {
         dispatcher <- ResourceOwner
           .forCloseable(() => Dispatcher[Offset]("sql-ledger", Offset.beforeBegin, ledgerEnd))
           .acquire()
-      } yield new ReadOnlySqlLedger(ledgerId, ledgerDao, dispatcher)
+        ledger <- ResourceOwner
+          .forCloseable(() => new ReadOnlySqlLedger(ledgerId, ledgerDao, dispatcher))
+          .acquire()
+      } yield ledger
   }
 
   private def initialize(

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -80,13 +80,11 @@ object ReadOnlySqlLedger {
       )
 
     private def dispatcherOwner(ledgerEnd: Offset): ResourceOwner[Dispatcher[Offset]] =
-      ResourceOwner.forCloseable(
-        () =>
-          Dispatcher[Offset](
-            name = "sql-ledger",
-            zeroIndex = Offset.beforeBegin,
-            headAtInitialization = ledgerEnd,
-        ))
+      Dispatcher.owner(
+        name = "sql-ledger",
+        zeroIndex = Offset.beforeBegin,
+        headAtInitialization = ledgerEnd,
+      )
   }
 
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/ReadOnlySqlLedger.scala
@@ -9,7 +9,6 @@ import akka.actor.Cancellable
 import akka.stream._
 import akka.stream.scaladsl.{Keep, RestartSource, Sink, Source}
 import akka.{Done, NotUsed}
-import com.daml.dec.{DirectExecutionContext => DEC}
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.participant.state.v1.Offset
@@ -17,71 +16,63 @@ import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
 import com.daml.platform.common.LedgerIdMismatchException
 import com.daml.platform.configuration.ServerRole
-import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerReadDao}
 import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerReadDao}
 import com.daml.platform.store.{BaseLedger, ReadOnlyLedger}
 import com.daml.resources.ProgramResource.StartupException
-import com.daml.resources.ResourceOwner
+import com.daml.resources.{Resource, ResourceOwner}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 object ReadOnlySqlLedger {
 
+  private val logger = ContextualizedLogger.get(this.getClass)
+
   //jdbcUrl must have the user/password encoded in form of: "jdbc:postgresql://localhost/test?user=fred&password=secret"
-  def owner(
+  final class Owner(
       serverRole: ServerRole,
       jdbcUrl: String,
-      ledgerId: LedgerId,
+      initialLedgerId: LedgerId,
       eventsPageSize: Int,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
-  )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[ReadOnlyLedger] =
-    for {
-      ledgerReadDao <- JdbcLedgerDao.readOwner(
-        serverRole,
-        jdbcUrl,
-        eventsPageSize,
-        metrics,
-        lfValueTranslationCache,
-      )
-      factory = new Factory(ledgerReadDao)
-      ledger <- ResourceOwner.forFutureCloseable(() => factory.createReadOnlySqlLedger(ledgerId))
-    } yield ledger
-
-  private class Factory(ledgerDao: LedgerReadDao)(implicit logCtx: LoggingContext) {
-
-    private val logger = ContextualizedLogger.get(this.getClass)
-
-    /**
-      * Creates a DB backed Ledger implementation.
-      *
-      * @return a compliant read-only Ledger implementation
-      */
-    def createReadOnlySqlLedger(initialLedgerId: LedgerId)(
-        implicit mat: Materializer
-    ): Future[ReadOnlySqlLedger] = {
-      implicit val ec: ExecutionContext = DEC
+  )(implicit mat: Materializer, logCtx: LoggingContext)
+      extends ResourceOwner[ReadOnlyLedger] {
+    override def acquire()(
+        implicit executionContext: ExecutionContext
+    ): Resource[ReadOnlyLedger] =
       for {
-        ledgerId <- initialize(initialLedgerId)
-        ledgerEnd <- ledgerDao.lookupLedgerEnd()
+        ledgerDao <- JdbcLedgerDao
+          .readOwner(
+            serverRole,
+            jdbcUrl,
+            eventsPageSize,
+            metrics,
+            lfValueTranslationCache,
+          )
+          .acquire()
+        ledgerId <- Resource.fromFuture(initialize(ledgerDao, initialLedgerId))
+        ledgerEnd <- Resource.fromFuture(ledgerDao.lookupLedgerEnd())
       } yield new ReadOnlySqlLedger(ledgerId, ledgerEnd, ledgerDao)
-    }
-
-    private def initialize(initialLedgerId: LedgerId): Future[LedgerId] =
-      ledgerDao
-        .lookupLedgerId()
-        .flatMap {
-          case Some(foundLedgerId @ `initialLedgerId`) =>
-            logger.info(s"Found existing ledger with ID: $foundLedgerId")
-            Future.successful(foundLedgerId)
-          case Some(foundLedgerId) =>
-            Future.failed(
-              new LedgerIdMismatchException(foundLedgerId, initialLedgerId) with StartupException)
-          case None =>
-            Future.successful(initialLedgerId)
-        }(DEC)
   }
+
+  private def initialize(
+      ledgerDao: LedgerReadDao,
+      initialLedgerId: LedgerId,
+  )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): Future[LedgerId] =
+    ledgerDao
+      .lookupLedgerId()
+      .flatMap {
+        case Some(foundLedgerId @ `initialLedgerId`) =>
+          logger.info(s"Found existing ledger with ID: $foundLedgerId")
+          Future.successful(foundLedgerId)
+        case Some(foundLedgerId) =>
+          Future.failed(
+            new LedgerIdMismatchException(foundLedgerId, initialLedgerId) with StartupException)
+        case None =>
+          Future.successful(initialLedgerId)
+      }
 
 }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -68,25 +68,23 @@ object SandboxIndexAndWriteService {
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
   )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[IndexAndWriteService] =
-    SqlLedger
-      .owner(
-        serverRole = ServerRole.Sandbox,
-        jdbcUrl = jdbcUrl,
-        ledgerId = ledgerId,
-        participantId = participantId,
-        timeProvider = timeProvider,
-        acs = acs,
-        packages = templateStore,
-        initialLedgerEntries = ledgerEntries,
-        queueDepth = queueDepth,
-        transactionCommitter = transactionCommitter,
-        startMode = startMode,
-        eventsPageSize = eventsPageSize,
-        metrics = metrics,
-        lfValueTranslationCache
-      )
-      .flatMap(ledger =>
-        owner(MeteredLedger(ledger, metrics), participantId, initialConfig, timeProvider))
+    new SqlLedger.Owner(
+      serverRole = ServerRole.Sandbox,
+      jdbcUrl = jdbcUrl,
+      ledgerId = ledgerId,
+      participantId = participantId,
+      timeProvider = timeProvider,
+      acs = acs,
+      packages = templateStore,
+      initialLedgerEntries = ledgerEntries,
+      queueDepth = queueDepth,
+      transactionCommitter = transactionCommitter,
+      startMode = startMode,
+      eventsPageSize = eventsPageSize,
+      metrics = metrics,
+      lfValueTranslationCache
+    ).flatMap(ledger =>
+      owner(MeteredLedger(ledger, metrics), participantId, initialConfig, timeProvider))
 
   def inMemory(
       ledgerId: LedgerIdMode,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -53,7 +53,7 @@ object SandboxIndexAndWriteService {
   private val logger = LoggerFactory.getLogger(SandboxIndexAndWriteService.getClass)
 
   def postgres(
-      ledgerId: LedgerIdMode,
+      initialLedgerId: LedgerIdMode,
       participantId: ParticipantId,
       jdbcUrl: String,
       initialConfig: ParticipantState.Configuration,
@@ -71,7 +71,7 @@ object SandboxIndexAndWriteService {
     new SqlLedger.Owner(
       serverRole = ServerRole.Sandbox,
       jdbcUrl = jdbcUrl,
-      ledgerId = ledgerId,
+      initialLedgerId = initialLedgerId,
       participantId = participantId,
       timeProvider = timeProvider,
       acs = acs,
@@ -87,7 +87,7 @@ object SandboxIndexAndWriteService {
       owner(MeteredLedger(ledger, metrics), participantId, initialConfig, timeProvider))
 
   def inMemory(
-      ledgerId: LedgerIdMode,
+      initialLedgerId: LedgerIdMode,
       participantId: ParticipantId,
       intialConfig: ParticipantState.Configuration,
       timeProvider: TimeProvider,
@@ -99,7 +99,7 @@ object SandboxIndexAndWriteService {
   )(implicit mat: Materializer): ResourceOwner[IndexAndWriteService] = {
     val ledger =
       new InMemoryLedger(
-        ledgerId.or(LedgerIdGenerator.generateRandomId()),
+        initialLedgerId.or(LedgerIdGenerator.generateRandomId()),
         participantId,
         timeProvider,
         acs,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -217,12 +217,11 @@ object SqlLedger {
       )
 
     private def dispatcherOwner(ledgerEnd: Offset): ResourceOwner[Dispatcher[Offset]] =
-      ResourceOwner.forCloseable(
-        () =>
-          Dispatcher[Offset](
-            name = "sql-ledger",
-            zeroIndex = Offset.beforeBegin,
-            headAtInitialization = ledgerEnd))
+      Dispatcher.owner(
+        name = "sql-ledger",
+        zeroIndex = Offset.beforeBegin,
+        headAtInitialization = ledgerEnd,
+      )
 
     private def sqlLedgerOwner(
         ledgerId: LedgerId,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -101,18 +101,22 @@ object SqlLedger {
         dispatcher <- ResourceOwner
           .forCloseable(() => Dispatcher[Offset]("sql-ledger", Offset.beforeBegin, ledgerEnd))
           .acquire()
-      } yield
-        new SqlLedger(
-          ledgerId,
-          participantId,
-          ledgerConfig.map(_._2),
-          ledgerDao,
-          dispatcher,
-          timeProvider,
-          packages,
-          queueDepth,
-          transactionCommitter,
-        )
+        ledger <- ResourceOwner
+          .forCloseable(
+            () =>
+              new SqlLedger(
+                ledgerId,
+                participantId,
+                ledgerConfig.map(_._2),
+                ledgerDao,
+                dispatcher,
+                timeProvider,
+                packages,
+                queueDepth,
+                transactionCommitter,
+            ))
+          .acquire()
+      } yield ledger
 
     private def initialize(
         initialLedgerId: LedgerIdMode,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/BaseLedger.scala
@@ -7,16 +7,6 @@ import java.time.Instant
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.index.v2
-import com.daml.ledger.participant.state.index.v2.CommandDeduplicationResult
-import com.daml.ledger.participant.state.v1.{Configuration, Offset}
-import com.daml.lf.archive.Decode
-import com.daml.lf.data.Ref
-import com.daml.lf.data.Ref.{Identifier, PackageId, Party}
-import com.daml.lf.language.Ast
-import com.daml.lf.transaction.Node
-import com.daml.lf.value.Value
-import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.TransactionId
@@ -31,6 +21,16 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse
 }
+import com.daml.ledger.participant.state.index.v2
+import com.daml.ledger.participant.state.index.v2.CommandDeduplicationResult
+import com.daml.ledger.participant.state.v1.{Configuration, Offset}
+import com.daml.lf.archive.Decode
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.{Identifier, PackageId, Party}
+import com.daml.lf.language.Ast
+import com.daml.lf.transaction.Node
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.akkastreams.dispatcher.SubSource.RangeSource
 import com.daml.platform.store.dao.LedgerReadDao
@@ -42,17 +42,11 @@ import scala.util.Try
 
 abstract class BaseLedger(
     val ledgerId: LedgerId,
-    headAtInitialization: Offset,
-    ledgerDao: LedgerReadDao)
-    extends ReadOnlyLedger {
+    ledgerDao: LedgerReadDao,
+    dispatcher: Dispatcher[Offset],
+) extends ReadOnlyLedger {
 
   implicit private val DEC: ExecutionContext = DirectExecutionContext
-
-  protected final val dispatcher: Dispatcher[Offset] = Dispatcher[Offset](
-    "sql-ledger",
-    Offset.beforeBegin,
-    headAtInitialization
-  )
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
 
@@ -174,7 +168,5 @@ abstract class BaseLedger(
   override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party): Future[Unit] =
     ledgerDao.stopDeduplicatingCommand(commandId, submitter)
 
-  override def close(): Unit = {
-    dispatcher.close()
-  }
+  override def close(): Unit = ()
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
@@ -67,7 +67,7 @@ object LedgerResource {
         ledger <- new SqlLedger.Owner(
           serverRole = ServerRole.Testing(testClass),
           jdbcUrl = database.url,
-          ledgerId = LedgerIdMode.Static(ledgerId),
+          initialLedgerId = LedgerIdMode.Static(ledgerId),
           participantId = participantId,
           timeProvider = timeProvider,
           acs = InMemoryActiveLedgerState.empty,

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/LedgerResource.scala
@@ -64,7 +64,7 @@ object LedgerResource {
     new OwnedResource(
       for {
         database <- PostgresResource.owner()
-        ledger <- SqlLedger.owner(
+        ledger <- new SqlLedger.Owner(
           serverRole = ServerRole.Testing(testClass),
           jdbcUrl = database.url,
           ledgerId = LedgerIdMode.Static(ledgerId),

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -175,26 +175,24 @@ class SqlLedgerSpec
   ): Future[Ledger] = {
     metrics.getNames.forEach(name => { val _ = metrics.remove(name) })
     val ledger = newLoggingContext { implicit logCtx =>
-      SqlLedger
-        .owner(
-          serverRole = ServerRole.Testing(getClass),
-          jdbcUrl = postgresDatabase.url,
-          ledgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
-          participantId = participantId,
-          timeProvider = TimeProvider.UTC,
-          acs = InMemoryActiveLedgerState.empty,
-          packages = InMemoryPackageStore.empty
-            .withPackages(Instant.EPOCH, None, packages)
-            .fold(sys.error, identity),
-          initialLedgerEntries = ImmArray.empty,
-          queueDepth = queueDepth,
-          transactionCommitter = LegacyTransactionCommitter,
-          startMode = SqlStartMode.ContinueIfExists,
-          eventsPageSize = 100,
-          metrics = new Metrics(metrics),
-          lfValueTranslationCache = LfValueTranslation.Cache.none,
-        )
-        .acquire()(system.dispatcher)
+      new SqlLedger.Owner(
+        serverRole = ServerRole.Testing(getClass),
+        jdbcUrl = postgresDatabase.url,
+        ledgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
+        participantId = participantId,
+        timeProvider = TimeProvider.UTC,
+        acs = InMemoryActiveLedgerState.empty,
+        packages = InMemoryPackageStore.empty
+          .withPackages(Instant.EPOCH, None, packages)
+          .fold(sys.error, identity),
+        initialLedgerEntries = ImmArray.empty,
+        queueDepth = queueDepth,
+        transactionCommitter = LegacyTransactionCommitter,
+        startMode = SqlStartMode.ContinueIfExists,
+        eventsPageSize = 100,
+        metrics = new Metrics(metrics),
+        lfValueTranslationCache = LfValueTranslation.Cache.none,
+      ).acquire()(system.dispatcher)
     }
     createdLedgers += ledger
     ledger.asFuture

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -178,7 +178,7 @@ class SqlLedgerSpec
       new SqlLedger.Owner(
         serverRole = ServerRole.Testing(getClass),
         jdbcUrl = postgresDatabase.url,
-        ledgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
+        initialLedgerId = ledgerId.fold[LedgerIdMode](LedgerIdMode.Dynamic)(LedgerIdMode.Static),
         participantId = participantId,
         timeProvider = TimeProvider.UTC,
         acs = InMemoryActiveLedgerState.empty,


### PR DESCRIPTION
This allows us to (in the future) use the same ledger end dispatcher for the indexer and API server, which opens the doors to potential performance improvements.

To make this clean, I had to clean up the `SqlLedger` and `ReadOnlySqlLedger` acquisition a bit.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
