### PR TITLE
LF: Move GlobalKey and GlobalKeyWithMaintainers outside Node

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -7,7 +7,7 @@ import com.daml.lf.data.{Numeric, Ref}
 import com.daml.lf.ledger.EventId
 import com.daml.lf.scenario.api.{v1 => proto}
 import com.daml.lf.speedy.{SError, SValue, Speedy, PartialTransaction => SPartialTransaction}
-import com.daml.lf.transaction.{Node => N, NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{GlobalKey, Node => N, NodeId, Transaction => Tx}
 import com.daml.lf.ledger._
 import com.daml.lf.value.{Value => V}
 
@@ -170,7 +170,7 @@ final class Conversions(
     builder.build
   }
 
-  def convertGlobalKey(globalKey: N.GlobalKey): proto.GlobalKey = {
+  def convertGlobalKey(globalKey: GlobalKey): proto.GlobalKey = {
     proto.GlobalKey.newBuilder
       .setTemplateId(convertIdentifier(globalKey.templateId))
       .setKey(convertValue(globalKey.key))

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Result.scala
@@ -6,7 +6,7 @@ package com.daml.lf.engine
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{BackStack, ImmArray, ImmArrayCons}
 import com.daml.lf.language.Ast._
-import com.daml.lf.transaction.Node.GlobalKeyWithMaintainers
+import com.daml.lf.transaction.GlobalKeyWithMaintainers
 import com.daml.lf.value.Value._
 import scalaz.Monad
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
@@ -6,7 +6,7 @@ package com.daml.lf
 import com.daml.lf.data._
 import com.daml.lf.engine.Engine
 import com.daml.lf.testing.parser.Implicits._
-import com.daml.lf.transaction.Node
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value.ContractId
 import com.daml.lf.value.{Value, ValueVersions}
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -102,7 +102,7 @@ class ContractDiscriminatorFreshnessCheckSpec
     )
 
   private def globalKey(party: Ref.Party, idx: Int) =
-    Node.GlobalKey(tmplId, keyRecord(party, idx))
+    GlobalKey(tmplId, keyRecord(party, idx))
 
   private val alice = Ref.Party.assertFromString("Alice")
   private val participant = Ref.ParticipantId.assertFromString("participant")
@@ -118,7 +118,7 @@ class ContractDiscriminatorFreshnessCheckSpec
   private def submit(
       cmds: ImmArray[command.Command],
       pcs: Value.ContractId => Option[Value.ContractInst[Value.VersionedValue[ContractId]]],
-      keys: Node.GlobalKey => Option[ContractId]
+      keys: GlobalKey => Option[ContractId]
   ) =
     engine
       .submit(

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -381,7 +381,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     }
 
     "translate Optional values" in {
-      val (optionalPkgId, optionalPkg @ _, allOptionalPackages) =
+      val (optionalPkgId, _, allOptionalPackages) =
         loadPackage("daml-lf/tests/Optional.dar")
 
       val translator = new preprocessing.Preprocessor(ConcurrentCompiledPackages.apply())
@@ -1344,7 +1344,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         lookerUpCid,
         "Lookup",
         ValueRecord(None, ImmArray((Some[Name]("n"), ValueInt64(57)))))
-      val Right((tx, txMeta @ _)) = engine
+      val Right((tx, _)) = engine
         .submit(Commands(alice, ImmArray(exerciseCmd), now, "test"), participant, submissionSeed)
         .consume(lookupContractMap.get, lookupPackage, lookupKey)
 
@@ -1417,7 +1417,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         case Some(Node.NodeFetch(_, _, _, _, _, _, key)) =>
           key match {
             // just test that the maintainers match here, getting the key out is a bit hairier
-            case Some(Node.KeyWithMaintainers(keyValue @ _, maintainers)) =>
+            case Some(Node.KeyWithMaintainers(_, maintainers)) =>
               assert(maintainers == Set(alice))
             case None => fail("the recomputed fetch didn't have a key")
           }
@@ -1479,7 +1479,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
           case (id, nf: Node.NodeFetch[_, _]) =>
             nf.key match {
               // just test that the maintainers match here, getting the key out is a bit hairier
-              case Some(Node.KeyWithMaintainers(keyValue @ _, maintainers)) =>
+              case Some(Node.KeyWithMaintainers(_, maintainers)) =>
                 assert(maintainers == Set(alice))
               case None => fail("the recomputed fetch didn't have a key")
             }

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1344,7 +1344,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         lookerUpCid,
         "Lookup",
         ValueRecord(None, ImmArray((Some[Name]("n"), ValueInt64(57)))))
-      val Right((tx, _)) = engine
+      val Right((tx, txMeta)) = engine
         .submit(Commands(alice, ImmArray(exerciseCmd), now, "test"), participant, submissionSeed)
         .consume(lookupContractMap.get, lookupPackage, lookupKey)
 

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -13,8 +13,10 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data._
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.Util._
-import com.daml.lf.transaction.Node._
+import com.daml.lf.transaction.Node
 import com.daml.lf.transaction.{
+  GlobalKey,
+  GlobalKeyWithMaintainers,
   NodeId,
   SubmittedTransaction,
   GenTransaction => GenTx,
@@ -656,7 +658,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
     "mark all the exercise nodes as performed byKey" in {
       val exerciseNodes = tx.nodes.collect {
-        case (id, _: NodeExercises[_, _, _]) => id
+        case (id, _: Node.NodeExercises[_, _, _]) => id
       }
       txMeta.byKeyNodes shouldBe 'nonEmpty
       txMeta.byKeyNodes.toSeq.toSet shouldBe exerciseNodes.toSet
@@ -704,8 +706,8 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       tx.roots should have length 2
       tx.nodes.keySet.toList should have length 2
       val ImmArray(create, exercise) = tx.roots.map(tx.nodes)
-      create shouldBe a[NodeCreate[_, _]]
-      exercise shouldBe a[NodeExercises[_, _, _]]
+      create shouldBe a[Node.NodeCreate[_, _]]
+      exercise shouldBe a[Node.NodeExercises[_, _, _]]
     }
 
     "reinterpret to the same result" in {
@@ -958,7 +960,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       val bobView = Blinding.divulgedTransaction(blindingInfo.disclosure, bob, tx.transaction)
       bobView.nodes.size shouldBe 2
       findNodeByIdx(bobView.nodes, 0).getOrElse(fail("node not found")) match {
-        case NodeExercises(
+        case Node.NodeExercises(
             coid,
             _,
             choice,
@@ -981,7 +983,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
       }
 
       findNodeByIdx(bobView.nodes, 1).getOrElse(fail("node not found")) match {
-        case NodeCreate(_, coins, _, _, stakeholders, _) =>
+        case Node.NodeCreate(_, coins, _, _, stakeholders, _) =>
           coins.template shouldBe templateId
           stakeholders shouldBe Set(alice, clara)
         case _ => fail("create event is expected")
@@ -993,7 +995,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
       claraView.nodes.size shouldBe 1
       findNodeByIdx(claraView.nodes, 1).getOrElse(fail("node not found")) match {
-        case NodeCreate(_, coins, _, _, stakeholders, _) =>
+        case Node.NodeCreate(_, coins, _, _, stakeholders, _) =>
           coins.template shouldBe templateId
           stakeholders shouldBe Set(alice, clara)
         case _ => fail("create event is expected")
@@ -1117,9 +1119,9 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     val let = Time.Timestamp.now()
     val seeding = Engine.initialSeeding(submissionSeed, participant, let)
 
-    def actFetchActors[Nid, Cid, Val](n: GenNode[Nid, Cid, Val]): Set[Party] = {
+    def actFetchActors[Nid, Cid, Val](n: Node.GenNode[Nid, Cid, Val]): Set[Party] = {
       n match {
-        case NodeFetch(_, _, _, actingParties, _, _, _) => actingParties.getOrElse(Set.empty)
+        case Node.NodeFetch(_, _, _, actingParties, _, _, _) => actingParties.getOrElse(Set.empty)
         case _ => Set()
       }
     }
@@ -1173,8 +1175,8 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     "be retained when reinterpreting single fetch nodes" in {
       val Right((tx, txMeta)) = runExample(fetcher1Cid, clara)
       val fetchNodes =
-        tx.transaction.fold(Seq[(NodeId, GenNode.WithTxValue[NodeId, ContractId])]()) {
-          case (ns, (nid, n @ NodeFetch(_, _, _, _, _, _, _))) => ns :+ ((nid, n))
+        tx.transaction.fold(Seq[(NodeId, Node.GenNode.WithTxValue[NodeId, ContractId])]()) {
+          case (ns, (nid, n @ Node.NodeFetch(_, _, _, _, _, _, _))) => ns :+ ((nid, n))
           case (ns, _) => ns
         }
 
@@ -1226,7 +1228,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     "succeed with a fresh engine, correctly compiling packages" in {
       val engine = Engine.DevEngine()
 
-      val fetchNode = NodeFetch(
+      val fetchNode = Node.NodeFetch(
         coid = fetchedCid,
         templateId = fetchedTid,
         optLocation = None,
@@ -1282,9 +1284,9 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
     def firstLookupNode[Nid, Cid, Val](
         tx: GenTx[Nid, Cid, Val],
-    ): Option[(Nid, NodeLookupByKey[Cid, Val])] =
+    ): Option[(Nid, Node.NodeLookupByKey[Cid, Val])] =
       tx.nodes.collectFirst {
-        case (nid, nl @ NodeLookupByKey(_, _, _, _)) => nid -> nl
+        case (nid, nl @ Node.NodeLookupByKey(_, _, _, _)) => nid -> nl
       }
 
     val now = Time.Timestamp.now()
@@ -1300,7 +1302,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         .consume(lookupContractMap.get, lookupPackage, lookupKey)
 
       val lookupNodes = tx.transaction.nodes.collect {
-        case (id, _: NodeLookupByKey[_, _]) => id
+        case (id, _: Node.NodeLookupByKey[_, _]) => id
       }
 
       txMeta.byKeyNodes shouldBe 'nonEmpty
@@ -1412,10 +1414,10 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
         .consume(lookupContractMap.get, lookupPackage, lookupKey)
 
       tx.transaction.nodes.values.headOption match {
-        case Some(NodeFetch(_, _, _, _, _, _, key)) =>
+        case Some(Node.NodeFetch(_, _, _, _, _, _, key)) =>
           key match {
             // just test that the maintainers match here, getting the key out is a bit hairier
-            case Some(KeyWithMaintainers(keyValue @ _, maintainers)) =>
+            case Some(Node.KeyWithMaintainers(keyValue @ _, maintainers)) =>
               assert(maintainers == Set(alice))
             case None => fail("the recomputed fetch didn't have a key")
           }
@@ -1474,10 +1476,10 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
 
       tx.transaction.nodes
         .collectFirst {
-          case (id, nf: NodeFetch[_, _]) =>
+          case (id, nf: Node.NodeFetch[_, _]) =>
             nf.key match {
               // just test that the maintainers match here, getting the key out is a bit hairier
-              case Some(KeyWithMaintainers(keyValue @ _, maintainers)) =>
+              case Some(Node.KeyWithMaintainers(keyValue @ _, maintainers)) =>
                 assert(maintainers == Set(alice))
               case None => fail("the recomputed fetch didn't have a key")
             }
@@ -1534,7 +1536,7 @@ class EngineTest extends WordSpec with Matchers with EitherValues with BazelRunf
     "be partially reinterpretable" in {
       val Right((tx, txMeta)) = run(3)
       val ImmArray(_, exeNode1) = tx.transaction.roots
-      val NodeExercises(_, _, _, _, _, _, _, _, _, _, children, _, _) =
+      val Node.NodeExercises(_, _, _, _, _, _, _, _, _, _, children, _, _) =
         tx.transaction.nodes(exeNode1)
       val nids = children.toSeq.take(2).toImmArray
 
@@ -1638,7 +1640,9 @@ object EngineTest {
     a
   }
 
-  private def findNodeByIdx[Cid, Val](nodes: Map[NodeId, GenNode[NodeId, Cid, Val]], idx: Int) =
+  private def findNodeByIdx[Cid, Val](
+      nodes: Map[NodeId, Node.GenNode[NodeId, Cid, Val]],
+      idx: Int) =
     nodes.collectFirst { case (nodeId, node) if nodeId.index == idx => node }
 
   @SuppressWarnings(Array("org.wartremover.warts.Any"))
@@ -1690,7 +1694,7 @@ object EngineTest {
                   (contracts, keys),
                   (
                     _,
-                    NodeExercises(
+                    Node.NodeExercises(
                       targetCoid: ContractId,
                       _,
                       _,
@@ -1705,7 +1709,9 @@ object EngineTest {
                       _,
                       _))) =>
                 (contracts - targetCoid, keys)
-              case ((contracts, keys), (_, NodeCreate(cid: ContractId, coinst, _, _, _, key))) =>
+              case (
+                  (contracts, keys),
+                  (_, Node.NodeCreate(cid: ContractId, coinst, _, _, _, key))) =>
                 (
                   contracts.updated(
                     cid,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -10,6 +10,7 @@ import com.daml.lf.ledger._
 import com.daml.lf.transaction.Node._
 import com.daml.lf.transaction.{
   CommittedTransaction,
+  GlobalKey,
   NodeId,
   SubmittedTransaction,
   Transaction => Tx

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -19,7 +19,7 @@ import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SValue.{SValue => SV}
 import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.{Value => V}
-import com.daml.lf.transaction.Node.{GlobalKey, GlobalKeyWithMaintainers, KeyWithMaintainers}
+import com.daml.lf.transaction.{Node, GlobalKey, GlobalKeyWithMaintainers}
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeSet
@@ -1117,7 +1117,7 @@ private[lf] object SBuiltin {
       machine.ptx = machine.ptx.insertLookup(
         templateId,
         machine.lastLocation,
-        KeyWithMaintainers(
+        Node.KeyWithMaintainers(
           key = keyWithMaintainers.key,
           maintainers = keyWithMaintainers.maintainers,
         ),
@@ -1594,7 +1594,7 @@ private[lf] object SBuiltin {
 
   private[this] def extractKeyWithMaintainers(
       v: SValue,
-  ): KeyWithMaintainers[V[Nothing]] =
+  ): Node.KeyWithMaintainers[V[Nothing]] =
     v match {
       case SStruct(flds, vals)
           if flds.length == 2 && flds(0) == Ast.keyFieldName && flds(1) == Ast.maintainersFieldName =>
@@ -1607,7 +1607,7 @@ private[lf] object SBuiltin {
               .left
               .map(coid => s"Unexpected contract id in key: $coid")
           } yield
-            KeyWithMaintainers(
+            Node.KeyWithMaintainers(
               key = keyVal,
               maintainers = extractParties(vals.get(1))
             ))
@@ -1616,7 +1616,7 @@ private[lf] object SBuiltin {
 
   private[this] def extractOptionalKeyWithMaintainers(
       optKey: SValue,
-  ): Option[KeyWithMaintainers[V[Nothing]]] =
+  ): Option[Node.KeyWithMaintainers[V[Nothing]]] =
     optKey match {
       case SOptional(mbKey) => mbKey.map(extractKeyWithMaintainers)
       case v => crash(s"Expected optional key with maintainers, got: $v")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -6,8 +6,7 @@ package com.daml.lf.speedy
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
 import com.daml.lf.ledger.EventId
-import com.daml.lf.transaction.Node.GlobalKey
-import com.daml.lf.transaction.{NodeId, Transaction => Tx}
+import com.daml.lf.transaction.{GlobalKey, NodeId, Transaction => Tx}
 import com.daml.lf.value.Value
 import com.daml.lf.scenario.ScenarioLedger
 import com.daml.lf.value.Value.ContractId

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SResult.scala
@@ -7,9 +7,8 @@ import com.daml.lf.CompiledPackages
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
-import com.daml.lf.transaction.{SubmittedTransaction, Transaction => Tx}
+import com.daml.lf.transaction.{GlobalKeyWithMaintainers, SubmittedTransaction, Transaction => Tx}
 import com.daml.lf.speedy.SError._
-import com.daml.lf.transaction.Node.GlobalKeyWithMaintainers
 
 /** The result from small-step evaluation.
   * If the result is not Done or Continue, then the machine

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -8,6 +8,7 @@ import com.daml.lf.data.Ref.{ChoiceName, Location, Party, TypeConName}
 import com.daml.lf.data.{BackStack, ImmArray, Time}
 import com.daml.lf.transaction.{
   GenTransaction,
+  GlobalKey,
   Node,
   NodeId,
   SubmittedTransaction,
@@ -164,7 +165,7 @@ private[lf] case class PartialTransaction(
     consumedBy: Map[Value.ContractId, NodeId],
     context: PartialTransaction.Context,
     aborted: Option[Tx.TransactionError],
-    keys: Map[Node.GlobalKey, Option[Value.ContractId]],
+    keys: Map[GlobalKey, Option[Value.ContractId]],
 ) {
 
   import PartialTransaction._
@@ -288,7 +289,7 @@ private[lf] case class PartialTransaction(
       key match {
         case None => Right((cid, ptx))
         case Some(kWithM) =>
-          val ck = Node.GlobalKey(coinst.template, kWithM.key)
+          val ck = GlobalKey(coinst.template, kWithM.key)
           Right((cid, ptx.copy(keys = ptx.keys.updated(ck, Some(cid)))))
       }
     }
@@ -382,7 +383,7 @@ private[lf] case class PartialTransaction(
             consumedBy = if (consuming) consumedBy.updated(targetId, nid) else consumedBy,
             keys = mbKey match {
               case Some(kWithM) if consuming =>
-                keys.updated(Node.GlobalKey(templateId, kWithM.key), None)
+                keys.updated(GlobalKey(templateId, kWithM.key), None)
               case _ => keys
             },
           ),

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -8,11 +8,15 @@ import com.daml.lf.scenario.ScenarioLedger
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{SubmittedTransaction, TransactionVersion, Transaction => Tx}
+import com.daml.lf.transaction.{
+  GlobalKey,
+  SubmittedTransaction,
+  TransactionVersion,
+  Transaction => Tx
+}
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
-import com.daml.lf.transaction.Node.GlobalKey
 import com.daml.lf.value.ValueVersion
 
 private case class SRunnerException(err: SError) extends RuntimeException(err.toString)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -1,0 +1,39 @@
+package com.daml.lf
+package transaction
+
+import com.daml.lf.data.Ref
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value.ContractId
+
+/** Useful in various circumstances -- basically this is what a ledger implementation must use as
+  * a key. The 'hash' is guaranteed to be stable over time.
+  */
+final class GlobalKey private (
+    val templateId: Ref.TypeConName,
+    val key: Value[ContractId],
+    val hash: crypto.Hash
+) extends {
+  override def equals(obj: Any): Boolean = obj match {
+    case that: GlobalKey => this.hash == that.hash
+    case _ => false
+  }
+
+  override def hashCode(): Int = hash.hashCode()
+}
+
+object GlobalKey {
+  def apply(templateId: Ref.TypeConName, key: Value[Nothing]): GlobalKey =
+    new GlobalKey(templateId, key, crypto.Hash.safeHashContractKey(templateId, key))
+
+  // Will fail if key contains contract ids
+  def build(templateId: Ref.TypeConName, key: Value[ContractId]): Either[String, GlobalKey] =
+    crypto.Hash.hashContractKey(templateId, key).map(new GlobalKey(templateId, key, _))
+
+  def assertBuild(templateId: Ref.TypeConName, key: Value[ContractId]): GlobalKey =
+    data.assertRight(build(templateId, key))
+}
+
+final case class GlobalKeyWithMaintainers(
+    globalKey: GlobalKey,
+    maintainers: Set[Ref.Party]
+)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.lf
 package transaction
 
@@ -37,3 +40,4 @@ final case class GlobalKeyWithMaintainers(
     globalKey: GlobalKey,
     maintainers: Set[Ref.Party]
 )
+

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/GlobalKey.scala
@@ -40,4 +40,3 @@ final case class GlobalKeyWithMaintainers(
     globalKey: GlobalKey,
     maintainers: Set[Ref.Party]
 )
-

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/store/serialization/KeyHasher.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/store/serialization/KeyHasher.scala
@@ -7,7 +7,7 @@ import java.nio.ByteBuffer
 import java.security.MessageDigest
 
 import com.daml.lf.data.{Numeric, Utf8}
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/store/serialization/KeyHasherSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/store/serialization/KeyHasherSpec.scala
@@ -8,7 +8,7 @@ import java.security.MessageDigest
 import com.daml.lf
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value._
 import org.scalatest.{Matchers, WordSpec}

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V2_1__Rebuild_Acs.scala
@@ -17,7 +17,7 @@ import com.daml.ledger.participant.state.v1.{ContractInst, TransactionId}
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.engine.Blinding
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.ledger.api.domain.RejectionReason

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V32_1__Fix_key_hashes.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V32_1__Fix_key_hashes.scala
@@ -4,7 +4,7 @@
 package db.migration.postgres
 
 import com.daml.lf.data.Ref
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.platform.store.serialization.ValueSerializer
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
@@ -9,7 +9,7 @@ import java.sql.{Connection, ResultSet}
 
 import anorm.{BatchSql, NamedParameter}
 import com.daml.lf.data.Ref
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value.ContractId
 import com.daml.platform.store.serialization.{KeyHasher, ValueSerializer}
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -31,7 +31,7 @@ import com.daml.ledger.participant.state.index.v2.IndexService
 import com.daml.ledger.participant.state.v1.{Configuration, PackageId, ParticipantId, Party}
 import com.daml.lf.data.Ref
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.Node
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.metrics.{Metrics, Timed}
 
@@ -126,7 +126,7 @@ final class TimedIndexService(delegate: IndexService, metrics: Metrics) extends 
 
   override def lookupContractKey(
       submitter: Party,
-      key: Node.GlobalKey
+      key: GlobalKey
   ): Future[Option[Value.ContractId]] =
     Timed.future(
       metrics.daml.services.index.lookupContractKey,

--- a/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.participant.state.v1.{Configuration, Offset, ParticipantI
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{Identifier, PackageId, Party}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.daml_lf_dev.DamlLf.Archive

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -24,7 +24,7 @@ import com.daml.ledger.participant.state.v1.{Configuration, Offset}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{Identifier, PackageId, Party}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.metrics.{Metrics, Timed}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerState.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerState.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 import com.daml.ledger.participant.state.v1.ContractInst
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.ledger.TransactionId

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.participant.state.v1.ContractInst
 import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.transaction.{CommittedTransaction, NodeId, Node => N}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -28,7 +28,7 @@ import com.daml.lf.archive.Decode
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{Identifier, PackageId, Party}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.Node
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
@@ -50,7 +50,7 @@ abstract class BaseLedger(
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
 
-  override def lookupKey(key: Node.GlobalKey, forParty: Party): Future[Option[ContractId]] =
+  override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[ContractId]] =
     ledgerDao.lookupKey(key, forParty)
 
   override def flatTransactions(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.participant.state.v1.{Configuration, Offset}
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{Identifier, PackageId, Party}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.daml_lf_dev.DamlLf.Archive

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -27,7 +27,7 @@ import com.daml.ledger.WorkflowId
 import com.daml.lf.archive.Decode
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{PackageId, Party}
-import com.daml.lf.transaction.Node
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value.ContractId
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
@@ -460,7 +460,7 @@ private class JdbcLedgerDao(
     }
   }
 
-  override def lookupKey(key: Node.GlobalKey, forParty: Party): Future[Option[ContractId]] =
+  override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[ContractId]] =
     contractsReader.lookupContractKey(forParty, key)
 
   override def storeTransaction(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -20,7 +20,7 @@ import com.daml.ledger.participant.state.v1.{
 }
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{PackageId, Party}
-import com.daml.lf.transaction.Node
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.daml_lf_dev.DamlLf.Archive
@@ -77,7 +77,7 @@ trait LedgerReadDao extends ReportsHealth {
     * @param forParty the party for which the contract must be visible
     * @return the optional ContractId
     */
-  def lookupKey(key: Node.GlobalKey, forParty: Party): Future[Option[ContractId]]
+  def lookupKey(key: GlobalKey, forParty: Party): Future[Option[ContractId]]
 
   /** Returns a list of party details for the parties specified. */
   def getParties(parties: Seq[Party]): Future[List[PartyDetails]]

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.participant.state.index.v2.{CommandDeduplicationResult, P
 import com.daml.ledger.participant.state.v1._
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.{PackageId, Party}
-import com.daml.lf.transaction.Node
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.metrics.{Metrics, Timed}
@@ -60,7 +60,7 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: Metrics) extends L
 
   override def transactionsReader: TransactionsReader = ledgerDao.transactionsReader
 
-  override def lookupKey(key: Node.GlobalKey, forParty: Party): Future[Option[Value.ContractId]] =
+  override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[Value.ContractId]] =
     Timed.future(metrics.daml.index.db.lookupKey, ledgerDao.lookupKey(key, forParty))
 
   override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/package.scala
@@ -24,8 +24,8 @@ package object events {
   private[events] type Exercise = lftx.Node.NodeExercises.WithTxValue[NodeId, ContractId]
   private[events] type Fetch = lftx.Node.NodeFetch.WithTxValue[ContractId]
   private[events] type LookupByKey = lftx.Node.NodeLookupByKey.WithTxValue[ContractId]
-  private[events] type Key = lftx.Node.GlobalKey
-  private[events] val Key = lftx.Node.GlobalKey
+  private[events] type Key = lftx.GlobalKey
+  private[events] val Key = lftx.GlobalKey
 
   import com.daml.lf.{data => lfdata}
   private[events] type Party = lfdata.Ref.Party

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.Party
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -11,7 +11,7 @@ import com.daml.lf.crypto
 import com.daml.lf.data
 import com.daml.lf.data.Ref.{Identifier, LedgerString, Party}
 import com.daml.lf.data.Time
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.transaction._
 import com.daml.lf.transaction.VersionTimeline.Implicits._
 import com.daml.lf.value.Value.{ContractId, VersionedValue}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -17,7 +17,7 @@ import com.daml.ledger.participant.state.kvutils.committer.{
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.Engine
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.transaction.{TransactionCoder, TransactionOuterClass}
 import com.daml.lf.value.ValueOuterClass
 import com.daml.metrics.Metrics

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Adapter.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.participant.state.kvutils.test
 
 import com.daml.lf.data._
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{Transaction => Tx, Node, NodeId, SubmittedTransaction}
+import com.daml.lf.transaction.{Transaction => Tx, GlobalKey, Node, NodeId, SubmittedTransaction}
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
@@ -65,8 +65,8 @@ private[test] final class Adapter(packages: Map[Ref.PackageId, Ast.Package]) {
       arg = coinst.arg.copy(value = adapt(coinst.arg.value)),
     )
 
-  def adapt(gkey: Node.GlobalKey): Node.GlobalKey =
-    Node.GlobalKey.assertBuild(adapt(gkey.templateId), adapt(gkey.key))
+  def adapt(gkey: GlobalKey): GlobalKey =
+    GlobalKey.assertBuild(adapt(gkey.templateId), adapt(gkey.key))
 
   private[this] def adapt(value: Value[ContractId]): Value[ContractId] =
     value match {

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
@@ -18,7 +18,7 @@ import com.daml.lf.crypto
 import com.daml.lf.data._
 import com.daml.lf.engine.Engine
 import com.daml.lf.language.{Ast, Util => AstUtil}
-import com.daml.lf.transaction.Node.{GlobalKey, GlobalKeyWithMaintainers}
+import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers}
 import com.daml.lf.transaction.{
   Node,
   SubmittedTransaction,
@@ -228,7 +228,7 @@ object Replay {
     val allContractsWithKey = createsNodes.flatMap { node =>
       node.key.toList.map(
         key =>
-          node.coid -> Node.GlobalKey(
+          node.coid -> GlobalKey(
             node.coinst.template,
             key.key.value.assertNoCid(key => s"found cid in key $key")))
     }.toMap

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/InMemoryActiveLedgerState.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/InMemoryActiveLedgerState.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.participant.state.v1.ContractInst
 import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
-import com.daml.lf.transaction.Node.GlobalKey
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.transaction.{CommittedTransaction, NodeId}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -24,7 +24,7 @@ import com.daml.api.util.TimeProvider
 import com.daml.lf.data.Ref.{LedgerString, PackageId, Party}
 import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{Node, TransactionCommitter}
+import com.daml.lf.transaction.{GlobalKey, TransactionCommitter}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.daml_lf_dev.DamlLf.Archive
@@ -253,7 +253,7 @@ class InMemoryLedger(
         .map(_.contract)
     })
 
-  override def lookupKey(key: Node.GlobalKey, forParty: Party): Future[Option[ContractId]] =
+  override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[ContractId]] =
     Future.successful(this.synchronized {
       acs.keys.get(key).filter(acs.isVisibleForStakeholders(_, forParty))
     })


### PR DESCRIPTION
following comments that @oggy-  made in #6781, we move the `GlobalKey` and the `GlobalKeyWithMaintainers` outside from `com.daml.lf.transaction.Node` object.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
