### PR TITLE
Fix project versions of DAML Script and DAML Triggers

### DIFF
--- a/daml-script/daml/BUILD.bazel
+++ b/daml-script/daml/BUILD.bazel
@@ -3,7 +3,7 @@
 
 # TODO Once daml_compile uses build instead of package we should use
 # daml_compile instead of a genrule.
-load("@build_environment//:configuration.bzl", "sdk_version")
+load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
 
 DAML_LF_VERSIONS = [
     "1.7",
@@ -27,7 +27,7 @@ DAML_LF_VERSIONS = [
 sdk-version: {sdk}
 name: daml-script
 source: daml
-version: {sdk}
+version: {ghc}
 dependencies:
   - daml-stdlib
   - daml-prim
@@ -44,6 +44,7 @@ EOF
                 lf_version,
             ] if lf_version else []),
             sdk = sdk_version,
+            ghc = ghc_version,
         ),
         tools = ["//compiler/damlc"],
         visibility = ["//visibility:public"],

--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -4,7 +4,7 @@
 # TODO Once daml_compile uses build instead of package we should use
 # daml_compile instead of a genrule.
 
-load("@build_environment//:configuration.bzl", "sdk_version")
+load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
 
 DAML_LF_VERSIONS = [
     "1.7",
@@ -31,7 +31,7 @@ DAML_LF_VERSIONS = [
 sdk-version: {sdk}
 name: daml-trigger
 source: daml
-version: {sdk}
+version: {ghc}
 dependencies:
   - daml-stdlib
   - daml-prim
@@ -48,6 +48,7 @@ EOF
                 lf_version,
             ] if lf_version else []),
             sdk = sdk_version,
+            ghc = ghc_version,
         ),
         tools = ["//compiler/damlc"],
         visibility = ["//visibility:public"],


### PR DESCRIPTION
GHC has weird restriction on version numbers which damlc inserits so
we need to use `ghc_version` instead of `sdk_version`. That only makes
a difference for snapshot versions where the `-snapshot.` part is
replaced by `.`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
