### PR TITLE
Trigger service: change convention for updating running trigger store

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -101,8 +101,9 @@ class Server(
       triggerName: Identifier): Either[String, JsValue] = {
     for {
       trigger <- Trigger.fromIdentifier(compiledPackages, triggerName)
-      party = TokenManagement.decodeCredentials(secretKey, credentials)._1
       triggerInstance = UUID.randomUUID
+      _ <- triggerDao.addRunningTrigger(RunningTrigger(triggerInstance, triggerName, credentials))
+      party = TokenManagement.decodeCredentials(secretKey, credentials)._1
       _ = ctx.spawn(
         TriggerRunner(
           new TriggerRunner.Config(

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -46,7 +46,7 @@ class TriggerRunner(
       Behaviors
         .supervise(
           Behaviors
-            .supervise(TriggerRunnerImpl(ctx.self, config))
+            .supervise(TriggerRunnerImpl(config))
             .onFailure[InitializationHalted](stop)
         )
         .onFailure(

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -7,7 +7,6 @@ import akka.actor.typed.{Behavior, PostStop}
 import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.SupervisorStrategy._
 import akka.actor.typed.Signal
-import akka.actor.typed.PostStop
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.ActorContext
 import akka.stream.Materializer

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -47,7 +47,7 @@ object TriggerRunnerImpl {
   final private case class QueriedACS(runner: Runner, acs: Seq[CreatedEvent], offset: LedgerOffset)
       extends Message
 
-  def apply(parent: ActorRef[Message], config: Config)(
+  def apply(config: Config)(
       implicit esf: ExecutionSequencerFactory,
       mat: Materializer): Behavior[Message] =
     Behaviors.setup { ctx =>
@@ -55,7 +55,7 @@ object TriggerRunnerImpl {
       implicit val ec: ExecutionContext = ctx.executionContext
       // Report to the server that this trigger is starting.
       val runningTrigger =
-        RunningTrigger(config.triggerInstance, config.triggerName, config.credentials, parent)
+        RunningTrigger(config.triggerInstance, config.triggerName, config.credentials)
       config.server ! TriggerStarting(runningTrigger)
       ctx.log.info(s"Trigger $name is starting")
       val appId = ApplicationId(name)

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/package.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/package.scala
@@ -6,7 +6,6 @@ package com.daml.lf.engine
 import java.time.Duration
 import java.util.UUID
 
-import akka.actor.typed.ActorRef
 import com.daml.lf.data.Ref.Identifier
 import com.daml.platform.services.time.TimeProviderType
 
@@ -34,6 +33,5 @@ package object trigger {
       credentials: UserCredentials,
       // TODO(SF, 2020-0610): Add access token field here in the
       // presence of authentication.
-      runner: ActorRef[TriggerRunner.Message]
   )
 }


### PR DESCRIPTION
This modifies the convention for updating the running trigger store. Currently we add to the store when a TriggerRunnerImpl has started the runner and remove when it fails for some reason. With this change, we add immediately on a start request and remove only on a stop request. This changes the semantics of the running triggers from those which are actually running to those which have been requested to run. This both simplifies the code and helps make recovery using a database store more robust.

This change makes more sense when also changing the restart strategy for triggers to an unlimited number of restarts with an exponential backoff, so that a trigger requested to start is always "running".

One issue is that triggers which have no chance at running continuously, e.g. those with fatal errors in the code, will be restarted indefinitely (albeit with decreasing frequency). We could argue that is the fault of the client supplying the trigger and they can use the log for that trigger to figure out what went wrong and stop it if need be.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
