### PR TITLE
Enter application with args already evaluated to values.

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -130,8 +130,11 @@ object SExpr {
       with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
       val vfun = fun.lookupValue(machine)
-      //TODO: evaluate args to SValue here
-      enterApplication(machine, vfun, args)
+      val actuals = new util.ArrayList[SValue](args.size)
+      for (i <- 0 until args.size) {
+        actuals.add(args(i).lookupValue(machine))
+      }
+      enterApplication(machine, vfun, actuals)
     }
   }
 
@@ -144,9 +147,7 @@ object SExpr {
       val arity = builtin.arity
       val actuals = new util.ArrayList[SValue](arity)
       for (i <- 0 to arity - 1) {
-        val arg = args(i)
-        val v = arg.lookupValue(machine)
-        actuals.add(v)
+        actuals.add(args(i).lookupValue(machine))
       }
       builtin.executeEffect(actuals, machine)
     }


### PR DESCRIPTION
Enter application with args already evaluated to values.

- Combined with a small optimization for when `actualsSoFar` is empty, this means that we avoid constructing a new array for `actuals` and instead just use `newActuals` directly.

- Also, in the case of an _over-application_, we can save just the over-applied `SValue`s (not args) in the `KOverApp` continuation, thus avoiding the need to save/restore the environment.

This change is somewhat related to the idea suggested in issue #6522

I ran some perf on this change, and it is actually significant. Running 6-way (here,master,here,master,here,master) on my nice shiny cloud perf machine.. shows about 2% improvement
```
          53.599 ±(99.9%) 0.330 ms/op [Average]
          54.542 ±(99.9%) 0.440 ms/op [Average]
          53.651 ±(99.9%) 0.540 ms/op [Average]
          55.257 ±(99.9%) 0.431 ms/op [Average]
          53.745 ±(99.9%) 0.659 ms/op [Average]
          54.747 ±(99.9%) 0.260 ms/op [Average]
```


changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
