### PR TITLE
sandbox: Add a command line flag to disable DAML stack traces

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -29,11 +29,11 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
   def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
     Option(_defns.get(dref))
 
-  def profilingMode = _profilingMode
+  override def profilingMode = _profilingMode
   def profilingMode_=(profilingMode: speedy.Compiler.ProfilingMode) = {
     _profilingMode = profilingMode
   }
-  def stackTraceMode = _stackTraceMode
+  override def stackTraceMode = _stackTraceMode
   def stackTraceMode_=(stackTraceMode: speedy.Compiler.StackTraceMode) = {
     _stackTraceMode = stackTraceMode
   }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -23,15 +23,19 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
   private[this] val _packageDeps: ConcurrentHashMap[PackageId, Set[PackageId]] =
     new ConcurrentHashMap()
   private[this] var _profilingMode: speedy.Compiler.ProfilingMode = speedy.Compiler.NoProfile
+  private[this] var _stackTraceMode: speedy.Compiler.StackTraceMode = speedy.Compiler.FullStackTrace
 
   def getPackage(pId: PackageId): Option[Package] = _packages.get(pId)
   def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
     Option(_defns.get(dref))
 
-  def stackTraceMode = speedy.Compiler.FullStackTrace
   def profilingMode = _profilingMode
   def profilingMode_=(profilingMode: speedy.Compiler.ProfilingMode) = {
     _profilingMode = profilingMode
+  }
+  def stackTraceMode = _stackTraceMode
+  def stackTraceMode_=(stackTraceMode: speedy.Compiler.StackTraceMode) = {
+    _stackTraceMode = stackTraceMode
   }
 
   /** Might ask for a package if the package you're trying to add references it.

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -402,6 +402,11 @@ final class Engine(config: Engine.Config) {
     this.profileDir = Some(profileDir)
     compiledPackages.profilingMode = speedy.Compiler.FullProfile
   }
+
+  def enableStackTraces(enable: Boolean) = {
+    compiledPackages.stackTraceMode =
+      if (enable) speedy.Compiler.FullStackTrace else speedy.Compiler.NoStackTrace
+  }
 }
 
 object Engine {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -138,6 +138,7 @@ final class SandboxServer(
       Files.createDirectories(profileDir)
       engine.startProfiling(profileDir)
   }
+  engine.enableStackTraces(config.stackTraces)
 
   // Name of this participant
   // TODO: Pass this info in command-line (See issue #2025)
@@ -342,7 +343,7 @@ final class SandboxServer(
     } yield {
       Banner.show(Console.out)
       logger.withoutContext.info(
-        "Initialized sandbox version {} with ledger-id = {}, port = {}, dar file = {}, time mode = {}, ledger = {}, auth-service = {}, contract ids seeding = {}{}",
+        "Initialized sandbox version {} with ledger-id = {}, port = {}, dar file = {}, time mode = {}, ledger = {}, auth-service = {}, contract ids seeding = {}{}{}",
         BuildInfo.Version,
         ledgerId,
         apiServer.port.toString,
@@ -351,6 +352,7 @@ final class SandboxServer(
         ledgerType,
         authService.getClass.getSimpleName,
         config.seeding.fold("no")(_.toString.toLowerCase),
+        if (config.stackTraces) "" else ", stack traces = no",
         config.profileDir match {
           case None => ""
           case Some(profileDir) => s", profile directory = ${profileDir}"

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -303,6 +303,12 @@ object Cli {
         .action((dir, config) => config.copy(profileDir = Some(dir.toPath)))
         .text("Enable profiling and write the profiles into the given directory.")
 
+      opt[Boolean]("stack-traces")
+        .hidden()
+        .optional()
+        .action((enabled, config) => config.copy(stackTraces = enabled))
+        .text("Enable stack traces. Default is to enable them.")
+
       opt[Long]("max-ledger-time-skew")
         .optional()
         .action((value, config) => {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -307,7 +307,7 @@ object Cli {
         .hidden()
         .optional()
         .action((enabled, config) => config.copy(stackTraces = enabled))
-        .text("Enable stack traces. Default is to enable them.")
+        .text("Enable/disable stack traces. Default is to enable them.")
 
       opt[Long]("max-ledger-time-skew")
         .optional()

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/config/SandboxConfig.scala
@@ -44,6 +44,7 @@ final case class SandboxConfig(
     lfValueTranslationEventCacheConfiguration: SizedCache.Configuration,
     lfValueTranslationContractCacheConfiguration: SizedCache.Configuration,
     profileDir: Option[Path],
+    stackTraces: Boolean,
 )
 
 object SandboxConfig {
@@ -83,6 +84,7 @@ object SandboxConfig {
       lfValueTranslationEventCacheConfiguration = DefaultLfValueTranslationCacheConfiguration,
       lfValueTranslationContractCacheConfiguration = DefaultLfValueTranslationCacheConfiguration,
       profileDir = None,
+      stackTraces = true,
     )
 
   lazy val default: SandboxConfig =


### PR DESCRIPTION
The sandbox now accepts a `--stack-traces no` flag which will turn off
the location tracking in DAML Engine required to produce stack traces
for failing DAML code.

Benchmarks suggest that DAML Engine spends about 10% of its time with
tracking locations. Thus, this flag will give us roughly a 1.1x
speedup when stack traces are not needed.

This flag is still hidden because we would like to validate its
usefulness before we commit to supporting it.

CHANGELOG_BEGIN
CHANGELOG_END
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6512)
<!-- Reviewable:end -->
