### PR TITLE
Ledger API: Only set the offset in the last ACS response

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTable.scala
@@ -90,7 +90,7 @@ private[events] object EventsTable
       events.map {
         case entry if entry.event.isCreated =>
           GetActiveContractsResponse(
-            offset = ApiOffset.toApiString(entry.eventOffset),
+            offset = "", // settings this explicitly to an empty string because only the last response will have an offset.
             workflowId = entry.workflowId,
             activeContracts = Seq(entry.event.getCreated),
             traceContext = None,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTable.scala
@@ -90,7 +90,7 @@ private[events] object EventsTable
       events.map {
         case entry if entry.event.isCreated =>
           GetActiveContractsResponse(
-            offset = "", // settings this explicitly to an empty string because only the last response will have an offset.
+            offset = "", // only the last response will have an offset.
             workflowId = entry.workflowId,
             activeContracts = Seq(entry.event.getCreated),
             traceContext = None,


### PR DESCRIPTION
Fixes #6757.

CHANGELOG_BEGIN
[Sandbox][DAML Integration Kit]: Bug Fix: The ActiveContractService now only sets
the offset in the last response again instead of in every response
element.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
