### PR TITLE
Time model docs

### DIFF
--- a/docs/source/app-dev/app-arch.rst
+++ b/docs/source/app-dev/app-arch.rst
@@ -170,3 +170,10 @@ How is this used in practice?
 - Set ``min_ledger_time_abs`` or ``min_ledger_time_rel`` if the duration of command interpretation and transmission is likely to take a long time relative to the tolerance interval set by the ledger.
 - In some corner cases, the participant node may be unable to determine a suitable ledger time by itself. If you get an error that no ledger time could be found, check whether you have contention on any contract referenced by your command or whether the referenced contracts are sensitive to small changes of ``getTime``.
 
+More precisely, the ledger time is implemented as follows:
+
+- Each transaction has a ledger time ``lt_TX`` assigned by the participant during command submission and a *record time* ``rt_TX`` assigned by the ledger during the transaction commit.
+- The ledger time ``lt_TX`` is set to the local time on the participant server and adjusted to satisfy both the user-defined mimimum ledger time and causal monotonicity (see above).
+- The participant submits the transaction to the ledger when its local clock reaches ``lt_TX - transaction_latency``, i.e., with the intention that the transaction is committed at its ledger time, taking into account the *average* latency between the submission and the commit, ``transaction_latency``.
+- During the transaction commit, the ledger assigns a *record time* ``rt_TX`` and and validates that the ledger time statisfies ``rt_TX - min_skew <= lt_TX`` and ``lt_TX <= rt_TX + max_skew``.
+- The parameters ``min_skew``, ``max_skew``, and ``transaction_latency`` are part of the *ledger time model* that can be changed by ledger operators through the :ref:`ledger configuration service <ledger-configuration-service>`.

--- a/docs/source/app-dev/app-arch.rst
+++ b/docs/source/app-dev/app-arch.rst
@@ -172,7 +172,7 @@ How is this used in practice?
 
 More precisely, the ledger time is implemented as follows:
 
-- Each transaction has a ledger time ``lt_TX`` assigned by the participant during command submission and a *record time* ``rt_TX`` assigned by the ledger during the transaction commit.
+- Each transaction has a *ledger time* ``lt_TX`` assigned by the participant during command submission and a *record time* ``rt_TX`` assigned by the ledger during the transaction commit.
 - The ledger time ``lt_TX`` is set to the local time on the participant server and adjusted to satisfy both the user-defined mimimum ledger time and causal monotonicity (see above).
 - The participant submits the transaction to the ledger when its local clock reaches ``lt_TX - transaction_latency``, i.e., with the intention that the transaction is committed at its ledger time, taking into account the *average* latency between the submission and the commit, ``transaction_latency``.
 - During the transaction commit, the ledger assigns a *record time* ``rt_TX`` and and validates that the ledger time statisfies ``rt_TX - min_skew <= lt_TX`` and ``lt_TX <= rt_TX + max_skew``.

--- a/docs/source/daml/intro/5_Restrictions.rst
+++ b/docs/source/daml/intro/5_Restrictions.rst
@@ -78,13 +78,13 @@ There's also quite a lot going on inside the ``do`` block of the ``Redeem`` choi
 Time on DAML ledgers
 --------------------
 
-Each transaction on a DAML ledger has two timestamps called the *ledger effective time (LET)* and the *record time (RT)*. The ledger effective time is set by the submitter of a transaction, the record time is set by the consensus protocol.
+Each transaction on a DAML ledger has two timestamps called the *ledger effective time (LET)* and the *record time (RT)*. The ledger effective time is set by the participant, the record time is set by the consensus protocol.
 
-Each DAML ledger has a policy on the allowed difference between LET and RT called the *skew*. The submitter has to take a good guess at what the record time will be. If it's too far off, the transaction will be rejected.
+Each DAML ledger has a policy on the allowed difference between LET and RT called the *skew*. The participant has to take a good guess at what the record time will be. If it's too far off, the transaction will be rejected.
 
 ``getTime`` is an action that gets the LET from the ledger. In the above example, that time is taken apart into day of week and hour of day using standard library functions from ``DA.Date`` and ``DA.Time``. The hour of the day is checked to be in the range from 8 to 18.
 
-Suppose now that the ledger had a skew of 10 seconds, but a submission took less than 4 seconds to commit. At 18:00:05, Alice could submit a transaction with a LET of 17:59:59 to redeem an Iou. It would be a valid transaction and be committed successfully as ``getTime`` will return 17:59:59 so ``hrs == 17``. Since RT will be before 18:00:09, ``LET - RT < 10 seconds`` and the transaction won't be rejected.
+Consider the following example: Suppose that the ledger had a skew of 10 seconds. At 17:55:55, Alice submits a transaction to redeem an Iou. The transaction is assigned a LET of 17:59:56, but then takes 10 seconds to commit and is recorded on the ledger at 18:00:06. Even though it was committed after business hours, it would be a valid transaction and be committed successfully as ``getTime`` will return 17:59:56 so ``hrs == 17``. Since the RT is 18:00:06, ``LET - RT < 10 seconds`` and the transaction won't be rejected.
 
 Time therefore has to be considered slightly fuzzy in DAML, with the fuzziness depending on the skew parameter.
 


### PR DESCRIPTION
This PR corrects an outdated description of ledger time in the DAML intro, and adds a detailed description of our ledger time model. 


Preview:

<img width="833" alt="Screenshot 2020-07-10 at 12 34 45" src="https://user-images.githubusercontent.com/31539813/87145609-de1e2300-c2a9-11ea-999e-11f6debc45c1.png">
