### PR TITLE
remove warnings from skeletn template

### DIFF
--- a/templates/skeleton/daml/Main.daml
+++ b/templates/skeleton/daml/Main.daml
@@ -18,6 +18,7 @@ template Asset
           create this with
             owner = newOwner
 
+setup : Scenario AssetId
 setup = scenario do
   alice <- getParty "Alice"
   bob <- getParty "Bob"

--- a/templates/skeleton/daml/Setup.daml
+++ b/templates/skeleton/daml/Setup.daml
@@ -18,7 +18,7 @@ initialize = do
   bobTV <- submit alice do
     exerciseCmd aliceTV Give with newOwner = bob
 
-  submit bob do
+  _ <- submit bob do
     exerciseCmd bobTV Give with newOwner = alice
 
   pure ()


### PR DESCRIPTION
If a user were to follow @cocreature's [suggestions][0] for compiler warnings, the current skeleton template would generate two warnings. That seems like it may give a bad impression, so I believe we should fix it, even though the warnings are not enabled by default.

[0]: https://discuss.daml.com/t/making-the-most-out-of-daml-compiler-warnings/739

CHANGELOG_BEGIN
CHANGELOG_END