### PR TITLE
DAML REPL - Explicit package imports

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -13,7 +13,6 @@ import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.LF.Ast.Optics (packageRefs)
 import qualified DA.Daml.LF.ReplClient as ReplClient
 import DA.Daml.LFConversion.UtilGHC
-import DA.Daml.Options.Packaging.Metadata
 import DA.Daml.Options.Types
 import qualified DA.Daml.Preprocessor.Records as Preprocessor
 import Data.Bifunctor (first)
@@ -21,6 +20,7 @@ import Data.Functor.Alt
 import Data.Foldable
 import Data.Generics.Uniplate.Data (descendBi)
 import Data.Graph
+import Data.List (intercalate)
 import qualified Data.Map.Strict as Map
 import Data.Maybe
 import qualified Data.NameMap as NM
@@ -40,6 +40,7 @@ import HsPat (Pat(..))
 import HscTypes (HscEnv(..))
 import Language.Haskell.GhclibParserEx.Parse
 import Lexer (ParseResult(..))
+import Module (unitIdString, stringToUnitId)
 import OccName (occName, OccSet, elemOccSet, mkOccSet, mkVarOcc)
 import Outputable (ppr, showSDoc)
 import RdrName (mkRdrUnqual)
@@ -183,9 +184,9 @@ parseReplInput input dflags =
 
 -- | Load all packages in the given session.
 --
--- Returns the list of modules in the main DALFs.
-loadPackages :: ReplClient.Handle -> IdeState -> IO [ImportDecl GhcPs]
-loadPackages replClient ideState = do
+-- Returns the list of modules in the specified import packages.
+loadPackages :: [String] -> ReplClient.Handle -> IdeState -> IO [ImportDecl GhcPs]
+loadPackages importPkgs replClient ideState = do
     -- Load packages
     Just (PackageMap pkgs) <- runAction ideState (use GeneratePackageMap "Dummy.daml")
     Just stablePkgs <- runAction ideState (use GenerateStablePackages "Dummy.daml")
@@ -196,19 +197,26 @@ loadPackages replClient ideState = do
                 hPutStrLn stderr ("Package could not be loaded: " <> show err)
                 exitFailure
             Right _ -> pure ()
-    -- Determine module names in main DALFs.
-    md <- readMetadata (toNormalizedFilePath' ".")
+    -- Determine module names in imported DALFs.
+    importLfPkgs <- forM importPkgs $ \pkgId ->
+        case Map.lookup (stringToUnitId pkgId) pkgs of
+            Just lfPkg -> pure lfPkg
+            Nothing -> do
+                hPutStrLn stderr $
+                    "Could not find package for import: " <> show pkgId <> "\n"
+                    <> "Known packages: " <> intercalate ", " (unitIdString <$> Map.keys pkgs)
+                exitFailure
     pure
       [ simpleImportDecl . mkModuleName . T.unpack . LF.moduleNameString $ mod
-      | dep <- directDependencies md
-      , let pkg = LF.extPackagePkg $ LF.dalfPackagePkg $ pkgs Map.! dep
+      | lfPkg <- importLfPkgs
+      , let pkg = LF.extPackagePkg $ LF.dalfPackagePkg $ lfPkg
       , mod <- NM.names $ LF.packageModules pkg
       ]
 
 
-runRepl :: Options -> ReplClient.Handle -> IdeState -> IO ()
-runRepl opts replClient ideState = do
-    imports <- loadPackages replClient ideState
+runRepl :: [String] -> Options -> ReplClient.Handle -> IdeState -> IO ()
+runRepl importPkgs opts replClient ideState = do
+    imports <- loadPackages importPkgs replClient ideState
     let initReplState = ReplState
           { imports = imports
           , bindings = []

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -29,6 +29,7 @@ import DA.Daml.LF.ScenarioServiceClient (readScenarioServiceConfig, withScenario
 import qualified DA.Daml.LF.ReplClient as ReplClient
 import DA.Daml.Compiler.Validate (validateDar)
 import qualified DA.Daml.LF.Ast as LF
+import DA.Daml.LF.Ast.Util (splitUnitId)
 import qualified DA.Daml.LF.Proto3.Archive as Archive
 import DA.Daml.LF.Reader
 import DA.Daml.LanguageServer
@@ -91,6 +92,7 @@ import "ghc-lib" HscStats
 import "ghc-lib-parser" HscTypes
 import qualified "ghc-lib-parser" Outputable as GHC
 import qualified SdkVersion
+import "ghc-lib-parser" Util (looksLikePackageName)
 
 --------------------------------------------------------------------------------
 -- Commands
@@ -272,11 +274,18 @@ cmdRepl numProcessors =
                         help "Optional max inbound message size in bytes."
                     )
             <*> timeModeFlag
-    packageImport = fmap stringToUnitId . strOption $
+    packageImport = option readPackage $
         long "import"
         <> short 'i'
         <> help "Import modules of these packages into the REPL"
         <> metavar "PACKAGE"
+      where
+        readPackage = eitherReader $ \s -> do
+            let pkg@(name, _) = splitUnitId (stringToUnitId s)
+                strName = T.unpack . LF.unPackageName $ name
+            unless (looksLikePackageName strName) $
+                fail $ "Illegal package name: " ++ strName
+            pure pkg
     accessTokenFileFlag = optional . option str $
         long "access-token-file"
         <> metavar "TOKEN_PATH"
@@ -589,7 +598,7 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb =
 execRepl
     :: ProjectOpts
     -> Options
-    -> FilePath -> [FilePath] -> [UnitId]
+    -> FilePath -> [FilePath] -> [(LF.PackageName, Maybe LF.PackageVersion)]
     -> String -> String
     -> Maybe FilePath
     -> Maybe ReplClient.ClientSSLConfig

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -261,6 +261,7 @@ cmdRepl numProcessors =
             <*> strOption (long "script-lib" <> value "daml-script" <> internal)
             -- ^ This is useful for tests and `bazel run`.
             <*> many (strArgument (help "DAR to load in the repl" <> metavar "DAR"))
+            <*> many (strOption (long "import" <> short 'i' <> help "Import modules of these packages into the REPL" <> metavar "PACKAGE"))
             <*> strOption (long "ledger-host" <> help "Host of the ledger API")
             <*> strOption (long "ledger-port" <> help "Port of the ledger API")
             <*> accessTokenFileFlag
@@ -583,14 +584,14 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb =
 execRepl
     :: ProjectOpts
     -> Options
-    -> FilePath -> [FilePath]
+    -> FilePath -> [FilePath] -> [String]
     -> String -> String
     -> Maybe FilePath
     -> Maybe ReplClient.ClientSSLConfig
     -> Maybe ReplClient.MaxInboundMessageSize
     -> ReplClient.ReplTimeMode
     -> Command
-execRepl projectOpts opts scriptDar dars ledgerHost ledgerPort mbAuthToken mbSslConf mbMaxInboundMessageSize timeMode = Command Repl (Just projectOpts) effect
+execRepl projectOpts opts scriptDar dars importPkgs ledgerHost ledgerPort mbAuthToken mbSslConf mbMaxInboundMessageSize timeMode = Command Repl (Just projectOpts) effect
   where effect = do
             -- We change directory so make this absolute
             dars <- mapM makeAbsolute dars
@@ -619,7 +620,7 @@ execRepl projectOpts opts scriptDar dars ledgerHost ledgerPort mbAuthToken mbSsl
                 initPackageDb opts (InitPkgDb True)
                 -- We want diagnostics to go to stdout in the repl.
                 withDamlIdeState opts logger (hDiagnosticsLogger stdout)
-                    (Repl.runRepl opts replHandle)
+                    (Repl.runRepl importPkgs opts replHandle)
 
 -- | Remove any build artifacts if they exist.
 execClean :: ProjectOpts -> Command

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -70,7 +70,7 @@ import Development.IDE.Types.Location
 import Development.IDE.Types.Options (clientSupportsProgress)
 import "ghc-lib-parser" DynFlags
 import GHC.Conc
-import "ghc-lib-parser" Module (unitIdString)
+import "ghc-lib-parser" Module (unitIdString, stringToUnitId)
 import qualified Network.Socket as NS
 import Options.Applicative.Extended
 import qualified Proto3.Suite as PS
@@ -261,7 +261,7 @@ cmdRepl numProcessors =
             <*> strOption (long "script-lib" <> value "daml-script" <> internal)
             -- ^ This is useful for tests and `bazel run`.
             <*> many (strArgument (help "DAR to load in the repl" <> metavar "DAR"))
-            <*> many (strOption (long "import" <> short 'i' <> help "Import modules of these packages into the REPL" <> metavar "PACKAGE"))
+            <*> many packageImport
             <*> strOption (long "ledger-host" <> help "Host of the ledger API")
             <*> strOption (long "ledger-port" <> help "Port of the ledger API")
             <*> accessTokenFileFlag
@@ -272,6 +272,11 @@ cmdRepl numProcessors =
                         help "Optional max inbound message size in bytes."
                     )
             <*> timeModeFlag
+    packageImport = fmap stringToUnitId . strOption $
+        long "import"
+        <> short 'i'
+        <> help "Import modules of these packages into the REPL"
+        <> metavar "PACKAGE"
     accessTokenFileFlag = optional . option str $
         long "access-token-file"
         <> metavar "TOKEN_PATH"
@@ -584,7 +589,7 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb =
 execRepl
     :: ProjectOpts
     -> Options
-    -> FilePath -> [FilePath] -> [String]
+    -> FilePath -> [FilePath] -> [UnitId]
     -> String -> String
     -> Maybe FilePath
     -> Maybe ReplClient.ClientSSLConfig

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -506,6 +506,7 @@ da_haskell_test(
         "directory",
         "extra",
         "filepath",
+        "ghc-lib-parser",
         "ghcide",
         "hspec",
         "process",

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -506,7 +506,6 @@ da_haskell_test(
         "directory",
         "extra",
         "filepath",
-        "ghc-lib-parser",
         "ghcide",
         "hspec",
         "process",
@@ -522,6 +521,7 @@ da_haskell_test(
     visibility = ["//visibility:public"],
     deps = [
         "//:sdk-version-hs-lib",
+        "//compiler/daml-lf-ast",
         "//compiler/damlc:damlc-lib",
         "//compiler/damlc/daml-compiler",
         "//compiler/damlc/daml-ide-core",

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -127,7 +127,7 @@ testConnection damlc scriptDar testDar ledgerPort mbTokenFile mbCaCrt = do
                      , scriptDar
                      , testDar
                      , "--import"
-                     , "repl-test-0.1.0"
+                     , "repl-test"
                      ]
                    , [ "--access-token-file=" <> tokenFile | Just tokenFile <- [mbTokenFile] ]
                    , [ "--cacrt=" <> cacrt | Just cacrt <- [mbCaCrt] ]
@@ -191,5 +191,5 @@ testSetTime damlc scriptDar testDar ledgerPort = do
                    , scriptDar
                    , testDar
                    , "--import"
-                   , "repl-test-0.1.0"
+                   , "repl-test"
                    ]

--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -126,6 +126,8 @@ testConnection damlc scriptDar testDar ledgerPort mbTokenFile mbCaCrt = do
                      , "--script-lib"
                      , scriptDar
                      , testDar
+                     , "--import"
+                     , "repl-test-0.1.0"
                      ]
                    , [ "--access-token-file=" <> tokenFile | Just tokenFile <- [mbTokenFile] ]
                    , [ "--cacrt=" <> cacrt | Just cacrt <- [mbCaCrt] ]
@@ -188,4 +190,6 @@ testSetTime damlc scriptDar testDar ledgerPort = do
                    , "--script-lib"
                    , scriptDar
                    , testDar
+                   , "--import"
+                   , "repl-test-0.1.0"
                    ]

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -264,7 +264,7 @@ testInteraction replClient serviceOut options ideState steps = do
         withBinaryFile stdinFile ReadMode $ \readIn ->
             redirectingHandle stdin readIn $ do
             Right () <- ReplClient.clearResults replClient
-            capture_ $ runRepl ["repl-test-0.1.0", "repl-test-two-0.1.0"] options replClient ideState
+            capture_ $ runRepl ["repl-test", "repl-test-two"] options replClient ideState
     -- Write output to a file so we can conveniently read individual characters.
     withTempFile $ \clientOutFile -> do
         writeFileUTF8 clientOutFile out

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -23,6 +23,7 @@ import Development.IDE.Types.Location
 import qualified DA.Service.Logger as Logger
 import qualified DA.Service.Logger.Impl.IO as Logger
 import GHC.IO.Handle
+import Module (stringToUnitId)
 import SdkVersion
 import System.Directory
 import System.FilePath
@@ -264,7 +265,8 @@ testInteraction replClient serviceOut options ideState steps = do
         withBinaryFile stdinFile ReadMode $ \readIn ->
             redirectingHandle stdin readIn $ do
             Right () <- ReplClient.clearResults replClient
-            capture_ $ runRepl ["repl-test", "repl-test-two"] options replClient ideState
+            let imports = map stringToUnitId ["repl-test", "repl-test-two"]
+            capture_ $ runRepl imports options replClient ideState
     -- Write output to a file so we can conveniently read individual characters.
     withTempFile $ \clientOutFile -> do
         writeFileUTF8 clientOutFile out

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -264,7 +264,7 @@ testInteraction replClient serviceOut options ideState steps = do
         withBinaryFile stdinFile ReadMode $ \readIn ->
             redirectingHandle stdin readIn $ do
             Right () <- ReplClient.clearResults replClient
-            capture_ $ runRepl options replClient ideState
+            capture_ $ runRepl ["repl-test-0.1.0", "repl-test-two-0.1.0"] options replClient ideState
     -- Write output to a file so we can conveniently read individual characters.
     withTempFile $ \clientOutFile -> do
         writeFileUTF8 clientOutFile out

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -11,6 +11,7 @@ import DA.Bazel.Runfiles
 import DA.Cli.Damlc.Packaging
 import DA.Cli.Output
 import DA.Daml.Compiler.Repl
+import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.ReplClient as ReplClient
 import DA.Daml.Options.Types
 import DA.Daml.Package.Config
@@ -23,7 +24,6 @@ import Development.IDE.Types.Location
 import qualified DA.Service.Logger as Logger
 import qualified DA.Service.Logger.Impl.IO as Logger
 import GHC.IO.Handle
-import Module (stringToUnitId)
 import SdkVersion
 import System.Directory
 import System.FilePath
@@ -265,7 +265,7 @@ testInteraction replClient serviceOut options ideState steps = do
         withBinaryFile stdinFile ReadMode $ \readIn ->
             redirectingHandle stdin readIn $ do
             Right () <- ReplClient.clearResults replClient
-            let imports = map stringToUnitId ["repl-test", "repl-test-two"]
+            let imports = [(LF.PackageName name, Nothing) | name <- ["repl-test", "repl-test-two"]]
             capture_ $ runRepl imports options replClient ideState
     -- Write output to a file so we can conveniently read individual characters.
     withTempFile $ \clientOutFile -> do


### PR DESCRIPTION
DAML REPL no longer automatically imports all modules from the main DALFs of all loaded DARs. Instead, the user can specify which package's modules should be imported at start-up by specifying the package-id or package-name at the command-line using the `--import` flag.

This adds test cases for the `--import` flag to the repl tests.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
