### PR TITLE
Fix record update evaluation order.

### DIFF
--- a/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Context.hs
+++ b/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Context.hs
@@ -633,7 +633,7 @@ extRecEnvTCons = mapM_ step
     step :: (IsPhase ph, MonadEnv m ph) => (FieldName, Type) -> m ()
     step (f,typ) = do
       mbFields <- recTypFields typ
-      whenJust mbFields $ \fsRec -> 
+      whenJust mbFields $ \fsRec ->
         extRecEnv (fieldName2VarName f) $ map fst fsRec
 
 -- | Extend the environment with a new skolem variable.
@@ -898,6 +898,7 @@ recExpFields (EStructProj f e) = do
       Just e' -> recExpFields e'
       Nothing -> throwError $ UnknownRecField f
     Nothing -> return Nothing
+recExpFields (ELocation _ e) = recExpFields e
 recExpFields _ = return Nothing
 
 applySubstInBoolExpr :: Subst -> BoolExpr -> BoolExpr

--- a/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Solve.hs
+++ b/compiler/daml-lf-verify/src/DA/Daml/LF/Verify/Solve.hs
@@ -172,6 +172,7 @@ instance ConstrExpr Expr where
       builtin_op e = error ("Unsupported builtin expression: " ++ show e)
   toCExp syns (ETmApp (ETyApp (EVal (Qualified _ _ (ExprValName w))) _) e) = case w of
     "intToNumeric" -> toCExp syns e
+    "$cnegate1" -> CNeg (toCExp syns e)
     _ -> error ("Unsupported builtin value: " ++ T.unpack w)
   toCExp syns (ETmApp (ETyApp (ETyApp (EBuiltin BECastNumeric) _) _) e) = toCExp syns e
   toCExp syns (ELocation _ e) = toCExp syns e

--- a/compiler/damlc/tests/daml-test-files/RecordUpdateEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordUpdateEvalOrder.daml
@@ -1,0 +1,37 @@
+-- | This test checks that the "record update" syntax has the expected evaluation
+-- order in DAML. The expected order is that the record is evaluated before the
+-- field, and fields are evaluated in order. (This makes a difference when
+-- two or more of these computations diverge.)
+--
+-- @ERROR a1 failed
+-- @ERROR b2.f failed
+-- @ERROR b3.g failed
+module RecordUpdateEvalOrder  (main1, main2, main3) where
+
+data A = A { f : Int }
+
+a1 : A
+a1 = error "a1 failed"
+
+a2 : A -- expect a1 to fail
+a2 = a1 { f = error "a2 failed" }
+
+data B = B { f : Int, g : Int }
+
+b1 : B
+b1 = B { f = 0, g = 0 }
+
+b2 : B -- expect b2.f to fail
+b2 = b1 { f = error "b2.f failed", g = error "b2.g failed" }
+
+b3 : B -- expect b3.g to fail
+b3 = b1 { g = error "b3.g failed", f = error "b3.f failed" }
+
+main1 = scenario do
+    pure a2
+
+main2 = scenario do
+    pure b2
+
+main3 = scenario do
+    pure b3


### PR DESCRIPTION
This PR only fixes the evaluation order for single-constructor record types. Fixing it for variant records, if we do, will be a major challenge.

This PR also adds a regression test.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
