### PR TITLE
kvutils/integrity-check: Rewrite without `Await`.

### DIFF
--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -49,6 +49,7 @@ da_scala_binary(
         "//ledger/participant-state",
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils:daml_kvutils_java_proto",
+        "//libs-scala/direct-execution-context",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheckV2.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheckV2.scala
@@ -4,8 +4,12 @@
 package com.daml.ledger.participant.state.kvutils.tools
 
 import java.io.{DataInputStream, FileInputStream}
+import java.util.concurrent.{Executors, TimeUnit}
 
+import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.participant.state.kvutils.export.LedgerDataExporter
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 
 object IntegrityCheckV2 {
   def main(args: Array[String]): Unit = {
@@ -18,9 +22,22 @@ object IntegrityCheckV2 {
 
     val filename = args(0)
     println(s"Verifying integrity of $filename...")
-    val ledgerDumpStream =
-      new DataInputStream(new FileInputStream(filename))
-    new IntegrityChecker(LogAppendingCommitStrategySupport).run(ledgerDumpStream)
-    sys.exit(0)
+
+    val executionContext: ExecutionContextExecutorService =
+      ExecutionContext.fromExecutorService(
+        Executors.newFixedThreadPool(sys.runtime.availableProcessors()))
+    val ledgerDumpStream = new DataInputStream(new FileInputStream(filename))
+    new IntegrityChecker(LogAppendingCommitStrategySupport)
+      .run(ledgerDumpStream)(executionContext)
+      .andThen {
+        case _ =>
+          executionContext.shutdown()
+          executionContext.awaitTermination(1, TimeUnit.MINUTES)
+      }(DirectExecutionContext)
+      .failed
+      .foreach { exception =>
+        exception.printStackTrace()
+        sys.exit(1)
+      }(DirectExecutionContext)
   }
 }

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheckV2.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheckV2.scala
@@ -31,6 +31,7 @@ object IntegrityCheckV2 {
       .run(ledgerDumpStream)(executionContext)
       .andThen {
         case _ =>
+          ledgerDumpStream.close()
           executionContext.shutdown()
           executionContext.awaitTermination(1, TimeUnit.MINUTES)
       }(DirectExecutionContext)

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityChecker.scala
@@ -27,7 +27,7 @@ import com.daml.lf.engine.Engine
 import com.daml.metrics.Metrics
 import com.google.protobuf.ByteString
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService}
 import scala.io.AnsiColor
 
@@ -82,7 +82,7 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
         reader,
         commitStrategy
       )
-      Await.ready(validationFuture, Duration(10, TimeUnit.SECONDS))
+      Await.ready(validationFuture, 1.minute)
       counter += 1
       val actualWriteSet = queryableWriteSet.getAndClearRecordedWriteSet()
       val sortedActualWriteSet = actualWriteSet.sortBy(_._1.asReadOnlyByteBuffer())


### PR DESCRIPTION
Not every submission can be processed in 10 seconds. I experienced timeouts when attempting to check submissions running through customer code.

This changes the submission check loop to lean on futures rather than `Await`-ing.

Tested manually.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
