### PR TITLE
Ledger API Test Tool: deprecate unneeded tests and options 

### DIFF
--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -82,13 +82,12 @@ Use the following command line flags to select which tests to run:
 - ``--list-all``: print all available tests to the console, shows if they are run by default
 - ``--include``: only run the tests that match the argument
 - ``--exclude``: do not run the tests that match the argument
-- ``--all-tests``: include all default and optional tests. This flag can be combined with the ``--exclude`` flag.
 - ``--perf-tests``: list performance tests to run; cannot be combined with normal tests
 
 Include and exclude are matched as prefixes, e.g. ``--exclude=SemanticTests``
 will exclude all tests whose name starts with ``SemanticTests``. Test names
-always start with their suite name followed by a colon, so the test suite names shown by ``--list`` can be
-useful for coarse-grained inclusion/exclusion.
+always start with their suite name followed by a colon, so the test suite
+names shown by ``--list`` can be useful for coarse-grained inclusion/exclusion.
 
 Both ``--include`` and ``--exclude`` (and ``--perf-tests``) can be specified
 multiple times and/or provide comma-separated lists, i.e. all of these are
@@ -102,12 +101,10 @@ The logic is always to first select included tests, then remove from that the
 excluded ones, i.e. include directives never override a corresponding exclude
 directive.
 
-If no ``--include`` flag is given, all of the default tests are included. If
-``--all-tests`` is given, all of the non-performance tests are included. You
+If no ``--include`` flag is given, all of the tests are included. You
 cannot run performance and non-performance tests in the same invocation.
 ``--exclude`` is ignored when running performance tests, and the program will
-stop if it detects that both ``--perf-tests`` and ``--include`` (or
-``--all-tests``) have been specified.
+stop if it detects that both ``--perf-tests`` and ``--include`` have been specified.
 
 Examples (hitting a single participant at ``localhost:6865``):
 
@@ -117,19 +114,19 @@ Examples (hitting a single participant at ``localhost:6865``):
    $ java -jar ledger-api-test-tool.jar --include TestA localhost:6865
 
 .. code-block:: console
-   :caption: Run all default tests, but not ``TestB``
+   :caption: Run all tests, but not ``TestB``
 
    $ java -jar ledger-api-test-tool.jar --exclude TestB localhost:6865
 
 .. code-block:: console
    :caption: Run all tests
 
-   $ java -jar ledger-api-test-tool.jar --all-tests localhost:6865
+   $ java -jar ledger-api-test-tool.jar localhost:6865
 
 .. code-block:: console
    :caption: Run all tests, but not ``TestC``
 
-   $ java -jar ledger-api-test-tool.jar --all-tests --exclude TestC
+   $ java -jar ledger-api-test-tool.jar --exclude TestC
 
 
 Try out the Ledger API Test Tool against DAML Sandbox
@@ -179,5 +176,23 @@ Use the command line option ``--verbose`` to print full stack traces on failures
 Concurrent test runs
 ====================
 
-To minimize parallelized runs of tests, ``--concurrent-test-runs`` can be set to 1 or 2.
+To minimize concurrent runs of tests, ``--concurrent-test-runs`` can be set to 1 or 2.
 The default value is the number of processors available.
+
+Note that certain tests, known to be possibly interfering with others (e.g.
+configuration management), are always run sequentially and as the last tests in a run.
+
+Retired tests
+=============
+
+A few tests can be retired over time as they could be deemed not providing the
+necessary signal to a developer or operator that an integration correctly
+implements the DAML Ledger API. Those test will nominally be kept in the
+test suite for a time to prevent unwanted breakages of existing CI pipelines.
+They will however not be run and they will eventually be removed. You are
+advised to remove any explicit reference to those tests while they are in
+their deprecation period.
+
+Retired tests are not listed when using ``--list`` or ``--list-all`` but can
+be included in a run using ``--include``. In this case, nothing will be run
+and the test report will mention that the test has been retired and skipped.

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -159,3 +159,18 @@ conformance_test(
         "--pem $(rlocation $TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:client.pem))",
     ],
 )
+
+# Explicitly include retired tests here to make sure existing CI pipelines are not broken
+# Retired tests will be eventually removed
+conformance_test(
+    name = "retired-tests",
+    server = "//ledger/ledger-on-memory:app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant participant-id=ssl-test,port=6865",
+    ],
+    test_tool_args = [
+        "--include=LotsOfPartiesIT",
+        "--include=TransactionScaleIT",
+    ],
+)

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -174,3 +174,19 @@ conformance_test(
         "--include=TransactionScaleIT",
     ],
 )
+
+# Makes sure that deprecated CLI options can still be used to make sure existing CI pipelines are not broken
+# Deprecated CLI options will be eventually removed
+conformance_test(
+    name = "deprecated-cli-options",
+    server = "//ledger/ledger-on-memory:app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant participant-id=ssl-test,port=6865",
+    ],
+    test_tool_args = [
+        "--include=IdentityIT",
+        "--all-tests",
+        "--load-scale-factor=1",
+    ],
+)

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -188,5 +188,6 @@ conformance_test(
         "--include=IdentityIT",
         "--all-tests",
         "--load-scale-factor=1",
+        "--target-port=8080",
     ],
 )

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -176,6 +176,8 @@ conformance_test(
 )
 
 # Makes sure that deprecated CLI options can still be used to make sure existing CI pipelines are not broken
+# This test should fail if any deprecated CLI option has any effect whatsoever -- they are preserved
+# exclusively for backwards-compatibility
 # Deprecated CLI options will be eventually removed
 conformance_test(
     name = "deprecated-cli-options",
@@ -187,7 +189,7 @@ conformance_test(
     test_tool_args = [
         "--include=IdentityIT",
         "--all-tests",
-        "--load-scale-factor=1",
-        "--target-port=8080",
+        "--load-scale-factor=THIS_OPTION_IS_DEPRECATED_AND_HAS_NO_EFFECT",
+        "--target-port=THIS_OPTION_IS_DEPRECATED_AND_HAS_NO_EFFECT",
     ],
 )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -67,6 +67,7 @@ object Cli {
     opt[String]("target-port")
       .optional()
       .text("DEPRECATED: this option is no longer used and has no effect")
+      .hidden()
 
     opt[String]("pem")
       .optional()
@@ -95,22 +96,18 @@ object Cli {
 
     opt[Double](name = "load-scale-factor")
       .optional()
-      .action((v, c) => c.copy(loadScaleFactor = v))
-      .text("""Scale factor for the load used in scale test suites. Useful to adapt the load
-              |depending on the environment and the Ledger implementation under test.
-              |Defaults to 1.0. Use numbers higher than 1.0 to increase the load,
-              |use numbers lower than 1.0 to decrease the load.""".stripMargin)
+      .text("DEPRECATED: this option is no longer used and has no effect")
+      .hidden()
 
     opt[Int](name = "concurrent-test-runs")
       .optional()
       .action((v, c) => c.copy(concurrentTestRuns = v))
-      .text("""Number of tests to run concurrently. Defaults to the number of available
-              |processors.""".stripMargin)
+      .text("Number of tests to run concurrently. Defaults to the number of available processors")
 
     opt[Unit]("verbose")
       .abbr("v")
       .action((_, c) => c.copy(verbose = true))
-      .text("Prints full stacktraces on failures.")
+      .text("Prints full stack traces on failures.")
 
     opt[Unit]("must-fail")
       .action((_, c) => c.copy(mustFail = true))
@@ -146,11 +143,12 @@ object Cli {
     opt[Path]("perf-tests-report")
       .action((inc, c) => c.copy(performanceTestsReport = Some(inc)))
       .optional()
-      .text("""The path of the the benchmark report file produced by performance tests (default: stdout).""")
+      .text(
+        "The path of the the benchmark report file produced by performance tests (default: stdout).")
 
     opt[Unit]("all-tests")
-      .action((_, c) => c.copy(allTests = true))
-      .text("""Run all default and optional tests. Respects the --exclude flag.""")
+      .text("DEPRECATED: All tests are always run by default.")
+      .hidden()
 
     opt[Unit]("shuffle-participants")
       .action((_, c) => c.copy(shuffleParticipants = true))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -14,6 +14,14 @@ import scopt.Read.{intRead, stringRead}
 
 object Cli {
 
+  private def reportUsageOfDeprecatedOption[A, B](
+      option: String,
+  )(ignoredValue: A, ignoredConfig: B): B = {
+    System.err.println(
+      s"WARNING: $option has been deprecated and will be removed in a future version")
+    ignoredConfig
+  }
+
   private def endpointRead: Read[(String, Int)] = new Read[(String, Int)] {
     val arity = 2
     val reads: String => (String, Int) = { s: String =>
@@ -67,6 +75,7 @@ object Cli {
     opt[String]("target-port")
       .optional()
       .text("DEPRECATED: this option is no longer used and has no effect")
+      .action(reportUsageOfDeprecatedOption("--target-port"))
       .hidden()
 
     opt[String]("pem")
@@ -97,6 +106,7 @@ object Cli {
     opt[Double](name = "load-scale-factor")
       .optional()
       .text("DEPRECATED: this option is no longer used and has no effect")
+      .action(reportUsageOfDeprecatedOption("--load-scale-factor"))
       .hidden()
 
     opt[Int](name = "concurrent-test-runs")
@@ -148,6 +158,7 @@ object Cli {
 
     opt[Unit]("all-tests")
       .text("DEPRECATED: All tests are always run by default.")
+      .action(reportUsageOfDeprecatedOption("--all-tests"))
       .hidden()
 
     opt[Unit]("shuffle-participants")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -103,7 +103,7 @@ object Cli {
               |Defaults to 1.0. Use numbers higher than 1.0 to make test timeouts more lax,
               |use numbers lower than 1.0 to make test timeouts more strict.""".stripMargin)
 
-    opt[Double](name = "load-scale-factor")
+    opt[String](name = "load-scale-factor")
       .optional()
       .text("DEPRECATED: this option is no longer used and has no effect")
       .action(reportUsageOfDeprecatedOption("--load-scale-factor"))

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -15,7 +15,6 @@ final case class Config(
     mustFail: Boolean,
     verbose: Boolean,
     timeoutScaleFactor: Double,
-    loadScaleFactor: Double,
     concurrentTestRuns: Int,
     extract: Boolean,
     tlsConfig: Option[TlsConfiguration],
@@ -25,7 +24,6 @@ final case class Config(
     performanceTestsReport: Option[Path],
     listTests: Boolean,
     listTestSuites: Boolean,
-    allTests: Boolean,
     shuffleParticipants: Boolean,
     partyAllocation: PartyAllocationConfiguration,
 )
@@ -37,7 +35,6 @@ object Config {
     mustFail = false,
     verbose = false,
     timeoutScaleFactor = 1.0,
-    loadScaleFactor = 1.0,
     concurrentTestRuns = Runtime.getRuntime.availableProcessors(),
     extract = false,
     tlsConfig = None,
@@ -47,7 +44,6 @@ object Config {
     performanceTestsReport = None,
     listTests = false,
     listTestSuites = false,
-    allTests = false,
     shuffleParticipants = false,
     partyAllocation = PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants,
   )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -11,6 +11,7 @@ import com.daml.ledger.api.testtool.infrastructure.{
   LedgerSessionConfiguration,
   LedgerTestCase,
   LedgerTestCasesRunner,
+  LedgerTestSuite,
   LedgerTestSummary
 }
 import org.slf4j.LoggerFactory
@@ -38,29 +39,25 @@ object LedgerApiTestTool {
   private def exitCode(summaries: Vector[LedgerTestSummary], expectFailure: Boolean): Int =
     if (summaries.exists(_.result.isLeft) == expectFailure) 0 else 1
 
-  private def printListOfTests[A](defaults: Seq[A], optionals: Seq[A])(
-      getName: A => String): Unit = {
-    println("Tests marked with * are run by default.")
-    println(
-      "You can include extra tests with `--include=TEST-NAME`, or run all tests with `--all-tests`.\n")
-    defaults.map(getName(_) + " * ").sorted.foreach(println(_))
-    optionals.map(getName).sorted.foreach(println(_))
+  private def printListOfTests[A](tests: Seq[A])(getName: A => String): Unit = {
+    println("All tests are run by default.")
+    println()
+    tests.map(getName).sorted.foreach(println(_))
 
-    println("\nAlternatively, you can run performance tests.")
-    println(
-      "Performance tests are not run by default, but can be run with `--perf-tests=TEST-NAME`.\n")
+    println()
+    println("Alternatively, you can run performance tests.")
+    println("They are not run by default, but can be run with `--perf-tests=TEST-NAME`.")
+    println()
     Tests.PerformanceTestsKeys.sorted.foreach(println(_))
   }
   private def printAvailableTestSuites(config: Config): Unit = {
     println("Listing test suites. Run with --list-all to see individual tests.")
-    printListOfTests(Tests.default.values.toSeq, Tests.optional(config).values.toSeq)(_.name)
+    printListOfTests(Tests.all)(_.name)
   }
 
   private def printAvailableTests(config: Config): Unit = {
     println("Listing all tests. Run with --list to only see test suites.")
-    printListOfTests(
-      Tests.default.values.flatMap(_.tests).toSeq,
-      Tests.optional(config).values.flatMap(_.tests).toSeq)(_.name)
+    printListOfTests(Tests.all.flatMap(_.tests).toSeq)(_.name)
   }
 
   private def extractResources(resources: String*): Unit = {
@@ -74,6 +71,12 @@ object LedgerApiTestTool {
       println(s"Extracted $resource to $targetFile")
     }
   }
+
+  private def cases(m: Map[String, LedgerTestSuite]): Iterable[LedgerTestCase] =
+    m.values.flatMap(_.tests)
+
+  private def matches(prefixes: Iterable[String])(test: LedgerTestCase): Boolean =
+    prefixes.exists(test.name.startsWith)
 
   def main(args: Array[String]): Unit = {
 
@@ -104,11 +107,7 @@ object LedgerApiTestTool {
       sys.exit(0)
     }
 
-    val cases: Tests.Tests => Iterable[LedgerTestCase] = m => m.values.flatMap(_.tests)
-    val matches: Iterable[String] => LedgerTestCase => Boolean = prefixes =>
-      test => prefixes.exists(prefix => test.name.startsWith(prefix))
-
-    val allTestCaseNames: Set[String] = cases(Tests.all(config)).map(_.name).toSet
+    val allTestCaseNames: Set[String] = (Tests.all ++ Tests.retired).map(_.name).toSet
     val missingTests = (config.included ++ config.excluded).filterNot(prefix =>
       allTestCaseNames.exists(_.startsWith(prefix)))
     if (missingTests.nonEmpty) {
@@ -122,7 +121,7 @@ object LedgerApiTestTool {
     val performanceTestsToRun =
       Tests.performanceTests(config.performanceTestsReport).filterKeys(config.performanceTests)
 
-    if ((config.allTests || config.included.nonEmpty) && performanceTestsToRun.nonEmpty) {
+    if (config.included.nonEmpty && performanceTestsToRun.nonEmpty) {
       println("Either regular or performance tests can be run, but not both.")
       sys.exit(64)
     }
@@ -134,11 +133,15 @@ object LedgerApiTestTool {
         sys.exit(1)
       })
 
+    val allCases = Tests.all.flatMap(_.tests)
+    val retiredCases = Tests.retired.flatMap(_.tests)
+
+    val includedTests =
+      if (config.included.isEmpty) allCases
+      else (allCases ++ retiredCases).filter(matches(config.included))
+
     val testsToRun: Iterable[LedgerTestCase] =
-      (if (config.allTests) cases(Tests.all(config))
-       else if (config.included.isEmpty) cases(Tests.default)
-       else cases(Tests.all(config)).filter(matches(config.included)))
-        .filterNot(matches(config.excluded))
+      includedTests.filterNot(matches(config.excluded))
 
     val runner =
       if (performanceTestsToRun.nonEmpty)
@@ -155,7 +158,10 @@ object LedgerApiTestTool {
 
     runner.verifyRequirementsAndRun {
       case Success(summaries) =>
-        new ColorizedPrintStreamReporter(System.out, config.verbose).report(summaries)
+        new ColorizedPrintStreamReporter(
+          System.out,
+          config.verbose,
+        ).report(summaries)
         sys.exit(exitCode(summaries, config.mustFail))
       case Failure(e) =>
         logger.error(e.getMessage, e)
@@ -172,7 +178,6 @@ object LedgerApiTestTool {
         config.participants,
         config.shuffleParticipants,
         config.tlsConfig,
-        config.loadScaleFactor,
         config.partyAllocation,
       ),
       cases.toVector,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -11,54 +11,41 @@ import com.daml.ledger.api.testtool.tests._
 import org.slf4j.LoggerFactory
 
 object Tests {
-  type Tests = Map[String, LedgerTestSuite]
 
-  /**
-    * These tests are safe to be run concurrently and are
-    * always run by default, unless otherwise specified.
-    */
-  val default: Tests = Seq(
-    new ActiveContractsServiceIT,
-    new CommandServiceIT,
-    new CommandSubmissionCompletionIT,
-    new CommandDeduplicationIT,
-    new ContractKeysIT,
-    new DivulgenceIT,
-    new HealthServiceIT,
-    new IdentityIT,
-    new LedgerConfigurationServiceIT,
-    new PackageManagementServiceIT,
-    new PackageServiceIT,
-    new PartyManagementServiceIT,
-    new SemanticTests,
-    new TransactionServiceIT,
-    new WitnessesIT,
-    new WronglyTypedContractIdIT,
-    new ClosedWorldIT,
-  ).map(suite => (suite.name, suite)).toMap
-
-  /**
-    * These tests can:
-    * - change the global state of the ledger, or
-    * - be especially resource intensive (by design)
-    *
-    * These are consequently not run unless otherwise specified.
-    */
-  def optional(config: Config): Tests =
-    Seq(
+  val all: Vector[LedgerTestSuite] =
+    Vector(
+      new ActiveContractsServiceIT,
+      new ClosedWorldIT,
+      new CommandServiceIT,
+      new CommandSubmissionCompletionIT,
+      new CommandDeduplicationIT,
       new ConfigManagementServiceIT,
-      new LotsOfPartiesIT,
-      new TransactionScaleIT(config.loadScaleFactor),
-    ).map(suite => (suite.name, suite)).toMap
+      new ContractKeysIT,
+      new DivulgenceIT,
+      new HealthServiceIT,
+      new IdentityIT,
+      new LedgerConfigurationServiceIT,
+      new PackageManagementServiceIT,
+      new PackageServiceIT,
+      new PartyManagementServiceIT,
+      new SemanticTests,
+      new TransactionServiceIT,
+      new WitnessesIT,
+      new WronglyTypedContractIdIT,
+    )
 
-  def all(config: Config): Tests = default ++ optional(config)
+  val retired: Vector[LedgerTestSuite] =
+    Vector(
+      new LotsOfPartiesIT,
+      new TransactionScaleIT,
+    )
 
   /**
     * These are performance envelope tests that also provide benchmarks and are always run
     * sequentially; they also must be specified explicitly with --perf-tests and will exclude
     * all other tests.
     */
-  def performanceTests(path: Option[Path]): Tests = {
+  def performanceTests(path: Option[Path]): Map[String, LedgerTestSuite] = {
     val reporter =
       (key: String, value: Double) =>
         path

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
@@ -9,6 +9,5 @@ private[testtool] final case class LedgerSessionConfiguration(
     participants: Vector[(String, Int)],
     shuffleParticipants: Boolean,
     ssl: Option[TlsConfiguration],
-    loadScaleFactor: Double,
     partyAllocation: PartyAllocationConfiguration,
 )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
@@ -8,15 +8,26 @@ import com.daml.lf.data.Ref
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class LedgerTestCase(
+/**
+  *
+  * @param suite To which collection of tests this case belongs to
+  * @param shortIdentifier A unique identifier used to generate party names, command identifiers, etc.
+  * @param description A human-readable description of what this case tests
+  * @param timeoutScale The factor applied to the default
+  * @param isolated True if the test is safe be ran in parallel without affecting other tests, false otherwise
+  * @param participants What parties need to be allocated on what participants as a setup for the test case
+  * @param runTestCase The body of the test to be executed
+  */
+sealed class LedgerTestCase(
     val suite: LedgerTestSuite,
     val shortIdentifier: Ref.LedgerString,
     val description: String,
     val timeoutScale: Double,
+    val isolated: Boolean,
     participants: ParticipantAllocation,
     runTestCase: ExecutionContext => Participants => Future[Unit],
 ) {
-  val name: String = s"${suite.name}:${shortIdentifier}"
+  val name: String = s"${suite.name}:$shortIdentifier"
   def apply(context: LedgerTestContext)(implicit ec: ExecutionContext): Future[Unit] =
     context.allocate(participants).flatMap(p => runTestCase(ec)(p))
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCase.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param shortIdentifier A unique identifier used to generate party names, command identifiers, etc.
   * @param description A human-readable description of what this case tests
   * @param timeoutScale The factor applied to the default
-  * @param isolated True if the test is safe be ran in parallel without affecting other tests, false otherwise
+  * @param runConcurrently True if the test is safe be ran concurrently with other tests without affecting their results
   * @param participants What parties need to be allocated on what participants as a setup for the test case
   * @param runTestCase The body of the test to be executed
   */
@@ -23,7 +23,7 @@ sealed class LedgerTestCase(
     val shortIdentifier: Ref.LedgerString,
     val description: String,
     val timeoutScale: Double,
-    val isolated: Boolean,
+    val runConcurrently: Boolean,
     participants: ParticipantAllocation,
     runTestCase: ExecutionContext => Participants => Future[Unit],
 ) {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -10,6 +10,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestCasesRunner._
+import com.daml.ledger.api.testtool.infrastructure.Result.Retired
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessionManager
 import org.slf4j.LoggerFactory
 
@@ -82,6 +83,8 @@ final class LedgerTestCasesRunner(
     startedTest
       .map[Either[Result.Failure, Result.Success]](duration => Right(Result.Succeeded(duration)))
       .recover[Either[Result.Failure, Result.Success]] {
+        case Retired =>
+          Right(Retired)
         case _: TimeoutException =>
           Left(Result.TimedOut)
         case failure: AssertionError =>
@@ -100,8 +103,7 @@ final class LedgerTestCasesRunner(
   private def summarize(
       suite: LedgerTestSuite,
       test: LedgerTestCase,
-      result: Either[Result.Failure, Result.Success])(
-      implicit ec: ExecutionContext,
+      result: Either[Result.Failure, Result.Success],
   ): LedgerTestSummary =
     LedgerTestSummary(suite.name, test.name, test.description, config, result)
 
@@ -111,28 +113,38 @@ final class LedgerTestCasesRunner(
     result(start(test, session))
 
   private def run(completionCallback: Try[Vector[LedgerTestSummary]] => Unit): Unit = {
+
     val system: ActorSystem = ActorSystem(classOf[LedgerTestCasesRunner].getSimpleName)
     implicit val materializer: Materializer = Materializer(system)
     implicit val executionContext: ExecutionContext = materializer.executionContext
 
     val participantSessionManager = new ParticipantSessionManager
     val ledgerSession = new LedgerSession(config, participantSessionManager)
-    val testCount = testCases.size
 
-    logger.info(s"Running $testCount tests, ${math.min(testCount, concurrentTestRuns)} at a time.")
-
-    val tests = testCases.zipWithIndex
-    Source(tests)
-      .mapAsyncUnordered(concurrentTestRuns) {
-        case (test, index) => {
-          run(test, ledgerSession).map(testResult => (test.suite, test, testResult) -> index)
+    def runTestCases(
+        testCases: Vector[LedgerTestCase],
+        concurrency: Int,
+    ): Future[Vector[LedgerTestSummary]] = {
+      val testCount = testCases.size
+      logger.info(s"Running $testCount tests, ${math.min(testCount, concurrency)} at a time.")
+      Source(testCases.zipWithIndex)
+        .mapAsyncUnordered(concurrency) {
+          case (test, index) =>
+            run(test, ledgerSession).map(summarize(test.suite, test, _) -> index)
         }
-      }
-      .map {
-        case ((suite, test, testResult), index) => summarize(suite, test, testResult) -> index
-      }
-      .runWith(Sink.seq)
-      .map(_.toVector.sortBy(_._2).map(_._1))
+        .runWith(Sink.seq)
+        .map(_.toVector.sortBy(_._2).map(_._1))
+    }
+
+    val (isolatedTestCases, unrestrictedTestCases) = testCases.partition(_.isolated)
+
+    val testResults =
+      for {
+        isolatedTestsResults <- runTestCases(isolatedTestCases, concurrentTestRuns)
+        unrestrictedTestsResults <- runTestCases(unrestrictedTestCases, concurrency = 1)
+      } yield isolatedTestsResults ++ unrestrictedTestsResults
+
+    testResults
       .recover { case NonFatal(e) => throw LedgerTestCasesRunner.UncaughtExceptionError(e) }
       .onComplete { result =>
         participantSessionManager.closeAll()

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -136,13 +136,13 @@ final class LedgerTestCasesRunner(
         .map(_.toVector.sortBy(_._2).map(_._1))
     }
 
-    val (isolatedTestCases, unrestrictedTestCases) = testCases.partition(_.isolated)
+    val (concurrentTestCases, sequentialTestCases) = testCases.partition(_.runConcurrently)
 
     val testResults =
       for {
-        isolatedTestsResults <- runTestCases(isolatedTestCases, concurrentTestRuns)
-        unrestrictedTestsResults <- runTestCases(unrestrictedTestCases, concurrency = 1)
-      } yield isolatedTestsResults ++ unrestrictedTestsResults
+        concurrentTestsResults <- runTestCases(concurrentTestCases, concurrentTestRuns)
+        sequentialTestsResults <- runTestCases(sequentialTestCases, concurrency = 1)
+      } yield concurrentTestsResults ++ sequentialTestsResults
 
     testResults
       .recover { case NonFatal(e) => throw LedgerTestCasesRunner.UncaughtExceptionError(e) }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
@@ -21,6 +21,7 @@ private[testtool] abstract class LedgerTestSuite {
       description: String,
       participants: ParticipantAllocation,
       timeoutScale: Double = 1.0,
+      isolated: Boolean = true,
   )(testCase: ExecutionContext => Participants => Future[Unit]): Unit = {
     val shortIdentifierRef = Ref.LedgerString.assertFromString(shortIdentifier)
     testCaseBuffer.append(
@@ -29,6 +30,7 @@ private[testtool] abstract class LedgerTestSuite {
         shortIdentifierRef,
         description,
         timeoutScale,
+        isolated,
         participants,
         testCase,
       ),

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestSuite.scala
@@ -21,7 +21,7 @@ private[testtool] abstract class LedgerTestSuite {
       description: String,
       participants: ParticipantAllocation,
       timeoutScale: Double = 1.0,
-      isolated: Boolean = true,
+      runConcurrently: Boolean = true,
   )(testCase: ExecutionContext => Participants => Future[Unit]): Unit = {
     val shortIdentifierRef = Ref.LedgerString.assertFromString(shortIdentifier)
     testCaseBuffer.append(
@@ -30,7 +30,7 @@ private[testtool] abstract class LedgerTestSuite {
         shortIdentifierRef,
         description,
         timeoutScale,
-        isolated,
+        runConcurrently,
         participants,
         testCase,
       ),

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -38,8 +38,10 @@ object Reporter {
         .map(_.getLineNumber)
   }
 
-  final class ColorizedPrintStreamReporter(s: PrintStream, printStackTraces: Boolean)
-      extends Reporter[Unit] {
+  final class ColorizedPrintStreamReporter(
+      s: PrintStream,
+      printStackTraces: Boolean,
+  ) extends Reporter[Unit] {
 
     import ColorizedPrintStreamReporter._
 
@@ -59,8 +61,8 @@ object Reporter {
             result match {
               case Right(Result.Succeeded(duration)) =>
                 s.println(green(s"Success (${duration.toMillis} ms)"))
-              case Right(Result.Skipped(reason)) =>
-                s.println(yellow(s"Skipped (reason: $reason)"))
+              case Right(Result.Retired) =>
+                s.println(yellow(s"Skipped (retired test)"))
               case Left(Result.TimedOut) => s.println(red(s"Timeout"))
               case Left(Result.Failed(cause)) =>
                 val message =

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Result.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Result.scala
@@ -4,13 +4,14 @@
 package com.daml.ledger.api.testtool.infrastructure
 
 import scala.concurrent.duration.Duration
+import scala.util.control.NoStackTrace
 
 private[testtool] object Result {
 
   sealed trait Success
 
   final case class Succeeded(duration: Duration) extends Success
-  final case class Skipped(reason: String) extends Success
+  case object Retired extends RuntimeException with NoStackTrace with Success
 
   sealed trait Failure
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagementServiceIT.scala
@@ -15,6 +15,7 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
     "CMSetAndGetTimeModel",
     "It should be able to get, set and restore the time model",
     allocate(NoParties),
+    isolated = false,
   )(implicit ec => {
     case Participants(Participant(ledger)) =>
       val newTimeModel = TimeModel(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ConfigManagementServiceIT.scala
@@ -15,7 +15,7 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
     "CMSetAndGetTimeModel",
     "It should be able to get, set and restore the time model",
     allocate(NoParties),
-    isolated = false,
+    runConcurrently = false,
   )(implicit ec => {
     case Participants(Participant(ledger)) =>
       val newTimeModel = TimeModel(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LotsOfPartiesIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/LotsOfPartiesIT.scala
@@ -4,222 +4,36 @@
 package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
-import com.daml.ledger.api.testtool.infrastructure.Assertions._
+import com.daml.ledger.api.testtool.infrastructure.Result.Retired
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
-import com.daml.ledger.api.testtool.infrastructure.Synchronize.synchronize
-import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
-import com.daml.ledger.api.v1.event.CreatedEvent
-import com.daml.ledger.api.v1.transaction.Transaction
-import com.daml.ledger.client.binding.Primitive.{ContractId, Party}
-import com.daml.ledger.test.model.Test.WithObservers
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
+// This test suite has been retired (see https://github.com/digital-asset/daml/pull/6651)
 final class LotsOfPartiesIT extends LedgerTestSuite {
-  type Parties = Set[Party]
-  type PartyMap[T] = Map[Party, T]
-
-  // Can be set to 1024 parties again after fixing
-  // https://github.com/digital-asset/daml/issues/3747
-  private val partyCount = 125
-
-  private val allocation: ParticipantAllocation =
-    allocate(Parties(partyCount / 2), Parties(partyCount / 2))
-
-  // allocating parties seems to be really slow on a real database
-  private val timeoutScale = 4.0
 
   test(
     "LOPseeTransactionsInMultipleSinglePartySubscriptions",
     "Observers should see transactions in multiple single-party subscriptions",
-    allocation,
-    timeoutScale,
-  )(implicit ec => {
-    case TestParticipants(t) =>
-      for {
-        contractId <- t.alpha.create(t.giver, WithObservers(t.giver, t.observers))
-        _ <- synchronize(t.alpha, t.beta)
-        alphaTransactionsByParty <- transactionsForEachParty(t.alpha, t.alphaParties)
-        betaTransactionsByParty <- transactionsForEachParty(t.beta, t.betaParties)
-      } yield {
-        assertWitnessesOfSinglePartySubscriptions(
-          t.alphaParties.toSet,
-          contractId,
-          activeContractsFrom(alphaTransactionsByParty),
-        )
-        assertWitnessesOfSinglePartySubscriptions(
-          t.betaParties.toSet,
-          contractId,
-          activeContractsFrom(betaTransactionsByParty),
-        )
-      }
-  })
+    allocate(NoParties),
+  )(_ => _ => Future.failed(Retired))
 
   test(
     "LOPseeTransactionsInSingleMultiPartySubscription",
     "Observers should see transactions in a single multi-party subscription",
-    allocation,
-    timeoutScale,
-  )(implicit ec => {
-    case TestParticipants(t) =>
-      for {
-        contractId <- t.alpha.create(t.giver, WithObservers(t.giver, t.observers))
-        _ <- synchronize(t.alpha, t.beta)
-        alphaTransactions <- t.alpha.flatTransactions(t.alphaParties: _*)
-        betaTransactions <- t.beta.flatTransactions(t.betaParties: _*)
-      } yield {
-        assertWitnessesOfAMultiPartySubscription(
-          t.alphaParties.toSet,
-          contractId,
-          activeContractsFrom(alphaTransactions),
-        )
-        assertWitnessesOfAMultiPartySubscription(
-          t.betaParties.toSet,
-          contractId,
-          activeContractsFrom(betaTransactions),
-        )
-      }
-  })
+    allocate(NoParties),
+  )(_ => _ => Future.failed(Retired))
 
   test(
     "LOPseeActiveContractsInMultipleSinglePartySubscriptions",
     "Observers should see active contracts in multiple single-party subscriptions",
-    allocation,
-    timeoutScale,
-  )(implicit ec => {
-    case TestParticipants(t) =>
-      for {
-        contractId <- t.alpha.create(t.giver, WithObservers(t.giver, t.observers))
-        _ <- synchronize(t.alpha, t.beta)
-        alphaContractsByParty <- activeContractsForEachParty(t.alpha, t.alphaParties)
-        betaContractsByParty <- activeContractsForEachParty(t.beta, t.betaParties)
-      } yield {
-        assertWitnessesOfSinglePartySubscriptions(
-          t.alphaParties.toSet,
-          contractId,
-          alphaContractsByParty,
-        )
-        assertWitnessesOfSinglePartySubscriptions(
-          t.betaParties.toSet,
-          contractId,
-          betaContractsByParty,
-        )
-      }
-  })
+    allocate(NoParties),
+  )(_ => _ => Future.failed(Retired))
 
   test(
     "LOPseeActiveContractsInSingleMultiPartySubscription",
     "Observers should see active contracts in a single multi-party subscription",
-    allocation,
-    timeoutScale,
-  )(implicit ec => {
-    case TestParticipants(t) =>
-      for {
-        contractId <- t.alpha.create(t.giver, WithObservers(t.giver, t.observers))
-        _ <- synchronize(t.alpha, t.beta)
-        alphaContracts <- t.alpha.activeContracts(t.alphaParties: _*)
-        betaContracts <- t.beta.activeContracts(t.betaParties: _*)
-      } yield {
-        assertWitnessesOfAMultiPartySubscription(t.alphaParties.toSet, contractId, alphaContracts)
-        assertWitnessesOfAMultiPartySubscription(t.betaParties.toSet, contractId, betaContracts)
-      }
-  })
+    allocate(NoParties),
+  )(_ => _ => Future.failed(Retired))
 
-  private def transactionsForEachParty(
-      ledger: ParticipantTestContext,
-      observers: Vector[Party],
-  )(implicit ec: ExecutionContext): Future[PartyMap[Vector[Transaction]]] = {
-    Future
-      .sequence(observers.map(observer => ledger.flatTransactions(observer).map(observer -> _)))
-      .map(_.toMap)
-  }
-
-  private def activeContractsForEachParty(
-      ledger: ParticipantTestContext,
-      observers: Vector[Party],
-  )(implicit ec: ExecutionContext): Future[PartyMap[Vector[CreatedEvent]]] = {
-    Future
-      .sequence(observers.map(observer => ledger.activeContracts(observer).map(observer -> _)))
-      .map(_.toMap)
-  }
-
-  private def activeContractsFrom(
-      transactionsByParty: PartyMap[Vector[Transaction]],
-  ): PartyMap[Vector[CreatedEvent]] = {
-    transactionsByParty.mapValues(transactions => activeContractsFrom(transactions))
-  }
-
-  private def activeContractsFrom(transactions: Vector[Transaction]): Vector[CreatedEvent] = {
-    transactions.map(transaction => {
-      val event = assertSingleton("single transaction event", transaction.events)
-      event.event.created.get
-    })
-  }
-
-  private def assertWitnessesOfSinglePartySubscriptions(
-      observers: Set[Party],
-      contractId: ContractId[WithObservers],
-      activeContracts: PartyMap[Seq[CreatedEvent]],
-  ): Unit = {
-    val expectedContractIds: PartyMap[Seq[ContractId[WithObservers]]] =
-      observers.map(observer => observer -> Seq(contractId)).toMap
-    val actualContractIds: PartyMap[Seq[ContractId[WithObservers]]] =
-      activeContracts.mapValues(_.map(e => ContractId(e.contractId)))
-    assertEquals("single-party contract IDs", actualContractIds, expectedContractIds)
-
-    val expectedWitnesses: Set[Seq[Parties]] =
-      observers.map(observer => Seq(Set(observer)))
-    val actualWitnesses: Set[Seq[Parties]] =
-      activeContracts.values.map(_.map(_.witnessParties.map(Party(_)).toSet)).toSet
-    assertEquals("single-party witnesses", actualWitnesses, expectedWitnesses)
-  }
-
-  private def assertWitnessesOfAMultiPartySubscription(
-      observers: Set[Party],
-      contractId: ContractId[WithObservers],
-      activeContracts: Seq[CreatedEvent],
-  ): Unit = {
-    val expectedContractIds: Seq[ContractId[WithObservers]] =
-      Seq(contractId)
-    val actualContractIds: Seq[ContractId[WithObservers]] =
-      activeContracts.map(e => ContractId(e.contractId))
-    assertEquals("multi-party contract IDs", actualContractIds, expectedContractIds)
-
-    val expectedWitnesses: Seq[Parties] =
-      Seq(observers)
-    val actualWitnesses: Seq[Parties] =
-      activeContracts.map(_.witnessParties.map(Party(_)).toSet)
-    assertEquals("multi-party witnesses", actualWitnesses, expectedWitnesses)
-  }
-
-  private case class TestParticipants(
-      alpha: ParticipantTestContext,
-      beta: ParticipantTestContext,
-      giver: Party,
-      alphaObservers: Vector[Party],
-      betaObservers: Vector[Party],
-  ) {
-    val observers: Vector[Party] = alphaObservers ++ betaObservers
-    val alphaParties: Vector[Party] = giver +: alphaObservers
-    val betaParties: Vector[Party] = betaObservers
-  }
-
-  private object TestParticipants {
-    def unapply(participants: Participants): Option[TestParticipants] = participants match {
-      case Participants(
-          Participant(alpha, giver, alphaObserversSeq @ _*),
-          Participant(beta, betaObserversSeq @ _*),
-          ) =>
-        Some(
-          TestParticipants(
-            alpha,
-            beta,
-            giver,
-            alphaObserversSeq.toVector,
-            betaObserversSeq.toVector,
-          ),
-        )
-      case _ => None
-    }
-  }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionScaleIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionScaleIT.scala
@@ -4,57 +4,24 @@
 package com.daml.ledger.api.testtool.tests
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
-import com.daml.ledger.api.testtool.infrastructure.Assertions._
+import com.daml.ledger.api.testtool.infrastructure.Result.Retired
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
-import com.daml.ledger.api.testtool.tests.TransactionScaleIT.numberOfCommandsUnit
-import com.daml.ledger.test.model.Test.{Dummy, TextContainer}
 
 import scala.concurrent.Future
 
-class TransactionScaleIT(loadScaleFactor: Double) extends LedgerTestSuite {
-  require(
-    numberOfCommands(units = 1) > 0,
-    s"The load scale factor must be at least ${1.0 / numberOfCommandsUnit}",
-  )
+// This test suite has been retired (see https://github.com/digital-asset/daml/pull/6651)
+final class TransactionScaleIT extends LedgerTestSuite {
 
   test(
     "TXLargeCommand",
     "Accept huge submissions with a large number of commands",
-    allocate(SingleParty),
-  )(implicit ec => {
-    case Participants(Participant(ledger, party)) =>
-      val targetNumberOfSubCommands = numberOfCommands(units = 3)
-      val request = ledger.submitAndWaitRequest(
-        party,
-        List.fill(targetNumberOfSubCommands)(Dummy(party).create.command): _*,
-      )
-      for {
-        result <- ledger.submitAndWaitForTransaction(request)
-      } yield {
-        val _ = assertLength("LargeCommand", targetNumberOfSubCommands, result.events)
-      }
-  })
+    allocate(NoParties),
+  )(_ => _ => Future.failed(Retired))
 
-  test("TXManyCommands", "Accept many, large commands at once", allocate(SingleParty))(
-    implicit ec => {
-      case Participants(Participant(ledger, party)) =>
-        val targetNumberOfCommands = numberOfCommands(units = 1)
-        val oneKbOfText = new String(Array.fill(512 /* two bytes each */ )('a'))
-        for {
-          contractIds <- Future.sequence(
-            (1 to targetNumberOfCommands).map(_ =>
-              ledger.create(party, TextContainer(party, oneKbOfText))),
-          )
-        } yield {
-          val _ = assertLength("ManyCommands", targetNumberOfCommands, contractIds)
-        }
-    })
+  test(
+    "TXManyCommands",
+    "Accept many, large commands at once",
+    allocate(NoParties),
+  )(_ => _ => Future.failed(Retired))
 
-  private def numberOfCommands(units: Int): Int =
-    (units * numberOfCommandsUnit * loadScaleFactor).toInt
-
-}
-
-object TransactionScaleIT {
-  private val numberOfCommandsUnit = 500
 }

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -123,8 +123,6 @@ conformance_test(
     ],
     test_tool_args = [
         "--verbose",
-        "--all-tests",
-        "--exclude=ConfigManagementServiceIT",
     ],
 )
 
@@ -143,8 +141,6 @@ conformance_test(
     ],
     test_tool_args = [
         "--verbose",
-        "--all-tests",
-        "--exclude=ConfigManagementServiceIT",
     ],
 )
 
@@ -158,7 +154,6 @@ conformance_test(
     ],
     test_tool_args = [
         "--verbose",
-        "--include=ConfigManagementServiceIT",
     ],
 )
 

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -141,19 +141,7 @@ conformance_test(
     ],
     test_tool_args = [
         "--verbose",
-    ],
-)
-
-conformance_test(
-    name = "conformance-test-config-management",
-    ports = [6865],
-    server = ":app",
-    server_args = [
-        "--contract-id-seeding=testing-weak",
-        "--participant participant-id=example,port=6865",
-    ],
-    test_tool_args = [
-        "--verbose",
+        "--exclude=ConfigManagementServiceIT",
     ],
 )
 

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -241,22 +241,6 @@ da_scala_test_suite(
             tags = db.get("conformance_test_tags", []),
             test_tool_args = db.get("conformance_test_tool_args", []) + [
                 "--verbose",
-                "--all-tests",
-                "--exclude=ConfigManagementServiceIT",
-            ],
-        ),
-        conformance_test(
-            name = "conformance-test-config-management-{}".format(db["name"]),
-            ports = [6865],
-            server = ":conformance-test-{}-bin".format(db["name"]),
-            server_args = [
-                "--contract-id-seeding=testing-weak",
-                "--participant participant-id=conformance-test,port=6865",
-            ] + db.get("conformance_test_server_args", []),
-            tags = db.get("conformance_test_tags", []),
-            test_tool_args = db.get("conformance_test_tool_args", []) + [
-                "--verbose",
-                "--include=ConfigManagementServiceIT",
             ],
         ),
         conformance_test(

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -397,8 +397,6 @@ server_conformance_test(
     servers = SERVERS,
     test_tool_args = [
         "--open-world",
-        "--all-tests",
-        "--exclude=ConfigManagementServiceIT",
         "--exclude=ClosedWorldIT",
     ],
 )
@@ -411,33 +409,7 @@ server_conformance_test(
     servers = SERVERS,
     test_tool_args = [
         "--open-world",
-        "--all-tests",
-        "--exclude=ConfigManagementServiceIT",
         "--exclude=ClosedWorldIT",
-    ],
-)
-
-server_conformance_test(
-    name = "conformance-test-config-management",
-    server_args = [
-        "--wall-clock-time",
-    ],
-    servers = SERVERS,
-    test_tool_args = [
-        "--open-world",
-        "--include=ConfigManagementServiceIT",
-    ],
-)
-
-server_conformance_test(
-    name = "conformance-test-command-deduplication",
-    server_args = [
-        "--wall-clock-time",
-    ],
-    servers = SERVERS,
-    test_tool_args = [
-        "--open-world",
-        "--include=CommandDeduplicationIT",
     ],
 )
 
@@ -450,8 +422,6 @@ server_conformance_test(
     servers = SERVERS,
     test_tool_args = [
         "--open-world",
-        "--all-tests",
-        "--exclude=ConfigManagementServiceIT",
         "--exclude=ClosedWorldIT",
     ],
 )
@@ -483,9 +453,7 @@ server_conformance_test(
     servers = NEXT_SERVERS,
     test_tool_args = [
         "--open-world",
-        "--all-tests",
         "--exclude=ClosedWorldIT",
-        "--exclude=ConfigManagementServiceIT",
     ],
 )
 
@@ -497,21 +465,7 @@ server_conformance_test(
     servers = NEXT_SERVERS,
     test_tool_args = [
         "--open-world",
-        "--all-tests",
         "--exclude=ClosedWorldIT",
-        "--exclude=ConfigManagementServiceIT",
-    ],
-)
-
-server_conformance_test(
-    name = "next-conformance-test-config-management",
-    server_args = [
-        "--wall-clock-time",
-    ],
-    servers = NEXT_SERVERS,
-    test_tool_args = [
-        "--open-world",
-        "--include=ConfigManagementServiceIT",
     ],
 )
 


### PR DESCRIPTION
Furthermore, now all active tests are run be default without needing
to specify `--all-tests`. The scheduler makes sure to run non-isolated
tests last (and sequentially).

Fixes #3747
Fixes #6518

A bit of historical context: tests in the Ledger API Test Tool used to
be the sandbox integration tests. As part of the Ledger API Test Tool
project, those tests have been ported one-to-one, with little review of
those same tests.

Examining the tests that cause #3747, it became evident that those tests
were originally put in place to verify that an isolated sandbox spun up
for a single test could withstand a number of commands slightly lower
than what at the time was the hard-coded back-pressure threshold. Hence,
implementing back-pressure on the Ledger API Test Tool would have
basically negated the usefulness of those tests. Furthermore, those
tests can be easily passed by simply raising the back-pressure
threshold. As such, they do not convey any meaningful information for
the DAML ledger implementer. This means we are retiring those tests. The
tests will be nominally kept in for a deprecation period to not break
existing build scripts, but running them explicitly will simply show
them as skipped. The documentation has been updated with the information
necessary to users to deal with retired tests.

Since all tests are now run by default `--all-tests` is being deprecated.
`--load-scale-factor` is also deprecated as it was used only by
`TransactionScaleIT`.

changelog_begin
[Ledger API Test Tool] The LotsOfPartiesIT and TransactionScaleIT test
suite have been deemed not providing relevant signal to DAML ledger
implementers and have been retired. The tests will be nominally kept in
but will be skipped while they are in a deprecation period. You are
advised to remove explicit references to those tests before they are
fully removed.
[Ledger API Test Tool] All tests are now run by default. The --all-tests
option is now ineffective and deprecated. You are advised to remove its
usages from your build scripts. Non-isolated tests that could affect the
global state of the ledger and interfere with other tests are now
automatically scheduled by the test tool to run sequentially at the end
of the run.
[Ledger API Test Tool] The --load-scale-factor option is now unused and
deprecated. You are advised to remove its usages from your build
scripts.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
