### PR TITLE
Set YARN_CACHE_FOLDER in all tests

### DIFF
--- a/compatibility/bazel_tools/create-daml-app/Main.hs
+++ b/compatibility/bazel_tools/create-daml-app/Main.hs
@@ -145,7 +145,8 @@ withTools tests = do
   tests tools
 
 main :: IO ()
-main = do
+main = withTempDir $ \yarnCache -> do
+  setEnv "YARN_CACHE_FOLDER" yarnCache True
   setEnv "TASTY_NUM_THREADS" "1" True
   let options =
         [ Option @DamlOption Proxy

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
@@ -24,7 +24,8 @@ import DA.Test.Process (callCommandSilent)
 import DA.Test.Util
 
 main :: IO ()
-main = do
+main = withTempDir $ \yarnCache -> do
+    setEnv "YARN_CACHE_FOLDER" yarnCache True
     yarn : args <- getArgs
     javaPath <- locateRunfiles "local_jdk/bin"
     oldPath <- getSearchPath

--- a/language-support/ts/codegen/tests/build-and-lint.sh
+++ b/language-support/ts/codegen/tests/build-and-lint.sh
@@ -18,6 +18,7 @@ else
     TMP_DIR="$BUILD_AND_LINT_TMP_DIR"
     rm -rf $TMP_DIR && mkdir -p $TMP_DIR
 fi
+export YARN_CACHE_FOLDER=$TMP_DIR/yarn
 echo "Temp directory : $TMP_DIR"
 
 # --- begin runfiles.bash initialization v2 ---

--- a/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
+++ b/language-support/ts/codegen/tests/src/DA/Test/Daml2js.hs
@@ -31,7 +31,8 @@ typescriptEslintVersion :: T.Text
 typescriptEslintVersion = "~2.31.0"
 
 main :: IO ()
-main = do
+main = withTempDir $ \yarnCache -> do
+    setEnv "YARN_CACHE_FOLDER" yarnCache True
     yarnPath : args <- getArgs
     damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
     daml2js <- locateRunfiles (mainWorkspace </> "language-support" </> "ts" </> "codegen" </> exe "daml2js")


### PR DESCRIPTION
The default cache directories in yarn don’t work in the Bazel
sandbox. This results in Yarn creating tons of temp directories for
each test that are never cleared up.

This PR changes this to create actual temp directories that are
properly cleaned up.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
