### PR TITLE
DAML-LF: Simplify inference of output transaction/value version.

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -20,7 +20,6 @@ import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SExpr.{LfDefRef, SDefinitionRef}
 import com.daml.lf.transaction.TransactionVersions
 import com.daml.lf.validation.Validation
-import com.daml.lf.value.ValueVersions
 import com.google.protobuf.ByteString
 
 import scala.collection.immutable.HashMap
@@ -154,7 +153,6 @@ class Context(val contextId: Context.ContextId) {
         compiledPackages,
         txSeeding,
         defn,
-        ValueVersions.SupportedDevVersions,
         TransactionVersions.SupportedDevVersions,
       )
   }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -290,6 +290,7 @@ class Engine(config: Engine.Config = Engine.StableConfig) {
     runSafely(
       loadPackages(commands.foldLeft(Set.empty[PackageId])(_ + _.templateId.packageId).toList)
     ) {
+      compiledPackages.compiler.unsafeCompile(commands)
       val machine = Machine(
         compiledPackages = compiledPackages,
         submissionTime = submissionTime,
@@ -298,8 +299,7 @@ class Engine(config: Engine.Config = Engine.StableConfig) {
           .SEApp(compiledPackages.compiler.unsafeCompile(commands), Array(SExpr.SEValue.Token)),
         globalCids = globalCids,
         committers = submitters,
-        supportedValueVersions = config.allowedOutputValueVersions,
-        supportedTransactionVersions = config.allowedOutputTransactionVersions,
+        outputTransactionVersions = config.allowedOutputTransactionVersions,
         validating = validating,
       )
       interpretLoop(machine, ledgerTime)
@@ -370,7 +370,10 @@ class Engine(config: Engine.Config = Engine.StableConfig) {
       }
     }
 
-    machine.ptx.finish(machine.supportedValueVersions, machine.supportedTransactionVersions) match {
+    machine.ptx.finish(
+      machine.outputTransactionVersions,
+      compiledPackages.packageLanguageVersion,
+    ) match {
       case Left(p) =>
         ResultError(Error(s"Interpretation error: ended with partial result: $p"))
       case Right(tx) =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -290,13 +290,12 @@ class Engine(config: Engine.Config = Engine.StableConfig) {
     runSafely(
       loadPackages(commands.foldLeft(Set.empty[PackageId])(_ + _.templateId.packageId).toList)
     ) {
-      compiledPackages.compiler.unsafeCompile(commands)
+      val sexpr = compiledPackages.compiler.unsafeCompile(commands)
       val machine = Machine(
         compiledPackages = compiledPackages,
         submissionTime = submissionTime,
         initialSeeding = seeding,
-        expr = SExpr
-          .SEApp(compiledPackages.compiler.unsafeCompile(commands), Array(SExpr.SEValue.Token)),
+        expr = SExpr.SEApp(sexpr, Array(SExpr.SEValue.Token)),
         globalCids = globalCids,
         committers = submitters,
         outputTransactionVersions = config.allowedOutputTransactionVersions,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
@@ -11,10 +11,10 @@ class EngineInfoTest extends WordSpec with Matchers {
     val DefaultEngineInfo = new EngineInfo(Engine.StableConfig)
     "show supported LF, Transaction and Value versions" in {
       DevEngineInfo.show shouldBe
-        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.dev; Input Transaction versions: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10; Input Value versions: 1, 2, 3, 4, 5, 6, 7; Output Transaction versions: 10; Output Value versions: 6, 7"
+        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.dev; Input Transaction versions: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11; Input Value versions: 1, 2, 3, 4, 5, 6, 7; Output Transaction versions: 10, 11; Output Value versions: 6, 7"
 
       DefaultEngineInfo.show shouldBe
-        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.dev; Input Transaction versions: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10; Input Value versions: 1, 2, 3, 4, 5, 6, 7; Output Transaction versions: 10; Output Value versions: 6"
+        "DAML LF Engine supports LF versions: 0, 0.dev, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.dev; Input Transaction versions: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11; Input Value versions: 1, 2, 3, 4, 5, 6, 7; Output Transaction versions: 10; Output Value versions: 6"
 
     }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1227,7 +1227,10 @@ private[lf] object SBuiltin {
           throw SpeedyHungry(SResultScenarioInsertMustFail(committerOld, commitLocationOld))
 
         case SBool(false) =>
-          ptxOld.finish(machine.supportedValueVersions, machine.supportedTransactionVersions) match {
+          ptxOld.finish(
+            machine.outputTransactionVersions,
+            machine.compiledPackages.packageLanguageVersion,
+          ) match {
             case Left(_) =>
               machine.clearCommit
               machine.returnValue = SV.Unit
@@ -1247,7 +1250,10 @@ private[lf] object SBuiltin {
     private[this] final def executeCommit(args: util.ArrayList[SValue], machine: Machine): Unit = {
       val tx =
         machine.ptx
-          .finish(machine.supportedValueVersions, machine.supportedTransactionVersions)
+          .finish(
+            machine.outputTransactionVersions,
+            machine.compiledPackages.packageLanguageVersion,
+          )
           .fold(
             ptx => {
               checkAborted(ptx)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -15,7 +15,7 @@ import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.transaction.{TransactionVersion, TransactionVersions}
-import com.daml.lf.value.{ValueVersion, ValueVersions, Value => V}
+import com.daml.lf.value.{Value => V}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -98,10 +98,8 @@ private[lf] object Speedy {
 
   /** The speedy CEK machine. */
   final class Machine(
-      /* Value versions that the machine can output */
-      val supportedValueVersions: VersionRange[value.ValueVersion],
       /* Transaction versions that the machine can output */
-      val supportedTransactionVersions: VersionRange[transaction.TransactionVersion],
+      val outputTransactionVersions: VersionRange[transaction.TransactionVersion],
       /* Whether the current submission is validating the transaction, or interpreting
        * it. If this is false, the committers must be a singleton set.
        */
@@ -536,13 +534,11 @@ private[lf] object Speedy {
         expr: SExpr,
         globalCids: Set[V.ContractId],
         committers: Set[Party],
-        supportedValueVersions: VersionRange[value.ValueVersion],
-        supportedTransactionVersions: VersionRange[transaction.TransactionVersion],
+        outputTransactionVersions: VersionRange[transaction.TransactionVersion],
         validating: Boolean = false,
     ): Machine =
       new Machine(
-        supportedValueVersions = supportedValueVersions,
-        supportedTransactionVersions = supportedTransactionVersions,
+        outputTransactionVersions = outputTransactionVersions,
         validating = validating,
         ctrl = expr,
         returnValue = null,
@@ -573,8 +569,7 @@ private[lf] object Speedy {
         compiledPackages: CompiledPackages,
         transactionSeed: crypto.Hash,
         scenario: SExpr,
-        supportedValueVersions: VersionRange[ValueVersion],
-        supportedTransactionVersions: VersionRange[TransactionVersion],
+        outputTransactionVersions: VersionRange[TransactionVersion],
     ): Machine = Machine(
       compiledPackages = compiledPackages,
       submissionTime = Time.Timestamp.MinValue,
@@ -582,8 +577,7 @@ private[lf] object Speedy {
       expr = SEApp(scenario, Array(SEValue.Token)),
       globalCids = Set.empty,
       committers = Set.empty,
-      supportedValueVersions = supportedValueVersions,
-      supportedTransactionVersions = supportedTransactionVersions,
+      outputTransactionVersions = outputTransactionVersions,
     )
 
     @throws[PackageNotFound]
@@ -593,15 +587,13 @@ private[lf] object Speedy {
         compiledPackages: CompiledPackages,
         transactionSeed: crypto.Hash,
         scenario: Expr,
-        supportedValueVersions: VersionRange[ValueVersion],
-        supportedTransactionVersions: VersionRange[TransactionVersion],
+        outputTransactionVersions: VersionRange[TransactionVersion],
     ): Machine =
       fromScenarioSExpr(
         compiledPackages = compiledPackages,
         transactionSeed = transactionSeed,
         scenario = compiledPackages.compiler.unsafeCompile(scenario),
-        supportedValueVersions = supportedValueVersions,
-        supportedTransactionVersions = supportedTransactionVersions,
+        outputTransactionVersions = outputTransactionVersions,
       )
 
     @throws[PackageNotFound]
@@ -618,8 +610,7 @@ private[lf] object Speedy {
         expr = expr,
         globalCids = Set.empty,
         committers = Set.empty,
-        supportedValueVersions = ValueVersions.SupportedDevVersions,
-        supportedTransactionVersions = TransactionVersions.SupportedDevVersions,
+        outputTransactionVersions = TransactionVersions.SupportedDevVersions,
       )
 
     @throws[PackageNotFound]

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -23,7 +23,6 @@ import java.nio.file.{Path, Paths}
 import java.io.PrintStream
 
 import com.daml.lf.transaction.TransactionVersions
-import com.daml.lf.value.ValueVersions
 import org.jline.builtins.Completers
 import org.jline.reader.{History, LineReader, LineReaderBuilder}
 import org.jline.reader.impl.completer.{AggregateCompleter, ArgumentCompleter, StringsCompleter}
@@ -186,11 +185,11 @@ object Repl {
 
     private val seed = nextSeed()
 
-    val (valVersions, txVersions) =
+    val (txVersions) =
       if (devMode)
-        (ValueVersions.SupportedDevVersions, TransactionVersions.SupportedDevVersions)
+        TransactionVersions.SupportedDevVersions
       else
-        (ValueVersions.SupportedStableVersions, TransactionVersions.SupportedStableVersions)
+        TransactionVersions.SupportedStableVersions
 
     def run(expr: Expr): (
         Speedy.Machine,
@@ -200,7 +199,6 @@ object Repl {
           compiledPackages,
           seed,
           expr,
-          valVersions,
           txVersions,
         )
       (machine, ScenarioRunner(machine).run())

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -185,7 +185,7 @@ object Repl {
 
     private val seed = nextSeed()
 
-    val (txVersions) =
+    val txVersions =
       if (devMode)
         TransactionVersions.SupportedDevVersions
       else

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -17,7 +17,6 @@ import com.daml.lf.transaction.{
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
-import com.daml.lf.value.ValueVersion
 
 private case class SRunnerException(err: SError) extends RuntimeException(err.toString)
 
@@ -253,16 +252,14 @@ object ScenarioRunner {
       scenarioDef: Ast.Definition,
       compiledPackages: CompiledPackages,
       transactionSeed: crypto.Hash,
-      supportedValueVersions: VersionRange[ValueVersion],
-      supportedTransactionVersions: VersionRange[TransactionVersion],
+      outputTransactionVersions: VersionRange[TransactionVersion],
   ): ScenarioLedger = {
     val scenarioExpr = getScenarioExpr(scenarioRef, scenarioDef)
     val speedyMachine = Speedy.Machine.fromScenarioExpr(
       compiledPackages,
       transactionSeed,
       scenarioExpr,
-      supportedValueVersions,
-      supportedTransactionVersions,
+      outputTransactionVersions,
     )
     ScenarioRunner(speedyMachine).run() match {
       case Left(e) =>

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -19,7 +19,6 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 
 import com.daml.lf.transaction.TransactionVersions
-import com.daml.lf.value.ValueVersions
 import org.openjdk.jmh.annotations._
 
 class CollectAuthority {
@@ -58,7 +57,6 @@ class CollectAuthorityState {
       compiledPackages,
       seeding(),
       expr,
-      ValueVersions.SupportedDevVersions,
       TransactionVersions.SupportedDevVersions,
     )
     the_sexpr = machine.ctrl

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -8,7 +8,6 @@ import com.daml.lf.data.Ref
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast.ScenarioGetParty
 import com.daml.lf.transaction.TransactionVersions
-import com.daml.lf.value.ValueVersions
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
@@ -23,7 +22,6 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
         compiledPackages,
         txSeed,
         e,
-        ValueVersions.SupportedDevVersions,
         TransactionVersions.SupportedDevVersions,
       )
       val sr = ScenarioRunner(m, _ + "-XXX")

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
@@ -58,12 +58,8 @@ object VersionTimeline {
       This(That(TransactionVersion("9"))),
       That(LanguageVersion(LMV.V1, "8")),
       This(That(TransactionVersion("10"))),
-      // FIXME https://github.com/digital-asset/daml/issues/2256
-      //  * change the following line when LF 1.9 is frozen.
-      //  * do not insert line after this once until 1.9 is frozen.
-      This(This(ValueVersion("7"))),
       // add new versions above this line (but see more notes below)
-      That(LanguageVersion(LMV.V1, Dev)),
+      Both(Both(ValueVersion("7"), TransactionVersion("11")), LanguageVersion(LMV.V1, Dev)),
       // do *not* backfill to make more Boths, because such would
       // invalidate the timeline, except to accompany Dev language
       // versions; use This and That instead as needed.

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
@@ -7,11 +7,13 @@ package transaction
 import data.ImmArray
 import value.{Value, ValueVersion, ValueVersions}
 import Value.{ContractId, ValueOptional, VersionedValue}
+import com.daml.lf.language.LanguageVersion
+import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.collection.immutable.HashMap
 
-class TransactionVersionSpec extends WordSpec with Matchers {
+class TransactionVersionSpec extends WordSpec with Matchers with TableDrivenPropertyChecks {
   import TransactionVersionSpec._
 
   import VersionTimeline.maxVersion
@@ -53,6 +55,77 @@ class TransactionVersionSpec extends WordSpec with Matchers {
       val hasExerciseResult =
         dummyExerciseWithResultTransaction map3 (identity, identity, v => ValueOptional(Some(v)))
       TransactionVersions.assignVersion(assignValueVersions(hasExerciseResult), supportedVersions) shouldBe 'left
+    }
+
+  }
+
+  "TransactionVersions.assignVersions" should {
+
+    import VersionTimeline.Implicits._
+
+    val txVersionToValVersion = Map(
+      TransactionVersion("10") -> ValueVersion("6"),
+      TransactionVersion("11") -> ValueVersion("7")
+    )
+
+    val Seq(v1_1, v1_5, v1_6, v1_7) = Seq("1", "5", "6", "7").map(minor =>
+      LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor.Stable(minor)))
+
+    val v1_dev =
+      LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor.Dev)
+
+    val langVersions = Table("language version", v1_1, v1_5, v1_6, v1_7)
+
+    "pick always the min supported version for package using LF 1.7 or earlier" in {
+      val supportedVersionRanges =
+        Table(
+          "supported Versions",
+          VersionRange(TransactionVersion("10"), TransactionVersion("10")),
+          VersionRange(TransactionVersion("10"), TransactionVersion("11")),
+          VersionRange(TransactionVersion("11"), TransactionVersion("11")),
+        )
+
+      forEvery(supportedVersionRanges) { supportedTxVersions =>
+        val expectedTxVersion = supportedTxVersions.min
+        val expectedValVersion = txVersionToValVersion(expectedTxVersion)
+        val expectedOutput = Right(expectedTxVersion -> expectedValVersion)
+
+        TransactionVersions.assignVersions(supportedTxVersions, Seq.empty) shouldBe expectedOutput
+        forEvery(langVersions) { langVersion =>
+          TransactionVersions.assignVersions(supportedTxVersions, Seq(langVersion)) shouldBe expectedOutput
+        }
+      }
+    }
+
+    "pick version 11 for package using LF 1.dev" in {
+      val supportedVersionRanges =
+        Table(
+          "supported Versions",
+          VersionRange(TransactionVersion("10"), TransactionVersion("11")),
+          VersionRange(TransactionVersion("11"), TransactionVersion("11")),
+        )
+
+      forEvery(supportedVersionRanges) { supportedTxVersions =>
+        val expectedTxVersion = TransactionVersion("11")
+        val expectedValVersion = txVersionToValVersion(expectedTxVersion)
+        val expectedOutput = Right(expectedTxVersion -> expectedValVersion)
+
+        TransactionVersions.assignVersions(supportedTxVersions, Seq(v1_dev)) shouldBe expectedOutput
+        forEvery(langVersions) { langVersion =>
+          TransactionVersions.assignVersions(supportedTxVersions, Seq(langVersion, v1_dev)) shouldBe expectedOutput
+        }
+      }
+    }
+
+    "fail if the inferred version is not supported" in {
+      forEvery(langVersions) { langVersion =>
+        TransactionVersions.assignVersions(
+          VersionRange(TransactionVersion("9"), TransactionVersion("9")),
+          Seq(langVersion)) shouldBe 'left
+        TransactionVersions.assignVersions(
+          VersionRange(TransactionVersion("10"), TransactionVersion("10")),
+          Seq(v1_dev, langVersion)) shouldBe 'left
+      }
     }
 
   }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/VersionTimelineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/VersionTimelineSpec.scala
@@ -4,8 +4,9 @@
 package com.daml.lf
 package transaction
 
+import com.daml.lf.language.LanguageMinorVersion.Dev
 import com.daml.lf.language._
-import value.ValueVersions
+import value.{ValueVersion, ValueVersions}
 
 import scala.language.higherKinds
 import scalaz.{ICons, INil, NonEmptyList}
@@ -14,7 +15,7 @@ import scalaz.syntax.foldable._
 import org.scalacheck.Gen
 import org.scalatest.{Inside, Matchers, WordSpec}
 import org.scalatest.prop.PropertyChecks
-import scalaz.\&/.That
+import scalaz.\&/.Both
 
 class VersionTimelineSpec extends WordSpec with Matchers with PropertyChecks with Inside {
   import VersionTimeline._
@@ -65,7 +66,9 @@ class VersionTimelineSpec extends WordSpec with Matchers with PropertyChecks wit
 
     "end with a dev version" in {
       inside(inAscendingOrder.last) {
-        case That(LanguageVersion(_, LanguageMinorVersion.Dev)) =>
+        case Both(
+            Both(ValueVersion("7"), TransactionVersion("11")),
+            LanguageVersion(LanguageVersion.Major.V1, Dev)) =>
       }
     }
 

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/ScenarioLoader.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/ScenarioLoader.scala
@@ -129,8 +129,7 @@ object ScenarioLoader {
       scenarioDef = scenarioDef,
       compiledPackages = compiledPackages,
       transactionSeed = transactionSeed,
-      supportedValueVersions = engineConfig.allowedOutputValueVersions,
-      supportedTransactionVersions = engineConfig.allowedOutputTransactionVersions,
+      outputTransactionVersions = engineConfig.allowedOutputTransactionVersions,
     )
     (scenarioLedger, scenarioRef)
   }


### PR DESCRIPTION
As part of #5164, we simplify the way transaction and value versions
are inferred for the engine output.



The versioning of a transaction `tr` is done as follow:
* Let  `tvMin` be the minimal transaction version allowed by the DAML engine configuration
* Let `tvMax` be the maximal transaction version allowed by the DAML engine configuration
* Let `n₁, ..., nₘ` be the nodes of `tr`.
* Let `pkgᵢ` be the package of the template associated to the node `nᵢ`
* Let `lvᵢ` be the maximal language version that `pkgᵢ` uses (directly or through its dependencies)
* let `tvᵢ` be the maximal transaction version supported by all engines that support both `lvᵢ` and `tvMin`
* Let `vvᵢ` be the maximal value version supported by all engines that support `tvᵢ`.
* Let `tv` be the maximal transaction version between `tv₁, ..., tvₘ`.
* If `tv` is not greater than `tvMax`
  + then
    - Version the values of each node `nᵢ` according `vvᵢ`
    - Version `tr` according `tv`
  + fail otherwise     
  

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
