### PR TITLE
Allow running StandaloneApiServer in read-only mode.

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/LedgerIdNotFoundException.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/LedgerIdNotFoundException.scala
@@ -4,4 +4,5 @@
 package com.daml.platform.common
 
 class LedgerIdNotFoundException(attempts: Int)
-    extends RuntimeException(s"""No ledger ID found in the index database after $attempts attempts.""")
+    extends RuntimeException(
+      s"""No ledger ID found in the index database after $attempts attempts.""")

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/LedgerIdNotFoundException.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/common/LedgerIdNotFoundException.scala
@@ -1,0 +1,7 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.common
+
+class LedgerIdNotFoundException(attempts: Int)
+    extends RuntimeException(s"""No ledger ID found in the index database after $attempts attempts.""")

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -64,7 +64,7 @@ object Main {
     ): ResourceOwner[KeyValueLedger] = {
       val metrics = createMetrics(participantConfig, config)
       new InMemoryLedgerReaderWriter.Owner(
-        initialLedgerId = config.ledgerId,
+        ledgerId = config.ledgerId,
         config.extra.batchingLedgerWriterConfig,
         participantId = participantConfig.participantId,
         metrics = metrics,

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.on.memory
 
-import java.util.UUID
-
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
@@ -21,7 +19,6 @@ import com.daml.ledger.validator.batch.{
   BatchedSubmissionValidatorFactory,
   ConflictDetection
 }
-import com.daml.lf.data.Ref
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
@@ -69,7 +66,7 @@ object InMemoryLedgerReaderWriter {
   val DefaultTimeProvider: TimeProvider = TimeProvider.UTC
 
   final class SingleParticipantOwner(
-      initialLedgerId: Option[LedgerId],
+      ledgerId: LedgerId,
       batchingLedgerWriterConfig: BatchingLedgerWriterConfig,
       participantId: ParticipantId,
       timeProvider: TimeProvider = DefaultTimeProvider,
@@ -85,7 +82,7 @@ object InMemoryLedgerReaderWriter {
       for {
         dispatcher <- dispatcherOwner.acquire()
         readerWriter <- new Owner(
-          initialLedgerId,
+          ledgerId,
           batchingLedgerWriterConfig,
           participantId,
           metrics,
@@ -100,7 +97,7 @@ object InMemoryLedgerReaderWriter {
   }
 
   final class Owner(
-      initialLedgerId: Option[LedgerId],
+      ledgerId: LedgerId,
       batchingLedgerWriterConfig: BatchingLedgerWriterConfig,
       participantId: ParticipantId,
       metrics: Metrics,
@@ -114,8 +111,6 @@ object InMemoryLedgerReaderWriter {
     override def acquire()(
         implicit executionContext: ExecutionContext
     ): Resource[KeyValueLedger] = {
-      val ledgerId =
-        initialLedgerId.getOrElse(Ref.LedgerString.assertFromString(UUID.randomUUID.toString))
       val keyValueCommitting =
         new KeyValueCommitting(
           engine,

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
@@ -39,7 +39,7 @@ abstract class InMemoryLedgerReaderWriterIntegrationSpecBase(enableBatching: Boo
   override val isPersistent: Boolean = false
 
   override def participantStateFactory(
-      ledgerId: Option[LedgerId],
+      ledgerId: LedgerId,
       participantId: ParticipantId,
       testId: String,
       metrics: Metrics,

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
@@ -20,7 +20,7 @@ abstract class SqlLedgerReaderWriterIntegrationSpecBase(implementationName: Stri
   override protected final val startIndex: Long = StartIndex
 
   override protected final def participantStateFactory(
-      ledgerId: Option[LedgerId],
+      ledgerId: LedgerId,
       participantId: ParticipantId,
       testId: String,
       metrics: Metrics,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -125,8 +125,7 @@ object Config {
         })
       opt[String]("ledger-id")
         .optional()
-        .text(
-          "The ID of the ledger. This must be the same each time the ledger is started. Defaults to a random UUID.")
+        .text("The ID of the ledger. This must be the same each time the ledger is started. Defaults to a random UUID.")
         .action((ledgerId, config) => config.copy(ledgerId = ledgerId))
 
       opt[String]("pem")

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.participant.state.kvutils.app
 import java.io.File
 import java.nio.file.Path
 import java.time.Duration
+import java.util.UUID
 
 import com.daml.caching
 import com.daml.ledger.api.tls.TlsConfiguration
@@ -19,7 +20,7 @@ import com.daml.resources.ResourceOwner
 import scopt.OptionParser
 
 final case class Config[Extra](
-    ledgerId: Option[String],
+    ledgerId: String,
     archiveFiles: Seq[Path],
     tlsConfig: Option[TlsConfiguration],
     participants: Seq[ParticipantConfig],
@@ -59,7 +60,7 @@ object Config {
 
   def createDefault[Extra](extra: Extra): Config[Extra] =
     Config(
-      ledgerId = None,
+      ledgerId = UUID.randomUUID().toString,
       archiveFiles = Vector.empty,
       tlsConfig = None,
       participants = Vector.empty,
@@ -123,9 +124,10 @@ object Config {
           config.copy(participants = config.participants :+ partConfig)
         })
       opt[String]("ledger-id")
+        .optional()
         .text(
           "The ID of the ledger. This must be the same each time the ledger is started. Defaults to a random UUID.")
-        .action((ledgerId, config) => config.copy(ledgerId = Some(ledgerId)))
+        .action((ledgerId, config) => config.copy(ledgerId = ledgerId))
 
       opt[String]("pem")
         .optional()

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -89,12 +89,12 @@ final class Runner[T <: ReadWriteService, Extra](
                 lfValueTranslationCache = lfValueTranslationCache,
               ).acquire()
               _ <- new StandaloneApiServer(
+                ledgerId = config.ledgerId,
                 config = factory.apiServerConfig(participantConfig, config),
                 commandConfig = factory.commandConfig(participantConfig, config),
                 partyConfig = factory.partyConfig(config),
                 ledgerConfig = factory.ledgerConfig(config),
-                readService = readService,
-                writeService = writeService,
+                optWriteService = Some(writeService),
                 authService = factory.authService(config),
                 transformIndexService = service => new TimedIndexService(service, metrics),
                 metrics = metrics,

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -188,7 +188,7 @@ class RecoveringIndexerIntegrationSpec extends AsyncWordSpec with Matchers with 
     for {
       actorSystem <- AkkaResourceOwner.forActorSystem(() => ActorSystem())
       materializer <- AkkaResourceOwner.forMaterializer(() => Materializer(actorSystem))
-      participantState <- newParticipantState(Some(ledgerId), participantId)(materializer, logCtx)
+      participantState <- newParticipantState(ledgerId, participantId)(materializer, logCtx)
       _ <- new StandaloneIndexerServer(
         readService = participantState,
         config = IndexerConfig(
@@ -226,14 +226,14 @@ object RecoveringIndexerIntegrationSpec {
     SubmissionId.assertFromString(UUID.randomUUID().toString)
 
   private trait ParticipantStateFactory {
-    def apply(ledgerId: Option[LedgerId], participantId: ParticipantId)(
+    def apply(ledgerId: LedgerId, participantId: ParticipantId)(
         implicit materializer: Materializer,
         logCtx: LoggingContext,
     ): ResourceOwner[ParticipantState]
   }
 
   private object SimpleParticipantState extends ParticipantStateFactory {
-    override def apply(ledgerId: Option[LedgerId], participantId: ParticipantId)(
+    override def apply(ledgerId: LedgerId, participantId: ParticipantId)(
         implicit materializer: Materializer,
         logCtx: LoggingContext
     ): ResourceOwner[ParticipantState] = {
@@ -249,7 +249,7 @@ object RecoveringIndexerIntegrationSpec {
   }
 
   private object ParticipantStateThatFailsOften extends ParticipantStateFactory {
-    override def apply(ledgerId: Option[LedgerId], participantId: ParticipantId)(
+    override def apply(ledgerId: LedgerId, participantId: ParticipantId)(
         implicit materializer: Materializer,
         logCtx: LoggingContext
     ): ResourceOwner[ParticipantState] =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -71,7 +71,6 @@ final class StandaloneApiServer(
       indexService <- JdbcIndex
         .owner(
           ServerRole.ApiServer,
-          ledgerConfig.initialConfiguration,
           domain.LedgerId(ledgerId),
           participantId,
           config.jdbcUrl,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala
@@ -9,7 +9,6 @@ import java.time.Instant
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
 import com.daml.api.util.TimeProvider
 import com.daml.buildinfo.BuildInfo
 import com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor
@@ -17,7 +16,7 @@ import com.daml.ledger.api.auth.{AuthService, Authorizer}
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.participant.state.index.v2.IndexService
-import com.daml.ledger.participant.state.v1.{ParticipantId, ReadService, SeedService, WriteService}
+import com.daml.ledger.participant.state.v1.{LedgerId, ParticipantId, SeedService, WriteService}
 import com.daml.lf.engine.Engine
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
@@ -25,7 +24,7 @@ import com.daml.platform.configuration.{
   CommandConfiguration,
   LedgerConfiguration,
   PartyConfiguration,
-  ServerRole,
+  ServerRole
 }
 import com.daml.platform.index.JdbcIndex
 import com.daml.platform.packages.InMemoryPackageStore
@@ -42,12 +41,12 @@ import scala.concurrent.ExecutionContext
 // Main entry point to start an index server that also hosts the ledger API.
 // See v2.ReferenceServer on how it is used.
 final class StandaloneApiServer(
+    ledgerId: LedgerId,
     config: ApiServerConfig,
     commandConfig: CommandConfiguration,
     partyConfig: PartyConfiguration,
     ledgerConfig: LedgerConfiguration,
-    readService: ReadService,
-    writeService: WriteService,
+    optWriteService: Option[WriteService],
     authService: AuthService,
     transformIndexService: IndexService => IndexService = identity,
     metrics: Metrics,
@@ -69,17 +68,11 @@ final class StandaloneApiServer(
     preloadPackages(packageStore)
 
     val owner = for {
-      initialConditions <- ResourceOwner.forFuture(() =>
-        readService.getLedgerInitialConditions().runWith(Sink.head))
-      authorizer = new Authorizer(
-        () => java.time.Clock.systemUTC.instant(),
-        initialConditions.ledgerId,
-        participantId)
       indexService <- JdbcIndex
         .owner(
           ServerRole.ApiServer,
-          initialConditions.config,
-          domain.LedgerId(initialConditions.ledgerId),
+          ledgerConfig.initialConfiguration,
+          domain.LedgerId(ledgerId),
           participantId,
           config.jdbcUrl,
           config.eventsPageSize,
@@ -87,15 +80,16 @@ final class StandaloneApiServer(
           lfValueTranslationCache,
         )
         .map(transformIndexService)
+      authorizer = new Authorizer(
+        () => java.time.Clock.systemUTC.instant(),
+        ledgerId,
+        participantId)
       healthChecks = new HealthChecks(
-        "index" -> indexService,
-        "read" -> readService,
-        "write" -> writeService,
-      )
+        Seq("index" -> indexService) ++ optWriteService.toList.map("write" -> _): _*)
       executionSequencerFactory <- new ExecutionSequencerFactoryOwner()
       apiServicesOwner = new ApiServices.Owner(
         participantId = participantId,
-        writeService = writeService,
+        optWriteService = optWriteService,
         indexService = indexService,
         authorizer = authorizer,
         engine = engine,
@@ -124,7 +118,7 @@ final class StandaloneApiServer(
     } yield {
       writePortFile(apiServer.port)
       logger.info(
-        s"Initialized API server version ${BuildInfo.Version} with ledger-id = ${initialConditions.ledgerId}, port = ${apiServer.port}, dar file = ${config.archiveFiles}")
+        s"Initialized API server version ${BuildInfo.Version} with ledger-id = $ledgerId, port = ${apiServer.port}, dar file = ${config.archiveFiles}")
       apiServer
     }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/JdbcIndex.scala
@@ -3,13 +3,10 @@
 
 package com.daml.platform.index
 
-import akka.NotUsed
 import akka.stream.Materializer
-import akka.stream.scaladsl.Source
 import com.daml.ledger.api.domain.LedgerId
-import com.daml.ledger.participant.state.index.v2
 import com.daml.ledger.participant.state.index.v2.IndexService
-import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId}
+import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
@@ -19,7 +16,6 @@ import com.daml.resources.ResourceOwner
 object JdbcIndex {
   def owner(
       serverRole: ServerRole,
-      initialConfig: Configuration,
       ledgerId: LedgerId,
       participantId: ParticipantId,
       jdbcUrl: String,
@@ -35,10 +31,6 @@ object JdbcIndex {
       metrics,
       lfValueTranslationCache,
     ).map { ledger =>
-      new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId) {
-        override def getLedgerConfiguration(): Source[v2.LedgerConfiguration, NotUsed] =
-          // FIXME(JM): The indexer should on start set the default configuration.
-          Source.single(v2.LedgerConfiguration(initialConfig.maxDeduplicationTime))
-      }
+      new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId)
     }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/SandboxServer.scala
@@ -303,7 +303,7 @@ final class SandboxServer(
       executionSequencerFactory <- new ExecutionSequencerFactoryOwner().acquire()
       apiServicesOwner = new ApiServices.Owner(
         participantId = participantId,
-        writeService = new TimedWriteService(indexAndWriteService.writeService, metrics),
+        optWriteService = Some(new TimedWriteService(indexAndWriteService.writeService, metrics)),
         indexService = new TimedIndexService(indexAndWriteService.indexService, metrics),
         authorizer = authorizer,
         engine = SandboxServer.engine,

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -6,7 +6,6 @@ package com.daml.platform.sandbox.stores
 import java.time.Instant
 import java.util.concurrent.CompletionStage
 
-import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.api.util.TimeProvider
@@ -40,7 +39,7 @@ import org.slf4j.LoggerFactory
 
 import scala.compat.java8.FutureConverters
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{ExecutionContext, Future}
 
 trait IndexAndWriteService {
   def indexService: IndexService
@@ -116,12 +115,7 @@ object SandboxIndexAndWriteService {
       initialConfig: Configuration,
       timeProvider: TimeProvider,
   )(implicit mat: Materializer): ResourceOwner[IndexAndWriteService] = {
-    val indexSvc = new LedgerBackedIndexService(ledger, participantId) {
-      override def getLedgerConfiguration(): Source[LedgerConfiguration, NotUsed] =
-        Source
-          .single(LedgerConfiguration(initialConfig.maxDeduplicationTime))
-          .concat(Source.future(Promise[LedgerConfiguration]().future)) // we should keep the stream open!
-    }
+    val indexSvc = new LedgerBackedIndexService(ledger, participantId)
     val writeSvc = new LedgerBackedWriteService(ledger, timeProvider)
 
     for {

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandboxnext/Runner.scala
@@ -140,9 +140,10 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   case TimeProviderType.WallClock =>
                     None
                 }
+                ledgerId = specifiedLedgerId.getOrElse(UUID.randomUUID().toString)
                 isReset = startupMode == StartupMode.ResetAndStart
                 readerWriter <- new SqlLedgerReaderWriter.Owner(
-                  initialLedgerId = specifiedLedgerId,
+                  ledgerId = ledgerId,
                   participantId = ParticipantId,
                   metrics = metrics,
                   jdbcUrl = ledgerJdbcUrl,
@@ -200,6 +201,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   )
                 }
                 apiServer <- new StandaloneApiServer(
+                  ledgerId = ledgerId,
                   config = ApiServerConfig(
                     participantId = ParticipantId,
                     archiveFiles = if (isReset) List.empty else config.damlPackages,
@@ -219,8 +221,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     implicitPartyAllocation = config.implicitPartyAllocation,
                   ),
                   ledgerConfig = config.ledgerConfig,
-                  readService = readService,
-                  writeService = writeService,
+                  optWriteService = Some(writeService),
                   authService = authService,
                   transformIndexService = new TimedIndexService(_, metrics),
                   metrics = metrics,


### PR DESCRIPTION
Also fixes #5635.

CHANGELOG_BEGIN
[DAML Integration Kit]: ``StandaloneApiServer`` can now be run in a read-only mode.
  - The type of the constructor parameter ``writeService`` of ``StandaloneApiServer`` changed to ``Option[WriteService]``. Passing ``None`` will not start any of the admin services, the command service, and the command submission service.
  - The constructor parameter ``readService`` of ``StandaloneApiServer`` has been removed.
  - A new constructor parameter ``ledgerId`` has been added to ``StandaloneApiServer``. It is used to verify that that ``StandaloneApiServer`` is run against an index storage for the same ledgerId. Initialization is aborted if this is not the case.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
