### PR TITLE
default Engine to StableConfig

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -46,7 +46,7 @@ import java.nio.file.{Files, Path, Paths}
   *
   * This class is thread safe as long `nextRandomInt` is.
   */
-class Engine(config: Engine.Config) {
+class Engine(config: Engine.Config = Engine.StableConfig) {
   private[this] val compiledPackages = ConcurrentCompiledPackages()
   private[this] val preprocessor = new preprocessing.Preprocessor(compiledPackages)
   private[this] var profileDir: Option[Path] = None


### PR DESCRIPTION
Default new Engine constructor to Engine.StableConfig so it does not
need to be overridden unless you specifically want to run in
Engine.DevConfig mode

