### PR TITLE
update versions bbased on git tags

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -480,7 +480,7 @@ jobs:
 
   - job: compat_versions_pr
     dependsOn:
-    - release
+    #- release
     - check_for_release
     pool:
       name: linux-pool

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -480,7 +480,7 @@ jobs:
 
   - job: compat_versions_pr
     dependsOn:
-    #- release
+    - release
     - check_for_release
     pool:
       name: linux-pool

--- a/compatibility/update-versions.sh
+++ b/compatibility/update-versions.sh
@@ -2,11 +2,14 @@
 # Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+set -euo pipefail
 
 cd "$(dirname "$0")"
 eval "$(../dev-env/bin/dade-assist)"
 
-bazel run //versions:update-versions -- -o $PWD/versions.bzl
+# Note: not using Bazel run so we actually have access to local files to run
+# `git tag`
+bazel run --run_under "cd $PWD &&" //versions:update-versions -- -o $PWD/versions.bzl
 
 # We refer to latest_stable_version so this might need changing.
 bazel run @unpinned_maven//:pin

--- a/compatibility/versions/BUILD
+++ b/compatibility/versions/BUILD
@@ -16,6 +16,7 @@ da_haskell_binary(
         "lens",
         "memory",
         "optparse-applicative",
+        "process",
         "semver",
         "text",
         "unordered-containers",


### PR DESCRIPTION
We currently run the update script as part of the release process. This causes an issue (highlighted by @cocreature in #6560): the update script currently relies on querying the docs website to get the list of versions, but the docs website is updated on a cron, which means by the time we run the update script it is not up-to-date yet.

This PR changes the update script to instead rely on the local git repo and its list of tags, as that is updated synchronously.

CHANGELOG_BEGIN
CHANGELOG_END