### PR TITLE
Fix DAML Script test for listKnownParties

### DIFF
--- a/daml-script/test/daml/MultiTest.daml
+++ b/daml-script/test/daml/MultiTest.daml
@@ -49,4 +49,4 @@ listKnownPartiesTest = do
   p2 <- allocatePartyOn "p2" (ParticipantName "two")
   parties1' <- listKnownPartiesOn (ParticipantName "one")
   parties2' <- listKnownPartiesOn (ParticipantName "two")
-  pure (parties1' \\ parties1, parties2' \\ parties2)
+  pure (sortOn displayName (parties1' \\ parties1), sortOn displayName (parties2' \\ parties2))

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/MultiParticipant.scala
@@ -4,6 +4,7 @@
 package com.daml.lf.engine.script.test
 
 import java.io.File
+import scala.collection.JavaConverters._
 import scalaz.syntax.traverse._
 
 import com.daml.lf.archive.Dar
@@ -13,6 +14,8 @@ import com.daml.lf.data.{FrontStack, FrontStackCons}
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Ref.{Party => LedgerParty}
 import com.daml.lf.language.Ast._
+import com.daml.lf.speedy.svalue
+import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId}
@@ -63,6 +66,7 @@ case class MultiPartyIdHintTest(dar: Dar[(PackageId, Package)], runner: TestRunn
 case class MultiListKnownPartiesTest(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId =
     Identifier(dar.main._1, QualifiedName.assertFromString("MultiTest:listKnownPartiesTest"))
+  implicit def `SValue Ordering`: Ordering[SValue] = svalue.Ordering
   def runTests() = {
     runner.genericTest(
       "listKnownPartiesTest",
@@ -75,24 +79,32 @@ case class MultiListKnownPartiesTest(dar: Dar[(PackageId, Package)], runner: Tes
                   FrontStackCons(
                     SRecord(_, _, x),
                     FrontStackCons(SRecord(_, _, y), FrontStack()))) =>
-                Right(Seq(x, y))
-              case v => Left(s"Exppected list with one element but got $v")
+                // We take the tail since we only want the display name and isLocal
+                Right(Seq(x, y).map(fs => Seq(fs.asScala: _*).tail))
+              case v => Left(s"Exppected list with two elements but got $v")
             }
-            newPartyDetails2 <- vals.get(0) match {
+            newPartyDetails2 <- vals.get(1) match {
               case SList(
                   FrontStackCons(
                     SRecord(_, _, x),
                     FrontStackCons(SRecord(_, _, y), FrontStack()))) =>
-                Right(Seq(x, y))
-              case v => Left(s"Exppected list with one element but got $v")
+                Right(Seq(x, y).map(fs => Seq(fs.asScala: _*).tail))
+              case v => Left(s"Exppected list with two elements but got $v")
             }
-            // Note that at this point ledger-on-memory will return both parties on both
-            // participants with is_local = true so we cannot do the check you
-            // might expect here.
-            _ <- TestRunner.assertEqual(newPartyDetails1.length, 2, "partyDetails1 length")
-            _ <- TestRunner.assertEqual(newPartyDetails2.length, 2, "partyDetails2 length")
             _ <- TestRunner
-              .assertEqual(newPartyDetails1, newPartyDetails2, "partyDetails are equal")
+              .assertEqual(
+                newPartyDetails1,
+                Seq(
+                  Seq[SValue](SOptional(Some(SText("p1"))), SBool(true)),
+                  Seq[SValue](SOptional(Some(SText("p2"))), SBool(false))),
+                "partyDetails1")
+            _ <- TestRunner
+              .assertEqual(
+                newPartyDetails2,
+                Seq(
+                  Seq[SValue](SOptional(Some(SText("p1"))), SBool(false)),
+                  Seq[SValue](SOptional(Some(SText("p2"))), SBool(true))),
+                "partyDetails2")
           } yield ()
       }
     )


### PR DESCRIPTION
Apart from the current test being broken since it tested the
vals.get(0) twice :facepalm: we can now also test is_local properly
since the issue mentioned in the comment has been fixed in #6533.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
