### PR TITLE
Bump migration timeout in compat tests

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -107,6 +107,7 @@ test_suite(
 
 migration_test(
     name = "migration-stable",
+    timeout = "long",
     # Exclusive due to hardcoded postgres ports.
     tags = [
         "exclusive",
@@ -129,6 +130,7 @@ migration_test(
 
 migration_test(
     name = "migration-all",
+    timeout = "long",
     # Exclusive due to hardcoded postgres ports.
     tags = ["exclusive"],
     versions = platform_versions,


### PR DESCRIPTION
With the increasing number of snapshots we sometimes hit the 300s timeout.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
