### PR TITLE
Improve contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,28 +86,26 @@ Here are a few practical tips:
 
 ### List of components for changelog entries
 
-  * Compiler
-  * DAML Maven Plugin
+  * DAML Compiler
   * DAML on SQL
   * DAML Studio
-  * Examples & Docs
   * Extractor
   * Java Bindings
   * Java Codegen
   * JavaScript Client Libraries
+  * JavaScript Codegen
   * JSON API
   * Ledger API Specification
-  * Ledger API Test Tool
+  * Integration Kit (Ledger API Test Tool and changes only relevant for ledger integrations, e.g, kvutils changes, metrics, …)
   * Navigator
-  * REPL
+  * DAML REPL
   * Sandbox
   * Scala Bindings
   * Scala Codegen
-  * Script
-  * SDK Assistant
-  * Standard Library
-  * Test Library
-  * Triggers
+  * DAML Script
+  * DAML Assistant
+  * DAML Standard Library
+  * DAML Triggers
 
 ## Working with issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,9 +86,12 @@ Here are a few practical tips:
 
 ### List of components for changelog entries
 
+This list should cover the vast majority of needs. If unsure, ask on the relevant GitHub issue or PR.
+
   * DAML Compiler
   * DAML on SQL
   * DAML Studio
+  * Distribution/Releases
   * Extractor
   * Java Bindings
   * Java Codegen
@@ -96,7 +99,7 @@ Here are a few practical tips:
   * JavaScript Codegen
   * JSON API
   * Ledger API Specification
-  * Integration Kit (Ledger API Test Tool and changes only relevant for ledger integrations, e.g, kvutils changes, metrics, …)
+  * Integration Kit †
   * Navigator
   * DAML REPL
   * Sandbox
@@ -106,6 +109,8 @@ Here are a few practical tips:
   * DAML Assistant
   * DAML Standard Library
   * DAML Triggers
+
+† Covers the Ledger API Test Tool and changes to libraries that affect ledger integrations (e.g. `kvutils`)
 
 ## Working with issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ For Git commit messages, our principle is that `git log --pretty=oneline` should
 - Does your PR include appropriate tests?
 - Make sure your PR title and description makes it easy for other developers to understand what the contained commits do. The title should say what the changes do. The description should expand on what it does (if not obvious from the title alone), and say why it is being done.
 - If your PR corresponds to an issue, add “Fixes #XX” to your pull request description. This will auto-close the corresponding issue when the commit is merged into master and tie the PR to the issue.
-- If your PR includes user-facing changes, the squashed commit for the PR must include in its body a section between the ``CHANGELOG_BEGIN`` and ``CHANGELOG_END`` tags that includes relevant changelog entries, where each entry starts with the component to which it belongs in square brackets. Use RST to format links as this text will be added to the changelog upon release.
+- If your PR includes user-facing changes, the squashed commit for the PR must include in its body a section between the ``CHANGELOG_BEGIN`` and ``CHANGELOG_END`` tags that includes relevant changelog entries, where each entry starts with the component to which it belongs in square brackets. Use RST to format links as this text will be added to the changelog upon release. [Follow these guidelines on how to write a good changelog entry](#writing-a-good-changelog-entry).
 - If your PR does not include user-facing changes, you still need to include a changelog section, but it can be empty, i.e. it is valid for the `CHANGELOG_END` to be right after the `CHANGELOG_BEGIN` line.
 
 The following is an example of a well-formed commit, including the description (first line) and a body that includes changelog additions:
@@ -61,9 +61,48 @@ If you want to verify the changelog entries as described by a range of Git revis
 
     ./unreleased.sh master..
 
+## Writing a good changelog entry
+
+Writing good changelog entries is **important**: as a developer, it gives visibility on your contribution; as a user, it makes clear what is new, what changes and two deal with those, making the product more accessible and your work more meaningful.
+
+The raw changelog is used to compile a meaningful summary of changes across releases. This happens some time after the PR has been merged and the person taking the responsability of summarizing new user-facing features must be in the position of easily understand the nature of the change and report it. The ideal changelog entry can be more or less incorporated verbatim in the release notes.
+
+Here are a few practical tips
+
+* the first term to appear should be the affected component -- [here's a list](#list-of-components-for-changelog-entries)
+* write as many as necessary changelog entries as necessary
+* don't be _too_ succinct: a single entry does **not have to** fit on a single line
+* on the other end, if the size grows beyond 5-6 lines, rather add a link to a relevant documentation or issue with more details
+* the ultimate target are end users: focus on the impact on them, tell them what's new or how to deal with a change
+
+### List of components for changelog entries
+
+  * Compiler
+  * DAML Maven Plugin
+  * DAML on SQL
+  * DAML Studio
+  * Examples & Docs
+  * Extractor
+  * Java Bindings
+  * Java Codegen
+  * JavaScript Client Libraries
+  * JSON API
+  * Ledger API Specification
+  * Ledger API Test Tool
+  * Navigator
+  * REPL
+  * Sandbox
+  * Scala Bindings
+  * Scala Codegen
+  * Script
+  * SDK Assistant
+  * Standard Library
+  * Test Library
+  * Triggers
+
 ## Working with issues
 
-We use issues and [pull requests](https://help.github.com/articles/about-pull-requests/) to collaborate and track our work. Anyone is welcome to open an issue. If you just want to ask a question, please ask away on [Stack Overflow](https://stackoverflow.com/questions/tagged/daml) using the tag `daml`.
+We use issues and [pull requests](https://help.github.com/articles/about-pull-requests/) to collaborate and track our work. Anyone is welcome to open an issue. If you just want to ask a question, please ask away on [the DAML forum](https://discuss.daml.com).
 
 We encourage everyone to vote on issues that they support or not:
 
@@ -112,3 +151,4 @@ You can also join a `#daml-contributors` channel on our Slack: [damldriven.slack
 # Thank you!
 
 Thank you for taking the time to contribute!
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,14 +63,14 @@ If you want to verify the changelog entries as described by a range of Git revis
 
 ## Writing a good changelog entry
 
-Writing good changelog entries is **important**: as a developer, it gives visibility on your contribution; as a user, it makes clear what is new, what changes and two deal with those, making the product more accessible and your work more meaningful.
+Writing good changelog entries is **important**: as a developer, it gives visibility on your contribution; as a user, it makes clear what is new, what's changed, and how to deal with them, making the product more accessible and your work more meaningful.
 
-The raw changelog is used to compile a meaningful summary of changes across releases. This happens some time after the PR has been merged and the person taking the responsability of summarizing new user-facing features must be in the position of easily understand the nature of the change and report it. The ideal changelog entry can be more or less incorporated verbatim in the release notes.
+The raw changelog is used to compile a meaningful summary of changes across releases. This happens some time after the PR has been merged and the person taking the responsibility of summarizing new user-facing features must be in the position to easily understand the nature of the change and report it. The ideal changelog entry can be more or less incorporated verbatim in the release notes.
 
-Here are a few practical tips
+Here are a few practical tips:
 
 * the first term to appear should be the affected component -- [here's a list](#list-of-components-for-changelog-entries)
-* write as many as necessary changelog entries as necessary
+* write as many changelog entries as necessary
 * don't be _too_ succinct: a single entry does **not have to** fit on a single line
 * on the other end, if the size grows beyond 5-6 lines, rather add a link to a relevant documentation or issue with more details
 * the ultimate target are end users: focus on the impact on them, tell them what's new or how to deal with a change
@@ -151,4 +151,3 @@ You can also join a `#daml-contributors` channel on our Slack: [damldriven.slack
 # Thank you!
 
 Thank you for taking the time to contribute!
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,11 @@ For Git commit messages, our principle is that `git log --pretty=oneline` should
 
 ## Pull request checklist
 
-- Read this document (contribution guidelines).
-- Does your PR include appropriate tests?
-- Make sure your PR title and description makes it easy for other developers to understand what the contained commits do. The title should say what the changes do. The description should expand on what it does (if not obvious from the title alone), and say why it is being done.
-- If your PR corresponds to an issue, add “Fixes #XX” to your pull request description. This will auto-close the corresponding issue when the commit is merged into master and tie the PR to the issue.
-- If your PR includes user-facing changes, the squashed commit for the PR must include in its body a section between the ``CHANGELOG_BEGIN`` and ``CHANGELOG_END`` tags that includes relevant changelog entries, where each entry starts with the component to which it belongs in square brackets. Use RST to format links as this text will be added to the changelog upon release. [Follow these guidelines on how to write a good changelog entry](#writing-a-good-changelog-entry).
-- If your PR does not include user-facing changes, you still need to include a changelog section, but it can be empty, i.e. it is valid for the `CHANGELOG_END` to be right after the `CHANGELOG_BEGIN` line.
+* Read this document (contribution guidelines).
+* Does your PR include appropriate tests?
+* Make sure your PR title and description makes it easy for other developers to understand what the contained commits do. The title should say what the changes do. The description should expand on what it does (if not obvious from the title alone), and say why it is being done.
+* If your PR corresponds to an issue, add “Fixes #XX” to your pull request description. This will auto-close the corresponding issue when the commit is merged into master and tie the PR to the issue.
+* the squashed commit for the PR **MUST** include in its body a section between the ``CHANGELOG_BEGIN`` and ``CHANGELOG_END`` tags. This section **MAY** include a list of _user-facing_ changes [Follow these guidelines on how to write a good changelog entry](#writing-a-good-changelog-entry).
 
 The following is an example of a well-formed commit, including the description (first line) and a body that includes changelog additions:
 
@@ -57,6 +56,15 @@ If you want to amend an existing changelog entry part of a PR already merged on 
 
       CHANGELOG_END
 
+If the PR contains no _user-facing_ change, the section **MUST** be there but can be left empty, as in the following example:
+
+      Fixes #6666
+
+      Improve contribution guidelines
+
+      CHANGELOG_BEGIN
+      CHANGELOG_END
+
 If you want to verify the changelog entries as described by a range of Git revisions, you can use the `unreleased.sh` script. In most cases, to see the entries added as part of commits added since branching off of `master`, you can run:
 
     ./unreleased.sh master..
@@ -69,6 +77,7 @@ The raw changelog is used to compile a meaningful summary of changes across rele
 
 Here are a few practical tips:
 
+* if there are no user-facing changes, keep the changelog entry list empty
 * the first term to appear should be the affected component -- [here's a list](#list-of-components-for-changelog-entries)
 * write as many changelog entries as necessary
 * don't be _too_ succinct: a single entry does **not have to** fit on a single line


### PR DESCRIPTION
Thanks @bame-da for the suggestions.

changelog_begin
changelog_end

What an ironically empty changelog entry list. :)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
