### PR TITLE
improve "patch bazel windows" UX

### DIFF
--- a/ci/patch_bazel_windows/compile.yml
+++ b/ci/patch_bazel_windows/compile.yml
@@ -32,6 +32,8 @@ jobs:
       setvar should_run $SHOULD_RUN
       setvar target $TARGET
       setvar target_url $TARGET_URL
+
+      echo "Final hash and URL will be printed by the ${{parameters.final_job_name}} job."
     name: out
 
 - job: patch_bazel_compile
@@ -72,6 +74,7 @@ jobs:
       mkdir '$(Build.StagingDirectory)\patched-bazel'
       zip bazel.zip bazel.exe
       cp bazel.zip '$(Build.StagingDirectory)\patched-bazel'
+      echo "Final hash and URL will be printed by the ${{parameters.final_job_name}} job."
     condition: eq(variables.should_run, 'true')
   - task: PublishPipelineArtifact@1
     inputs:

--- a/dev-env/windows/manifests/bazel.json
+++ b/dev-env/windows/manifests/bazel.json
@@ -5,8 +5,8 @@
   "bin": "bazel.exe",
   "architecture": {
     "64bit": {
-      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-d35eaf58b847cc6adba694d1b0744ac1.zip",
-      "hash": "a62884b3be00d0440e8065e2570a4ce084bae2fcf6ef4d1edc13367e1d90a72e"
+      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-2dfaf3c3b85bf9d78615a70a0afddc28.zip",
+      "hash": "3c54a367a682bd3f2ba0b0ed673846756b16704a1fcb58f89d939fc3f00b8c4b"
     }
   },
   "depends": [


### PR DESCRIPTION
This does not get used very often so it is likely nobody will remember how it works when we do use it. It's And due to the ordering Azure makes of jobs in its UI, it's very easy to miss that there is a final, Linux-based step and the values are actually printed there.

So this adds a little note to remind us of that.

Note that as this changes the `ci/patch_bazel_windows` folder, this will also generate a new Bazel, so this PR will also update the Scoop reference.

CHANGELOG_BEGIN
CHANGELOG_END