### PR TITLE
Revert unneeded kvutils format version bump

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -83,8 +83,7 @@ object Version {
     *   5: * Add active_at to DamlContractKeyState to be able to check causal monotonicity of positive key lookups,
     *        i.e. whether the contract currently associated with a contract key was created in a transaction with
     *        ledger_effective_time <= the ledger_effective_time of the transaction under validation.
-    *   6: * Remove fields record_time from DamlCommandDedupValue and DamlSubmissionDedupValue.
     *
     */
-  val version: Long = 6
+  val version: Long = 5
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Version.scala
@@ -83,6 +83,7 @@ object Version {
     *   5: * Add active_at to DamlContractKeyState to be able to check causal monotonicity of positive key lookups,
     *        i.e. whether the contract currently associated with a contract key was created in a transaction with
     *        ledger_effective_time <= the ledger_effective_time of the transaction under validation.
+    *      * Remove fields record_time from DamlCommandDedupValue and DamlSubmissionDedupValue.
     *
     */
   val version: Long = 5


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

This format version bump turned out not to be needed (b/c the new format is backwards-compatible) and to cause dump compatibility test failures.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
