### PR TITLE
Share postgres instance in compatibility tests

### DIFF
--- a/compatibility/bazel-haskell-deps.bzl
+++ b/compatibility/bazel-haskell-deps.bzl
@@ -74,6 +74,7 @@ def daml_haskell_deps():
             "optparse-applicative",
             "unix-compat",
             "unordered-containers",
+            "uuid",
         ] + (["unix"] if not is_windows else ["Win32"]),
         stack = "@stack_windows//:stack.exe" if is_windows else None,
         tools = [

--- a/compatibility/bazel_tools/client_server/with-postgres/BUILD
+++ b/compatibility/bazel_tools/client_server/with-postgres/BUILD
@@ -15,6 +15,7 @@ da_haskell_library(
         "process",
         "safe-exceptions",
         "text",
+        "uuid",
     ],
     visibility = ["//visibility:public"],
 )

--- a/compatibility/test.sh
+++ b/compatibility/test.sh
@@ -18,10 +18,43 @@ eval "$(../dev-env/bin/dade-assist)"
 # it unconditionally since it should be cheap enough.
 cp ../.bazelrc .bazelrc
 
+# Set up a shared PostgreSQL instance. This is the same code as in //:build.sh.
+export POSTGRESQL_ROOT_DIR="${TMPDIR:-/tmp}/daml/postgresql"
+export POSTGRESQL_DATA_DIR="${POSTGRESQL_ROOT_DIR}/data"
+export POSTGRESQL_LOG_FILE="${POSTGRESQL_ROOT_DIR}/postgresql.log"
+export POSTGRESQL_HOST='localhost'
+export POSTGRESQL_PORT=54321
+export POSTGRESQL_USERNAME='test'
+function start_postgresql() {
+  mkdir -p "$POSTGRESQL_DATA_DIR"
+  bazel run -- @postgresql_nix//:bin/initdb --auth=trust --encoding=UNICODE --locale=en_US.UTF-8 --username="$POSTGRESQL_USERNAME" "$POSTGRESQL_DATA_DIR"
+  eval "echo \"$(cat ../ci/postgresql.conf)\"" > "$POSTGRESQL_DATA_DIR/postgresql.conf"
+  bazel run -- @postgresql_nix//:bin/pg_ctl -w --pgdata="$POSTGRESQL_DATA_DIR" --log="$POSTGRESQL_LOG_FILE" start || {
+    if [[ -f "$POSTGRESQL_LOG_FILE" ]]; then
+      echo >&2 'PostgreSQL logs:'
+      cat >&2 "$POSTGRESQL_LOG_FILE"
+    fi
+    return 1
+  }
+}
+function stop_postgresql() {
+  if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
+    bazel run -- @postgresql_nix//:bin/pg_ctl -w --pgdata="$POSTGRESQL_DATA_DIR" --mode=immediate stop || :
+    rm -rf "$POSTGRESQL_ROOT_DIR"
+  fi
+}
+trap stop_postgresql EXIT
+stop_postgresql # in case it's running from a previous build
+start_postgresql
+
 bazel build //...
+
+BAZEL_TARGET="//..."
 if [ "${1:-}" = "--quick" ]; then
-    bazel test //:head-quick
-else
-    bazel test //...
+    BAZEL_TARGET="//:head-quick"
 fi
 
+bazel test $BAZEL_TARGET \
+  --test_env "POSTGRESQL_HOST=${POSTGRESQL_HOST}" \
+  --test_env "POSTGRESQL_PORT=${POSTGRESQL_PORT}" \
+  --test_env "POSTGRESQL_USERNAME=${POSTGRESQL_USERNAME}" \


### PR DESCRIPTION
This introduces the same trick for sharing the postgres instance that
we use in the main workspace to the compatibility workspace. The bash
code for that is currently duplicated. Didn’t seem worth trying to
make it sufficiently generic that we can share it (it hasn’t changed
since we added it) but if someone disagrees, I’m happy to reconsider
that.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
