### PR TITLE
Renamed some `default` variables

### DIFF
--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/ExtraConfig.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/ExtraConfig.scala
@@ -10,7 +10,7 @@ final case class ExtraConfig(
 )
 
 object ExtraConfig {
-  val default =
+  val reasonableDefault =
     ExtraConfig(
       batchingLedgerWriterConfig =
         BatchingLedgerWriterConfig.reasonableDefault.copy(maxBatchConcurrentCommits = 2))

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -81,7 +81,7 @@ object Main {
     override def ledgerConfig(config: Config[ExtraConfig]): LedgerConfiguration =
       LedgerConfiguration.defaultLocalLedger
 
-    override val defaultExtraConfig: ExtraConfig = ExtraConfig.default
+    override val defaultExtraConfig: ExtraConfig = ExtraConfig.reasonableDefault
 
     override final def extraConfigParser(parser: OptionParser[Config[ExtraConfig]]): Unit = {
       parser

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -57,7 +57,7 @@ object Config {
 
   val DefaultMaxInboundMessageSize: Int = 64 * 1024 * 1024
 
-  def default[Extra](extra: Extra): Config[Extra] =
+  def createDefault[Extra](extra: Extra): Config[Extra] =
     Config(
       ledgerId = None,
       archiveFiles = Vector.empty,
@@ -90,7 +90,7 @@ object Config {
       defaultExtra: Extra,
       args: Seq[String],
   ): Option[Config[Extra]] =
-    parser(name, extraOptions).parse(args, default(defaultExtra))
+    parser(name, extraOptions).parse(args, createDefault(defaultExtra))
 
   private def parser[Extra](
       name: String,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -30,7 +30,7 @@ import scala.concurrent.{ExecutionContext, Future}
 object BatchedSubmissionValidatorFactory {
   def defaultParametersFor(enableBatching: Boolean): BatchedSubmissionValidatorParameters =
     if (enableBatching) {
-      BatchedSubmissionValidatorParameters.default
+      BatchedSubmissionValidatorParameters.reasonableDefault
     } else {
       BatchedSubmissionValidatorParameters(
         cpuParallelism = 1,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorParameters.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorParameters.scala
@@ -16,7 +16,7 @@ case class BatchedSubmissionValidatorParameters(
 )
 
 object BatchedSubmissionValidatorParameters {
-  lazy val default: BatchedSubmissionValidatorParameters = {
+  lazy val reasonableDefault: BatchedSubmissionValidatorParameters = {
     val availableProcessors = Runtime.getRuntime.availableProcessors()
     BatchedSubmissionValidatorParameters(
       cpuParallelism = availableProcessors,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -40,7 +40,7 @@ class BatchedSubmissionValidatorSpec
 
     "return validation failure for invalid envelope" in {
       val validator = BatchedSubmissionValidator[Unit](
-        BatchedSubmissionValidatorParameters.default,
+        BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
         metrics)
 
@@ -61,7 +61,7 @@ class BatchedSubmissionValidatorSpec
 
     "return validation failure for invalid message type in envelope" in {
       val validator = BatchedSubmissionValidator[Unit](
-        BatchedSubmissionValidatorParameters.default,
+        BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
         metrics)
       val notASubmission = Envelope.enclose(DamlStateValue.getDefaultInstance)
@@ -83,7 +83,7 @@ class BatchedSubmissionValidatorSpec
 
     "return validation failure for invalid envelope in batch" in {
       val validator = BatchedSubmissionValidator[Unit](
-        BatchedSubmissionValidatorParameters.default,
+        BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
         metrics)
       val batchSubmission = DamlSubmissionBatch.newBuilder
@@ -127,7 +127,7 @@ class BatchedSubmissionValidatorSpec
           outputStateCaptor.capture()))
         .thenReturn(Future.unit)
       val validator = BatchedSubmissionValidator[Unit](
-        BatchedSubmissionValidatorParameters.default,
+        BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
         metrics)
 
@@ -182,7 +182,8 @@ class BatchedSubmissionValidatorSpec
           any[Map[DamlStateKey, DamlStateValue]]
         ))
         .thenReturn(Future.unit)
-      val validatorConfig = BatchedSubmissionValidatorParameters.default.copy(commitParallelism = 1)
+      val validatorConfig =
+        BatchedSubmissionValidatorParameters.reasonableDefault.copy(commitParallelism = 1)
       val validator = BatchedSubmissionValidator[Unit](validatorConfig, engine, metrics)
 
       validator
@@ -236,7 +237,7 @@ class BatchedSubmissionValidatorSpec
         ))
         .thenReturn(Future.unit)
       val validator = BatchedSubmissionValidator[Unit](
-        BatchedSubmissionValidatorParameters.default,
+        BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
         metrics)
 
@@ -283,7 +284,7 @@ class BatchedSubmissionValidatorSpec
         .thenReturn(Future.unit)
       val validator =
         BatchedSubmissionValidator[Unit](
-          BatchedSubmissionValidatorParameters.default,
+          BatchedSubmissionValidatorParameters.reasonableDefault,
           engine,
           metrics)
 
@@ -337,7 +338,8 @@ class BatchedSubmissionValidatorSpec
         outputStateCaptor.capture()))
       .thenReturn(Future.unit)
     val validatorConfig =
-      BatchedSubmissionValidatorParameters.default.copy(commitParallelism = commitParallelism)
+      BatchedSubmissionValidatorParameters.reasonableDefault.copy(
+        commitParallelism = commitParallelism)
     val validator = BatchedSubmissionValidator[Unit](validatorConfig, engine, metrics)
 
     validator

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityChecker.scala
@@ -40,7 +40,7 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
     val metricRegistry = new MetricRegistry
     val metrics = new Metrics(metricRegistry)
     val submissionValidator = BatchedSubmissionValidator[LogResult](
-      BatchedSubmissionValidatorParameters.default,
+      BatchedSubmissionValidatorParameters.reasonableDefault,
       new KeyValueCommitting(engine, metrics),
       new ConflictDetection(metrics),
       metrics,


### PR DESCRIPTION
`default` is a reserved keyword in Java so Java clients cannot access some default parameters that are named `default`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
