### PR TITLE
switch CI nodes from n1-standard-8 to c2-*

### DIFF
--- a/infra/vsts_agent_linux.tf
+++ b/infra/vsts_agent_linux.tf
@@ -17,7 +17,7 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-linux" {
   provider           = "google-beta"
   name               = "vsts-agent-linux"
   base_instance_name = "vsts-agent-linux"
-  region             = "us-east-1"
+  region             = "us-east1"
   target_size        = 10
 
   version {

--- a/infra/vsts_agent_linux.tf
+++ b/infra/vsts_agent_linux.tf
@@ -17,7 +17,7 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-linux" {
   provider           = "google-beta"
   name               = "vsts-agent-linux"
   base_instance_name = "vsts-agent-linux"
-  region             = "${local.region}"
+  region             = "us-east-1"
   target_size        = 10
 
   version {
@@ -35,7 +35,7 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-linux" {
 
 resource "google_compute_instance_template" "vsts-agent-linux" {
   name_prefix  = "vsts-agent-linux-"
-  machine_type = "n1-standard-8"
+  machine_type = "c2-standard-8"
   labels       = "${local.labels}"
 
   disk {

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -15,7 +15,7 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
   # -5 for the random postfix:
   base_instance_name = "vsts-win"
 
-  region      = "${local.region}"
+  region      = "us-east-1"
   target_size = 6
 
   version {
@@ -38,7 +38,7 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
 
 resource "google_compute_instance_template" "vsts-agent-windows" {
   name_prefix  = "vsts-agent-windows-"
-  machine_type = "n1-standard-8"
+  machine_type = "c2-standard-8"
   labels       = "${local.labels}"
 
   disk {

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -15,7 +15,7 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
   # -5 for the random postfix:
   base_instance_name = "vsts-win"
 
-  region      = "us-east-1"
+  region      = "us-east1"
   target_size = 6
 
   version {


### PR DESCRIPTION
A while back (#4520), I did a bunch of performance tests when trying to size up the requirements for the hosted macOS nodes we needed to buy. As part of that testing, it looked like `c2-standard-8` nodes were faster (full build down from ~95 to ~75 minutes) and marginally cheaper ($0.4176 vs $0.4280) than the `n1-standard-8` we are currently using.

Then I got distracted, and I forgot to upgrade our existing machines.

CHANGELOG_BEGIN
CHANGELOG_END