### PR TITLE
Backport #6712: Fix for event_offset to event_sequential_id conversion

### DIFF
--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/JdbcLedgerDao.scala
@@ -894,7 +894,8 @@ private class JdbcLedgerDao(
 
   override val transactionsReader: TransactionsReader =
     new TransactionsReader(dbDispatcher, dbType, eventsPageSize, metrics, translation)(
-      executionContext)
+      executionContext,
+      logCtx)
 
   private val contractsReader: ContractsReader =
     ContractsReader(dbDispatcher, dbType, metrics, lfValueTranslationCache)(executionContext)

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsRange.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/EventsRange.scala
@@ -6,10 +6,19 @@ import anorm.SqlParser.get
 import anorm.SqlStringInterpolation
 import com.daml.ledger.participant.state.v1.Offset
 
+// (startExclusive, endInclusive]
 final case class EventsRange[A](startExclusive: A, endInclusive: A)
 
 object EventsRange {
-  private val EmptyEventSeqIdRange = EventsRange(0L, 0L)
+  private val EmptyLedgerEventSeqId = 0L
+
+  // (0, 0] -- non-existent range
+  private val EmptyEventSeqIdRange = EventsRange(EmptyLedgerEventSeqId, EmptyLedgerEventSeqId)
+
+  def isEmpty[A: Ordering](range: EventsRange[A]): Boolean = {
+    val A = implicitly[Ordering[A]]
+    A.gteq(range.startExclusive, range.endInclusive)
+  }
 
   /**
     * Converts Offset range to Event Sequential ID range.
@@ -19,11 +28,15 @@ object EventsRange {
     * @return Event Sequential ID range
     */
   def readEventSeqIdRange(range: EventsRange[Offset])(
-      connection: java.sql.Connection): EventsRange[Long] =
-    EventsRange(
-      startExclusive = readLowerBound(range.startExclusive)(connection),
-      endInclusive = readUpperBound(range.endInclusive)(connection)
-    )
+      connection: java.sql.Connection
+  ): EventsRange[Long] =
+    if (isEmpty(range))
+      EmptyEventSeqIdRange
+    else
+      EventsRange(
+        startExclusive = readEventSeqId(range.startExclusive)(connection),
+        endInclusive = readEventSeqId(range.endInclusive)(connection)
+      )
 
   /**
     * Converts ledger end offset to Event Sequential ID.
@@ -33,32 +46,19 @@ object EventsRange {
     * @return Event Sequential ID range.
     */
   def readEventSeqIdRange(endInclusive: Offset)(
-      connection: java.sql.Connection): EventsRange[Long] =
-    EmptyEventSeqIdRange.copy(endInclusive = readUpperBound(endInclusive)(connection))
+      connection: java.sql.Connection
+  ): EventsRange[Long] = {
+    if (endInclusive == Offset.beforeBegin) EmptyEventSeqIdRange
+    else EmptyEventSeqIdRange.copy(endInclusive = readEventSeqId(endInclusive)(connection))
+  }
 
-  private def readLowerBound(startExclusive: Offset)(connection: java.sql.Connection): Long =
-    if (startExclusive == Offset.beforeBegin) {
-      EmptyEventSeqIdRange.startExclusive
-    } else {
-      import com.daml.platform.store.Conversions.OffsetToStatement
-      // This query could be: "select min(event_sequential_id) - 1 from participant_events where event_offset > ${range.startExclusive}"
-      // however there are cases when postgres decides not to use the index. We are forcing the index usage specifying `order by event_offset`
-      SQL"select min(event_sequential_id) from participant_events where event_offset > ${startExclusive} group by event_offset order by event_offset asc limit 1"
-        .as(get[Long](1).singleOpt)(connection)
-        .map(_ - 1L)
-        .getOrElse(EmptyEventSeqIdRange.startExclusive)
-    }
-
-  private def readUpperBound(endInclusive: Offset)(connection: java.sql.Connection): Long =
-    if (endInclusive == Offset.beforeBegin) {
-      EmptyEventSeqIdRange.endInclusive
-    } else {
-      import com.daml.platform.store.Conversions.OffsetToStatement
-      // This query could be: "select max(event_sequential_id) from participant_events where event_offset <= ${range.endInclusive}"
-      // however tests using PostgreSQL 12 with tens of millions of events have shown that the index
-      // on `event_offset` is not used unless we _hint_ at it by specifying `order by event_offset`
-      SQL"select max(event_sequential_id) from participant_events where event_offset <= ${endInclusive} group by event_offset order by event_offset desc limit 1"
-        .as(get[Long](1).singleOpt)(connection)
-        .getOrElse(EmptyEventSeqIdRange.endInclusive)
-    }
+  private def readEventSeqId(offset: Offset)(connection: java.sql.Connection): Long = {
+    import com.daml.platform.store.Conversions.OffsetToStatement
+    // This query could be: "select max(event_sequential_id) from participant_events where event_offset <= ${range.endInclusive}"
+    // however tests using PostgreSQL 12 with tens of millions of events have shown that the index
+    // on `event_offset` is not used unless we _hint_ at it by specifying `order by event_offset`
+    SQL"select max(event_sequential_id) from participant_events where event_offset <= ${offset} group by event_offset order by event_offset desc limit 1"
+      .as(get[Long](1).singleOpt)(connection)
+      .getOrElse(EmptyLedgerEventSeqId)
+  }
 }

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/dao/events/TransactionsReader.scala
@@ -17,6 +17,7 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse
 }
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{DatabaseMetrics, Metrics, Timed}
 import com.daml.platform.ApiOffset
 import com.daml.platform.store.DbType
@@ -38,11 +39,13 @@ private[dao] final class TransactionsReader(
     pageSize: Int,
     metrics: Metrics,
     lfValueTranslation: LfValueTranslation,
-)(implicit executionContext: ExecutionContext) {
+)(implicit executionContext: ExecutionContext, loggingContext: LoggingContext) {
 
   private val dbMetrics = metrics.daml.index.db
 
   private val sqlFunctions = SqlFunctions(dbType)
+
+  private val logger = ContextualizedLogger.get(this.getClass)
 
   private def offsetFor(response: GetTransactionsResponse): Offset =
     ApiOffset.assertFromString(response.transactions.head.offset)
@@ -65,10 +68,13 @@ private[dao] final class TransactionsReader(
       verbose: Boolean,
   ): Source[(Offset, GetTransactionsResponse), NotUsed] = {
 
+    logger.debug(s"getFlatTransactions($startExclusive, $endInclusive, $filter, $verbose)")
+
     val requestedRangeF = getEventSeqIdRange(startExclusive, endInclusive)
 
     val query = (range: EventsRange[Long]) =>
-      (connection: Connection) =>
+      (connection: Connection) => {
+        logger.debug(s"getFlatTransactions query($range)")
         EventsTable
           .preparePagedGetFlatTransactions(sqlFunctions)(
             range = range,
@@ -77,6 +83,7 @@ private[dao] final class TransactionsReader(
           )
           .withFetchSize(Some(pageSize))
           .asVectorOf(EventsTable.rawFlatEventParser)(connection)
+    }
 
     val events: Source[EventsTable.Entry[Event], NotUsed] =
       Source
@@ -126,10 +133,14 @@ private[dao] final class TransactionsReader(
       verbose: Boolean,
   ): Source[(Offset, GetTransactionTreesResponse), NotUsed] = {
 
+    logger.debug(
+      s"getTransactionTrees($startExclusive, $endInclusive, $requestingParties, $verbose)")
+
     val requestedRangeF = getEventSeqIdRange(startExclusive, endInclusive)
 
     val query = (range: EventsRange[Long]) =>
-      (connection: Connection) =>
+      (connection: Connection) => {
+        logger.debug(s"getTransactionTrees query($range)")
         EventsTable
           .preparePagedGetTransactionTrees(sqlFunctions)(
             eventsRange = range,
@@ -138,6 +149,7 @@ private[dao] final class TransactionsReader(
           )
           .withFetchSize(Some(pageSize))
           .asVectorOf(EventsTable.rawTreeEventParser)(connection)
+    }
 
     val events: Source[EventsTable.Entry[TreeEvent], NotUsed] =
       Source
@@ -186,18 +198,21 @@ private[dao] final class TransactionsReader(
       verbose: Boolean,
   ): Source[GetActiveContractsResponse, NotUsed] = {
 
+    logger.debug(s"getActiveContracts($activeAt, $filter, $verbose)")
+
     val requestedRangeF: Future[EventsRange[(Offset, Long)]] = getAcsEventSeqIdRange(activeAt)
 
-    val query = (range: EventsRange[(Offset, Long)]) =>
-      (connection: Connection) =>
-        EventsTable
-          .preparePagedGetActiveContracts(sqlFunctions)(
-            range = range,
-            filter = filter,
-            pageSize = pageSize,
-          )
-          .withFetchSize(Some(pageSize))
-          .asVectorOf(EventsTable.rawFlatEventParser)(connection)
+    val query = (range: EventsRange[(Offset, Long)]) => { (connection: Connection) =>
+      logger.debug(s"getActiveContracts query($range)")
+      EventsTable
+        .preparePagedGetActiveContracts(sqlFunctions)(
+          range = range,
+          filter = filter,
+          pageSize = pageSize,
+        )
+        .withFetchSize(Some(pageSize))
+        .asVectorOf(EventsTable.rawFlatEventParser)(connection)
+    }
 
     val events: Source[EventsTable.Entry[Event], NotUsed] =
       Source
@@ -238,21 +253,25 @@ private[dao] final class TransactionsReader(
     dispatcher.executeSql(dbMetrics.getEventSeqIdRange)(
       EventsRange.readEventSeqIdRange(EventsRange(startExclusive, endInclusive)))
 
-  private def streamEvents[A, E](
+  private def streamEvents[A: Ordering, E](
       verbose: Boolean,
       queryMetric: DatabaseMetrics,
       query: EventsRange[A] => Connection => Vector[EventsTable.Entry[Raw[E]]],
       getNextPageRange: EventsTable.Entry[E] => EventsRange[A],
   )(range: EventsRange[A]): Source[EventsTable.Entry[E], NotUsed] =
     PaginatingAsyncStream.streamFrom(range, getNextPageRange) { range1 =>
-      val rawEvents: Future[Vector[EventsTable.Entry[Raw[E]]]] =
-        dispatcher.executeSql(queryMetric)(query(range1))
-      rawEvents.flatMap(
-        es =>
-          Timed.future(
-            future = Future.traverse(es)(deserializeEntry(verbose)),
-            timer = queryMetric.translationTimer,
+      if (EventsRange.isEmpty(range1))
+        Future.successful(Vector.empty)
+      else {
+        val rawEvents: Future[Vector[EventsTable.Entry[Raw[E]]]] =
+          dispatcher.executeSql(queryMetric)(query(range1))
+        rawEvents.flatMap(
+          es =>
+            Timed.future(
+              future = Future.traverse(es)(deserializeEntry(verbose)),
+              timer = queryMetric.translationTimer,
+          )
         )
-      )
+      }
     }
 }


### PR DESCRIPTION
Fixing event_offset to event_sequential_id conversion handling the conversion on an empty ledger, adding a bit more logging, skipping DB query on an empty range.

Backported #6712 to 1.3.x

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
