### PR TITLE
Engine: add maintainers to contract key call back

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -353,7 +353,7 @@ class Engine(config: Engine.Config = Engine.StableConfig) {
               if (cb(SKeyLookupResult(result)))
                 interpretLoop(machine, time)
               else
-                ResultError(Error(s"dependency error: couldn't find key ${gk.gkey}"))
+                ResultError(Error(s"dependency error: couldn't find key ${gk.globalKey}"))
           )
 
         case _: SResultScenarioCommit =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -353,7 +353,7 @@ class Engine(config: Engine.Config = Engine.StableConfig) {
               if (cb(SKeyLookupResult(result)))
                 interpretLoop(machine, time)
               else
-                ResultError(Error(s"dependency error: couldn't find key ${gk.key}"))
+                ResultError(Error(s"dependency error: couldn't find key ${gk.gkey}"))
           )
 
         case _: SResultScenarioCommit =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -39,7 +39,6 @@ sealed trait Result[+A] extends Product with Serializable {
       ResultNeedKey(gk, mbAcoid => resume(mbAcoid).flatMap(f))
   }
 
-  // quick and dirty way to consume a Result
   def consume(
       pcs: ContractId => Option[ContractInst[VersionedValue[ContractId]]],
       packages: PackageId => Option[Package],

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -6,7 +6,7 @@ package com.daml.lf.engine
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{BackStack, ImmArray, ImmArrayCons}
 import com.daml.lf.language.Ast._
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.Node.GlobalKeyWithMaintainers
 import com.daml.lf.value.Value._
 import scalaz.Monad
 
@@ -43,7 +43,7 @@ sealed trait Result[+A] extends Product with Serializable {
   def consume(
       pcs: ContractId => Option[ContractInst[VersionedValue[ContractId]]],
       packages: PackageId => Option[Package],
-      keys: GlobalKey => Option[ContractId]): Either[Error, A] = {
+      keys: GlobalKeyWithMaintainers => Option[ContractId]): Either[Error, A] = {
     @tailrec
     def go(res: Result[A]): Either[Error, A] =
       res match {
@@ -87,7 +87,9 @@ final case class ResultNeedContract[A](
 final case class ResultNeedPackage[A](packageId: PackageId, resume: Option[Package] => Result[A])
     extends Result[A]
 
-final case class ResultNeedKey[A](key: GlobalKey, resume: Option[ContractId] => Result[A])
+final case class ResultNeedKey[A](
+    key: GlobalKeyWithMaintainers,
+    resume: Option[ContractId] => Result[A])
     extends Result[A]
 
 object Result {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
@@ -131,7 +131,7 @@ class ContractDiscriminatorFreshnessCheckSpec
         participantId = participant,
         submissionSeed = submissionSeed,
       )
-      .consume(pcs, pkgs, keyWithMaintainers => keys(keyWithMaintainers.gkey))
+      .consume(pcs, pkgs, keyWithMaintainers => keys(keyWithMaintainers.globalKey))
 
   val engine = Engine.DevEngine()
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
@@ -131,7 +131,7 @@ class ContractDiscriminatorFreshnessCheckSpec
         participantId = participant,
         submissionSeed = submissionSeed,
       )
-      .consume(pcs, pkgs, keys)
+      .consume(pcs, pkgs, keyWithMaintainers => keys(keyWithMaintainers.gkey))
 
   val engine = Engine.DevEngine()
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -117,7 +117,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
   }
 
   def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] =
-    (key.gkey.templateId, key.gkey.key) match {
+    (key.globalKey.templateId, key.globalKey.key) match {
       case (
           BasicTests_WithKey,
           ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
@@ -1264,7 +1264,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     )
 
     def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] = {
-      (key.gkey.templateId, key.gkey.key) match {
+      (key.globalKey.templateId, key.globalKey.key) match {
         case (
             BasicTests_WithKey,
             ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
@@ -1435,7 +1435,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       )
 
       def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] = {
-        (key.gkey.templateId, key.gkey.key) match {
+        (key.globalKey.templateId, key.globalKey.key) match {
           case (
               BasicTests_WithKey,
               ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
@@ -1683,7 +1683,7 @@ object EngineTest {
                 nodeSeedMap.get(nodeId),
                 txMeta.submissionTime,
                 ledgerEffectiveTime)
-              .consume(contracts0.get, lookupPackages, k => keys0.get(k.gkey))
+              .consume(contracts0.get, lookupPackages, k => keys0.get(k.globalKey))
             (tr1, meta1) = currentStep
             (contracts1, keys1) = tr1.transaction.fold((contracts0, keys0)) {
               case (

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -116,8 +116,8 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     allPackages.get(pkgId)
   }
 
-  def lookupKey(key: GlobalKey): Option[ContractId] =
-    (key.templateId, key.key) match {
+  def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] =
+    (key.gkey.templateId, key.gkey.key) match {
       case (
           BasicTests_WithKey,
           ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
@@ -1263,8 +1263,8 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       ""
     )
 
-    def lookupKey(key: GlobalKey): Option[ContractId] = {
-      (key.templateId, key.key) match {
+    def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] = {
+      (key.gkey.templateId, key.gkey.key) match {
         case (
             BasicTests_WithKey,
             ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
@@ -1434,8 +1434,8 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         ""
       )
 
-      def lookupKey(key: GlobalKey): Option[ContractId] = {
-        (key.templateId, key.key) match {
+      def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] = {
+        (key.gkey.templateId, key.gkey.key) match {
           case (
               BasicTests_WithKey,
               ValueRecord(_, ImmArray((_, ValueParty(`alice`)), (_, ValueInt64(42)))),
@@ -1683,7 +1683,7 @@ object EngineTest {
                 nodeSeedMap.get(nodeId),
                 txMeta.submissionTime,
                 ledgerEffectiveTime)
-              .consume(contracts0.get, lookupPackages, keys0.get)
+              .consume(contracts0.get, lookupPackages, k => keys0.get(k.gkey))
             (tr1, meta1) = currentStep
             (contracts1, keys1) = tr1.transaction.fold((contracts0, keys0)) {
               case (

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -19,7 +19,7 @@ import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SValue.{SValue => SV}
 import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.{Value => V}
-import com.daml.lf.transaction.Node.{GlobalKey, KeyWithMaintainers}
+import com.daml.lf.transaction.Node.{GlobalKey, GlobalKeyWithMaintainers, KeyWithMaintainers}
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeSet
@@ -1072,7 +1072,7 @@ private[lf] object SBuiltin {
           // that.
           throw SpeedyHungry(
             SResultNeedKey(
-              gkey,
+              GlobalKeyWithMaintainers(gkey, keyWithMaintainers.maintainers),
               machine.committers, {
                 case SKeyLookupResult.Found(cid) =>
                   machine.ptx = machine.ptx.copy(keys = machine.ptx.keys + (gkey -> Some(cid)))
@@ -1151,7 +1151,7 @@ private[lf] object SBuiltin {
           // that.
           throw SpeedyHungry(
             SResultNeedKey(
-              gkey,
+              GlobalKeyWithMaintainers(gkey, keyWithMaintainers.maintainers),
               machine.committers, {
                 case SKeyLookupResult.Found(cid) =>
                   machine.ptx = machine.ptx.copy(keys = machine.ptx.keys + (gkey -> Some(cid)))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -9,7 +9,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
 import com.daml.lf.transaction.{SubmittedTransaction, Transaction => Tx}
 import com.daml.lf.speedy.SError._
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.Node.GlobalKeyWithMaintainers
 
 /** The result from small-step evaluation.
   * If the result is not Done or Continue, then the machine
@@ -83,7 +83,7 @@ object SResult {
   ) extends SResult
 
   final case class SResultNeedKey(
-      key: GlobalKey,
+      key: GlobalKeyWithMaintainers,
       committers: Set[Party],
       // Callback.
       // returns true if machine can continue with the given result.

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -89,7 +89,7 @@ final case class ScenarioRunner(
           getParty(partyText, callback)
 
         case SResultNeedKey(keyWithMaintainers, committers, cb) =>
-          lookupKey(keyWithMaintainers.gkey, committers, cb)
+          lookupKey(keyWithMaintainers.globalKey, committers, cb)
       }
     }
     val endTime = System.nanoTime()

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -88,8 +88,8 @@ final case class ScenarioRunner(
         case SResultScenarioGetParty(partyText, callback) =>
           getParty(partyText, callback)
 
-        case SResultNeedKey(gk, committers, cb) =>
-          lookupKey(gk, committers, cb)
+        case SResultNeedKey(keyWithMaintainers, committers, cb) =>
+          lookupKey(keyWithMaintainers.gkey, committers, cb)
       }
     }
     val endTime = System.nanoTime()

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -427,6 +427,11 @@ object Node {
   sealed trait WithTxValue3[F[+ _, + _, + _]] {
     type WithTxValue[+Nid, +Cid] = F[Nid, Cid, Transaction.Value[Cid]]
   }
+
+  final case class GlobalKeyWithMaintainers(
+      gkey: GlobalKey,
+      maintainers: Set[Party]
+  )
 }
 
 final case class NodeId(index: Int)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -429,7 +429,7 @@ object Node {
   }
 
   final case class GlobalKeyWithMaintainers(
-      gkey: GlobalKey,
+      globalKey: GlobalKey,
       maintainers: Set[Party]
   )
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -119,7 +119,7 @@ final class StoreBackedCommandExecutor(
           Timed
             .future(
               metrics.daml.execution.lookupContractKey,
-              contractStore.lookupContractKey(submitter, key))
+              contractStore.lookupContractKey(submitter, key.gkey))
             .flatMap { contractId =>
               lookupContractKeyTime.addAndGet(System.nanoTime() - start)
               lookupContractKeyCount.incrementAndGet()

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -119,7 +119,7 @@ final class StoreBackedCommandExecutor(
           Timed
             .future(
               metrics.daml.execution.lookupContractKey,
-              contractStore.lookupContractKey(submitter, key.gkey))
+              contractStore.lookupContractKey(submitter, key.globalKey))
             .flatMap { contractId =>
               lookupContractKeyTime.addAndGet(System.nanoTime() - start)
               lookupContractKeyCount.incrementAndGet()

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -559,7 +559,7 @@ private[kvutils] class TransactionCommitter(
     //      to lookup the contract
     //    - the separate contract keys check ensures that all contracts pointed to by
     //    contract keys respect causal monotonicity.
-    val stateKey = Conversions.globalKeyToStateKey(key.gkey)
+    val stateKey = Conversions.globalKeyToStateKey(key.globalKey)
     val contractId = for {
       stateValue <- inputState.get(stateKey).flatten
       if stateValue.getContractKeyState.getContractId.nonEmpty

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -547,7 +547,7 @@ private[kvutils] class TransactionCommitter(
       transactionEntry: DamlTransactionEntrySummary,
       inputState: DamlStateMap,
       knownKeys: Map[DamlContractKey, Value.ContractId],
-  )(key: Node.GlobalKey): Option[Value.ContractId] = {
+  )(key: Node.GlobalKeyWithMaintainers): Option[Value.ContractId] = {
     // we don't check whether the contract is active or not, because in we might not have loaded it earlier.
     // this is not a problem, because:
     // a) if the lookup was negative and we actually found a contract,
@@ -559,7 +559,7 @@ private[kvutils] class TransactionCommitter(
     //      to lookup the contract
     //    - the separate contract keys check ensures that all contracts pointed to by
     //    contract keys respect causal monotonicity.
-    val stateKey = Conversions.globalKeyToStateKey(key)
+    val stateKey = Conversions.globalKeyToStateKey(key.gkey)
     val contractId = for {
       stateValue <- inputState.get(stateKey).flatten
       if stateValue.getContractKeyState.getContractId.nonEmpty


### PR DESCRIPTION
We add the maintainer in the engine call back for contract key. 

This is usefull for some ledger implementations. 
 
CHANGELOG_BEGIN
[Engine] - Change the callback for contract key from GlobalKey => Option[ContractId] to  GlobalKeyWithMaintainers => Option[ContractId]
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
