### PR TITLE
add JSON output to ledger-api-test-tool

### DIFF
--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -130,6 +130,7 @@ da_scala_binary(
         "//libs-scala/build-info",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:io_netty_netty_handler",
+        "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -154,7 +154,7 @@ object Cli {
       .action((inc, c) => c.copy(performanceTestsReport = Some(inc)))
       .optional()
       .text(
-        "The path of the the benchmark report file produced by performance tests (default: stdout).")
+        "The path of the benchmark report file produced by performance tests (default: stdout).")
 
     opt[Unit]("all-tests")
       .text("DEPRECATED: All tests are always run by default.")
@@ -190,6 +190,11 @@ object Cli {
       .optional()
       .action((_, _) => { println(BuildInfo.Version); sys.exit(0) })
       .text("Prints the version on stdout and exit.")
+
+    opt[Path]("json-report")
+      .action((inc, c) => c.copy(jsonReport = Some(inc)))
+      .optional()
+      .text("If this option is passed, the test tool will produce a JSON-formatted report of the current test run at the given path. This does not affect the normal output on stdout. No effect on performance tests.")
 
     help("help").text("Prints this usage text")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -26,6 +26,7 @@ final case class Config(
     listTestSuites: Boolean,
     shuffleParticipants: Boolean,
     partyAllocation: PartyAllocationConfiguration,
+    jsonReport: Option[Path],
 )
 
 object Config {
@@ -46,5 +47,6 @@ object Config {
     listTestSuites = false,
     shuffleParticipants = false,
     partyAllocation = PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants,
+    jsonReport = None,
   )
 }


### PR DESCRIPTION
As a small first step towards #5838, this PR adds the option to print out test results in JSON.

CHANGELOG_BEGIN

- [Ledger API Test Tool] Added an option to write a JSON report of a run to a file.

CHANGELOG_END
