### PR TITLE
Only ship disclosure information once in scenario service

### DIFF
--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -398,10 +398,6 @@ message Party {
   string party = 1;
 }
 
-message NodeAndParties {
-  NodeId node_id = 1;
-  repeated Party parties = 2;
-}
 message Disclosure {
   Party party = 1;
   int32 since_tx_id = 2;
@@ -496,10 +492,6 @@ message Transaction {
   sfixed64 effectiveAt = 2;
   repeated NodeId roots = 3;
   repeated NodeId nodes = 4;
-
-  // Transaction nodes that must be disclosed to individual parties
-  // to make this transaction valid.
-  repeated NodeAndParties disclosures = 5;
 
   // If non-empty, the transaction failed due to these failed authorizations.
   FailedAuthorizations failed_authorizations = 6;

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -360,20 +360,6 @@ final class Conversions(
       .setEffectiveAt(rtx.effectiveAt.micros)
       .addAllRoots(rtx.transaction.roots.map(convertNodeId(rtx.transactionId, _)).toSeq.asJava)
       .addAllNodes(rtx.transaction.nodes.keys.map(convertNodeId(rtx.transactionId, _)).asJava)
-      // previously rtx.disclosures returned both global and local implicit disclosures, but this is not the case anymore
-      // therefore we need to explicitly add the contracts that are divulged directly (via ContractId rather than ScenarioNodeId)
-      .addAllDisclosures(
-        (rtx
-          .disclosures(coidToEventId))
-          .toSeq
-          .map {
-            case (nodeId, parties) =>
-              proto.NodeAndParties.newBuilder
-                .setNodeId(convertEventId(nodeId))
-                .addAllParties(parties.map(convertParty).asJava)
-                .build
-          }
-          .asJava)
       .setFailedAuthorizations(convertFailedAuthorizations(rtx.failedAuthorizations))
       .build
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -82,13 +82,7 @@ object ScenarioLedger {
       explicitDisclosure: Relation[Tx.NodeId, Party],
       globalImplicitDisclosure: Relation[ContractId, Party],
       failedAuthorizations: FailedAuthorizations,
-  ) {
-    def disclosures(coidToEventId: ContractId => EventId): Relation[EventId, Party] =
-      Relation.union(
-        Relation.mapKeys(explicitDisclosure)(EventId(transactionId, _)),
-        Relation.mapKeys(globalImplicitDisclosure)(coidToEventId),
-      )
-  }
+  )
 
   object RichTransaction {
 


### PR DESCRIPTION
Currently, the scenario service ships the disclosure information of a
transaction twice. One of the two copies is completely unused. This PR
simply deletes it. I hope this reduces confusion in the future.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6578)
<!-- Reviewable:end -->
