### PR TITLE
Remove record time from DAML state values

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -353,8 +353,7 @@ message DamlCommandDedupKey {
 }
 
 message DamlCommandDedupValue {
-  // record time will be used in the future for pruning
-  google.protobuf.Timestamp record_time = 1;
+  reserved 1; // was record_time
   // the time until when future commands with the same
   // deduplication key will be rejected due to a duplicate submission
   google.protobuf.Timestamp deduplicated_until = 2;
@@ -377,8 +376,7 @@ message DamlSubmissionDedupKey {
 }
 
 message DamlSubmissionDedupValue {
-  // record time will be used in the future for pruning
-  google.protobuf.Timestamp record_time = 1;
+  reserved 1; // was record_time
 }
 
 // DAML contract state, recording the activeness state of a contract.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -83,7 +83,8 @@ object Version {
     *   5: * Add active_at to DamlContractKeyState to be able to check causal monotonicity of positive key lookups,
     *        i.e. whether the contract currently associated with a contract key was created in a transaction with
     *        ledger_effective_time <= the ledger_effective_time of the transaction under validation.
+    *   6: * Remove fields record_time from DamlCommandDedupValue and DamlSubmissionDedupValue.
     *
     */
-  val version: Long = 5
+  val version: Long = 6
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -158,12 +158,7 @@ private[kvutils] class ConfigCommitter(
 
     ctx.set(
       configDedupKey(ctx.getParticipantId, result.submission.getSubmissionId),
-      DamlStateValue.newBuilder
-        .setSubmissionDedup(
-          DamlSubmissionDedupValue.newBuilder
-            .setRecordTime(buildTimestamp(ctx.getRecordTime))
-            .build)
-        .build
+      DamlStateValue.newBuilder.build
     )
 
     StepStop(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -132,12 +132,7 @@ private[kvutils] class PackageCommitter(
     }
     ctx.set(
       packageUploadDedupKey(ctx.getParticipantId, uploadEntry.getSubmissionId),
-      DamlStateValue.newBuilder
-        .setSubmissionDedup(
-          DamlSubmissionDedupValue.newBuilder
-            .setRecordTime(buildTimestamp(ctx.getRecordTime))
-            .build)
-        .build
+      DamlStateValue.newBuilder.build
     )
     StepStop(
       DamlLogEntry.newBuilder

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
@@ -113,12 +113,7 @@ private[kvutils] class PartyAllocationCommitter(
 
     ctx.set(
       partyAllocationDedupKey(ctx.getParticipantId, partyAllocationEntry.getSubmissionId),
-      DamlStateValue.newBuilder
-        .setSubmissionDedup(
-          DamlSubmissionDedupValue.newBuilder
-            .setRecordTime(buildTimestamp(ctx.getRecordTime))
-            .build)
-        .build
+      DamlStateValue.newBuilder.build
     )
 
     StepStop(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -349,7 +349,6 @@ private[kvutils] class TransactionCommitter(
       DamlStateValue.newBuilder
         .setCommandDedup(
           DamlCommandDedupValue.newBuilder
-            .setRecordTime(buildTimestamp(commitContext.getRecordTime))
             .setDeduplicatedUntil(transactionEntry.submitterInfo.getDeduplicateUntil)
             .build)
         .build

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -33,8 +33,8 @@ class BatchedSubmissionValidatorSpec
     with AkkaBeforeAndAfterAll
     with MockitoSugar {
 
-  val engine = Engine.DevEngine()
-  val metrics = new Metrics(new MetricRegistry)
+  private val engine = Engine.DevEngine()
+  private val metrics = new Metrics(new MetricRegistry)
 
   "validateAndCommit" should {
 
@@ -196,12 +196,12 @@ class BatchedSubmissionValidatorSpec
         )
         .map { _ =>
           verify(mockCommit, times(nSubmissions)).commit(
-            any[ParticipantId](),
-            any[String](),
-            any[DamlLogEntryId](),
-            any[DamlLogEntry](),
-            any[DamlInputState](),
-            any[DamlOutputState]())
+            any[ParticipantId],
+            any[String],
+            any[DamlLogEntryId],
+            any[DamlLogEntry],
+            any[DamlInputState],
+            any[DamlOutputState])
           // Verify that the log entries have been committed in the right order.
           val logEntries = logEntryCaptor.getAllValues.asScala.map(_.asInstanceOf[DamlLogEntry])
           logEntries.map(_.getPartyAllocationEntry) should be(
@@ -252,12 +252,12 @@ class BatchedSubmissionValidatorSpec
         .map { _ =>
           // We must have 1 commit only (for the first submission).
           verify(mockCommit, times(1)).commit(
-            any[ParticipantId](),
-            any[String](),
-            any[DamlLogEntryId](),
-            any[DamlLogEntry](),
-            any[DamlInputState](),
-            any[DamlOutputState]())
+            any[ParticipantId],
+            any[String],
+            any[DamlLogEntryId],
+            any[DamlLogEntry],
+            any[DamlInputState],
+            any[DamlOutputState])
           succeed
         }
     }
@@ -353,12 +353,12 @@ class BatchedSubmissionValidatorSpec
         // We expected two state fetches and two commits.
         verify(mockLedgerStateReader, times(nSubmissions)).readState(any[Seq[DamlStateKey]]())
         verify(mockCommit, times(nSubmissions)).commit(
-          any[ParticipantId](),
-          any[String](),
-          any[DamlLogEntryId](),
-          any[DamlLogEntry](),
-          any[DamlInputState](),
-          any[DamlOutputState]())
+          any[ParticipantId],
+          any[String],
+          any[DamlLogEntryId],
+          any[DamlLogEntry],
+          any[DamlInputState],
+          any[DamlOutputState])
         // Verify we have all the expected log entries.
         val logEntries = logEntryCaptor.getAllValues.asScala.map(_.asInstanceOf[DamlLogEntry])
         logEntries.map(_.getPartyAllocationEntry) should contain allElementsOf


### PR DESCRIPTION
Summary of changes:
* Removed `record_time` field from DamlCommandDedupValue and DamlSubmissionDedupValue.
* Upped kvutils version to 6.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
