### PR TITLE
Disable scenario service during packaging

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -70,7 +70,7 @@ import SdkVersion
 --   and then remap references to those dummy packages to the original DAML-LF
 --   package id.
 createProjectPackageDb :: NormalizedFilePath -> Options -> PackageSdkVersion -> MS.Map UnitId GHC.ModuleName -> [FilePath] -> [FilePath] -> IO ()
-createProjectPackageDb projectRoot opts thisSdkVer modulePrefixes deps dataDeps
+createProjectPackageDb projectRoot (disableScenarioService -> opts) thisSdkVer modulePrefixes deps dataDeps
   | null dataDeps && all (`elem` basePackages) deps =
     -- Initializing the package db is expensive since it requires calling GenerateStablePackages and GeneratePackageMap.
     --Therefore we only do it if we actually have a dependency.
@@ -193,6 +193,11 @@ createProjectPackageDb projectRoot opts thisSdkVer modulePrefixes deps dataDeps
         -- reinitializing everything, we probably want to change this.
         removePathForcibly dbPath
         createDirectoryIfMissing True $ dbPath </> "package.conf.d"
+
+disableScenarioService :: Options -> Options
+disableScenarioService opts = opts
+  { optScenarioService = EnableScenarioService False
+  }
 
 toGhcModuleName :: LF.ModuleName -> GHC.ModuleName
 toGhcModuleName = GHC.mkModuleName . T.unpack . LF.moduleNameString


### PR DESCRIPTION
For `damlc test` and `damlc ide`, `optScenarioService` is (correctly)
enabled. However, every call to `withDamlIdeState` will spawn a
scenario service. This means that during package initialization we
will spawn at least one extra scenario service (potentially) more. On
a simple project this gets `damlc test` from 10s down to 7s and I see
a noticeable (although hard to measure) speedup in IDE startup time.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
