### PR TITLE
Make AddFriend choice preconsuming

### DIFF
--- a/templates/create-daml-app/daml/User.daml
+++ b/templates/create-daml-app/daml/User.daml
@@ -16,12 +16,11 @@ template User with
     maintainer key
 
     -- FOLLOW_BEGIN
-    nonconsuming choice Follow: ContractId User with
+    preconsuming choice Follow: ContractId User with
         userToFollow: Party
       controller username
       do
         assertMsg "You cannot follow yourself" (userToFollow /= username)
         assertMsg "You cannot follow the same user twice" (notElem userToFollow following)
-        archive self
         create this with following = userToFollow :: following
     -- FOLLOW_END


### PR DESCRIPTION
Reading the docs, it appears that a _nonconsuming_ choice with an explicit archive is equivalent to a _preconsuming_ choice.

In fact, it looks like `preconsuming` was added precisely to lift this common pattern into the syntax.

> Choices marked explicitly as preconsuming are now equivalent to a nonconsuming choice that calls archive self at the beginning. — https://docs.daml.com/support/release-notes.html#daml-compiler

I could be very wrong about all this, but here's a PR in case I'm not mistaken 😃