### PR TITLE
Bazel: Upgrade Buildifier.

### DIFF
--- a/bazel_tools/dev_env_tool/dev_env_tool.bzl
+++ b/bazel_tools/dev_env_tool/dev_env_tool.bzl
@@ -62,7 +62,7 @@ def _dadew_where(ctx, ps):
     return ps_result.stdout.splitlines()[0]
 
 def _dadew_tool_home(dadew, tool):
-    return "%s\\scoop\\apps\%s\\current" % (dadew, tool)
+    return "%s\\scoop\\apps\\%s\\current" % (dadew, tool)
 
 def _find_files_recursive(ctx, find, root):
     find_result = ctx.execute([find, "-L", root, "-type", "f", "-print0"])
@@ -113,10 +113,10 @@ def _dev_env_tool_impl(ctx):
         find = _dadew_tool_home(dadew, "msys2") + "\\usr\\bin\\find.exe"
         tool_home = _dadew_tool_home(dadew, ctx.attr.win_tool)
         for i in ctx.attr.win_include:
-            src = "%s\%s" % (tool_home, i)
+            src = "%s\\%s" % (tool_home, i)
             dst = ctx.attr.win_include_as.get(i, i)
             if ctx.attr.prefix:
-                dst = "%s\%s" % (ctx.attr.prefix, dst)
+                dst = "%s\\%s" % (ctx.attr.prefix, dst)
             _symlink_files_recursive(ctx, find, src, dst)
     else:
         find = "find"

--- a/bazel_tools/pkg.bzl
+++ b/bazel_tools/pkg.bzl
@@ -36,7 +36,7 @@ def _remap(remap_paths, path):
     return path
 
 def _quote(filename, protect = "="):
-    """Quote the filename, by escaping = by \= and \ by \\ """
+    """Quote the filename, by escaping = by \\= and \\ by \\ """
     return filename.replace("\\", "\\\\").replace(protect, "\\" + protect)
 
 def _pkg_tar_impl(ctx):

--- a/bazel_tools/proto.bzl
+++ b/bazel_tools/proto.bzl
@@ -42,7 +42,7 @@ def _proto_gen_impl(ctx):
 
     sources_out = ctx.actions.declare_directory(ctx.attr.name + "-sources")
 
-    descriptor_set_delim = "\;" if _is_windows(ctx) else ":"
+    descriptor_set_delim = "\\;" if _is_windows(ctx) else ":"
 
     args = []
     args += [

--- a/compiler/daml-extension/BUILD.bazel
+++ b/compiler/daml-extension/BUILD.bazel
@@ -66,8 +66,8 @@ genrule(
             cp ../$$f $$dir/$$file
         done
         cd ..
-        tar c node_modules \
-          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        tar c node_modules \\
+          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
           | gzip -n > $@
     """,
 )

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -264,21 +264,21 @@ genrule(
         "daml-base-hoogle.txt",
     ],
     cmd = """
-        $(location //compiler/damlc) -- docs \
-            --output=daml-base-rst \
-            --input-format=json \
-            --format=Rst \
-            --exclude-instances=HasField \
-            --drop-orphan-instances \
-            --template=$(location :daml-base-rst-template) \
-            --index-template=$(location :daml-base-rst-index-template) \
-            --hoogle-template=$(location :daml-base-hoogle-template) \
-            --base-url=https://docs.daml.com/daml/stdlib \
-            --output-hoogle=$(location :daml-base-hoogle.txt) \
-            --output-anchor=$(location :daml-base-anchors.json) \
+        $(location //compiler/damlc) -- docs \\
+            --output=daml-base-rst \\
+            --input-format=json \\
+            --format=Rst \\
+            --exclude-instances=HasField \\
+            --drop-orphan-instances \\
+            --template=$(location :daml-base-rst-template) \\
+            --index-template=$(location :daml-base-rst-index-template) \\
+            --hoogle-template=$(location :daml-base-hoogle-template) \\
+            --base-url=https://docs.daml.com/daml/stdlib \\
+            --output-hoogle=$(location :daml-base-hoogle.txt) \\
+            --output-anchor=$(location :daml-base-anchors.json) \\
             $(location :daml-stdlib.json) $(location :daml-prim.json)
-        tar c daml-base-rst \
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        tar c daml-base-rst \\
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
             | gzip -n > $(location :daml-base-rst.tar.gz)
     """,
     tools = ["//compiler/damlc"],

--- a/compiler/damlc/pkg-db/util.bzl
+++ b/compiler/damlc/pkg-db/util.bzl
@@ -37,9 +37,9 @@ copyright: 2020 Digital Asset Holdings
 maintainer: Digital Asset
 exposed: True
 exposed-modules: {modules}
-import-dirs: \$topdir/__ID__
-library-dirs: \$topdir/__ID__
-data-dir: \$topdir/__ID__
+import-dirs: \\$topdir/__ID__
+library-dirs: \\$topdir/__ID__
+data-dir: \\$topdir/__ID__
 depends: {depends}
 """
 

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -30,43 +30,43 @@ genrule(
       MVN=($(locations @mvn_dev_env//:mvn))
       MVN="$${{MVN[0]}}"
       install_mvn() {{
-          "$$MVN" -q install:install-file \
-          -Dmaven.repo.local=$$MVN_DB \
-          "-DgroupId=$$1" \
-          "-DartifactId=$$2" \
-          "-Dfile=$$3" \
-          "-DpomFile=$$4" \
-          -Dpackaging=jar \
+          "$$MVN" -q install:install-file \\
+          -Dmaven.repo.local=$$MVN_DB \\
+          "-DgroupId=$$1" \\
+          "-DartifactId=$$2" \\
+          "-Dfile=$$3" \\
+          "-DpomFile=$$4" \\
+          -Dpackaging=jar \\
           -Dversion={mvn}
       }}
       tar xf $(location //docs:quickstart-java.tar.gz) -C "$$TMP_DIR"
-      install_mvn \
-        "com.daml" "daml-lf-archive" \
-        $(location //daml-lf/archive:daml_lf_dev_archive_java_proto) \
+      install_mvn \\
+        "com.daml" "daml-lf-archive" \\
+        $(location //daml-lf/archive:daml_lf_dev_archive_java_proto) \\
         $(location //daml-lf/archive:daml_lf_dev_archive_java_proto_pom)
-      install_mvn \
-        "com.daml" "bindings-java" \
-        $(location //language-support/java/bindings:libbindings-java.jar) \
+      install_mvn \\
+        "com.daml" "bindings-java" \\
+        $(location //language-support/java/bindings:libbindings-java.jar) \\
         $(location //language-support/java/bindings:bindings-java_pom.xml)
-      install_mvn \
-        "com.daml" "bindings-rxjava" \
-        $(location //language-support/java/bindings-rxjava:libbindings-rxjava.jar) \
+      install_mvn \\
+        "com.daml" "bindings-rxjava" \\
+        $(location //language-support/java/bindings-rxjava:libbindings-rxjava.jar) \\
         $(location //language-support/java/bindings-rxjava:bindings-rxjava_pom.xml)
-      install_mvn \
-        "com.daml" "codegen-java" \
-        $(location //language-support/java/codegen:shaded_binary.jar) \
+      install_mvn \\
+        "com.daml" "codegen-java" \\
+        $(location //language-support/java/codegen:shaded_binary.jar) \\
         $(location //language-support/java/codegen:shaded_binary_pom.xml)
-      install_mvn \
-        "com.daml" "rs-grpc-bridge" \
-        $(location //ledger-api/rs-grpc-bridge:librs-grpc-bridge.jar) \
+      install_mvn \\
+        "com.daml" "rs-grpc-bridge" \\
+        $(location //ledger-api/rs-grpc-bridge:librs-grpc-bridge.jar) \\
         $(location //ledger-api/rs-grpc-bridge:rs-grpc-bridge_pom.xml)
-      install_mvn \
-        "com.daml" "ledger-api-auth-client" \
-        $(location //ledger/ledger-api-auth-client:libledger-api-auth-client.jar) \
+      install_mvn \\
+        "com.daml" "ledger-api-auth-client" \\
+        $(location //ledger/ledger-api-auth-client:libledger-api-auth-client.jar) \\
         $(location //ledger/ledger-api-auth-client:ledger-api-auth-client_pom.xml)
       "$$MVN" -q -Dmaven.repo.local=$$MVN_DB -f "$$TMP_DIR/quickstart-java/pom.xml" dependency:resolve dependency:resolve-plugins
-      tar cf $(location integration-tests-mvn.tar) -C $$(dirname $$MVN_DB) $$(basename $$MVN_DB) \
-        --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name
+      tar cf $(location integration-tests-mvn.tar) -C $$(dirname $$MVN_DB) $$(basename $$MVN_DB) \\
+        --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name
     """.format(mvn = mvn_version),
 )
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -36,8 +36,8 @@ rules_haskell_version = "a4bf003b7d913c116e966f1834e8c493f44eaf53"
 rules_haskell_sha256 = "7cf407198590be786cba49b0a12a4e77274ab81866295e2acebf27e9f29d8a63"
 rules_nixpkgs_version = "d3c7bc94fed4001d5375632a936d743dc085c9a1"
 rules_nixpkgs_sha256 = "903c6b98aa6a298bf45a6b931e77a3313c40a0cb1b44fa00d9792f9e8aedbb35"
-buildifier_version = "0.26.0"
-buildifier_sha256 = "86592d703ecbe0c5cbb5139333a63268cf58d7efd2c459c8be8e69e77d135e29"
+buildifier_version = "3.3.0"
+buildifier_sha256 = "f11fc80da0681a6d64632a850346ed2d4e5cbb0908306d9a2a2915f707048a10"
 zlib_version = "cacf7f1d4e3d44d871b605da3b647f07d718623f"
 zlib_sha256 = "6d4d6640ca3121620995ee255945161821218752b551a1a180f4215f7d124d45"
 rules_nodejs_version = "1.6.0"
@@ -321,14 +321,14 @@ genrule(
   cmd = '''
     DIR=$$(dirname $(execpath _config.yml))
     $(execpath @jekyll_nix//:bin/jekyll) build -s $$DIR
-    tar hc _site \
-        --owner=1000 \
-        --group=1000 \
-        --mtime=2000-01-01\ 00:00Z \
-        --no-acls \
-        --no-xattrs \
-        --no-selinux \
-        --sort=name \
+    tar hc _site \\
+        --owner=1000 \\
+        --group=1000 \\
+        --mtime=2000-01-01\\ 00:00Z \\
+        --no-acls \\
+        --no-xattrs \\
+        --no-selinux \\
+        --sort=name \\
         | gzip -n > $(OUTS)
   ''',
 )

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -233,25 +233,25 @@ genrule(
         ln -s ../external/npm/node_modules .
 
         # Run sass and grunt
-        ../$(location @sass_nix//:bin/sass) \
-            -I bower_components_static/bourbon/dist \
-            -I bower_components_static/neat/app/assets/stylesheets \
-            -I bower_components_static/font-awesome/scss \
-            -I bower_components_static/wyrm/sass \
-            --style compressed \
-            --sourcemap=none \
-            --update \
+        ../$(location @sass_nix//:bin/sass) \\
+            -I bower_components_static/bourbon/dist \\
+            -I bower_components_static/neat/app/assets/stylesheets \\
+            -I bower_components_static/font-awesome/scss \\
+            -I bower_components_static/wyrm/sass \\
+            --style compressed \\
+            --sourcemap=none \\
+            --update \\
             sass:da_theme/static/css
         ../$(location :grunt) build
 
-        tar c da_theme \
-            --owner=1000 \
-            --group=1000 \
-            --mtime=2000-01-01\ 00:00Z \
-            --no-acls \
-            --no-xattrs \
-            --no-selinux \
-            --sort=name \
+        tar c da_theme \\
+            --owner=1000 \\
+            --group=1000 \\
+            --mtime=2000-01-01\\ 00:00Z \\
+            --no-acls \\
+            --no-xattrs \\
+            --no-selinux \\
+            --sort=name \\
             | gzip -n > ../$(location da_theme.tar.gz)
     """,
     tools = [
@@ -276,8 +276,8 @@ genrule(
 
         # Copy in Stdlib
         mkdir -p source/daml/stdlib
-        tar xf $(location //compiler/damlc:daml-base-rst.tar.gz) \
-            --strip-components 1 \
+        tar xf $(location //compiler/damlc:daml-base-rst.tar.gz) \\
+            --strip-components 1 \\
             -C source/daml/stdlib
 
         # Copy in daml-trigger documentation
@@ -293,8 +293,8 @@ genrule(
         cp -L $(location //:LICENSE) source/LICENSE
         cp -L $(location //:NOTICES) source/NOTICES
 
-        tar c source \
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        tar c source \\
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
             | gzip -n > $(location source.tar.gz)
     """,
 )
@@ -421,7 +421,7 @@ genrule(
         # Unfortunately, an update is not so easy because Sphinx 2.3.1 breaks
         # the PDF documentation due to issues with the FreeSerif font in the
         # fontspec package. So, for now we ignore `FutureWarning`.
-        WARNINGS=$$(../$(location @sphinx_nix//:bin/sphinx-build) -c docs/configs/html docs/source html 2>&1 | \
+        WARNINGS=$$(../$(location @sphinx_nix//:bin/sphinx-build) -c docs/configs/html docs/source html 2>&1 | \\
             grep -Pi "(?<!future)warning:" || true)
 
         if [ "$$WARNINGS" != "" ]; then
@@ -445,7 +445,7 @@ genrule(
         # registry and on docs.daml.com. The docs at the npm registry contain a link pointing
         # to docs.daml.com. We remove it for the version published at docs.daml.com as it would be
         # pointing to itself.
-        sed -i -e 's,^.*\(Comprehensive documentation\|<h2>Documentation</h2>\|0.0.0-SDKVERSION\).*$$,,' html/app-dev/bindings-ts/*/index.html
+        sed -i -e 's,^.*\\(Comprehensive documentation\\|<h2>Documentation</h2>\\|0.0.0-SDKVERSION\\).*$$,,' html/app-dev/bindings-ts/*/index.html
 
         # Get the daml cheat sheet
         mkdir -p html/cheat-sheet
@@ -455,8 +455,8 @@ genrule(
         mkdir -p html/hoogle_db
         cp -rL ../$(location //compiler/damlc:daml-base-hoogle.txt) html/hoogle_db/base.txt
 
-        tar c html \
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        tar c html \\
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
             | gzip -n > ../$(location html-only.tar.gz)
         """.format(sdk = sdk_version),
     tools = [
@@ -484,8 +484,8 @@ genrule(
                 sed -i -e "s,__URL__,$${to}," redirects/$$from
             fi
         done <docs/redirects.map
-        tar c redirects \
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        tar c redirects \\
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
             | gzip -n > $(location redirects.tar.gz)
     """,
 )
@@ -507,9 +507,9 @@ genrule(
         cp -L docs/error.html html
         cd html
         find . -name '*.html' | sort | sed -e 's,^\\./,https://docs.daml.com/,' > sitemap
-        SMHEAD=\"{head}\"
-        SMITEM=\"{item}\"
-        SMFOOT=\"{foot}\"
+        SMHEAD="{head}"
+        SMITEM="{item}"
+        SMFOOT="{foot}"
         echo $$SMHEAD > sitemap.xml
         while read item; do
             echo $$SMITEM | sed -e "s,%DATE%,$${{VERSION_DATE}}," | sed -e "s,%LOC%,$${{item}}," >> sitemap.xml
@@ -521,8 +521,8 @@ genrule(
         cp -L $(location :pdf-docs) html/_downloads
         # Remove Sphinx build products
         rm -rf .buildinfo .doctrees objects.inv
-        tar c html \
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        tar c html \\
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
             | gzip -n > $(location html.tar.gz)
     """.format(
         head = """<?xml version='1.0' encoding='UTF-8'?><urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd'>""",
@@ -556,8 +556,8 @@ genrule(
         mkdir -p quickstart-java
         cp -rL docs/source/app-dev/bindings-java/quickstart/template-root/* quickstart-java/
         sed -i "s/__VERSION__/{mvn}/" quickstart-java/pom.xml
-        tar c quickstart-java \
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        tar c quickstart-java \\
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
             | gzip -n > $@
     """.format(mvn = mvn_version),
     visibility = ["//visibility:public"],

--- a/language-support/ts/typedoc.bzl
+++ b/language-support/ts/typedoc.bzl
@@ -17,8 +17,8 @@ def ts_docs(pkg_name):
           # resolve the imported packages.
           $(location @language_support_ts_deps//typedoc/bin:typedoc) --out docs --ignoreCompilerErrors --readme README.md --stripInternal $(SRCS)
           sed -i -e 's/0.0.0-SDKVERSION/{sdk_version}/' docs/**/*.html
-          tar -hc docs \
-               --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+          tar -hc docs \\
+               --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
                | gzip -n > $@
         """,
         visibility = ["//visibility:public"],

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -24,14 +24,14 @@ cat > $@ <<EOF
 set -euo pipefail
 
 f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "\$${RUNFILES_DIR:-/dev/null}/\$$f" 2>/dev/null || \
-  source "\$$(grep -sm1 "^\$$f " "\$${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "\$$0.runfiles/\$$f" 2>/dev/null || \
-  source "\$$(grep -sm1 "^\$$f " "\$$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "\$$(grep -sm1 "^\$$f " "\$$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find \$$f"; exit 1; }; f=; set -e
+source "\\$${RUNFILES_DIR:-/dev/null}/\\$$f" 2>/dev/null || \\
+  source "\\$$(grep -sm1 "^\\$$f " "\\$${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \\
+  source "\\$$0.runfiles/\\$$f" 2>/dev/null || \\
+  source "\\$$(grep -sm1 "^\\$$f " "\\$$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \\
+  source "\\$$(grep -sm1 "^\\$$f " "\\$$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \\
+  { echo>&2 "ERROR: cannot find \\$$f"; exit 1; }; f=; set -e
 
-PATH="\$$(rlocation coreutils_nix/bin):\$$(rlocation curl_nix/bin):\$$(rlocation grpcurl_nix/bin):\$$(rlocation jq_dev_env/bin):\$$PATH"
+PATH="\\$$(rlocation coreutils_nix/bin):\\$$(rlocation curl_nix/bin):\\$$(rlocation grpcurl_nix/bin):\\$$(rlocation jq_dev_env/bin):\\$$PATH"
 export PATH
 
 EOF

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -175,8 +175,8 @@ genrule(
         cp -L $(location :sandbox-binary_deploy.jar) sandbox-tarball/sandbox/sandbox-{mvn}.jar
         out=$$(realpath $@)
         cd sandbox-tarball
-        tar c sandbox \
-          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        tar c sandbox \\
+          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
           | gzip -n > $$out
     """.format(mvn = mvn_version),
     visibility = ["//visibility:public"],

--- a/navigator/frontend/BUILD.bazel
+++ b/navigator/frontend/BUILD.bazel
@@ -106,18 +106,18 @@ genrule(
     # -d --progress --display-error-details --verbose
     WP_IN={WP_IN}
     WP_OUT={WP_OUT}
-    $(execpath :webpack) \
-      --config="$$IN/webpack.config.js" \
-      --env.prod \
-      --env.paths_case_check="{PATHS_CASE_CHECK}" \
-      --env.bazel_in_dir="{WP_IN_ESCAPED}" \
+    $(execpath :webpack) \\
+      --config="$$IN/webpack.config.js" \\
+      --env.prod \\
+      --env.paths_case_check="{PATHS_CASE_CHECK}" \\
+      --env.bazel_in_dir="{WP_IN_ESCAPED}" \\
       --env.bazel_out_dir="{WP_OUT_ESCAPED}"
 
     # Package result (.TGZ)
     # To debug, change 'c' to 'cv'.
     echo "Packaging result from $$OUT to $(@D)/frontend.tgz"
-    tar c -C $$OUT . \
-        --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+    tar c -C $$OUT . \\
+        --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
         | gzip -n > "$(@D)/frontend.tgz"
 
     # Package result (.JAR)

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -78,8 +78,8 @@ def sdk_tarball(name, version):
           cp -L $(location //triggers/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/trigger-logback.xml
           cp -L $(location //daml-script/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/script-logback.xml
 
-          tar c --format=ustar $$OUT \
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+          tar c --format=ustar $$OUT \\
+            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
             | gzip -n > $@
         """.format(version = version),
         visibility = ["//visibility:public"],

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -68,8 +68,8 @@ EOF
         mkdir -p $$OUT/daml-patterns
         tar xf $(location //docs:daml-patterns) --strip-components=1 -C $$OUT/daml-patterns
 
-        tar c templates-tarball \
-          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
+        tar c templates-tarball \\
+          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
           | gzip -n >$(location :templates-tarball.tar.gz)
     """,
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Buildifier now comes with a handy attachment to catch single `\` characters inside strings and replace them with `\\` if the escape sequence is invalid. Skylark/Python will do this at runtime anyway; this just makes it clearer what the actual behavior is.

I needed to change `\` characters at the end of lines to `\\` manually in order to stop Buildifier from simply concatenating the lines together. Everything else was automatic.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
