### PR TITLE
Only pass --implicit-party-allocation to versions that support it

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -302,6 +302,10 @@ def sdk_platform_test(sdk_version, platform_version):
 
     json_api_args = ["json-api"]
 
+    # --implicit-party-allocation=false only exists in SDK >= 1.2.0 so
+    # for older versions we still have to disable ClosedWorldIT
+    (extra_sandbox_next_args, extra_sandbox_next_exclusions) = (["--implicit-party-allocation=false"], []) if versions.is_at_least("1.2.0", platform_version) else ([], ["--exclude=ClosedWorldIT"])
+
     # ledger-api-test-tool test-cases
     name = "ledger-api-test-tool-{sdk_version}-platform-{platform_version}".format(
         sdk_version = version_to_name(sdk_version),
@@ -313,12 +317,12 @@ def sdk_platform_test(sdk_version, platform_version):
         client = ledger_api_test_tool,
         client_args = [
             "localhost:6865",
-        ] + exclusions,
+        ] + exclusions + extra_sandbox_next_exclusions,
         data = [dar_files],
         runner = "@//bazel_tools/client_server:runner",
         runner_args = ["6865"],
         server = sandbox,
-        server_args = sandbox_args + ["--implicit-party-allocation=false"],
+        server_args = sandbox_args + extra_sandbox_next_args,
         server_files = ["$(rootpaths {dar_files})".format(
             dar_files = dar_files,
         )],
@@ -348,12 +352,12 @@ def sdk_platform_test(sdk_version, platform_version):
         client = ledger_api_test_tool,
         client_args = [
             "localhost:6865",
-        ] + exclusions,
+        ] + exclusions + extra_sandbox_next_exclusions,
         data = [dar_files],
         runner = "@//bazel_tools/client_server:runner",
         runner_args = ["6865"],
         server = ":sandbox-with-postgres-{}".format(platform_version),
-        server_args = [platform_version] + sandbox_args + ["--implicit-party-allocation=false"],
+        server_args = [platform_version] + sandbox_args + extra_sandbox_next_args,
         server_files = ["$(rootpaths {dar_files})".format(
             dar_files = dar_files,
         )],


### PR DESCRIPTION
I broke the tests for Sandbox < 1.2.0 when I switched to explicit
party allocation yesterday since I didn’t realize this only landed in
SDK 1.2.0 (sorry about that).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
