### PR TITLE
Make ledger-api-auth classes private

### DIFF
--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/ActiveContractsServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/ActiveContractsServiceImpl.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.rxjava.grpc.helpers
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services.ActiveContractsServiceAuthorization
+import com.daml.ledger.api.auth.internal.services.ActiveContractsServiceAuthorization
 import com.daml.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc.ActiveContractsService
 import com.daml.ledger.api.v1.active_contracts_service.{
   ActiveContractsServiceGrpc,

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/CommandCompletionServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/CommandCompletionServiceImpl.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.rxjava.grpc.helpers
 
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services.CommandCompletionServiceAuthorization
+import com.daml.ledger.api.auth.internal.services.CommandCompletionServiceAuthorization
 import com.daml.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc.CommandCompletionService
 import com.daml.ledger.api.v1.command_completion_service._
 import io.grpc.ServerServiceDefinition

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/CommandServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/CommandServiceImpl.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.rxjava.grpc.helpers
 
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services.CommandServiceAuthorization
+import com.daml.ledger.api.auth.internal.services.CommandServiceAuthorization
 import com.daml.ledger.api.v1.command_service.CommandServiceGrpc.CommandService
 import com.daml.ledger.api.v1.command_service._
 import com.google.protobuf.empty.Empty

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/CommandSubmissionServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/CommandSubmissionServiceImpl.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.rxjava.grpc.helpers
 
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services.CommandSubmissionServiceAuthorization
+import com.daml.ledger.api.auth.internal.services.CommandSubmissionServiceAuthorization
 import com.daml.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc.CommandSubmissionService
 import com.daml.ledger.api.v1.command_submission_service.{
   CommandSubmissionServiceGrpc,

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerConfigurationServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerConfigurationServiceImpl.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.rxjava.grpc.helpers
 
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services.LedgerConfigurationServiceAuthorization
+import com.daml.ledger.api.auth.internal.services.LedgerConfigurationServiceAuthorization
 import com.daml.ledger.api.v1.ledger_configuration_service.LedgerConfigurationServiceGrpc.LedgerConfigurationService
 import com.daml.ledger.api.v1.ledger_configuration_service.{
   GetLedgerConfigurationRequest,

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerIdentityServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerIdentityServiceImpl.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.rxjava.grpc.helpers
 
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services.LedgerIdentityServiceAuthorization
+import com.daml.ledger.api.auth.internal.services.LedgerIdentityServiceAuthorization
 import com.daml.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc.LedgerIdentityService
 import com.daml.ledger.api.v1.ledger_identity_service.{
   GetLedgerIdentityRequest,

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServices.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/LedgerServices.scala
@@ -11,8 +11,12 @@ import com.daml.ledger.rxjava.grpc._
 import com.daml.ledger.rxjava.grpc.helpers.TransactionsServiceImpl.LedgerItem
 import com.daml.ledger.rxjava.{CommandCompletionClient, LedgerConfigurationClient, PackageClient}
 import com.daml.grpc.adapter.{ExecutionSequencerFactory, SingleThreadExecutionSequencerPool}
-import com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor
-import com.daml.ledger.api.auth.{AuthService, AuthServiceWildcard, Authorizer}
+import com.daml.ledger.api.auth.{
+  AuthService,
+  AuthServiceWildcard,
+  AuthorizationInterceptor,
+  Authorizer
+}
 import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.daml.ledger.api.v1.command_completion_service.{
   CompletionEndResponse,

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/PackageServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/PackageServiceImpl.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.rxjava.grpc.helpers
 
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services.PackageServiceAuthorization
+import com.daml.ledger.api.auth.internal.services.PackageServiceAuthorization
 import com.daml.ledger.api.v1.package_service.PackageServiceGrpc.PackageService
 import com.daml.ledger.api.v1.package_service._
 import io.grpc.ServerServiceDefinition

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TimeServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TimeServiceImpl.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.rxjava.grpc.helpers
 
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services.TimeServiceAuthorization
+import com.daml.ledger.api.auth.internal.services.TimeServiceAuthorization
 import com.daml.ledger.api.v1.testing.time_service.TimeServiceGrpc.TimeService
 import com.daml.ledger.api.v1.testing.time_service.{
   GetTimeRequest,

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionsServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionsServiceImpl.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.rxjava.grpc.helpers.TransactionsServiceImpl.{
   ledgerOffsetOrdering
 }
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services.TransactionServiceAuthorization
+import com.daml.ledger.api.auth.internal.services.TransactionServiceAuthorization
 import com.daml.ledger.api.v1.event.Event
 import com.daml.ledger.api.v1.event.Event.Event.{Archived, Created, Empty}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthorizationInterceptor.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthorizationInterceptor.scala
@@ -1,19 +1,11 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.interceptor
+package com.daml.ledger.api.auth
 
-import com.daml.ledger.api.auth.{AuthService, Claims}
+import com.daml.ledger.api.auth.internal.AsyncForwardingListener
 import com.daml.platform.server.api.validation.ErrorFactories.unauthenticated
-import io.grpc.{
-  Context,
-  Contexts,
-  Metadata,
-  ServerCall,
-  ServerCallHandler,
-  ServerInterceptor,
-  Status
-}
+import io.grpc._
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.compat.java8.FutureConverters

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Authorizer.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.api.auth
 
 import java.time.Instant
 
-import com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor
+import com.daml.ledger.api.auth.internal.OngoingAuthorizationObserver
 import com.daml.ledger.api.v1.transaction_filter.TransactionFilter
 import com.daml.platform.server.api.validation.ErrorFactories.permissionDenied
 import io.grpc.stub.{ServerCallStreamObserver, StreamObserver}

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/AsyncForwardingListener.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/AsyncForwardingListener.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.interceptor
+package com.daml.ledger.api.auth.internal
 
 import io.grpc.ServerCall
 
@@ -13,13 +13,13 @@ import scala.collection.mutable
   *
   * The target listener is usually created through `Contexts.interceptCall` or `ServerCallHandler.startCall`.
   * */
-abstract class AsyncForwardingListener[ReqT] extends ServerCall.Listener[ReqT] {
+abstract private[auth] class AsyncForwardingListener[ReqT] extends ServerCall.Listener[ReqT] {
   protected type Listener = ServerCall.Listener[ReqT]
   private[this] val lock = new Object
   private[this] val stash: mutable.ListBuffer[Listener => Unit] = new mutable.ListBuffer
   private[this] var nextListener: Option[Listener] = None
 
-  private def enqueueOrProcess(msg: Listener => Unit): Unit = lock.synchronized {
+  private[this] def enqueueOrProcess(msg: Listener => Unit): Unit = lock.synchronized {
     if (nextListener.isDefined) {
       msg(nextListener.get)
     } else {

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/OngoingAuthorizationObserver.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/OngoingAuthorizationObserver.scala
@@ -1,11 +1,12 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth
+package com.daml.ledger.api.auth.internal
 
+import com.daml.ledger.api.auth.Claims
 import io.grpc.stub.ServerCallStreamObserver
 
-final class OngoingAuthorizationObserver[A](
+final private[auth] class OngoingAuthorizationObserver[A](
     observer: ServerCallStreamObserver[A],
     claims: Claims,
     authorized: Claims => Boolean,

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/ActiveContractsServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/ActiveContractsServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/CommandCompletionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/CommandCompletionServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/CommandServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/CommandServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/CommandSubmissionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/CommandSubmissionServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/ConfigManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/ConfigManagementServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/LedgerConfigurationServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/LedgerConfigurationServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/LedgerIdentityServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/LedgerIdentityServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/PackageManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/PackageManagementServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/PackageServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/PackageServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/PartyManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/PartyManagementServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/TimeServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/TimeServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/TransactionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/internal/services/TransactionServiceAuthorization.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.api.auth.services
+package com.daml.ledger.api.auth.internal.services
 
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.auth.Authorizer

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServices.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/ApiServices.scala
@@ -7,7 +7,7 @@ import akka.stream.Materializer
 import com.daml.api.util.TimeProvider
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.ledger.api.auth.Authorizer
-import com.daml.ledger.api.auth.services._
+import com.daml.ledger.api.auth.internal.services._
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.api.v1.command_completion_service.CompletionEndRequest

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -12,8 +12,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import com.daml.api.util.TimeProvider
 import com.daml.buildinfo.BuildInfo
-import com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor
-import com.daml.ledger.api.auth.{AuthService, Authorizer}
+import com.daml.ledger.api.auth.{AuthService, AuthorizationInterceptor, Authorizer}
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.participant.state.index.v2.IndexService
@@ -25,7 +24,7 @@ import com.daml.platform.configuration.{
   CommandConfiguration,
   LedgerConfiguration,
   PartyConfiguration,
-  ServerRole,
+  ServerRole
 }
 import com.daml.platform.index.JdbcIndex
 import com.daml.platform.packages.InMemoryPackageStore

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -13,8 +13,12 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.api.util.TimeProvider
 import com.daml.buildinfo.BuildInfo
 import com.daml.dec.DirectExecutionContext
-import com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor
-import com.daml.ledger.api.auth.{AuthService, AuthServiceWildcard, Authorizer}
+import com.daml.ledger.api.auth.{
+  AuthService,
+  AuthServiceWildcard,
+  AuthorizationInterceptor,
+  Authorizer
+}
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.participant.state.v1.metrics.TimedWriteService


### PR DESCRIPTION
This PR makes the following classes private to the ledger-api-auth package:
- `AsyncForwardingListener`
- `OngoingAuthorizationObserver`

Additionally, it moves the following classes from `com.daml.ledger.api.auth.*` to `com.daml.ledger.api.auth.internal`, to denote that they are not part of the public API of the DAML SDK:
- `AsyncForwardingListener`
- `OngoingAuthorizationObserver`
- Everything previously under `com.daml.ledger.api.auth.services`