### PR TITLE
Filter out silencer from pom file

### DIFF
--- a/bazel_tools/pom_file.bzl
+++ b/bazel_tools/pom_file.bzl
@@ -113,7 +113,9 @@ def _collect_maven_info_impl(_target, ctx):
         d
         for d in deps.to_list()
         if not (only_external_deps and (d.split(":")[0].startswith("com.daml") or
-                                        d.split(":")[0].startswith("com.digitalasset")))
+                                        d.split(":")[0].startswith("com.digitalasset"))) and
+           # Filter out silencer-lib since it’s a compile-only thing.
+           not d.startswith("com.github.ghik:silencer-lib_")
     ]
 
     if maven_coordinates:


### PR DESCRIPTION
The dependency on silencer forces users on a specific minor release of Scala for no good reason since it’s a compile-only dependency.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
