### PR TITLE
Do not expose log entry ID to committers

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -392,8 +392,7 @@ message DamlContractState {
   // Optional, if set the contract has been archived.
   google.protobuf.Timestamp archived_at = 2;
 
-  // Optional. The log entry that caused the contract to be archived.
-  DamlLogEntryId archived_by_entry = 3;
+  reserved 3; // was archived_by_entry
 
   // The parties to which this contract has been explicitly disclosed, that is,
   // the parties which witnessed the creation of the contract.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -204,7 +204,6 @@ private[state] object Conversions {
 
   def contractIdStructOrStringToStateKey[A](
       transactionVersion: TransactionVersion,
-      entryId: DamlLogEntryId,
       coidString: String,
       coidStruct: ValueOuterClass.ContractId,
   ): DamlStateKey =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -105,7 +105,6 @@ class KeyValueCommitting private[daml] (
     try {
       val (logEntry, outputState) = processPayload(
         engine,
-        entryId,
         Some(recordTime),
         defaultConfig,
         submission,
@@ -131,7 +130,6 @@ class KeyValueCommitting private[daml] (
 
   private def processPayload(
       engine: Engine,
-      entryId: DamlLogEntryId,
       recordTime: Option[Timestamp],
       defaultConfig: Configuration,
       submission: DamlSubmission,
@@ -141,7 +139,6 @@ class KeyValueCommitting private[daml] (
     submission.getPayloadCase match {
       case DamlSubmission.PayloadCase.PACKAGE_UPLOAD_ENTRY =>
         new PackageCommitter(engine, metrics).run(
-          entryId,
           recordTime,
           submission.getPackageUploadEntry,
           participantId,
@@ -150,7 +147,6 @@ class KeyValueCommitting private[daml] (
 
       case DamlSubmission.PayloadCase.PARTY_ALLOCATION_ENTRY =>
         new PartyAllocationCommitter(metrics).run(
-          entryId,
           recordTime,
           submission.getPartyAllocationEntry,
           participantId,
@@ -161,7 +157,6 @@ class KeyValueCommitting private[daml] (
         val maximumRecordTime = parseTimestamp(
           submission.getConfigurationSubmission.getMaximumRecordTime)
         new ConfigCommitter(defaultConfig, maximumRecordTime, metrics).run(
-          entryId,
           recordTime,
           submission.getConfigurationSubmission,
           participantId,
@@ -171,7 +166,6 @@ class KeyValueCommitting private[daml] (
       case DamlSubmission.PayloadCase.TRANSACTION_ENTRY =>
         new TransactionCommitter(defaultConfig, engine, metrics, inStaticTimeMode)
           .run(
-            entryId,
             recordTime,
             submission.getTransactionEntry,
             participantId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -3,11 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntryId,
-  DamlStateKey,
-  DamlStateValue
-}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.{
   DamlStateMap,
   DamlStateMapWithFingerprints,
@@ -40,7 +36,6 @@ private[kvutils] trait CommitContext {
   private val accessedInputKeysAndFingerprints: mutable.Set[(DamlStateKey, Fingerprint)] =
     mutable.Set.empty[(DamlStateKey, Fingerprint)]
 
-  def getEntryId: DamlLogEntryId
   def getRecordTime: Option[Timestamp]
   def getParticipantId: ParticipantId
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -8,18 +8,11 @@ import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlConfigurationEntry,
   DamlLogEntry,
-  DamlLogEntryId,
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.{
-  Conversions,
-  DamlStateMap,
-  DamlStateMapWithFingerprints,
-  FingerprintPlaceholder,
-  Err
-}
 import com.daml.ledger.participant.state.kvutils.committer.Committer._
+import com.daml.ledger.participant.state.kvutils._
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId}
 import com.daml.lf.data.Time
 import com.daml.lf.data.Time.Timestamp
@@ -71,7 +64,6 @@ private[committer] trait Committer[Submission, PartialResult] {
   /** A committer can `run` a submission and produce a log entry and output states. */
   @SuppressWarnings(Array("org.wartremover.warts.Return"))
   def run(
-      entryId: DamlLogEntryId,
       recordTime: Option[Time.Timestamp],
       submission: Submission,
       participantId: ParticipantId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -79,7 +79,6 @@ private[committer] trait Committer[Submission, PartialResult] {
   ): (DamlLogEntry, Map[DamlStateKey, DamlStateValue]) =
     runTimer.time { () =>
       val ctx = new CommitContext {
-        override def getEntryId: DamlLogEntryId = entryId
         override def getRecordTime: Option[Time.Timestamp] = recordTime
         override def getParticipantId: ParticipantId = participantId
         override def inputsWithFingerprints: DamlStateMapWithFingerprints =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -399,7 +399,6 @@ private[kvutils] class TransactionCommitter(
           .setContractState(
             cs.toBuilder
               .setArchivedAt(buildTimestamp(transactionEntry.ledgerEffectiveTime))
-              .setArchivedByEntry(commitContext.getEntryId)
           )
           .build
       )

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -137,7 +137,7 @@ object KVTest {
     } yield {
       // Verify that all state touched matches with "submissionOutputs".
       assert(
-        newState.keySet subsetOf keyValueCommitting.submissionOutputs(entryId, submission)
+        newState.keySet subsetOf keyValueCommitting.submissionOutputs(submission)
       )
 
       // Verify that we can always process the log entry

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -139,7 +139,6 @@ object KVTest {
       assert(
         newState.keySet subsetOf keyValueCommitting.submissionOutputs(submission)
       )
-
       // Verify that we can always process the log entry
       val _ = KeyValueConsumption.logEntryToUpdate(entryId, logEntry)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -4,17 +4,12 @@
 package com.daml.ledger.participant.state.kvutils.committer
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntryId,
   DamlPartyAllocation,
   DamlStateKey,
   DamlStateValue
 }
 import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
-import com.daml.ledger.participant.state.kvutils.{
-  DamlKvutils,
-  DamlStateMapWithFingerprints,
-  TestHelpers
-}
+import com.daml.ledger.participant.state.kvutils.{DamlStateMapWithFingerprints, TestHelpers}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.data.Time
 import org.scalatest.{Matchers, WordSpec}
@@ -110,8 +105,6 @@ class CommitContextSpec extends WordSpec with Matchers {
 
   private class TestCommitContext(override val inputsWithFingerprints: DamlStateMapWithFingerprints)
       extends CommitContext {
-    override def getEntryId: DamlKvutils.DamlLogEntryId = DamlLogEntryId.getDefaultInstance
-
     override def getRecordTime: Option[Time.Timestamp] = Some(Time.Timestamp.now())
 
     override def getParticipantId: ParticipantId = TestHelpers.mkParticipantId(1)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/FakeCommitContext.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/FakeCommitContext.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import com.daml.ledger.participant.state.kvutils.TestHelpers.{mkEntryId, mkParticipantId}
-import com.daml.ledger.participant.state.kvutils.{DamlKvutils, DamlStateMapWithFingerprints}
+import com.daml.ledger.participant.state.kvutils.DamlStateMapWithFingerprints
+import com.daml.ledger.participant.state.kvutils.TestHelpers.mkParticipantId
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.data.Time.Timestamp
 
@@ -15,8 +15,6 @@ class FakeCommitContext(
     entryId: Int = 0)
     extends CommitContext {
   override def getRecordTime: Option[Timestamp] = recordTime
-
-  override def getEntryId: DamlKvutils.DamlLogEntryId = mkEntryId(entryId)
 
   override def getParticipantId: ParticipantId = mkParticipantId(participantId)
 }


### PR DESCRIPTION
Summary of changes:
* `CommitContext` no longer exposes log entry ID to committers.
* Deprecated field `DamlContractState.archived_by_entry`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
