### PR TITLE
Remove some dead code from transaction enrichment

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -50,9 +50,12 @@ object Blinding {
     if (enrichedTx.failedAuthorizations.isEmpty) {
       Right(
         BlindingInfo(
-          enrichedTx.explicitDisclosure,
-          enrichedTx.localImplicitDisclosure,
-          enrichedTx.globalImplicitDisclosure))
+          disclosure = enrichedTx.explicitDisclosure,
+          // NOTE(MH): Local divulgences are a thing of the past and are not
+          // produced by the current implementation anymore.
+          localDivulgence = Map.empty,
+          globalDivulgence = enrichedTx.globalImplicitDisclosure,
+        ))
     } else {
       Left(
         AuthorizationError(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -80,14 +80,12 @@ object ScenarioLedger {
       transactionId: LedgerString,
       transaction: Tx.CommittedTransaction,
       explicitDisclosure: Relation[Tx.NodeId, Party],
-      localImplicitDisclosure: Relation[Tx.NodeId, Party],
       globalImplicitDisclosure: Relation[ContractId, Party],
       failedAuthorizations: FailedAuthorizations,
   ) {
     def disclosures(coidToEventId: ContractId => EventId): Relation[EventId, Party] =
       Relation.union(
-        Relation.mapKeys(Relation.union(explicitDisclosure, localImplicitDisclosure))(
-          EventId(transactionId, _)),
+        Relation.mapKeys(explicitDisclosure)(EventId(transactionId, _)),
         Relation.mapKeys(globalImplicitDisclosure)(coidToEventId),
       )
   }
@@ -113,7 +111,6 @@ object ScenarioLedger {
         transactionId = transactionId,
         transaction = enrichedTx.tx,
         explicitDisclosure = enrichedTx.explicitDisclosure,
-        localImplicitDisclosure = enrichedTx.localImplicitDisclosure,
         globalImplicitDisclosure = enrichedTx.globalImplicitDisclosure,
         failedAuthorizations = enrichedTx.failedAuthorizations,
       )


### PR DESCRIPTION
When trying to understand how disclosure/divulgence information is
computed for the scneario service, I stumbled on some dead code:

* The `EnrichState.divulgeContracts` function is never used. Let's
  remove it.

* The `EnrichState.localDivulgendes` field is initialized with an empty
  map and never touched again. Thus, it's always going to stay an empty
  map. This means that the
  `EnrichedTransaction.localImplicitDisclosure` is also always going to
  be an empty map. Both fields can hence be removed.

I'm not sure if the `BlindingInfo.localDivulgence` field can be removed
as well. In my understanding, this data structure could be loaded from
transactions serialized with the field being non-empty in the past.
Thus, I've refrained from removing the field and set it to an empty map
when constructing a `BlindingInfo` from an `EnrichedTransaction`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6507)
<!-- Reviewable:end -->
