### PR TITLE
kvutils: When creating the reference ledger dump, do it less eagerly.

### DIFF
--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -163,6 +163,7 @@ client_server_build(
     testonly = True,  # only test targets can depend on this.
     client = "//ledger/ledger-api-test-tool",
     client_args = [
+        "--concurrent-test-runs=4",
         "--timeout-scale-factor=20",
         "localhost:6865",
     ],


### PR DESCRIPTION
Our build is intermittently failing on CI on the target, `//ledger/participant-state/kvutils:reference-ledger-dump`.

Creating the reference ledger dump exercises ledger-on-memory with the Ledger API Test Tool as a side effect. The real goal is to run any kind of kvutils ledger and generate a load of data. With that in mind, the idea is to be somewhat stable, not fast.

This decreases the number of concurrent tests running at once to generate the reference dump from the number of CPUs (presumably 8 on CI, though I'm not sure) to 4.

It does not change the number of concurrent tests when running `//ledger/ledger-on-memory/conformance-test`. This will still default to the number of CPUs.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
