### PR TITLE
fix the the typo

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -23,7 +23,7 @@
 ---------------------------------------------------------------------
 -- DICTIONARY SANITIZATION
 --
--- GHC's desugaring for default methods relies on the the fact that Haskell is
+-- GHC's desugaring for default methods relies on the fact that Haskell is
 -- lazy. In contrast, DAML-LF is strict. This mismatch causes a few problems.
 -- For instance, GHC desugars:
 --

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -299,7 +299,7 @@ cmdRepl numProcessors =
             ]
         mbCACert <- optional $ strOption $ mconcat
             [ long "cacrt"
-            , help "The crt file to be used as the the trusted root CA."
+            , help "The crt file to be used as the trusted root CA."
             ]
         mbClientKeyCertPair <- optional $ liftA2 ReplClient.ClientSSLKeyCertPair
             (strOption $ mconcat
@@ -704,7 +704,7 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
     targetFilePath = fromMaybe defaultDarFile mbOutFile
 
 -- | Given a path to a .dalf or a .dar return the bytes of either the .dalf file
--- or the the main dalf from the .dar
+-- or the main dalf from the .dar
 -- In addition to the bytes, we also return the basename of the dalf file.
 getDalfBytes :: FilePath -> IO (B.ByteString, FilePath)
 getDalfBytes fp

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -93,7 +93,7 @@ object ReplServiceMain extends App {
 
       opt[String]("cacrt")
         .optional()
-        .text("TLS: The crt file to be used as the the trusted root CA.")
+        .text("TLS: The crt file to be used as the trusted root CA.")
         .validate(path => validatePath(path, "The file specified via --cacrt does not exist"))
         .action((path, arguments) =>
           arguments.copy(tlsConfig = arguments.tlsConfig.fold(

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -287,7 +287,7 @@ commandParser = subparser $ fold
             ]
         mbCACert <- optional $ strOption $ mconcat
             [ long "cacrt"
-            , help "The crt file to be used as the the trusted root CA."
+            , help "The crt file to be used as the trusted root CA."
             ]
         mbClientKeyCertPair <- optional $ liftA2 ClientSSLKeyCertPair
             (strOption $ mconcat

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/ImmArray.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
   * they keep referring to the same underlying array.
   *
   * Note that we _very intentionally_ do _not_ make this an instance of any sorts of `Seq`, since
-  * using `Seq` encourages patterns where the the performance of what you're doing is totally
+  * using `Seq` encourages patterns where the performance of what you're doing is totally
   * unclear. Use `toSeq` if you want a `Seq`, and think about what that means.
   */
 final class ImmArray[+A] private (

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
@@ -121,7 +121,7 @@ object RunnerConfig {
 
     opt[String]("cacrt")
       .optional()
-      .text("TLS: The crt file to be used as the the trusted root CA.")
+      .text("TLS: The crt file to be used as the trusted root CA.")
       .validate(path => validatePath(path, "The file specified via --cacrt does not exist"))
       .action((path, arguments) =>
         arguments.copy(tlsConfig = arguments.tlsConfig.fold(

--- a/docs/source/concepts/ledger-model/ledger-structure.rst
+++ b/docs/source/concepts/ledger-model/ledger-structure.rst
@@ -176,13 +176,12 @@ proper subaction of the exercise on the `Iou Bank A`.
    :align: center
    :width: 60%
 
-Similarly, a **subtransaction** of a transaction is either the
-transaction itself, or a **proper subtransaction**: a transaction
-obtained by removing at least one action, or replacing it by a subtransaction
-of its consequences. For example, given the the transaction
-consisting of just one action, the paint offer acceptance, the image
-below shows all its proper subtransactions on the right (yellow boxes).
-
+Similarly, a **subtransaction** of a transaction is either the transaction
+itself, or a **proper subtransaction**: a transaction obtained by removing at
+least one action, or replacing it by a subtransaction of its consequences. For
+example, given the transaction consisting of just one action, the paint offer
+acceptance, the image below shows all its proper subtransactions on the right
+(yellow boxes).
 
 .. https://www.lucidchart.com/documents/edit/a4735a72-2d27-485c-a3ed-0c053dab0e11
 .. image:: ./images/subtransactions-paint-offer.svg

--- a/docs/source/daml/intro/6_Parties.rst
+++ b/docs/source/daml/intro/6_Parties.rst
@@ -151,7 +151,7 @@ The authorizers of transactions are:
 An authorization example
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The final transaction in the scenario of the the source file for this section is authorized as follows, ignoring fetches:
+The final transaction in the scenario of the source file for this section is authorized as follows, ignoring fetches:
 
 - Bob submits the transaction so he's the authorizer on the root transaction.
 - The root transaction has a single action, which is to exercise ``Send_Iou`` on a ``IouSender`` contract with Bob as ``sender`` and Charlie as ``receiver``. Since the controller of that choice is the ``sender``, Bob is the required authorizer.

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -88,7 +88,7 @@ From a DAML project directory:
             TLS: The crt file to be used as the cert chain.
             Required for client authentication.
       --cacrt <value>
-            TLS: The crt file to be used as the the trusted root CA.
+            TLS: The crt file to be used as the trusted root CA.
       --tls
             TLS: Enable tls. This is redundant if --pem, --crt or --cacrt are set
       --package-reload-interval <value>

--- a/docs/source/tools/extractor.rst
+++ b/docs/source/tools/extractor.rst
@@ -155,7 +155,7 @@ To see the full list of options, run the ``--help`` command, which gives the fol
     --pem <value>            TLS: The pem file to be used as the private key.
     --crt <value>            TLS: The crt file to be used as the cert chain.
                              Required if any other TLS parameters are set.
-    --cacrt <value>          TLS: The crt file to be used as the the trusted root CA.
+    --cacrt <value>          TLS: The crt file to be used as the trusted root CA.
 
   Authentication:
     --access-token-file <value>

--- a/language-support/ts/daml-ledger/README.md
+++ b/language-support/ts/daml-ledger/README.md
@@ -11,7 +11,7 @@ Comprehensive documentation for `@daml/ledger` can be found
 ## Usage
 
 The best way to get you started quickly is to look at [Create DAML
-App](https://github.com/digital-asset/create-daml-app) and to read the the [Quickstart
+App](https://github.com/digital-asset/create-daml-app) and to read the [Quickstart
 Guide](https://docs.daml.com/getting-started/quickstart.html).
 
 We recommend to use the [React](https://reactjs.org) framework and the `@daml/react` library to

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/party_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/party_management_service.proto
@@ -60,7 +60,7 @@ service PartyManagementService {
   // the consensus layer and call rejected if the identifier is already present.
   // canton: completely different globally unique identifier is allocated.
   // Behind the scenes calls to an internal protocol are made. As that protocol
-  // is richer than the the surface protocol, the arguments take implicit values
+  // is richer than the surface protocol, the arguments take implicit values
   rpc AllocateParty (AllocatePartyRequest) returns (AllocatePartyResponse);
 }
 

--- a/ledger-service/cli-opts/src/main/scala/ledger/api/tls/TlsConfigurationCli.scala
+++ b/ledger-service/cli-opts/src/main/scala/ledger/api/tls/TlsConfigurationCli.scala
@@ -36,7 +36,7 @@ object TlsConfigurationCli {
 
     opt[String]("cacrt")
       .optional()
-      .text("TLS: The crt file to be used as the the trusted root CA.")
+      .text("TLS: The crt file to be used as the trusted root CA.")
       .validate(validatePath(_, "The file specified via --cacrt does not exist"))
       .action { (path, c) =>
         enableSet(_ copy (trustCertCollectionFile = Some(Paths.get(path).toFile)), c)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -92,7 +92,7 @@ object Cli {
 
     opt[String]("cacrt")
       .optional()
-      .text("TLS: The crt file to be used as the the trusted root CA. Applied to all endpoints.")
+      .text("TLS: The crt file to be used as the trusted root CA. Applied to all endpoints.")
       .action(cacrtConfig)
 
     opt[Double](name = "timeout-scale-factor")
@@ -154,7 +154,7 @@ object Cli {
       .action((inc, c) => c.copy(performanceTestsReport = Some(inc)))
       .optional()
       .text(
-        "The path of the the benchmark report file produced by performance tests (default: stdout).")
+        "The path of the benchmark report file produced by performance tests (default: stdout).")
 
     opt[Unit]("all-tests")
       .text("DEPRECATED: All tests are always run by default.")

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -138,7 +138,7 @@ object Config {
           config.withTlsConfig(c => c.copy(keyCertChainFile = Some(new File(path)))))
       opt[String]("cacrt")
         .optional()
-        .text("TLS: The crt file to be used as the the trusted root CA.")
+        .text("TLS: The crt file to be used as the trusted root CA.")
         .action((path, config) =>
           config.withTlsConfig(c => c.copy(trustCertCollectionFile = Some(new File(path)))))
 

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/ReadService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/ReadService.scala
@@ -146,7 +146,7 @@ trait ReadService extends ReportsHealth {
     *   `A`, respectively `B`.
     * The projections of `tx1` and `tx2` to the nodes visible to both `A` and `B` is the same.
     *
-    * Note that the the transaction `tx1` associated to `tid` on `p1` is not required to be the same as
+    * Note that the transaction `tx1` associated to `tid` on `p1` is not required to be the same as
     * the transaction `tx2` associated to `tid` on `p2`, as these two participants do not necessarily
     * host the same parties; and some implementations ensure data segregation on the ledger. Requiring
     * only the projections to sets of parties to be equal leaves just enough leeway for this

--- a/ledger/sandbox/README.md
+++ b/ledger/sandbox/README.md
@@ -31,7 +31,7 @@ as run from the main project root directory (adjust the location of the JAR acco
   <archive>...             Daml archives to load. Only DAML-LF v1 Archives are currently supported.
   --pem <value>            TLS: The pem file to be used as the private key
   --crt <value>            TLS: The crt file to be used as the cert chain. Required if any other TLS parameters are set.
-  --cacrt <value>          TLS: The crt file to be used as the the trusted root CA.
+  --cacrt <value>          TLS: The crt file to be used as the trusted root CA.
   --help                   Print the usage text
 ```
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/cli/Cli.scala
@@ -124,7 +124,7 @@ object Cli {
 
       opt[String]("cacrt")
         .optional()
-        .text("TLS: The crt file to be used as the the trusted root CA.")
+        .text("TLS: The crt file to be used as the trusted root CA.")
         .action((path, config) =>
           config.copy(tlsConfig = config.tlsConfig
             .fold(Some(TlsConfiguration(enabled = true, None, None, Some(new File(path)))))(c =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
@@ -118,7 +118,7 @@ object Arguments {
 
       opt[String]("cacrt")
         .optional()
-        .text("TLS: The crt file to be used as the the trusted root CA.")
+        .text("TLS: The crt file to be used as the trusted root CA.")
         .validate(path => validatePath(path, "The file specified via --cacrt does not exist"))
         .action((path, arguments) =>
           arguments.copy(tlsConfig = arguments.tlsConfig.fold(

--- a/navigator/frontend/src/ui-core/src/api/DamlLfType.ts
+++ b/navigator/frontend/src/ui-core/src/api/DamlLfType.ts
@@ -104,7 +104,7 @@ export function mapTypeVars(t: DamlLfType, f: (t: DamlLfTypeVar) => DamlLfType):
 
 /**
  * Instantiate a type constructor.
- * `tc.name` should the the identifier of the given `ddt`
+ * `tc.name` should the identifier of the given `ddt`
  * The result is a closed type (i.e., one without type variables).
  */
 export function instantiate(tc: DamlLfTypeCon, ddt: DamlLfDefDataType): DamlLfDataType {

--- a/release/src/Upload.hs
+++ b/release/src/Upload.hs
@@ -141,7 +141,7 @@ prepareStagingRepo baseRequest manager = do
     -- Note in Profile IDs
     --
     -- Currently the profile IDs are hardcoded. The IDs are fixed to the "namespaces" ('com.daml' and 'com.digitialasset')
-    -- attached to the Digitalasset accounts on the the Sonatype OSSRH.
+    -- attached to the Digitalasset accounts on the Sonatype OSSRH.
     --
 
     --

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -110,7 +110,7 @@ object RunnerConfig {
 
     opt[String]("cacrt")
       .optional()
-      .text("TLS: The crt file to be used as the the trusted root CA.")
+      .text("TLS: The crt file to be used as the trusted root CA.")
       .validate(path => validatePath(path, "The file specified via --cacrt does not exist"))
       .action((path, arguments) =>
         arguments.copy(tlsConfig = arguments.tlsConfig.fold(


### PR DESCRIPTION
I was trying to find that one line I wanted to save from #6720, and `grep` showed me way too many results.

```
s/the the /the /
```

CHANGELOG_BEGIN
CHANGELOG_END