### PR TITLE
Fix for event_offset to event_sequential_id conversion

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -894,7 +894,8 @@ private class JdbcLedgerDao(
 
   override val transactionsReader: TransactionsReader =
     new TransactionsReader(dbDispatcher, dbType, eventsPageSize, metrics, translation)(
-      executionContext)
+      executionContext,
+      logCtx)
 
   private val contractsReader: ContractsReader =
     ContractsReader(dbDispatcher, dbType, metrics, lfValueTranslationCache)(executionContext)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsRange.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsRange.scala
@@ -30,16 +30,15 @@ object EventsRange {
   def readEventSeqIdRange(range: EventsRange[Offset])(
       connection: java.sql.Connection
   ): EventsRange[Long] =
-    if (isEmpty(range)) EmptyEventSeqIdRange
-    else readEventSeqIdRangeOpt(range)(connection).getOrElse(EmptyEventSeqIdRange)
-
-  private def readEventSeqIdRangeOpt(range: EventsRange[Offset])(
-      connection: java.sql.Connection
-  ): Option[EventsRange[Long]] =
-    for {
-      startExclusive <- readEventSeqId(range.startExclusive)(connection)
-      endInclusive <- readEventSeqId(range.endInclusive)(connection)
-    } yield EventsRange(startExclusive = startExclusive, endInclusive = endInclusive)
+    if (isEmpty(range))
+      EmptyEventSeqIdRange
+    else
+      EventsRange(
+        startExclusive =
+          readEventSeqId(range.startExclusive)(connection).getOrElse(EmptyLedgerEventSeqId),
+        endInclusive =
+          readEventSeqId(range.endInclusive)(connection).getOrElse(EmptyLedgerEventSeqId),
+      )
 
   /**
     * Converts ledger end offset to Event Sequential ID.

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsReader.scala
@@ -17,6 +17,7 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse
 }
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{DatabaseMetrics, Metrics, Timed}
 import com.daml.platform.ApiOffset
 import com.daml.platform.store.DbType
@@ -38,11 +39,13 @@ private[dao] final class TransactionsReader(
     pageSize: Int,
     metrics: Metrics,
     lfValueTranslation: LfValueTranslation,
-)(implicit executionContext: ExecutionContext) {
+)(implicit executionContext: ExecutionContext, loggingContext: LoggingContext) {
 
   private val dbMetrics = metrics.daml.index.db
 
   private val sqlFunctions = SqlFunctions(dbType)
+
+  private val logger = ContextualizedLogger.get(this.getClass)
 
   private def offsetFor(response: GetTransactionsResponse): Offset =
     ApiOffset.assertFromString(response.transactions.head.offset)
@@ -65,10 +68,13 @@ private[dao] final class TransactionsReader(
       verbose: Boolean,
   ): Source[(Offset, GetTransactionsResponse), NotUsed] = {
 
+    logger.debug(s"getFlatTransactions($startExclusive, $endInclusive, $filter, $verbose)")
+
     val requestedRangeF = getEventSeqIdRange(startExclusive, endInclusive)
 
     val query = (range: EventsRange[Long]) =>
-      (connection: Connection) =>
+      (connection: Connection) => {
+        logger.debug(s"getFlatTransactions query($range)")
         EventsTable
           .preparePagedGetFlatTransactions(sqlFunctions)(
             range = range,
@@ -77,6 +83,7 @@ private[dao] final class TransactionsReader(
           )
           .withFetchSize(Some(pageSize))
           .asVectorOf(EventsTable.rawFlatEventParser)(connection)
+    }
 
     val events: Source[EventsTable.Entry[Event], NotUsed] =
       Source
@@ -126,10 +133,14 @@ private[dao] final class TransactionsReader(
       verbose: Boolean,
   ): Source[(Offset, GetTransactionTreesResponse), NotUsed] = {
 
+    logger.debug(
+      s"getTransactionTrees($startExclusive, $endInclusive, $requestingParties, $verbose)")
+
     val requestedRangeF = getEventSeqIdRange(startExclusive, endInclusive)
 
     val query = (range: EventsRange[Long]) =>
-      (connection: Connection) =>
+      (connection: Connection) => {
+        logger.debug(s"getTransactionTrees query($range)")
         EventsTable
           .preparePagedGetTransactionTrees(sqlFunctions)(
             eventsRange = range,
@@ -138,6 +149,7 @@ private[dao] final class TransactionsReader(
           )
           .withFetchSize(Some(pageSize))
           .asVectorOf(EventsTable.rawTreeEventParser)(connection)
+    }
 
     val events: Source[EventsTable.Entry[TreeEvent], NotUsed] =
       Source
@@ -186,18 +198,21 @@ private[dao] final class TransactionsReader(
       verbose: Boolean,
   ): Source[GetActiveContractsResponse, NotUsed] = {
 
+    logger.debug(s"getActiveContracts($activeAt, $filter, $verbose)")
+
     val requestedRangeF: Future[EventsRange[(Offset, Long)]] = getAcsEventSeqIdRange(activeAt)
 
-    val query = (range: EventsRange[(Offset, Long)]) =>
-      (connection: Connection) =>
-        EventsTable
-          .preparePagedGetActiveContracts(sqlFunctions)(
-            range = range,
-            filter = filter,
-            pageSize = pageSize,
-          )
-          .withFetchSize(Some(pageSize))
-          .asVectorOf(EventsTable.rawFlatEventParser)(connection)
+    val query = (range: EventsRange[(Offset, Long)]) => { (connection: Connection) =>
+      logger.debug(s"getActiveContracts query($range)")
+      EventsTable
+        .preparePagedGetActiveContracts(sqlFunctions)(
+          range = range,
+          filter = filter,
+          pageSize = pageSize,
+        )
+        .withFetchSize(Some(pageSize))
+        .asVectorOf(EventsTable.rawFlatEventParser)(connection)
+    }
 
     val events: Source[EventsTable.Entry[Event], NotUsed] =
       Source
@@ -238,21 +253,25 @@ private[dao] final class TransactionsReader(
     dispatcher.executeSql(dbMetrics.getEventSeqIdRange)(
       EventsRange.readEventSeqIdRange(EventsRange(startExclusive, endInclusive)))
 
-  private def streamEvents[A, E](
+  private def streamEvents[A: Ordering, E](
       verbose: Boolean,
       queryMetric: DatabaseMetrics,
       query: EventsRange[A] => Connection => Vector[EventsTable.Entry[Raw[E]]],
       getNextPageRange: EventsTable.Entry[E] => EventsRange[A],
   )(range: EventsRange[A]): Source[EventsTable.Entry[E], NotUsed] =
     PaginatingAsyncStream.streamFrom(range, getNextPageRange) { range1 =>
-      val rawEvents: Future[Vector[EventsTable.Entry[Raw[E]]]] =
-        dispatcher.executeSql(queryMetric)(query(range1))
-      rawEvents.flatMap(
-        es =>
-          Timed.future(
-            future = Future.traverse(es)(deserializeEntry(verbose)),
-            timer = queryMetric.translationTimer,
+      if (EventsRange.isEmpty(range1))
+        Future.successful(Vector.empty)
+      else {
+        val rawEvents: Future[Vector[EventsTable.Entry[Raw[E]]]] =
+          dispatcher.executeSql(queryMetric)(query(range1))
+        rawEvents.flatMap(
+          es =>
+            Timed.future(
+              future = Future.traverse(es)(deserializeEntry(verbose)),
+              timer = queryMetric.translationTimer,
+          )
         )
-      )
+      }
     }
 }


### PR DESCRIPTION
Closes: #6698 

Handling a special case when `event_offset` does not yet have an entry in the `participant_events` table but we need to be able to convert it to the `event_sequential_id`. Apparently there is another level of pagination on top of `TransactionReader` and this top-level pagination does some `event_offset` increments.

Adding `isLedgerEmpty` check before returning `EmptyEventSeqIdRange`. If conversion function returns nothing on non-empty ledger, throwing a runtime exception. This technically should never happen. But the defaulting to `EmptyEventSeqIdRange.startExclusive` was actually the cause of the faulty pagination:
```
---- (Offset(Bytes(0000000000000019)), Offset(Bytes(000000000000001a))]
---- EventsRange(33,34)
---- (Offset(Bytes(000000000000001a)), Offset(Bytes(000000000000001b))]
---- EventsRange(0,34)
---- (Offset(Bytes(000000000000001b)), Offset(Bytes(000000000000001c))]
---- EventsRange(34,39)
```
`EventsRange(0,34)` supposed to be `EventsRange(34,34)` that was the case when
`select min(event_sequential_id) from participant_events where event_offset > ${offset}` returned `null` for non-existent offset and we defaulted to `0`, that query is fixed.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
