### PR TITLE
Fix the package version of daml-trigger and daml-script

### DIFF
--- a/daml-script/daml/BUILD.bazel
+++ b/daml-script/daml/BUILD.bazel
@@ -27,7 +27,7 @@ DAML_LF_VERSIONS = [
 sdk-version: {sdk}
 name: daml-script
 source: daml
-version: 0.0.1
+version: {sdk}
 dependencies:
   - daml-stdlib
   - daml-prim

--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -31,7 +31,7 @@ DAML_LF_VERSIONS = [
 sdk-version: {sdk}
 name: daml-trigger
 source: daml
-version: 0.0.1
+version: {sdk}
 dependencies:
   - daml-stdlib
   - daml-prim


### PR DESCRIPTION
It makes no sense to keep this at 0.0.1.

changelog_begin

- [DAML Script] The DAML Script library now has the version of the
  corresponding SDK.

- [DAML Trigger] The DAML Trigger library now has the version of the
  corresponding SDK.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
