### PR TITLE
Fix unmangling of dotted identifiers in scenario service

### DIFF
--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Mangling.hs
@@ -113,7 +113,7 @@ mangleIdentifier txt = case T.foldl' f (MangledSize 0 0) txt of
             | otherwise = MangledSize 1 (word16s + 6)
 
 -- | Newtype to make it explicit when we have already unmangled a string.
-newtype UnmangledIdentifier = UnmangledIdentifier T.Text
+newtype UnmangledIdentifier = UnmangledIdentifier { getUnmangledIdentifier :: T.Text }
 
 unmangleIdentifier :: T.Text -> Either String UnmangledIdentifier
 unmangleIdentifier txt = mapLeft (\err -> "Could not unmangle name " ++ show txt ++ ": " ++ err) $ coerce $ do

--- a/compiler/damlc/tests/daml-test-files/MangledScenario'.daml
+++ b/compiler/damlc/tests/daml-test-files/MangledScenario'.daml
@@ -6,8 +6,12 @@ template T'
   where
     signatory p
 
+data NestedT
+  = T1 { t1 : Int }
+  | T2 { t2 : Int }
+
 mangled' = scenario do
   alice <- getParty "Alice"
   t' <- submit alice (create T' with p = alice)
   submit alice (exercise t' Archive)
-  pure ()
+  pure (T1 0)

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -258,12 +258,15 @@ basicTests mbScenarioService = Tasty.testGroup "Basic tests"
                 , "  alice <- getParty \"Alice\""
                 , "  t' <- submit alice (create (T' alice))"
                 , "  submit alice (exercise t' Archive)"
+                , "  pure (T1 0)"
+                , "data NestedT = T1 { t1 : Int } | T2 { t2 : Int }"
                 ]
             setFilesOfInterest [a]
             expectNoErrors
             let va = VRScenario a "mangled'"
             setOpenVirtualResources [va]
             expectVirtualResource va "title=\"MangledScenario':T'\""
+            expectVirtualResource va "MangledScenario&#39;:NestedT:T1"
 
 
     ,   testCaseFails' "Modules must match their filename DEL-7175" $ do


### PR DESCRIPTION
'.' is not a valid character in a mangled name which caused unmangling
to fail. Sadly the scenario service does not properly distinguish
between dotted an undotted names but for now everything we unmangle is
dotted anyway so I’ve taken the easy approach of simply changing our
unmangling to take that into account.

We might want to change the scenario service here but I’ll leave that
for a separate PR.

changelog_begin

- [DAML Studio] Fix a crash in scenarios that referenced records
  originating from definitions like `data T = T1 { f1 : Int } | T2 { f2
  : Int }`.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
