### PR TITLE
Drop the global from globalImplicitDisclosure and globalDivulgence

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -51,7 +51,7 @@ object Blinding {
       Right(
         BlindingInfo(
           disclosure = enrichedTx.explicitDisclosure,
-          globalDivulgence = enrichedTx.globalImplicitDisclosure,
+          divulgence = enrichedTx.implicitDisclosure,
         ))
     } else {
       Left(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/EnrichedTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/EnrichedTransaction.scala
@@ -19,7 +19,7 @@ object EnrichedTransaction {
   /** State to use during enriching a transaction with disclosure information. */
   private final case class EnrichState(
       disclosures: Relation[Tx.NodeId, Party],
-      globalDivulgences: Relation[ContractId, Party],
+      divulgences: Relation[ContractId, Party],
       failedAuthorizations: Map[Tx.NodeId, FailedAuthorization],
   ) {
 
@@ -38,8 +38,8 @@ object EnrichedTransaction {
 
     def divulgeCoidTo(witnesses: Set[Party], acoid: ContractId): EnrichState = {
       copy(
-        globalDivulgences = globalDivulgences
-          .updated(acoid, witnesses union globalDivulgences.getOrElse(acoid, Set.empty)),
+        divulgences = divulgences
+          .updated(acoid, witnesses union divulgences.getOrElse(acoid, Set.empty)),
       )
     }
 
@@ -383,7 +383,7 @@ object EnrichedTransaction {
     new EnrichedTransaction(
       tx,
       explicitDisclosure = finalState.disclosures,
-      globalImplicitDisclosure = finalState.globalDivulgences,
+      implicitDisclosure = finalState.divulgences,
       failedAuthorizations = finalState.failedAuthorizations,
     )
   }
@@ -396,7 +396,7 @@ final case class EnrichedTransaction[Transaction <: Tx.Transaction](
     explicitDisclosure: Relation[Tx.NodeId, Party],
     // A relation between contract id and the parties to which the contract id gets
     // explicitly disclosed.
-    globalImplicitDisclosure: Relation[ContractId, Party],
+    implicitDisclosure: Relation[ContractId, Party],
     // A map from node ids to authorizations that failed for them.
     failedAuthorizations: FailedAuthorizations,
 )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -80,7 +80,7 @@ object ScenarioLedger {
       transactionId: LedgerString,
       transaction: Tx.CommittedTransaction,
       explicitDisclosure: Relation[Tx.NodeId, Party],
-      globalImplicitDisclosure: Relation[ContractId, Party],
+      implicitDisclosure: Relation[ContractId, Party],
       failedAuthorizations: FailedAuthorizations,
   )
 
@@ -105,7 +105,7 @@ object ScenarioLedger {
         transactionId = transactionId,
         transaction = enrichedTx.tx,
         explicitDisclosure = enrichedTx.explicitDisclosure,
-        globalImplicitDisclosure = enrichedTx.globalImplicitDisclosure,
+        implicitDisclosure = enrichedTx.implicitDisclosure,
         failedAuthorizations = enrichedTx.failedAuthorizations,
       )
 
@@ -528,7 +528,7 @@ object ScenarioLedger {
             cacheP.updateLedgerNodeInfo(EventId(richTr.transactionId, nodeId))(
               _.addDisclosures(witnesses.map(_ -> Disclosure(since = trId, explicit = true)).toMap))
         }
-      richTr.globalImplicitDisclosure.foldLeft(cacheWithExplicitDisclosures) {
+      richTr.implicitDisclosure.foldLeft(cacheWithExplicitDisclosures) {
         case (cacheP, (coid, divulgees)) =>
           cacheP.updateLedgerNodeInfo(cacheAfterProcess.coidToNodeId(coid))(
             _.addDisclosures(divulgees.map(_ -> Disclosure(since = trId, explicit = false)).toMap))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
@@ -28,5 +28,5 @@ final case class BlindingInfo(
       * containing only contract ids, this map may also
       * contain contracts produced in the same transaction.
       */
-    globalDivulgence: Relation[ContractId, Party],
+    divulgence: Relation[ContractId, Party],
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -406,7 +406,7 @@ private[kvutils] class TransactionCommitter(
     }
 
     // Update contract state of divulged contracts
-    blindingInfo.globalDivulgence.foreach {
+    blindingInfo.divulgence.foreach {
       case (coid, parties) =>
         val key = contractIdToStateKey(coid)
         val cs = getContractState(commitContext, key)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -152,7 +152,7 @@ case class InMemoryActiveLedgerState(
       submitter: Option[Party],
       transaction: Tx.CommittedTransaction,
       disclosure: Relation[Tx.NodeId, Party],
-      globalDivulgence: Relation[ContractId, Party],
+      divulgence: Relation[ContractId, Party],
       referencedContracts: List[(Value.ContractId, ContractInst)]
   ): Either[Set[RejectionReason], InMemoryActiveLedgerState] =
     acManager.addTransaction(
@@ -162,7 +162,7 @@ case class InMemoryActiveLedgerState(
       submitter,
       transaction,
       disclosure,
-      globalDivulgence,
+      divulgence,
       referencedContracts)
 
   /**

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -51,13 +51,13 @@ trait Ledger extends ReadOnlyLedger {
 
 object Ledger {
 
-  type GlobalDivulgence = Relation[ContractId, Party]
+  type Divulgence = Relation[ContractId, Party]
 
   def convertToCommittedTransaction(
       committer: TransactionCommitter,
       transactionId: TransactionId,
       transaction: SubmittedTransaction
-  ): (CommittedTransaction, Relation[Tx.NodeId, Party], GlobalDivulgence) = {
+  ): (CommittedTransaction, Relation[Tx.NodeId, Party], Divulgence) = {
 
     // First we "commit" the transaction by converting all relative contractIds to absolute ones
     val committedTransaction = committer.commitTransaction(transactionId, transaction)
@@ -68,6 +68,6 @@ object Ledger {
     // convert LF NodeId to Index EventId
     val disclosureForIndex = blindingInfo.disclosure
 
-    (committedTransaction, disclosureForIndex, blindingInfo.globalDivulgence)
+    (committedTransaction, disclosureForIndex, blindingInfo.divulgence)
   }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -252,7 +252,7 @@ object ScenarioLoader {
           Some(richTransaction.committer),
           tx,
           richTransaction.explicitDisclosure,
-          richTransaction.globalImplicitDisclosure,
+          richTransaction.implicitDisclosure,
           List.empty
         ) match {
           case Right(newAcs) =>

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -310,7 +310,7 @@ class InMemoryLedger(
       .fold(
         reason => handleError(submitterInfo, RejectionReason.InvalidLedgerTime(reason)),
         _ => {
-          val (committedTransaction, disclosureForIndex, globalDivulgence) =
+          val (committedTransaction, disclosureForIndex, divulgence) =
             Ledger
               .convertToCommittedTransaction(
                 transactionCommitter,
@@ -324,7 +324,7 @@ class InMemoryLedger(
             Some(submitterInfo.submitter),
             committedTransaction,
             disclosureForIndex,
-            globalDivulgence,
+            divulgence,
             List.empty
           )
           acsRes match {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsWriter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsWriter.scala
@@ -119,7 +119,7 @@ private[dao] final class TransactionsWriter(
     val localDivulgence = divulgence(transaction, blinding.disclosure, toBeInserted)
     val fullDivulgence = Relation.union(
       localDivulgence,
-      blinding.globalDivulgence.filterKeys(cid => !toBeDeleted(cid) && !transient(cid))
+      blinding.divulgence.filterKeys(cid => !toBeDeleted(cid) && !transient(cid))
     )
     val insertWitnessesBatch = contractWitnessesTable.prepareBatchInsert(fullDivulgence)
     if (localDivulgence.nonEmpty) {

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -288,7 +288,7 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
     "insert into disclosures(transaction_id, event_id, party) values({transaction_id}, {event_id}, {party})"
 
   // Note: the SQL backend may receive divulgence information for the same (contract, party) tuple
-  // more than once through BlindingInfo.globalDivulgence.
+  // more than once through BlindingInfo.divulgence.
   // The ledger offsets for the same (contract, party) tuple should always be increasing, and the database
   // stores the offset at which the contract was first disclosed.
   // We therefore don't need to update anything if there is already some data for the given (contract, party) tuple.
@@ -318,7 +318,7 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
   private def updateActiveContractSet(
       offset: Long,
       tx: LedgerEntry.Transaction,
-      globalDivulgence: Relation[ContractId, Party])(implicit connection: Connection): Unit =
+      divulgence: Relation[ContractId, Party])(implicit connection: Connection): Unit =
     tx match {
       case LedgerEntry.Transaction(
           _,
@@ -396,7 +396,7 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
           tx.submittingParty,
           transaction,
           mappedDisclosure,
-          globalDivulgence,
+          divulgence,
           List.empty
         )
 
@@ -666,7 +666,7 @@ class V2_1__Rebuild_Acs extends BaseJavaMigration {
           .collect { case tx: LedgerEntry.Transaction => tx }
           .foreach(tx => {
             val blindingInfo = Blinding.blind(tx.transaction)
-            updateActiveContractSet(offset, tx, blindingInfo.globalDivulgence)
+            updateActiveContractSet(offset, tx, blindingInfo.divulgence)
           })
       }
     })


### PR DESCRIPTION
Since we have only absolute contract ids, there is no more distinction
between local and global disclosure/divulgence. Let's please remove the
`global` prefix since it causes confusion (at least for me it did).

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6588)
<!-- Reviewable:end -->
