### PR TITLE
Use Distroless for the Java Docker base image.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -737,10 +737,11 @@ container_deps()
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
-    name = "openjdk_base",
-    registry = "docker.io",
-    repository = "openjdk",
-    tag = "8-alpine",
+    name = "java_base",
+    digest = "sha256:7cef6d99241bc86e09659d41842e3656a1cab99adf0e440a44d2858c8e52a71a",
+    registry = "gcr.io",
+    repository = "distroless/java",
+    tag = "8",
 )
 
 load("@io_bazel_rules_docker//java:image.bzl", java_image_repositories = "repositories")

--- a/deps.bzl
+++ b/deps.bzl
@@ -151,9 +151,9 @@ def daml_deps():
     if "io_bazel_rules_docker" not in native.existing_rules():
         http_archive(
             name = "io_bazel_rules_docker",
-            url = "https://github.com/bazelbuild/rules_docker/releases/download/v0.12.1/rules_docker-v0.12.1.tar.gz",
-            strip_prefix = "rules_docker-0.12.1",
-            sha256 = "14ac30773fdb393ddec90e158c9ec7ebb3f8a4fd533ec2abbfd8789ad81a284b",
+            url = "https://github.com/bazelbuild/rules_docker/releases/download/v0.14.3/rules_docker-v0.14.3.tar.gz",
+            strip_prefix = "rules_docker-0.14.3",
+            sha256 = "6287241e033d247e9da5ff705dd6ef526bac39ae82f3d17de1b69f8cb313f9cd",
         )
 
     if "com_google_protobuf" not in native.existing_rules():

--- a/dev-env/bin/docker-credential-gcloud
+++ b/dev-env/bin/docker-credential-gcloud
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -180,7 +180,7 @@ conformance_test(
 
 java_image(
     name = "app-image",
-    base = "@openjdk_base//image",
+    base = "@java_base//image",
     main_class = "com.daml.ledger.on.memory.Main",
     resources = ["src/app/resources/logback.xml"],
     visibility = ["//visibility:public"],

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -178,7 +178,7 @@ genrule(
 
 container_image(
     name = "sandbox-image-base",
-    base = "@openjdk_base//image",
+    base = "@java_base//image",
     cmd = None,
     directory = "/usr/bin",
     files = [

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -222,8 +222,9 @@ in rec {
     # Cloud tools
     aws = pkgs.awscli;
     gcloud = pkgs.google-cloud-sdk;
-    bq     = gcloud;
+    bq = gcloud;
     gsutil = gcloud;
+    docker-credential-gcloud = gcloud;
     # used to set up the webide CI pipeline in azure-cron.yml
     docker-credential-gcr = pkgs.docker-credential-gcr;
     # Note: we need to pin Terraform to 0.11 until nixpkgs includes a version


### PR DESCRIPTION
We switched away from Distroless because it was causing issues with `docker pull` when you had Docker configured to use `gcloud` for authentication, but weren't actually authenticated.

Adding `docker-credential-gcloud` to dev-env should hopefully fix this, meaning we can switch back to a base image that is better-maintained.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
