### PR TITLE
`CommitContext` records accessed input keys

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -29,7 +29,7 @@ private[kvutils] trait CommitContext {
   private val outputs: mutable.Map[DamlStateKey, DamlStateValue] =
     mutable.HashMap.empty[DamlStateKey, DamlStateValue]
   private val accessedInputKeys: mutable.Set[DamlStateKey] =
-    mutable.LinkedHashSet.empty[DamlStateKey]
+    mutable.Set.empty[DamlStateKey]
 
   def getEntryId: DamlLogEntryId
   def getMaximumRecordTime: Timestamp
@@ -69,8 +69,8 @@ private[kvutils] trait CommitContext {
         case _ => false
       }
 
-  /** Get the accessed input keys, in access order. */
-  def getAccessedInputKeys: Iterable[DamlStateKey] =
+  /** Get the accessed input key set. */
+  def getAccessedInputKeys: collection.Set[DamlStateKey] =
     accessedInputKeys
 
   private def inputAlreadyContains(key: DamlStateKey, value: DamlStateValue): Boolean =

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -28,21 +28,19 @@ class CommitContextSpec extends WordSpec with Matchers {
       context.get(aKey) shouldBe Some(aValue)
     }
 
-    // If the access order is deterministic, then the iteration order is not just stable but also deterministic.
-    "records all accessed input keys and iterates over them in a stable order" in {
+    "record all accessed input keys" in {
       val context = newInstance(Map(aKey -> Some(aValue), anotherKey -> Some(anotherValue)))
       context.get(aKey)
       context.get(anotherKey)
-      context.get(aKey)
 
-      context.getAccessedInputKeys.toSeq shouldBe Seq(aKey, anotherKey)
+      context.getAccessedInputKeys shouldBe Set(aKey, anotherKey)
     }
 
-    "does not record input keys that are not accessed" in {
+    "not record input keys that are not accessed" in {
       val context = newInstance(Map(aKey -> Some(aValue), anotherKey -> Some(anotherValue)))
       context.get(aKey)
 
-      context.getAccessedInputKeys.toSeq shouldBe Seq(aKey)
+      context.getAccessedInputKeys shouldBe Set(aKey)
     }
 
     "throw in case key cannot be found" in {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -38,6 +38,13 @@ class CommitContextSpec extends WordSpec with Matchers {
       context.getAccessedInputKeys.toSeq shouldBe Seq(aKey, anotherKey)
     }
 
+    "does not record input keys that are not accessed" in {
+      val context = newInstance(Map(aKey -> Some(aValue), anotherKey -> Some(anotherValue)))
+      context.get(aKey)
+
+      context.getAccessedInputKeys.toSeq shouldBe Seq(aKey)
+    }
+
     "throw in case key cannot be found" in {
       val context = newInstance()
       assertThrows[MissingInputState](context.get(aKey))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -28,6 +28,22 @@ class CommitContextSpec extends WordSpec with Matchers {
       context.get(aKey) shouldBe Some(aValue)
     }
 
+    "record accessed input keys" in {
+      val context = newInstance(Map(aKey -> Some(aValue)))
+      context.get(aKey)
+      context.getAccessedInputKeys.size shouldBe 1
+      context.getAccessedInputKeys.head shouldBe aKey
+    }
+
+    "maintain the order of accessed input keys based on when they were accessed first" in {
+      val context = newInstance(Map(aKey -> Some(aValue), anotherKey -> Some(anotherValue)))
+      context.get(aKey)
+      context.get(anotherKey)
+      context.get(aKey)
+
+      context.getAccessedInputKeys.toSeq shouldBe Seq(aKey, anotherKey)
+    }
+
     "throw in case key cannot be found" in {
       val context = newInstance()
       assertThrows[MissingInputState](context.get(aKey))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -28,14 +28,7 @@ class CommitContextSpec extends WordSpec with Matchers {
       context.get(aKey) shouldBe Some(aValue)
     }
 
-    "record accessed input keys" in {
-      val context = newInstance(Map(aKey -> Some(aValue)))
-      context.get(aKey)
-      context.getAccessedInputKeys.size shouldBe 1
-      context.getAccessedInputKeys.head shouldBe aKey
-    }
-
-    "maintain the order of accessed input keys based on when they were accessed first" in {
+    "records all accessed input keys and iterates over them in a stable order" in {
       val context = newInstance(Map(aKey -> Some(aValue), anotherKey -> Some(anotherValue)))
       context.get(aKey)
       context.get(anotherKey)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -28,6 +28,7 @@ class CommitContextSpec extends WordSpec with Matchers {
       context.get(aKey) shouldBe Some(aValue)
     }
 
+    // If the access order is deterministic, then the iteration order is not just stable but also deterministic.
     "records all accessed input keys and iterates over them in a stable order" in {
       val context = newInstance(Map(aKey -> Some(aValue), anotherKey -> Some(anotherValue)))
       context.get(aKey)


### PR DESCRIPTION
Enables `CommitContext` to record and output (without iteration requirements) the input keys that were accessed.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
