### PR TITLE
Trigger service: Remove retries when checking trigger ids

### DIFF
--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -169,15 +169,10 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
     } yield triggerIds
   }
 
-  def assertTriggerIds(uri: Uri, party: User, pred: Vector[UUID] => Boolean): Future[Assertion] = {
-    eventually {
-      val actualTriggerIds = Await.result(for {
-        resp <- listTriggers(uri, party)
-        result <- parseTriggerIds(resp)
-      } yield result, Duration.Inf)
-      assert(pred(actualTriggerIds))
-    }
-  }
+  def assertTriggerIds(uri: Uri, party: User, pred: Vector[UUID] => Boolean): Future[Assertion] = for {
+    resp <- listTriggers(uri, party)
+    result <- parseTriggerIds(resp)
+  } yield assert(pred(result))
 
   def parseTriggerStatus(resp: HttpResponse): Future[Vector[String]] = {
     for {

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -169,10 +169,10 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
     } yield triggerIds
   }
 
-  def assertTriggerIds(uri: Uri, party: User, pred: Vector[UUID] => Boolean): Future[Assertion] = for {
+  def assertTriggerIds(uri: Uri, party: User, expected: Vector[UUID]): Future[Assertion] = for {
     resp <- listTriggers(uri, party)
     result <- parseTriggerIds(resp)
-  } yield assert(pred(result))
+  } yield assert(result == expected)
 
   def parseTriggerStatus(resp: HttpResponse): Future[Vector[String]] = {
     for {
@@ -237,7 +237,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
         _ <- mainPackageId should not be empty
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
         triggerId <- parseTriggerId(resp)
-        _ <- assertTriggerIds(uri, alice, _ == Vector(triggerId))
+        _ <- assertTriggerIds(uri, alice, Vector(triggerId))
         resp <- stopTrigger(uri, triggerId, alice)
         stoppedTriggerId <- parseTriggerId(resp)
         _ <- stoppedTriggerId should equal(triggerId)
@@ -253,26 +253,26 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
         // Start trigger for Alice.
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
         aliceTrigger <- parseTriggerId(resp)
-        _ <- assertTriggerIds(uri, alice, _ == Vector(aliceTrigger))
+        _ <- assertTriggerIds(uri, alice, Vector(aliceTrigger))
         // Start trigger for Bob.
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", bob)
         bobTrigger1 <- parseTriggerId(resp)
-        _ <- assertTriggerIds(uri, bob, _ == Vector(bobTrigger1))
+        _ <- assertTriggerIds(uri, bob, Vector(bobTrigger1))
         // Start another trigger for Bob.
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", bob)
         bobTrigger2 <- parseTriggerId(resp)
-        _ <- assertTriggerIds(uri, bob, _ == Vector(bobTrigger1, bobTrigger2).sorted)
+        _ <- assertTriggerIds(uri, bob, Vector(bobTrigger1, bobTrigger2).sorted)
         // Stop Alice's trigger.
         resp <- stopTrigger(uri, aliceTrigger, alice)
         _ <- assert(resp.status.isSuccess)
-        _ <- assertTriggerIds(uri, alice, _.isEmpty)
-        _ <- assertTriggerIds(uri, bob, _ == Vector(bobTrigger1, bobTrigger2).sorted)
+        _ <- assertTriggerIds(uri, alice, Vector())
+        _ <- assertTriggerIds(uri, bob, Vector(bobTrigger1, bobTrigger2).sorted)
         // Stop Bob's triggers.
         resp <- stopTrigger(uri, bobTrigger1, bob)
         _ <- assert(resp.status.isSuccess)
         resp <- stopTrigger(uri, bobTrigger2, bob)
         _ <- assert(resp.status.isSuccess)
-        _ <- assertTriggerIds(uri, bob, _.isEmpty)
+        _ <- assertTriggerIds(uri, bob, Vector())
       } yield succeed
   }
 
@@ -325,7 +325,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
       // The start request should succeed and an entry should be added to the running trigger store,
       // even though the trigger will not be able to start.
       aliceTrigger <- parseTriggerId(resp)
-      _ <- assertTriggerIds(uri, alice, _ == Vector(aliceTrigger))
+      _ <- assertTriggerIds(uri, alice, Vector(aliceTrigger))
       // Check the log for an initialization failure.
       _ <- assertTriggerStatus(uri, aliceTrigger, _.contains("stopped: initialization failure"))
       // Finally establish the connection and check that the trigger eventually starts.
@@ -342,7 +342,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
       // Request a trigger be started for Alice.
       resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
       aliceTrigger <- parseTriggerId(resp)
-      _ <- assertTriggerIds(uri, alice, _ == Vector(aliceTrigger))
+      _ <- assertTriggerIds(uri, alice, Vector(aliceTrigger))
       // Proceed when it's confirmed to be running.
       _ <- assertTriggerStatus(uri, aliceTrigger, _.last == "running")
       // Simulate brief network connectivity loss and observe the trigger fail.
@@ -359,7 +359,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
       for {
         resp <- startTrigger(uri, s"$testPkgId:ErrorTrigger:trigger", alice)
         aliceTrigger <- parseTriggerId(resp)
-        _ <- assertTriggerIds(uri, alice, _ == Vector(aliceTrigger))
+        _ <- assertTriggerIds(uri, alice, Vector(aliceTrigger))
         // We will attempt to restart the trigger indefinitely.
         // Just check that we see a few failures and restart attempts.
         // This relies on a small minimum restart interval as the interval doubles after each
@@ -377,7 +377,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
       for {
         resp <- startTrigger(uri, s"$testPkgId:LowLevelErrorTrigger:trigger", alice)
         aliceTrigger <- parseTriggerId(resp)
-        _ <- assertTriggerIds(uri, alice, _ == Vector(aliceTrigger))
+        _ <- assertTriggerIds(uri, alice, Vector(aliceTrigger))
         // We will attempt to restart the trigger indefinitely.
         // Just check that we see a few failures and restart attempts.
         // This relies on a small minimum restart interval as the interval doubles after each
@@ -494,7 +494,7 @@ class TriggerServiceTestWithDb
         // start trigger defined in previously uploaded dar
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
         triggerId <- parseTriggerId(resp)
-        _ <- assertTriggerIds(uri, alice, _ == Vector(triggerId))
+        _ <- assertTriggerIds(uri, alice, Vector(triggerId))
       } yield succeed
     }
   } yield succeed)
@@ -506,7 +506,7 @@ class TriggerServiceTestWithDb
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
         triggerId <- parseTriggerId(resp)
         // The new trigger should be in the running trigger store and eventually running.
-        _ <- assertTriggerIds(uri, alice, _ == Vector(triggerId))
+        _ <- assertTriggerIds(uri, alice, Vector(triggerId))
         _ <- assertTriggerStatus(uri, triggerId, _.last == "running")
       } yield succeed
     }
@@ -524,7 +524,7 @@ class TriggerServiceTestWithDb
 
         // Finally go ahead and stop the trigger.
         resp <- stopTrigger(uri, aliceTrigger, alice)
-        _ <- assertTriggerIds(uri, alice, _.isEmpty)
+        _ <- assertTriggerIds(uri, alice, Vector())
         _ <- assertTriggerStatus(uri, aliceTrigger, _.last == "stopped: by user request")
       } yield succeed
     }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -169,10 +169,11 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
     } yield triggerIds
   }
 
-  def assertTriggerIds(uri: Uri, party: User, expected: Vector[UUID]): Future[Assertion] = for {
-    resp <- listTriggers(uri, party)
-    result <- parseTriggerIds(resp)
-  } yield assert(result == expected)
+  def assertTriggerIds(uri: Uri, party: User, expected: Vector[UUID]): Future[Assertion] =
+    for {
+      resp <- listTriggers(uri, party)
+      result <- parseTriggerIds(resp)
+    } yield assert(result == expected)
 
   def parseTriggerStatus(resp: HttpResponse): Future[Vector[String]] = {
     for {


### PR DESCRIPTION
The running trigger store is now written to synchronously by the server, so there's no need for retry logic.

Also assert equality of trigger ids rather than an arbitrary predicate, as it gives better error messages and we don't use other types of predicates for this function.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
