### PR TITLE
Sequence the acquisition of connections in ledger-on-sql

### DIFF
--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
@@ -52,7 +52,7 @@ object Database {
   // entries missing.
   private val MaximumWriterConnectionPoolSize: Int = 1
 
-  private final class ConnectionPoolName(override val toString: String) extends AnyVal
+  private final class ConnectionPoolName(val string: String) extends AnyVal
 
   private object ConnectionPoolName {
     private val Prefix = "Ledger-Pool"
@@ -161,7 +161,7 @@ object Database {
       readOnly: Boolean = false,
   ): HikariDataSource = {
     val pool = new HikariDataSource()
-    pool.setPoolName(name.toString)
+    pool.setPoolName(name.string)
     pool.setAutoCommit(false)
     pool.setJdbcUrl(jdbcUrl)
     pool.setReadOnly(readOnly)
@@ -175,7 +175,7 @@ object Database {
       readOnly: Boolean = false,
   ): HikariDataSource = {
     val pool = newHikariDataSource(name, jdbcUrl, readOnly)
-    pool.setMaximumPoolSize(MaximumWriterConnectionPoolSize)
+    pool.setMaximumPoolSize(maxPoolSize)
     pool
   }
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Transactor.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Transactor.scala
@@ -55,7 +55,7 @@ sealed abstract class Transactor[Q](
           result
         } catch {
           case NonFatal(e) =>
-            logger.debug("Rolling back transaction if connection is open", e)
+            logger.error("Transaction failed, rolling back if connection is open", e)
             if (!connection.isClosed) {
               logger.debug("Connection open, rolling back.")
               connection.rollback()

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Transactor.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Transactor.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.on.sql
+
+import java.sql.Connection
+
+import com.daml.ledger.on.sql.queries.{ReadQueries, ReadWriteQueries}
+import com.daml.logging.LoggingContext
+import com.daml.metrics.{Metrics, Timed}
+import javax.sql.DataSource
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+import scala.util.control.NonFatal
+
+sealed abstract class Transactor[Q](
+    queries: Connection => Q,
+    connectionPool: DataSource,
+    metrics: Metrics,
+)(implicit ec: ExecutionContext) {
+
+  def inTransaction[T](name: String)(body: Q => Try[T])(
+      implicit logCtx: LoggingContext): Future[T] =
+    Future {
+      // Connection is acquired in the same future to ensure that
+      // two connection acquisition are not accidentally scheduled
+      // one after the other, causing a deadlock on a connection
+      // pool with a single available slot (the first connection
+      // is acquired but cannot be scheduled, the second connection
+      // acquisition is scheduled but cannot be performed until
+      // the first connection is used and made available again)
+      val connection = Timed.value(
+        metrics.daml.ledger.database.transactions.acquireConnection(name),
+        connectionPool.getConnection()
+      )
+      try {
+        val result = body(queries(connection)).get
+        connection.commit()
+        result
+      } catch {
+        case NonFatal(e) =>
+          connection.rollback()
+          throw e
+      } finally {
+        connection.close()
+      }
+    }
+
+}
+
+object Transactor {
+
+  final class ReadWrite(
+      queries: Connection => ReadWriteQueries,
+      connectionPool: DataSource,
+      metrics: Metrics,
+      executionContext: ExecutionContext,
+  ) extends Transactor[ReadWriteQueries](queries, connectionPool, metrics)(executionContext)
+
+  final class ReadOnly(
+      queries: Connection => ReadQueries,
+      connectionPool: DataSource,
+      metrics: Metrics,
+      executionContext: ExecutionContext,
+  ) extends Transactor[ReadQueries](queries, connectionPool, metrics)(executionContext)
+
+}

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
@@ -8,7 +8,7 @@ import java.sql.Connection
 import anorm.SqlParser._
 import anorm._
 import com.daml.ledger.on.sql.Index
-import com.daml.ledger.on.sql.queries.Queries._
+import com.daml.ledger.on.sql.queries.ReadWriteQueries._
 import com.daml.ledger.participant.state.kvutils.OffsetBuilder
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
@@ -16,7 +16,7 @@ import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import scala.collection.{breakOut, immutable}
 import scala.util.Try
 
-trait CommonQueries extends Queries {
+trait CommonQueries extends ReadWriteQueries {
   protected implicit val connection: Connection
 
   override final def selectLatestLogEntryId(): Try[Option[Index]] = Try {

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
@@ -8,14 +8,14 @@ import java.sql.Connection
 import anorm.SqlParser._
 import anorm._
 import com.daml.ledger.on.sql.Index
-import com.daml.ledger.on.sql.queries.Queries._
+import com.daml.ledger.on.sql.queries.ReadWriteQueries._
 import com.daml.ledger.participant.state.v1.LedgerId
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
 import scala.util.Try
 
 final class H2Queries(override protected implicit val connection: Connection)
-    extends Queries
+    extends ReadWriteQueries
     with CommonQueries {
   override def updateOrRetrieveLedgerId(providedLedgerId: LedgerId): Try[LedgerId] = Try {
     SQL"MERGE INTO #$MetaTable USING DUAL ON table_key = $MetaTableKey WHEN NOT MATCHED THEN INSERT (table_key, ledger_id) VALUES ($MetaTableKey, $providedLedgerId)"
@@ -48,7 +48,7 @@ final class H2Queries(override protected implicit val connection: Connection)
 }
 
 object H2Queries {
-  def apply(connection: Connection): Queries = {
+  def apply(connection: Connection): ReadWriteQueries = {
     implicit val conn: Connection = connection
     new H2Queries
   }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
@@ -8,14 +8,14 @@ import java.sql.Connection
 import anorm.SqlParser._
 import anorm._
 import com.daml.ledger.on.sql.Index
-import com.daml.ledger.on.sql.queries.Queries._
+import com.daml.ledger.on.sql.queries.ReadWriteQueries._
 import com.daml.ledger.participant.state.v1.LedgerId
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
 import scala.util.Try
 
 final class PostgresqlQueries(override protected implicit val connection: Connection)
-    extends Queries
+    extends ReadWriteQueries
     with CommonQueries {
   override def updateOrRetrieveLedgerId(providedLedgerId: LedgerId): Try[LedgerId] = Try {
     SQL"INSERT INTO #$MetaTable (table_key, ledger_id) VALUES ($MetaTableKey, $providedLedgerId) ON CONFLICT DO NOTHING"
@@ -41,7 +41,7 @@ final class PostgresqlQueries(override protected implicit val connection: Connec
 }
 
 object PostgresqlQueries {
-  def apply(connection: Connection): Queries = {
+  def apply(connection: Connection): ReadWriteQueries = {
     implicit val conn: Connection = connection
     new PostgresqlQueries
   }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadWriteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadWriteQueries.scala
@@ -19,9 +19,9 @@ import anorm.{
 }
 import com.google.protobuf.ByteString
 
-trait Queries extends ReadQueries with WriteQueries
+trait ReadWriteQueries extends ReadQueries with WriteQueries
 
-object Queries {
+object ReadWriteQueries {
   val TablePrefix = "ledger"
   val LogTable = s"${TablePrefix}_log"
   val MetaTable = s"${TablePrefix}_meta"

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
@@ -8,14 +8,14 @@ import java.sql.Connection
 import anorm.SqlParser._
 import anorm._
 import com.daml.ledger.on.sql.Index
-import com.daml.ledger.on.sql.queries.Queries._
+import com.daml.ledger.on.sql.queries.ReadWriteQueries._
 import com.daml.ledger.participant.state.v1.LedgerId
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
 import scala.util.Try
 
 final class SqliteQueries(override protected implicit val connection: Connection)
-    extends Queries
+    extends ReadWriteQueries
     with CommonQueries {
   override def updateOrRetrieveLedgerId(providedLedgerId: LedgerId): Try[LedgerId] = Try {
     SQL"INSERT INTO #$MetaTable (table_key, ledger_id) VALUES ($MetaTableKey, $providedLedgerId) ON CONFLICT DO NOTHING"
@@ -48,7 +48,7 @@ final class SqliteQueries(override protected implicit val connection: Connection
 }
 
 object SqliteQueries {
-  def apply(connection: Connection): Queries = {
+  def apply(connection: Connection): ReadWriteQueries = {
     implicit val conn: Connection = connection
     new SqliteQueries
   }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedReadQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedReadQueries.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.on.sql.queries
+
+import com.daml.ledger.on.sql.Index
+import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
+import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.metrics.{Metrics, Timed}
+
+import scala.collection.immutable
+import scala.util.Try
+
+class TimedReadQueries(delegate: ReadQueries, metrics: Metrics) extends ReadQueries {
+
+  override def selectLatestLogEntryId(): Try[Option[Index]] =
+    Timed.value(
+      metrics.daml.ledger.database.queries.selectLatestLogEntryId,
+      delegate.selectLatestLogEntryId(),
+    )
+
+  override def selectFromLog(start: Index, end: Index): Try[immutable.Seq[(Index, LedgerRecord)]] =
+    Timed.value(
+      metrics.daml.ledger.database.queries.selectFromLog,
+      delegate.selectFromLog(start, end),
+    )
+
+  override def selectStateValuesByKeys(keys: Seq[Key]): Try[immutable.Seq[Option[Value]]] =
+    Timed.value(
+      metrics.daml.ledger.database.queries.selectStateValuesByKeys,
+      delegate.selectStateValuesByKeys(keys),
+    )
+
+}

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedReadWriteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedReadWriteQueries.scala
@@ -4,35 +4,21 @@
 package com.daml.ledger.on.sql.queries
 
 import com.daml.ledger.on.sql.Index
-import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
 import com.daml.ledger.participant.state.v1.LedgerId
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.metrics.{Metrics, Timed}
 
-import scala.collection.immutable
 import scala.util.Try
 
-final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
-
-  override def selectLatestLogEntryId(): Try[Option[Index]] =
-    Timed.value(
-      metrics.daml.ledger.database.queries.selectLatestLogEntryId,
-      delegate.selectLatestLogEntryId())
-
-  override def selectFromLog(start: Index, end: Index): Try[immutable.Seq[(Index, LedgerRecord)]] =
-    Timed.value(
-      metrics.daml.ledger.database.queries.selectFromLog,
-      delegate.selectFromLog(start, end))
-
-  override def selectStateValuesByKeys(keys: Seq[Key]): Try[immutable.Seq[Option[Value]]] =
-    Timed.value(
-      metrics.daml.ledger.database.queries.selectStateValuesByKeys,
-      delegate.selectStateValuesByKeys(keys))
+final class TimedReadWriteQueries(delegate: ReadWriteQueries, metrics: Metrics)
+    extends TimedReadQueries(delegate, metrics)
+    with ReadWriteQueries {
 
   override def updateOrRetrieveLedgerId(providedLedgerId: LedgerId): Try[LedgerId] =
     Timed.value(
       metrics.daml.ledger.database.queries.updateOrRetrieveLedgerId,
-      delegate.updateOrRetrieveLedgerId(providedLedgerId))
+      delegate.updateOrRetrieveLedgerId(providedLedgerId),
+    )
 
   override def insertRecordIntoLog(key: Key, value: Value): Try[Index] =
     Timed.value(
@@ -42,7 +28,8 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
   override def updateState(stateUpdates: Seq[(Key, Value)]): Try[Unit] =
     Timed.value(
       metrics.daml.ledger.database.queries.updateState,
-      delegate.updateState(stateUpdates))
+      delegate.updateState(stateUpdates),
+    )
 
   override def truncate(): Try[Unit] =
     Timed.value(metrics.daml.ledger.database.queries.truncate, delegate.truncate())

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -253,8 +253,6 @@ final class Metrics(val registry: MetricRegistry) {
 
           def acquireConnection(name: String): Timer =
             registry.timer(Prefix :+ name :+ "acquire_connection")
-          def run(name: String): Timer =
-            registry.timer(Prefix :+ name :+ "run")
         }
       }
 

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -569,7 +569,10 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)(
           .map(i => Ref.Party.assertFromString(s"party-%0${partyIdDigits}d".format(i)))
           .toVector
 
-      val updatesF = ps
+      // Wait before trying to read the results to ensure that single-threaded
+      // implementations don't end up having reads and writes step on each
+      // other's toes
+      lazy val updatesF = ps
         .stateUpdates(beginAfter = None)
         .idleTimeout(IdleTimeout)
         .take(partyCount)


### PR DESCRIPTION
Fixes #6716

The acquisition of a database connection, execution of a query and
further clean-up operations are now performed in a single callback to
make sure that a connection to the database is not attempted before the
previous query has been run, which could lead to unexpected failures as
a long query can prevent the acquisition of a connection for a time
longer than the connection acquisition timeout.

changelog_begin
[Sandbox] Fixed an issue that may have caused unexpected failures when
processing large transactions. Transaction can now be processed as long
as they fit in the queues configured using the back-pressure CLI
options. For more details:
https://github.com/digital-asset/daml/issues/6716.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
