### PR TITLE
Fix syntax-highlighting of type signatures

### DIFF
--- a/compiler/daml-extension/syntaxes/daml12.tmLanguage.xml
+++ b/compiler/daml-extension/syntaxes/daml12.tmLanguage.xml
@@ -599,7 +599,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?=\)|$|,|}|\b(in|then|else|of|with)\b(?!')|(:?&lt;\-))</string>
+			<string>(?=\)|$|,|}|\b(in|then|else|of|with)\b(?!')|(?&lt;![\p{S}\p{P}&amp;&amp;[^(),;\[\]`{}_"']])(?:(\\|&lt;\-|=))([(),;\[\]`{}_"']|[^\p{S}\p{P}]))</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
fixes #6791

This is based on
https://github.com/JustusAdam/language-haskell/blob/master/syntaxes/haskell.YAML-tmLanguage#L1326.

It roughly boils down to the following:

1. Negative look-behind to check that this is not part of something
   else.

2. Match on \\,<-|= (I’ve left out the unicode characters, I don’t want
   to encourage their use in DAML and I’ve also left out ArrowSyntax).

3. Check that the next character doesn’t make this something that is
   part of something else.

As for tests, I’ll refer to https://twitter.com/hillelogram/status/1284189687628824576

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
