### PR TITLE
Type nested decoders with type arguments in daml2js

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -437,16 +437,18 @@ renderSerializableDef SerializableDef{..}
           ]
     in (jsDecl, tsDecl)
   | otherwise = assert (null serKeys) $
-    let tsDecl = T.unlines
+    let tsDecl = T.unlines $
             -- If we have type parameters, the serializable definition is
             -- a function and we generate extra properties on that function
             -- for each nested decoder.
-            [ "export declare const " <> serName <> " : " <> tyArgs <> " => "
-            , "  damlTypes.Serializable<" <> serName <> tyParams <> ">;"
+            [ "export declare const " <> serName <> " :"
+            , "  (" <> tyArgs <> " => damlTypes.Serializable<" <> serName <> tyParams <> ">) & {"
+            ] ++
+            [ "  " <> n <> ": (" <> tyArgs <> " => damlTypes.Serializable<" <> serName <.> n <> ">);"
+            | (n, _) <- serNestedDecoders
+            ] ++
+            [ "};"
             ]
-            -- NOTE (MK) It would be nice to type the nested
-            -- fields here as well (we didn’t do that when we generated
-            -- TS code either).
         jsSource = T.unlines $
             -- If we have type parameters, the serializable definition is
             -- a function and we generate extra properties on that function


### PR DESCRIPTION
Turns out you can easily intersect function types with object literals
to get what we want here.

While I am very annoyed by it, I don’t know how to write a test for
this. Afaik I can only test this by writing something that hits the
decoder directly but that doesn’t work since it’s impossible (afaik)
to write DAML code that generates DAML-LF that uses the nested type
directly in some API-relevant position (choice arg/return type, key
type, …). Of course, I could handwrite some DAML-LF but only Rémy is
allowed to do that.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
