### PR TITLE
Improve test output

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -127,7 +127,6 @@ final class CommandDeduplicationIT extends LedgerTestSuite {
   )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
       val key = UUID.randomUUID().toString
-      val commandId = UUID.randomUUID().toString
 
       for {
         // Create a helper and a text key
@@ -135,11 +134,12 @@ final class CommandDeduplicationIT extends LedgerTestSuite {
         _ <- ledger.create(party, TextKey(party, key, List()))
 
         // Create two competing requests
-        requestTemplate = ledger.submitAndWaitRequest(
+        requestA = ledger.submitAndWaitRequest(
           party,
           ko.exerciseTKOFetchAndRecreate(party, Tuple2(party, key)).command)
-        requestA = requestTemplate.update(_.commands.commandId := commandId + "-A")
-        requestB = requestTemplate.update(_.commands.commandId := commandId + "-B")
+        requestB = ledger.submitAndWaitRequest(
+          party,
+          ko.exerciseTKOFetchAndRecreate(party, Tuple2(party, key)).command)
 
         // Submit both requests in parallel.
         // Either both succeed (if one transaction is recorded faster than the other submission starts command interpretation, unlikely)

--- a/ledger/test-common/src/main/daml/model/Test.daml
+++ b/ledger/test-common/src/main/daml/model/Test.daml
@@ -80,6 +80,13 @@ template DummyWithParam
         with paramString: Text
         do return ()
 
+template DummyWithAnnotation
+  with
+    operator : Party
+    annotation : Text
+  where
+    signatory operator
+
 template DummyFactory
   with
     operator: Party


### PR DESCRIPTION
This PR modifies the deduplication IT to make it more reliable.

In particular, the test does not rely on completions arriving in the same order as submissions anymore. In addition, it should work even if transaction submissions are significantly delayed on the ledger.