### PR TITLE
make @silent annotations narrower

### DIFF
--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -71,7 +71,7 @@ da_scala_test(
     plugins = [
         "@maven//:com_github_ghik_silencer_plugin_2_12_11",
     ],
-    scalacopts = lf_scalacopts,
+    scalacopts = lf_scalacopts + ["-P:silencer:checkUnused"],
     deps = [
         ":transaction",
         ":transaction_java_proto",

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/crypto/HashSpec.scala
@@ -17,7 +17,7 @@ import scala.language.implicitConversions
 
 class HashSpec extends WordSpec with Matchers {
 
-  @com.github.ghik.silencer.silent // dead code. Well, yeah
+  @com.github.ghik.silencer.silent("dead code following this construct")
   private implicit val ordNo: scalaz.Order[Nothing] = (a, _) => a // principle of explosion
 
   private val packageId0 = Ref.PackageId.assertFromString("package")

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -155,7 +155,7 @@ object Queries {
       sql"""INSERT INTO ledger_offset VALUES ($party, $tpid, $newOffset)""".update.run
     )
 
-  @silent // pas is demonstrably used; try taking it out
+  @silent(" pas .* never used")
   def insertContracts[F[_]: cats.Foldable: Functor, CK: JsonWriter, PL: JsonWriter](
       dbcs: F[DBContract[SurrogateTpId, CK, PL, Seq[String]]])(
       implicit log: LogHandler,
@@ -194,7 +194,7 @@ object Queries {
     hd ++ go(0, tl.size)
   }
 
-  @silent // gvs is demonstrably used; try taking it out
+  @silent(" gvs .* never used")
   private[http] def selectContracts(party: String, tpid: SurrogateTpId, predicate: Fragment)(
       implicit log: LogHandler,
       gvs: Get[Vector[String]]): Query0[DBContract[Unit, JsValue, JsValue, Vector[String]]] = {

--- a/ledger/ledger-api-client/BUILD.bazel
+++ b/ledger/ledger-api-client/BUILD.bazel
@@ -37,6 +37,7 @@ da_scala_test_suite(
     plugins = [
         "@maven//:com_github_ghik_silencer_plugin_2_12_11",
     ],
+    scalacopts = ["-P:silencer:checkUnused"],
     deps = [
         ":ledger-api-client",
         "//language-support/scala/bindings",

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/configuration/LedgerIdRequirementTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/configuration/LedgerIdRequirementTest.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.client.configuration
 import com.github.ghik.silencer.silent
 import org.scalatest.{Matchers, WordSpec}
 
-@silent("deprecated")
+@silent("LedgerIdRequirement is deprecated \\(since 1.3.0\\): Use Option-based (copy|constructor)")
 class LedgerIdRequirementTest extends WordSpec with Matchers {
 
   "LedgerIdRequirement" when {

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -14,6 +14,7 @@ da_scala_library(
         "@maven//:org_spire_math_kind_projector_2_12",
         "@maven//:com_github_ghik_silencer_plugin_2_12_11",
     ],
+    scalacopts = ["-P:silencer:checkUnused"],
     tags = ["maven_coordinates=com.daml:ledger-api-common:__VERSION__"],
     visibility = [
         "//visibility:public",

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherImpl.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherImpl.scala
@@ -34,7 +34,7 @@ final class DispatcherImpl[Index: Ordering](
 
   // the following silent are due to
   // <https://github.com/scala/bug/issues/4440>
-  @silent
+  @silent("The outer reference in this type test cannot be checked at run time")
   private final case class Running(lastIndex: Index, signalDispatcher: SignalDispatcher)
       extends State {
     override def getLastIndex: Index = lastIndex
@@ -42,7 +42,7 @@ final class DispatcherImpl[Index: Ordering](
     override def getSignalDispatcher: Option[SignalDispatcher] = Some(signalDispatcher)
   }
 
-  @silent
+  @silent("The outer reference in this type test cannot be checked at run time")
   private final case class Closed(lastIndex: Index) extends State {
     override def getLastIndex: Index = lastIndex
 

--- a/ledger/participant-state/BUILD.bazel
+++ b/ledger/participant-state/BUILD.bazel
@@ -14,6 +14,7 @@ da_scala_library(
         "@maven//:com_github_ghik_silencer_plugin_2_12_11",
     ],
     resources = glob(["src/main/resources/**/*"]),
+    scalacopts = ["-P:silencer:checkUnused"],
     tags = ["maven_coordinates=com.daml:participant-state:__VERSION__"],
     visibility = [
         "//visibility:public",

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -23,6 +23,7 @@ da_scala_library(
     plugins = [
         "@maven//:com_github_ghik_silencer_plugin_2_12_11",
     ],
+    scalacopts = ["-P:silencer:checkUnused"],
     tags = ["maven_coordinates=com.daml:participant-state-kvutils:__VERSION__"],
     visibility = [
         "//visibility:public",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
@@ -32,7 +32,8 @@ trait LedgerWriter extends ReportsHealth {
     * @return future for sending the submission; for possible results see
     *         [[com.daml.ledger.participant.state.v1.SubmissionResult]]
     */
-  @silent("deprecated")
+  @silent(
+    "method commit in trait LedgerWriter is deprecated \\(since 1.3.0\\): Will be removed in 1.4.0")
   def commit(
       correlationId: String,
       envelope: Bytes,

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WriteService.scala
@@ -95,7 +95,8 @@ trait WriteService
     *                                    handling submitted transactions differently.
     * @return an async result of a SubmissionResult
     */
-  @silent("deprecated")
+  @silent(
+    "method submitTransaction in trait WriteService is deprecated \\(since 1.3.0\\): Will be removed in 1.4.0")
   def submitTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,


### PR DESCRIPTION
We can be specific about what warnings we're silencing, so do that everywhere. We also fail if the silence is no longer needed, so should be removed.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
