### PR TITLE
Reduce dependencies of live-preview script

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -376,7 +376,7 @@ genrule(
         "//language-support/ts/daml-ledger:docs",
         "//language-support/ts/daml-types:docs",
         "//templates:templates-tarball",
-        "//templates:create-daml-app-test-resources/messaging.patch",
+        "//templates:create-daml-app-docs",
         "//templates:create-daml-app-test-resources/index.test.ts",
         "@daml-cheat-sheet//:site",
     ],
@@ -397,13 +397,11 @@ genrule(
         CODE_DIR=$$PWD/build/docs/source/getting-started/code/
         mkdir -p $$CODE_DIR
         tar -zxf $(location //templates:templates-tarball) -C $$CODE_DIR
+        rm -rf $$CODE_DIR/templates-tarball/create-daml-app
+        tar -zxf $(location //templates:create-daml-app-docs) -C $$CODE_DIR/templates-tarball/
         # Copy create-daml-app tests
         mkdir $$CODE_DIR/testing
         cp $(location //templates:create-daml-app-test-resources/index.test.ts) $$CODE_DIR/testing
-        # Apply patch for messaging feature (we only need the "after" state)
-        PATCH_TOOL=$$PWD/$(location @patch_dev_env//:patch)
-        MESSAGING_PATCH=$$PWD/$(location //templates:create-daml-app-test-resources/messaging.patch)
-        (cd $$CODE_DIR/templates-tarball; $$PATCH_TOOL -s -p1 < $$MESSAGING_PATCH)
 
         # Build with Sphinx
         cd build
@@ -461,7 +459,6 @@ genrule(
         """.format(sdk = sdk_version),
     tools = [
         "@sphinx_nix//:bin/sphinx-build",
-        "@patch_dev_env//:patch",
     ] + (["@glibc_locales//:locale-archive"] if is_linux else []),
 ) if not is_windows else None
 

--- a/docs/scripts/live-preview.sh
+++ b/docs/scripts/live-preview.sh
@@ -40,9 +40,9 @@ cp ../../NOTICES ../source
 
 # GSG source, while this is arguably part of --gen
 # it is quick enough and important enough to always include it.
-bazel build //templates:templates-tarball
-mkdir -p $BUILD_DIR/source/getting-started/code
-tar -zxf ../../bazel-bin/templates/templates-tarball.tar.gz -C $BUILD_DIR/source/getting-started/code/
+bazel build //templates:create-daml-app-docs
+mkdir -p $BUILD_DIR/source/getting-started/code/templates-tarball
+tar -zxf ../../bazel-bin/templates/create-daml-app-docs.tar.gz -C $BUILD_DIR/source/getting-started/code/templates-tarball/
 
 for arg in "$@"
 do

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -3,6 +3,34 @@
 
 exports_files(glob(["create-daml-app-test-resources/*"]))
 
+# Split out into a separate rule so we can cheaply include this in the
+# live-preview.
+genrule(
+    name = "create-daml-app-docs",
+    srcs = glob(
+        ["create-daml-app/**"],
+        exclude = ["**/NO_AUTO_COPYRIGHT"],
+    ) + [
+        "//templates:create-daml-app-test-resources/messaging.patch",
+    ],
+    outs = ["create-daml-app-docs.tar.gz"],
+    cmd = """
+SRC=templates
+OUT=create-daml-app
+mkdir -p $$OUT
+cp -rL $$SRC/create-daml-app/* $$OUT
+# Apply patch for messaging feature (we only need the "after" state)
+PATCH_TOOL=$$PWD/$(location @patch_dev_env//:patch)
+MESSAGING_PATCH=$$PWD/$(location //templates:create-daml-app-test-resources/messaging.patch)
+$$PATCH_TOOL -s -p1 < $$MESSAGING_PATCH
+tar c create-daml-app \\
+    --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
+    | gzip -n >$(location :create-daml-app-docs.tar.gz)
+""",
+    tools = ["@patch_dev_env//:patch"],
+    visibility = ["//visibility:public"],
+)
+
 genrule(
     name = "templates-tarball",
     srcs = glob(


### PR DESCRIPTION
The intention was to pull in the source for the GSG but it turns out
that the templates tarball doesn’t just bundle up files, it also
includes generated scala code for the scala quickstart which depends
on damlc. This PR splits the GSG sources including the patching into a
separate rule which does not depend on damlc and only copies that in
live-preview.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
