### PR TITLE
Fix leakage of SDK installations

### DIFF
--- a/libs-haskell/test-utils/DA/Test/Util.hs
+++ b/libs-haskell/test-utils/DA/Test/Util.hs
@@ -44,7 +44,12 @@ withTempFileResource :: (IO FilePath -> TestTree) -> TestTree
 withTempFileResource f = withResource newTempFile snd (f . fmap fst)
 
 withTempDirResource :: (IO FilePath -> TestTree) -> TestTree
-withTempDirResource f = withResource newTempDir snd (f . fmap fst)
+withTempDirResource f = withResource newTempDir delete (f . fmap fst)
+  -- The delete action provided by `newTempDir` calls `removeDirectoryRecursively`
+  -- and silently swallows errors. SDK installations are marked read-only
+  -- which means that they don’t end up being removed which is obviously
+  -- not what we intend.
+  where delete (d, _delete) = removePathForcibly d
 
 nullDevice :: FilePath
 nullDevice


### PR DESCRIPTION
This fixes an issue where the integration tests leaked SDK
installations. Easily verified by `ls /tmp/extra-dir*` before and
after running the tests.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
