### PR TITLE
[kvutils] Do not expose fingerprints to Committers

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -109,7 +109,7 @@ class KeyValueCommitting private[daml] (
       defaultConfig: Configuration,
       submission: DamlSubmission,
       participantId: ParticipantId,
-      inputState: Map[DamlStateKey, (Option[DamlStateValue], Fingerprint)],
+      inputState: DamlStateMap,
   ): PreExecutionResult =
     createCommitter(engine, defaultConfig, submission).runWithPreExecution(
       submission,
@@ -278,7 +278,7 @@ class KeyValueCommitting private[daml] (
 
 object KeyValueCommitting {
   case class PreExecutionResult(
-      readSet: Map[DamlStateKey, Fingerprint],
+      readSet: Set[DamlStateKey],
       successfulLogEntry: DamlLogEntry,
       stateUpdates: Map[DamlStateKey, DamlStateValue],
       outOfTimeBoundsLogEntry: DamlLogEntry,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -10,12 +10,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.{
-  DamlStateMap,
-  DamlStateMapWithFingerprints,
-  Err,
-  Fingerprint
-}
+import com.daml.ledger.participant.state.kvutils.{DamlStateMap, Err}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.data.Time.Timestamp
 import org.slf4j.LoggerFactory
@@ -28,10 +23,7 @@ import scala.collection.mutable
 private[kvutils] trait CommitContext {
   private[this] val logger = LoggerFactory.getLogger(this.getClass)
 
-  def inputsWithFingerprints: DamlStateMapWithFingerprints
-  final def inputs: DamlStateMap = inputsWithFingerprints.map {
-    case (key, (value, _)) => (key, value)
-  }
+  def inputs: DamlStateMap
 
   // NOTE(JM): The outputs must be iterable in deterministic order, hence we
   // keep track of insertion order.
@@ -39,8 +31,7 @@ private[kvutils] trait CommitContext {
     mutable.ArrayBuffer()
   private val outputs: mutable.Map[DamlStateKey, DamlStateValue] =
     mutable.HashMap.empty[DamlStateKey, DamlStateValue]
-  private val accessedInputKeysAndFingerprints: mutable.Set[(DamlStateKey, Fingerprint)] =
-    mutable.Set.empty[(DamlStateKey, Fingerprint)]
+  private val accessedInputKeys: mutable.Set[DamlStateKey] = mutable.Set.empty[DamlStateKey]
 
   var minimumRecordTime: Option[Instant] = None
   var maximumRecordTime: Option[Instant] = None
@@ -58,9 +49,9 @@ private[kvutils] trait CommitContext {
   /** Retrieve value from output state, or if not found, from input state. */
   def get(key: DamlStateKey): Option[DamlStateValue] =
     outputs.get(key).orElse {
-      val value = inputsWithFingerprints.getOrElse(key, throw Err.MissingInputState(key))
-      accessedInputKeysAndFingerprints += key -> value._2
-      value._1
+      val value = inputs.getOrElse(key, throw Err.MissingInputState(key))
+      accessedInputKeys += key
+      value
     }
 
   /** Set a value in the output state. */
@@ -89,8 +80,7 @@ private[kvutils] trait CommitContext {
       }
 
   /** Get the accessed input key set. */
-  def getAccessedInputKeysWithFingerprints: collection.Set[(DamlStateKey, Fingerprint)] =
-    accessedInputKeysAndFingerprints
+  def getAccessedInputKeys: collection.Set[DamlStateKey] = accessedInputKeys
 
   private def inputAlreadyContains(key: DamlStateKey, value: DamlStateValue): Boolean =
     inputs.get(key).exists(_.contains(value))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -89,10 +89,7 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
 
         override def getParticipantId: ParticipantId = participantId
 
-        override def inputsWithFingerprints: DamlStateMapWithFingerprints =
-          inputState.map {
-            case (key, value) => (key, (value, FingerprintPlaceholder))
-          }
+        override val inputs: DamlStateMap = inputState
       }
       val logEntry = runSteps(ctx, submission)
       logEntry -> ctx.getOutputs.toMap
@@ -101,7 +98,7 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
   def runWithPreExecution(
       submission: DamlSubmission,
       participantId: ParticipantId,
-      inputState: DamlStateMapWithFingerprints,
+      inputState: DamlStateMap,
   ): PreExecutionResult =
     preExecutionRunTimer.time { () =>
       val commitContext = new CommitContext {
@@ -109,7 +106,7 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
 
         override def getParticipantId: ParticipantId = participantId
 
-        override def inputsWithFingerprints: DamlStateMapWithFingerprints = inputState
+        override val inputs: DamlStateMap = inputState
       }
       preExecute(submission, participantId, inputState, commitContext)
     }
@@ -117,12 +114,12 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
   private[committer] def preExecute(
       submission: DamlSubmission,
       participantId: ParticipantId,
-      inputState: DamlStateMapWithFingerprints,
+      inputState: DamlStateMap,
       commitContext: CommitContext,
   ): PreExecutionResult = {
     val successfulLogEntry = runSteps(commitContext, submission)
     PreExecutionResult(
-      readSet = commitContext.getAccessedInputKeysWithFingerprints.toMap,
+      readSet = commitContext.getAccessedInputKeys.toSet,
       successfulLogEntry = successfulLogEntry,
       stateUpdates = commitContext.getOutputs.toMap,
       outOfTimeBoundsLogEntry = constructOutOfTimeBoundsLogEntry(commitContext),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/SubmissionExecutor.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/SubmissionExecutor.scala
@@ -9,8 +9,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateValue,
   DamlSubmission
 }
+import com.daml.ledger.participant.state.kvutils.DamlStateMap
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
-import com.daml.ledger.participant.state.kvutils.{DamlStateMap, DamlStateMapWithFingerprints}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.data.Time
 
@@ -25,6 +25,6 @@ trait SubmissionExecutor {
   def runWithPreExecution(
       submission: DamlSubmission,
       participantId: ParticipantId,
-      inputState: DamlStateMapWithFingerprints,
+      inputState: DamlStateMap,
   ): PreExecutionResult
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -120,7 +120,7 @@ class PreExecutingSubmissionValidator[WriteSet](
       inputState.mapValues { case (value, _) => value })
   }
 
-  private def generateReadSet(
+  private[preexecution] def generateReadSet(
       fetchedInputs: DamlInputStateWithFingerprints,
       accessedKeys: Set[DamlStateKey]): ReadSet =
     accessedKeys

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -18,7 +18,6 @@ import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.Engine
 import com.daml.lf.transaction.Transaction
 import com.daml.metrics.Metrics
-import com.google.protobuf.ByteString
 import scalaz.State
 import scalaz.std.list._
 import scalaz.syntax.traverse._
@@ -317,7 +316,7 @@ object KVTest {
       _ <- addDamlState(newState)
     } yield {
       assert(
-        readSet.keySet subsetOf inputKeys.toSet
+        readSet subsetOf inputKeys.toSet
       )
       // Verify that we can always process both the successful and rejection log entries
       KeyValueConsumption.logEntryToUpdate(
@@ -341,14 +340,12 @@ object KVTest {
 
   private[this] def createInputState(
       inputKeys: mutable.Buffer[DamlStateKey],
-      testState: KVTestState): Map[DamlStateKey, (Option[DamlStateValue], ByteString)] = {
+      testState: KVTestState): Map[DamlStateKey, Option[DamlStateValue]] = {
     inputKeys.map { key =>
       {
         val damlStateValue = testState.damlState
           .get(key)
-        key -> (damlStateValue -> damlStateValue
-          .map(_.toByteString)
-          .getOrElse(FingerprintPlaceholder))
+        key -> damlStateValue
       }
     }.toMap
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -7,13 +7,12 @@ import java.time.Instant
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
+import com.daml.ledger.participant.state.kvutils.DamlKvutils
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.committer.Committer.StepInfo
-import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Fingerprint}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.metrics.Metrics
-import com.google.protobuf.ByteString
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
@@ -32,17 +31,17 @@ class CommitterSpec extends WordSpec with Matchers with MockitoSugar {
       when(mockContext.deduplicateUntil).thenReturn(None)
       when(mockContext.outOfTimeBoundsLogEntry).thenReturn(Some(aRejectionLogEntry))
       val expectedReadSet = Set(
-        DamlStateKey.newBuilder.setContractId("1").build -> ByteString.copyFromUtf8("fp1"),
-        DamlStateKey.newBuilder.setContractId("2").build -> ByteString.copyFromUtf8("fp2")
+        DamlStateKey.newBuilder.setContractId("1").build,
+        DamlStateKey.newBuilder.setContractId("2").build
       )
-      when(mockContext.getAccessedInputKeysWithFingerprints).thenReturn(expectedReadSet)
+      when(mockContext.getAccessedInputKeys).thenReturn(expectedReadSet)
       val instance = createCommitter()
 
       val actual = instance.preExecute(aDamlSubmission, aParticipantId, Map.empty, mockContext)
 
       verify(mockContext, times(1)).getOutputs
-      verify(mockContext, times(1)).getAccessedInputKeysWithFingerprints
-      actual.readSet shouldBe expectedReadSet.toMap
+      verify(mockContext, times(1)).getAccessedInputKeys
+      actual.readSet shouldBe expectedReadSet
       actual.successfulLogEntry shouldBe aLogEntry
       actual.stateUpdates shouldBe expectedOutputs
       actual.minimumRecordTime shouldBe Some(Timestamp.assertFromInstant(expectedMinRecordTime))
@@ -56,8 +55,7 @@ class CommitterSpec extends WordSpec with Matchers with MockitoSugar {
       when(mockContext.deduplicateUntil).thenReturn(None)
       when(mockContext.outOfTimeBoundsLogEntry).thenReturn(Some(aRejectionLogEntry))
       when(mockContext.getOutputs).thenReturn(Map.empty)
-      when(mockContext.getAccessedInputKeysWithFingerprints)
-        .thenReturn(Set.empty[(DamlStateKey, Fingerprint)])
+      when(mockContext.getAccessedInputKeys).thenReturn(Set.empty[DamlStateKey])
       val instance = createCommitter()
 
       val actual = instance.preExecute(aDamlSubmission, aParticipantId, Map.empty, mockContext)
@@ -70,8 +68,7 @@ class CommitterSpec extends WordSpec with Matchers with MockitoSugar {
       val mockContext = mock[CommitContext]
       when(mockContext.outOfTimeBoundsLogEntry).thenReturn(Some(aRejectionLogEntry))
       when(mockContext.getOutputs).thenReturn(Iterable.empty)
-      when(mockContext.getAccessedInputKeysWithFingerprints)
-        .thenReturn(Set.empty[(DamlStateKey, Fingerprint)])
+      when(mockContext.getAccessedInputKeys).thenReturn(Set.empty[DamlStateKey])
       val expectedMinRecordTime = Instant.ofEpochSecond(100)
       val expectedMaxRecordTime = Instant.ofEpochSecond(200)
       val expectedDuplicateUntil = Instant.ofEpochSecond(99)
@@ -95,8 +92,7 @@ class CommitterSpec extends WordSpec with Matchers with MockitoSugar {
       val mockContext = mock[CommitContext]
       when(mockContext.outOfTimeBoundsLogEntry).thenReturn(None)
       when(mockContext.getOutputs).thenReturn(Iterable.empty)
-      when(mockContext.getAccessedInputKeysWithFingerprints)
-        .thenReturn(Set.empty[(DamlStateKey, Fingerprint)])
+      when(mockContext.getAccessedInputKeys).thenReturn(Set.empty[DamlStateKey])
       when(mockContext.minimumRecordTime).thenReturn(None)
       when(mockContext.maximumRecordTime).thenReturn(None)
       val instance = createCommitter()

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/FakeCommitContext.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/FakeCommitContext.scala
@@ -3,14 +3,14 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import com.daml.ledger.participant.state.kvutils.DamlStateMapWithFingerprints
+import com.daml.ledger.participant.state.kvutils.DamlStateMap
 import com.daml.ledger.participant.state.kvutils.TestHelpers.mkParticipantId
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.data.Time.Timestamp
 
 class FakeCommitContext(
     recordTime: Option[Timestamp],
-    override val inputsWithFingerprints: DamlStateMapWithFingerprints = Map.empty,
+    override val inputs: DamlStateMap = Map.empty,
     participantId: Int = 0,
     entryId: Int = 0)
     extends CommitContext {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategySpec.scala
@@ -32,7 +32,7 @@ class LogAppenderPreExecutingCommitStrategySpec
       val logEntryId = aLogEntryId()
       val expectedLogEntryKey = logEntryId.toByteString
       val preExecutionResult = PreExecutionResult(
-        readSet = Map.empty,
+        readSet = Set.empty,
         successfulLogEntry = aLogEntry,
         stateUpdates = Map(aStateKey(0) -> aStateValue, aStateKey(1) -> aStateValue),
         outOfTimeBoundsLogEntry = aRejectionLogEntry,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -143,6 +143,20 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
     }
   }
 
+  "generateReadSet" should {
+    "throw in case an input key is declared in the read set but not fetched as input" in {
+      val instance = createInstance()
+
+      assertThrows[IllegalStateException](
+        instance
+          .generateReadSet(
+            fetchedInputs = Map.empty,
+            accessedKeys = TestHelper.allDamlStateKeyTypes.toSet
+          )
+      )
+    }
+  }
+
   private val recordTime = Timestamp.now()
 
   private val metrics = new Metrics(new MetricRegistry)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -6,25 +6,24 @@ package com.daml.ledger.validator.preexecution
 import java.time.Instant
 
 import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch.CorrelatedSubmission
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.kvutils.{Envelope, _}
 import com.daml.ledger.participant.state.v1.Configuration
-import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidator.DamlInputStateWithFingerprints
+import com.daml.ledger.validator.TestHelper.{aLogEntry, anInvalidEnvelope}
+import com.daml.ledger.validator.ValidationFailed.ValidationError
 import com.daml.ledger.validator.{StateKeySerializationStrategy, TestHelper}
 import com.daml.lf.data.Ref.ParticipantId
 import com.daml.lf.data.Time.Timestamp
 import com.daml.metrics.Metrics
-import com.google.protobuf.{ByteString, Empty}
+import com.google.protobuf.ByteString
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{AsyncWordSpec, Matchers}
-import TestHelper.aLogEntry
-import TestHelper.anInvalidEnvelope
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch.CorrelatedSubmission
-import com.daml.ledger.validator.ValidationFailed.ValidationError
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
 class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers with MockitoSugar {
@@ -46,10 +45,14 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
         expectedOutOfTimeBoundsWriteSet = expectedOutOfTimeBoundsWriteSet,
         expectedInvolvedParticipants = expectedInvolvedParticipants
       )
-      val mockLedgerStateReader = createMockLedgerStateReader()
+      val ledgerStateReader = createLedgerStateReader(expectedReadSet)
 
       instance
-        .validate(anEnvelope(), aCorrelationId, aParticipantId, mockLedgerStateReader)
+        .validate(
+          anEnvelope(expectedReadSet.keySet),
+          aCorrelationId,
+          aParticipantId,
+          ledgerStateReader)
         .map { actual =>
           actual.minRecordTime shouldBe expectedMinRecordTime
           actual.maxRecordTime shouldBe expectedMaxRecordTime
@@ -60,13 +63,19 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
         }
     }
 
-    "return a sorted read set" in {
-      val expectedReadSet = TestHelper.allDamlStateKeyTypes.map(_ -> FingerprintPlaceholder).toMap
+    "return a sorted read set with correct fingerprints" in {
+      val expectedReadSet =
+        TestHelper.allDamlStateKeyTypes.map(key => key -> key.toByteString).toMap
       val instance = createInstance(expectedReadSet = expectedReadSet)
-      val mockLedgerStateReader = createMockLedgerStateReader()
+      val ledgerStateReader = createLedgerStateReader(expectedReadSet)
 
-      instance.validate(anEnvelope(), aCorrelationId, aParticipantId, mockLedgerStateReader).map {
-        actual =>
+      instance
+        .validate(
+          anEnvelope(expectedReadSet.keySet),
+          aCorrelationId,
+          aParticipantId,
+          ledgerStateReader)
+        .map { actual =>
           val expectedSortedReadSet = expectedReadSet
             .map {
               case (key, fingerprint) =>
@@ -75,7 +84,7 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
             .toSeq
             .sortBy(_._1.asReadOnlyByteBuffer())
           actual.readSet shouldBe expectedSortedReadSet
-      }
+        }
     }
 
     "fail in case a batched submission is input" in {
@@ -86,14 +95,13 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
             .setCorrelationId("correlated submission")
             .setSubmission(anEnvelope()))
         .build()
-      val mockLedgerStateReader = createMockLedgerStateReader()
 
       instance
         .validate(
           Envelope.enclose(aBatchedSubmission),
           aCorrelationId,
           aParticipantId,
-          mockLedgerStateReader)
+          mock[DamlLedgerStateReaderWithFingerprints])
         .failed
         .map {
           case ValidationError(actualReason) =>
@@ -103,10 +111,13 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
 
     "fail in case an invalid envelope is input" in {
       val instance = createInstance()
-      val mockLedgerStateReader = createMockLedgerStateReader()
 
       instance
-        .validate(anInvalidEnvelope, aCorrelationId, aParticipantId, mockLedgerStateReader)
+        .validate(
+          anInvalidEnvelope,
+          aCorrelationId,
+          aParticipantId,
+          mock[DamlLedgerStateReaderWithFingerprints])
         .failed
         .map {
           case ValidationError(actualReason) =>
@@ -116,11 +127,14 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
 
     "fail in case an unexpected message type is input in the envelope" in {
       val instance = createInstance()
-      val mockLedgerStateReader = createMockLedgerStateReader()
       val anEnvelopedDamlLogEntry = Envelope.enclose(aLogEntry)
 
       instance
-        .validate(anEnvelopedDamlLogEntry, aCorrelationId, aParticipantId, mockLedgerStateReader)
+        .validate(
+          anEnvelopedDamlLogEntry,
+          aCorrelationId,
+          aParticipantId,
+          mock[DamlLedgerStateReaderWithFingerprints])
         .failed
         .map {
           case ValidationError(actualReason) =>
@@ -139,11 +153,11 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
 
   private val aParticipantId = TestHelpers.mkParticipantId(1)
 
-  private def anEnvelope(): Bytes = {
+  private def anEnvelope(expectedReadSet: Set[DamlStateKey] = Set.empty): Bytes = {
     val submission = DamlSubmission
       .newBuilder()
       .setConfigurationSubmission(DamlConfigurationSubmission.getDefaultInstance)
-      .addInputDamlState(DamlStateKey.newBuilder.setConfiguration(Empty.getDefaultInstance))
+      .addAllInputDamlState(expectedReadSet.asJava)
       .build
     Envelope.enclose(submission)
   }
@@ -162,10 +176,10 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
         any[Configuration],
         any[DamlSubmission],
         any[ParticipantId],
-        any[DamlInputStateWithFingerprints]))
+        any[DamlStateMap]))
       .thenReturn(
         PreExecutionResult(
-          expectedReadSet,
+          expectedReadSet.keySet,
           aLogEntry,
           Map.empty,
           aLogEntry,
@@ -192,11 +206,15 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
       mockCommitStrategy)
   }
 
-  private def createMockLedgerStateReader(): DamlLedgerStateReaderWithFingerprints =
+  private def createLedgerStateReader(expectedReadSet: Map[DamlStateKey, Fingerprint] = Map.empty)
+    : DamlLedgerStateReaderWithFingerprints =
     (keys: Seq[DamlStateKey]) =>
       Future.successful {
-        keys.map { _ =>
-          (None, FingerprintPlaceholder)
+        keys.map {
+          case key if expectedReadSet.isDefinedAt(key) =>
+            Some(DamlStateValue.getDefaultInstance) -> expectedReadSet(key)
+          case _ =>
+            None -> FingerprintPlaceholder
         }
     }
 }


### PR DESCRIPTION
Summary of changes:
* Use standard `DamlInputState` as input to pre-executing committers as well.
* Have `PreExecutingSubmissionValidator` construct read set that returns key-fingerprint pairs.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
