### PR TITLE
CI: Increase the PostgreSQL connections from 100 to 200.

### DIFF
--- a/ci/postgresql.conf
+++ b/ci/postgresql.conf
@@ -1,5 +1,6 @@
 listen_addresses = '${POSTGRESQL_HOST}'
 port = ${POSTGRESQL_PORT}
+max_connections = 200
 unix_socket_directories = '${POSTGRESQL_ROOT_DIR}'
 fsync = off
 synchronous_commit = off


### PR DESCRIPTION
We saw a flake recently where PostgreSQL stopped accepting connections during a CI run, leading the build to fail. This increases the number of connections to 200 from the default of 100, hopefully mitigating issues such as this one.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
