### PR TITLE
run tests on auto-compat pr

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -565,6 +565,7 @@ jobs:
         az extension add --name azure-devops
         echo "$(System.AccessToken)" | az devops login --org "https://dev.azure.com/digitalasset"
         az pipelines build queue --branch $(branch) --definition-name "digital-asset.daml-daily-compat" --org "https://dev.azure.com/digitalasset" --project daml
+        az pipelines build queue --branch $(branch) --definition-name "digital-asset.daml" --org "https://dev.azure.com/digitalasset" --project daml
 
   - job: write_ledger_dump
     dependsOn:


### PR DESCRIPTION
While closely following the 1.3 release through our pipeline to check that #6709 worked as expected, I realized that the automatically-created PR does not start the normal tests either, presumably because it's been opened by a bot. The bot doe shave write access to the repo (obviously, as it can create the PR in the first place), but somehow that doesn't seem to count as a PR with write access for Azure.

So this PR adds the normal test run too, so we don't need to manually say `/azp run` on the PR.

CHANGELOG_BEGIN
CHANGELOG_END