### PR TITLE
Fixing a flaky test

### DIFF
--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -451,7 +451,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
     import scalaz.std.vector._
     import scalaz.std.scalaFuture._
 
-    val storeDelayed = (a: (Offset, LedgerEntry.Transaction)) => Free.liftF(store(a))
+    val storeDelayed = (a: (Offset, LedgerEntry.Transaction)) => Free.suspend(Free.liftF(store(a)))
 
     // force synchronous future processing with Free monad
     // to provide the guarantees that all transactions persisted in the specified order

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -453,7 +453,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
     import scalaz.std.vector._
     import scalaz.std.scalaFuture._
 
-    val storeDelayed = (a: (Offset, LedgerEntry.Transaction)) => scalaz.Free.liftFU(store(a))
+    val storeDelayed = (a: (Offset, LedgerEntry.Transaction)) => Free.liftFU(store(a))
 
     // force synchronous future processing with Free monad
     // to provide the guarantees that all transactions persisted in the specified order

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -461,7 +461,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
     // the order of `nextOffset()` calls is important
     val beginOffset = nextOffset()
 
-    val commandWithOffsetGaps: Vector[(Offset, LedgerEntry.Transaction)] =
+    val commandsWithOffsetGaps: Vector[(Offset, LedgerEntry.Transaction)] =
       Vector(singleCreate) ++ offsetGap ++
         Vector.fill(2)(singleCreate) ++ offsetGap ++
         Vector.fill(3)(singleCreate) ++ offsetGap ++ offsetGap ++
@@ -469,10 +469,10 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
 
     val endOffset = nextOffset()
 
-    commandWithOffsetGaps should have length 11L
+    commandsWithOffsetGaps should have length 11L
 
     for {
-      _ <- storeSync(commandWithOffsetGaps)
+      _ <- storeSync(commandsWithOffsetGaps)
 
       // `pageSize = 2` and the offset gaps in the `commandWithOffsetGaps` above are to make sure
       // that streaming works with event pages separated by offsets that don't have events in the store
@@ -490,7 +490,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
     } yield {
       val readTxOffsets: Vector[String] = readTxs.map(_.offset)
       readTxOffsets shouldBe readTxOffsets.sorted
-      readTxOffsets shouldBe commandWithOffsetGaps.map(_._1.toHexString)
+      readTxOffsets shouldBe commandsWithOffsetGaps.map(_._1.toHexString)
     }
   }
 

--- a/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/sandbox/src/test/lib/scala/com/digitalasset/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -474,7 +474,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
 
     val endOffset = nextOffset()
 
-    commandWithOffsetGaps.size shouldBe 11
+    commandWithOffsetGaps should have length 11L
 
     for {
       _ <- commandWithOffsetGaps.traverse(x => store(x))
@@ -493,7 +493,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
 
       readTxs = extractAllTransactions(response)
     } yield {
-      readTxs.size shouldBe commandWithOffsetGaps.size
+      readTxs should have length commandWithOffsetGaps.size.toLong
       val readTxOffsets: Vector[String] = readTxs.map(_.offset)
       readTxOffsets shouldBe readTxOffsets.sorted
       readTxOffsets shouldBe commandWithOffsetGaps.map(_._1.toHexString)


### PR DESCRIPTION
Closes: #6760

- introducing `storeSync` to guarantee that test transactions get processed in the specified order
- removing unnecessary assertion that hid the fact that the order of offsets read from DB was invalid, the side-effect of this was that offset to row_id conversion streamed more/less transactions than expected.
- the check for the number of read transactions is guaranteed by another assertion

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
