### PR TITLE
fix auto compat update PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -500,6 +500,16 @@ jobs:
         set -euo pipefail
         eval "$(./dev-env/bin/dade-assist)"
 
+        DELAY=1
+        while ! curl --fail -I https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/$(release_tag)/ledger-api-test-tool-$(release_tag).jar; do
+            sleep $DELAY
+            DELAY=$(( DELAY * 2 ))
+            if (( $DELAY > 2000 )); then
+                echo "Too many attempts waiting for Maven."
+                exit 1
+            fi
+        done
+
         # With `persistCredentials: true`, Azure Pipelines will store the
         # credentials to interact with GitHub in the url for the origin remote,
         # using basic auth format:
@@ -509,6 +519,8 @@ jobs:
 
         git checkout origin/master
         BRANCH=update-compat-versions-for-$(release_tag)
+        # if this is a rerun, branch might already exist
+        git branch -D $BRANCH || true
         git checkout -b $BRANCH
         cp .bazelrc compatibility/
         compatibility/update-versions.sh
@@ -518,7 +530,7 @@ jobs:
         git -c user.name="Azure Pipelines DAML Build" \
             -c user.email="support@digitalasset.com" \
             commit \
-            -m "update compat versions for $(release_tag)\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n"
+            -m "$(printf "update compat versions for $(release_tag)\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n"))"
         git push origin $BRANCH:$BRANCH
         curl -H "Content-Type: application/json" \
              -u $AUTH \
@@ -527,6 +539,9 @@ jobs:
              --location \
              -d "{\"title\": \"update compat versions for $(release_tag)\", \"head\": \"$BRANCH\", \"base\": \"master\"}" \
              https://api.github.com/repos/digital-asset/daml/pulls
+    - template: ci/tell-slack-failed.yml
+      parameters:
+        trigger_sha: '$(trigger_sha)'
 
   - job: write_ledger_dump
     dependsOn:


### PR DESCRIPTION
This PR fixes a few things with the script that automatically updates the compat test matrix on release, based on its use over the past two weeks. Specifically:

- Send an error message to Slack in case this job fails. Previously, failures here were silent.
- Add an exponential backoff strategy to wait for the artifact to be available on Maven. Previously, the update script just failed.
- Allow for rerunning on the same machine after failure by removing the branch if it exists.
- Fix the commit message to include proper newlines instead of literal `\n`'s.

CHANGELOG_BEGIN
CHANGELOG_END