### PR TITLE
DAMLLF: clean up Transaction definitions

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -7,7 +7,7 @@ import com.daml.lf.data.{Numeric, Ref}
 import com.daml.lf.ledger.EventId
 import com.daml.lf.scenario.api.{v1 => proto}
 import com.daml.lf.speedy.{SError, SValue, Speedy, PartialTransaction => SPartialTransaction}
-import com.daml.lf.transaction.{Node => N, Transaction => Tx}
+import com.daml.lf.transaction.{Node => N, NodeId, Transaction => Tx}
 import com.daml.lf.ledger._
 import com.daml.lf.value.{Value => V}
 
@@ -387,10 +387,10 @@ final class Conversions(
   def convertEventId(nodeId: EventId): proto.NodeId =
     proto.NodeId.newBuilder.setId(nodeId.toLedgerString).build
 
-  def convertNodeId(trId: Ref.LedgerString, nodeId: Tx.NodeId): proto.NodeId =
+  def convertNodeId(trId: Ref.LedgerString, nodeId: NodeId): proto.NodeId =
     proto.NodeId.newBuilder.setId(EventId(trId, nodeId).toLedgerString).build
 
-  def convertTxNodeId(nodeId: Tx.NodeId): proto.NodeId =
+  def convertTxNodeId(nodeId: NodeId): proto.NodeId =
     proto.NodeId.newBuilder.setId(nodeId.index.toString).build
 
   def convertNode(eventId: EventId, nodeInfo: ScenarioLedger.LedgerNodeInfo): proto.Node = {
@@ -438,7 +438,7 @@ final class Conversions(
             .build,
         )
       case ex: N.NodeExercises[
-            Tx.NodeId,
+            NodeId,
             V.ContractId,
             Tx.Value[
               V.ContractId,
@@ -488,7 +488,7 @@ final class Conversions(
 
   def convertNode[Val](
       convertValue: Val => proto.Value,
-      nodeWithId: (Tx.NodeId, N.GenNode[V.NodeId, V.ContractId, Val]),
+      nodeWithId: (NodeId, N.GenNode[NodeId, V.ContractId, Val]),
   ): proto.Node = {
     val (nodeId, node) = nodeWithId
     val builder = proto.Node.newBuilder
@@ -520,7 +520,7 @@ final class Conversions(
             .addAllStakeholders(fetch.stakeholders.map(convertParty).asJava)
             .build,
         )
-      case ex: N.NodeExercises[V.NodeId, V.ContractId, Val] =>
+      case ex: N.NodeExercises[NodeId, V.ContractId, Val] =>
         ex.optLocation.map(loc => builder.setLocation(convertLocation(loc)))
         builder.setExercise(
           proto.Node.Exercise.newBuilder

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -6,7 +6,7 @@ package com.daml.lf.engine
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises, NodeFetch, NodeLookupByKey}
-import com.daml.lf.transaction.{BlindingInfo, GenTransaction, Transaction}
+import com.daml.lf.transaction.{BlindingInfo, GenTransaction, NodeId, Transaction}
 import com.daml.lf.ledger._
 import com.daml.lf.data.Relation.Relation
 
@@ -19,7 +19,7 @@ object Blinding {
       authorization: Authorization): Either[AuthorizationError, BlindingInfo] = {
     val enrichedTx =
       EnrichedTransaction(authorization, tx)
-    def authorizationErrors(failures: Map[Transaction.NodeId, FailedAuthorization]) = {
+    def authorizationErrors(failures: Map[NodeId, FailedAuthorization]) = {
       failures
         .map {
           case (id, failure) =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -11,7 +11,7 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.{InitialSeeding, Pretty, SExpr}
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.speedy.SResult._
-import com.daml.lf.transaction.{TransactionVersions, Transaction => Tx}
+import com.daml.lf.transaction.{NodeId, TransactionVersions, Transaction => Tx}
 import com.daml.lf.transaction.Node._
 import com.daml.lf.value.{Value, ValueVersions}
 import java.nio.file.{Files, Path, Paths}
@@ -130,7 +130,7 @@ class Engine(config: Engine.Config) {
     */
   def reinterpret(
       submitters: Set[Party],
-      node: GenNode.WithTxValue[Value.NodeId, Value.ContractId],
+      node: GenNode.WithTxValue[NodeId, Value.ContractId],
       nodeSeed: Option[crypto.Hash],
       submissionTime: Time.Timestamp,
       ledgerEffectiveTime: Time.Timestamp,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -10,7 +10,7 @@ import java.util
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.language.Ast
 import com.daml.lf.speedy.SValue
-import com.daml.lf.transaction.{GenTransaction, Node, Transaction}
+import com.daml.lf.transaction.{GenTransaction, Node, NodeId}
 import com.daml.lf.value.Value
 
 import scala.annotation.tailrec
@@ -141,7 +141,7 @@ private[engine] final class Preprocessor(compiledPackages: MutableCompiledPackag
       unsafePreprocessCommands(cmds)
     }
 
-  private def getTemplateId(node: Node.GenNode.WithTxValue[Transaction.NodeId, _]) =
+  private def getTemplateId(node: Node.GenNode.WithTxValue[NodeId, _]) =
     node match {
       case Node.NodeCreate(coid @ _, coinst, optLoc @ _, sigs @ _, stks @ _, key @ _) =>
         coinst.template
@@ -167,7 +167,7 @@ private[engine] final class Preprocessor(compiledPackages: MutableCompiledPackag
     }
 
   def translateNode[Cid <: Value.ContractId](
-      node: Node.GenNode.WithTxValue[Transaction.NodeId, Cid],
+      node: Node.GenNode.WithTxValue[NodeId, Cid],
   ): Result[(speedy.Command, Set[Value.ContractId])] =
     safelyRun(getDependencies(List.empty, List(getTemplateId(node)))) {
       val (cmd, (globalCids, _)) = unsafeTranslateNode((Set.empty, Set.empty), node)
@@ -175,7 +175,7 @@ private[engine] final class Preprocessor(compiledPackages: MutableCompiledPackag
     }
 
   def translateTransactionRoots[Cid <: Value.ContractId](
-      tx: GenTransaction.WithTxValue[Transaction.NodeId, Cid],
+      tx: GenTransaction.WithTxValue[NodeId, Cid],
   ): Result[(ImmArray[speedy.Command], Set[Value.ContractId])] =
     safelyRun(
       getDependencies(List.empty, tx.roots.toList.map(id => getTemplateId(tx.nodes(id))))

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -6,7 +6,7 @@ package engine
 package preprocessing
 
 import com.daml.lf.data.{BackStack, ImmArray}
-import com.daml.lf.transaction.{GenTransaction, Node, Transaction}
+import com.daml.lf.transaction.{GenTransaction, Node, NodeId}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 
@@ -28,7 +28,7 @@ private[preprocessing] final class TransactionPreprocessor(
   @throws[PreprocessorException]
   def unsafeTranslateNode[Cid <: Value.ContractId](
       acc: (Set[Value.ContractId], Set[Value.ContractId]),
-      node: Node.GenNode.WithTxValue[Transaction.NodeId, Cid]
+      node: Node.GenNode.WithTxValue[NodeId, Cid]
   ): (speedy.Command, (Set[Value.ContractId], Set[Value.ContractId])) = {
 
     val (localCids, globalCids) = acc
@@ -75,7 +75,7 @@ private[preprocessing] final class TransactionPreprocessor(
 
   @throws[PreprocessorException]
   def unsafeTranslateTransactionRoots[Cid <: Value.ContractId](
-      tx: GenTransaction.WithTxValue[Transaction.NodeId, Cid],
+      tx: GenTransaction.WithTxValue[NodeId, Cid],
   ): (ImmArray[speedy.Command], Set[ContractId]) = {
 
     type Acc = ((Set[Value.ContractId], Set[Value.ContractId]), BackStack[speedy.Command])

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -17,6 +17,7 @@ import com.daml.lf.transaction.Node._
 import com.daml.lf.transaction.{
   TransactionVersions => TxVersions,
   GenTransaction => GenTx,
+  NodeId,
   Transaction => Tx
 }
 import com.daml.lf.value.Value
@@ -547,7 +548,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val partyEvents = events.events.values.toList.filter(_.witnesses contains party)
       partyEvents.size shouldBe 1
       partyEvents(0) match {
-        case _: ExerciseEvent[Tx.NodeId, ContractId, Tx.Value[ContractId]] => succeed
+        case _: ExerciseEvent[NodeId, ContractId, Tx.Value[ContractId]] => succeed
         case _ => fail("expected exercise")
       }
     }
@@ -1649,7 +1650,7 @@ object EngineTest {
   private def reinterpret(
       engine: Engine,
       submitters: Set[Party],
-      nodes: ImmArray[Tx.NodeId],
+      nodes: ImmArray[NodeId],
       tx: Tx.Transaction,
       txMeta: Tx.Metadata,
       ledgerEffectiveTime: Time.Timestamp,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.daml.lf.engine
+
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.daml.lf.data.{FrontStack, FrontStackCons}
 import com.daml.lf.transaction.Node._
-import com.daml.lf.transaction.{Transaction => Tx}
-import com.daml.lf.value.Value._
+import com.daml.lf.transaction.{NodeId, Transaction => Tx}
+import com.daml.lf.value.Value.{NodeId => _, _}
 
 import scala.annotation.tailrec
 
@@ -31,7 +32,7 @@ private[engine] class InMemoryPrivateLedgerData extends PrivateLedgerData {
     this.synchronized {
       // traverse in topo order and add / remove
       @tailrec
-      def go(remaining: FrontStack[Tx.NodeId]): Unit = remaining match {
+      def go(remaining: FrontStack[NodeId]): Unit = remaining match {
         case FrontStack() => ()
         case FrontStackCons(nodeId, nodeIds) =>
           val node = tx.nodes(nodeId)
@@ -39,7 +40,7 @@ private[engine] class InMemoryPrivateLedgerData extends PrivateLedgerData {
             case nc: NodeCreate.WithTxValue[ContractId] =>
               pcs.put(nc.coid, nc.coinst)
               go(nodeIds)
-            case ne: NodeExercises.WithTxValue[Tx.NodeId, ContractId] =>
+            case ne: NodeExercises.WithTxValue[NodeId, ContractId] =>
               go(ne.children ++: nodeIds)
             case _: NodeLookupByKey[_, _] | _: NodeFetch[_, _] =>
               go(nodeIds)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/LargeTransactionTest.scala
@@ -12,9 +12,9 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.Transaction.Transaction
-import com.daml.lf.transaction.{Node => N, Transaction => Tx}
+import com.daml.lf.transaction.{Node => N, NodeId, Transaction => Tx}
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value._
+import com.daml.lf.value.Value.{NodeId => _, _}
 import com.daml.lf.command._
 import org.scalameter
 import org.scalameter.Quantity
@@ -183,7 +183,7 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
       exerciseCmdTx: Transaction,
       expectedNumberOfContracts: Int): Assertion = {
 
-    val newContracts: List[N.GenNode.WithTxValue[Tx.NodeId, Value.ContractId]] =
+    val newContracts: List[N.GenNode.WithTxValue[NodeId, Value.ContractId]] =
       firstRootNode(exerciseCmdTx) match {
         case ne: N.NodeExercises[_, _, _] => ne.children.toList.map(nid => exerciseCmdTx.nodes(nid))
         case n @ _ => fail(s"Unexpected match: $n")
@@ -309,8 +309,7 @@ class LargeTransactionTest extends WordSpec with Matchers with BazelRunfiles {
     exerciseCmdTx.roots.length shouldBe 1
     exerciseCmdTx.nodes.size shouldBe 2
 
-    val createNode
-      : N.GenNode.WithTxValue[Tx.NodeId, ContractId] = firstRootNode(exerciseCmdTx) match {
+    val createNode: N.GenNode.WithTxValue[NodeId, ContractId] = firstRootNode(exerciseCmdTx) match {
       case ne: N.NodeExercises[_, _, _] => exerciseCmdTx.nodes(ne.children.head)
       case n @ _ => fail(s"Unexpected match: $n")
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -8,9 +8,9 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
 import com.daml.lf.ledger._
 import com.daml.lf.transaction.Node._
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.{NodeId, Transaction => Tx}
 import com.daml.lf.value.Value
-import Value._
+import Value.{NodeId => _, _}
 import com.daml.lf.data.Relation.Relation
 
 import scala.annotation.tailrec
@@ -50,7 +50,7 @@ object ScenarioLedger {
     * transaction node in the node identifier, where here the identifier
     * is an eventId.
     */
-  type Node = GenNode.WithTxValue[Tx.NodeId, ContractId]
+  type Node = GenNode.WithTxValue[NodeId, ContractId]
 
   /** A transaction as it is committed to the ledger.
     *
@@ -79,7 +79,7 @@ object ScenarioLedger {
       effectiveAt: Time.Timestamp,
       transactionId: LedgerString,
       transaction: Tx.CommittedTransaction,
-      explicitDisclosure: Relation[Tx.NodeId, Party],
+      explicitDisclosure: Relation[NodeId, Party],
       implicitDisclosure: Relation[ContractId, Party],
       failedAuthorizations: FailedAuthorizations,
   )
@@ -405,7 +405,7 @@ object ScenarioLedger {
       richTr: RichTransaction,
       ledgerData: LedgerData,
   ): Either[UniqueKeyViolation, LedgerData] = {
-    type ExerciseNodeProcessing = (Option[Tx.NodeId], List[Tx.NodeId])
+    type ExerciseNodeProcessing = (Option[NodeId], List[NodeId])
 
     @tailrec
     def processNodes(
@@ -465,7 +465,7 @@ object ScenarioLedger {
 
                       processNodes(Right(newCacheP), idsToProcess)
 
-                    case ex: NodeExercises.WithTxValue[Tx.NodeId, ContractId] =>
+                    case ex: NodeExercises.WithTxValue[NodeId, ContractId] =>
                       val newCache0 =
                         newCache.updateLedgerNodeInfo(ex.targetCoid)(
                           info =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -7,13 +7,13 @@ import org.typelevel.paiges._
 import org.typelevel.paiges.Doc._
 import com.daml.lf.ledger.EventId
 import com.daml.lf.value.Value
-import Value._
+import Value.{NodeId => _, _}
 import com.daml.lf.transaction.Node._
 import com.daml.lf.ledger._
 import com.daml.lf.data.Ref._
 import com.daml.lf.scenario.ScenarioLedger.TransactionId
 import com.daml.lf.scenario._
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.{NodeId, Transaction => Tx}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SBuiltin._
@@ -81,7 +81,7 @@ private[lf] object Pretty {
         "create" &: prettyContractInst(create.coinst)
       case fetch: NodeFetch[Value.ContractId, Value[Value.ContractId]] =>
         "fetch" &: prettyContractId(fetch.coid)
-      case ex: NodeExercises[Value.NodeId, Value.ContractId, Value[Value.ContractId]] =>
+      case ex: NodeExercises[NodeId, Value.ContractId, Value[Value.ContractId]] =>
         intercalate(text(", "), ex.actingParties.map(p => text(p))) &
           text("exercises") & text(ex.choiceId) + char(':') + prettyIdentifier(ex.templateId) &
           text("on") & prettyContractId(ex.targetCoid) /
@@ -277,7 +277,7 @@ private[lf] object Pretty {
       case ea: NodeFetch[ContractId, Tx.Value[ContractId]] =>
         "ensure active" &: prettyContractId(ea.coid)
       case ex: NodeExercises[
-            Tx.NodeId,
+            NodeId,
             ContractId,
             Tx.Value[ContractId]
           ] =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -7,7 +7,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
 import com.daml.lf.ledger.EventId
 import com.daml.lf.transaction.Node.GlobalKey
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.{NodeId, Transaction => Tx}
 import com.daml.lf.value.Value
 import com.daml.lf.scenario.ScenarioLedger
 import com.daml.lf.value.Value.ContractId
@@ -57,7 +57,7 @@ object SError {
   final case class DamlELocalContractNotActive(
       coid: ContractId,
       templateId: TypeConName,
-      consumedBy: Tx.NodeId,
+      consumedBy: NodeId,
   ) extends SErrorDamlException
 
   /** Error during an operation on the update transaction. */

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -7,8 +7,8 @@ package test
 
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.data.Ref.{ChoiceName, Name}
-import com.daml.lf.transaction.Node.GenNode
-import com.daml.lf.transaction.{Transaction => Tx}
+import transaction.Node.GenNode
+import transaction.{Transaction => Tx}
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 
 import scala.collection.immutable.HashMap
@@ -69,7 +69,7 @@ object TransactionBuilder {
 
   type Value = value.Value[ContractId]
   type TxValue = value.Value.VersionedValue[ContractId]
-  type NodeId = Tx.NodeId
+  type NodeId = transaction.NodeId
   type Node = Node.GenNode[NodeId, ContractId, Value]
   type TxNode = Node.GenNode[NodeId, ContractId, TxValue]
 
@@ -77,21 +77,21 @@ object TransactionBuilder {
   type Exercise = Node.NodeExercises[NodeId, ContractId, Value]
   type Fetch = Node.NodeFetch[ContractId, Value]
   type LookupByKey = Node.NodeLookupByKey[ContractId, Value]
-  type KeyWithMaintainers = com.daml.lf.transaction.Node.KeyWithMaintainers[Value]
+  type KeyWithMaintainers = transaction.Node.KeyWithMaintainers[Value]
 
   type TxExercise = Node.NodeExercises[NodeId, ContractId, TxValue]
-  type TxKeyWithMaintainers = com.daml.lf.transaction.Node.KeyWithMaintainers[TxValue]
+  type TxKeyWithMaintainers = transaction.Node.KeyWithMaintainers[TxValue]
 
   private val ValueVersions = com.daml.lf.value.ValueVersions
   private val LfValue = com.daml.lf.value.Value
 
-  private val NodeId = com.daml.lf.transaction.Transaction.NodeId
-  private val Create = com.daml.lf.transaction.Node.NodeCreate
-  private val Exercise = com.daml.lf.transaction.Node.NodeExercises
-  private val Fetch = com.daml.lf.transaction.Node.NodeFetch
-  private val LookupByKey = com.daml.lf.transaction.Node.NodeLookupByKey
+  private val NodeId = transaction.NodeId
+  private val Create = transaction.Node.NodeCreate
+  private val Exercise = transaction.Node.NodeExercises
+  private val Fetch = transaction.Node.NodeFetch
+  private val LookupByKey = transaction.Node.NodeLookupByKey
 
-  private val KeyWithMaintainers = com.daml.lf.transaction.Node.KeyWithMaintainers
+  private val KeyWithMaintainers = transaction.Node.KeyWithMaintainers
 
   def version(v: Value): TxValue =
     ValueVersions.assertAsVersionedValue(v)

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -77,7 +77,7 @@ object ValueGenerators {
 
   val nameGen: Gen[Name] = {
     val firstChars =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_".toVector
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$".toVector
     val mainChars =
       firstChars ++ "1234567890"
     for {

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -12,11 +12,12 @@ import com.daml.lf.transaction.VersionTimeline.Implicits._
 import com.daml.lf.transaction.{
   BlindingInfo,
   GenTransaction,
+  NodeId,
   TransactionVersion,
   TransactionVersions,
   Transaction => Tx
 }
-import com.daml.lf.value.Value._
+import com.daml.lf.value.Value.{NodeId => _, _}
 import org.scalacheck.{Arbitrary, Gen}
 import Arbitrary.arbitrary
 
@@ -76,7 +77,7 @@ object ValueGenerators {
 
   val nameGen: Gen[Name] = {
     val firstChars =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_".toVector
+      """abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$""".toVector
     val mainChars =
       firstChars ++ "1234567890"
     for {
@@ -296,7 +297,7 @@ object ValueGenerators {
 
   /** Makes exercise nodes with some random child IDs. */
   val danglingRefExerciseNodeGen
-    : Gen[NodeExercises[Tx.NodeId, Value.ContractId, Tx.Value[Value.ContractId]]] = {
+    : Gen[NodeExercises[NodeId, Value.ContractId, Tx.Value[Value.ContractId]]] = {
     for {
       targetCoid <- coidGen
       templateId <- idGen
@@ -308,7 +309,7 @@ object ValueGenerators {
       signatories <- genNonEmptyParties
       children <- Gen
         .listOf(Arbitrary.arbInt.arbitrary)
-        .map(_.map(Tx.NodeId(_)))
+        .map(_.map(NodeId(_)))
         .map(ImmArray(_))
       exerciseResultValue <- versionedValueGen
       key <- versionedValueGen

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -77,7 +77,7 @@ object ValueGenerators {
 
   val nameGen: Gen[Name] = {
     val firstChars =
-      """abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$""".toVector
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_".toVector
     val mainChars =
       firstChars ++ "1234567890"
     for {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/EventId.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/EventId.scala
@@ -5,14 +5,14 @@ package com.daml.lf
 package ledger
 
 import com.daml.lf.data.Ref._
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.NodeId
 
 import scala.util.Try
 
 // transactionId should be small so the concatenation in toLedgerString does not exceed 255 chars
 case class EventId(
     transactionId: LedgerString,
-    nodeId: Tx.NodeId
+    nodeId: NodeId
 ) {
   lazy val toLedgerString: LedgerString = {
     val builder = StringBuilder.newBuilder
@@ -35,7 +35,7 @@ object EventId {
             for {
               ix <- Try(index.toInt).fold(_ => err, Right(_))
               transId <- LedgerString.fromString(transIdString)
-            } yield EventId(transId, Tx.NodeId(ix))
+            } yield EventId(transId, NodeId(ix))
           case _ => err
         }
       case _ => err

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/package.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/package.scala
@@ -5,6 +5,6 @@ package com.daml.lf
 
 package object ledger {
 
-  type FailedAuthorizations = Map[transaction.Transaction.NodeId, FailedAuthorization]
+  type FailedAuthorizations = Map[transaction.NodeId, FailedAuthorization]
 
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
@@ -21,7 +21,7 @@ import com.daml.lf.value.Value.ContractId
   */
 final case class BlindingInfo(
     /** Disclosure, specified in terms of local node IDs */
-    disclosure: Relation[Transaction.NodeId, Party],
+    disclosure: Relation[NodeId, Party],
     /**
       * Divulgence, specified in terms of contract IDs.
       * Note that if this info was produced by blinding a transaction

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -7,7 +7,7 @@ package transaction
 import com.daml.lf.crypto.Hash
 import com.daml.lf.data.{ImmArray, Ref, ScalazEqual}
 import com.daml.lf.data.Ref._
-import com.daml.lf.value.Value
+import com.daml.lf.value.{CidMapper, Value}
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 
 import scala.language.higherKinds
@@ -421,4 +421,14 @@ object Node {
   sealed trait WithTxValue3[F[+ _, + _, + _]] {
     type WithTxValue[+Nid, +Cid] = F[Nid, Cid, Transaction.Value[Cid]]
   }
+}
+
+/** The constructor is private so that we make sure that only this object constructs
+  * node ids -- we don't want external code to manipulate them.
+  */
+final case class NodeId(index: Int)
+
+object NodeId {
+  implicit def cidMapperInstance[In, Out]: CidMapper[NodeId, NodeId, In, Out] =
+    CidMapper.trivialMapper
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -423,9 +423,6 @@ object Node {
   }
 }
 
-/** The constructor is private so that we make sure that only this object constructs
-  * node ids -- we don't want external code to manipulate them.
-  */
 final case class NodeId(index: Int)
 
 object NodeId {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -471,10 +471,12 @@ private[lf] object GenTransaction extends value.CidContainer3[GenTransaction] {
 
 object Transaction {
 
-  type NodeId = Value.NodeId
-  val NodeId = Value.NodeId
+  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.3.0")
+  type NodeId = transaction.NodeId
+  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.3.0")
+  val NodeId = transaction.NodeId
 
-  @deprecated("Use daml.lf.value.Value.ContractId directly", since = "1.4.0")
+  @deprecated("Use daml.lf.value.Value.ContractId directly", since = "1.2.0")
   type TContractId = Value.ContractId
 
   type Value[+Cid] = Value.VersionedValue[Cid]
@@ -482,7 +484,7 @@ object Transaction {
   type ContractInst[+Cid] = Value.ContractInst[Value[Cid]]
 
   /** Transaction nodes */
-  type Node = Node.GenNode.WithTxValue[NodeId, Value.ContractId]
+  type Node = Node.GenNode.WithTxValue[transaction.NodeId, Value.ContractId]
   type LeafNode = Node.LeafOnlyNode.WithTxValue[Value.ContractId]
 
   /** (Complete) transactions, which are the result of interpreting a
@@ -493,7 +495,9 @@ object Transaction {
     *  divulgence of contracts.
     *
     */
-  type Transaction = VersionedTransaction[NodeId, Value.ContractId]
+  def p5 = "1"
+
+  type Transaction = VersionedTransaction[transaction.NodeId, Value.ContractId]
   val Transaction = VersionedTransaction
 
   /** Transaction meta data
@@ -518,8 +522,8 @@ object Transaction {
       submissionTime: Time.Timestamp,
       usedPackages: Set[PackageId],
       dependsOnTime: Boolean,
-      nodeSeeds: ImmArray[(Value.NodeId, crypto.Hash)],
-      byKeyNodes: ImmArray[Value.NodeId],
+      nodeSeeds: ImmArray[(transaction.NodeId, crypto.Hash)],
+      byKeyNodes: ImmArray[transaction.NodeId],
   )
 
   sealed abstract class DiscriminatedSubtype[X] {
@@ -565,7 +569,7 @@ object Transaction {
   final case class ContractNotActive(
       coid: Value.ContractId,
       templateId: TypeConName,
-      consumedBy: NodeId)
+      consumedBy: transaction.NodeId)
       extends TransactionError
 
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -102,7 +102,7 @@ object VersionedTransaction extends value.CidContainer2[VersionedTransaction] {
   * For performance reasons, users are not required to call `isWellFormed`.
   * Therefore, it is '''forbidden''' to create ill-formed instances, i.e., instances with `!isWellFormed.isEmpty`.
   */
-case class GenTransaction[Nid, +Cid, +Val](
+final case class GenTransaction[Nid, +Cid, +Val](
     nodes: HashMap[Nid, Node.GenNode[Nid, Cid, Val]],
     roots: ImmArray[Nid],
 ) extends HasTxNodes[Nid, Cid, Val]

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -496,8 +496,6 @@ object Transaction {
     *  divulgence of contracts.
     *
     */
-  def p5 = "1"
-
   type Transaction = VersionedTransaction[transaction.NodeId, Value.ContractId]
   val Transaction = VersionedTransaction
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -102,7 +102,7 @@ object VersionedTransaction extends value.CidContainer2[VersionedTransaction] {
   * For performance reasons, users are not required to call `isWellFormed`.
   * Therefore, it is '''forbidden''' to create ill-formed instances, i.e., instances with `!isWellFormed.isEmpty`.
   */
-final private[lf] case class GenTransaction[Nid, +Cid, +Val](
+case class GenTransaction[Nid, +Cid, +Val](
     nodes: HashMap[Nid, Node.GenNode[Nid, Cid, Val]],
     roots: ImmArray[Nid],
 ) extends HasTxNodes[Nid, Cid, Val]
@@ -423,22 +423,23 @@ sealed abstract class HasTxNodes[Nid, +Cid, +Val] {
 
 }
 
-private[lf] object GenTransaction extends value.CidContainer3[GenTransaction] {
+object GenTransaction extends value.CidContainer3[GenTransaction] {
 
   type WithTxValue[Nid, +Cid] = GenTransaction[Nid, Cid, Transaction.Value[Cid]]
 
-  private val Empty =
+  private[this] val Empty =
     GenTransaction[Nothing, Nothing, Nothing](
       HashMap.empty[Nothing, Nothing],
       ImmArray.empty[Nothing])
 
-  def empty[A, B, C]: GenTransaction[A, B, C] = Empty.asInstanceOf[GenTransaction[A, B, C]]
+  private[lf] def empty[A, B, C]: GenTransaction[A, B, C] =
+    Empty.asInstanceOf[GenTransaction[A, B, C]]
 
-  case class NotWellFormedError[Nid](nid: Nid, reason: NotWellFormedErrorReason)
-  sealed trait NotWellFormedErrorReason
-  case object DanglingNodeId extends NotWellFormedErrorReason
-  case object OrphanedNode extends NotWellFormedErrorReason
-  case object AliasedNode extends NotWellFormedErrorReason
+  private[lf] case class NotWellFormedError[Nid](nid: Nid, reason: NotWellFormedErrorReason)
+  private[lf] sealed trait NotWellFormedErrorReason
+  private[lf] case object DanglingNodeId extends NotWellFormedErrorReason
+  private[lf] case object OrphanedNode extends NotWellFormedErrorReason
+  private[lf] case object AliasedNode extends NotWellFormedErrorReason
 
   override private[lf] def map3[A1, A2, A3, B1, B2, B3](
       f1: A1 => B1,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -32,25 +32,25 @@ object TransactionCoder {
     def fromString(s: String): Either[DecodeError, Nid]
   }
 
-  val NidEncoder: EncodeNid[Value.NodeId] = new EncodeNid[Value.NodeId] {
-    override def asString(id: Value.NodeId): String = id.index.toString
+  val NidEncoder: EncodeNid[NodeId] = new EncodeNid[NodeId] {
+    override def asString(id: NodeId): String = id.index.toString
   }
 
-  val NidDecoder: DecodeNid[Value.NodeId] = new DecodeNid[Value.NodeId] {
-    override def fromString(s: String): Either[DecodeError, Value.NodeId] =
+  val NidDecoder: DecodeNid[NodeId] = new DecodeNid[NodeId] {
+    override def fromString(s: String): Either[DecodeError, NodeId] =
       scalaz.std.string
         .parseInt(s)
-        .fold(_ => Left(DecodeError(s"cannot parse node Id $s")), idx => Right(Value.NodeId(idx)))
+        .fold(_ => Left(DecodeError(s"cannot parse node Id $s")), idx => Right(NodeId(idx)))
   }
 
-  def EventIdEncoder(trId: Ref.LedgerString): EncodeNid[Value.NodeId] =
-    new EncodeNid[Value.NodeId] {
-      override def asString(id: Value.NodeId): String = ledger.EventId(trId, id).toLedgerString
+  def EventIdEncoder(trId: Ref.LedgerString): EncodeNid[NodeId] =
+    new EncodeNid[NodeId] {
+      override def asString(id: NodeId): String = ledger.EventId(trId, id).toLedgerString
     }
 
-  def EventIdDecoder(trId: Ref.LedgerString): DecodeNid[Value.NodeId] =
-    new DecodeNid[Value.NodeId] {
-      override def fromString(s: String): Either[DecodeError, Value.NodeId] =
+  def EventIdDecoder(trId: Ref.LedgerString): DecodeNid[NodeId] =
+    new DecodeNid[NodeId] {
+      override def fromString(s: String): Either[DecodeError, NodeId] =
         ledger.EventId
           .fromString(s)
           .fold(

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -5,7 +5,6 @@ package com.daml.lf
 package transaction
 
 import com.daml.lf.transaction.Node.KeyWithMaintainers
-import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.{Value, ValueVersion}
 
 final case class TransactionVersion(protoValue: String)
@@ -110,18 +109,18 @@ private[lf] object TransactionVersions
   }
 
   def asVersionedTransaction(
-      tx: GenTransaction.WithTxValue[Tx.NodeId, Value.ContractId],
+      tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
       supportedVersions: VersionRange[TransactionVersion] = SupportedDevVersions,
-  ): Either[String, Tx.Transaction] =
+  ): Either[String, Transaction.Transaction] =
     for {
       v <- assignVersion(tx, supportedVersions)
     } yield VersionedTransaction(v, tx)
 
   @throws[IllegalArgumentException]
   def assertAsVersionedTransaction(
-      tx: GenTransaction.WithTxValue[Tx.NodeId, Value.ContractId],
+      tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
       supportedVersions: VersionRange[TransactionVersion] = SupportedDevVersions,
-  ): Tx.Transaction =
+  ): Transaction.Transaction =
     data.assertRight(asVersionedTransaction(tx, supportedVersions))
 
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -445,15 +445,10 @@ object Value extends CidContainer1[Value] {
       CidMapper.basicMapperInstance[ContractId, ContractId.V1]
   }
 
-  /** The constructor is private so that we make sure that only this object constructs
-    * node ids -- we don't want external code to manipulate them.
-    */
-  final case class NodeId(index: Int)
-
-  object NodeId {
-    implicit def cidMapperInstance[In, Out]: CidMapper[NodeId, NodeId, In, Out] =
-      CidMapper.trivialMapper
-  }
+  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.3.0")
+  type NodeId = transaction.NodeId
+  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.3.0")
+  val NodeId = transaction.NodeId
 
   /*** Keys cannot contain contract ids */
   type Key = Value[Nothing]

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -53,12 +53,12 @@ class TransactionCoderSpec
               TransactionCoder.NidEncoder,
               ValueCoder.CidEncoder,
               defaultTransactionVersion,
-              Tx.NodeId(0),
+              NodeId(0),
               node,
             )
             .toOption
             .get
-          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
+          Right((NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
             TransactionCoder.NidDecoder,
             ValueCoder.CidDecoder,
             defaultTransactionVersion,
@@ -81,12 +81,12 @@ class TransactionCoderSpec
                 TransactionCoder.NidEncoder,
                 ValueCoder.CidEncoder,
                 defaultTransactionVersion,
-                Tx.NodeId(0),
+                NodeId(0),
                 node,
               )
               .toOption
               .get
-          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
+          Right((NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
             TransactionCoder.NidDecoder,
             ValueCoder.CidDecoder,
             defaultTransactionVersion,
@@ -101,19 +101,19 @@ class TransactionCoderSpec
 
     "do NodeExercises" in {
       forAll(danglingRefExerciseNodeGen) {
-        node: NodeExercises[Tx.NodeId, Value.ContractId, Tx.Value[Value.ContractId]] =>
+        node: NodeExercises[NodeId, Value.ContractId, Tx.Value[Value.ContractId]] =>
           val encodedNode =
             TransactionCoder
               .encodeNode(
                 TransactionCoder.NidEncoder,
                 ValueCoder.CidEncoder,
                 defaultTransactionVersion,
-                Tx.NodeId(0),
+                NodeId(0),
                 node,
               )
               .toOption
               .get
-          Right((Tx.NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
+          Right((NodeId(0), node)) shouldEqual TransactionCoder.decodeNode(
             TransactionCoder.NidDecoder,
             ValueCoder.CidDecoder,
             defaultTransactionVersion,
@@ -136,7 +136,7 @@ class TransactionCoderSpec
               .encodeTransaction(TransactionCoder.NidEncoder, ValueCoder.CidEncoder, t),
           )
 
-        val decodedVersionedTx: VersionedTransaction[Tx.NodeId, Value.ContractId] =
+        val decodedVersionedTx: VersionedTransaction[NodeId, Value.ContractId] =
           assertRight(
             TransactionCoder
               .decodeTransaction(
@@ -311,7 +311,7 @@ class TransactionCoderSpec
           key = None,
         )
       val nodes = ImmArray((1 to 10000).map { nid =>
-        Value.NodeId(nid) -> node
+        NodeId(nid) -> node
       })
       val tx = TransactionVersions.assertAsVersionedTransaction(
         GenTransaction(nodes = HashMap(nodes.toSeq: _*), roots = nodes.map(_._1)))
@@ -335,7 +335,7 @@ class TransactionCoderSpec
   }
 
   private def isTransactionWithAtLeastOneVersionedValue(
-      tx: GenTransaction.WithTxValue[Tx.NodeId, Value.ContractId],
+      tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
   ): Boolean =
     tx.nodes.values
       .exists {
@@ -346,9 +346,9 @@ class TransactionCoderSpec
       }
 
   private def changeAllValueVersions(
-      tx: GenTransaction.WithTxValue[Tx.NodeId, Value.ContractId],
+      tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
       ver: ValueVersion,
-  ): GenTransaction.WithTxValue[Tx.NodeId, Value.ContractId] =
+  ): GenTransaction.WithTxValue[NodeId, Value.ContractId] =
     tx.map3(identity, identity, _.copy(version = ver))
 
   def withoutExerciseResult[Nid, Cid, Val](gn: GenNode[Nid, Cid, Val]): GenNode[Nid, Cid, Val] =

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -27,39 +27,39 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
 
   "isWellFormed" - {
     "detects dangling references in roots" in {
-      val tx = mkTransaction(HashMap.empty, ImmArray(V.NodeId(1)))
-      tx.isWellFormed shouldBe Set(NotWellFormedError(V.NodeId(1), DanglingNodeId))
+      val tx = mkTransaction(HashMap.empty, ImmArray(NodeId(1)))
+      tx.isWellFormed shouldBe Set(NotWellFormedError(NodeId(1), DanglingNodeId))
     }
 
     "detects dangling references in children" in {
       val tx = mkTransaction(
-        HashMap(V.NodeId(1) -> dummyExerciseNode("cid1", ImmArray(V.NodeId(2)))),
-        ImmArray(V.NodeId(1)))
-      tx.isWellFormed shouldBe Set(NotWellFormedError(V.NodeId(2), DanglingNodeId))
+        HashMap(NodeId(1) -> dummyExerciseNode("cid1", ImmArray(NodeId(2)))),
+        ImmArray(NodeId(1)))
+      tx.isWellFormed shouldBe Set(NotWellFormedError(NodeId(2), DanglingNodeId))
     }
 
     "detects cycles" in {
       val tx = mkTransaction(
-        HashMap(V.NodeId(1) -> dummyExerciseNode("cid1", ImmArray(V.NodeId(1)))),
-        ImmArray(V.NodeId(1)))
-      tx.isWellFormed shouldBe Set(NotWellFormedError(V.NodeId(1), AliasedNode))
+        HashMap(NodeId(1) -> dummyExerciseNode("cid1", ImmArray(NodeId(1)))),
+        ImmArray(NodeId(1)))
+      tx.isWellFormed shouldBe Set(NotWellFormedError(NodeId(1), AliasedNode))
     }
 
     "detects aliasing from roots and exercise" in {
       val tx = mkTransaction(
         HashMap(
-          V.NodeId(0) -> dummyExerciseNode("cid0", ImmArray(V.NodeId(1))),
-          V.NodeId(1) -> dummyExerciseNode("cid1", ImmArray(V.NodeId(2))),
-          V.NodeId(2) -> dummyCreateNode("cid2"),
+          NodeId(0) -> dummyExerciseNode("cid0", ImmArray(NodeId(1))),
+          NodeId(1) -> dummyExerciseNode("cid1", ImmArray(NodeId(2))),
+          NodeId(2) -> dummyCreateNode("cid2"),
         ),
-        ImmArray(V.NodeId(0), V.NodeId(2)),
+        ImmArray(NodeId(0), NodeId(2)),
       )
-      tx.isWellFormed shouldBe Set(NotWellFormedError(V.NodeId(2), AliasedNode))
+      tx.isWellFormed shouldBe Set(NotWellFormedError(NodeId(2), AliasedNode))
     }
 
     "detects orphans" in {
-      val tx = mkTransaction(HashMap(V.NodeId(1) -> dummyCreateNode("cid1")), ImmArray.empty)
-      tx.isWellFormed shouldBe Set(NotWellFormedError(V.NodeId(1), OrphanedNode))
+      val tx = mkTransaction(HashMap(NodeId(1) -> dummyCreateNode("cid1")), ImmArray.empty)
+      tx.isWellFormed shouldBe Set(NotWellFormedError(NodeId(1), OrphanedNode))
     }
   }
 
@@ -68,11 +68,11 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
     "collects contract IDs" in {
       val tx = mkTransaction(
         HashMap(
-          V.NodeId(0) -> dummyExerciseNode("cid0", ImmArray(V.NodeId(1))),
-          V.NodeId(1) -> dummyExerciseNode("cid1", ImmArray(V.NodeId(2))),
-          V.NodeId(2) -> dummyCreateNode("cid2"),
+          NodeId(0) -> dummyExerciseNode("cid0", ImmArray(NodeId(1))),
+          NodeId(1) -> dummyExerciseNode("cid1", ImmArray(NodeId(2))),
+          NodeId(2) -> dummyCreateNode("cid2"),
         ),
-        ImmArray(V.NodeId(0), V.NodeId(2)),
+        ImmArray(NodeId(0), NodeId(2)),
       )
 
       def collectCids(tx: Transaction): Set[V.ContractId] = {
@@ -92,12 +92,12 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
 
       val tx = mkTransaction(
         HashMap(
-          V.NodeId(0) -> dummyCreateNode("cid0"),
-          V.NodeId(1) -> dummyExerciseNode("cid0", ImmArray(V.NodeId(2))),
-          V.NodeId(2) -> dummyExerciseNode("cid1", ImmArray.empty),
-          V.NodeId(3) -> dummyCreateNode("cid2"),
+          NodeId(0) -> dummyCreateNode("cid0"),
+          NodeId(1) -> dummyExerciseNode("cid0", ImmArray(NodeId(2))),
+          NodeId(2) -> dummyExerciseNode("cid1", ImmArray.empty),
+          NodeId(3) -> dummyCreateNode("cid2"),
         ),
-        ImmArray(V.NodeId(0), V.NodeId(1), V.NodeId(3)),
+        ImmArray(NodeId(0), NodeId(1), NodeId(3)),
       )
 
       val result = tx.foldInExecutionOrder(List.empty[String])(
@@ -168,11 +168,11 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
 
       val tx = mkTransaction(
         HashMap(
-          V.NodeId(0) -> dummyCreateNode("cid1"),
-          V.NodeId(0) -> dummyExerciseNode("cid1", ImmArray(V.NodeId(0))),
-          V.NodeId(1) -> dummyExerciseNode("cid2", ImmArray(V.NodeId(1))),
+          NodeId(0) -> dummyCreateNode("cid1"),
+          NodeId(0) -> dummyExerciseNode("cid1", ImmArray(NodeId(0))),
+          NodeId(1) -> dummyExerciseNode("cid2", ImmArray(NodeId(1))),
         ),
-        ImmArray(V.NodeId(0), V.NodeId(1)),
+        ImmArray(NodeId(0), NodeId(1)),
       )
 
       val suffix1 = Bytes.assertFromString("01")
@@ -206,17 +206,17 @@ class TransactionSpec extends FreeSpec with Matchers with GeneratorDrivenPropert
 
 object TransactionSpec {
   private[this] type Value = V[V.ContractId]
-  type Transaction = GenTransaction[V.NodeId, V.ContractId, Value]
+  type Transaction = GenTransaction[NodeId, V.ContractId, Value]
   def mkTransaction(
-      nodes: HashMap[V.NodeId, GenNode[V.NodeId, V.ContractId, Value]],
-      roots: ImmArray[V.NodeId],
+      nodes: HashMap[NodeId, GenNode[NodeId, V.ContractId, Value]],
+      roots: ImmArray[NodeId],
   ): Transaction = GenTransaction(nodes, roots)
 
   def dummyExerciseNode(
       cid: V.ContractId,
-      children: ImmArray[V.NodeId],
+      children: ImmArray[NodeId],
       hasExerciseResult: Boolean = true,
-  ): NodeExercises[V.NodeId, V.ContractId, Value] =
+  ): NodeExercises[NodeId, V.ContractId, Value] =
     NodeExercises(
       targetCoid = cid,
       templateId = Ref.Identifier(

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
@@ -73,7 +73,7 @@ object TransactionVersionSpec {
 
   import TransactionSpec._
 
-  private[this] val singleId = Value.NodeId(0)
+  private[this] val singleId = NodeId(0)
   private val dummyCreateTransaction =
     mkTransaction(HashMap(singleId -> dummyCreateNode("cid1")), ImmArray(singleId))
   private val dummyExerciseWithResultTransaction =

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/participant/util/LfEngineToApi.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 import com.daml.lf.data.Ref.Identifier
 import com.daml.lf.data.{Numeric, Ref}
 import com.daml.lf.data.LawlessTraversals._
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.NodeId
 import com.daml.lf.transaction.Node.{KeyWithMaintainers, NodeCreate, NodeExercises}
 import com.daml.lf.value.{Value => Lf}
 import com.daml.ledger.EventId
@@ -176,7 +176,7 @@ object LfEngineToApi {
   def lfNodeCreateToEvent(
       verbose: Boolean,
       trId: Ref.LedgerString,
-      nodeId: Tx.NodeId,
+      nodeId: NodeId,
       node: NodeCreate.WithTxValue[Lf.ContractId],
   ): Either[String, Event] =
     for {
@@ -198,8 +198,8 @@ object LfEngineToApi {
 
   def lfNodeExercisesToEvent(
       trId: Ref.LedgerString,
-      nodeId: Tx.NodeId,
-      node: NodeExercises.WithTxValue[Tx.NodeId, Lf.ContractId],
+      nodeId: NodeId,
+      node: NodeExercises.WithTxValue[NodeId, Lf.ContractId],
   ): Either[String, Event] =
     Either.cond(
       node.consuming,
@@ -243,8 +243,8 @@ object LfEngineToApi {
       trId: Ref.LedgerString,
       eventId: EventId,
       witnessParties: Set[Ref.Party],
-      node: NodeExercises.WithTxValue[Tx.NodeId, Lf.ContractId],
-      filterChildren: Tx.NodeId => Boolean,
+      node: NodeExercises.WithTxValue[NodeId, Lf.ContractId],
+      filterChildren: NodeId => Boolean,
   ): Either[String, TreeEvent] =
     for {
       arg <- lfVersionedValueToApiValue(verbose, node.chosenValue)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Projections.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Projections.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.participant.state.kvutils
 import com.daml.lf.data.BackStack
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.transaction.BlindingInfo
-import com.daml.lf.transaction.Transaction.{NodeId, Transaction}
+import com.daml.lf.transaction.{NodeId, Transaction}
 
 final case class ProjectionRoots(
     party: Party,
@@ -25,7 +25,7 @@ object Projections {
     * we keep an explicit list of roots for each party.
     */
   def computePerPartyProjectionRoots(
-      tx: Transaction,
+      tx: Transaction.Transaction,
       blindingInfo: BlindingInfo): List[ProjectionRoots] = {
 
     val perPartyRoots = tx.foldWithPathState(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -19,7 +19,7 @@ import com.daml.lf.data.Ref.{PackageId, Party}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Blinding, Engine}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{BlindingInfo, Node, Transaction => Tx}
+import com.daml.lf.transaction.{BlindingInfo, Node, NodeId, Transaction => Tx}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.metrics.Metrics
@@ -384,7 +384,7 @@ private[kvutils] class TransactionCommitter(
       blindingInfo: BlindingInfo,
       commitContext: CommitContext): Unit = {
     val effects = InputsAndEffects.computeEffects(transactionEntry.transaction)
-    val cid2nid: Value.ContractId => Value.NodeId =
+    val cid2nid: Value.ContractId => NodeId =
       transactionEntry.transaction.localContracts
     // Add contract state entries to mark contract activeness (checked by 'validateModelConformance').
     for ((key, createNode) <- effects.createdContracts) {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -9,8 +9,8 @@ import com.daml.lf.data.{BackStack, ImmArray}
 import com.daml.lf.engine.Blinding
 import com.daml.lf.transaction.Transaction.Transaction
 import com.daml.lf.transaction.test.TransactionBuilder
-import com.daml.lf.transaction.Node
-import com.daml.lf.value.Value.{ContractId, ContractInst, NodeId, ValueText}
+import com.daml.lf.transaction.{Node, NodeId}
+import com.daml.lf.value.Value.{ContractId, ContractInst, ValueText}
 import org.scalatest.{Matchers, WordSpec}
 
 class ProjectionsSpec extends WordSpec with Matchers {

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state.v1
 
 import com.daml.lf.crypto
 import com.daml.lf.data.{ImmArray, Ref, Time}
-import com.daml.lf.transaction.{Transaction => Tx}
 
 /** Meta-data of a transaction visible to all parties that can see a part of
   * the transaction.
@@ -39,6 +38,6 @@ final case class TransactionMeta(
     submissionTime: Time.Timestamp,
     submissionSeed: crypto.Hash,
     optUsedPackages: Option[Set[Ref.PackageId]],
-    optNodeSeeds: Option[ImmArray[(Tx.NodeId, crypto.Hash)]],
-    optByKeyNodes: Option[ImmArray[Tx.NodeId]]
+    optNodeSeeds: Option[ImmArray[(NodeId, crypto.Hash)]],
+    optByKeyNodes: Option[ImmArray[NodeId]]
 )

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.participant.state
 
 import com.daml.lf.data.Ref
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction
 import com.daml.lf.value.Value
 
 /** Interfaces to read from and write to an (abstract) participant state.
@@ -84,7 +84,7 @@ package object v1 {
   type SubmissionId = Ref.LedgerString
 
   /** Identifiers for nodes in a transaction. */
-  type NodeId = Tx.NodeId
+  type NodeId = transaction.NodeId
 
   /** Identifiers for packages. */
   type PackageId = Ref.PackageId
@@ -96,14 +96,14 @@ package object v1 {
     *
     * See the Contract Id specification for more detail daml-lf/spec/contract-id.rst
     */
-  type SubmittedTransaction = Tx.SubmittedTransaction
+  type SubmittedTransaction = transaction.Transaction.SubmittedTransaction
 
   /** A transaction with globally unique contract IDs.
     *
     * Used to communicate transactions that have been accepted to the ledger.
     * See the Contract Id specification for more detail daml-lf/spec/contract-id.rst
     */
-  type CommittedTransaction = Tx.CommittedTransaction
+  type CommittedTransaction = transaction.Transaction.CommittedTransaction
 
   /** A contract instance. */
   type ContractInst =

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.participant.state
 
 import com.daml.lf.data.Ref
 import com.daml.lf.transaction
+import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.Value
 
 /** Interfaces to read from and write to an (abstract) participant state.
@@ -96,14 +97,14 @@ package object v1 {
     *
     * See the Contract Id specification for more detail daml-lf/spec/contract-id.rst
     */
-  type SubmittedTransaction = transaction.Transaction.SubmittedTransaction
+  type SubmittedTransaction = Tx.SubmittedTransaction
 
   /** A transaction with globally unique contract IDs.
     *
     * Used to communicate transactions that have been accepted to the ledger.
     * See the Contract Id specification for more detail daml-lf/spec/contract-id.rst
     */
-  type CommittedTransaction = transaction.Transaction.CommittedTransaction
+  type CommittedTransaction = Tx.CommittedTransaction
 
   /** A contract instance. */
   type ContractInst =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.transaction.Node.GlobalKey
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.{NodeId, Transaction => Tx}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.platform.store.Contract.{ActiveContract, DivulgedContract}
@@ -151,7 +151,7 @@ case class InMemoryActiveLedgerState(
       workflowId: Option[WorkflowId],
       submitter: Option[Party],
       transaction: Tx.CommittedTransaction,
-      disclosure: Relation[Tx.NodeId, Party],
+      disclosure: Relation[NodeId, Party],
       divulgence: Relation[ContractId, Party],
       referencedContracts: List[(Value.ContractId, ContractInst)]
   ): Either[Set[RejectionReason], InMemoryActiveLedgerState] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/Ledger.scala
@@ -10,7 +10,7 @@ import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.Blinding
-import com.daml.lf.transaction.{Transaction => Tx, TransactionCommitter}
+import com.daml.lf.transaction.{NodeId, TransactionCommitter}
 import com.daml.lf.value.Value.ContractId
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.platform.store.ReadOnlyLedger
@@ -57,7 +57,7 @@ object Ledger {
       committer: TransactionCommitter,
       transactionId: TransactionId,
       transaction: SubmittedTransaction
-  ): (CommittedTransaction, Relation[Tx.NodeId, Party], Divulgence) = {
+  ): (CommittedTransaction, Relation[NodeId, Party], Divulgence) = {
 
     // First we "commit" the transaction by converting all relative contractIds to absolute ones
     val committedTransaction = committer.commitTransaction(transactionId, transaction)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionCommitter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionCommitter.scala
@@ -42,7 +42,7 @@ object LegacyTransactionCommitter extends TransactionCommitter {
         .withDefault(identity)
 
     Transaction.CommittedTransaction(
-      VersionedTransaction.map2(identity[Transaction.NodeId], contractMapping)(transaction)
+      VersionedTransaction.map2(identity[NodeId], contractMapping)(transaction)
     )
 
   }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.transaction.Node.GlobalKey
-import com.daml.lf.transaction.{Transaction => Tx, Node => N}
+import com.daml.lf.transaction.{Node => N, NodeId, Transaction => Tx}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.platform.store.Contract.ActiveContract
@@ -64,7 +64,7 @@ class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => A
       workflowId: Option[WorkflowId],
       submitter: Option[Party],
       transaction: Tx.CommittedTransaction,
-      disclosure: Relation[Tx.NodeId, Party],
+      disclosure: Relation[NodeId, Party],
       divulgence: Relation[ContractId, Party],
       divulgedContracts: List[(Value.ContractId, ContractInst)])
     : Either[Set[RejectionReason], ALS] = {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Contract.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/Contract.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.transaction.Node.KeyWithMaintainers
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.NodeId
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst, VersionedValue}
 import com.daml.ledger.{TransactionId, WorkflowId}
@@ -53,7 +53,7 @@ object Contract {
       id: Value.ContractId,
       let: Instant, // time when the contract was committed
       transactionId: TransactionId, // transaction id where the contract originates
-      nodeId: Tx.NodeId,
+      nodeId: NodeId,
       workflowId: Option[WorkflowId], // workflow id from where the contract originates
       contract: ContractInst[VersionedValue[ContractId]],
       witnesses: Set[Party],

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/package.scala
@@ -18,7 +18,7 @@ package object events {
   private[events] val Contract = lfval.ContractInst
 
   import com.daml.lf.{transaction => lftx}
-  private[events] type NodeId = lftx.Transaction.NodeId
+  private[events] type NodeId = lftx.NodeId
   private[events] type Node = lftx.Node.GenNode.WithTxValue[NodeId, ContractId]
   private[events] type Create = lftx.Node.NodeCreate.WithTxValue[ContractId]
   private[events] type Exercise = lftx.Node.NodeExercises.WithTxValue[NodeId, ContractId]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/entries/LedgerEntry.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/entries/LedgerEntry.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.{NodeId, Transaction => Tx}
 import com.daml.ledger._
 import com.daml.ledger.api.domain.RejectionReason
 
@@ -32,6 +32,6 @@ object LedgerEntry {
       ledgerEffectiveTime: Instant,
       recordedAt: Instant,
       transaction: Tx.CommittedTransaction,
-      explicitDisclosure: Relation[Tx.NodeId, Party])
+      explicitDisclosure: Relation[NodeId, Party])
       extends LedgerEntry
 }

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/v25_backfill_participant_events/package.scala
@@ -14,7 +14,7 @@ package object v25_backfill_participant_events {
   type ContractId = lfval.ContractId
 
   import com.daml.lf.{transaction => lftx}
-  type NodeId = lftx.Transaction.NodeId
+  type NodeId = lftx.NodeId
   type Transaction = lftx.Transaction.Transaction
   type Create = lftx.Node.NodeCreate.WithTxValue[ContractId]
   type Exercise = lftx.Node.NodeExercises.WithTxValue[NodeId, ContractId]

--- a/ledger/sandbox/src/main/scala/db/migration/postgres/v29_fix_participant_events/package.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/postgres/v29_fix_participant_events/package.scala
@@ -14,7 +14,7 @@ package object v29_fix_participant_events {
   type ContractId = lfval.ContractId
 
   import com.daml.lf.{transaction => lftx}
-  type NodeId = lftx.Transaction.NodeId
+  type NodeId = lftx.NodeId
   type Transaction = lftx.Transaction.Transaction
   type Create = lftx.Node.NodeCreate.WithTxValue[ContractId]
   type Exercise = lftx.Node.NodeExercises.WithTxValue[NodeId, ContractId]

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -17,7 +17,7 @@ import com.daml.lf.archive.DarReader
 import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.transaction.Node._
-import com.daml.lf.transaction.{Node, Transaction => Tx}
+import com.daml.lf.transaction.{Node, NodeId, Transaction => Tx}
 import com.daml.lf.value.Value.{ContractId, ContractInst, ValueRecord, ValueText, ValueUnit}
 import com.daml.lf.value.Value
 import com.daml.daml_lf_dev.DamlLf
@@ -111,7 +111,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
 
   private def exercise(
       targetCid: ContractId,
-  ): NodeExercises[Tx.NodeId, ContractId, Value[ContractId]] =
+  ): NodeExercises[NodeId, ContractId, Value[ContractId]] =
     NodeExercises(
       targetCoid = targetCid,
       templateId = someTemplateId,
@@ -132,7 +132,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
     tx.transaction.fold(Set.empty[ContractId]) {
       case (set, (_, create: NodeCreate.WithTxValue[ContractId])) =>
         set + create.coid
-      case (set, (_, exercise: Node.NodeExercises.WithTxValue[Tx.NodeId, ContractId]))
+      case (set, (_, exercise: Node.NodeExercises.WithTxValue[NodeId, ContractId]))
           if exercise.consuming =>
         set - exercise.targetCoid
       case (set, _) =>

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
@@ -8,7 +8,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.participant.state.v1.Offset
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.NodeId
 import com.daml.lf.value.Value.ContractId
 import com.daml.ledger.EventId
 import com.daml.ledger.api.v1.transaction.TransactionTree
@@ -88,7 +88,7 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
     } yield {
       inside(result.value.transaction) {
         case Some(transaction) =>
-          val (nodeId, exerciseNode: NodeExercises.WithTxValue[Tx.NodeId, ContractId]) =
+          val (nodeId, exerciseNode: NodeExercises.WithTxValue[NodeId, ContractId]) =
             exercise.transaction.nodes.head
           transaction.commandId shouldBe exercise.commandId.get
           transaction.offset shouldBe ApiOffset.toApiString(offset)
@@ -127,7 +127,7 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
             }.get
           val (exerciseNodeId, exerciseNode) =
             tx.transaction.nodes.collectFirst {
-              case (nodeId, node: NodeExercises.WithTxValue[Tx.NodeId, ContractId]) =>
+              case (nodeId, node: NodeExercises.WithTxValue[NodeId, ContractId]) =>
                 nodeId -> node
             }.get
 
@@ -184,8 +184,8 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
           transaction.eventsById should have size 2
 
           transaction.rootEventIds should have size 2
-          transaction.rootEventIds(0) shouldBe EventId(transaction.transactionId, Tx.NodeId(2)).toLedgerString
-          transaction.rootEventIds(1) shouldBe EventId(transaction.transactionId, Tx.NodeId(3)).toLedgerString
+          transaction.rootEventIds(0) shouldBe EventId(transaction.transactionId, NodeId(2)).toLedgerString
+          transaction.rootEventIds(1) shouldBe EventId(transaction.transactionId, NodeId(3)).toLedgerString
       }
     }
   }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -8,7 +8,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.participant.state.v1.Offset
 import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.NodeId
 import com.daml.lf.value.Value.ContractId
 import com.daml.ledger.EventId
 import com.daml.ledger.api.v1.transaction.Transaction
@@ -94,7 +94,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
           transaction.workflowId shouldBe exercise.workflowId.getOrElse("")
           inside(transaction.events.loneElement.event.archived) {
             case Some(archived) =>
-              val (nodeId, exerciseNode: NodeExercises.WithTxValue[Tx.NodeId, ContractId]) =
+              val (nodeId, exerciseNode: NodeExercises.WithTxValue[NodeId, ContractId]) =
                 exercise.transaction.nodes.head
               archived.eventId shouldBe EventId(transaction.transactionId, nodeId).toLedgerString
               archived.witnessParties should contain only exercise.submittingParty.get


### PR DESCRIPTION
In this PR :
* we move the `NodeId` from `com.daml.lf.value` to `com.daml.lf.transaction` 
* we remove `private` keyword to class `GenTransaction` its companion object.


### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
