### PR TITLE
Load multiple DARs into DAML REPL

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -205,9 +205,9 @@ loadDar replClient ideState dar = do
     toImportDecl = simpleImportDecl . mkModuleName . T.unpack . LF.moduleNameString
 
 
-runRepl :: Options -> FilePath -> ReplClient.Handle -> IdeState -> IO ()
-runRepl opts mainDar replClient ideState = do
-    imports <- loadDar replClient ideState mainDar
+runRepl :: Options -> [FilePath] -> ReplClient.Handle -> IdeState -> IO ()
+runRepl opts dars replClient ideState = do
+    imports <- concat <$> mapM (loadDar replClient ideState) dars
     let initReplState = ReplState
           { imports = imports
           , bindings = []

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -196,7 +196,7 @@ loadPackages replClient ideState = do
                 hPutStrLn stderr ("Package could not be loaded: " <> show err)
                 exitFailure
             Right _ -> pure ()
-    -- Determine module names
+    -- Determine module names in main DALFs.
     md <- readMetadata (toNormalizedFilePath' ".")
     pure
       [ simpleImportDecl . mkModuleName . T.unpack . LF.moduleNameString $ mod

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -619,7 +619,7 @@ execRepl projectOpts opts scriptDar dars ledgerHost ledgerPort mbAuthToken mbSsl
                 initPackageDb opts (InitPkgDb True)
                 -- We want diagnostics to go to stdout in the repl.
                 withDamlIdeState opts logger (hDiagnosticsLogger stdout)
-                    (Repl.runRepl opts dars replHandle)
+                    (Repl.runRepl opts replHandle)
 
 -- | Remove any build artifacts if they exist.
 execClean :: ProjectOpts -> Command

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -620,7 +620,7 @@ execRepl projectOpts opts scriptDar mainDar ledgerHost ledgerPort mbAuthToken mb
                 initPackageDb opts (InitPkgDb True)
                 -- We want diagnostics to go to stdout in the repl.
                 withDamlIdeState opts logger (hDiagnosticsLogger stdout)
-                    (Repl.runRepl opts mainDar replHandle)
+                    (Repl.runRepl opts [mainDar] replHandle)
 
 -- | Remove any build artifacts if they exist.
 execClean :: ProjectOpts -> Command

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -422,6 +422,34 @@ EOF
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "repl-test-two",
+    srcs = [
+        "ReplTest2.daml",
+    ],
+    outs = ["repl-test-two.dar"],
+    cmd = """
+      set -eou pipefail
+      TMP_DIR=$$(mktemp -d)
+      mkdir -p $$TMP_DIR/daml
+      cp -L $(location ReplTest2.daml) $$TMP_DIR/daml
+      cat << EOF > $$TMP_DIR/daml.yaml
+sdk-version: {sdk}
+name: repl-test-two
+source: daml
+version: 0.1.0
+dependencies:
+  - daml-stdlib
+  - daml-prim
+build-options: ["--ghc-option", "-Werror"]
+EOF
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR -o $$PWD/$(location repl-test-two.dar)
+      rm -rf $$TMP_DIR
+    """.format(sdk = sdk_version),
+    tools = ["//compiler/damlc"],
+    visibility = ["//visibility:public"],
+)
+
 da_haskell_test(
     name = "repl",
     srcs = ["src/DA/Test/Repl.hs"],
@@ -464,6 +492,7 @@ da_haskell_test(
     srcs = ["src/DA/Test/Repl/FuncTests.hs"],
     data = [
         ":repl-test.dar",
+        ":repl-test-two.dar",
         ghc_pkg,
         "//compiler/damlc/pkg-db",
         "//compiler/damlc/stable-packages",

--- a/compiler/damlc/tests/ReplTest2.daml
+++ b/compiler/damlc/tests/ReplTest2.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module ReplTest2 where
+
+template T2
+  with
+    owner : Party
+  where
+    signatory owner

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -256,7 +256,7 @@ testInteraction testDar replClient serviceOut options ideState steps = do
         withBinaryFile stdinFile ReadMode $ \readIn ->
             redirectingHandle stdin readIn $ do
             Right () <- ReplClient.clearResults replClient
-            capture_ $ runRepl options testDar replClient ideState
+            capture_ $ runRepl options [testDar] replClient ideState
     -- Write output to a file so we can conveniently read individual characters.
     withTempFile $ \clientOutFile -> do
         writeFileUTF8 clientOutFile out

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -233,6 +233,15 @@ functionalTests replClient serviceOut options ideState = describe "repl func tes
           , input "debug proposal.accepter"
           , matchServiceOutput "'bob'"
           ]
+    , testInteraction' "symbols from different DARs"
+          [ input "party <- allocatePartyWithHint \"Party\" (PartyIdHint \"two_dars_party\")"
+          , input "proposal <- pure (T party party)"
+          , input "debug proposal"
+          , matchServiceOutput "^.*: T {proposer = 'two_dars_party', accepter = 'two_dars_party'}"
+          , input "t2 <- pure (T2 party)"
+          , input "debug t2"
+          , matchServiceOutput "^.*: T2 {owner = 'two_dars_party'}"
+          ]
     ]
   where
     testInteraction' testName steps =

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -47,7 +47,8 @@ main :: IO ()
 main = do
     setNumCapabilities 1
     scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml" </> "daml-script.dar")
-    testDar <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> "repl-test.dar")
+    testDars <- forM ["repl-test", "repl-test-two"] $ \name ->
+        locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> name <.> "dar")
     replDir <- locateRunfiles (mainWorkspace </> "compiler/repl-service/server")
     forM_ [stdin, stdout, stderr] $ \h -> hSetBuffering h LineBuffering
     let replJar = replDir </> "repl-service.jar"
@@ -61,7 +62,7 @@ main = do
     -- it will spin up sandbox and the repl client.
     withTempFile $ \portFile ->
         withBinaryFile nullDevice WriteMode $ \devNull ->
-        bracket (createSandbox portFile devNull defaultSandboxConf { dars = [testDar] }) destroySandbox $ \SandboxResource{sandboxPort} ->
+        bracket (createSandbox portFile devNull defaultSandboxConf { dars = testDars }) destroySandbox $ \SandboxResource{sandboxPort} ->
         ReplClient.withReplClient (ReplClient.Options replJar "localhost" (show sandboxPort) Nothing Nothing Nothing ReplClient.ReplWallClock CreatePipe) $ \replHandle mbServiceOut processHandle ->
         -- TODO We could share some of this setup with the actual repl code in damlc.
         withTempDir $ \dir ->
@@ -69,16 +70,16 @@ main = do
         Just serviceOut <- pure mbServiceOut
         hSetBuffering serviceOut LineBuffering
         withAsync (drainHandle serviceOut serviceLineChan) $ \_ -> do
-            initPackageConfig scriptDar testDar
+            initPackageConfig scriptDar testDars
             logger <- Logger.newStderrLogger Logger.Warning "repl-tests"
             withDamlIdeState options logger (hDiagnosticsLogger stdout) $ \ideState ->
-                (hspec $ functionalTests replHandle serviceLineChan testDar options ideState) `finally`
+                (hspec $ functionalTests replHandle serviceLineChan testDars options ideState) `finally`
                     -- We need to kill the process to avoid getting stuck in hGetLine on Windows.
                     terminateProcess processHandle
 
-initPackageConfig :: FilePath -> FilePath -> IO ()
-initPackageConfig scriptDar testDar = do
-    writeFileUTF8 "daml.yaml" $ unlines
+initPackageConfig :: FilePath -> [FilePath] -> IO ()
+initPackageConfig scriptDar dars = do
+    writeFileUTF8 "daml.yaml" $ unlines $
         [ "sdk-version: " <> sdkVersion
         , "name: repl"
         , "version: 0.0.1"
@@ -88,8 +89,7 @@ initPackageConfig scriptDar testDar = do
         , "- daml-stdlib"
         , "- " <> show scriptDar
         , "data-dependencies:"
-        , "- " <> show testDar
-        ]
+        ] ++ ["- " <> show dar | dar <- dars]
     withPackageConfig (ProjectPath ".") $ \PackageConfigFields {..} -> do
         dir <- getCurrentDirectory
         createProjectPackageDb (toNormalizedFilePath' dir) options pSdkVersion pModulePrefixes pDependencies pDataDependencies
@@ -102,8 +102,8 @@ drainHandle handle chan = forever $ do
 options :: Options
 options = (defaultOptions Nothing) { optScenarioService = EnableScenarioService False }
 
-functionalTests :: ReplClient.Handle -> Chan String -> FilePath -> Options -> IdeState -> Spec
-functionalTests replClient serviceOut testDar options ideState = describe "repl func tests" $ sequence_
+functionalTests :: ReplClient.Handle -> Chan String -> [FilePath] -> Options -> IdeState -> Spec
+functionalTests replClient serviceOut dars options ideState = describe "repl func tests" $ sequence_
     [ testInteraction' "create and query"
           [ input "alice <- allocateParty \"Alice\""
           , input "debug =<< query @T alice"
@@ -237,17 +237,17 @@ functionalTests replClient serviceOut testDar options ideState = describe "repl 
   where
     testInteraction' testName steps =
         it testName $
-        testInteraction testDar replClient serviceOut options ideState steps
+        testInteraction dars replClient serviceOut options ideState steps
 
 testInteraction
-    :: FilePath
+    :: [FilePath]
     -> ReplClient.Handle
     -> Chan String
     -> Options
     -> IdeState
     -> [Step]
     -> Expectation
-testInteraction testDar replClient serviceOut options ideState steps = do
+testInteraction dars replClient serviceOut options ideState steps = do
     let (inLines, outAssertions) = processSteps steps
     -- On Windows we cannot dup2 between a file handle and a pipe.
     -- Therefore, we redirect to files, run the action and assert afterwards.
@@ -256,7 +256,7 @@ testInteraction testDar replClient serviceOut options ideState steps = do
         withBinaryFile stdinFile ReadMode $ \readIn ->
             redirectingHandle stdin readIn $ do
             Right () <- ReplClient.clearResults replClient
-            capture_ $ runRepl options [testDar] replClient ideState
+            capture_ $ runRepl options dars replClient ideState
     -- Write output to a file so we can conveniently read individual characters.
     withTempFile $ \clientOutFile -> do
         writeFileUTF8 clientOutFile out


### PR DESCRIPTION
Users can now specify multiple DARs at the command-line of `daml repl`. All specified DARs will be loaded as `data-dependencies`. This follows the current behavior of the REPL around module loading: The modules of each main DALF of each DAR will imported into the REPL session automatically at REPL startup.

This adds a second DAR to the REPL func-tests and adds a test-case that ensures that symbols from both DARs are visible.

This changes the implementation of how DARs are loaded into the REPL. Previously, the REPL would load the DAR specified on the command-line twice. Once during package-db initialization and once more during REPL startup to determine the module names of the main DALF. This PR avoids the seconding loading of each DAR by instead relying on the [new serialized package metadata](https://github.com/digital-asset/daml/pull/5607) to determine the main DALFs (direct dependencies).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
