### PR TITLE
Spawn a ref ledger auth instance from text fixture

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -980,6 +980,6 @@ java_import(
 http_file(
     name = "ref-ledger-authentication",
     downloaded_file_path = "ref-ledger-authentication.jar",
-    sha256 = "be98a80f694d9e1c6630a3bbc8e1c1ac802d13179a8f9d522dc933c7c1eff13d",
-    urls = ["https://github.com/digital-asset/ref-ledger-authenticator/releases/download/v0.0.0-snapshot-20200623.5.214b7033/ref-ledger-authenticator-0.0.0-snapshot-20200623.5.214b7033.jar"],
+    sha256 = "377621e8df63fe9ca968af3bee0f44ef44be759d160fb2b05edd53dda55080b3",
+    urls = ["https://github.com/digital-asset/ref-ledger-authenticator/releases/download/v0.0.0-snapshot-20200625.8.b314c125/ref-ledger-authenticator-0.0.0-snapshot-20200625.8.b314c125.jar"],
 )


### PR DESCRIPTION
This PR launches a ref-ledger-authentication service instance from the trigger service test suite fixture.