### PR TITLE
add default compiler warnings

### DIFF
--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -325,7 +325,7 @@ patches we backport to the 1.0 release branch).
    1. Kill `daml start` with `Ctrl-C`.
    1. Run `daml studio --replace=always` and open `daml/Main.daml`. Verify that
       the scenario result appears within 30 seconds.
-   1. Add `+` at the end of line 26 after `"Alice"` and verify that you get an
+   1. Add `+` at the end of line 23 after `"Alice"` and verify that you get an
       error.
    1. Run through the tests for the getting started guide described above.
 

--- a/templates/skeleton/daml.yaml.template
+++ b/templates/skeleton/daml.yaml.template
@@ -12,3 +12,16 @@ dependencies:
   - daml-script
 sandbox-options:
   - --wall-clock-time
+
+# https://discuss.daml.com/t/making-the-most-out-of-daml-compiler-warnings/739
+build-options: [
+  # make compilation fail if there is a warning
+  #"--ghc-option", "-Werror",
+
+  # this is an example to get you started; uncomment the ones you want
+  "--ghc-option", "-Wunused-matches",
+  #"--ghc-option", "-Wunused-do-bind",
+  #"--ghc-option", "-Wincomplete-uni-patterns",
+  #"--ghc-option", "-Wredundant-constraints",
+  #"--ghc-option", "-Wmissing-signatures",
+  ]

--- a/templates/skeleton/daml/Main.daml
+++ b/templates/skeleton/daml/Main.daml
@@ -18,6 +18,7 @@ template Asset
           create this with
             owner = newOwner
 
+setup : Scenario AssetId
 setup = scenario do
   alice <- getParty "Alice"
   bob <- getParty "Bob"

--- a/templates/skeleton/daml/Setup.daml
+++ b/templates/skeleton/daml/Setup.daml
@@ -18,7 +18,7 @@ initialize = do
   bobTV <- submit alice do
     exerciseCmd aliceTV Give with newOwner = bob
 
-  submit bob do
+  _ <- submit bob do
     exerciseCmd bobTV Give with newOwner = alice
 
   pure ()


### PR DESCRIPTION
Based on @cocreature's [post][0] on the forum, I thought it would be a good idea to include at least some warnings in the daml.yaml file for the skeleton template because:

- This helps users figure out the syntax,
- This shows users this is possible at all; this is otherwise not a very discoverable feature, and
- It's a lot easier to start a project with warnings enabled and keep the compiler happy as you grow than to turn them on after 6 months of developments.

CHANGELOG_BEGIN

- [DAML Assistant] The default skeleton template now includes a section to enable compiler warnings in daml.yaml.

CHANGELOG_END

[0]: https://discuss.daml.com/t/making-the-most-out-of-daml-compiler-warnings/739