### PR TITLE
[kvutils] Added initial set of metrics for pre-execution

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -192,6 +192,7 @@ class Metrics(val registry: MetricRegistry) {
 
           // The below metrics are only generated for pre-execution.
           val validatePreExecute: Timer = registry.timer(Prefix :+ "validate_pre_execute")
+          val generateWriteSets: Timer = registry.timer(Prefix :+ "generate_write_sets")
 
           val validatePreExecuteRunning: Counter =
             registry.counter(Prefix :+ "validate_pre_execute_running")

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -189,6 +189,12 @@ class Metrics(val registry: MetricRegistry) {
           val fetchInputsRunning: Counter = registry.counter(Prefix :+ "fetch_inputs_running")
           val validateRunning: Counter = registry.counter(Prefix :+ "validate_running")
           val commitRunning: Counter = registry.counter(Prefix :+ "commit_running")
+
+          // The below metrics are only generated for pre-execution.
+          val validatePreExecute: Timer = registry.timer(Prefix :+ "validate_pre_execute")
+
+          val validatePreExecuteRunning: Counter =
+            registry.counter(Prefix :+ "validate_pre_execute_running")
         }
       }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -83,15 +83,15 @@ class PreExecutingSubmissionValidator[WriteSet](
 
           case Right(Envelope.SubmissionBatchMessage(_)) =>
             logger.error("Batched submissions are not supported for pre-execution")
-            throw new ValidationFailed.ValidationError(
+            throw ValidationFailed.ValidationError(
               "Batched submissions are not supported for pre-execution")
 
           case Right(other) =>
-            throw new ValidationFailed.ValidationError(
+            throw ValidationFailed.ValidationError(
               s"Unexpected message in envelope: ${other.getClass.getSimpleName}")
 
           case Left(error) =>
-            throw new ValidationFailed.ValidationError(s"Cannot open envelope: $error")
+            throw ValidationFailed.ValidationError(s"Cannot open envelope: $error")
         }
       }
     )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -53,8 +53,14 @@ class PreExecutingSubmissionValidator[WriteSet](
             fetchedInputs)
           logEntryId = BatchedSubmissionValidator.bytesToLogEntryId(submissionEnvelope)
           inputState = fetchedInputs.map { case (key, (value, _)) => key -> value }
-          generatedWriteSets <- commitStrategy
-            .generateWriteSets(submittingParticipantId, logEntryId, inputState, preExecutionResult)
+          generatedWriteSets <- Timed.future(
+            metrics.daml.kvutils.submission.validator.generateWriteSets,
+            commitStrategy.generateWriteSets(
+              submittingParticipantId,
+              logEntryId,
+              inputState,
+              preExecutionResult)
+          )
         } yield {
           PreExecutionOutput(
             minRecordTime = preExecutionResult.minimumRecordTime.map(_.toInstant),


### PR DESCRIPTION
Summary of changes:
* Added timers/counters under `kvutils.submission.validator`:
  * `validate_pre_execute`, `validate_pre_execute_running`
  * `generate_write_sets`
* Track number of decode tasks running in parallel for pre-execution as well.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
