### PR TITLE
DAML-LF: move some type definitions out of Transaction object

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -15,10 +15,11 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.language.Util._
 import com.daml.lf.transaction.Node._
 import com.daml.lf.transaction.{
-  TransactionVersions => TxVersions,
-  GenTransaction => GenTx,
   NodeId,
-  Transaction => Tx
+  SubmittedTransaction,
+  GenTransaction => GenTx,
+  Transaction => Tx,
+  TransactionVersions => TxVersions
 }
 import com.daml.lf.value.Value
 import Value._
@@ -1521,7 +1522,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
 
     "be validable in whole" in {
-      def validate(tx: Tx.SubmittedTransaction, metaData: Tx.Metadata) =
+      def validate(tx: SubmittedTransaction, metaData: Tx.Metadata) =
         engine
           .validate(tx, let, participant, metaData.submissionTime, submissionSeed)
           .consume(_ => None, lookupPackage, _ => None)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/EnrichedTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/EnrichedTransaction.scala
@@ -261,10 +261,10 @@ object EnrichedTransaction {
     * @param tx            transaction resulting from executing the update
     *                      expression at the given effective time.
     */
-  def apply[Transaction <: Tx.Transaction](
+  def apply(
       authorization: Authorization,
-      tx: Transaction,
-  ): EnrichedTransaction[Transaction] = {
+      tx: Tx.Transaction,
+  ): EnrichedTransaction = {
 
     // Before we traversed through an exercise node the exercise witnesses
     // contain only the initial authorizers.
@@ -376,7 +376,7 @@ object EnrichedTransaction {
     }
 
     val finalState =
-      tx.roots.foldLeft(EnrichState.Empty) { (s, nodeId) =>
+      tx.transaction.roots.foldLeft(EnrichState.Empty) { (s, nodeId) =>
         enrichNode(s, initialParentExerciseWitnesses, authorization, nodeId)
       }
 
@@ -390,8 +390,8 @@ object EnrichedTransaction {
 
 }
 
-final case class EnrichedTransaction[Transaction <: Tx.Transaction](
-    tx: Transaction,
+final case class EnrichedTransaction(
+    tx: Tx.Transaction,
     // A relation between a node id and the parties to which this node gets explicitly disclosed.
     explicitDisclosure: Relation[NodeId, Party],
     // A relation between contract id and the parties to which the contract id gets

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -7,7 +7,7 @@ import com.daml.lf.CompiledPackages
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.{SubmittedTransaction, Transaction => Tx}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.transaction.Node.GlobalKey
 
@@ -51,7 +51,7 @@ object SResult {
     * to be absolute. */
   final case class SResultScenarioCommit(
       value: SValue,
-      tx: Tx.SubmittedTransaction,
+      tx: SubmittedTransaction,
       committers: Set[Party],
       callback: SValue => Unit,
   ) extends SResult
@@ -65,7 +65,7 @@ object SResult {
     * commit this transaction with the expectation that it fails.
     * The callback signals success and clears the partial transaction. */
   final case class SResultScenarioMustFail(
-      ptx: Tx.SubmittedTransaction,
+      ptx: SubmittedTransaction,
       committers: Set[Party],
       callback: Unit => Unit,
   ) extends SResult

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -10,6 +10,7 @@ import com.daml.lf.transaction.{
   GenTransaction,
   Node,
   NodeId,
+  SubmittedTransaction,
   TransactionVersion,
   TransactionVersions,
   Transaction => Tx
@@ -220,7 +221,7 @@ private[lf] case class PartialTransaction(
   def finish(
       supportedValueVersions: VersionRange[ValueVersion],
       supportedTransactionVersions: VersionRange[TransactionVersion],
-  ): Either[PartialTransaction, Tx.SubmittedTransaction] = {
+  ): Either[PartialTransaction, SubmittedTransaction] = {
 
     val versionNode: Node => Tx.Node =
       Node.GenNode.map3(
@@ -231,7 +232,7 @@ private[lf] case class PartialTransaction(
 
     Either.cond(
       context.exeContext.isEmpty && aborted.isEmpty,
-      Tx.SubmittedTransaction(
+      SubmittedTransaction(
         TransactionVersions
           .asVersionedTransaction(
             GenTransaction(

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -8,7 +8,7 @@ import com.daml.lf.scenario.ScenarioLedger
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{TransactionVersion, Transaction => Tx}
+import com.daml.lf.transaction.{SubmittedTransaction, TransactionVersion, Transaction => Tx}
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
@@ -108,7 +108,7 @@ final case class ScenarioRunner(
     }
   }
 
-  private def mustFail(tx: Tx.SubmittedTransaction, committers: Set[Party]) = {
+  private def mustFail(tx: SubmittedTransaction, committers: Set[Party]) = {
     // Update expression evaluated successfully,
     // however we might still have an authorization failure.
     val committer =
@@ -129,7 +129,7 @@ final case class ScenarioRunner(
 
   private def commit(
       value: SValue,
-      tx: Tx.SubmittedTransaction,
+      tx: SubmittedTransaction,
       committers: Set[Party],
       callback: SValue => Unit) = {
     val committer =

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -57,9 +57,9 @@ final class TransactionBuilder {
     TransactionVersions.assertAsVersionedTransaction(GenTransaction(nodes.result(), roots.result()))
   }
 
-  def buildSubmitted(): Tx.SubmittedTransaction = Tx.SubmittedTransaction(build())
+  def buildSubmitted(): SubmittedTransaction = SubmittedTransaction(build())
 
-  def buildCommitted(): Tx.CommittedTransaction = Tx.CommittedTransaction(build())
+  def buildCommitted(): CommittedTransaction = CommittedTransaction(build())
 
   def newCid: ContractId = ContractId.V1(newHash())
 
@@ -196,16 +196,16 @@ object TransactionBuilder {
     builder.build()
   }
 
-  def justSubmitted(node: Node, nodes: Node*): Tx.SubmittedTransaction =
-    Tx.SubmittedTransaction(just(node, nodes: _*))
+  def justSubmitted(node: Node, nodes: Node*): SubmittedTransaction =
+    SubmittedTransaction(just(node, nodes: _*))
 
-  def justCommitted(node: Node, nodes: Node*): Tx.CommittedTransaction =
-    Tx.CommittedTransaction(just(node, nodes: _*))
+  def justCommitted(node: Node, nodes: Node*): CommittedTransaction =
+    CommittedTransaction(just(node, nodes: _*))
 
   // not valid transactions.
   val Empty: Tx.Transaction =
     TransactionVersions.assertAsVersionedTransaction(GenTransaction(HashMap.empty, ImmArray.empty))
-  val EmptySubmitted: Tx.SubmittedTransaction = Tx.SubmittedTransaction(Empty)
-  val EmptyCommitted: Tx.CommittedTransaction = Tx.CommittedTransaction(Empty)
+  val EmptySubmitted: SubmittedTransaction = SubmittedTransaction(Empty)
+  val EmptyCommitted: CommittedTransaction = CommittedTransaction(Empty)
 
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/DiscriminatedSubtype.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/DiscriminatedSubtype.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.lf.transaction
 
 import scala.language.higherKinds
@@ -15,3 +18,4 @@ object DiscriminatedSubtype {
     override def subst[F[_]](fx: F[X]): F[T] = fx
   }
 }
+

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/DiscriminatedSubtype.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/DiscriminatedSubtype.scala
@@ -18,4 +18,3 @@ object DiscriminatedSubtype {
     override def subst[F[_]](fx: F[X]): F[T] = fx
   }
 }
-

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/DiscriminatedSubtype.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/DiscriminatedSubtype.scala
@@ -1,0 +1,17 @@
+package com.daml.lf.transaction
+
+import scala.language.higherKinds
+
+sealed abstract class DiscriminatedSubtype[X] {
+  type T <: X
+  def apply(x: X): T
+  def subst[F[_]](fx: F[X]): F[T]
+}
+
+object DiscriminatedSubtype {
+  private[transaction] def apply[X]: DiscriminatedSubtype[X] = new DiscriminatedSubtype[X] {
+    override type T = X
+    override def apply(x: X): T = x
+    override def subst[F[_]](fx: F[X]): F[T] = fx
+  }
+}

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -9,12 +9,10 @@ import com.daml.lf.data._
 import com.daml.lf.language.LanguageVersion
 import com.daml.lf.transaction.GenTransaction.WithTxValue
 import com.daml.lf.value.Value
-import com.daml.lf.value.Value.VersionedValue
 import scalaz.Equal
 
 import scala.annotation.tailrec
 import scala.collection.immutable.HashMap
-import scala.language.higherKinds
 
 final case class VersionedTransaction[Nid, +Cid] private[lf] (
     version: TransactionVersion,
@@ -29,7 +27,7 @@ final case class VersionedTransaction[Nid, +Cid] private[lf] (
   def mapContractId[Cid2](f: Cid => Cid2): VersionedTransaction[Nid, Cid2] =
     VersionedTransaction(
       version,
-      transaction = GenTransaction.map3(identity[Nid], f, VersionedValue.map1(f))(transaction)
+      transaction = GenTransaction.map3(identity[Nid], f, Value.VersionedValue.map1(f))(transaction)
     )
 
   /** Increase the `version` if appropriate for `languageVersions`.
@@ -472,9 +470,9 @@ object GenTransaction extends value.CidContainer3[GenTransaction] {
 
 object Transaction {
 
-  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.3.0")
+  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.4.0")
   type NodeId = transaction.NodeId
-  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.3.0")
+  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.4.0")
   val NodeId = transaction.NodeId
 
   @deprecated("Use daml.lf.value.Value.ContractId directly", since = "1.2.0")
@@ -525,34 +523,27 @@ object Transaction {
       byKeyNodes: ImmArray[transaction.NodeId],
   )
 
-  sealed abstract class DiscriminatedSubtype[X] {
-    type T <: X
-    def apply(x: X): T
-    def subst[F[_]](fx: F[X]): F[T]
-  }
+  @deprecated("Use com.daml.lf.transaction.SubmittedTransaction", since = "1.4.0")
+  type SubmittedTransaction = transaction.SubmittedTransaction
 
-  object DiscriminatedSubtype {
-    def apply[X]: DiscriminatedSubtype[X] = new DiscriminatedSubtype[X] {
-      override type T = X
-      override def apply(x: X): T = x
-      override def subst[F[_]](fx: F[X]): F[T] = fx
-    }
-  }
+  @deprecated("Use com.daml.lf.transaction.SubmittedTransaction", since = "1.4.0")
+  val SubmittedTransaction = transaction.SubmittedTransaction
 
-  val SubmittedTransaction = DiscriminatedSubtype[Transaction]
-  type SubmittedTransaction = SubmittedTransaction.T
+  @deprecated("Use com.daml.lf.transaction.CommittedTransaction", since = "1.4.0")
+  type CommittedTransaction = transaction.CommittedTransaction
 
-  val CommittedTransaction = DiscriminatedSubtype[Transaction]
-  type CommittedTransaction = CommittedTransaction.T
-
-  def commitTransaction(tx: SubmittedTransaction): CommittedTransaction =
-    CommittedTransaction(tx)
+  @deprecated("Use com.daml.lf.transaction.CommittedTransaction", since = "1.4.0")
+  val CommittedTransaction = transaction.CommittedTransaction
 
   def commitTransaction(
-      tx: SubmittedTransaction,
+      submittedTransaction: transaction.SubmittedTransaction): transaction.CommittedTransaction =
+    transaction.CommittedTransaction(submittedTransaction)
+
+  def commitTransaction(
+      submittedTransaction: transaction.SubmittedTransaction,
       f: crypto.Hash => Bytes,
-  ): Either[String, CommittedTransaction] =
-    tx.suffixCid(f).map(CommittedTransaction(_))
+  ): Either[String, transaction.CommittedTransaction] =
+    submittedTransaction.suffixCid(f).map(transaction.CommittedTransaction(_))
 
   /** Errors that can happen during building transactions. */
   sealed abstract class TransactionError extends Product with Serializable

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
@@ -2,8 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.daml.lf
+
+import com.daml.lf.value.Value.ContractId
+
 import scala.collection.TraversableLike
 import scala.collection.generic.CanBuildFrom
+
+import scala.language.higherKinds
 
 package object transaction {
 
@@ -23,4 +28,25 @@ package object transaction {
       }
       Right(b.result())
     }
+
+  sealed abstract class DiscriminatedSubtype[X] {
+    type T <: X
+    def apply(x: X): T
+    def subst[F[_]](fx: F[X]): F[T]
+  }
+
+  object DiscriminatedSubtype {
+    def apply[X]: DiscriminatedSubtype[X] = new DiscriminatedSubtype[X] {
+      override type T = X
+      override def apply(x: X): T = x
+      override def subst[F[_]](fx: F[X]): F[T] = fx
+    }
+  }
+
+  val SubmittedTransaction = DiscriminatedSubtype[VersionedTransaction[NodeId, ContractId]]
+  type SubmittedTransaction = SubmittedTransaction.T
+
+  val CommittedTransaction = DiscriminatedSubtype[VersionedTransaction[NodeId, ContractId]]
+  type CommittedTransaction = CommittedTransaction.T
+
 }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/package.scala
@@ -8,8 +8,6 @@ import com.daml.lf.value.Value.ContractId
 import scala.collection.TraversableLike
 import scala.collection.generic.CanBuildFrom
 
-import scala.language.higherKinds
-
 package object transaction {
 
   /** This traversal fails the identity law so is unsuitable for [[scalaz.Traverse]].
@@ -28,20 +26,6 @@ package object transaction {
       }
       Right(b.result())
     }
-
-  sealed abstract class DiscriminatedSubtype[X] {
-    type T <: X
-    def apply(x: X): T
-    def subst[F[_]](fx: F[X]): F[T]
-  }
-
-  object DiscriminatedSubtype {
-    def apply[X]: DiscriminatedSubtype[X] = new DiscriminatedSubtype[X] {
-      override type T = X
-      override def apply(x: X): T = x
-      override def subst[F[_]](fx: F[X]): F[T] = fx
-    }
-  }
 
   val SubmittedTransaction = DiscriminatedSubtype[VersionedTransaction[NodeId, ContractId]]
   type SubmittedTransaction = SubmittedTransaction.T

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -445,9 +445,9 @@ object Value extends CidContainer1[Value] {
       CidMapper.basicMapperInstance[ContractId, ContractId.V1]
   }
 
-  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.3.0")
+  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.4.0")
   type NodeId = transaction.NodeId
-  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.3.0")
+  @deprecated("use com.daml.lf.transaction.NodeId", since = "1.4.0")
   val NodeId = transaction.NodeId
 
   /*** Keys cannot contain contract ids */

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.v1._
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.CommittedTransaction
 import com.google.common.io.BaseEncoding
 import com.google.protobuf.ByteString
 import org.slf4j.LoggerFactory
@@ -258,7 +258,7 @@ object KeyValueConsumption {
         optNodeSeeds = None,
         optByKeyNodes = None,
       ),
-      transaction = Tx.CommittedTransaction(transaction),
+      transaction = CommittedTransaction(transaction),
       transactionId = hexTxId,
       recordTime = recordTime,
       divulgedContracts = List.empty

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -19,7 +19,7 @@ import com.daml.lf.data.Ref.{PackageId, Party}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Blinding, Engine}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{BlindingInfo, Node, NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{BlindingInfo, Node, NodeId, SubmittedTransaction, Transaction => Tx}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.metrics.Metrics
@@ -210,7 +210,7 @@ private[kvutils] class TransactionCommitter(
 
         engine
           .validate(
-            Tx.SubmittedTransaction(transactionEntry.transaction),
+            SubmittedTransaction(transactionEntry.transaction),
             transactionEntry.ledgerEffectiveTime,
             commitContext.getParticipantId,
             transactionEntry.submissionTime,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -187,6 +187,19 @@ object KVTest {
       testState <- get[KVTestState]
       submInfo = createSubmitterInfo(submitter, commandId, deduplicationTime, testState)
       (tx, txMetaData) = transaction
+      subm = keyValueSubmission.transactionToSubmission(
+        submitterInfo = submInfo,
+        meta = TransactionMeta(
+          ledgerEffectiveTime = testState.recordTime.addMicros(letDelta.toNanos / 1000),
+          workflowId = None,
+          submissionTime = txMetaData.submissionTime,
+          submissionSeed = submissionSeed,
+          optUsedPackages = Some(txMetaData.usedPackages),
+          optNodeSeeds = None,
+          optByKeyNodes = None,
+        ),
+        submittedTransaction = tx
+      )
       subm = transactionToSubmission(submissionSeed, letDelta, testState, submInfo, tx, txMetaData)
       result <- submit(subm)
     } yield result

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -187,19 +187,6 @@ object KVTest {
       testState <- get[KVTestState]
       submInfo = createSubmitterInfo(submitter, commandId, deduplicationTime, testState)
       (tx, txMetaData) = transaction
-      subm = keyValueSubmission.transactionToSubmission(
-        submitterInfo = submInfo,
-        meta = TransactionMeta(
-          ledgerEffectiveTime = testState.recordTime.addMicros(letDelta.toNanos / 1000),
-          workflowId = None,
-          submissionTime = txMetaData.submissionTime,
-          submissionSeed = submissionSeed,
-          optUsedPackages = Some(txMetaData.usedPackages),
-          optNodeSeeds = None,
-          optByKeyNodes = None,
-        ),
-        submittedTransaction = tx
-      )
       subm = transactionToSubmission(submissionSeed, letDelta, testState, submInfo, tx, txMetaData)
       result <- submit(subm)
     } yield result

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Adapter.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.participant.state.kvutils.test
 
 import com.daml.lf.data._
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{Transaction => Tx, Node, NodeId}
+import com.daml.lf.transaction.{Transaction => Tx, Node, NodeId, SubmittedTransaction}
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
@@ -14,7 +14,7 @@ import scala.collection.mutable
 
 private[test] final class Adapter(packages: Map[Ref.PackageId, Ast.Package]) {
 
-  def adapt(tx: Tx.Transaction): Tx.SubmittedTransaction =
+  def adapt(tx: Tx.Transaction): SubmittedTransaction =
     tx.foldWithPathState(new TxBuilder, Option.empty[NodeId])(
         (builder, parent, _, node) =>
           (builder, Some(parent.fold(builder.add(adapt(node)))(builder.add(adapt(node), _))))

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
@@ -19,7 +19,12 @@ import com.daml.lf.data._
 import com.daml.lf.engine.Engine
 import com.daml.lf.language.{Ast, Util => AstUtil}
 import com.daml.lf.transaction.Node.GlobalKey
-import com.daml.lf.transaction.{Node, Transaction => Tx, TransactionCoder => TxCoder}
+import com.daml.lf.transaction.{
+  Node,
+  Transaction => Tx,
+  TransactionCoder => TxCoder,
+  SubmittedTransaction
+}
 import com.daml.lf.value.Value.ContractId
 import com.daml.lf.value.{Value, ValueCoder => ValCoder}
 import com.google.protobuf.ByteString
@@ -28,7 +33,7 @@ import org.openjdk.jmh.annotations._
 import scala.collection.JavaConverters._
 
 final case class TxEntry(
-    tx: Tx.SubmittedTransaction,
+    tx: SubmittedTransaction,
     participantId: ParticipantId,
     ledgerTime: Time.Timestamp,
     submissionTime: Time.Timestamp,
@@ -172,7 +177,7 @@ object Replay {
             TxCoder.NidDecoder,
             ValCoder.CidDecoder,
             submission.getTransactionEntry.getTransaction)
-          .fold(err => sys.error(err.toString), Tx.SubmittedTransaction(_))
+          .fold(err => sys.error(err.toString), SubmittedTransaction(_))
         Stream(
           TxEntry(
             tx = tx,

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/package.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state
 
 import com.daml.lf.data.Ref
 import com.daml.lf.transaction
-import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.Value
 
 /** Interfaces to read from and write to an (abstract) participant state.
@@ -97,14 +96,14 @@ package object v1 {
     *
     * See the Contract Id specification for more detail daml-lf/spec/contract-id.rst
     */
-  type SubmittedTransaction = Tx.SubmittedTransaction
+  type SubmittedTransaction = transaction.SubmittedTransaction
 
   /** A transaction with globally unique contract IDs.
     *
     * Used to communicate transactions that have been accepted to the ledger.
     * See the Contract Id specification for more detail daml-lf/spec/contract-id.rst
     */
-  type CommittedTransaction = Tx.CommittedTransaction
+  type CommittedTransaction = transaction.CommittedTransaction
 
   /** A contract instance. */
   type ContractInst =

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/CommandExecutionResult.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/execution/CommandExecutionResult.scala
@@ -4,7 +4,7 @@
 package com.daml.platform.apiserver.execution
 
 import com.daml.ledger.participant.state.v1.{SubmitterInfo, TransactionMeta}
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.SubmittedTransaction
 
 /**
   * The result of command execution.
@@ -23,7 +23,7 @@ import com.daml.lf.transaction.{Transaction => Tx}
 final case class CommandExecutionResult(
     submitterInfo: SubmitterInfo,
     transactionMeta: TransactionMeta,
-    transaction: Tx.SubmittedTransaction,
+    transaction: SubmittedTransaction,
     dependsOnLedgerTime: Boolean,
     interpretationTimeNanos: Long,
 )

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/services/ApiSubmissionService.scala
@@ -27,7 +27,7 @@ import com.daml.ledger.participant.state.v1.{
 }
 import com.daml.lf.crypto
 import com.daml.lf.data.Ref.Party
-import com.daml.lf.transaction.{Transaction => Tx}
+import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.Metrics
@@ -195,7 +195,7 @@ final class ApiSubmissionService private (
     } yield submissionResult
 
   private def allocateMissingInformees(
-      transaction: Tx.SubmittedTransaction,
+      transaction: SubmittedTransaction,
   ): Future[Seq[SubmissionResult]] =
     if (configuration.implicitPartyAllocation) {
       val parties: Set[Party] = transaction.nodes.values.flatMap(_.informeesOfNode).toSet

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/TransactionConversion.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/index/TransactionConversion.scala
@@ -7,7 +7,7 @@ import com.daml.api.util.TimestampConversion
 import com.daml.lf.data.{BackStack, FrontStack, FrontStackCons, Ref}
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.engine.Blinding
-import com.daml.lf.transaction.{NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{CommittedTransaction, NodeId, Transaction => Tx}
 import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
 import com.daml.lf
 import com.daml.ledger.{CommandId, EventId, TransactionId}
@@ -33,7 +33,7 @@ import scala.annotation.tailrec
 object TransactionConversion {
 
   private type ContractId = lf.value.Value.ContractId
-  private type Transaction = Tx.CommittedTransaction
+  private type Transaction = CommittedTransaction
   private type Node = Tx.Node
   private type Create = NodeCreate.WithTxValue[ContractId]
   private type Exercise = NodeExercises.WithTxValue[NodeId, ContractId]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.transaction.Node.GlobalKey
-import com.daml.lf.transaction.{NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{CommittedTransaction, NodeId}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.platform.store.Contract.{ActiveContract, DivulgedContract}
@@ -150,7 +150,7 @@ case class InMemoryActiveLedgerState(
       transactionId: TransactionId,
       workflowId: Option[WorkflowId],
       submitter: Option[Party],
-      transaction: Tx.CommittedTransaction,
+      transaction: CommittedTransaction,
       disclosure: Relation[NodeId, Party],
       divulgence: Relation[ContractId, Party],
       referencedContracts: List[(Value.ContractId, ContractInst)]

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionCommitter.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/sandbox/stores/ledger/TransactionCommitter.scala
@@ -3,7 +3,6 @@
 
 package com.daml.lf.transaction
 
-import com.daml.ledger.participant.state.v1.{CommittedTransaction, SubmittedTransaction}
 import com.daml.lf.data.Ref
 import com.daml.lf.value.Value
 
@@ -41,9 +40,7 @@ object LegacyTransactionCommitter extends TransactionCommitter {
           Value.ContractId.V0(Ref.ContractIdString.assertFromString(prefix + nid.index.toString)))
         .withDefault(identity)
 
-    Transaction.CommittedTransaction(
-      VersionedTransaction.map2(identity[NodeId], contractMapping)(transaction)
-    )
+    CommittedTransaction(VersionedTransaction.map2(identity[NodeId], contractMapping)(transaction))
 
   }
 

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/ActiveLedgerStateManager.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.transaction.Node.GlobalKey
-import com.daml.lf.transaction.{Node => N, NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{CommittedTransaction, NodeId, Node => N}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.platform.store.Contract.ActiveContract
@@ -63,7 +63,7 @@ class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => A
       transactionId: TransactionId,
       workflowId: Option[WorkflowId],
       submitter: Option[Party],
-      transaction: Tx.CommittedTransaction,
+      transaction: CommittedTransaction,
       disclosure: Relation[NodeId, Party],
       divulgence: Relation[ContractId, Party],
       divulgedContracts: List[(Value.ContractId, ContractInst)])

--- a/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/entries/LedgerEntry.scala
+++ b/ledger/sandbox/src/main/scala/com/digitalasset/platform/store/entries/LedgerEntry.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
-import com.daml.lf.transaction.{NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{CommittedTransaction, NodeId}
 import com.daml.ledger._
 import com.daml.ledger.api.domain.RejectionReason
 
@@ -31,7 +31,7 @@ object LedgerEntry {
       workflowId: Option[WorkflowId],
       ledgerEffectiveTime: Instant,
       recordedAt: Instant,
-      transaction: Tx.CommittedTransaction,
+      transaction: CommittedTransaction,
       explicitDisclosure: Relation[NodeId, Party])
       extends LedgerEntry
 }

--- a/ledger/sandbox/src/main/scala/db/migration/translation/TransactionSerializer.scala
+++ b/ledger/sandbox/src/main/scala/db/migration/translation/TransactionSerializer.scala
@@ -7,7 +7,7 @@ import java.io.InputStream
 
 import com.daml.lf.archive.{Decode, Reader}
 import com.daml.lf.data.Ref.LedgerString
-import com.daml.lf.transaction.{Transaction => Tx, TransactionCoder, TransactionOuterClass}
+import com.daml.lf.transaction.{CommittedTransaction, TransactionCoder, TransactionOuterClass}
 import com.daml.lf.value.ValueCoder
 import com.daml.lf.value.ValueCoder.{DecodeError, EncodeError}
 
@@ -15,13 +15,13 @@ trait TransactionSerializer {
 
   def serializeTransaction(
       trId: LedgerString,
-      transaction: Tx.CommittedTransaction,
+      transaction: CommittedTransaction,
   ): Either[EncodeError, Array[Byte]]
 
   def deserializeTransaction(
       trId: LedgerString,
       stream: InputStream,
-  ): Either[DecodeError, Tx.CommittedTransaction]
+  ): Either[DecodeError, CommittedTransaction]
 
 }
 
@@ -29,7 +29,7 @@ object TransactionSerializer extends TransactionSerializer {
 
   override def serializeTransaction(
       trId: LedgerString,
-      transaction: Tx.CommittedTransaction,
+      transaction: CommittedTransaction,
   ): Either[EncodeError, Array[Byte]] =
     TransactionCoder
       .encodeTransaction(
@@ -41,7 +41,8 @@ object TransactionSerializer extends TransactionSerializer {
 
   override def deserializeTransaction(
       trId: LedgerString,
-      stream: InputStream): Either[DecodeError, Tx.CommittedTransaction] =
+      stream: InputStream,
+  ): Either[DecodeError, CommittedTransaction] =
     TransactionCoder
       .decodeTransaction(
         TransactionCoder.EventIdDecoder(trId),
@@ -49,5 +50,5 @@ object TransactionSerializer extends TransactionSerializer {
         TransactionOuterClass.Transaction.parseFrom(
           Decode.damlLfCodedInputStream(stream, Reader.PROTOBUF_RECURSION_LIMIT))
       )
-      .map(Tx.CommittedTransaction(_))
+      .map(CommittedTransaction(_))
 }

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -17,7 +17,7 @@ import com.daml.lf.archive.DarReader
 import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.transaction.Node._
-import com.daml.lf.transaction.{Node, NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{CommittedTransaction, Node, NodeId, Transaction => Tx}
 import com.daml.lf.value.Value.{ContractId, ContractInst, ValueRecord, ValueText, ValueUnit}
 import com.daml.lf.value.Value
 import com.daml.daml_lf_dev.DamlLf
@@ -222,7 +222,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       workflowId = Some("workflowId"),
       ledgerEffectiveTime = let,
       recordedAt = let,
-      transaction = Tx.CommittedTransaction(txBuilder.buildCommitted()),
+      transaction = CommittedTransaction(txBuilder.buildCommitted()),
       explicitDisclosure = Map(nid -> Set("Alice", "Bob"))
     )
   }
@@ -254,7 +254,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
     val txBuilder = new TransactionBuilder
     val exerciseId = txBuilder.add(exercise(targetCid))
     val childId = txBuilder.add(create(txBuilder.newCid), exerciseId)
-    val tx = Tx.CommittedTransaction(txBuilder.build())
+    val tx = CommittedTransaction(txBuilder.build())
     val offset = nextOffset()
     val id = offset.toLong
     val txId = s"trId$id"
@@ -267,7 +267,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       Some("workflowId"),
       let,
       let,
-      Tx.CommittedTransaction(tx),
+      CommittedTransaction(tx),
       Map(exerciseId -> Set("Alice", "Bob"), childId -> Set("Alice", "Bob"))
     )
   }
@@ -430,7 +430,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         submitterInfo = submitterInfo,
         workflowId = entry.workflowId,
         transactionId = entry.transactionId,
-        transaction = Tx.CommittedTransaction(entry.transaction),
+        transaction = CommittedTransaction(entry.transaction),
         recordTime = entry.recordedAt,
         ledgerEffectiveTime = entry.ledgerEffectiveTime,
         offset = offset,

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -17,7 +17,7 @@ import com.daml.lf.archive.DarReader
 import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.transaction.Node._
-import com.daml.lf.transaction.{CommittedTransaction, Node, NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{CommittedTransaction, Node, NodeId}
 import com.daml.lf.value.Value.{ContractId, ContractInst, ValueRecord, ValueText, ValueUnit}
 import com.daml.lf.value.Value
 import com.daml.daml_lf_dev.DamlLf


### PR DESCRIPTION
`SubmittedTransaction` and `CommittedTransaction` are moved `from com.daml.lf.transaction.Transaction` to `com.daml.lf.transaction`.
     

This helps intelliJ type inference.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
