### PR TITLE
Remove index transformation

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -15,7 +15,6 @@ import com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor
 import com.daml.ledger.api.auth.{AuthService, Authorizer}
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.health.HealthChecks
-import com.daml.ledger.participant.state.index.v2.IndexService
 import com.daml.ledger.participant.state.v1.{LedgerId, ParticipantId, SeedService, WriteService}
 import com.daml.lf.engine.Engine
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -48,7 +47,6 @@ final class StandaloneApiServer(
     ledgerConfig: LedgerConfiguration,
     optWriteService: Option[WriteService],
     authService: AuthService,
-    transformIndexService: IndexService => IndexService = identity,
     metrics: Metrics,
     timeServiceBackend: Option[TimeServiceBackend] = None,
     otherServices: immutable.Seq[BindableService] = immutable.Seq.empty,
@@ -78,7 +76,7 @@ final class StandaloneApiServer(
           metrics,
           lfValueTranslationCache,
         )
-        .map(transformIndexService)
+        .map(index => new TimedIndexService(index, metrics))
       authorizer = new Authorizer(
         () => java.time.Clock.systemUTC.instant(),
         ledgerId,

--- a/ledger/participant-state/kvutils/app/BUILD.bazel
+++ b/ledger/participant-state/kvutils/app/BUILD.bazel
@@ -35,7 +35,6 @@ da_scala_library(
         "//ledger/metrics",
         "//ledger/participant-integration-api",
         "//ledger/participant-state",
-        "//ledger/participant-state-index",
         "//ledger/participant-state-metrics",
         "//ledger/participant-state/kvutils",
         "//libs-scala/contextualized-logging",

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -16,7 +16,7 @@ import com.daml.lf.archive.DarReader
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.JvmMetricSet
-import com.daml.platform.apiserver.{StandaloneApiServer, TimedIndexService}
+import com.daml.platform.apiserver.StandaloneApiServer
 import com.daml.platform.indexer.StandaloneIndexerServer
 import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.resources.akka.AkkaResourceOwner
@@ -96,7 +96,6 @@ final class Runner[T <: ReadWriteService, Extra](
                 ledgerConfig = factory.ledgerConfig(config),
                 optWriteService = Some(writeService),
                 authService = factory.authService(config),
-                transformIndexService = service => new TimedIndexService(service, metrics),
                 metrics = metrics,
                 timeServiceBackend = factory.timeServiceBackend(config),
                 otherInterceptors = factory.interceptors(config),

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -25,7 +25,6 @@ compile_deps = [
     "//ledger/ledger-on-sql",
     "//ledger/metrics",
     "//ledger/participant-state",
-    "//ledger/participant-state-index",
     "//ledger/participant-state-metrics",
     "//ledger/participant-state/kvutils",
     "//ledger/sandbox-common",

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -223,7 +223,6 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   ledgerConfig = config.ledgerConfig,
                   optWriteService = Some(writeService),
                   authService = authService,
-                  transformIndexService = new TimedIndexService(_, metrics),
                   metrics = metrics,
                   timeServiceBackend = timeServiceBackend,
                   otherServices = List(resetService),


### PR DESCRIPTION
The `IndexService` is not part of the public API, and should therefore not appear in the constructor params.

We also want to always enable metrics.

CHANGELOG_BEGIN
CHANGELOG_END
