### PR TITLE
LF: unset the field NodeFecth#value_version in transaction.proto

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -186,14 +186,13 @@ object TransactionCoder {
         }
 
       case nf @ NodeFetch(_, _, _, _, _, _, _) =>
-        val (vversion, etid) = ValueCoder.encodeIdentifier(
+        val (_, etid) = ValueCoder.encodeIdentifier(
           nf.templateId,
           valueVersion1Only(transactionVersion) option ValueVersion("1"),
         )
         val fetchBuilder = TransactionOuterClass.NodeFetch
           .newBuilder()
           .setTemplateId(etid)
-          .setValueVersion(vversion.protoValue)
           .addAllStakeholders(nf.stakeholders.toSet[String].asJava)
           .addAllSignatories(nf.signatories.toSet[String].asJava)
 


### PR DESCRIPTION
According transaction specification the field `value_version` : 
> is optional; if defined, it must be a version of the value
> specification, and `template_id` shall be consumed according to
> that version.  Otherwise, it is assumed to be version "1".
    
We take advantage that the encoding of identifier in value does not
change since version "1" to unset the field `value_version`, hence
using the default interpretation.
    
CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
