### PR TITLE
remove clean --expunge from Windows builds

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -49,10 +49,6 @@ function bazel() {
 # which is a workaround for this problem.
 bazel shutdown
 
-
-# TODO remove once nodes have been reset
-bazel clean --expunge
-
 # Prefetch nodejs_dev_env to avoid permission denied errors on external/nodejs_dev_env/nodejs_dev_env/node.exe
 # It isn’t clear where exactly those errors are coming from.
 bazel fetch @nodejs_dev_env//...

--- a/compatibility/build-release-artifacts-windows.ps1
+++ b/compatibility/build-release-artifacts-windows.ps1
@@ -37,8 +37,6 @@ function bazel() {
 
 
 bazel shutdown
-# TODO remove once nodes have been reset
-bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build `
   `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution_windows.log `

--- a/compatibility/test-windows.ps1
+++ b/compatibility/test-windows.ps1
@@ -45,8 +45,6 @@ cd compatibility
 cp ../.bazelrc .bazelrc
 
 bazel shutdown
-# TODO remove once nodes have been reset
-bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build //...
 bazel shutdown


### PR DESCRIPTION
Following #6604, I have reset all of our Windows nodes, so hopefully there is no broken local cache remaining.

CHANGELOG_BEGIN
CHANGELOG_END