### PR TITLE
Fix fine-grained exclusions in ledger-api-test-tool

### DIFF
--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -204,7 +204,7 @@ conformance_test(
         "--participant participant-id=test-name,port=6865",
     ],
     test_tool_args = [
-        "--include=ContractKeysIT",
-        "--include=ContractKeysIT:CKFetchOrLookup",
+        "--include=IdentityIT",
+        "--include=IdentityIT:IdNotEmpty",
     ],
 )

--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -193,3 +193,18 @@ conformance_test(
         "--target-port=THIS_OPTION_IS_DEPRECATED_AND_HAS_NO_EFFECT",
     ],
 )
+
+# Test that both --include ContractKeysIT as well as --include ContractKeysIT:CKFetchOrLookup
+# are supporte.
+conformance_test(
+    name = "test-name-syntax",
+    server = "//ledger/ledger-on-memory:app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant participant-id=test-name,port=6865",
+    ],
+    test_tool_args = [
+        "--include=ContractKeysIT",
+        "--include=ContractKeysIT:CKFetchOrLookup",
+    ],
+)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -107,7 +107,8 @@ object LedgerApiTestTool {
       sys.exit(0)
     }
 
-    val allTestCaseNames: Set[String] = (Tests.all ++ Tests.retired).map(_.name).toSet
+    val allTestCaseNames: Set[String] =
+      (Tests.all ++ Tests.retired).flatMap(_.tests).map(_.name).toSet
     val missingTests = (config.included ++ config.excluded).filterNot(prefix =>
       allTestCaseNames.exists(_.startsWith(prefix)))
     if (missingTests.nonEmpty) {


### PR DESCRIPTION
31995ee00073b446f7361016fc22d0fb0f320ce0 accidentally changed
`allTestCaseNames` to be a list of test suite names instead of a list
of test case names. That breaks fine-grained exclusions that we use in
our compatibility tests. I’ve also added a very basic test that both
the coarse-grained and fine-grained syntax is supported.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
