### PR TITLE
Return the ledger beginning as the ledger end on an empty ledger

### DIFF
--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
@@ -36,6 +36,8 @@ object Offset {
 
   val beforeBegin: Offset = Offset.fromByteArray(Array.empty[Byte])
 
+  val begin: Offset = Offset.fromByteArray(Array(0: Byte))
+
   def fromByteArray(bytes: Array[Byte]) = new Offset(Bytes.fromByteArray(bytes))
 
   def fromInputStream(is: InputStream) = new Offset(Bytes.fromInputStream(is))

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Offset.scala
@@ -36,8 +36,6 @@ object Offset {
 
   val beforeBegin: Offset = Offset.fromByteArray(Array.empty[Byte])
 
-  val begin: Offset = Offset.fromByteArray(Array(0: Byte))
-
   def fromByteArray(bytes: Array[Byte]) = new Offset(Bytes.fromByteArray(bytes))
 
   def fromInputStream(is: InputStream) = new Offset(Bytes.fromInputStream(is))

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/ApiOffset.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/ApiOffset.scala
@@ -12,6 +12,8 @@ import scala.util.{Failure, Success, Try}
 // offsets sent over the API and received from the API.
 object ApiOffset {
 
+  val begin: Offset = Offset.fromByteArray(Array(0: Byte))
+
   def fromString(s: String): Try[Offset] =
     Ref.HexString
       .fromString(s)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -145,7 +145,7 @@ abstract class LedgerBackedIndexService(
 
   override def currentLedgerEnd(): Future[LedgerOffset.Absolute] = {
     val offset =
-      if (ledger.ledgerEnd == Offset.beforeBegin) Offset.begin
+      if (ledger.ledgerEnd == Offset.beforeBegin) ApiOffset.begin
       else ledger.ledgerEnd
     Future.successful(toAbsolute(offset))
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -143,8 +143,12 @@ abstract class LedgerBackedIndexService(
         party -> filters.inclusive.fold(Set.empty[Identifier])(_.templateIds)
     }
 
-  override def currentLedgerEnd(): Future[LedgerOffset.Absolute] =
-    Future.successful(toAbsolute(ledger.ledgerEnd))
+  override def currentLedgerEnd(): Future[LedgerOffset.Absolute] = {
+    if (ledger.ledgerEnd == Offset.beforeBegin) {
+      Future.successful(toAbsolute(Offset.begin))
+    } else
+      Future.successful(toAbsolute(ledger.ledgerEnd))
+  }
 
   override def getTransactionById(
       transactionId: TransactionId,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/LedgerBackedIndexService.scala
@@ -144,10 +144,10 @@ abstract class LedgerBackedIndexService(
     }
 
   override def currentLedgerEnd(): Future[LedgerOffset.Absolute] = {
-    if (ledger.ledgerEnd == Offset.beforeBegin) {
-      Future.successful(toAbsolute(Offset.begin))
-    } else
-      Future.successful(toAbsolute(ledger.ledgerEnd))
+    val offset =
+      if (ledger.ledgerEnd == Offset.beforeBegin) Offset.begin
+      else ledger.ledgerEnd
+    Future.successful(toAbsolute(offset))
   }
 
   override def getTransactionById(

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
@@ -45,12 +45,12 @@ class EmptyLedgerIT
       implicitPartyAllocation = false
     )
 
-  private[this] val applicationId = "CompletionServiceIT"
+  private[this] val applicationId = getClass.getSimpleName
 
   // How long it takes to download the entire completion stream.
   // Because the stream does not terminate, we use a timeout to determine when the stream
   // is done emitting elements.
-  private[this] val completionTimeout = FiniteDuration(2, TimeUnit.SECONDS)
+  private[this] val completionTimeout = 2.seconds
 
   private[this] def completionsFromOffset(
       completionService: CommandCompletionServiceGrpc.CommandCompletionServiceStub,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
@@ -4,7 +4,6 @@
 package com.daml.platform.sandbox.services.completion
 
 import java.time.Duration
-import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.v1.command_completion_service.{

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.services.completion
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.ledger.api.v1.command_completion_service.{
+  CommandCompletionServiceGrpc,
+  CompletionEndRequest,
+  CompletionStreamRequest,
+  CompletionStreamResponse
+}
+import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import com.daml.platform.sandbox.SandboxBackend
+import com.daml.platform.sandbox.config.SandboxConfig
+import com.daml.platform.sandbox.services.TestCommands
+import com.daml.platform.sandboxnext.SandboxNextFixture
+import com.daml.platform.testing.StreamConsumer
+import org.scalatest.{AsyncWordSpec, Inspectors, Matchers}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scalaz.syntax.tag._
+
+class EmptyLedgerIT
+    extends AsyncWordSpec
+    with Matchers
+    with Inspectors
+    with SandboxNextFixture
+    with SandboxBackend.Postgresql
+    with TestCommands
+    with SuiteResourceManagementAroundAll {
+
+  // Start with empty daml packages and a large configuration delay, such that we can test the API's behavior
+  // on an empty index
+  override protected def config: SandboxConfig =
+    super.config.copy(
+      damlPackages = List.empty,
+      ledgerConfig = super.config.ledgerConfig.copy(
+        initialConfigurationSubmitDelay = Duration.ofDays(5)
+      ),
+      implicitPartyAllocation = false
+    )
+
+  private[this] val applicationId = "CompletionServiceIT"
+
+  // How long it takes to download the entire completion stream.
+  // Because the stream does not terminate, we use a timeout to determine when the stream
+  // is done emitting elements.
+  private[this] val completionTimeout = FiniteDuration(2, TimeUnit.SECONDS)
+
+  private[this] def completionsFromOffset(
+      completionService: CommandCompletionServiceGrpc.CommandCompletionServiceStub,
+      ledgerId: String,
+      parties: Seq[String],
+      offset: LedgerOffset,
+  ): Future[Vector[String]] = {
+    new StreamConsumer[CompletionStreamResponse](
+      completionService.completionStream(
+        CompletionStreamRequest(ledgerId, applicationId, parties, Some(offset)),
+        _
+      )
+    ).within(completionTimeout)
+      .map(_.flatMap(_.completions).map(_.commandId))
+  }
+
+  "CommandCompletionService gives sensible ledger end on an empty ledger" in {
+
+    val partyA = "partyA"
+    val lid = ledgerId().unwrap
+    val completionService = CommandCompletionServiceGrpc.stub(channel)
+    for {
+      end <- completionService.completionEnd(CompletionEndRequest(lid))
+      completions <- completionsFromOffset(completionService, lid, List(partyA), end.getOffset)
+    } yield {
+      completions shouldBe empty
+    }
+  }
+}

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
@@ -22,7 +22,7 @@ import com.daml.platform.testing.StreamConsumer
 import org.scalatest.{AsyncWordSpec, Inspectors, Matchers}
 
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.DurationInt
 import scalaz.syntax.tag._
 
 class EmptyLedgerIT


### PR DESCRIPTION
Previously, the services would return `Offset.beforeBegin` to the clients, and the other services deem this offset to be invalid.

Closes #6529 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
