### PR TITLE
Support --profile-dir and --stack-traces in sandbox next

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -14,7 +14,7 @@ import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{TransactionVersions, Transaction => Tx}
 import com.daml.lf.transaction.Node._
 import com.daml.lf.value.{Value, ValueVersions}
-import java.nio.file.{Path, Paths}
+import java.nio.file.{Files, Path, Paths}
 
 /**
   * Allows for evaluating [[Commands]] and validating [[Transaction]]s.
@@ -398,9 +398,15 @@ final class Engine(config: Engine.Config) {
   def preloadPackage(pkgId: PackageId, pkg: Package): Result[Unit] =
     compiledPackages.addPackage(pkgId, pkg)
 
-  def startProfiling(profileDir: Path) = {
-    this.profileDir = Some(profileDir)
-    compiledPackages.profilingMode = speedy.Compiler.FullProfile
+  def setProfileDir(optProfileDir: Option[Path]) = {
+    optProfileDir match {
+      case None =>
+        compiledPackages.profilingMode = speedy.Compiler.NoProfile
+      case Some(profileDir) =>
+        Files.createDirectories(profileDir)
+        this.profileDir = Some(profileDir)
+        compiledPackages.profilingMode = speedy.Compiler.FullProfile
+    }
   }
 
   def enableStackTraces(enable: Boolean) = {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -132,12 +132,7 @@ final class SandboxServer(
     this(config, materializer, new Metrics(new MetricRegistry))
 
   // NOTE(MH): We must do this _before_ we load the first package.
-  config.profileDir match {
-    case None => ()
-    case Some(profileDir) =>
-      Files.createDirectories(profileDir)
-      engine.startProfiling(profileDir)
-  }
+  engine.setProfileDir(config.profileDir)
   engine.enableStackTraces(config.stackTraces)
 
   // Name of this participant

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -68,6 +68,8 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
   private[this] val engineConfig = Engine.DevConfig
 
   private val engine = new Engine(engineConfig)
+  engine.setProfileDir(config.profileDir)
+  engine.enableStackTraces(config.stackTraces)
 
   private val (ledgerType, ledgerJdbcUrl, indexJdbcUrl, startupMode): (
       String,
@@ -231,7 +233,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
               } yield {
                 Banner.show(Console.out)
                 logger.withoutContext.info(
-                  "Initialized sandbox version {} with ledger-id = {}, port = {}, dar file = {}, time mode = {}, ledger = {}, auth-service = {}, contract ids seeding = {}",
+                  "Initialized sandbox version {} with ledger-id = {}, port = {}, dar file = {}, time mode = {}, ledger = {}, auth-service = {}, contract ids seeding = {}{}{}",
                   BuildInfo.Version,
                   ledgerId,
                   apiServer.port.toString,
@@ -240,6 +242,11 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   ledgerType,
                   authService.getClass.getSimpleName,
                   seeding.toString.toLowerCase,
+                  if (config.stackTraces) "" else ", stack traces = no",
+                  config.profileDir match {
+                    case None => ""
+                    case Some(profileDir) => s", profile directory = ${profileDir}"
+                  },
                 )
                 apiServer
               }


### PR DESCRIPTION
So far, these two flags only worked in sandbox classic because I wasn't
aware the code path consuming the options is not shared between both
implementation. Now, sandbox next is en par with sandbox classic.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6531)
<!-- Reviewable:end -->
