### PR TITLE
Remove documentation to use Navigator using old assistant

### DIFF
--- a/docs/source/tools/navigator/index.rst
+++ b/docs/source/tools/navigator/index.rst
@@ -347,50 +347,6 @@ To debug config file errors and learn more about the
 config file API, open the Navigator ``/config`` page in your browser
 (e.g., `<http://localhost:7500/config>`_).
 
-Using Navigator outside the SDK
-===============================
-
-This section explains how to work with the Navigator if you have a project created outside of the normal SDK workflow and want to use the Navigator to inspect the ledger and interact with it.
-
-.. note:: If you are using the Navigator as part of the DAML SDK, you do not need to read this section.
-
-The Navigator is released as a "fat" Java `.jar` file that bundles all required
-dependencies. This JAR is part of the SDK release and can be found using the
-SDK Assistant's ``path`` command::
-
-  da path navigator
-
-Use the ``run`` command to launch the Navigator JAR and print usage instructions::
-
-  da run navigator
-
-Arguments may be given at the end of a command, following a double dash. For example::
-
-  da run navigator -- server \
-    --config-file my-config.conf \
-    --port 8000 \
-    localhost 6865
-
-The Navigator requires a configuration file specifying each user and the party
-they act as. It has a ``.conf`` ending by convention. The file follows this
-form::
-
-  users {
-      <USERNAME> {
-          party = <PARTYNAME>
-      }
-      ..
-  }
-
-In many cases, a simple one-to-one correspondence between users and their
-respective parties is sufficient to configure the Navigator. Example::
-
-  users {
-      BANK1 { party = "BANK1" }
-      BANK2 { party = "BANK2" }
-      OPERATOR { party = "OPERATOR" }
-  }
-
 Using Navigator with a DAML Ledger
 ==================================
 


### PR DESCRIPTION
This references the old assistant and the deprecated configuration
files. The positioning for Navigator right now (correct me if I'm wrong)
is that it's a development tool, so I don't think it makes a lot of
sense publicizing it otherwise.

Closes #3237

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
