### PR TITLE
Revert "refactor ci jobs: add setvar to ci/lib.sh (#6708)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,17 +29,14 @@ jobs:
     steps:
       - bash: |
           set -euo pipefail
-
-          source ci/lib.sh
-
           if [ "$(Build.Reason)" == "PullRequest" ]; then
-              setvar branch $(git rev-parse HEAD^2)
-              setvar master $(git rev-parse HEAD^1)
-              setvar fork_point $(git merge-base $(git rev-parse HEAD^1) $(git rev-parse HEAD^2))
+              echo "##vso[task.setvariable variable=branch;isOutput=true]$(git rev-parse HEAD^2)"
+              echo "##vso[task.setvariable variable=master;isOutput=true]$(git rev-parse HEAD^1)"
+              echo "##vso[task.setvariable variable=fork_point;isOutput=true]$(git merge-base $(git rev-parse HEAD^1) $(git rev-parse HEAD^2))"
           else
-              setvar branch $(git rev-parse HEAD)
-              setvar master $(git rev-parse HEAD^1)
-              setvar fork_point $(git rev-parse HEAD^1)
+              echo "##vso[task.setvariable variable=branch;isOutput=true]$(git rev-parse HEAD)"
+              echo "##vso[task.setvariable variable=master;isOutput=true]$(git rev-parse HEAD^1)"
+              echo "##vso[task.setvariable variable=fork_point;isOutput=true]$(git rev-parse HEAD^1)"
           fi
         name: out
 
@@ -103,8 +100,8 @@ jobs:
       name: 'linux-pool'
       demands: assignment -equals default
     steps:
-      - checkout: self
       - template: ci/report-start.yml
+      - checkout: self
       - bash: |
           set -euo pipefail
           git checkout $(release_sha)
@@ -140,9 +137,9 @@ jobs:
       trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
       is_release: $[ dependencies.check_for_release.outputs['out.is_release'] ]
     steps:
-      - checkout: self
       - template: ci/report-start.yml
       - template: ci/clear-shared-segments-macos.yml
+      - checkout: self
       - bash: |
           set -euo pipefail
           git checkout $(release_sha)
@@ -178,8 +175,8 @@ jobs:
       name: 'windows-pool'
       demands: assignment -equals default
     steps:
-      - checkout: self
       - template: ci/report-start.yml
+      - checkout: self
       - bash: |
           set -euo pipefail
           git checkout $(release_sha)
@@ -209,8 +206,8 @@ jobs:
       name: linux-pool
       demands: assignment -equals default
     steps:
-      - checkout: self
       - template: ci/report-start.yml
+      - checkout: self
       - template: ci/compatibility_ts_libs.yml
       - template: ci/tell-slack-failed.yml
       - template: ci/report-end.yml
@@ -225,8 +222,8 @@ jobs:
       name: linux-pool
       demands: assignment -equals default
     steps:
-      - checkout: self
       - template: ci/report-start.yml
+      - checkout: self
       - template: ci/compatibility.yml
         parameters:
           test_flags: '--quick'
@@ -242,9 +239,9 @@ jobs:
     pool:
       name: macOS-pool
     steps:
-      - checkout: self
       - template: ci/report-start.yml
       - template: ci/clear-shared-segments-macos.yml
+      - checkout: self
       - template: ci/compatibility.yml
         parameters:
           test_flags: '--quick'
@@ -262,8 +259,8 @@ jobs:
       name: 'windows-pool'
       demands: assignment -equals default
     steps:
-      - checkout: self
       - template: ci/report-start.yml
+      - checkout: self
       - template: ci/compatibility-windows.yml
         parameters:
           test_flags: '--quick'
@@ -288,8 +285,6 @@ jobs:
       - bash: |
           set -euo pipefail
 
-          source ci/lib.sh
-
           ./release.sh check
 
           changes_release_files() {
@@ -304,6 +299,11 @@ jobs:
               add_one="1_0"
               change_one="1_1"
               [[ "$add_one" == "$changed" || "$change_one" == "$changed" ]]
+          }
+
+          setvar() {
+              echo "Setting '$1' to '$2'"
+              echo "##vso[task.setvariable variable=$1;isOutput=true]$2"
           }
 
           added_line() {
@@ -369,20 +369,17 @@ jobs:
       release_tag: $[ dependencies.check_for_release.outputs['out.release_tag'] ]
       trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
     steps:
+      - template: ci/report-start.yml
       - checkout: self
         persistCredentials: true
-      - template: ci/report-start.yml
       - bash: |
           set -euxo pipefail
-
-          source ci/lib.sh
-
           if git tag v$(release_tag) $(release_sha); then
             git push origin v$(release_tag)
             mkdir $(Build.StagingDirectory)/release
             mkdir $(Build.StagingDirectory)/bucket
           else
-            setvar skip-github TRUE
+            echo "##vso[task.setvariable variable=skip-github]TRUE"
           fi
       - task: DownloadPipelineArtifact@0
         inputs:
@@ -501,9 +498,6 @@ jobs:
     - bash: ci/dev-env-install.sh
     - bash: |
         set -euo pipefail
-
-        source ci/lib.sh
-
         eval "$(./dev-env/bin/dade-assist)"
 
         DELAY=1

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -71,30 +71,27 @@ steps:
                    eq('${{parameters.name}}', 'linux'))
   - bash: |
       set -euo pipefail
-
       eval "$(./dev-env/bin/dade-assist)"
-
-      source ci/lib.sh
 
       TARBALL=daml-sdk-${{parameters.release_tag}}-${{parameters.name}}.tar.gz
       cp bazel-bin/release/sdk-release-tarball.tar.gz $(Build.StagingDirectory)/$TARBALL
-      setvar tarball $TARBALL
+      echo "##vso[task.setvariable variable=tarball;isOutput=true]$TARBALL"
 
       PROTOS_ZIP=protobufs-${{parameters.release_tag}}.zip
       cp bazel-bin/release/protobufs.zip $(Build.StagingDirectory)/$PROTOS_ZIP
-      setvar protos-zip $PROTOS_ZIP
+      echo "##vso[task.setvariable variable=protos-zip;isOutput=true]$PROTOS_ZIP"
 
       DAML_ON_SQL=daml-on-sql-${{parameters.release_tag}}.jar
       ## Not built by default
       bazel build //ledger/sandbox:sandbox-binary_deploy.jar
       cp bazel-bin/ledger/sandbox/sandbox-binary_deploy.jar $(Build.StagingDirectory)/$DAML_ON_SQL
-      setvar daml-on-sql $DAML_ON_SQL
+      echo "##vso[task.setvariable variable=daml-on-sql;isOutput=true]$DAML_ON_SQL"
 
       JSON_API=http-json-${{parameters.release_tag}}.jar
       ## Not built by default
       bazel build //ledger-service/http-json:http-json-binary_deploy.jar
       cp bazel-bin/ledger-service/http-json/http-json-binary_deploy.jar $(Build.StagingDirectory)/$JSON_API
-      setvar json-api $JSON_API
+      echo "##vso[task.setvariable variable=json-api;isOutput=true]$JSON_API"
     env:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
     name: publish

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -30,9 +30,6 @@ steps:
 
   - bash: |
       set -euo pipefail
-
-      source ci/lib.sh
-
       INSTALLER=daml-sdk-${{parameters.release_tag}}-windows.exe
       mv "bazel-bin/release/windows-installer/daml-sdk-installer.exe" "$(Build.StagingDirectory)/$INSTALLER"
       chmod +wx "$(Build.StagingDirectory)/$INSTALLER"
@@ -44,10 +41,10 @@ steps:
       MSYS_NO_PATHCONV=1 signtool.exe sign '/f' signing_key.pfx '/fd' sha256 '/tr' "http://timestamp.digicert.com" '/v' "$(Build.StagingDirectory)/$INSTALLER"
       rm signing_key.pfx
       trap - EXIT
-      setvar installer $INSTALLER
+      echo "##vso[task.setvariable variable=installer;isOutput=true]$INSTALLER"
       TARBALL=daml-sdk-${{parameters.release_tag}}-windows.tar.gz
       cp bazel-bin/release/sdk-release-tarball.tar.gz '$(Build.StagingDirectory)'/$TARBALL
-      setvar tarball $TARBALL
+      echo "##vso[task.setvariable variable=tarball;isOutput=true]$TARBALL"
     name: publish
     env:
       SIGNING_KEY: $(microsoft-code-signing)

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -1,7 +1,0 @@
-# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-setvar() {
-    echo "Setting '$1' to '$2'"
-    echo "##vso[task.setvariable variable=$1;isOutput=true]$2"
-}

--- a/ci/report-end.yml
+++ b/ci/report-end.yml
@@ -4,10 +4,7 @@
 steps:
   - bash: |
       set -euo pipefail
-
-      source ci/lib.sh
-
-      setvar time $(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
+      echo "##vso[task.setvariable variable=time;isOutput=true]$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
     condition: always()
     name: end
 

--- a/ci/report-start.yml
+++ b/ci/report-start.yml
@@ -4,11 +4,8 @@
 steps:
   - bash: |
       set -euo pipefail
-
-      source ci/lib.sh
-
-      setvar time $(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
-      setvar machine $(Agent.MachineName)
+      echo "##vso[task.setvariable variable=time;isOutput=true]$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")"
+      echo "##vso[task.setvariable variable=machine;isOutput=true]$(Agent.MachineName)"
     condition: always()
     name: start
 


### PR DESCRIPTION
This reverts commit 61e9df3eaf10769d3fabf4872b87b2cb4ea60e96.

This interacts very badly with the fact that we check out old commits
for releases. While we could fix it for this particular issue, I don’t
think this buys us enough to make this worth doing and it makes it
easy to introduce issues in the future if we modify lib.sh

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
