### PR TITLE
Fix damlc test with relative --project-root

### DIFF
--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -194,6 +194,23 @@ testsForDamlcTest damlc = testGroup "damlc test" $
           exitCode @?= ExitSuccess
           assertBool ("Succeeding scenario in " <> stdout) ("Main.daml:test: ok" `isInfixOf` stdout)
           stderr @?= ""
+    , testCase "damlc test --project-root relative" $ withTempDir $ \projDir -> do
+          createDirectoryIfMissing True (projDir </> "relative")
+          writeFileUTF8 (projDir </> "relative" </> "Main.daml") $ unlines
+            [ "daml 1.2"
+            , "module Main where"
+            , "test = scenario do"
+            , "  assert True"
+            ]
+          writeFileUTF8 (projDir </> "relative" </> "daml.yaml") $ unlines
+            [ "sdk-version: " <> sdkVersion
+            , "name: relative"
+            , "version: 0.0.1"
+            , "source: ."
+            , "dependencies: [daml-prim, daml-stdlib]"
+            ]
+          withCurrentDirectory projDir $
+              callProcessSilent damlc ["test", "--project-root=relative"]
     ] <>
     [ testCase ("damlc test " <> unwords (args "") <> " in project") $ withTempDir $ \projDir -> do
           createDirectoryIfMissing True (projDir </> "a")

--- a/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
+++ b/daml-assistant/daml-project-config/DA/Daml/Project/Consts.hs
@@ -173,10 +173,10 @@ withProjectRoot mbProjectDir (ProjectCheck cmdName check) act = do
             when check $ do
                 hPutStrLn stderr (cmdName <> ": Not in project.")
                 exitFailure
-            act mbProjectPath pure
+            act Nothing pure
         Just projectPath -> do
             projectPath <- canonicalizePath projectPath
-            withCurrentDirectory projectPath $ act mbProjectPath $ \f -> do
+            withCurrentDirectory projectPath $ act (Just projectPath) $ \f -> do
                 absF <- canonicalizePath (previousCwd </> f)
                 pure (projectPath `makeRelative` absF)
 


### PR DESCRIPTION
Returning the original relative path from withProjectRoot makes no
sense since we change the directory in there so this PR fixes this to
return the canonicalized project root.

fixes #6245

changelog_begin

- [DAML Compiler] damlc test --project-root now works with relative
  paths as well.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
