### PR TITLE
Update rules_haskell

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -850,6 +850,9 @@ main :: IO ()
 main = do
     -- We need this to ensure that logs are flushed on SIGTERM.
     installSignalHandlers
+    -- Save the runfiles environment to work around
+    -- https://gitlab.haskell.org/ghc/ghc/-/issues/18418.
+    setRunfilesEnv
     numProcessors <- getNumProcessors
     let parse = ParseArgs.lax (parserInfo numProcessors)
     cliArgs <- getArgs

--- a/compiler/damlc/tests/util.bzl
+++ b/compiler/damlc/tests/util.bzl
@@ -25,19 +25,20 @@ def _damlc_compile_test_impl(ctx):
         stack_opt = stack_opt,
         heap_opt = heap_opt,
     )
+    binary = ctx.outputs.executable
     ctx.actions.write(
-        output = ctx.outputs.executable,
+        output = binary,
         content = script,
     )
 
     # To ensure the files needed by the script are available, we put them in
     # the runfiles.
+    damlc_runfiles = ctx.attr.damlc[DefaultInfo].default_runfiles
     runfiles = ctx.runfiles(
-        files =
-            ctx.files.srcs + ctx.files.main +
-            [ctx.executable.damlc],
-    )
+        files = [binary] + ctx.files.srcs + ctx.files.main,
+    ).merge(damlc_runfiles)
     return [DefaultInfo(
+        files = depset([binary]),
         runfiles = runfiles,
     )]
 

--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -62,6 +62,7 @@ da_haskell_binary(
     deps = [
         ":daml-helper-lib",
         "//daml-assistant:daml-project-config",
+        "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -5,6 +5,7 @@ module DA.Daml.Helper.Main (main) where
 
 import Control.Exception.Safe
 import Control.Monad
+import DA.Bazel.Runfiles
 import Data.Foldable
 import Data.List.Extra
 import Options.Applicative.Extended
@@ -25,7 +26,10 @@ import DA.Daml.Helper.Studio
 import DA.Daml.Helper.Util
 
 main :: IO ()
-main =
+main = do
+    -- Save the runfiles environment to work around
+    -- https://gitlab.haskell.org/ghc/ghc/-/issues/18418.
+    setRunfilesEnv
     withProgName "daml" $ go `catch` \(e :: DamlHelperError) -> do
         hPutStrLn stderr (displayException e)
         exitFailure

--- a/deps.bzl
+++ b/deps.bzl
@@ -32,8 +32,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 rules_scala_version = "6c16cff213b76a4126bdc850956046da5db1daaa"
 rules_scala_sha256 = "132cf8eeaab67f3142cec17152b8415901e7fa8396dd585d6334eec21bf7419d"
 
-rules_haskell_version = "a4bf003b7d913c116e966f1834e8c493f44eaf53"
-rules_haskell_sha256 = "7cf407198590be786cba49b0a12a4e77274ab81866295e2acebf27e9f29d8a63"
+rules_haskell_version = "5073048c9e307295ea1102459e214750d6a118ad"
+rules_haskell_sha256 = "7abcf5cd631d553ad7f4568b012e96941c77e2aacf79c66c172ab4a90e461a8a"
 rules_nixpkgs_version = "d3c7bc94fed4001d5375632a936d743dc085c9a1"
 rules_nixpkgs_sha256 = "903c6b98aa6a298bf45a6b931e77a3313c40a0cb1b44fa00d9792f9e8aedbb35"
 buildifier_version = "3.3.0"

--- a/language-support/ts/codegen/BUILD.bazel
+++ b/language-support/ts/codegen/BUILD.bazel
@@ -32,6 +32,7 @@ da_haskell_binary(
         "//compiler/daml-lf-proto",
         "//compiler/daml-lf-reader",
         "//daml-assistant:daml-project-config",
+        "//libs-haskell/bazel-runfiles",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/libs-haskell/bazel-runfiles/BUILD.bazel
+++ b/libs-haskell/bazel-runfiles/BUILD.bazel
@@ -10,6 +10,7 @@ da_haskell_library(
         "base",
         "directory",
         "filepath",
+        "safe-exceptions",
         "split",
         "transformers",
     ],


### PR DESCRIPTION
- Fixes the issue where a `sh_test` wrapping a `haskell_binary` couldn't add runfiles as is the case with other Bazel rules, see https://github.com/tweag/rules_haskell/pull/1387.
- The upgrade also includes a fix for `collect_data = True` breaking the REPL on errors in one of the source files, see https://github.com/tweag/rules_haskell/pull/1383.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
