### PR TITLE
Speedy Safe ANF

### DIFF
--- a/compiler/damlc/tests/daml-test-files/OverAppliedFoldEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/OverAppliedFoldEvalOrder.daml
@@ -1,12 +1,12 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR Aborted: BOOM
+-- @ERROR Aborted: OverAppliedFoldEvalOrder OK
 
 module OverAppliedFoldEvalOrder where
 
 boom = scenario do
   let id x = x
-  let boomCompose _ _ = error "BOOM"
-  let _ = foldr boomCompose id [id] (error "BANG")
+  let boomCompose _ _ = error "OverAppliedFoldEvalOrder OK"
+  let _ = foldr boomCompose id [id] (error "OverAppliedFoldEvalOrder failed")
   pure ()

--- a/compiler/damlc/tests/daml-test-files/OverAppliedFoldEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/OverAppliedFoldEvalOrder.daml
@@ -1,0 +1,12 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @ERROR Aborted: BOOM
+
+module OverAppliedFoldEvalOrder where
+
+boom = scenario do
+  let id x = x
+  let boomCompose _ _ = error "BOOM"
+  let _ = foldr boomCompose id [id] (error "BANG")
+  pure ()

--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -12,7 +12,6 @@
 --
 -- @ERROR Aborted: EvTyAbsErasableErr OK
 -- @ERROR Aborted: overApply OK
--- @ERROR Aborted: errorError OK
 -- @ERROR Aborted: EvExpAppErr1 OK
 -- @ERROR Aborted: EvExpAppErr2 OK
 -- @ERROR Aborted: EvExpLetErr OK

--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -12,6 +12,7 @@
 --
 -- @ERROR Aborted: EvTyAbsErasableErr OK
 -- @ERROR Aborted: overApply OK
+-- @ERROR Aborted: errorError OK
 -- @ERROR Aborted: EvExpAppErr1 OK
 -- @ERROR Aborted: EvExpAppErr2 OK
 -- @ERROR Aborted: EvExpLetErr OK
@@ -61,6 +62,10 @@ overApply = scenario do
   let f x = error "overApply OK"
   let _ = f 1 (error "overApply Failed")
   let _ = f 1 2
+  pure ()
+
+errorError = scenario do
+  let _ = (error "errorError OK") (error "errorError Failed")
   pure ()
 
 evExpAppErr1 = scenario do

--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -64,10 +64,6 @@ overApply = scenario do
   let _ = f 1 2
   pure ()
 
-errorError = scenario do
-  let _ = (error "errorError OK") (error "errorError Failed")
-  pure ()
-
 evExpAppErr1 = scenario do
   let _ = (error "EvExpAppErr1 OK") (error "EvExpAppErr1 failed")
   pure ()

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -12,6 +12,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.engine.script._
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{Ast, LanguageVersion}
+import com.daml.lf.speedy.AExpr
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.{Compiler, SValue, SExpr, SError}
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
@@ -190,7 +191,7 @@ class ReplService(
     mat: Materializer)
     extends ReplServiceGrpc.ReplServiceImplBase {
   var packages: Map[PackageId, Package] = Map.empty
-  var compiledDefinitions: Map[SDefinitionRef, SExpr] = Map.empty
+  var compiledDefinitions: Map[SDefinitionRef, AExpr] = Map.empty
   var results: Seq[SValue] = Seq()
   implicit val ec_ = ec
   implicit val esf_ = esf

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -191,7 +191,7 @@ class ReplService(
     mat: Materializer)
     extends ReplServiceGrpc.ReplServiceImplBase {
   var packages: Map[PackageId, Package] = Map.empty
-  var compiledDefinitions: Map[SDefinitionRef, AExpr] = Map.empty
+  private var compiledDefinitions: Map[SDefinitionRef, AExpr] = Map.empty
   var results: Seq[SValue] = Seq()
   implicit val ec_ = ec
   implicit val esf_ = esf

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -15,7 +15,7 @@ import com.daml.lf.speedy.Compiler
 import com.daml.lf.speedy.ScenarioRunner
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.Speedy
-import com.daml.lf.speedy.SExpr
+import com.daml.lf.speedy.AExpr
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SExpr.{LfDefRef, SDefinitionRef}
 import com.daml.lf.transaction.TransactionVersions
@@ -53,10 +53,10 @@ class Context(val contextId: Context.ContextId) {
   val homePackageId: PackageId = PackageId.assertFromString("-homePackageId-")
 
   private var extPackages: Map[PackageId, Ast.Package] = HashMap.empty
-  private var extDefns: Map[SDefinitionRef, SExpr] = HashMap.empty
+  private var extDefns: Map[SDefinitionRef, AExpr] = HashMap.empty
   private var modules: Map[ModuleName, Ast.Module] = HashMap.empty
-  private var modDefns: Map[ModuleName, Map[SDefinitionRef, SExpr]] = HashMap.empty
-  private var defns: Map[SDefinitionRef, SExpr] = HashMap.empty
+  private var modDefns: Map[ModuleName, Map[SDefinitionRef, AExpr]] = HashMap.empty
+  private var defns: Map[SDefinitionRef, AExpr] = HashMap.empty
 
   def loadedModules(): Iterable[ModuleName] = modules.keys
   def loadedPackages(): Iterable[PackageId] = extPackages.keys
@@ -149,7 +149,7 @@ class Context(val contextId: Context.ContextId) {
     for {
       defn <- defns.get(LfDefRef(identifier))
     } yield
-      Speedy.Machine.fromScenarioSExpr(
+      Speedy.Machine.fromScenarioAExpr(
         compiledPackages,
         txSeeding,
         defn,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -22,7 +22,7 @@ import scala.collection.concurrent.{Map => ConcurrentMap}
 final class ConcurrentCompiledPackages extends MutableCompiledPackages {
   private[this] val _packages: ConcurrentMap[PackageId, Package] =
     new ConcurrentHashMap().asScala
-  private[this] val _defns: ConcurrentHashMap[speedy.SExpr.SDefinitionRef, speedy.SExpr] =
+  private[this] val _defns: ConcurrentHashMap[speedy.SExpr.SDefinitionRef, speedy.AExpr] =
     new ConcurrentHashMap()
   private[this] val _packageDeps: ConcurrentHashMap[PackageId, Set[PackageId]] =
     new ConcurrentHashMap()
@@ -32,7 +32,7 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
     new ConcurrentHashMap().asScala
 
   override def getPackage(pId: PackageId): Option[Package] = _packages.get(pId)
-  override def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
+  override def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.AExpr] =
     Option(_defns.get(dref))
 
   override def packageLanguageVersion: PartialFunction[PackageId, LanguageVersion] =

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -8,7 +8,7 @@ import com.daml.lf.command._
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.{PackageId, ParticipantId, Party}
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.{InitialSeeding, Pretty, SExpr}
+import com.daml.lf.speedy.{InitialSeeding, Pretty}
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{
@@ -290,12 +290,11 @@ class Engine(config: Engine.Config = Engine.StableConfig) {
     runSafely(
       loadPackages(commands.foldLeft(Set.empty[PackageId])(_ + _.templateId.packageId).toList)
     ) {
-      val sexpr = compiledPackages.compiler.unsafeCompile(commands)
       val machine = Machine(
         compiledPackages = compiledPackages,
         submissionTime = submissionTime,
         initialSeeding = seeding,
-        expr = SExpr.SEApp(sexpr, Array(SExpr.SEValue.Token)),
+        anf = Machine.makeApplyToToken(compiledPackages.compiler.unsafeCompile(commands)),
         globalCids = globalCids,
         committers = submitters,
         outputTransactionVersions = config.allowedOutputTransactionVersions,

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -53,6 +53,7 @@ da_scala_test_suite(
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_scalaz_scalaz_scalacheck_binding_2_12",
         "@maven//:org_slf4j_slf4j_api",
+        "@maven//:org_typelevel_paiges_core_2_12",
     ],
 )
 

--- a/daml-lf/interpreter/perf/BUILD.bazel
+++ b/daml-lf/interpreter/perf/BUILD.bazel
@@ -32,6 +32,8 @@ da_scala_binary(
     data = [
         ":Examples.dar",
         ":Examples.dar.pp",
+        ":JsonParser.dar",
+        ":JsonParser.dar.pp",
     ],
     main_class = "com.daml.lf.speedy.explore.ExploreDar",
     runtime_deps = [

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -30,8 +30,8 @@ object PlaySpeedy {
 
     names.foreach { name =>
       val (expected, expr) = examples(name)
-      val converted = compiler.unsafeClosureConvert(expr)
-      val machine = Speedy.Machine.fromPureSExpr(noPackages, converted)
+      val anf = compiler.unsafeCompilationPipeline(expr)
+      val machine = Speedy.Machine.fromPureAExpr(noPackages, anf)
       runMachine(name, machine, expected)
     }
   }
@@ -84,7 +84,7 @@ object PlaySpeedy {
     }
   }
 
-  final case class MachineProblem(s: String) extends RuntimeException(s, null, false, false)
+  final case class MachineProblem(s: String) extends RuntimeException(s)
 
   def examples: Map[String, (Int, SExpr)] = {
 
@@ -97,6 +97,8 @@ object PlaySpeedy {
 
     def subtract2(x: SExpr, y: SExpr): SExpr = SEApp(SEBuiltin(SBSubInt64), Array(x, y))
     val subtract = SEAbs(2, subtract2(SEVar(2), SEVar(1)))
+
+    val identity = SEAbs(1, SEVar(1))
 
     def twice2(f: SExpr, x: SExpr): SExpr = SEApp(f, Array(SEApp(f, Array(x))))
     val twice = SEAbs(2, twice2(SEVar(2), SEVar(1)))
@@ -117,6 +119,10 @@ object PlaySpeedy {
         "subF", //88-55
         33,
         SEApp(subtract, Array(num(88), num(55)))),
+      (
+        "id-id", // id id 77
+        77,
+        SEApp(identity, Array(identity, num(77)))),
       (
         "thrice", // thrice (\x -> x - 1) 0
         -3,

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -30,6 +30,7 @@ object PlaySpeedy {
   }
 
   def parseArgs(args0: List[String]): Config = {
+    var moduleName: String = "Examples"
     var funcName: String = "triangle"
     var argValue: Long = 10
     var stacktracing: Compiler.StackTraceMode = Compiler.NoStackTrace
@@ -43,15 +44,19 @@ object PlaySpeedy {
       case "--stacktracing" :: args =>
         stacktracing = Compiler.FullStackTrace
         loop(args)
+      case "--base" :: x :: args =>
+        moduleName = x
+        loop(args)
       case x :: args =>
         funcName = x
         loop(args)
     }
     loop(args0)
-    Config(funcName, argValue, stacktracing)
+    Config(moduleName, funcName, argValue, stacktracing)
   }
 
   final case class Config(
+      moduleName: String,
       funcName: String,
       argValue: Long,
       stacktracing: Compiler.StackTraceMode,
@@ -60,8 +65,8 @@ object PlaySpeedy {
   def main(args0: List[String]) = {
 
     println("Start...")
-    val base = "Examples"
     val config = parseArgs(args0)
+    val base = config.moduleName
     val dar = s"daml-lf/interpreter/perf/${base}.dar"
     val darFile = new File(rlocation(dar))
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
@@ -7,18 +7,18 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.language.Ast.Package
 import com.daml.lf.language.LanguageVersion
 import com.daml.lf.speedy.SExpr.SDefinitionRef
-import com.daml.lf.speedy.{Compiler, SExpr}
+import com.daml.lf.speedy.{Compiler, AExpr}
 
 /** Trait to abstract over a collection holding onto DAML-LF package definitions + the
   * compiled speedy expressions.
   */
 abstract class CompiledPackages {
   def getPackage(pkgId: PackageId): Option[Package]
-  def getDefinition(dref: SDefinitionRef): Option[SExpr]
+  def getDefinition(dref: SDefinitionRef): Option[AExpr]
 
   def packages: PartialFunction[PackageId, Package] = Function.unlift(this.getPackage)
   def packageIds: Set[PackageId]
-  def definitions: PartialFunction[SDefinitionRef, SExpr] =
+  def definitions: PartialFunction[SDefinitionRef, AExpr] =
     Function.unlift(this.getDefinition)
 
   def packageLanguageVersion: PartialFunction[PackageId, LanguageVersion]
@@ -44,13 +44,13 @@ abstract class CompiledPackages {
 
 final class PureCompiledPackages private (
     packages: Map[PackageId, Package],
-    defns: Map[SDefinitionRef, SExpr],
+    defns: Map[SDefinitionRef, AExpr],
     stacktracing: Compiler.StackTraceMode,
     profiling: Compiler.ProfilingMode,
 ) extends CompiledPackages {
   override def packageIds: Set[PackageId] = packages.keySet
   override def getPackage(pkgId: PackageId): Option[Package] = packages.get(pkgId)
-  override def getDefinition(dref: SDefinitionRef): Option[SExpr] = defns.get(dref)
+  override def getDefinition(dref: SDefinitionRef): Option[AExpr] = defns.get(dref)
   override def stackTraceMode = stacktracing
   override def profilingMode = profiling
 
@@ -77,7 +77,7 @@ object PureCompiledPackages {
     */
   private[lf] def apply(
       packages: Map[PackageId, Package],
-      defns: Map[SDefinitionRef, SExpr],
+      defns: Map[SDefinitionRef, AExpr],
       stacktracing: Compiler.StackTraceMode,
       profiling: Compiler.ProfilingMode
   ): PureCompiledPackages =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/AExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/AExpr.scala
@@ -6,4 +6,4 @@ package com.daml.lf.speedy
 /**
   * The even more simplified AST for the speedy interpreter, following ANF transformation.
   */
-private[lf] final case class AExpr(wrapped: SExpr) extends Serializable
+final case class AExpr(wrapped: SExpr) extends Serializable

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/AExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/AExpr.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+
+/**
+  * The even more simplified AST for the speedy interpreter, following ANF transformation.
+  */
+private[lf] final case class AExpr(wrapped: SExpr) extends Serializable

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -1,0 +1,431 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+
+/**
+  Transformation to ANF based AST for the speedy interpreter.
+
+  "ANF" stands for A-normal form.
+  In essence it means that sub-expressions of most expression nodes are in atomic-form.
+  The one exception is the let-expression.
+
+  Atomic mean: a variable reference (ELoc), a (literal) value, or a builtin.
+  This is captured by any speedy-expression which `extends SExprAtomic`.
+
+  TODO: <EXAMPLE HERE>
+
+  The reason we convert to ANF is to improve the efficiency of speedy execution: the
+  execution engine can take advantage of the atomic assumption, and often removes
+  additional execution steps - in particular the pushing of continuations to allow
+  execution to continue after a compound expression is reduced to a value.
+
+  The speedy machine now expects that it will never have to execute a non-ANF expression,
+  crashing at runtime if one is encountered. In particular we must ensure that the
+  expression forms: SEAppGeneral and SECase are removed, and replaced by the simpler
+  SEAppAtomic and SECaseAtomic (plus SELet as required).
+
+  */
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.Compiler.CompilationError
+
+import scala.annotation.tailrec
+
+private[lf] object Anf {
+
+  /*** Entry point for the ANF transformation phase */
+  @throws[CompilationError]
+  def flattenToAnf(exp: SExpr): AExpr = {
+    val depth = DepthA(0)
+    val env = initEnv
+    flattenExp(depth, env, exp, flattenedExpression => Land(flattenedExpression)).bounce
+  }
+
+  /**
+    The transformation code is implemented using a what looks like
+    continuation-passing style; the code routinely creates new functions to
+    pass down the stack as it explores the expression tree. This is quite
+    common for translation to ANF. In general, naming nested compound
+    expressions requires turning an expression kind of inside out, lifting the
+    introduced let-expression up to the the nearest enclosing abstraction or
+    case-branch.
+
+    For speedy, the ANF pass occurs after translation to De Brujin and closure
+    conversions, which adds the additional complication of re-indexing the
+    variable indexes. This is achieved by tracking the old and new depth & the
+    mapping between them. See the types: DepthE, DepthA and Env.
+
+    Using a coding style that looks like CPS is a natural way to express the
+    ANF transformation. However, this means the transformation is very
+    stack-intensive. To address that, we need the code to be in "true" CPS
+    form, which is not quite the same as the semantics required by the ANF
+    transform. Having the code in ANF form allows us to use the trampoline
+    technique to execute the computation in constant stack space.
+
+    This means that, in some sense, the following code has two (interleaved)
+    levels of CPS-looking style. For the sake of clarity, in further comments
+    as well as in the code, we will use the term "continuation" and the
+    variable names "k", "txK" strictly for the "true" continuations that have
+    been added to achieve constant stack space, and use the term
+    "transformation function" and the variable names "transform", "tx" for
+    the functions that express the semantics of the ANF transformation.
+
+    Things are further muddied by the following:
+    1. A number of top-level functions defined in this object also qualify as
+       "transformation functions", even though they themselves receive
+       transformation functions as arguments and/or define new ones on the fly
+       (flattenExp, transformLet1, flattenAlts, transformExp, atomizeExp,
+       atomizeExps).
+    2. To achieve full CPS, transformation functions themselves need to accept
+       (and apply) a continuation.
+
+    Not all functions in this object are in CPS (only the ones that are part of
+    the main recursive loop), but those that do always take the continuation as
+    their last argument.
+
+    */
+  /** `DepthE` tracks the stack-depth of the original expression being traversed */
+  private[this] final case class DepthE(n: Int) {
+    def incr(m: Int): DepthE = DepthE(n + m)
+  }
+
+  /** `DepthA` tracks the stack-depth of the ANF expression being constructed */
+  private[this] final case class DepthA(n: Int) {
+    def incr(m: Int): DepthA = DepthA(n + m)
+  }
+
+  /** `Env` contains the mapping from old to new depth, as well as the old-depth as these
+    * components always travel together */
+  private[this] final case class Env(absMap: Map[DepthE, DepthA], oldDepth: DepthE)
+
+  private[this] val initEnv: Env = Env(absMap = Map.empty, oldDepth = DepthE(0))
+
+  private[this] def trackBindings(depth: DepthA, env: Env, n: Int): Env = {
+    val extra = (0 until n).map(i => (env.oldDepth.incr(i), depth.incr(i)))
+    Env(absMap = env.absMap ++ extra, oldDepth = env.oldDepth.incr(n))
+  }
+
+  // Returning a Bounce object allows a function to evict itself from the
+  // current stack.
+  private[this] sealed abstract class Trampoline[T] {
+    @tailrec
+    final def bounce: T = this match {
+      case Land(x) => x
+      case Bounce(continue) => continue().bounce
+    }
+  }
+
+  private[this] final case class Land[T](x: T) extends Trampoline[T]
+  private[this] final case class Bounce[T](continue: () => Trampoline[T]) extends Trampoline[T]
+
+  /**
+    * Tx is the type for the stacked transformation functions managed by the ANF
+    * transformation, mainly transformExp.
+    *
+    * All of the transformation functions would, without CPS, return an AExpr,
+    * so that is the input type of the continuation.
+    *
+    * Both type parameters are ultimately needed because SCaseAlt does not
+    * extend SExpr. If it did, T would always be SExpr and A would always be
+    * AExpr.
+    *
+    * Note that Scala does not seem to be able to generate anonymous function of
+    * a parameterized type, so we use nested `defs` instead.
+    *
+    * @tparam T The type of expression this will be applied to.
+    * @tparam A The return type of the continuation (minus the Trampoline
+    *           wrapping).
+    */
+  private[this] type Tx[T, A] = ((DepthA, T, K[AExpr, A]) => Trampoline[A])
+
+  /**
+    * K Is the type for contiunations.
+    *
+    * @tparam T Type the function would have returned had it not been in CPS.
+    * @tparam A The return type of the continuation (minus the Trampoline
+    *           wrapping).
+    */
+  private[this] type K[T, A] = T => Trampoline[A]
+
+  /** During conversion we need to deal with bindings which are made/found at a given
+    absolute stack depth. These are represented using `AbsBinding`. An absolute stack
+    depth is the offset from the depth of the stack when the function is entered. We call
+    it absolute because an offset doesn't change as new bindings are pushed onto the
+    stack.
+
+    Note the contrast with the expression form `ELocS` which contains a relative offset
+    from the end of the stack. This relative-position is used in both the original
+    expression which we traverse AND the new ANF expression we are constructing. The
+    relative-offset to a binding varies as new bindings are pushed on the stack.
+    */
+  private[this] case class AbsBinding(abs: DepthA)
+
+  private[this] def makeAbsoluteB(env: Env, rel: Int): AbsBinding = {
+    val oldAbs = env.oldDepth.incr(-rel)
+    env.absMap.get(oldAbs) match {
+      case None => throw CompilationError(s"makeAbsoluteB(env=$env,rel=$rel)")
+      case Some(abs) => AbsBinding(abs)
+    }
+  }
+
+  private[this] def makeRelativeB(depth: DepthA, binding: AbsBinding): Int = {
+    (depth.n - binding.abs.n)
+  }
+
+  private[this] type AbsAtom = Either[SExprAtomic, AbsBinding]
+
+  private[this] def makeAbsoluteA(env: Env, atom: SExprAtomic): AbsAtom = atom match {
+    case SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case x => Left(x)
+  }
+
+  private[this] def makeRelativeA(depth: DepthA)(atom: AbsAtom): SExprAtomic = atom match {
+    case Left(x: SELocS) => throw CompilationError(s"makeRelativeA: unexpected: $x")
+    case Left(atom) => atom
+    case Right(binding) => SELocS(makeRelativeB(depth, binding))
+  }
+
+  private[this] type AbsLoc = Either[SELoc, AbsBinding]
+
+  private[this] def makeAbsoluteL(env: Env, loc: SELoc): AbsLoc = loc match {
+    case SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case x: SELocA => Left(x)
+    case x: SELocF => Left(x)
+  }
+
+  private[this] def makeRelativeL(depth: DepthA)(loc: AbsLoc): SELoc = loc match {
+    case Left(x: SELocS) => throw CompilationError(s"makeRelativeL: unexpected: $x")
+    case Left(loc) => loc
+    case Right(binding) => SELocS(makeRelativeB(depth, binding))
+  }
+
+  private[this] def flattenExp[A](
+      depth: DepthA,
+      env: Env,
+      exp: SExpr,
+      k: K[AExpr, A]): Trampoline[A] = {
+    def tx(_d: DepthA, sexpr: SExpr, txK: K[AExpr, A]): Trampoline[A] = {
+      val _ = _d
+      Bounce(() => txK(AExpr(sexpr)))
+    }
+    Bounce(() => transformExp[A](depth, env, exp, tx, k))
+  }
+
+  private[this] def transformLet1[A](
+      depth: DepthA,
+      env: Env,
+      rhs: SExpr,
+      body: SExpr,
+      transform: Tx[SExpr, A],
+      k: K[AExpr, A]): Trampoline[A] = {
+    def tx(depth: DepthA, rhs: SExpr, txK: K[AExpr, A]): Trampoline[A] = {
+      val depth1 = depth.incr(1)
+      val env1 = trackBindings(depth, env, 1)
+      Bounce(
+        () =>
+          transformExp(
+            depth1,
+            env1,
+            body,
+            transform,
+            body1 => Bounce(() => txK(AExpr(SELet1(rhs, body1.wrapped))))))
+    }
+    Bounce(() => transformExp(depth, env, rhs, tx, k))
+  }
+
+  private[this] def flattenAlts[A](
+      depth: DepthA,
+      env: Env,
+      alts: Array[SCaseAlt],
+      k: K[Array[SCaseAlt], A]): Trampoline[A] = {
+    // Note: this could be made properly CPS and thus constant stack through
+    // trampoline by implementing a CPS version of map. However, map on an
+    // array is implemented as a loop so this should be fine.
+    Bounce(() =>
+      k(alts.map {
+        case SCaseAlt(pat, body0) =>
+          val n = patternNArgs(pat)
+          val env1 = trackBindings(depth, env, n)
+          flattenExp(depth.incr(n), env1, body0, body => {
+            Land(SCaseAlt(pat, body.wrapped))
+          }).bounce
+      }))
+  }
+
+  private[this] def patternNArgs(pat: SCasePat): Int = pat match {
+    case _: SCPEnum | _: SCPPrimCon | SCPNil | SCPDefault | SCPNone => 0
+    case _: SCPVariant | SCPSome => 1
+    case SCPCons => 2
+  }
+
+  /** `transformExp` is the function at the heart of the ANF transformation.
+    *  You can read its type as saying: "Caller, give me a general expression
+    *  `exp`, (& depth/env info), and a transformation function `transform`
+    *  which says what you want to do with the transformed expression. Then I
+    *  will do the transform, and call `transform` with it. I reserve the right
+    *  to wrap further expression-AST around the expression returned by
+    *  `transform`.
+    *
+    *  See: `atomizeExp` for an instance where this wrapping occurs.
+    *
+    *  Note: this wrapping is the reason why we need a "second" CPS transform to
+    *  achieve constant stack through trampoline.
+    */
+  private[this] def transformExp[A](
+      depth: DepthA,
+      env: Env,
+      exp: SExpr,
+      transform: Tx[SExpr, A],
+      k: K[AExpr, A]): Trampoline[A] =
+    exp match {
+      case atom0: SExprAtomic =>
+        val atom = makeRelativeA(depth)(makeAbsoluteA(env, atom0))
+        Bounce(() => transform(depth, atom, k))
+
+      case x: SEVal => Bounce(() => transform(depth, x, k))
+      case x: SEImportValue => Bounce(() => transform(depth, x, k))
+
+      case SEAppGeneral(func, args) => {
+        def tx2(
+            func: AbsAtom)(depth: DepthA, args: List[AbsAtom], txK: K[AExpr, A]): Trampoline[A] = {
+          val func1 = makeRelativeA(depth)(func)
+          val args1 = args.map(makeRelativeA(depth))
+          Bounce(() => transform(depth, SEAppAtomic(func1, args1.toArray), txK))
+        }
+        def tx1(depth: DepthA, func: AbsAtom, txK1: K[AExpr, A]): Trampoline[A] = {
+          Bounce(() => atomizeExps(depth, env, args.toList, tx2(func), txK1))
+        }
+        Bounce(() => atomizeExp(depth, env, func, tx1, k))
+      }
+      case SEMakeClo(fvs0, arity, body0) =>
+        val fvs = fvs0.map((loc) => makeRelativeL(depth)(makeAbsoluteL(env, loc)))
+        val body = flattenToAnf(body0).wrapped
+        Bounce(() => transform(depth, SEMakeClo(fvs, arity, body), k))
+
+      case SECase(scrut, alts0) => {
+        def tx(depth: DepthA, scrut: AbsAtom, txK: K[AExpr, A]): Trampoline[A] = {
+          val scrut1 = makeRelativeA(depth)(scrut)
+          Bounce(
+            () =>
+              flattenAlts(
+                depth,
+                env,
+                alts0,
+                alts => Bounce(() => transform(depth, SECaseAtomic(scrut1, alts), txK))))
+        }
+        Bounce(() => atomizeExp(depth, env, scrut, tx, k))
+      }
+
+      case SELet(rhss, body) =>
+        val expanded = expandMultiLet(rhss.toList, body)
+        Bounce(() => transformExp(depth, env, expanded, transform, k))
+
+      case SELet1General(rhs, body) =>
+        Bounce(() => transformLet1(depth, env, rhs, body, transform, k))
+
+      case SECatch(body0, handler0, fin0) =>
+        Bounce(
+          () =>
+            flattenExp(
+              depth,
+              env,
+              body0,
+              body =>
+                Bounce(() =>
+                  flattenExp(
+                    depth,
+                    env,
+                    handler0,
+                    handler =>
+                      Bounce(
+                        () =>
+                          flattenExp(
+                            depth,
+                            env,
+                            fin0,
+                            fin =>
+                              Bounce(() =>
+                                transform(
+                                  depth,
+                                  SECatch(body.wrapped, handler.wrapped, fin.wrapped),
+                                  k))))
+                ))
+          ))
+
+      case SELocation(loc, body) => {
+        def tx(depth: DepthA, body: SExpr, txK: K[AExpr, A]): Trampoline[A] =
+          Bounce(() => transform(depth, SELocation(loc, body), txK))
+        Bounce(() => transformExp(depth, env, body, tx, k))
+      }
+
+      case SELabelClosure(label, exp) => {
+        def tx(depth: DepthA, exp: SExpr, txK: K[AExpr, A]): Trampoline[A] =
+          Bounce(() => transform(depth, SELabelClosure(label, exp), txK))
+        Bounce(() => transformExp(depth, env, exp, tx, k))
+      }
+
+      case x: SEAbs => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SEWronglyTypeContractId => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SEVar => throw CompilationError(s"flatten: unexpected: $x")
+
+      case x: SEAppAtomicGeneral => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SEAppAtomicSaturatedBuiltin => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SELet1Builtin => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SECaseAtomic => throw CompilationError(s"flatten: unexpected: $x")
+
+    }
+
+  private[this] def atomizeExps[A](
+      depth: DepthA,
+      env: Env,
+      exps: List[SExpr],
+      transform: Tx[List[AbsAtom], A],
+      k: K[AExpr, A]): Trampoline[A] =
+    exps match {
+      case Nil => Bounce(() => transform(depth, Nil, k))
+      case exp :: exps => {
+        def tx2(
+            atom: AbsAtom)(depth: DepthA, atoms: List[AbsAtom], txK2: K[AExpr, A]): Trampoline[A] =
+          Bounce(() => transform(depth, atom :: atoms, txK2))
+        def tx1(depth: DepthA, atom: AbsAtom, txK1: K[AExpr, A]): Trampoline[A] =
+          Bounce(() => atomizeExps(depth, env, exps, tx2(atom), txK1))
+        Bounce(() => atomizeExp(depth, env, exp, tx1, k))
+      }
+    }
+
+  private[this] def atomizeExp[A](
+      depth: DepthA,
+      env: Env,
+      exp: SExpr,
+      transform: Tx[AbsAtom, A],
+      k: K[AExpr, A]): Trampoline[A] = {
+    exp match {
+      case ea: SExprAtomic => Bounce(() => transform(depth, makeAbsoluteA(env, ea), k))
+      case _ => {
+        def tx(depth: DepthA, anf: SExpr, txK: K[AExpr, A]): Trampoline[A] = {
+          val atom = Right(AbsBinding(depth))
+          Bounce(
+            () =>
+              transform(
+                depth.incr(1),
+                atom,
+                body => Bounce(() => txK(AExpr(SELet1(anf, body.wrapped))))))
+        }
+        Bounce(() => transformExp(depth, env, exp, tx, k))
+      }
+    }
+  }
+
+  private[this] def expandMultiLet(rhss: List[SExpr], body: SExpr): SExpr = {
+    //loop over rhss in reverse order
+    @tailrec
+    def loop(acc: SExpr, xs: List[SExpr]): SExpr = {
+      xs match {
+        case Nil => acc
+        case rhs :: xs => loop(SELet1General(rhs, acc), xs)
+      }
+    }
+    loop(body, rhss.reverse)
+  }
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -277,7 +277,7 @@ private[lf] object Anf {
         val safeFunc =
           func match {
             // we know that trivially in these two cases
-            case _: SEBuiltin => true
+            case SEBuiltin(b) => (args.size <= b.arity)
             case _: SEBuiltinRecursiveDefinition => (args.size <= 3)
             case _ => false
           }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -278,7 +278,7 @@ private[lf] object Anf {
           func match {
             // we know that trivially in these two cases
             case _: SEBuiltin => true
-            case _: SEBuiltinRecursiveDefinition => true
+            case _: SEBuiltinRecursiveDefinition => (args.size <= 3)
             case _ => false
           }
         // It's also safe to perform ANF for applications of a single argument.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -278,7 +278,7 @@ private[lf] object Anf {
           func match {
             // we know that trivially in these two cases
             case SEBuiltin(b) => (args.size <= b.arity)
-            case _: SEBuiltinRecursiveDefinition => (args.size <= 3)
+            case r: SEBuiltinRecursiveDefinition => (args.size <= r.arity)
             case _ => false
           }
         // It's also safe to perform ANF for applications of a single argument.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -24,22 +24,21 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
       var ebuiltin: Int = 0,
       var eval: Int = 0,
       var elocation: Int = 0,
-      var elet: Int = 0,
-      var ecase: Int = 0,
+      var eletG: Int = 0,
+      var elet1: Int = 0,
+      var eletB: Int = 0,
+      var ecaseE: Int = 0,
+      var ecaseA: Int = 0,
       var erecdef: Int = 0,
       var ecatch: Int = 0,
       var eimportvalue: Int = 0,
       var ewrongcid: Int = 0,
       // kont classification (ctrlValue)
       var kfinished: Int = 0,
-      var karg: Int = 0,
-      var kfun: Int = 0,
-      var kbuiltin: Int = 0,
-      var kpap: Int = 0,
+      var koverapp: Int = 0,
       var kpushto: Int = 0,
       var kcacheval: Int = 0,
       var klocation: Int = 0,
-      var kmatch: Int = 0,
       var kcatch: Int = 0,
   ) {
     def steps = ctrlExpr + ctrlValue
@@ -57,21 +56,20 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
         ("- ebuiltin", ebuiltin),
         ("- eval", eval),
         ("- elocation", elocation),
-        ("- elet", elet),
-        ("- ecase", ecase),
+        ("- eletG", eletG),
+        ("- elet1", elet1),
+        ("- eletB", eletB),
+        ("- ecaseE", ecaseE),
+        ("- ecaseA", ecaseA),
         ("- erecdef", erecdef),
         ("- ecatch", ecatch),
         ("- eimportvalue", eimportvalue),
         ("CtrlValue:", ctrlValue),
         ("- kfinished", kfinished),
-        ("- karg", karg),
-        ("- kfun", kfun),
-        ("- kbuiltin", kbuiltin),
-        ("- kpap", kpap),
+        ("- koverapp", koverapp),
         ("- kpushto", kpushto),
         ("- kcacheval", kcacheval),
         ("- klocation", klocation),
-        ("- kmatch", kmatch),
         ("- kcatch", kcatch),
       ).map { case (tag, n) => s"$tag : $n" }.mkString("\n")
     }
@@ -85,7 +83,9 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
       classifyKont(kont, counts)
     } else {
       counts.ctrlExpr += 1
-      classifyExpr(machine.ctrl, counts)
+      if (machine.ctrl != null) {
+        classifyExpr(machine.ctrl, counts)
+      }
     }
   }
 
@@ -98,14 +98,17 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
       case _: SELocA => counts.evarA += 1
       case _: SELocF => counts.evarF += 1
       case _: SEAppGeneral => counts.eappE += 1
-      case _: SEAppAtomicFun => counts.eappA += 1
-      case _: SEAppSaturatedBuiltinFun => counts.eappB += 1
+      case _: SEAppAtomicGeneral => counts.eappA += 1
+      case _: SEAppAtomicSaturatedBuiltin => counts.eappB += 1
       case _: SEMakeClo => counts.eclose += 1
       case _: SEBuiltin => counts.ebuiltin += 1
       case _: SEVal => counts.eval += 1
       case _: SELocation => counts.elocation += 1
-      case _: SELet => counts.elet += 1
-      case _: SECase => counts.ecase += 1
+      case _: SELet => counts.eletG += 1
+      case _: SELet1General => counts.elet1 += 1
+      case _: SELet1Builtin => counts.eletB += 1
+      case _: SECase => counts.ecaseE += 1
+      case _: SECaseAtomic => counts.ecaseA += 1
       case _: SEBuiltinRecursiveDefinition => counts.erecdef += 1
       case _: SECatch => counts.ecatch += 1
       case _: SELabelClosure => ()
@@ -117,14 +120,10 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
   def classifyKont(kont: Kont, counts: Counts): Unit = {
     kont match {
       case KFinished => counts.kfinished += 1
-      case _: KArg => counts.karg += 1
-      case _: KFun => counts.kfun += 1
-      case _: KBuiltin => counts.kbuiltin += 1
-      case _: KPap => counts.kpap += 1
+      case _: KOverApp => counts.koverapp += 1
       case _: KPushTo => counts.kpushto += 1
       case _: KCacheVal => counts.kcacheval += 1
       case _: KLocation => counts.klocation += 1
-      case _: KMatch => counts.kmatch += 1
       case _: KCatch => counts.kcatch += 1
       case _: KLabelClosure => ()
       case _: KLeaveClosure => ()

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -18,6 +18,7 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
       var evarA: Int = 0,
       var evarF: Int = 0,
       var eappE: Int = 0,
+      var eappN: Int = 0,
       var eappA: Int = 0,
       var eappB: Int = 0,
       var eclose: Int = 0,
@@ -98,6 +99,7 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
       case _: SELocA => counts.evarA += 1
       case _: SELocF => counts.evarF += 1
       case _: SEAppGeneral => counts.eappE += 1
+      case _: SEAppNonAtomic => counts.eappN += 1
       case _: SEAppAtomicGeneral => counts.eappA += 1
       case _: SEAppAtomicSaturatedBuiltin => counts.eappB += 1
       case _: SEMakeClo => counts.eclose += 1
@@ -120,6 +122,10 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
   def classifyKont(kont: Kont, counts: Counts): Unit = {
     kont match {
       case KFinished => counts.kfinished += 1
+      case _: KBuiltin => () //TODO count
+      case _: KArg => () //TODO count
+      case _: KFun => () //TODO count
+      case _: KPap => () //TODO count
       case _: KOverApp => counts.koverapp += 1
       case _: KPushTo => counts.kpushto += 1
       case _: KCacheVal => counts.kcacheval += 1

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -1091,6 +1091,7 @@ private[lf] final case class Compiler(
 
       case x: SEWronglyTypeContractId => throw CompilationError(s"closureConvert: unexpected: $x")
       case x: SEImportValue => throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SEAppNonAtomic => throw CompilationError(s"closureConvert: unexpected: $x")
       case x: SEAppAtomicGeneral => throw CompilationError(s"closureConvert: unexpected: $x")
       case x: SEAppAtomicSaturatedBuiltin =>
         throw CompilationError(s"closureConvert: unexpected: $x")
@@ -1158,6 +1159,7 @@ private[lf] final case class Compiler(
         case x: SEImportValue => throw CompilationError(s"freeVars: unexpected: $x")
         case x: SELoc => throw CompilationError(s"freeVars: unexpected: $x")
         case x: SEMakeClo => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SEAppNonAtomic => throw CompilationError(s"freeVars: unexpected: $x")
         case x: SEAppAtomicGeneral => throw CompilationError(s"freeVars: unexpected: $x")
         case x: SEAppAtomicSaturatedBuiltin => throw CompilationError(s"freeVars: unexpected: $x")
         case x: SELet1General => throw CompilationError(s"freeVars: unexpected: $x")
@@ -1212,6 +1214,9 @@ private[lf] final case class Compiler(
         case _: SEBuiltin => ()
         case _: SEBuiltinRecursiveDefinition => ()
         case SEValue(v) => goV(v)
+        case SEAppNonAtomic(fun, args) =>
+          go(fun)
+          args.foreach(go)
         case SEAppAtomicGeneral(fun, args) =>
           go(fun)
           args.foreach(go)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -10,6 +10,7 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.Anf.flattenToAnf
 import com.daml.lf.validation.{EUnknownDefinition, LEPackage, Validation, ValidationError}
 import org.slf4j.LoggerFactory
 
@@ -69,11 +70,11 @@ private[lf] object Compiler {
       stacktracing: StackTraceMode,
       profiling: ProfilingMode,
       validation: Boolean = true,
-  ): Either[String, Map[SDefinitionRef, SExpr]] = {
+  ): Either[String, Map[SDefinitionRef, AExpr]] = {
     val compiler = Compiler(packages, stacktracing, profiling)
     try {
       Right(
-        packages.keys.foldLeft(Map.empty[SDefinitionRef, SExpr])(
+        packages.keys.foldLeft(Map.empty[SDefinitionRef, AExpr])(
           _ ++ compiler.unsafeCompilePackage(_, validation))
       )
     } catch {
@@ -170,29 +171,37 @@ private[lf] final case class Compiler(
 
   @throws[PackageNotFound]
   @throws[CompilationError]
-  def unsafeCompile(cmds: ImmArray[Command]): SExpr =
-    validate(closureConvert(Map.empty, translateCommands(cmds)))
+  def unsafeCompile(cmds: ImmArray[Command]): AExpr =
+    validate(compilationPipeline(translateCommands(cmds)))
 
   @throws[PackageNotFound]
   @throws[CompilationError]
-  def unsafeCompile(expr: Expr): SExpr =
-    validate(closureConvert(Map.empty, translate(expr)))
+  def unsafeCompile(expr: Expr): AExpr = {
+    validate(compilationPipeline(translate(expr)))
+  }
 
   @throws[PackageNotFound]
   @throws[CompilationError]
-  def unsafeClosureConvert(sexpr: SExpr): SExpr =
-    validate(closureConvert(Map.empty, sexpr))
+  def unsafeCompilationPipeline(sexpr: SExpr): AExpr =
+    validate(compilationPipeline(sexpr))
+
+  // Run the compilation pipeline phases:
+  // (1) closure conversion
+  // (2) transform to ANF
+  private[this] def compilationPipeline(sexpr: SExpr): AExpr = {
+    flattenToAnf(closureConvert(Map.empty, sexpr))
+  }
 
   @throws[PackageNotFound]
   @throws[CompilationError]
   def unsafeCompileDefn(
       identifier: Identifier,
       defn: Definition,
-  ): List[(SDefinitionRef, SExpr)] =
+  ): List[(SDefinitionRef, AExpr)] =
     defn match {
       case DValue(_, _, body, _) =>
         val ref = LfDefRef(identifier)
-        List(ref -> withLabel(ref, unsafeCompile(body)))
+        List(ref -> AExpr(withLabel(ref, unsafeCompile(body).wrapped)))
 
       case DDataType(_, _, DataRecord(_, Some(tmpl))) =>
         // Compile choices into top-level definitions that exercise
@@ -220,7 +229,7 @@ private[lf] final case class Compiler(
   def unsafeCompilePackage(
       pkgId: PackageId,
       validation: Boolean = true,
-  ): Iterable[(SDefinitionRef, SExpr)] = {
+  ): Iterable[(SDefinitionRef, AExpr)] = {
     logger.trace(s"compilePackage: Compiling $pkgId...")
 
     val t0 = Time.Timestamp.now()
@@ -851,7 +860,7 @@ private[lf] final case class Compiler(
       tmplId: TypeConName,
       tmpl: Template,
       cname: ChoiceName,
-      choice: TemplateChoice): SExpr =
+      choice: TemplateChoice): AExpr =
     // Compiles a choice into:
     // SomeTemplate$SomeChoice = \<byKey flag> <actors> <cid> <choice arg> <token> ->
     //   let targ = fetch <cid>
@@ -860,8 +869,7 @@ private[lf] final case class Compiler(
     //       _ = $endExercise[tmplId]
     //   in result
     validate(
-      closureConvert(
-        Map.empty,
+      compilationPipeline(
         withEnv { _ =>
           env = env.incrPos // <byKey flag>
           env = env.incrPos // <actors>
@@ -1052,15 +1060,6 @@ private[lf] final case class Compiler(
         val newArgs = args.map(closureConvert(remaps, _))
         SEApp(newFun, newArgs)
 
-      case SEAppAtomicFun(fun, args) =>
-        val newFun = closureConvert(remaps, fun)
-        val newArgs = args.map(closureConvert(remaps, _))
-        SEApp(newFun, newArgs)
-
-      case SEAppSaturatedBuiltinFun(builtin, args) =>
-        val newArgs = args.map(closureConvert(remaps, _))
-        SEAppSaturatedBuiltinFun(builtin, newArgs)
-
       case SECase(scrut, alts) =>
         SECase(
           closureConvert(remaps, scrut),
@@ -1090,11 +1089,15 @@ private[lf] final case class Compiler(
       case SELabelClosure(label, expr) =>
         SELabelClosure(label, closureConvert(remaps, expr))
 
-      case x: SEWronglyTypeContractId =>
-        throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
+      case x: SEWronglyTypeContractId => throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SEImportValue => throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SEAppAtomicGeneral => throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SEAppAtomicSaturatedBuiltin =>
+        throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SELet1General => throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SELet1Builtin => throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SECaseAtomic => throw CompilationError(s"closureConvert: unexpected: $x")
 
-      case x: SEImportValue =>
-        throw CompilationError(s"unexpected SEImportValue: $x")
     }
   }
 
@@ -1137,16 +1140,8 @@ private[lf] final case class Compiler(
           go(body, bound, free)
         case SEAppGeneral(fun, args) =>
           args.foldLeft(go(fun, bound, free))((acc, arg) => go(arg, bound, acc))
-        case SEAppAtomicFun(fun, args) =>
-          args.foldLeft(go(fun, bound, free))((acc, arg) => go(arg, bound, acc))
-        case SEAppSaturatedBuiltinFun(_, args) =>
-          args.foldLeft(free)((acc, arg) => go(arg, bound, acc))
         case SEAbs(n, body) =>
           go(body, bound + n, free)
-        case x: SELoc =>
-          throw CompilationError(s"freeVars: unexpected SELoc: $x")
-        case x: SEMakeClo =>
-          throw CompilationError(s"freeVars: unexpected SEMakeClo: $x")
         case SECase(scrut, alts) =>
           alts.foldLeft(go(scrut, bound, free)) {
             case (acc, SCaseAlt(pat, body)) => go(body, bound + patternNArgs(pat), acc)
@@ -1159,10 +1154,15 @@ private[lf] final case class Compiler(
           go(body, bound, go(handler, bound, go(fin, bound, free)))
         case SELabelClosure(_, expr) =>
           go(expr, bound, free)
-        case x: SEWronglyTypeContractId =>
-          throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
-        case x: SEImportValue =>
-          throw CompilationError(s"unexpected SEImportValue: $x")
+        case x: SEWronglyTypeContractId => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SEImportValue => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SELoc => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SEMakeClo => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SEAppAtomicGeneral => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SEAppAtomicSaturatedBuiltin => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SELet1General => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SELet1Builtin => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SECaseAtomic => throw CompilationError(s"freeVars: unexpected: $x")
       }
     go(expr, initiallyBound, Set.empty)
   }
@@ -1170,7 +1170,7 @@ private[lf] final case class Compiler(
   /** Validate variable references in a speedy expression */
   // validate that we correctly captured all free-variables, and so reference to them is
   // via the surrounding closure, instead of just finding them higher up on the stack
-  def validate(expr0: SExpr): SExpr = {
+  def validate(anf0: AExpr): AExpr = {
 
     def goV(v: SValue): Unit = {
       v match {
@@ -1194,7 +1194,6 @@ private[lf] final case class Compiler(
     }
 
     def goBody(maxS: Int, maxA: Int, maxF: Int): SExpr => Unit = {
-
       def goLoc(loc: SELoc) = loc match {
         case SELocS(i) =>
           if (i < 1 || i > maxS)
@@ -1213,21 +1212,18 @@ private[lf] final case class Compiler(
         case _: SEBuiltin => ()
         case _: SEBuiltinRecursiveDefinition => ()
         case SEValue(v) => goV(v)
+        case SEAppAtomicGeneral(fun, args) =>
+          go(fun)
+          args.foreach(go)
+        case SEAppAtomicSaturatedBuiltin(_, args) =>
+          args.foreach(go)
         case SEAppGeneral(fun, args) =>
           go(fun)
           args.foreach(go)
-        case SEAppAtomicFun(fun, args) =>
-          go(fun)
-          args.foreach(go)
-        case SEAppSaturatedBuiltinFun(_, args) =>
-          args.foreach(go)
-        case x: SEVar =>
-          throw CompilationError(s"validate: SEVar encountered: $x")
-        case abs: SEAbs =>
-          throw CompilationError(s"validate: SEAbs encountered: $abs")
         case SEMakeClo(fvs, n, body) =>
           fvs.foreach(goLoc)
           goBody(0, n, fvs.length)(body)
+        case SECaseAtomic(scrut, alts) => go(SECase(scrut, alts))
         case SECase(scrut, alts) =>
           go(scrut)
           alts.foreach {
@@ -1235,12 +1231,6 @@ private[lf] final case class Compiler(
               val n = patternNArgs(pat)
               goBody(maxS + n, maxA, maxF)(body)
           }
-        case SELet(bounds, body) =>
-          bounds.zipWithIndex.foreach {
-            case (rhs, i) =>
-              goBody(maxS + i, maxA, maxF)(rhs)
-          }
-          goBody(maxS + bounds.length, maxA, maxF)(body)
         case SECatch(body, handler, fin) =>
           go(body)
           go(handler)
@@ -1249,15 +1239,32 @@ private[lf] final case class Compiler(
           go(body)
         case SELabelClosure(_, expr) =>
           go(expr)
-        case x: SEWronglyTypeContractId =>
-          throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
-        case x: SEImportValue =>
-          throw CompilationError(s"unexpected SEImportValue: $x")
+        case _: SELet1General => goLets(maxS)(expr)
+        case _: SELet1Builtin => goLets(maxS)(expr)
+        case x: SELet => throw CompilationError(s"validate: unexpected: $x")
+        case x: SEVar => throw CompilationError(s"validate: unexpected: $x")
+        case x: SEAbs => throw CompilationError(s"validate: unexpected: $x")
+        case x: SEWronglyTypeContractId => throw CompilationError(s"validate: unexpected: $x")
+        case x: SEImportValue => throw CompilationError(s"validate: unexpected: $x")
+      }
+      @tailrec
+      def goLets(maxS: Int)(expr: SExpr): Unit = {
+        def go = goBody(maxS, maxA, maxF)
+        expr match {
+          case SELet1General(rhs, body) =>
+            go(rhs)
+            goLets(maxS + 1)(body)
+          case SELet1Builtin(_, args, body) =>
+            args.foreach(go)
+            goLets(maxS + 1)(body)
+          case expr =>
+            go(expr)
+        }
       }
       go
     }
-    goBody(0, 0, 0)(expr0)
-    expr0
+    goBody(0, 0, 0)(anf0.wrapped)
+    anf0
   }
 
   private def compileFetch(tmplId: Identifier, coid: SExpr): SExpr = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -474,10 +474,11 @@ private[lf] object Pretty {
       (pat & text("=>") + lineOrSpace + prettySExpr(newIndex)(alt.body)).nested(2)
     }
 
-    def prettySELoc(loc: SELoc): Doc = loc match {
-      case SELocS(i) => char('S') + str(i)
-      case SELocA(i) => char('A') + str(i)
-      case SELocF(i) => char('F') + str(i)
+    def prettySELoc(index: Int)(loc: SELoc): Doc = loc match {
+      case SELocS(i) =>
+        text("S[") + str(i) + text("=abs:") + str(index - i) + text("]") // show absolute stack position, 0..
+      case SELocA(i) => text("A") + str(i)
+      case SELocF(i) => text("F") + str(i)
     }
 
     def prettySExpr(index: Int)(e: SExpr): Doc =
@@ -492,6 +493,7 @@ private[lf] object Pretty {
             case other => str(other)
           }
 
+        case SECaseAtomic(scrut, alts) => prettySExpr(index)(SECase(scrut, alts))
         case SECase(scrut, alts) =>
           (text("case") & prettySExpr(index)(scrut) & text("of") +
             line +
@@ -521,16 +523,16 @@ private[lf] object Pretty {
             case SBGetTime => text("$getTime")
             case _ => str(x)
           }
+        case SEAppAtomicGeneral(fun, args) =>
+          val prefix = prettySExpr(index)(fun) + char('(')
+          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
+            .tightBracketBy(prefix, char(')'))
+        case SEAppAtomicSaturatedBuiltin(builtin, args) =>
+          val prefix = prettySExpr(index)(SEBuiltin(builtin)) + char('(')
+          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
+            .tightBracketBy(prefix, char(')'))
         case SEAppGeneral(fun, args) =>
           val prefix = prettySExpr(index)(fun) + char('(')
-          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
-            .tightBracketBy(prefix, char(')'))
-        case SEAppAtomicFun(fun, args) =>
-          val prefix = prettySExpr(index)(fun) + char('(')
-          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
-            .tightBracketBy(prefix, char(')'))
-        case SEAppSaturatedBuiltinFun(builtin, args) =>
-          val prefix = prettySExpr(index)(SEBuiltin(builtin)) + char('(')
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))
         case SEAbs(n, body) =>
@@ -549,12 +551,12 @@ private[lf] object Pretty {
 
         case SEMakeClo(fv, n, body) =>
           val prefix = char('[') +
-            intercalate(space, fv.map(prettySELoc)) + char(']') + text("(\\") +
-            intercalate(space, (index to n + index - 1).map((v: Int) => str(v))) &
+            intercalate(space, fv.map(prettySELoc(index))) + char(']') + text("(\\") +
+            intercalate(space, (0 to n - 1).map((v: Int) => text("A") + str(v))) &
             text("-> ")
-          prettySExpr(index + n)(body).tightBracketBy(prefix, char(')'))
+          prettySExpr(0)(body).tightBracketBy(prefix, char(')'))
 
-        case loc: SELoc => prettySELoc(loc)
+        case loc: SELoc => prettySELoc(index)(loc)
 
         case SELet(bounds, body) =>
           // let [a, b, c] in X
@@ -563,6 +565,12 @@ private[lf] object Pretty {
               str(index + n) & char('=') & prettySExpr(index + n)(x)
           })).tightBracketBy(text("let ["), char(']')) +
             lineOrSpace + text("in") & prettySExpr(index + bounds.length)(body)
+
+        case SELet1General(rhs, body) =>
+          prettySExpr(index)(SELet(Array(rhs), body))
+
+        case SELet1Builtin(builtin, args, body) =>
+          prettySExpr(index)(SELet1General(SEAppAtomicSaturatedBuiltin(builtin, args), body))
 
         case x: SEBuiltinRecursiveDefinition => str(x)
         case x: SEImportValue => str(x)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -523,6 +523,10 @@ private[lf] object Pretty {
             case SBGetTime => text("$getTime")
             case _ => str(x)
           }
+        case SEAppNonAtomic(fun, args) =>
+          val prefix = prettySExpr(index)(fun) + char('(')
+          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
+            .tightBracketBy(prefix, char(')'))
         case SEAppAtomicGeneral(fun, args) =>
           val prefix = prettySExpr(index)(fun) + char('(')
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -34,6 +34,10 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
 
   def ppKont(k: Kont): String = k match {
     case KFinished => "KFinished"
+    case _: KArg => "KArg"
+    case _: KFun => "KFun"
+    case _: KBuiltin => "KBuiltin"
+    case _: KPap => "KPap"
     case _: KOverApp => "KOverApp"
     case _: KPushTo => "KPushTo"
     case _: KCacheVal => "KCacheVal"
@@ -60,6 +64,7 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
         case SEVar(n) => s"D#$n" //dont expect these at runtime
         case loc: SELoc => pp(loc)
         case SEAppGeneral(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
+        case SEAppNonAtomic(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
         case SEAppAtomicGeneral(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
         case SEAppAtomicSaturatedBuiltin(b, args) =>
           s"@B(${pp(SEBuiltin(b))},${commas(args.map(pp))})"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -34,14 +34,10 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
 
   def ppKont(k: Kont): String = k match {
     case KFinished => "KFinished"
-    case _: KArg => "KArg"
-    case _: KFun => "KFun"
-    case _: KBuiltin => "KBuiltin"
-    case _: KPap => "KPap"
+    case _: KOverApp => "KOverApp"
     case _: KPushTo => "KPushTo"
     case _: KCacheVal => "KCacheVal"
     case _: KLocation => "KLocation"
-    case _: KMatch => "KMatch"
     case _: KCatch => "KCatch"
     case _: KLabelClosure => "KLabelClosure"
     case _: KLeaveClosure => "KLeaveClosure"
@@ -57,26 +53,33 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     s"${x.ref.qualifiedName.name}"
   }
 
-  def pp(e: SExpr): String = e match {
-    case SEValue(v) => s"(VALUE)${pp(v)}"
-    case SEVar(n) => s"D#$n" //dont expect these at runtime
-    case loc: SELoc => pp(loc)
-    case SEAppGeneral(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
-    case SEAppAtomicFun(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
-    case SEAppSaturatedBuiltinFun(builtin, args) => s"@B($builtin,${commas(args.map(pp))})"
-    case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(pp))}]\\$arity.${pp(body)}"
-    case SEBuiltin(b) => s"(BUILTIN)$b"
-    case SEVal(ref) => s"(DEF)${pp(ref)}"
-    case SELocation(_, exp) => s"LOC(${pp(exp)})"
-    case SELet(rhss, body) => s"let (${commas(rhss.map(pp))}) in ${pp(body)}"
-    case SECase(scrut, _) => s"case ${pp(scrut)} of..."
-    case SEBuiltinRecursiveDefinition(_) => "<SEBuiltinRecursiveDefinition...>"
-    case SECatch(_, _, _) => "<SECatch...>" //not seen one yet
-    case SEAbs(_, _) => "<SEAbs...>" // will never get these on a running machine
-    case SELabelClosure(_, _) => "<SELabelClosure...>"
-    case SEImportValue(_) => "<SEImportValue...>"
-    case SEWronglyTypeContractId(_, _, _) => "<SEWronglyTypeContractId...>"
-  }
+  def pp(e: SExpr): String =
+    if (e == null) { "<null-expr>" } else
+      e match {
+        case SEValue(v) => s"(VALUE)${pp(v)}"
+        case SEVar(n) => s"D#$n" //dont expect these at runtime
+        case loc: SELoc => pp(loc)
+        case SEAppGeneral(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
+        case SEAppAtomicGeneral(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
+        case SEAppAtomicSaturatedBuiltin(b, args) =>
+          s"@B(${pp(SEBuiltin(b))},${commas(args.map(pp))})"
+        case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(pp))}]\\$arity.${pp(body)}"
+        case SEBuiltin(b) => s"(BUILTIN)$b"
+        case SEVal(ref) => s"(DEF)${pp(ref)}"
+        case SELocation(_, exp) => s"LOC(${pp(exp)})"
+        case SELet(rhss, body) => s"letG (${commas(rhss.map(pp))}) in ${pp(body)}"
+        case SELet1General(rhs, body) => s"let ${pp(rhs)} in ${pp(body)}"
+        case SELet1Builtin(builtin, args, body) =>
+          s"letB (${pp(SEBuiltin(builtin))},${commas(args.map(pp))}) in ${pp(body)}"
+        case SECaseAtomic(scrut, _) => s"case(atomic) ${pp(scrut)} of..."
+        case SECase(scrut, _) => s"case ${pp(scrut)} of..."
+        case SEBuiltinRecursiveDefinition(ref) => s"<SEBuiltinRecursiveDefinition:$ref>"
+        case SECatch(_, _, _) => "<SECatch...>" //not seen one yet
+        case SEAbs(_, _) => "<SEAbs...>" // will never get these on a running machine
+        case SELabelClosure(_, _) => "<SELabelClosure...>"
+        case SEImportValue(_) => "<SEImportValue...>"
+        case SEWronglyTypeContractId(_, _, _) => "<SEWronglyTypeContractId...>"
+      }
 
   def pp(v: SValue): String = v match {
     case SInt64(n) => s"$n"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -24,8 +24,17 @@ import com.daml.lf.transaction.{Node, GlobalKey, GlobalKeyWithMaintainers}
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeSet
 
-/** Speedy builtin functions */
-private[speedy] sealed abstract class SBuiltin(val arity: Int) {
+/**
+  Speedy builtins are stratified into two layers:
+  Parent: `SBuiltinEffect`, child: `SBuiltin` (which are pure).
+
+  Effectful builtin functions may raise `SpeedyHungry` exceptions or change machine state.
+  Pure builtins can be treated specially because their evaluation is immediate.
+  This fact is used by the execution of the ANF expression form: `SELet1Builtin`.
+
+  Most builtins are pure, and so they extend `SBuiltin`
+  */
+private[speedy] sealed abstract class SBuiltinEffect(val arity: Int) {
   // Helper for constructing expressions applying this builtin.
   // E.g. SBCons(SEVar(1), SEVar(2))
   private[speedy] def apply(args: SExpr*): SExpr =
@@ -33,10 +42,24 @@ private[speedy] sealed abstract class SBuiltin(val arity: Int) {
 
   /** Execute the builtin with 'arity' number of arguments in 'args'.
     * Updates the machine state accordingly. */
-  private[speedy] def execute(args: util.ArrayList[SValue], machine: Machine): Unit
+  private[speedy] def executeEffect(args: util.ArrayList[SValue], machine: Machine): Unit
+}
+
+private[speedy] sealed abstract class SBuiltin(val arity1: Int) extends SBuiltinEffect(arity1) {
+
+  override private[speedy] final def executeEffect(
+      args: util.ArrayList[SValue],
+      machine: Machine): Unit = {
+    machine.returnValue = execute(args)
+  }
+
+  /** Execute the (pure) builtin with 'arity' number of arguments in 'args'.
+    Returns the resultin value */
+  private[speedy] def execute(args: util.ArrayList[SValue]): SValue
 }
 
 private[lf] object SBuiltin {
+
   //
   // Arithmetic
   //
@@ -107,10 +130,8 @@ private[lf] object SBuiltin {
       }
 
   sealed abstract class SBBinaryOpInt64(op: (Long, Long) => Long) extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit =
-      machine.returnValue = (args.get(0), args.get(1)) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue =
+      (args.get(0), args.get(1)) match {
         case (SInt64(a), SInt64(b)) => SInt64(op(a, b))
         case _ => crash(s"type mismatch add: $args")
       }
@@ -155,29 +176,25 @@ private[lf] object SBuiltin {
       )
 
   sealed abstract class SBBinaryOpNumeric(op: (Numeric, Numeric) => Numeric) extends SBuiltin(3) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val a = args.get(1).asInstanceOf[SNumeric].value
       val b = args.get(2).asInstanceOf[SNumeric].value
       assert(a.scale == scale && b.scale == scale)
-      machine.returnValue = SNumeric(op(a, b))
+      SNumeric(op(a, b))
     }
   }
 
   sealed abstract class SBBinaryOpNumeric2(op: (Scale, Numeric, Numeric) => Numeric)
       extends SBuiltin(5) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val scaleA = args.get(0).asInstanceOf[STNat].n
       val scaleB = args.get(1).asInstanceOf[STNat].n
       val scale = args.get(2).asInstanceOf[STNat].n
       val a = args.get(3).asInstanceOf[SNumeric].value
       val b = args.get(4).asInstanceOf[SNumeric].value
       assert(a.scale == scaleA && b.scale == scaleB)
-      machine.returnValue = SNumeric(op(scale, a, b))
+      SNumeric(op(scale, a, b))
     }
   }
 
@@ -187,26 +204,22 @@ private[lf] object SBuiltin {
   final case object SBDivNumeric extends SBBinaryOpNumeric2(divide)
 
   final case object SBRoundNumeric extends SBuiltin(3) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val prec = args.get(1).asInstanceOf[SInt64].value
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.returnValue = SNumeric(
+      SNumeric(
         rightOrArithmeticError(s"Error while rounding (Numeric $scale)", Numeric.round(prec, x)),
       )
     }
   }
 
   final case object SBCastNumeric extends SBuiltin(3) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val inputScale = args.get(0).asInstanceOf[STNat].n
       val outputScale = args.get(1).asInstanceOf[STNat].n
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.returnValue = SNumeric(
+      SNumeric(
         rightOrArithmeticError(
           s"Error while casting (Numeric $inputScale) to (Numeric $outputScale)",
           Numeric.fromBigDecimal(outputScale, x),
@@ -216,13 +229,11 @@ private[lf] object SBuiltin {
   }
 
   final case object SBShiftNumeric extends SBuiltin(3) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val inputScale = args.get(0).asInstanceOf[STNat].n
       val outputScale = args.get(1).asInstanceOf[STNat].n
       val x = args.get(2).asInstanceOf[SNumeric].value
-      machine.returnValue = SNumeric(
+      SNumeric(
         rightOrArithmeticError(
           s"Error while shifting (Numeric $inputScale) to (Numeric $outputScale)",
           Numeric.fromBigDecimal(outputScale, x.scaleByPowerOfTen(inputScale - outputScale)),
@@ -235,10 +246,8 @@ private[lf] object SBuiltin {
   // Text functions
   //
   final case object SBExplodeText extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SText(t) =>
           SList(FrontStack(Utf8.explode(t).map(SText)))
         case _ =>
@@ -248,10 +257,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBImplodeText extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SList(xs) =>
           val ts = xs.map {
             case SText(t) => t
@@ -266,10 +273,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBAppendText extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = (args.get(0), args.get(1)) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      (args.get(0), args.get(1)) match {
         case (SText(head), SText(tail)) =>
           SText(head + tail)
         case _ =>
@@ -279,10 +284,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBToText extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = litToText(args)
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      litToText(args)
     }
 
     def litToText(vs: util.ArrayList[SValue]): SValue = {
@@ -301,38 +304,30 @@ private[lf] object SBuiltin {
   }
 
   final case object SBToTextNumeric extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val x = args.get(1).asInstanceOf[SNumeric].value
-      machine.returnValue = SText(Numeric.toUnscaledString(x))
+      SText(Numeric.toUnscaledString(x))
     }
   }
 
   final case object SBToQuotedTextParty extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val v = args.get(0).asInstanceOf[SParty]
-      machine.returnValue = SText(s"'${v.value: String}'")
+      SText(s"'${v.value: String}'")
     }
   }
 
   final case object SBToTextCodePoints extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val codePoints = args.get(0).asInstanceOf[SList].list.map(_.asInstanceOf[SInt64].value)
-      machine.returnValue = SText(Utf8.pack(codePoints.toImmArray))
+      SText(Utf8.pack(codePoints.toImmArray))
     }
   }
 
   final case object SBFromTextParty extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val v = args.get(0).asInstanceOf[SText]
-      machine.returnValue = Party.fromString(v.value) match {
+      Party.fromString(v.value) match {
         case Left(_) => SV.None
         case Right(p) => SOptional(Some(SParty(p)))
       }
@@ -342,19 +337,16 @@ private[lf] object SBuiltin {
   final case object SBFromTextInt64 extends SBuiltin(1) {
     private val pattern = """[+-]?\d+""".r.pattern
 
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val s = args.get(0).asInstanceOf[SText].value
-      machine.returnValue =
-        if (pattern.matcher(s).matches())
-          try {
-            SOptional(Some(SInt64(java.lang.Long.parseLong(s))))
-          } catch {
-            case _: NumberFormatException =>
-              SV.None
-          } else
-          SV.None
+      if (pattern.matcher(s).matches())
+        try {
+          SOptional(Some(SInt64(java.lang.Long.parseLong(s))))
+        } catch {
+          case _: NumberFormatException =>
+            SV.None
+        } else
+        SV.None
     }
   }
 
@@ -366,12 +358,10 @@ private[lf] object SBuiltin {
     private val validFormat =
       """([+-]?)0*(\d+)(\.(\d*[1-9]|0)0*)?""".r
 
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val string = args.get(1).asInstanceOf[SText].value
-      machine.returnValue = string match {
+      string match {
         case validFormat(signPart, intPart, _, decPartOrNull) =>
           val decPart = Option(decPartOrNull).filterNot(_ == "0").getOrElse("")
           // First, we count the number of significant digits to avoid the conversion attempts that
@@ -394,20 +384,16 @@ private[lf] object SBuiltin {
   }
 
   final case object SBFromTextCodePoints extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val string = args.get(0).asInstanceOf[SText].value
       val codePoints = Utf8.unpack(string)
-      machine.returnValue = SList(FrontStack(codePoints.map(SInt64)))
+      SList(FrontStack(codePoints.map(SInt64)))
     }
   }
 
   final case object SBSHA256Text extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SText(t) => SText(Utf8.sha256(t))
         case _ =>
           throw SErrorCrash(s"type mismatch textSHA256: $args")
@@ -416,10 +402,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBTextMapInsert extends SBuiltin(3) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(2) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(2) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -434,10 +418,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBTextMapLookup extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(1) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(1) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -452,10 +434,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBTextMapDelete extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(1) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(1) match {
         case STextMap(map) =>
           args.get(0) match {
             case SText(key) =>
@@ -471,10 +451,8 @@ private[lf] object SBuiltin {
 
   final case object SBTextMapToList extends SBuiltin(1) {
 
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case map: STextMap =>
           SValue.toList(map)
         case x =>
@@ -484,10 +462,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBTextMapSize extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case STextMap(map) =>
           SInt64(map.size.toLong)
         case x =>
@@ -497,10 +473,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBGenMapInsert extends SBuiltin(3) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(2) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(2) match {
         case SGenMap(map) =>
           val key = args.get(0)
           SGenMap.comparable(key)
@@ -512,10 +486,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBGenMapLookup extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(1) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(1) match {
         case SGenMap(value) =>
           val key = args.get(0)
           SGenMap.comparable(key)
@@ -527,10 +499,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBGenMapDelete extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(1) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(1) match {
         case SGenMap(value) =>
           val key = args.get(0)
           SGenMap.comparable(key)
@@ -542,10 +512,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBGenMapKeys extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SGenMap(value) =>
           SList(ImmArray(value.keys) ++: FrontStack.empty)
         case x =>
@@ -555,10 +523,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBGenMapValues extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SGenMap(value) =>
           SList(ImmArray(value.values) ++: FrontStack.empty)
         case x =>
@@ -568,10 +534,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBGenMapSize extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SGenMap(value) =>
           SInt64(value.size.toLong)
         case x =>
@@ -585,12 +549,10 @@ private[lf] object SBuiltin {
   //
 
   final case object SBInt64ToNumeric extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val scale = args.get(0).asInstanceOf[STNat].n
       val x = args.get(1).asInstanceOf[SInt64].value
-      machine.returnValue = SNumeric(
+      SNumeric(
         rightOrArithmeticError(
           s"overflow when converting $x to (Numeric $scale)",
           Numeric.fromLong(scale, x),
@@ -600,11 +562,9 @@ private[lf] object SBuiltin {
   }
 
   final case object SBNumericToInt64 extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       val x = args.get(1).asInstanceOf[SNumeric].value
-      machine.returnValue = SInt64(
+      SInt64(
         rightOrArithmeticError(
           s"Int64 overflow when converting ${Numeric.toString(x)} to Int64",
           Numeric.toLong(x),
@@ -614,10 +574,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBDateToUnixDays extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SDate(d) => SInt64(d.days.toLong)
         case _ =>
           throw SErrorCrash(s"type mismatch dateToUnixDays: $args")
@@ -626,10 +584,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBUnixDaysToDate extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SInt64(days) =>
           SDate(
             rightOrArithmeticError(
@@ -644,10 +600,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBTimestampToUnixMicroseconds extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case STimestamp(t) => SInt64(t.micros)
         case _ =>
           throw SErrorCrash(s"type mismatch timestampToUnixMicroseconds: $args")
@@ -656,10 +610,8 @@ private[lf] object SBuiltin {
   }
 
   final case object SBUnixMicrosecondsToTimestamp extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SInt64(t) =>
           STimestamp(
             rightOrArithmeticError(
@@ -677,18 +629,14 @@ private[lf] object SBuiltin {
   // Equality and comparisons
   //
   final case object SBEqual extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = SBool(svalue.Equality.areEqual(args.get(0), args.get(1)))
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      SBool(svalue.Equality.areEqual(args.get(0), args.get(1)))
     }
   }
 
   sealed abstract class SBCompare(pred: Int => Boolean) extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = SBool(pred(svalue.Ordering.compare(args.get(0), args.get(1))))
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      SBool(pred(svalue.Ordering.compare(args.get(0), args.get(1))))
     }
   }
 
@@ -699,10 +647,8 @@ private[lf] object SBuiltin {
 
   /** $consMany[n] :: a -> ... -> List a -> List a */
   final case class SBConsMany(n: Int) extends SBuiltin(1 + n) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(n) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(n) match {
         case SList(tail) =>
           SList(ImmArray(args.subList(0, n).asScala) ++: tail)
         case x =>
@@ -713,10 +659,8 @@ private[lf] object SBuiltin {
 
   /** $some :: a -> Optional a */
   final case object SBSome extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = SOptional(Some(args.get(0)))
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      SOptional(Some(args.get(0)))
     }
   }
 
@@ -724,19 +668,15 @@ private[lf] object SBuiltin {
   final case class SBRecCon(id: Identifier, fields: Array[Name])
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = SRecord(id, fields, args)
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      SRecord(id, fields, args)
     }
   }
 
   /** $rupd[R, field] :: R -> a -> R */
   final case class SBRecUpd(id: Identifier, field: Int) extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SRecord(id2, fields, values) =>
           if (id != id2) {
             crash(s"type mismatch on record update: expected $id, got record of type $id2")
@@ -752,10 +692,8 @@ private[lf] object SBuiltin {
 
   /** $rproj[R, field] :: R -> a */
   final case class SBRecProj(id: Identifier, field: Int) extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SRecord(id @ _, _, values) => values.get(field)
         case v =>
           crash(s"RecProj on non-record: $v")
@@ -767,19 +705,15 @@ private[lf] object SBuiltin {
   final case class SBStructCon(fields: Array[Name])
       extends SBuiltin(fields.length)
       with SomeArrayEquals {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = SStruct(fields, args)
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      SStruct(fields, args)
     }
   }
 
   /** $tproj[field] :: Struct -> a */
   final case class SBStructProj(field: Ast.FieldName) extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SStruct(fields, values) =>
           values.get(fields.indexOf(field))
         case v =>
@@ -790,10 +724,8 @@ private[lf] object SBuiltin {
 
   /** $tupd[field] :: Struct -> a -> Struct */
   final case class SBStructUpd(field: Ast.FieldName) extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SStruct(fields, values) =>
           val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
           values2.set(fields.indexOf(field), args.get(1))
@@ -807,10 +739,8 @@ private[lf] object SBuiltin {
   /** $vcon[V, variant] :: a -> V */
   final case class SBVariantCon(id: Identifier, variant: Ast.VariantConName, constructorRank: Int)
       extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = SVariant(id, variant, constructorRank, args.get(0))
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      SVariant(id, variant, constructorRank, args.get(0))
     }
   }
 
@@ -820,9 +750,7 @@ private[lf] object SBuiltin {
     *    -> Unit
     */
   final case class SBCheckPrecond(templateId: TypeConName) extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       if (args.get(0).isInstanceOf[STextMap])
         throw new Error(args.toString)
       args.get(1) match {
@@ -837,7 +765,7 @@ private[lf] object SBuiltin {
         case v =>
           crash(s"PrecondCheck on non-boolean: $v")
       }
-      machine.returnValue = SUnit
+      SUnit
     }
   }
 
@@ -850,8 +778,8 @@ private[lf] object SBuiltin {
     *    -> Token
     *    -> ContractId arg
     */
-  final case class SBUCreate(templateId: TypeConName) extends SBuiltin(6) {
-    override private[speedy] final def execute(
+  final case class SBUCreate(templateId: TypeConName) extends SBuiltinEffect(6) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(5))
@@ -898,9 +826,9 @@ private[lf] object SBuiltin {
       templateId: TypeConName,
       choiceId: ChoiceName,
       consuming: Boolean,
-  ) extends SBuiltin(9) {
+  ) extends SBuiltinEffect(9) {
 
-    override private[speedy] final def execute(
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(8))
@@ -949,8 +877,8 @@ private[lf] object SBuiltin {
     *    -> Value   (result of the exercise)
     *    -> ()
     */
-  final case class SBUEndExercise(templateId: TypeConName) extends SBuiltin(2) {
-    override private[speedy] final def execute(
+  final case class SBUEndExercise(templateId: TypeConName) extends SBuiltinEffect(2) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(0))
@@ -966,8 +894,8 @@ private[lf] object SBuiltin {
     *    -> Token
     *    -> a
     */
-  final case class SBUFetch(templateId: TypeConName) extends SBuiltin(2) {
-    override private[speedy] final def execute(
+  final case class SBUFetch(templateId: TypeConName) extends SBuiltinEffect(2) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(1))
@@ -1012,8 +940,9 @@ private[lf] object SBuiltin {
     *    -> Token
     *    -> ()
     */
-  final case class SBUInsertFetchNode(templateId: TypeConName, byKey: Boolean) extends SBuiltin(5) {
-    override private[speedy] final def execute(
+  final case class SBUInsertFetchNode(templateId: TypeConName, byKey: Boolean)
+      extends SBuiltinEffect(5) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(4))
@@ -1053,8 +982,8 @@ private[lf] object SBuiltin {
     *   -> Token
     *   -> Maybe (ContractId T)
     */
-  final case class SBULookupKey(templateId: TypeConName) extends SBuiltin(2) {
-    override private[speedy] final def execute(
+  final case class SBULookupKey(templateId: TypeConName) extends SBuiltinEffect(2) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(1))
@@ -1100,8 +1029,8 @@ private[lf] object SBuiltin {
     *    -> Token
     *    -> ()
     */
-  final case class SBUInsertLookupNode(templateId: TypeConName) extends SBuiltin(3) {
-    override private[speedy] final def execute(
+  final case class SBUInsertLookupNode(templateId: TypeConName) extends SBuiltinEffect(3) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(2))
@@ -1133,8 +1062,8 @@ private[lf] object SBuiltin {
     *   -> Token
     *   -> ContractId T
     */
-  final case class SBUFetchKey(templateId: TypeConName) extends SBuiltin(2) {
-    override private[speedy] final def execute(
+  final case class SBUFetchKey(templateId: TypeConName) extends SBuiltinEffect(2) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(1))
@@ -1171,8 +1100,8 @@ private[lf] object SBuiltin {
   }
 
   /** $getTime :: Token -> Timestamp */
-  final case object SBGetTime extends SBuiltin(1) {
-    override private[speedy] final def execute(
+  final case object SBGetTime extends SBuiltinEffect(1) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(0))
@@ -1184,8 +1113,8 @@ private[lf] object SBuiltin {
   }
 
   /** $beginCommit :: Party -> Token -> () */
-  final case class SBSBeginCommit(optLocation: Option[Location]) extends SBuiltin(2) {
-    override private[speedy] final def execute(
+  final case class SBSBeginCommit(optLocation: Option[Location]) extends SBuiltinEffect(2) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(1))
@@ -1198,8 +1127,8 @@ private[lf] object SBuiltin {
   }
 
   /** $endCommit[mustFail?] :: result -> Token -> () */
-  final case class SBSEndCommit(mustFail: Boolean) extends SBuiltin(2) {
-    override private[speedy] final def execute(
+  final case class SBSEndCommit(mustFail: Boolean) extends SBuiltinEffect(2) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(1))
@@ -1277,8 +1206,8 @@ private[lf] object SBuiltin {
   }
 
   /** $pass :: Int64 -> Token -> Timestamp */
-  final case object SBSPass extends SBuiltin(2) {
-    override private[speedy] final def execute(
+  final case object SBSPass extends SBuiltinEffect(2) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(1))
@@ -1297,8 +1226,8 @@ private[lf] object SBuiltin {
   }
 
   /** $getParty :: Text -> Token -> Party */
-  final case object SBSGetParty extends SBuiltin(2) {
-    override private[speedy] final def execute(
+  final case object SBSGetParty extends SBuiltinEffect(2) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       checkToken(args.get(1))
@@ -1314,8 +1243,8 @@ private[lf] object SBuiltin {
   }
 
   /** $trace :: Text -> a -> a */
-  final case object SBTrace extends SBuiltin(2) {
-    override private[speedy] final def execute(
+  final case object SBTrace extends SBuiltinEffect(2) {
+    override private[speedy] final def executeEffect(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
       args.get(0) match {
@@ -1330,9 +1259,7 @@ private[lf] object SBuiltin {
 
   /** $error :: Text -> a */
   final case object SBError extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit =
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue =
       throw DamlEUserError(args.get(0).asInstanceOf[SText].value)
   }
 
@@ -1341,10 +1268,8 @@ private[lf] object SBuiltin {
     *    -> Any (where t = ty)
     */
   final case class SBToAny(ty: Ast.Type) extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = SAny(ty, args.get(0))
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      SAny(ty, args.get(0))
     }
   }
 
@@ -1353,10 +1278,8 @@ private[lf] object SBuiltin {
     *    -> Optional t (where t = expectedType)
     */
   final case class SBFromAny(expectedTy: Ast.Type) extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SAny(actualTy, v) =>
           SOptional(if (actualTy == expectedTy) Some(v) else None)
         case v => crash(s"FromAny applied to non-Any: $v")
@@ -1368,12 +1291,10 @@ private[lf] object SBuiltin {
 
   /** $text_to_upper :: Text -> Text */
   final case object SBTextToUpper extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       args.get(0) match {
         case SText(t) =>
-          machine.returnValue = SText(t.toUpperCase(util.Locale.ROOT))
+          SText(t.toUpperCase(util.Locale.ROOT))
         // TODO [FM]: replace with ASCII-specific function, or not
         case x =>
           throw SErrorCrash(s"type mismatch SBTextoUpper, expected Text got $x")
@@ -1383,12 +1304,10 @@ private[lf] object SBuiltin {
 
   /** $text_to_lower :: Text -> Text */
   final case object SBTextToLower extends SBuiltin(1) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
       args.get(0) match {
         case SText(t) =>
-          machine.returnValue = SText(t.toLowerCase(util.Locale.ROOT))
+          SText(t.toLowerCase(util.Locale.ROOT))
         // TODO [FM]: replace with ASCII-specific function, or not
         case x =>
           throw SErrorCrash(s"type mismatch SBTextToLower, expected Text got $x")
@@ -1398,10 +1317,8 @@ private[lf] object SBuiltin {
 
   /** $text_slice :: Int -> Int -> Text -> Text */
   final case object SBTextSlice extends SBuiltin(3) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SInt64(from) =>
           args.get(1) match {
             case SInt64(to) =>
@@ -1436,10 +1353,8 @@ private[lf] object SBuiltin {
 
   /** $text_slice_index :: Text -> Text -> Optional Int */
   final case object SBTextSliceIndex extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SText(slice) =>
           args.get(1) match {
             case SText(t) =>
@@ -1461,10 +1376,8 @@ private[lf] object SBuiltin {
 
   /** $text_contains_only :: Text -> Text -> Bool */
   final case object SBTextContainsOnly extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SText(alphabet) =>
           args.get(1) match {
             case SText(t) =>
@@ -1482,10 +1395,8 @@ private[lf] object SBuiltin {
 
   /** $text_replicate :: Int -> Text -> Text */
   final case object SBTextReplicate extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SInt64(n) =>
           args.get(1) match {
             case SText(t) =>
@@ -1506,10 +1417,8 @@ private[lf] object SBuiltin {
 
   /** $text_split_on :: Text -> Text -> List Text */
   final case object SBTextSplitOn extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SText(pattern) =>
           args.get(1) match {
             case SText(t) =>
@@ -1535,10 +1444,8 @@ private[lf] object SBuiltin {
 
   /** $text_intercalate :: Text -> List Text -> Text */
   final case object SBTextIntercalate extends SBuiltin(2) {
-    override private[speedy] final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
-      machine.returnValue = args.get(0) match {
+    override private[speedy] final def execute(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
         case SText(sep) =>
           args.get(1) match {
             case SList(vs) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -124,6 +124,18 @@ object SExpr {
     }
   }
 
+  /** Function application: non-ANF case: 'fun' atomic; 'args' not so.
+    This case is produced by the ANF transform when it is unable to ensure
+    that the standard ANF transform will not change evaluation order. */
+  final case class SEAppNonAtomic(fun: SExprAtomic, args: Array[SExpr])
+      extends SExpr
+      with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      val vfun = fun.lookupValue(machine)
+      executeApplication(machine, vfun, args)
+    }
+  }
+
   /** Function application: ANF case: 'fun' and 'args' are atomic expressions */
   final case class SEAppAtomicGeneral(fun: SExprAtomic, args: Array[SExprAtomic])
       extends SExpr

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -36,7 +36,12 @@ sealed abstract class SExpr extends Product with Serializable {
 object SExpr {
 
   sealed abstract class SExprAtomic extends SExpr {
-    def evaluate(machine: Machine): SValue
+    def lookupValue(machine: Machine): SValue
+
+    def execute(machine: Machine): Unit = {
+      machine.returnValue = lookupValue(machine)
+    }
+
   }
 
   /** Reference to a variable. 'index' is the 1-based de Bruijn index,
@@ -45,10 +50,7 @@ object SExpr {
     * https://en.wikipedia.org/wiki/De_Bruijn_index
     * This expression form is only allowed prior to closure conversion
     */
-  final case class SEVar(index: Int) extends SExprAtomic {
-    def evaluate(machine: Machine): SValue = {
-      crash("unexpected SEVar, expected SELoc(S/A/F)")
-    }
+  final case class SEVar(index: Int) extends SExpr {
     def execute(machine: Machine): Unit = {
       crash("unexpected SEVar, expected SELoc(S/A/F)")
     }
@@ -83,19 +85,10 @@ object SExpr {
   }
 
   /** Reference to a builtin function */
-  final case class SEBuiltin(b: SBuiltin) extends SExprAtomic {
-    def evaluate(machine: Machine): SValue = {
+  final case class SEBuiltin(b: SBuiltinEffect) extends SExprAtomic {
+    def lookupValue(machine: Machine): SValue = {
       /* special case for nullary record constructors */
       b match {
-        case SBRecCon(id, fields) if b.arity == 0 =>
-          SRecord(id, fields, new util.ArrayList())
-        case _ =>
-          SPAP(PBuiltin(b), new util.ArrayList(), b.arity)
-      }
-    }
-    def execute(machine: Machine): Unit = {
-      /* special case for nullary record constructors */
-      machine.returnValue = b match {
         case SBRecCon(id, fields) if b.arity == 0 =>
           SRecord(id, fields, new util.ArrayList())
         case _ =>
@@ -106,75 +99,67 @@ object SExpr {
 
   /** A pre-computed value, usually primitive literal, e.g. integer, text, boolean etc. */
   final case class SEValue(v: SValue) extends SExprAtomic {
-    def evaluate(machine: Machine): SValue = {
+    def lookupValue(machine: Machine): SValue = {
       v
-    }
-    def execute(machine: Machine): Unit = {
-      machine.returnValue = v
     }
   }
 
   object SEValue extends SValueContainer[SEValue]
 
-  /** Function application:
-    General case: 'fun' and 'args' are any kind of expression */
+  /** Function application: General case: 'fun' and 'args' are any kind of expression */
   final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KArg(args, machine.frame, machine.actuals, machine.env.size))
-      machine.ctrl = fun
-    }
-  }
-
-  /** Function application:
-    Special case: 'fun' is an atomic expression. */
-  final case class SEAppAtomicFun(fun: SExprAtomic, args: Array[SExpr])
-      extends SExpr
-      with SomeArrayEquals {
-    def execute(machine: Machine): Unit = {
-      val vfun = fun.evaluate(machine)
-      executeApplication(machine, vfun, args)
-    }
-  }
-
-  /** Function application:
-    Special case: 'fun' is a builtin; size of `args' matches the builtin arity.
-    */
-  // A fully saturated builtin application
-  final case class SEAppSaturatedBuiltinFun(builtin: SBuiltin, args: Array[SExpr])
-      extends SExpr
-      with SomeArrayEquals {
-    if (args.size != builtin.arity) {
-      throw SErrorCrash(s"SEAppB: arg.size != builtin.arity")
-    }
-    def execute(machine: Machine): Unit = {
-      val arity = builtin.arity
-      val actuals = new util.ArrayList[SValue](arity)
-      machine.pushKont(KBuiltin(builtin, actuals, machine.env.size))
-      evaluateArguments(machine, actuals, args, args.length);
+      // We never encounter a general application node when executing on the speedy machine
+      // This is because all speedy expression must have been converted to ANF form
+      // The wrapper type `AExpr` helps ensure this restrction is adhered to.
+      // Better still would be to properly separate the `SExpr` and `AExpr` types.
+      throw SErrorCrash(s"execute: unexpected SEAppGeneral")
     }
   }
 
   object SEApp {
-
+    //TODO: SEApp is no longer a smart constructor; remove this indirection.
     def apply(fun: SExpr, args: Array[SExpr]): SExpr = {
-      fun match {
-        // Detect special cases of function-application which can we executed more efficiently
+      SEAppGeneral(fun, args)
+    }
+  }
 
+  /** Function application: ANF case: 'fun' and 'args' are atomic expressions */
+  final case class SEAppAtomicGeneral(fun: SExprAtomic, args: Array[SExprAtomic])
+      extends SExpr
+      with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      val vfun = fun.lookupValue(machine)
+      //TODO: evaluate args to SValue here
+      enterApplication(machine, vfun, args)
+    }
+  }
+
+  /** Function application: ANF case: 'fun' is builtin; 'args' are atomic expressions.  Size
+    * of `args' matches the builtin arity. */
+  final case class SEAppAtomicSaturatedBuiltin(builtin: SBuiltinEffect, args: Array[SExprAtomic])
+      extends SExpr
+      with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      val arity = builtin.arity
+      val actuals = new util.ArrayList[SValue](arity)
+      for (i <- 0 to arity - 1) {
+        val arg = args(i)
+        val v = arg.lookupValue(machine)
+        actuals.add(v)
+      }
+      builtin.executeEffect(actuals, machine)
+    }
+  }
+
+  object SEAppAtomic {
+    // smart constructor: detect special case of saturated builtin application
+    def apply(func: SExprAtomic, args: Array[SExprAtomic]): SExpr = {
+      func match {
         case SEBuiltin(builtin) if builtin.arity == args.length =>
-          SEAppSaturatedBuiltinFun(builtin, args)
-
-        case SEBuiltin(builtin) if builtin.arity < args.length =>
-          val arity = builtin.arity
-          val extra = args.length - arity
-          val arityArgs = new Array[SExpr](arity)
-          val extraArgs = new Array[SExpr](extra)
-          System.arraycopy(args, 0, arityArgs, 0, arity)
-          System.arraycopy(args, arity, extraArgs, 0, extra)
-          SEApp(SEAppSaturatedBuiltinFun(builtin, arityArgs), extraArgs)
-
-        case vfun: SExprAtomic => SEAppAtomicFun(vfun, args)
-
-        case _ => SEAppGeneral(fun, args) // fall back to the general case
+          SEAppAtomicSaturatedBuiltin(builtin, args)
+        case _ =>
+          SEAppAtomicGeneral(func, args) // general case
       }
     }
   }
@@ -207,7 +192,7 @@ object SExpr {
       val sValues = Array.ofDim[SValue](fvs.length)
       var i = 0
       while (i < fvs.length) {
-        sValues(i) = fvs(i).lookup(machine)
+        sValues(i) = fvs(i).lookupValue(machine)
         i += 1
       }
       machine.returnValue =
@@ -220,33 +205,25 @@ object SExpr {
     This is the closure-converted form of SEVar. There are three sub-forms, with sufffix:
     S/A/F, indicating [S]tack, [A]argument, or [F]ree variable captured by a closure.
     */
-  sealed abstract class SELoc extends SExprAtomic {
-    def lookup(machine: Machine): SValue
-    def evaluate(machine: Machine): SValue = {
-      lookup(machine)
-    }
-    def execute(machine: Machine): Unit = {
-      machine.returnValue = lookup(machine)
-    }
-  }
+  sealed abstract class SELoc extends SExprAtomic
 
   // SELocS -- variable is located on the stack (SELet & binding forms of SECasePat)
   final case class SELocS(n: Int) extends SELoc {
-    def lookup(machine: Machine): SValue = {
+    def lookupValue(machine: Machine): SValue = {
       machine.getEnvStack(n)
     }
   }
 
   // SELocS -- variable is located in the args array of the application
   final case class SELocA(n: Int) extends SELoc {
-    def lookup(machine: Machine): SValue = {
+    def lookupValue(machine: Machine): SValue = {
       machine.getEnvArg(n)
     }
   }
 
   // SELocF -- variable is located in the free-vars array of the closure being applied
   final case class SELocF(n: Int) extends SELoc {
-    def lookup(machine: Machine): SValue = {
+    def lookupValue(machine: Machine): SValue = {
       machine.getEnvFree(n)
     }
   }
@@ -254,25 +231,55 @@ object SExpr {
   /** Pattern match. */
   final case class SECase(scrut: SExpr, alts: Array[SCaseAlt]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KMatch(alts, machine.frame, machine.actuals, machine.env.size))
-      machine.ctrl = scrut
+      // All SEcase are converted to SECaseAtomic in Anf.flattenToAnf
+      throw SErrorCrash(s"execute: unexpected SEcase")
     }
-
     override def toString: String = s"SECase($scrut, ${alts.mkString("[", ",", "]")})"
   }
 
-  object SECase {
-
-    // Helper for constructing case expressions:
-    // SECase(scrut) of(
-    //   SECaseAlt(SCPNil ,...),
-    //   SECaseAlt(SCPDefault, ...),
-    // )
-    case class PartialSECase(scrut: SExpr) {
-      def of(alts: SCaseAlt*): SExpr = SECase(scrut, alts.toArray)
+  final case class SECaseAtomic(scrut: SExprAtomic, alts: Array[SCaseAlt])
+      extends SExpr
+      with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      val vscrut = scrut.lookupValue(machine)
+      executeMatchAlts(machine, alts, vscrut)
     }
+  }
 
-    def apply(scrut: SExpr) = PartialSECase(scrut)
+  /** A let-expression with a single RHS */
+  final case class SELet1General(rhs: SExpr, body: SExpr) extends SExpr with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      machine.pushKont(KPushTo(machine.env, body, machine.frame, machine.actuals, machine.env.size))
+      machine.ctrl = rhs
+    }
+  }
+
+  /** A (single) let-expression with an unhungry,saturated builtin-application as RHS */
+  final case class SELet1Builtin(builtin: SBuiltin, args: Array[SExprAtomic], body: SExpr)
+      extends SExpr
+      with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      val arity = builtin.arity
+      val actuals = new util.ArrayList[SValue](arity)
+      for (i <- 0 to arity - 1) {
+        val arg = args(i)
+        val v = arg.lookupValue(machine)
+        actuals.add(v)
+      }
+      val v = builtin.execute(actuals)
+      machine.env.add(v)
+      machine.ctrl = body
+    }
+  }
+
+  object SELet1 {
+    def apply(rhs: SExpr, body: SExpr): SExpr = {
+      rhs match {
+        case SEAppAtomicSaturatedBuiltin(builtin: SBuiltin, args) =>
+          SELet1Builtin(builtin, args, body)
+        case _ => SELet1General(rhs, body)
+      }
+    }
   }
 
   /** A non-recursive, non-parallel let block. Each bound expression
@@ -423,19 +430,26 @@ object SExpr {
   // definition to save java stack
   //
 
-  final case class SEBuiltinRecursiveDefinition(ref: SEBuiltinRecursiveDefinition.Reference)
-      extends SExpr {
+  final case class SEBuiltinRecursiveDefinition(
+      ref: SEBuiltinRecursiveDefinition.Reference,
+  ) extends SExprAtomic {
 
     import SEBuiltinRecursiveDefinition._
 
-    def execute(machine: Machine): Unit = {
-      val body = ref match {
-        case Reference.FoldL => foldLBody
-        case Reference.FoldR => foldRBody
-        case Reference.EqualList => equalListBody
-      }
-      body.execute(machine)
+    private val frame = Array.ofDim[SValue](0) // no free vars
+    private val arity = 3
+
+    private def body: SExpr = ref match {
+      case Reference.FoldL => foldLBody
+      case Reference.FoldR => foldRBody
+      case Reference.EqualList => equalListBody
     }
+
+    private def closure: SValue =
+      SPAP(PClosure(Profile.LabelUnset, body, frame), new util.ArrayList[SValue](), arity)
+
+    def lookupValue(machine: Machine): SValue = closure
+
   }
 
   final object SEBuiltinRecursiveDefinition {
@@ -448,107 +462,109 @@ object SExpr {
       final case object EqualList extends Reference
     }
 
-    val FoldL: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.FoldL)
-    val FoldR: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.FoldR)
-    val EqualList: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.EqualList)
+    val FoldL = SEBuiltinRecursiveDefinition(Reference.FoldL)
+    val FoldR = SEBuiltinRecursiveDefinition(Reference.FoldR)
+    val EqualList = SEBuiltinRecursiveDefinition(Reference.EqualList)
 
-    private val foldLBody: SExpr =
-      // foldl f z xs =
-      SEMakeClo(
-        Array(),
-        3,
-        // case xs of
-        SECase(SELocA(2)) of (
-          // nil -> z
-          SCaseAlt(SCPNil, SELocA(1)),
-          // cons y ys ->
-          SCaseAlt(
+    // The body of an expanded recursive-builtin will always be in ANF form.
+    // The comments show where variables are to be found at runtime.
+
+    private def foldLBody: SExpr =
+      SECaseAtomic( // case xs of
+        SELocA(2),
+        Array(
+          SCaseAlt(SCPNil, SELocA(1)), // nil -> z
+          SCaseAlt( // cons y ys ->
             SCPCons,
-            // foldl f (f z y) ys
-            SEApp(
-              FoldL,
-              Array(
-                SELocA(0), /* f */
-                SEApp(
-                  SELocA(0),
-                  Array(
-                    SELocA(1), /* z */
-                    SELocS(2) /* y */
-                  )
-                ),
-                SELocS(1) /* ys */
+            SELet1( // let sub = (f z y) in
+              SEAppAtomicGeneral(
+                SELocA(0), // f
+                Array(
+                  SELocA(1), // z
+                  SELocS(2) // y
+                )
+              ),
+              SEAppAtomicGeneral(
+                FoldL,
+                Array(
+                  SELocA(0), // f
+                  SELocS(1), // (f z y)
+                  SELocS(2) // ys
+                ))
+            )
+          )
+        )
+      )
+
+    private def foldRBody: SExpr =
+      SECaseAtomic( // case xs of
+        SELocA(2),
+        Array( // nil -> z
+          SCaseAlt(SCPNil, SELocA(1)),
+          SCaseAlt( // cons y ys ->
+            SCPCons,
+            SELet1General( // let sub = (foldr f z ys) in
+              SEAppAtomicGeneral(
+                FoldR,
+                Array(
+                  SELocA(0), // f
+                  SELocA(1), // z
+                  SELocS(1) // ys
+                )),
+              SEAppAtomicGeneral(
+                SELocA(0), // f
+                Array(
+                  SELocS(3), // y
+                  SELocS(1) // (foldr f z ys)
+                )
               )
             )
           )
         )
       )
 
-    private val foldRBody: SExpr =
-      // foldr f z xs =
-      SEMakeClo(
-        Array(),
-        3,
-        // case xs of
-        SECase(SELocA(2)) of (// nil -> z
-        SCaseAlt(SCPNil, SELocA(1)),
-        // cons y ys ->
-        SCaseAlt(
-          SCPCons,
-          // f y (foldr f z ys)
-          SEApp(
-            SELocA(0),
-            Array(
-              /* f */
-              SELocS(2), /* y */
-              SEApp(
-                FoldR,
-                Array(
-                  /* foldr f z ys */
-                  SELocA(0), /* f */
-                  SELocA(1), /* z */
-                  SELocS(1) /* ys */
-                )
-              )
-            )
-          )
-        ))
-      )
-
-    private val equalListBody: SExpr =
-      // equalList f xs ys =
-      SEMakeClo(
-        Array(),
-        3,
-        // case xs of
-        SECase(SELocA(1) /* xs */ ) of (
-          // nil ->
+    private def equalListBody: SExpr =
+      SECaseAtomic( // case xs of
+        SELocA(1),
+        Array(
           SCaseAlt(
-            SCPNil,
-            // case ys of
-            //   nil -> True
-            //   default -> False
-            SECase(SELocA(2)) of (SCaseAlt(SCPNil, SEValue.True),
-            SCaseAlt(SCPDefault, SEValue.False))
+            SCPNil, // nil ->
+            SECaseAtomic( // case ys of
+              SELocA(2),
+              Array(
+                SCaseAlt(SCPNil, SEValue.True), // nil -> True
+                SCaseAlt(SCPDefault, SEValue.False))) // default -> False
           ),
-          // cons x xss ->
-          SCaseAlt(
+          SCaseAlt( // cons x xss ->
             SCPCons,
-            // case ys of
-            //       True -> listEqual f xss yss
-            //       False -> False
-            SECase(SELocA(2) /* ys */ ) of (
-              // nil -> False
-              SCaseAlt(SCPNil, SEValue.False),
-              // cons y yss ->
-              SCaseAlt(
-                SCPCons,
-                // case f x y of
-                SECase(SEApp(SELocA(0), Array(SELocS(2), SELocS(4)))) of (
-                  SCaseAlt(
-                    SCPPrimCon(PCTrue),
-                    SEApp(EqualList, Array(SELocA(0), SELocS(1), SELocS(3))),
-                  ),
-                  SCaseAlt(SCPPrimCon(PCFalse), SEValue.False)
+            SECaseAtomic( // case ys of
+              SELocA(2),
+              Array(
+                SCaseAlt(SCPNil, SEValue.False), // nil -> False
+                SCaseAlt( // cons y yss ->
+                  SCPCons,
+                  SELet1( // let sub = (f y x) in
+                    SEAppAtomicGeneral(
+                      SELocA(0), // f
+                      Array(
+                        SELocS(2), // y
+                        SELocS(4))), // x
+                    SECaseAtomic( // case (f y x) of
+                      SELocS(1),
+                      Array(
+                        SCaseAlt(
+                          SCPPrimCon(PCTrue), // True ->
+                          SEAppAtomicGeneral(
+                            EqualList,
+                            Array(
+                              SELocA(0), // f
+                              SELocS(2), // yss
+                              SELocS(4))) // xss
+                        ),
+                        SCaseAlt(SCPPrimCon(PCFalse), SEValue.False) // False -> False
+                      )
+                    )
+                  )
                 )
               )
             )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -437,7 +437,7 @@ object SExpr {
     import SEBuiltinRecursiveDefinition._
 
     private val frame = Array.ofDim[SValue](0) // no free vars
-    private val arity = 3
+    val arity = 3
 
     private def body: SExpr = ref match {
       case Reference.FoldL => foldLBody

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -113,7 +113,7 @@ object SValue {
 
   /** "Primitives" that can be applied. */
   sealed trait Prim
-  final case class PBuiltin(b: SBuiltin) extends Prim
+  final case class PBuiltin(b: SBuiltinEffect) extends Prim
 
   /** A closure consisting of an expression together with the values the
     * expression is closing over.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -10,6 +10,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.Compiler.{CompilationError, PackageNotFound}
+import com.daml.lf.speedy.Anf.flattenToAnf
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
@@ -84,12 +85,7 @@ private[lf] object Speedy {
    the current frame, actuals and env-stack-depth within the continuation. Then, when the
    continuation is entered, it will call `restoreEnv`.
 
-   We do this for KArg, KMatch, KPushTo, KCatch.
-
-   We *dont* need to do this for KFun. Because, when KFun is entered, it immediately
-   changes `frame` to point to itself, and there will be no references to existing
-   stack-variables within the body of the function. (They will have been translated to
-   free-var reference by the compiler).
+   We do this for KPushTo, KCatch and KOverApp.
    */
 
   private type Frame = Array[SValue]
@@ -223,7 +219,8 @@ private[lf] object Speedy {
         // NOTE(MH): If the top of the continuation stack is the monadic token,
         // we push location information under it to account for the implicit
         // lambda binding the token.
-        case Some(KArg(Array(SEValue.Token), _, _, _)) => {
+        // TODO: re-work the location handling, to avoid the following fragile special-case
+        case Some(KPushTo(_, SEAppAtomicGeneral(SELocS(1), Array(SEValue.Token)), _, _, _)) => {
           // Can't call pushKont here, because we don't push at the top of the stack.
           kontStack.add(last_index, KLocation(loc))
           if (enableInstrumentation) {
@@ -279,9 +276,10 @@ private[lf] object Speedy {
     /** Reuse an existing speedy machine to evaluate a new expression.
       Do not use if the machine is partway though an existing evaluation.
       i.e. run() has returned an `SResult` requiring a callback.
+      This function takes an `AExpr` to prove that the expression has been converted to ANF
       */
-    def setExpressionToEvaluate(expr: SExpr): Unit = {
-      ctrl = expr
+    def setExpressionToEvaluate(anf: AExpr): Unit = {
+      ctrl = anf.wrapped
       kontStack = initialKontStack()
       env = emptyEnv
       steps = 0
@@ -362,7 +360,7 @@ private[lf] object Speedy {
           compiledPackages.getDefinition(ref) match {
             case Some(body) =>
               pushKont(KCacheVal(eval, Nil))
-              ctrl = body
+              ctrl = body.wrapped
             case None =>
               if (compiledPackages.getPackage(ref.packageId).isDefined)
                 crash(
@@ -531,7 +529,7 @@ private[lf] object Speedy {
         compiledPackages: CompiledPackages,
         submissionTime: Time.Timestamp,
         initialSeeding: InitialSeeding,
-        expr: SExpr,
+        anf: AExpr,
         globalCids: Set[V.ContractId],
         committers: Set[Party],
         outputTransactionVersions: VersionRange[transaction.TransactionVersion],
@@ -540,7 +538,7 @@ private[lf] object Speedy {
       new Machine(
         outputTransactionVersions = outputTransactionVersions,
         validating = validating,
-        ctrl = expr,
+        ctrl = anf.wrapped,
         returnValue = null,
         frame = null,
         actuals = null,
@@ -565,20 +563,24 @@ private[lf] object Speedy {
     @throws[PackageNotFound]
     @throws[CompilationError]
     // Construct a machine for running scenario.
-    def fromScenarioSExpr(
+    def fromScenarioAExpr(
         compiledPackages: CompiledPackages,
         transactionSeed: crypto.Hash,
-        scenario: SExpr,
+        scenario: AExpr,
         outputTransactionVersions: VersionRange[TransactionVersion],
     ): Machine = Machine(
       compiledPackages = compiledPackages,
       submissionTime = Time.Timestamp.MinValue,
       initialSeeding = InitialSeeding.TransactionSeed(transactionSeed),
-      expr = SEApp(scenario, Array(SEValue.Token)),
+      anf = makeApplyToToken(scenario),
       globalCids = Set.empty,
       committers = Set.empty,
       outputTransactionVersions = outputTransactionVersions,
     )
+
+    def makeApplyToToken(anf: AExpr): AExpr = {
+      AExpr(SELet1General(anf.wrapped, SEAppAtomicGeneral(SELocS(1), Array(SEValue.Token))))
+    }
 
     @throws[PackageNotFound]
     @throws[CompilationError]
@@ -589,7 +591,7 @@ private[lf] object Speedy {
         scenario: Expr,
         outputTransactionVersions: VersionRange[TransactionVersion],
     ): Machine =
-      fromScenarioSExpr(
+      fromScenarioAExpr(
         compiledPackages = compiledPackages,
         transactionSeed = transactionSeed,
         scenario = compiledPackages.compiler.unsafeCompile(scenario),
@@ -602,12 +604,22 @@ private[lf] object Speedy {
     def fromPureSExpr(
         compiledPackages: CompiledPackages,
         expr: SExpr,
+    ): Machine = fromPureAExpr(
+      compiledPackages = compiledPackages,
+      anf = flattenToAnf(expr),
+    )
+
+    @throws[PackageNotFound]
+    @throws[CompilationError]
+    def fromPureAExpr(
+        compiledPackages: CompiledPackages,
+        anf: AExpr,
     ): Machine =
       Machine(
         compiledPackages = compiledPackages,
         submissionTime = Time.Timestamp.MinValue,
         initialSeeding = InitialSeeding.NoSeed,
-        expr = expr,
+        anf = anf,
         globalCids = Set.empty,
         committers = Set.empty,
         outputTransactionVersions = TransactionVersions.SupportedDevVersions,
@@ -620,8 +632,7 @@ private[lf] object Speedy {
         compiledPackages: CompiledPackages,
         expr: Expr,
     ): Machine =
-      fromPureSExpr(compiledPackages, compiledPackages.compiler.unsafeCompile(expr))
-
+      fromPureAExpr(compiledPackages, compiledPackages.compiler.unsafeCompile(expr))
   }
 
   // Environment
@@ -663,32 +674,12 @@ private[lf] object Speedy {
     }
   }
 
-  /** Evaluate the first 'n' arguments in 'args'.
-    'args' will contain at least 'n' expressions, but it may contain more(!)
-
-    This is because, in the call from 'executeApplication' below, although over-applied
-    arguments are pushed into a continuation, they are not removed from the original array
-    which is passed here as 'args'.
-    */
-  private[speedy] def evaluateArguments(
-      machine: Machine,
-      actuals: util.ArrayList[SValue],
-      args: Array[SExpr],
-      n: Int) = {
-    var i = 1
-    while (i < n) {
-      val arg = args(n - i)
-      machine.pushKont(KPushTo(actuals, arg, machine.frame, machine.actuals, machine.env.size))
-      i = i + 1
-    }
-    machine.ctrl = args(0)
-  }
-
   /** The function has been evaluated to a value, now start evaluating the arguments. */
-  private[speedy] def executeApplication(
+  // This code replaces `executeApplication` which is almost dead.
+  private[speedy] def enterApplication(
       machine: Machine,
       vfun: SValue,
-      newArgs: Array[SExpr]): Unit = {
+      newArgs: Array[SExprAtomic]): Unit = {
     vfun match {
       case SPAP(prim, actualsSoFar, arity) =>
         val missing = arity - actualsSoFar.size
@@ -699,37 +690,135 @@ private[lf] object Speedy {
 
         val othersLength = newArgs.length - missing
 
-        // Not enough arguments. Push a continuation to construct the PAP.
+        // Evaluate the arguments
+        for (i <- 0 to newArgsLimit - 1) {
+          val newArg = newArgs(i)
+          val v = newArg.lookupValue(machine)
+          actuals.add(v)
+        }
+
+        // Not enough arguments. Return a PAP.
         if (othersLength < 0) {
-          machine.pushKont(KPap(prim, actuals, arity))
+          machine.returnValue = SPAP(prim, actuals, arity)
+
         } else {
           // Too many arguments: Push a continuation to re-apply the over-applied args.
           if (othersLength > 0) {
-            val others = new Array[SExpr](othersLength)
+            val others = new Array[SExprAtomic](othersLength)
             System.arraycopy(newArgs, missing, others, 0, othersLength)
-            machine.pushKont(KArg(others, machine.frame, machine.actuals, machine.env.size))
+            machine.pushKont(KOverApp(others, machine.frame, machine.actuals, machine.env.size))
           }
           // Now the correct number of arguments is ensured. What kind of prim do we have?
           prim match {
             case closure: PClosure =>
-              // Push a continuation to execute the function body when the arguments have been evaluated
-              machine.pushKont(KFun(closure, actuals, machine.env.size))
+              machine.frame = closure.frame
+              machine.actuals = actuals
+              // Maybe push a continuation for the profiler
+              val label = closure.label
+              if (label != null) {
+                machine.profile.addOpenEvent(label)
+                machine.pushKont(KLeaveClosure(label))
+              }
+              // Start evaluating the body of the closure.
+              machine.ctrl = closure.expr
 
             case PBuiltin(builtin) =>
-              // Push a continuation to execute the builtin when the arguments have been evaluated
-              machine.pushKont(KBuiltin(builtin, actuals, machine.env.size))
+              machine.actuals = actuals
+              try {
+                builtin.executeEffect(actuals, machine)
+              } catch {
+                // We turn arithmetic exceptions into a daml exception that can be caught.
+                case e: ArithmeticException =>
+                  throw DamlEArithmeticError(e.getMessage)
+              }
+
           }
         }
-        evaluateArguments(machine, actuals, newArgs, newArgsLimit)
 
       case _ =>
         crash(s"Applying non-PAP: $vfun")
     }
   }
 
-  /** The function has been evaluated to a value. Now restore the environment and execute the application */
-  private[speedy] final case class KArg(
-      newArgs: Array[SExpr],
+  /** The scrutinee of a match has been evaluated, now match the alternatives against it. */
+  private[speedy] def executeMatchAlts(machine: Machine, alts: Array[SCaseAlt], v: SValue): Unit = {
+    val altOpt = v match {
+      case SBool(b) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPPrimCon(PCTrue) => b
+            case SCPPrimCon(PCFalse) => !b
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SVariant(_, _, rank1, arg) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPVariant(_, _, rank2) if rank1 == rank2 =>
+              machine.pushEnv(arg)
+              true
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SEnum(_, _, rank1) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPEnum(_, _, rank2) => rank1 == rank2
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SList(lst) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPNil if lst.isEmpty => true
+            case SCPCons if !lst.isEmpty =>
+              val Some((head, tail)) = lst.pop
+              machine.pushEnv(head)
+              machine.pushEnv(SList(tail))
+              true
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SUnit =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPPrimCon(PCUnit) => true
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SOptional(mbVal) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPNone if mbVal.isEmpty => true
+            case SCPSome =>
+              mbVal match {
+                case None => false
+                case Some(x) =>
+                  machine.pushEnv(x)
+                  true
+              }
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SContractId(_) | SDate(_) | SNumeric(_) | SInt64(_) | SParty(_) | SText(_) | STimestamp(
+            _) | SStruct(_, _) | STextMap(_) | SGenMap(_) | SRecord(_, _, _) | SAny(_, _) |
+          STypeRep(_) | STNat(_) | _: SPAP | SToken =>
+        crash(s"Match on non-matchable value: $v")
+    }
+
+    machine.ctrl = altOpt
+      .getOrElse(throw DamlEMatchError(s"No match for $v in ${alts.toList}"))
+      .body
+  }
+
+  private[speedy] final case class KOverApp(
+      newArgs: Array[SExprAtomic],
       frame: Frame,
       actuals: Actuals,
       envSize: Int)
@@ -737,144 +826,7 @@ private[lf] object Speedy {
       with SomeArrayEquals {
     def execute(vfun: SValue, machine: Machine) = {
       machine.restoreEnv(frame, actuals, envSize)
-      executeApplication(machine, vfun, newArgs)
-    }
-  }
-
-  /** The function-closure and arguments have been evaluated. Now execute the body. */
-  private[speedy] final case class KFun(
-      closure: PClosure,
-      actuals: util.ArrayList[SValue],
-      envSize: Int)
-      extends Kont
-      with SomeArrayEquals {
-    def execute(v: SValue, machine: Machine) = {
-      actuals.add(v)
-      // Set frame/actuals to allow access to the function arguments and closure free-varables.
-      machine.restoreEnv(closure.frame, actuals, envSize)
-      // Maybe push a continuation for the profiler
-      val label = closure.label
-      if (label != null) {
-        machine.profile.addOpenEvent(label)
-        machine.pushKont(KLeaveClosure(label))
-      }
-      // Start evaluating the body of the closure.
-      machine.ctrl = closure.expr
-    }
-  }
-
-  /** The builtin arguments have been evaluated. Now execute the builtin. */
-  private[speedy] final case class KBuiltin(
-      builtin: SBuiltin,
-      actuals: util.ArrayList[SValue],
-      envSize: Int)
-      extends Kont {
-    def execute(v: SValue, machine: Machine) = {
-      actuals.add(v)
-      // A builtin has no free-vars, so we set the frame to null.
-      machine.restoreEnv(null, actuals, envSize)
-      try {
-        builtin.execute(actuals, machine)
-      } catch {
-        // We turn arithmetic exceptions into a daml exception that can be caught.
-        case e: ArithmeticException =>
-          throw DamlEArithmeticError(e.getMessage)
-      }
-    }
-  }
-
-  /** The function's partial-arguments have been evaluated. Construct and return the PAP */
-  private[speedy] final case class KPap(prim: Prim, actuals: util.ArrayList[SValue], arity: Int)
-      extends Kont {
-    def execute(v: SValue, machine: Machine) = {
-      actuals.add(v)
-      machine.returnValue = SPAP(prim, actuals, arity)
-    }
-  }
-
-  /** The scrutinee of a match has been evaluated, now match the alternatives against it. */
-  private[speedy] final case class KMatch(
-      alts: Array[SCaseAlt],
-      frame: Frame,
-      actuals: Actuals,
-      envSize: Int)
-      extends Kont
-      with SomeArrayEquals {
-    def execute(v: SValue, machine: Machine) = {
-      machine.restoreEnv(frame, actuals, envSize)
-      val altOpt = v match {
-        case SBool(b) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPPrimCon(PCTrue) => b
-              case SCPPrimCon(PCFalse) => !b
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SVariant(_, _, rank1, arg) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPVariant(_, _, rank2) if rank1 == rank2 =>
-                machine.pushEnv(arg)
-                true
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SEnum(_, _, rank1) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPEnum(_, _, rank2) => rank1 == rank2
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SList(lst) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPNil if lst.isEmpty => true
-              case SCPCons if !lst.isEmpty =>
-                val Some((head, tail)) = lst.pop
-                machine.pushEnv(head)
-                machine.pushEnv(SList(tail))
-                true
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SUnit =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPPrimCon(PCUnit) => true
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SOptional(mbVal) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPNone if mbVal.isEmpty => true
-              case SCPSome =>
-                mbVal match {
-                  case None => false
-                  case Some(x) =>
-                    machine.pushEnv(x)
-                    true
-                }
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SContractId(_) | SDate(_) | SNumeric(_) | SInt64(_) | SParty(_) | SText(_) |
-            STimestamp(_) | SStruct(_, _) | STextMap(_) | SGenMap(_) | SRecord(_, _, _) |
-            SAny(_, _) | STypeRep(_) | STNat(_) | _: SPAP | SToken =>
-          crash("Match on non-matchable value")
-      }
-
-      machine.ctrl = altOpt
-        .getOrElse(throw DamlEMatchError(s"No match for $v in ${alts.toList}"))
-        .body
+      enterApplication(machine, vfun, newArgs)
     }
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
@@ -176,7 +176,8 @@ class AnfTest extends WordSpec with Matchers {
   private def clo1(fv: SELoc, n: Int, body: SExpr): SExpr = SEMakeClo(Array(fv), n, body)
 
   private def app(func: SExpr, arg: SExpr): SExpr = SEAppGeneral(func, Array(arg))
-  private def app2(func: SExpr, arg1: SExpr, arg2: SExpr): SExpr = SEAppGeneral(func, Array(arg1, arg2))
+  private def app2(func: SExpr, arg1: SExpr, arg2: SExpr): SExpr =
+    SEAppGeneral(func, Array(arg1, arg2))
   private def binop(op: SBuiltin, x: SExpr, y: SExpr): SExpr = SEApp(SEBuiltin(op), Array(x, y))
 
   private def ite(i: SExpr, t: SExpr, e: SExpr): SExpr =
@@ -198,7 +199,11 @@ class AnfTest extends WordSpec with Matchers {
   private def appa(func: SExprAtomic, arg: SExprAtomic): SExpr =
     SEAppAtomicGeneral(func, Array(arg))
 
-  private def appa3(func: SExprAtomic, arg1: SExprAtomic, arg2: SExprAtomic, arg3: SExprAtomic): SExpr =
+  private def appa3(
+      func: SExprAtomic,
+      arg1: SExprAtomic,
+      arg2: SExprAtomic,
+      arg3: SExprAtomic): SExpr =
     SEAppAtomicGeneral(func, Array(arg1, arg2, arg3))
 
   private def binopa(op: SBuiltin, x: SExprAtomic, y: SExprAtomic): SExpr =

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
@@ -125,6 +125,23 @@ class AnfTest extends WordSpec with Matchers {
     }
   }
 
+  "error applied to 1 arg" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(1, SEApp(SEBuiltin(SBError), Array(arg0)))
+      val expected = AExpr(lam(1, SEAppAtomicSaturatedBuiltin(SBError, Array(arg0))))
+      testTransform(original, expected)
+    }
+  }
+
+  "error (over) applied to 2 arg" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(2, SEApp(SEBuiltin(SBError), Array(arg0, arg1)))
+      val expected =
+        AExpr(lam(2, SELet1Builtin(SBError, Array(arg0), appa(stack1, arg1))))
+      testTransform(original, expected)
+    }
+  }
+
   "case expression: [\\a b c. if a then b else c]" should {
     "be transformed to ANF as expected" in {
       val original = lam(3, ite(arg0, arg1, arg2))

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
@@ -1,0 +1,205 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+
+import org.scalatest.{Assertion, WordSpec, Matchers}
+
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SBuiltin._
+import com.daml.lf.speedy.Anf.flattenToAnf
+import com.daml.lf.speedy.Pretty.SExpr._
+import com.daml.lf.data.Ref._
+
+class AnfTest extends WordSpec with Matchers {
+
+  "identity: [\\x. x]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(1, arg0)
+      val expected = AExpr(original)
+      testTransform(original, expected)
+    }
+  }
+
+  "twice: [\\f x. f (f x)]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(2, app(arg0, app(arg0, arg1)))
+      val expected = AExpr(lam(2, let1(appa(arg0, arg1), appa(arg0, stack1))))
+      testTransform(original, expected)
+    }
+  }
+
+  "thrice: [\\f x. f (f (f x))]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(2, app(arg0, app(arg0, app(arg0, arg1))))
+      val expected =
+        AExpr(lam(2, let1(appa(arg0, arg1), let1(appa(arg0, stack1), appa(arg0, stack1)))))
+      testTransform(original, expected)
+    }
+  }
+
+  "arithmetic non-atomic: [\\f x. f (x+1)]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(2, app(arg0, binop(SBAddInt64, arg1, num1)))
+      val expected = AExpr(lam(2, let1b2(SBAddInt64, arg1, num1, appa(arg0, stack1))))
+      testTransform(original, expected)
+    }
+  }
+
+  "nested (4x non-atomic): [\\f x. f(x+1) - f(x+2)]" should {
+    "be transformed to ANF as expected" in {
+      val original =
+        lam(
+          2,
+          binop(
+            SBSubInt64,
+            app(arg0, binop(SBAddInt64, arg1, num1)),
+            app(arg0, binop(SBAddInt64, arg1, num2))))
+      val expected =
+        AExpr(
+          lam(
+            2,
+            let1b2(
+              SBAddInt64,
+              arg1,
+              num1,
+              let1(
+                appa(arg0, stack1),
+                let1b2(
+                  SBAddInt64,
+                  arg1,
+                  num2,
+                  let1(appa(arg0, stack1), binopa(SBSubInt64, stack3, stack1)))))))
+      testTransform(original, expected)
+    }
+  }
+
+  "multi-arg fun: [\\f g. f (g 1) (g 2)]" should {
+    "be transformed to ANF as expected" in {
+      val original =
+        lam(2, app2(arg0, app(arg1, num1), app(arg1, num2)))
+      val expected =
+        AExpr(lam(2, let1(appa(arg1, num1), let1(appa(arg1, num2), app2a(arg0, stack2, stack1)))))
+      testTransform(original, expected)
+    }
+  }
+
+  "case expression: [\\a b c. if a then b else c]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(3, ite(arg0, arg1, arg2))
+      val expected = AExpr(lam(3, itea(arg0, arg1, arg2)))
+      testTransform(original, expected)
+    }
+  }
+
+  "non-atomic in branch: [\\f x. if x==0 then 1 else f (div(1,x))]" should {
+    "be transformed to ANF as expected" in {
+      val original =
+        lam(2, ite(binop(SBEqual, arg1, num0), num1, app(arg0, binop(SBDivInt64, num1, arg1))))
+      val expected =
+        AExpr(
+          lam(
+            2,
+            let1b2(
+              SBEqual,
+              arg1,
+              num0,
+              itea(stack1, num1, let1b2(SBDivInt64, num1, arg1, appa(arg0, stack1))))))
+      testTransform(original, expected)
+    }
+  }
+
+  "nested lambda: [\\f g x. g (\\y. f (f y)) x]" should {
+    "be transformed to ANF as expected" in {
+      val original =
+        lam(3, app2(arg1, clo1(arg0, 1, app(free0, app(free0, arg0))), arg2))
+      val expected =
+        AExpr(
+          lam(
+            3,
+            let1(
+              clo1(arg0, 1, let1(appa(free0, arg0), appa(free0, stack1))),
+              app2a(arg1, stack1, arg2))))
+      testTransform(original, expected)
+    }
+  }
+
+  "issue 6535: [\\f x. f x x]" should {
+    "be transformed to ANF as expected (with no redundant lets)" in {
+      val original = lam(2, app2(arg0, arg1, arg1))
+      val expected = AExpr(lam(2, app2a(arg0, arg1, arg1)))
+      testTransform(original, expected)
+    }
+  }
+
+  // expression builders
+  private def lam(n: Int, body: SExpr): SExpr = SEMakeClo(Array(), n, body)
+  private def clo1(fv: SELoc, n: Int, body: SExpr): SExpr = SEMakeClo(Array(fv), n, body)
+
+  private def app(func: SExpr, arg: SExpr): SExpr = SEAppGeneral(func, Array(arg))
+  private def app2(func: SExpr, arg1: SExpr, arg2: SExpr): SExpr = SEAppGeneral(func, Array(arg1, arg2))
+  private def binop(op: SBuiltin, x: SExpr, y: SExpr): SExpr = SEApp(SEBuiltin(op), Array(x, y))
+
+  private def ite(i: SExpr, t: SExpr, e: SExpr): SExpr =
+    SECase(i, Array(SCaseAlt(patTrue, t), SCaseAlt(patFalse, e)))
+
+  // anf builders
+  private def let1(rhs: SExpr, body: SExpr): SExpr =
+    SELet1General(rhs, body)
+
+  private def let1b2(op: SBuiltin, arg1: SExprAtomic, arg2: SExprAtomic, body: SExpr): SExpr =
+    SELet1Builtin(op, Array(arg1, arg2), body)
+
+  private def appa(func: SExprAtomic, arg: SExprAtomic): SExpr =
+    SEAppAtomicGeneral(func, Array(arg))
+
+  private def app2a(func: SExprAtomic, arg1: SExprAtomic, arg2: SExprAtomic): SExpr =
+    SEAppAtomicGeneral(func, Array(arg1, arg2))
+
+  private def binopa(op: SBuiltin, x: SExprAtomic, y: SExprAtomic): SExpr =
+    SEAppAtomicSaturatedBuiltin(op, Array(x, y))
+
+  private def itea(i: SExprAtomic, t: SExpr, e: SExpr): SExpr =
+    SECaseAtomic(i, Array(SCaseAlt(patTrue, t), SCaseAlt(patFalse, e)))
+
+  // true/false case-patterns
+  private def patTrue: SCasePat =
+    SCPVariant(Identifier.assertFromString("P:M:bool"), IdString.Name.assertFromString("True"), 1)
+
+  private def patFalse: SCasePat =
+    SCPVariant(Identifier.assertFromString("P:M:bool"), IdString.Name.assertFromString("False"), 2)
+
+  // atoms
+  private def arg0 = SELocA(0)
+  private def arg1 = SELocA(1)
+  private def arg2 = SELocA(2)
+  private def free0 = SELocF(0)
+  private def stack1 = SELocS(1)
+  private def stack2 = SELocS(2)
+  private def stack3 = SELocS(3)
+  private def num0 = num(0)
+  private def num1 = num(1)
+  private def num2 = num(2)
+  private def num(n: Long): SExprAtomic = SEValue(SInt64(n))
+
+  // run a test...
+  private def testTransform(original: SExpr, expected: AExpr, show: Boolean = false): Assertion = {
+    val transformed = flattenToAnf(original)
+    if (show) {
+      println(s"**original:\n${pp(original)}\n")
+      println(s"**transformed:\n${ppa(transformed)}\n")
+      println(s"**expected:\n${ppa(expected)}\n")
+    }
+    transformed shouldBe (expected)
+  }
+
+  private def ppa(a: AExpr): String = {
+    pp(a.wrapped)
+  }
+
+  private def pp(e: SExpr): String = {
+    prettySExpr(0)(e).render(80)
+  }
+
+}

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
@@ -182,10 +182,10 @@ class AnfTest extends WordSpec with Matchers {
   private def ite(i: SExpr, t: SExpr, e: SExpr): SExpr =
     SECase(i, Array(SCaseAlt(patTrue, t), SCaseAlt(patFalse, e)))
 
-  def folde: SExprAtomic = SEBuiltinRecursiveDefinition.FoldL
-  def app3(func: SExpr, arg1: SExpr, arg2: SExpr, arg3: SExpr): SExpr =
+  private def folde: SExprAtomic = SEBuiltinRecursiveDefinition.FoldL
+  private def app3(func: SExpr, arg1: SExpr, arg2: SExpr, arg3: SExpr): SExpr =
     SEAppGeneral(func, Array(arg1, arg2, arg3))
-  def app4(func: SExpr, arg1: SExpr, arg2: SExpr, arg3: SExpr, arg4: SExpr): SExpr =
+  private def app4(func: SExpr, arg1: SExpr, arg2: SExpr, arg3: SExpr, arg4: SExpr): SExpr =
     SEAppGeneral(func, Array(arg1, arg2, arg3, arg4))
 
   // anf builders
@@ -198,19 +198,8 @@ class AnfTest extends WordSpec with Matchers {
   private def appa(func: SExprAtomic, arg: SExprAtomic): SExpr =
     SEAppAtomicGeneral(func, Array(arg))
 
-  private def app2a(func: SExprAtomic, arg1: SExprAtomic, arg2: SExprAtomic): SExpr =
-    SEAppAtomicGeneral(func, Array(arg1, arg2))
-
   private def appa3(func: SExprAtomic, arg1: SExprAtomic, arg2: SExprAtomic, arg3: SExprAtomic): SExpr =
     SEAppAtomicGeneral(func, Array(arg1, arg2, arg3))
-
-  private def appa4(
-      func: SExprAtomic,
-      arg1: SExprAtomic,
-      arg2: SExprAtomic,
-      arg3: SExprAtomic,
-      arg4: SExprAtomic): SExpr =
-    SEAppAtomicGeneral(func, Array(arg1, arg2, arg3, arg4))
 
   private def binopa(op: SBuiltin, x: SExprAtomic, y: SExprAtomic): SExpr =
     SEAppAtomicSaturatedBuiltin(op, Array(x, y))

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -424,8 +424,8 @@ object Repl {
     defs.get(idToRef(state, args(0))) match {
       case None =>
         println("Error: definition '" + args(0) + "' not found. Try :list."); usage
-      case Some(expr) =>
-        println(Pretty.SExpr.prettySExpr(0)(expr).render(80))
+      case Some(anf) =>
+        println(Pretty.SExpr.prettySExpr(0)(anf.wrapped).render(80))
     }
   }
 

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -10,6 +10,7 @@ import com.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.daml.lf.data.Ref.{Identifier, Party, QualifiedName}
 import com.daml.lf.data.Time
 import com.daml.lf.language.Ast.EVal
+import com.daml.lf.speedy.AExpr
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.Transaction.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
@@ -37,7 +38,7 @@ class CollectAuthorityState {
   private var scenario: String = _
 
   var machine: Machine = null
-  var the_sexpr: SExpr = null
+  var the_anf: AExpr = null
 
   @Setup(Level.Trial)
   def init(): Unit = {
@@ -59,7 +60,7 @@ class CollectAuthorityState {
       expr,
       TransactionVersions.SupportedDevVersions,
     )
-    the_sexpr = machine.ctrl
+    the_anf = AExpr(machine.ctrl)
 
     // fill the caches!
     setup()
@@ -73,7 +74,7 @@ class CollectAuthorityState {
 
   // This is function that we benchmark
   def run(): Unit = {
-    machine.setExpressionToEvaluate(the_sexpr)
+    machine.setExpressionToEvaluate(the_anf)
     var step = 0
     var finalValue: SValue = null
     while (finalValue == null) {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -312,14 +312,15 @@ class Runner(
         AExpr(SEMakeClo(Array(), 1, SELocA(0)))
     }
     new CompiledPackages {
-      override def getPackage(pkgId: PackageId): Option[Package] = compiledPackages.getPackage(pkgId)
+      override def getPackage(pkgId: PackageId): Option[Package] =
+        compiledPackages.getPackage(pkgId)
       override def getDefinition(dref: SDefinitionRef): Option[AExpr] =
         fromLedgerValue.andThen(Some(_)).applyOrElse(dref, compiledPackages.getDefinition)
       // FIXME: avoid override of non abstract method
       override def packages: PartialFunction[PackageId, Package] = compiledPackages.packages
       override def packageIds: Set[PackageId] = compiledPackages.packageIds
       // FIXME: avoid override of non abstract method
-      override def definitions: PartialFunction[SDefinitionRef, SExpr] =
+      override def definitions: PartialFunction[SDefinitionRef, AExpr] =
         fromLedgerValue.orElse(compiledPackages.definitions)
       override def stackTraceMode: Compiler.FullStackTrace.type = Compiler.FullStackTrace
       override def profilingMode: Compiler.NoProfile.type = Compiler.NoProfile

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -33,7 +33,8 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.iface.EnvironmentInterface
 import com.daml.lf.iface.reader.InterfaceReader
 import com.daml.lf.language.Ast._
-import com.daml.lf.speedy.{Compiler, Pretty, SExpr, SValue, Speedy}
+import com.daml.lf.speedy.{Compiler, Pretty, AExpr, SExpr, SValue, Speedy}
+import com.daml.lf.speedy.Anf.flattenToAnf
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
@@ -306,14 +307,13 @@ class Runner(
   // This is a type error but Speedy doesn’t care about the types and the only thing we do
   // with the result is convert it to ledger values/record so this is safe.
   private val extendedCompiledPackages = {
-    val fromLedgerValue: PartialFunction[SDefinitionRef, SExpr] = {
+    val fromLedgerValue: PartialFunction[SDefinitionRef, AExpr] = {
       case LfDefRef(id) if id == script.scriptIds.damlScript("fromLedgerValue") =>
-        SEMakeClo(Array(), 1, SELocA(0))
+        AExpr(SEMakeClo(Array(), 1, SELocA(0)))
     }
     new CompiledPackages {
-      override def getPackage(pkgId: PackageId): Option[Package] =
-        compiledPackages.getPackage(pkgId)
-      override def getDefinition(dref: SDefinitionRef): Option[SExpr] =
+      override def getPackage(pkgId: PackageId): Option[Package] = compiledPackages.getPackage(pkgId)
+      override def getDefinition(dref: SDefinitionRef): Option[AExpr] =
         fromLedgerValue.andThen(Some(_)).applyOrElse(dref, compiledPackages.getDefinition)
       // FIXME: avoid override of non abstract method
       override def packages: PartialFunction[PackageId, Package] = compiledPackages.packages
@@ -361,7 +361,7 @@ class Runner(
       }
 
     def run(expr: SExpr): Future[SValue] = {
-      machine.setExpressionToEvaluate(expr)
+      machine.setExpressionToEvaluate(flattenToAnf(expr))
       stepToValue()
         .fold(Future.failed, Future.successful)
         .flatMap {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -356,7 +356,7 @@ case class ScriptExample(dar: Dar[(PackageId, Package)], runner: TestRunner) {
 
 case class TraceOrder(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:traceOrder"))
-  def traceMsg(msg: String) = s"""[DA.Internal.Prelude:540]: "$msg""""
+  def traceMsg(msg: String) = s"""[GHC.Base:52]: "$msg""""
   def runTests(): Unit = {
     runner.genericTest(
       "traceOrder",

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -356,7 +356,7 @@ case class ScriptExample(dar: Dar[(PackageId, Package)], runner: TestRunner) {
 
 case class TraceOrder(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId = Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:traceOrder"))
-  def traceMsg(msg: String) = s"""[GHC.Base:52]: "$msg""""
+  def traceMsg(msg: String) = s"""[DA.Internal.Prelude:540]: "$msg""""
   def runTests(): Unit = {
     runner.genericTest(
       "traceOrder",


### PR DESCRIPTION
Safe ANF transformation for Speedy.

This PR reinstates the ANF transformation as part of the Speedy compilation phase. The original PR #6440 changed evaluation order in some pathological cases, and so was reverted by PR #6645.

This new PR modifies the original work to be careful not to apply the ANF transform in cases where it can't be sure the evaluation order wont change. This PR was prepared by reinstating the reverting change & working from there. Specifically, we have made the following steps:

- (1) `9665562af` reinstate ANF transform; get FAIL for EvaluationOrder test
  
  This undoes the effect of the revert commit but keeps the `EvaluationOrder` test which shows the bug in full ANF.

      git revert 02c59d4f2
      git reset HEAD^
      git checkout compiler/damlc/tests/daml-test-files/EvaluationOrder.daml

- (2) `f66047fc8` Bend `scalafmt` to my will.

  This change cherry picks commit `992b1dc1d` from PR: #6641 which was already approved, but never got merged before ANF was reverted.  We bring it in here because it makes `Anf.scala` vastly more readable.

- (3) `41be460e7` fix ANF transform to be safe for evaluation order

  The ANF transform is applied only when it is safe to do so. We defined safe cases as: (a) an application with only a single argument, and (b) an application when the expression in function position is a builtin.

  There is some potential for more safe cases, but the returns are diminishing since most applications either fall in the above two categories, or else are cases we have no hope of ever proving as safe.

  In the unsafe cases we expand the multi-application into a cascade of simple applications, and perform ANF on the result. This does not change the evaluation order!

- (4) `777b4962d` revert location change in `traceMsg`. The location is unchanged by safe ANF

  The modified ANF transform doesn't change the location. Which is good I guess.

- (5) `aa450e705` adapt AnfTests to show modified (safe) ANF transform

  Update tests to show the modified transform where necessary.


### Performance

Here is the perf for `CollectAuthority`, running interleaved 6-way vs master on my cloud machine. About x1.15 speedup.

    here:    55.141 ±(99.9%) 0.477 ms/op [Average]
    master:  63.887 ±(99.9%) 0.336 ms/op [Average]
    here:    56.083 ±(99.9%) 0.511 ms/op [Average]
    master:  62.538 ±(99.9%) 0.351 ms/op [Average]
    here:    54.814 ±(99.9%) 0.234 ms/op [Average]
    master:  63.585 ±(99.9%) 0.198 ms/op [Average]


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
