### PR TITLE
Privatize ledger-api-auth classes

### DIFF
--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/OngoingAuthorizationObserver.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/OngoingAuthorizationObserver.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.api.auth
 
 import io.grpc.stub.ServerCallStreamObserver
 
-final class OngoingAuthorizationObserver[A](
+private[auth] final class OngoingAuthorizationObserver[A](
     observer: ServerCallStreamObserver[A],
     claims: Claims,
     authorized: Claims => Boolean,

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/interceptor/AsyncForwardingListener.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/interceptor/AsyncForwardingListener.scala
@@ -13,13 +13,13 @@ import scala.collection.mutable
   *
   * The target listener is usually created through `Contexts.interceptCall` or `ServerCallHandler.startCall`.
   * */
-abstract class AsyncForwardingListener[ReqT] extends ServerCall.Listener[ReqT] {
+private[auth] abstract class AsyncForwardingListener[ReqT] extends ServerCall.Listener[ReqT] {
   protected type Listener = ServerCall.Listener[ReqT]
   private[this] val lock = new Object
   private[this] val stash: mutable.ListBuffer[Listener => Unit] = new mutable.ListBuffer
   private[this] var nextListener: Option[Listener] = None
 
-  private def enqueueOrProcess(msg: Listener => Unit): Unit = lock.synchronized {
+  private[this] def enqueueOrProcess(msg: Listener => Unit): Unit = lock.synchronized {
     if (nextListener.isDefined) {
       msg(nextListener.get)
     } else {

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/ActiveContractsServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/ActiveContractsServiceAuthorization.scala
@@ -16,7 +16,7 @@ import com.daml.platform.server.api.ProxyCloseable
 import io.grpc.ServerServiceDefinition
 import io.grpc.stub.StreamObserver
 
-final class ActiveContractsServiceAuthorization(
+private[daml] final class ActiveContractsServiceAuthorization(
     protected val service: ActiveContractsService with AutoCloseable,
     private val authorizer: Authorizer)
     extends ActiveContractsService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandCompletionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandCompletionServiceAuthorization.scala
@@ -14,7 +14,7 @@ import io.grpc.stub.StreamObserver
 
 import scala.concurrent.Future
 
-final class CommandCompletionServiceAuthorization(
+private[daml] final class CommandCompletionServiceAuthorization(
     protected val service: CommandCompletionService with AutoCloseable,
     private val authorizer: Authorizer)
     extends CommandCompletionService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandServiceAuthorization.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 /** Note: the command service internally uses calls to the CommandSubmissionService and CommandCompletionService.
   * These calls already require authentication, but it is better to check authorization here as well.
   */
-final class CommandServiceAuthorization(
+private[daml] final class CommandServiceAuthorization(
     protected val service: CommandService with AutoCloseable,
     private val authorizer: Authorizer)
     extends CommandService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandSubmissionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/CommandSubmissionServiceAuthorization.scala
@@ -14,7 +14,7 @@ import io.grpc.ServerServiceDefinition
 
 import scala.concurrent.Future
 
-final class CommandSubmissionServiceAuthorization(
+private[daml] final class CommandSubmissionServiceAuthorization(
     protected val service: CommandSubmissionService with AutoCloseable,
     private val authorizer: Authorizer)
     extends CommandSubmissionService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/ConfigManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/ConfigManagementServiceAuthorization.scala
@@ -13,7 +13,7 @@ import io.grpc.ServerServiceDefinition
 
 import scala.concurrent.Future
 
-final class ConfigManagementServiceAuthorization(
+private[daml] final class ConfigManagementServiceAuthorization(
     protected val service: ConfigManagementService with AutoCloseable,
     private val authorizer: Authorizer)
     extends ConfigManagementService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/LedgerConfigurationServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/LedgerConfigurationServiceAuthorization.scala
@@ -12,7 +12,7 @@ import com.daml.platform.server.api.ProxyCloseable
 import io.grpc.ServerServiceDefinition
 import io.grpc.stub.StreamObserver
 
-final class LedgerConfigurationServiceAuthorization(
+private[daml] final class LedgerConfigurationServiceAuthorization(
     protected val service: LedgerConfigurationService with AutoCloseable,
     private val authorizer: Authorizer)
     extends LedgerConfigurationService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/LedgerIdentityServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/LedgerIdentityServiceAuthorization.scala
@@ -16,7 +16,7 @@ import io.grpc.ServerServiceDefinition
 
 import scala.concurrent.Future
 
-final class LedgerIdentityServiceAuthorization(
+private[daml] final class LedgerIdentityServiceAuthorization(
     protected val service: LedgerIdentityServiceGrpc.LedgerIdentityService with AutoCloseable,
     private val authorizer: Authorizer)
     extends LedgerIdentityServiceGrpc.LedgerIdentityService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PackageManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PackageManagementServiceAuthorization.scala
@@ -13,7 +13,7 @@ import io.grpc.ServerServiceDefinition
 
 import scala.concurrent.Future
 
-final class PackageManagementServiceAuthorization(
+private[daml] final class PackageManagementServiceAuthorization(
     protected val service: PackageManagementService with AutoCloseable,
     private val authorizer: Authorizer)
     extends PackageManagementService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PackageServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PackageServiceAuthorization.scala
@@ -13,7 +13,7 @@ import io.grpc.ServerServiceDefinition
 
 import scala.concurrent.Future
 
-final class PackageServiceAuthorization(
+private[daml] final class PackageServiceAuthorization(
     protected val service: PackageService with AutoCloseable,
     private val authorizer: Authorizer)
     extends PackageService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PartyManagementServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/PartyManagementServiceAuthorization.scala
@@ -13,7 +13,7 @@ import io.grpc.ServerServiceDefinition
 
 import scala.concurrent.Future
 
-final class PartyManagementServiceAuthorization(
+private[daml] final class PartyManagementServiceAuthorization(
     protected val service: PartyManagementService with AutoCloseable,
     private val authorizer: Authorizer)
     extends PartyManagementService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TimeServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TimeServiceAuthorization.scala
@@ -15,7 +15,7 @@ import io.grpc.stub.StreamObserver
 
 import scala.concurrent.Future
 
-final class TimeServiceAuthorization(
+private[daml] final class TimeServiceAuthorization(
     protected val service: TimeService with AutoCloseable,
     private val authorizer: Authorizer)
     extends TimeService

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TransactionServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/TransactionServiceAuthorization.scala
@@ -15,7 +15,7 @@ import io.grpc.stub.StreamObserver
 
 import scala.concurrent.Future
 
-final class TransactionServiceAuthorization(
+private[daml] final class TransactionServiceAuthorization(
     protected val service: TransactionService with AutoCloseable,
     private val authorizer: Authorizer)
     extends TransactionService


### PR DESCRIPTION
A small PR that marks some obviously private classes as such.

CHANGELOG_BEGIN
CHANGELOG_END