### PR TITLE
include contract keys in the Scala codegen output plan when using --root

### DIFF
--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/dependencygraph/DependencyGraph.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/dependencygraph/DependencyGraph.scala
@@ -39,12 +39,12 @@ private final case class LFDependencyGraph(private val util: lf.LFUtil)
     val templateNodes = decls.to[ImmArraySeq].collect {
       case (qualName, InterfaceType.Template(typ, tpl)) =>
         val recDeps = typ.foldMap(Util.genTypeTopLevelDeclNames)
-        val choiceDeps = tpl.foldMap(Util.genTypeTopLevelDeclNames)
+        val choiceAndKeyDeps = tpl.foldMap(Util.genTypeTopLevelDeclNames)
         (
           qualName,
           Node(
             TemplateWrapper(DefTemplateWithRecord(typ, tpl)),
-            recDeps ++ choiceDeps,
+            recDeps ++ choiceAndKeyDeps,
             collectDepError = true))
     }
     Graph.cyclicDependencies(internalNodes = typeDeclNodes, roots = templateNodes)

--- a/language-support/scala/codegen/src/test/scala/com/digitalasset/codegen/lf/LFUtilSpec.scala
+++ b/language-support/scala/codegen/src/test/scala/com/digitalasset/codegen/lf/LFUtilSpec.scala
@@ -1,7 +1,8 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.codegen.lf
+package com.daml.codegen
+package lf
 
 import com.daml.lf.data.Ref
 import org.scalatest.{Inside, Matchers, WordSpec}
@@ -12,6 +13,7 @@ import scalaz._
 import scalaz.std.anyVal._
 import scalaz.syntax.foldable1._
 import scalaz.syntax.monad._
+import scalaz.syntax.std.map._
 
 class LFUtilSpec extends WordSpec with Matchers with Inside with PropertyChecks {
   import LFUtilSpec._
@@ -110,6 +112,16 @@ class LFUtilSpec extends WordSpec with Matchers with Inside with PropertyChecks 
       }
     }
   }
+
+  "orderedDependencies" should {
+    "include contract keys" in {
+      val ei = CodeGen.filterTemplatesBy(Seq("HasKey".r))(envInterfaceWithKey)
+      LFUtil("a", ei, new java.io.File("."))
+        .orderedDependencies(ei)
+        .deps map (_._1) should ===(
+        Vector("a:b:It", "a:b:HasKey") map Ref.Identifier.assertFromString)
+    }
+  }
 }
 
 object LFUtilSpec {
@@ -126,4 +138,19 @@ object LFUtilSpec {
     Shrink { nela =>
       Shrink.shrink((nela.head, nela.tail.toVector)) map { case (h, t) => NonEmptyList(h, t: _*) }
     }
+
+  import com.daml.lf.iface._
+  import com.daml.lf.data.ImmArray.ImmArraySeq
+
+  private[this] val fooRec = Record(ImmArraySeq.empty)
+  val envInterfaceWithKey = EnvironmentInterface(
+    Map(
+      "a:b:HasKey" -> InterfaceType.Template(
+        fooRec,
+        DefTemplate(
+          Map.empty,
+          Some(TypeCon(TypeConName(Ref.Identifier assertFromString "a:b:It"), ImmArraySeq.empty)))),
+      "a:b:NoKey" -> InterfaceType.Template(fooRec, DefTemplate(Map.empty, None)),
+      "a:b:It" -> InterfaceType.Normal(DefDataType(ImmArraySeq.empty, fooRec)),
+    ) mapKeys Ref.Identifier.assertFromString)
 }


### PR DESCRIPTION
Fix to #6660: when filtering with `--root`, contract keys weren't included in the Scala codegen output plan. We fix it by refining #1586, bringing the key types in line with the way types are generally treated in the definition interface types: as the `Ty` type variable.

Thanks to @SamirTalwar-DA for discovering.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
