### PR TITLE
Fix typing of nested decoders in daml2js

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -444,7 +444,7 @@ renderSerializableDef SerializableDef{..}
             [ "export declare const " <> serName <> " :"
             , "  (" <> tyArgs <> " => damlTypes.Serializable<" <> serName <> tyParams <> ">) & {"
             ] ++
-            [ "  " <> n <> ": (" <> tyArgs <> " => damlTypes.Serializable<" <> serName <.> n <> ">);"
+            [ "  " <> n <> ": (" <> tyArgs <> " => damlTypes.Serializable<" <> serName <.> n <> tyParams <> ">);"
             | (n, _) <- serNestedDecoders
             ] ++
             [ "};"

--- a/language-support/ts/codegen/tests/build-and-lint.sh
+++ b/language-support/ts/codegen/tests/build-and-lint.sh
@@ -65,7 +65,8 @@ PATH=`dirname $YARN`:$PATH $DAML2TS -o daml2js $DAR
 # Build, lint, test.
 cd build-and-lint-test
 $YARN install --pure-lockfile > /dev/null
-$YARN run build && $YARN run lint
+$YARN run build
+$YARN run lint
 # Invoke 'yarn test'. Control is thereby passed to
 # 'language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts'.
 JAVA=$JAVA SANDBOX=$SANDBOX JSON_API=$JSON_API DAR=$DAR $YARN test


### PR DESCRIPTION
I accidentally broke this when I added the types (very sorry about
that). Unfortunately while the tests should actually have caught this,
they didn’t because they are also broken. The `&&` results in bash
assuming the exit code is handled and `set -e` doesn’t kick in so
despite an error things proceeded just fine.

The change turns
```
  Add2: (<a_a1Ag>(a_a1Ag: damlTypes.Serializable<a_a1Ag>) => damlTypes.Serializable<Expr2.Add2>);
```
into
```
  Add2: (<a_a1Ag>(a_a1Ag: damlTypes.Serializable<a_a1Ag>) => damlTypes.Serializable<Expr2.Add2<a_a1Ag>>);
```

which is obviuosly what we want and also fixes the test. I did verify
that the tests fail afterwards without the change to daml2js.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
