### PR TITLE
support Scala-typed exercise-by-key in Scala codegen

### DIFF
--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
@@ -259,6 +259,15 @@ private[client] object OnlyPrimitive extends Primitive {
                 choiceArgument = Some(argument)
               )
             )
+          case _: ExerciseOn.OnKey[Tpl] =>
+            rpccmd.Command.Command.ExerciseByKey(
+              rpccmd.ExerciseByKeyCommand(
+                templateId = Some(templateCompanion.id.unwrap),
+                contractKey = Some((receiver: Template.Key[Tpl]).encodedKey),
+                choice = choiceId,
+                choiceArgument = Some(argument)
+              )
+            )
         }
       },
       templateCompanion

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Template.scala
@@ -43,4 +43,12 @@ object Template {
     * }}}
     */
   final case class CreateForExercise[+T](value: T with Template[T])
+
+  /** Part of an `ExerciseByKey` command.
+    *
+    * {{{
+    *   Iou key foo exerciseTransfer (controller, ...)
+    * }}}
+    */
+  final case class Key[+T](encodedKey: rpcvalue.Value)
 }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
@@ -37,6 +37,13 @@ abstract class TemplateCompanion[T](implicit isTemplate: T <~< Template[T])
     */
   implicit final def `the TemplateCompanion`: this.type = this
 
+  /** The template's key type, or [[Nothing]] if there is no key type. */
+  type key
+
+  /** Prepare an exercise-by-key Update. */
+  final def key(k: key)(implicit enc: ValueEncoder[key]): Template.Key[T] =
+    Template.Key(Value encode k)
+
   /** Proof that T <: Template[T].  Expressed here instead of as a type parameter
     * bound because the latter is much more inconvenient in practice.
     */
@@ -87,6 +94,7 @@ abstract class TemplateCompanion[T](implicit isTemplate: T <~< Template[T])
 object TemplateCompanion {
   abstract class Empty[T](implicit isTemplate: T <~< Template[T]) extends TemplateCompanion[T] {
     protected def onlyInstance: T
+    override type key = Nothing
     type view[C[_]] = RecordView.Empty[C]
     override def toNamedArguments(associatedType: T) = ` arguments`()
     override def fromNamedArguments(namedArguments: rpcvalue.Record): Option[T] = Some(onlyInstance)

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/encoding/ExerciseOn.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/encoding/ExerciseOn.scala
@@ -10,14 +10,16 @@ import Template.CreateForExercise
 import scala.annotation.implicitNotFound
 
 @implicitNotFound(
-  """Cannot decide how to exercise a choice on ${Self}; only well-typed contract IDs and Templates (.createAnd) are candidates for choice exercise""")
+  """Cannot decide how to exercise a choice on ${Self}; only well-typed contract IDs, Templates (.createAnd), and keys (TemplateType key k) are candidates for choice exercise""")
 sealed abstract class ExerciseOn[-Self, Tpl]
 
 object ExerciseOn {
   implicit def OnId[T]: ExerciseOn[ContractId[T], T] = new OnId
   implicit def CreateAndOnTemplate[T]: ExerciseOn[CreateForExercise[T], T] =
     new CreateAndOnTemplate
+  implicit def OnKey[T]: ExerciseOn[Template.Key[T], T] = new OnKey
 
   private[binding] final class OnId[T] extends ExerciseOn[ContractId[T], T]
   private[binding] final class CreateAndOnTemplate[T] extends ExerciseOn[CreateForExercise[T], T]
+  private[binding] final class OnKey[T] extends ExerciseOn[Template.Key[T], T]
 }

--- a/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
+++ b/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
@@ -439,6 +439,19 @@ template TemplateWith23Arguments
     arg23: Bool
   where signatory arg1
 
+template KeyedNumber
+  with
+    owner: Party
+    number: Int
+  where
+    signatory owner
+    key owner : Party
+    maintainer key
+    controller owner can
+      Increment: ContractId KeyedNumber
+        with delta: Int
+        do create KeyedNumber with owner; number = number + delta
+
 data Enum = E1 | E2 Unit | E3
   deriving (Show, Eq)
 

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
@@ -3,7 +3,7 @@
 
 package com.daml.codegen
 
-import com.daml.sample.MyMain.SimpleListExample
+import com.daml.sample.MyMain.{Increment, KeyedNumber, SimpleListExample}
 import com.daml.ledger.api.v1.{commands => rpccmd}
 import com.daml.ledger.client.binding.{Primitive => P}
 
@@ -27,6 +27,19 @@ class GeneratedCommandsUT extends WordSpec with Matchers with Inside {
         case rpccmd.Command.Command
               .CreateAndExercise(rpccmd.CreateAndExerciseCommand(_, _, _, _)) =>
           ()
+      }
+    }
+  }
+
+  "key" should {
+    "make an exercise-by-key command" in {
+      inside((KeyedNumber key alice exerciseIncrement (alice, 42)).command.command) {
+        case rpccmd.Command.Command.ExerciseByKey(
+            rpccmd.ExerciseByKeyCommand(Some(tid), Some(k), "Increment", Some(choiceArg))) =>
+          import com.daml.ledger.client.binding.Value.encode
+          tid should ===(KeyedNumber.id)
+          k should ===(encode(alice))
+          choiceArg should ===(encode(Increment(42)))
       }
     }
   }

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlContractTemplateGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlContractTemplateGen.scala
@@ -9,6 +9,7 @@ import com.daml.codegen.Util
 import com.daml.lf.data.ImmArray.ImmArraySeq
 import com.daml.lf.data.Ref.{Identifier, QualifiedName}
 import com.typesafe.scalalogging.Logger
+import scalaz.syntax.std.option._
 
 import scala.reflect.runtime.universe._
 
@@ -77,6 +78,7 @@ object DamlContractTemplateGen {
       q"""implicit final class ${TypeName(s"${contractName.name} syntax")}[$syntaxIdDecl](private val id: $syntaxIdType) extends _root_.scala.AnyVal {
             ..$templateChoiceMethods
           }""",
+      q"type key = ${templateInterface.template.key.cata(util.genTypeToScalaType, LFUtil.nothingType)}",
       consumingChoicesMethod,
       toNamedArgumentsMethod,
       fromNamedArgumentsMethod

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
@@ -378,6 +378,7 @@ object LFUtil {
   val stdMapCompanion = q"_root_.scala.collection.immutable.Map"
   val stdVectorType = tq"_root_.scala.collection.immutable.Vector"
   val stdSeqCompanion = q"_root_.scala.collection.immutable.Seq"
+  val nothingType = q"_root_.scala.Nothing"
 
   def toTypeDef(s: String): TypeDef = q"type ${TypeName(s)}"
 


### PR DESCRIPTION
Fixes #6466.

```scala
MyContract key 42 exerciseFoo (actor, "hi")
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
