### PR TITLE
Daml REPL - use data dependencies

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Packaging/Metadata.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Packaging/Metadata.hs
@@ -36,7 +36,7 @@ data PackageDbMetadata = PackageDbMetadata
   { directDependencies :: [Ghc.UnitId]
   -- ^ Unit ids of direct dependencies. These are exposed by default
   , moduleRenamings :: Map Ghc.UnitId (Ghc.ModuleName, [LF.ModuleName])
-  -- ^ Map frm GHC unit id to the prefix and a list of all modules in this package.
+  -- ^ Map from GHC unit id to the prefix and a list of all modules in this package.
   -- We do not bother differentiating between exposed and unexposed modules
   -- since we already warn on non-exposed modules anyway and this
   -- is intended for data-dependencies where everything is exposed.

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -614,6 +614,7 @@ execRepl projectOpts opts scriptDar mainDar ledgerHost ledgerPort mbAuthToken mb
                     , "- daml-prim"
                     , "- daml-stdlib"
                     , "- " <> show scriptDar
+                    , "data-dependencies:"
                     , "- " <> show mainDar
                     ]
                 initPackageDb opts (InitPkgDb True)

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -292,9 +292,38 @@ da_haskell_test(
 )
 
 genrule(
+    name = "repl-test-indirect",
+    srcs = [
+        "ReplTestIndirect.daml",
+    ],
+    outs = ["repl-test-indirect.dar"],
+    cmd = """
+      set -eou pipefail
+      TMP_DIR=$$(mktemp -d)
+      mkdir -p $$TMP_DIR/daml
+      cp -L $(location ReplTestIndirect.daml) $$TMP_DIR/daml
+      cat << EOF > $$TMP_DIR/daml.yaml
+sdk-version: {sdk}
+name: repl-test-indirect
+source: daml
+version: 0.1.0
+dependencies:
+  - daml-stdlib
+  - daml-prim
+build-options: ["--ghc-option", "-Werror"]
+EOF
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR -o $$PWD/$(location repl-test-indirect.dar)
+      rm -rf $$TMP_DIR
+    """.format(sdk = sdk_version),
+    tools = ["//compiler/damlc"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
     name = "repl-test",
     srcs = [
         "ReplTest.daml",
+        "repl-test-indirect.dar",
     ],
     outs = ["repl-test.dar"],
     cmd = """
@@ -302,6 +331,7 @@ genrule(
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
       cp -L $(location ReplTest.daml) $$TMP_DIR/daml
+      cp -L $(location repl-test-indirect.dar) $$TMP_DIR
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: repl-test
@@ -310,6 +340,7 @@ version: 0.1.0
 dependencies:
   - daml-stdlib
   - daml-prim
+  - repl-test-indirect.dar
 build-options: ["--ghc-option", "-Werror"]
 EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR -o $$PWD/$(location repl-test.dar)

--- a/compiler/damlc/tests/ReplTest.daml
+++ b/compiler/damlc/tests/ReplTest.daml
@@ -4,6 +4,8 @@
 
 module ReplTest where
 
+import ReplTestIndirect
+
 template T
   with
     proposer : Party
@@ -20,5 +22,5 @@ template TProposal
     observer accepter
     choice Accept : ContractId T
       controller accepter
-      do  create (T proposer accepter)
+      do  myCreate (T proposer accepter)
 

--- a/compiler/damlc/tests/ReplTestIndirect.daml
+++ b/compiler/damlc/tests/ReplTestIndirect.daml
@@ -1,0 +1,8 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module ReplTestIndirect where
+
+-- Re-export create to test transitive DAR dependencies in the REPL.
+myCreate : HasCreate t => t -> Update (ContractId t)
+myCreate = create

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -87,6 +87,7 @@ initPackageConfig scriptDar testDar = do
         , "- daml-prim"
         , "- daml-stdlib"
         , "- " <> show scriptDar
+        , "data-dependencies:"
         , "- " <> show testDar
         ]
     withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do


### PR DESCRIPTION
The generated `daml.yaml` declares `data-dependencies` on the specified DAR rather than `dependencies`. This enables load DARs with transitive DAR dependencies into the REPL. The REPL test's DAR is modified to include a transitive DAR dependency.

Note, loading a DAR that was generated with an older SDK still fails if the DAR itself depends on `daml-script` with an error of the form
```
Transitive dependencies with same unit id but conflicting package ids: daml-script-0.0.1 [01d759e0639449ee8de4766e32c9d963007b0404af3b7c0c2039e7a29b722f75,afc00281e795979ba84cedbe3ece16cab3accb50b0d0b331168e414bf4dd9bbb]
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
