### PR TITLE
sandbox: Accept a new time model when none is set.

### DIFF
--- a/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/AcsBench.scala
+++ b/ledger/sandbox-perf/src/perf/benches/scala/com/digitalasset/platform/sandbox/perf/AcsBench.scala
@@ -46,7 +46,7 @@ class AcsBench extends TestCommands with InfAwait {
       ledgerId = ledgerId,
       commandId = s"command-id-exercise-$sequenceNumber",
       commands = Seq(exerciseWithUnit(template, contractId, "DummyChoice1")),
-      appId = "app1"
+      applicationId = "app1",
     ).toSync
   }
 

--- a/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/DummyCommands.scala
+++ b/ledger/sandbox-perf/src/perf/lib/scala/com/digitalasset/platform/sandbox/perf/DummyCommands.scala
@@ -24,7 +24,7 @@ trait DummyCommands extends TestCommands {
             ledgerId = ledgerId,
             commandId = s"command-id-create-$i",
             commands = Seq(createWithOperator(templates.dummy)),
-            appId = "app1"
+            applicationId = "app1",
           ).toSync)
   }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/configuration/LedgerConfiguration.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/configuration/LedgerConfiguration.scala
@@ -32,16 +32,22 @@ case class LedgerConfiguration(
 
 object LedgerConfiguration {
 
+  val NoGeneration: Long = 0
+
+  val StartingGeneration: Long = 1
+
+  private val reasonableInitialConfiguration: Configuration = Configuration(
+    generation = StartingGeneration,
+    timeModel = TimeModel.reasonableDefault,
+    maxDeduplicationTime = Duration.ofDays(1),
+  )
+
   /** Default configuration for a ledger-backed index,
     * i.e., if there is zero delay between the ledger and the index.
     * Example: Sandbox classic.
     */
   val defaultLedgerBackedIndex: LedgerConfiguration = LedgerConfiguration(
-    initialConfiguration = Configuration(
-      generation = 1,
-      timeModel = TimeModel.reasonableDefault,
-      maxDeduplicationTime = Duration.ofDays(1)
-    ),
+    initialConfiguration = reasonableInitialConfiguration,
     initialConfigurationSubmitDelay = Duration.ZERO,
     configurationLoadTimeout = Duration.ofSeconds(1),
   )
@@ -51,11 +57,7 @@ object LedgerConfiguration {
     * Example: Sandbox next.
     */
   val defaultLocalLedger: LedgerConfiguration = LedgerConfiguration(
-    initialConfiguration = Configuration(
-      generation = 1,
-      timeModel = TimeModel.reasonableDefault,
-      maxDeduplicationTime = Duration.ofDays(1)
-    ),
+    initialConfiguration = reasonableInitialConfiguration,
     initialConfigurationSubmitDelay = Duration.ofMillis(500),
     configurationLoadTimeout = Duration.ofSeconds(5),
   )
@@ -64,11 +66,7 @@ object LedgerConfiguration {
     * i.e., if there may be significant delay between the ledger and the index.
     */
   val defaultRemote: LedgerConfiguration = LedgerConfiguration(
-    initialConfiguration = Configuration(
-      generation = 1,
-      timeModel = TimeModel.reasonableDefault,
-      maxDeduplicationTime = Duration.ofDays(1)
-    ),
+    initialConfiguration = reasonableInitialConfiguration,
     initialConfigurationSubmitDelay = Duration.ofSeconds(5),
     configurationLoadTimeout = Duration.ofSeconds(10),
   )

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TestCommands.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TestCommands.scala
@@ -6,10 +6,7 @@ package com.daml.platform.sandbox.services
 import java.io.File
 import java.util
 
-import com.daml.lf.archive.DarReader
-import com.daml.lf.data.Ref.PackageId
 import com.daml.ledger.api.domain
-import com.daml.ledger.api.testing.utils.MockMessages.applicationId
 import com.daml.ledger.api.testing.utils.{MockMessages => M}
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
@@ -18,6 +15,8 @@ import com.daml.ledger.api.v1.commands.{Command, Commands, CreateCommand, Exerci
 import com.daml.ledger.api.v1.value.Value.Sum
 import com.daml.ledger.api.v1.value.Value.Sum.{Bool, Party, Text, Timestamp}
 import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value, Variant}
+import com.daml.lf.archive.DarReader
+import com.daml.lf.data.Ref.PackageId
 import com.daml.platform.participant.util.ValueConversions._
 import com.daml.platform.testing.TestTemplateIdentifiers
 import scalaz.syntax.tag._
@@ -34,12 +33,14 @@ trait TestCommands {
       ledgerId: domain.LedgerId,
       commandId: String,
       commands: Seq[Command],
-      appId: String = applicationId,
+      applicationId: String = M.applicationId,
+      party: String = M.party,
   ): SubmitRequest =
     M.submitRequest.update(
       _.commands.commandId := commandId,
       _.commands.ledgerId := ledgerId.unwrap,
-      _.commands.applicationId := appId,
+      _.commands.applicationId := applicationId,
+      _.commands.party := party,
       _.commands.commands := commands,
     )
 
@@ -49,13 +50,14 @@ trait TestCommands {
       party: String = M.party,
   ): SubmitRequest =
     buildRequest(
-      ledgerId,
-      commandId,
-      List(
+      ledgerId = ledgerId,
+      commandId = commandId,
+      commands = List(
         createWithOperator(templateIds.dummy, party),
         createWithOperator(templateIds.dummyWithParam, party),
         createWithOperator(templateIds.dummyFactory, party)
-      )
+      ),
+      party = party,
     )
 
   protected def createWithOperator(templateId: Identifier, party: String = M.party): Command =

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TimeModelHelpers.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/sandbox/services/TimeModelHelpers.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.services
+
+import com.daml.api.util.DurationConversion
+import com.daml.ledger.api.v1.admin.config_management_service.{
+  ConfigManagementServiceGrpc,
+  GetTimeModelRequest,
+  SetTimeModelRequest,
+  TimeModel => ProtobufTimeModel
+}
+import com.daml.ledger.participant.state.v1.TimeModel
+import com.google.protobuf.timestamp.Timestamp
+import io.grpc.Channel
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object TimeModelHelpers {
+  def publishATimeModel(channel: Channel)(implicit ec: ExecutionContext): Future[Unit] = {
+    val configService = ConfigManagementServiceGrpc.stub(channel)
+    for {
+      current <- configService.getTimeModel(GetTimeModelRequest())
+      generation = current.configurationGeneration
+      timeModel = TimeModel.reasonableDefault
+      _ <- configService.setTimeModel(
+        SetTimeModelRequest(
+          "config-submission",
+          Some(Timestamp(30, 0)),
+          generation,
+          Some(ProtobufTimeModel(
+            avgTransactionLatency =
+              Some(DurationConversion.toProto(timeModel.avgTransactionLatency)),
+            minSkew = Some(DurationConversion.toProto(timeModel.minSkew)),
+            maxSkew = Some(DurationConversion.toProto(timeModel.maxSkew))
+          ))
+        ))
+    } yield ()
+  }
+}

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/CompletionServiceWithEmptyLedgerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/CompletionServiceWithEmptyLedgerIT.scala
@@ -94,15 +94,14 @@ final class CompletionServiceWithEmptyLedgerIT
       _ <- publishATimeModel(channel)
       _ <- uploadDarFile(darFile, channel)
       _ <- allocateParty(party, channel)
-      completionsF = completionsFromOffset(
+      _ <- submissionService.submit(dummyCommands(lid, commandId, party))
+      completions <- completionsFromOffset(
         completionService = completionService,
         ledgerId = lid,
         parties = List(party),
         offset = end.getOffset,
-        completionTimeout = 10.seconds,
+        completionTimeout = 2.seconds,
       )
-      _ <- submissionService.submit(dummyCommands(lid, commandId, party))
-      completions <- completionsF
     } yield {
       completions shouldBe Vector(commandId)
     }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
@@ -5,7 +5,14 @@ package com.daml.platform.sandbox.services.completion
 
 import java.time.Duration
 
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.api.util.DurationConversion
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundEach
+import com.daml.ledger.api.v1.admin.config_management_service.{
+  ConfigManagementServiceGrpc,
+  GetTimeModelRequest,
+  SetTimeModelRequest,
+  TimeModel => ProtobufTimeModel
+}
 import com.daml.ledger.api.v1.command_completion_service.{
   CommandCompletionServiceGrpc,
   CompletionEndRequest,
@@ -13,12 +20,15 @@ import com.daml.ledger.api.v1.command_completion_service.{
   CompletionStreamResponse
 }
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import com.daml.ledger.participant.state.v1.TimeModel
+import com.daml.platform.ApiOffset
 import com.daml.platform.sandbox.SandboxBackend
 import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.platform.sandbox.services.TestCommands
 import com.daml.platform.sandbox.services.completion.EmptyLedgerIT._
 import com.daml.platform.sandboxnext.SandboxNextFixture
 import com.daml.platform.testing.StreamConsumer
+import com.google.protobuf.timestamp.Timestamp
 import org.scalatest.{AsyncWordSpec, Inspectors, Matchers}
 import scalaz.syntax.tag._
 
@@ -32,7 +42,7 @@ final class EmptyLedgerIT
     with SandboxNextFixture
     with SandboxBackend.Postgresql
     with TestCommands
-    with SuiteResourceManagementAroundAll {
+    with SuiteResourceManagementAroundEach {
 
   // Start with empty daml packages and a large configuration delay, such that we can test the API's behavior
   // on an empty index
@@ -53,6 +63,37 @@ final class EmptyLedgerIT
       end <- completionService.completionEnd(CompletionEndRequest(lid))
       completions <- completionsFromOffset(completionService, lid, List(partyA), end.getOffset)
     } yield {
+      end.getOffset.value.absolute.get shouldBe ApiOffset.begin.toHexString
+      completions shouldBe empty
+    }
+  }
+
+  "ConfigManagementService accepts a configuration when none is set" in {
+    val partyA = "partyA"
+    val lid = ledgerId().unwrap
+    val completionService = CommandCompletionServiceGrpc.stub(channel)
+    val configService = ConfigManagementServiceGrpc.stub(channel)
+    for {
+      end <- completionService.completionEnd(CompletionEndRequest(lid))
+      completions <- completionsFromOffset(completionService, lid, List(partyA), end.getOffset)
+      current <- configService.getTimeModel(GetTimeModelRequest())
+      generation = current.configurationGeneration
+      timeModel = TimeModel.reasonableDefault
+      _ <- configService.setTimeModel(
+        SetTimeModelRequest(
+          "config-submission",
+          Some(Timestamp(30, 0)),
+          generation,
+          Some(ProtobufTimeModel(
+            avgTransactionLatency =
+              Some(DurationConversion.toProto(timeModel.avgTransactionLatency)),
+            minSkew = Some(DurationConversion.toProto(timeModel.minSkew)),
+            maxSkew = Some(DurationConversion.toProto(timeModel.maxSkew))
+          ))
+        ))
+      newEnd <- completionService.completionEnd(CompletionEndRequest(lid))
+    } yield {
+      newEnd.getOffset.value.absolute.get should not be ApiOffset.begin.toHexString
       completions shouldBe empty
     }
   }

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
@@ -3,6 +3,8 @@
 
 package com.daml.platform.sandbox.services.completion
 
+import java.io.File
+import java.nio.file.Files
 import java.time.Duration
 
 import com.daml.api.util.DurationConversion
@@ -13,22 +15,38 @@ import com.daml.ledger.api.v1.admin.config_management_service.{
   SetTimeModelRequest,
   TimeModel => ProtobufTimeModel
 }
+import com.daml.ledger.api.v1.admin.package_management_service.{
+  PackageManagementServiceGrpc,
+  UploadDarFileRequest,
+  UploadDarFileResponse
+}
+import com.daml.ledger.api.v1.admin.party_management_service.{
+  AllocatePartyRequest,
+  AllocatePartyResponse,
+  PartyManagementServiceGrpc
+}
 import com.daml.ledger.api.v1.command_completion_service.{
   CommandCompletionServiceGrpc,
   CompletionEndRequest,
   CompletionStreamRequest,
   CompletionStreamResponse
 }
+import com.daml.ledger.api.v1.command_service.{CommandServiceGrpc, SubmitAndWaitRequest}
+import com.daml.ledger.api.v1.commands.{Command, Commands, CreateCommand}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.participant.state.v1.TimeModel
 import com.daml.platform.ApiOffset
+import com.daml.platform.participant.util.ValueConversions.CreateCommands
 import com.daml.platform.sandbox.SandboxBackend
 import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.platform.sandbox.services.TestCommands
 import com.daml.platform.sandbox.services.completion.EmptyLedgerIT._
 import com.daml.platform.sandboxnext.SandboxNextFixture
 import com.daml.platform.testing.StreamConsumer
+import com.google.protobuf.ByteString
 import com.google.protobuf.timestamp.Timestamp
+import io.grpc.Channel
 import org.scalatest.{AsyncWordSpec, Inspectors, Matchers}
 import scalaz.syntax.tag._
 
@@ -56,12 +74,12 @@ final class EmptyLedgerIT
     )
 
   "CommandCompletionService gives sensible ledger end on an empty ledger" in {
-    val partyA = "partyA"
     val lid = ledgerId().unwrap
+    val party = "partyA"
     val completionService = CommandCompletionServiceGrpc.stub(channel)
     for {
       end <- completionService.completionEnd(CompletionEndRequest(lid))
-      completions <- completionsFromOffset(completionService, lid, List(partyA), end.getOffset)
+      completions <- completionsFromOffset(completionService, lid, List(party), end.getOffset)
     } yield {
       end.getOffset.value.absolute.get shouldBe ApiOffset.begin.toHexString
       completions shouldBe empty
@@ -69,13 +87,56 @@ final class EmptyLedgerIT
   }
 
   "ConfigManagementService accepts a configuration when none is set" in {
-    val partyA = "partyA"
     val lid = ledgerId().unwrap
     val completionService = CommandCompletionServiceGrpc.stub(channel)
-    val configService = ConfigManagementServiceGrpc.stub(channel)
+    for {
+      _ <- publishATimeModel(channel)
+      end <- completionService.completionEnd(CompletionEndRequest(lid))
+    } yield {
+      end.getOffset.value.absolute.get should not be ApiOffset.begin.toHexString
+    }
+  }
+
+  "CommandCompletionService can stream completions from the beginning" in {
+    val lid = ledgerId().unwrap
+    val party = "partyA"
+    val commandId = "commandId"
+    val command: Command = CreateCommand(
+      Some(templateIds.dummy),
+      Some(
+        Record(
+          Some(templateIds.dummy),
+          Seq(RecordField("operator", Option(Value(Value.Sum.Party(party)))))))).wrap
+    val commands = Commands(lid, workflowId, applicationId, commandId, party, Seq(command))
+
+    val commandService = CommandServiceGrpc.stub(channel)
+    val completionService = CommandCompletionServiceGrpc.stub(channel)
     for {
       end <- completionService.completionEnd(CompletionEndRequest(lid))
-      completions <- completionsFromOffset(completionService, lid, List(partyA), end.getOffset)
+      _ <- publishATimeModel(channel)
+      _ <- uploadDarFile(darFile, channel)
+      _ <- allocateParty(party, channel)
+      _ <- commandService.submitAndWait(SubmitAndWaitRequest(Some(commands), None))
+      completions <- completionsFromOffset(completionService, lid, List(party), end.getOffset)
+    } yield {
+      completions shouldBe Vector(commandId)
+    }
+  }
+}
+
+object EmptyLedgerIT {
+  private val applicationId = classOf[EmptyLedgerIT].getSimpleName
+
+  private val workflowId = "workflowId"
+
+  // How long it takes to download the entire completion stream.
+  // Because the stream does not terminate, we use a timeout to determine when the stream
+  // is done emitting elements.
+  private val completionTimeout = 2.seconds
+
+  private def publishATimeModel(channel: Channel)(implicit ec: ExecutionContext): Future[Unit] = {
+    val configService = ConfigManagementServiceGrpc.stub(channel)
+    for {
       current <- configService.getTimeModel(GetTimeModelRequest())
       generation = current.configurationGeneration
       timeModel = TimeModel.reasonableDefault
@@ -91,21 +152,26 @@ final class EmptyLedgerIT
             maxSkew = Some(DurationConversion.toProto(timeModel.maxSkew))
           ))
         ))
-      newEnd <- completionService.completionEnd(CompletionEndRequest(lid))
-    } yield {
-      newEnd.getOffset.value.absolute.get should not be ApiOffset.begin.toHexString
-      completions shouldBe empty
-    }
+    } yield ()
   }
-}
 
-object EmptyLedgerIT {
-  private val applicationId = classOf[EmptyLedgerIT].getSimpleName
+  private def uploadDarFile(darFile: File, channel: Channel): Future[UploadDarFileResponse] = {
+    val packageService = PackageManagementServiceGrpc.stub(channel)
+    val darContents = {
+      val inputStream = Files.newInputStream(darFile.toPath)
+      try {
+        ByteString.readFrom(inputStream)
+      } finally {
+        inputStream.close()
+      }
+    }
+    packageService.uploadDarFile(UploadDarFileRequest(darContents, "uploadSubmissionId"))
+  }
 
-  // How long it takes to download the entire completion stream.
-  // Because the stream does not terminate, we use a timeout to determine when the stream
-  // is done emitting elements.
-  private val completionTimeout = 2.seconds
+  private def allocateParty(party: String, channel: Channel): Future[AllocatePartyResponse] = {
+    val partyService = PartyManagementServiceGrpc.stub(channel)
+    partyService.allocateParty(AllocatePartyRequest(party))
+  }
 
   private def completionsFromOffset(
       completionService: CommandCompletionServiceGrpc.CommandCompletionServiceStub,

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/completion/EmptyLedgerIT.scala
@@ -8,7 +8,8 @@ import java.nio.file.Files
 import java.time.Duration
 
 import com.daml.api.util.DurationConversion
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundEach
+import com.daml.ledger.api.domain
+import com.daml.ledger.api.testing.utils.{MockMessages, SuiteResourceManagementAroundEach}
 import com.daml.ledger.api.v1.admin.config_management_service.{
   ConfigManagementServiceGrpc,
   GetTimeModelRequest,
@@ -31,13 +32,10 @@ import com.daml.ledger.api.v1.command_completion_service.{
   CompletionStreamRequest,
   CompletionStreamResponse
 }
-import com.daml.ledger.api.v1.command_service.{CommandServiceGrpc, SubmitAndWaitRequest}
-import com.daml.ledger.api.v1.commands.{Command, Commands, CreateCommand}
+import com.daml.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
-import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
 import com.daml.ledger.participant.state.v1.TimeModel
 import com.daml.platform.ApiOffset
-import com.daml.platform.participant.util.ValueConversions.CreateCommands
 import com.daml.platform.sandbox.SandboxBackend
 import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.platform.sandbox.services.TestCommands
@@ -50,7 +48,7 @@ import io.grpc.Channel
 import org.scalatest.{AsyncWordSpec, Inspectors, Matchers}
 import scalaz.syntax.tag._
 
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
 final class EmptyLedgerIT
@@ -74,12 +72,18 @@ final class EmptyLedgerIT
     )
 
   "CommandCompletionService gives sensible ledger end on an empty ledger" in {
-    val lid = ledgerId().unwrap
+    val lid = ledgerId()
     val party = "partyA"
     val completionService = CommandCompletionServiceGrpc.stub(channel)
     for {
-      end <- completionService.completionEnd(CompletionEndRequest(lid))
-      completions <- completionsFromOffset(completionService, lid, List(party), end.getOffset)
+      end <- completionService.completionEnd(CompletionEndRequest(lid.unwrap))
+      completions <- completionsFromOffset(
+        completionService = completionService,
+        ledgerId = lid,
+        parties = List(party),
+        offset = end.getOffset,
+        completionTimeout = 2.seconds,
+      )
     } yield {
       end.getOffset.value.absolute.get shouldBe ApiOffset.begin.toHexString
       completions shouldBe empty
@@ -98,26 +102,26 @@ final class EmptyLedgerIT
   }
 
   "CommandCompletionService can stream completions from the beginning" in {
-    val lid = ledgerId().unwrap
+    val lid = ledgerId()
     val party = "partyA"
     val commandId = "commandId"
-    val command: Command = CreateCommand(
-      Some(templateIds.dummy),
-      Some(
-        Record(
-          Some(templateIds.dummy),
-          Seq(RecordField("operator", Option(Value(Value.Sum.Party(party)))))))).wrap
-    val commands = Commands(lid, workflowId, applicationId, commandId, party, Seq(command))
 
-    val commandService = CommandServiceGrpc.stub(channel)
+    val submissionService = CommandSubmissionServiceGrpc.stub(channel)
     val completionService = CommandCompletionServiceGrpc.stub(channel)
     for {
-      end <- completionService.completionEnd(CompletionEndRequest(lid))
+      end <- completionService.completionEnd(CompletionEndRequest(lid.unwrap))
       _ <- publishATimeModel(channel)
       _ <- uploadDarFile(darFile, channel)
       _ <- allocateParty(party, channel)
-      _ <- commandService.submitAndWait(SubmitAndWaitRequest(Some(commands), None))
-      completions <- completionsFromOffset(completionService, lid, List(party), end.getOffset)
+      completionsF = completionsFromOffset(
+        completionService = completionService,
+        ledgerId = lid,
+        parties = List(party),
+        offset = end.getOffset,
+        completionTimeout = 10.seconds,
+      )
+      _ <- submissionService.submit(dummyCommands(lid, commandId, party))
+      completions <- completionsF
     } yield {
       completions shouldBe Vector(commandId)
     }
@@ -125,15 +129,6 @@ final class EmptyLedgerIT
 }
 
 object EmptyLedgerIT {
-  private val applicationId = classOf[EmptyLedgerIT].getSimpleName
-
-  private val workflowId = "workflowId"
-
-  // How long it takes to download the entire completion stream.
-  // Because the stream does not terminate, we use a timeout to determine when the stream
-  // is done emitting elements.
-  private val completionTimeout = 2.seconds
-
   private def publishATimeModel(channel: Channel)(implicit ec: ExecutionContext): Future[Unit] = {
     val configService = ConfigManagementServiceGrpc.stub(channel)
     for {
@@ -175,13 +170,16 @@ object EmptyLedgerIT {
 
   private def completionsFromOffset(
       completionService: CommandCompletionServiceGrpc.CommandCompletionServiceStub,
-      ledgerId: String,
+      ledgerId: domain.LedgerId,
       parties: Seq[String],
       offset: LedgerOffset,
+      // Because the stream does not terminate, we use a timeout to cut it off when it *should* be
+      // done. Obviously, this is prone to error, so the timeouts are fairly generous.
+      completionTimeout: FiniteDuration,
   )(implicit ec: ExecutionContext): Future[Vector[String]] = {
     new StreamConsumer[CompletionStreamResponse](
       completionService.completionStream(
-        CompletionStreamRequest(ledgerId, applicationId, parties, Some(offset)),
+        CompletionStreamRequest(ledgerId.unwrap, MockMessages.applicationId, parties, Some(offset)),
         _
       )
     ).within(completionTimeout)

--- a/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/configuration/ConfigurationServiceWithEmptyLedgerIT.scala
+++ b/ledger/sandbox/src/test/suite/scala/com/digitalasset/platform/sandbox/services/configuration/ConfigurationServiceWithEmptyLedgerIT.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.services.configuration
+
+import java.time.Duration
+
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundEach
+import com.daml.ledger.api.v1.command_completion_service.{
+  CommandCompletionServiceGrpc,
+  CompletionEndRequest
+}
+import com.daml.platform.ApiOffset
+import com.daml.platform.sandbox.SandboxBackend
+import com.daml.platform.sandbox.config.SandboxConfig
+import com.daml.platform.sandbox.services.TestCommands
+import com.daml.platform.sandbox.services.TimeModelHelpers.publishATimeModel
+import com.daml.platform.sandboxnext.SandboxNextFixture
+import org.scalatest.{AsyncWordSpec, Inspectors, Matchers}
+import scalaz.syntax.tag._
+
+final class ConfigurationServiceWithEmptyLedgerIT
+    extends AsyncWordSpec
+    with Matchers
+    with Inspectors
+    with SandboxNextFixture
+    with SandboxBackend.Postgresql
+    with TestCommands
+    with SuiteResourceManagementAroundEach {
+
+  // Start with no DAML packages and a large configuration delay, such that we can test the API's
+  // behavior on an empty index.
+  override protected def config: SandboxConfig =
+    super.config.copy(
+      damlPackages = List.empty,
+      ledgerConfig = super.config.ledgerConfig.copy(
+        initialConfigurationSubmitDelay = Duration.ofDays(5),
+      ),
+      implicitPartyAllocation = false,
+    )
+
+  "ConfigManagementService accepts a configuration when none is set" in {
+    val lid = ledgerId().unwrap
+    val completionService = CommandCompletionServiceGrpc.stub(channel)
+    for {
+      _ <- publishATimeModel(channel)
+      end <- completionService.completionEnd(CompletionEndRequest(lid))
+    } yield {
+      end.getOffset.value.absolute.get should not be ApiOffset.begin.toHexString
+    }
+  }
+}


### PR DESCRIPTION
And add some tests to make sure that completions can be streamed from the beginning.

Closes #6640.

### Changelog

- **[Ledger API Server + (Sandbox / Ledger Integration Kit)]**
  Accept a new time model if none is set. Previously, it would erroneously be rejected because the generation number submitted to was incorrectly set to `2` rather than `1`.

  This would not affect most users of Sandbox or other kvutils-based ledgers, as if a configuration is set automatically on startup when creating a new ledger. It only affects users who explicitly override the initial ledger configuration submit delay to something longer than a few milliseconds.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
