### PR TITLE
add more scalac 2.12 warnings

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -33,6 +33,8 @@ common_scalacopts = [
     "-target:jvm-1.8",
     "-encoding",
     "UTF-8",
+    # more detailed type errors
+    "-explaintypes",
     # more detailed information about type-erasure related warnings
     "-unchecked",
     # warn if using deprecated stuff

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -53,7 +53,6 @@ common_scalacopts = [
     "-Xlint:missing-interpolator",
     "-Xlint:by-name-right-associative",  # will never be by-name if used correctly
     "-Xlint:constant",  # / 0
-    "-Xlint:doc-detached",  # floating Scaladoc comment
     "-Xlint:inaccessible",  # method uses invisible types
     "-Xlint:infer-any",  # less thorough but less buggy version of the Any wart
     "-Xlint:option-implicit",  # implicit conversion arg might be null

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -49,6 +49,16 @@ common_scalacopts = [
     "-Xfatal-warnings",
     # catch missing string interpolators
     "-Xlint:missing-interpolator",
+    "-Xlint:by-name-right-associative",  # will never be by-name if used correctly
+    "-Xlint:constant",  # / 0
+    "-Xlint:doc-detached",  # floating Scaladoc comment
+    "-Xlint:inaccessible",  # method uses invisible types
+    "-Xlint:option-implicit",  # implicit conversion arg might be null
+    "-Xlint:package-object-classes",  # put them directly in the package
+    "-Xlint:poly-implicit-overload",  # implicit conversions don't mix with overloads
+    "-Xlint:private-shadow",  # name shadowing
+    "-Xlint:type-parameter-shadow",  # name shadowing
+    "-Xlint:unsound-match",
     # adapted args is a deprecated feature:
     # `def foo(a: (A, B))` can be called with `foo(a, b)`.
     # properly it should be `foo((a,b))`

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -55,7 +55,7 @@ common_scalacopts = [
     "-Xlint:constant",  # / 0
     "-Xlint:doc-detached",  # floating Scaladoc comment
     "-Xlint:inaccessible",  # method uses invisible types
-    "-Xlint:infer-any",  # less through but less buggy version of the Any wart
+    "-Xlint:infer-any",  # less thorough but less buggy version of the Any wart
     "-Xlint:option-implicit",  # implicit conversion arg might be null
     "-Xlint:package-object-classes",  # put them directly in the package
     "-Xlint:poly-implicit-overload",  # implicit conversions don't mix with overloads

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -53,6 +53,7 @@ common_scalacopts = [
     "-Xlint:constant",  # / 0
     "-Xlint:doc-detached",  # floating Scaladoc comment
     "-Xlint:inaccessible",  # method uses invisible types
+    "-Xlint:infer-any",  # less through but less buggy version of the Any wart
     "-Xlint:option-implicit",  # implicit conversion arg might be null
     "-Xlint:package-object-classes",  # put them directly in the package
     "-Xlint:poly-implicit-overload",  # implicit conversions don't mix with overloads

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NoCopy.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NoCopy.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.lf.data
 
 trait NoCopy {

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NoCopy.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NoCopy.scala
@@ -1,0 +1,6 @@
+package com.daml.lf.data
+
+  trait NoCopy {
+    // prevents autogeneration of copy method in case class
+    protected def copy(nothing: Nothing): Nothing = nothing
+  }

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NoCopy.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/NoCopy.scala
@@ -1,6 +1,6 @@
 package com.daml.lf.data
 
-  trait NoCopy {
-    // prevents autogeneration of copy method in case class
-    protected def copy(nothing: Nothing): Nothing = nothing
-  }
+trait NoCopy {
+  // prevents autogeneration of copy method in case class
+  protected def copy(nothing: Nothing): Nothing = nothing
+}

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/package.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/package.scala
@@ -15,9 +15,4 @@ package object data {
   }
   type Numeric = Numeric.Numeric
 
-  trait NoCopy {
-    // prevents autogeneration of copy method in case class
-    protected def copy(nothing: Nothing): Nothing = nothing
-  }
-
 }

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -736,19 +736,19 @@ private[daml] class EncodeV1(val minor: LV.Minor) {
 
 object EncodeV1 {
 
-  private sealed abstract class LeftRecMatcher[Left, Right] {
-    def unapply(arg: Left): Option[(Left, ImmArray[Right])]
+  private sealed abstract class LeftRecMatcher[L, R] {
+    def unapply(arg: L): Option[(L, ImmArray[R])]
   }
 
   private object LeftRecMatcher {
-    def apply[Left, Right](
-        split: PartialFunction[Left, (Left, Right)]
-    ): LeftRecMatcher[Left, Right] = new LeftRecMatcher[Left, Right] {
+    def apply[L, R](
+        split: PartialFunction[L, (L, R)]
+    ): LeftRecMatcher[L, R] = new LeftRecMatcher[L, R] {
       @tailrec
       private def go(
-          x: Left,
-          stack: FrontStack[Right] = FrontStack.empty
-      ): Option[(Left, ImmArray[Right])] =
+          x: L,
+          stack: FrontStack[R] = FrontStack.empty
+      ): Option[(L, ImmArray[R])] =
         if (split.isDefinedAt(x)) {
           val (left, right) = split(x)
           go(left, right +: stack)
@@ -759,24 +759,24 @@ object EncodeV1 {
         }
 
       @inline
-      final def unapply(arg: Left): Option[(Left, ImmArray[Right])] = go(x = arg)
+      final def unapply(arg: L): Option[(L, ImmArray[R])] = go(x = arg)
     }
   }
 
-  private sealed abstract class RightRecMatcher[Left, Right] {
-    def unapply(arg: Right): Option[(ImmArray[Left], Right)]
+  private sealed abstract class RightRecMatcher[L, R] {
+    def unapply(arg: R): Option[(ImmArray[L], R)]
   }
 
   private object RightRecMatcher {
-    def apply[Left, Right](
-        split: PartialFunction[Right, (Left, Right)]
-    ): RightRecMatcher[Left, Right] = new RightRecMatcher[Left, Right] {
+    def apply[L, R](
+        split: PartialFunction[R, (L, R)]
+    ): RightRecMatcher[L, R] = new RightRecMatcher[L, R] {
 
       @tailrec
       private def go(
-          stack: BackStack[Left] = BackStack.empty,
-          x: Right
-      ): Option[(ImmArray[Left], Right)] =
+          stack: BackStack[L] = BackStack.empty,
+          x: R
+      ): Option[(ImmArray[L], R)] =
         if (split.isDefinedAt(x)) {
           val (left, right) = split(x)
           go(stack :+ left, right)
@@ -787,7 +787,7 @@ object EncodeV1 {
         }
 
       @inline
-      final def unapply(arg: Right): Option[(ImmArray[Left], Right)] = go(x = arg)
+      final def unapply(arg: R): Option[(ImmArray[L], R)] = go(x = arg)
     }
   }
 

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/package.scala
@@ -15,14 +15,16 @@ import com.squareup.javapoet._
 
 import scala.collection.JavaConverters._
 
+package inner {
+  case class FieldInfo(damlName: String, damlType: Type, javaName: String, javaType: TypeName)
+}
+
 package object inner {
 
   private[inner] def generateArgumentList(fields: IndexedSeq[String]): CodeBlock =
     CodeBlock.join(fields.map(CodeBlock.of("$L", _)).asJava, ", ")
 
   private[inner] def newNameGenerator = Iterator.from(0).map(n => s"v$$$n")
-
-  case class FieldInfo(damlName: String, damlType: Type, javaName: String, javaType: TypeName)
 
   type Fields = IndexedSeq[FieldInfo]
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -293,7 +293,7 @@ private[http] object ContractsFetch {
         * This turns such a graph into a flow with the value materialized.
         */
       def divertToHead(implicit noM: M <~< NotUsed): Flow[A, Y, Future[Z]] = {
-        type CK[-A] = (A, Future[Z]) => Future[Z]
+        type CK[-T] = (T, Future[Z]) => Future[Z]
         divertToMat(Sink.head)(noM.subst[CK](Keep.right[NotUsed, Future[Z]]))
       }
     }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -194,7 +194,7 @@ class ContractsService(
   }
 
   // we store create arguments as JSON in DB, that is why it is `domain.ActiveContract[JsValue]` in the result
-  def searchDb(dao: dbbackend.ContractDao, fetch: ContractsFetch)(
+  private def searchDb(dao: dbbackend.ContractDao, fetch: ContractsFetch)(
       jwt: Jwt,
       party: domain.Party,
       templateIds: Set[domain.TemplateId.RequiredPkg],

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -57,18 +57,18 @@ object WebSocketService {
       }
       .collect { case Some(\/-(oli)) => oli }
 
-  private final case class StepAndErrors[+Pos, +LfV](
+  private final case class StepAndErrors[+Pos, +LfVT](
       errors: Seq[ServerError],
-      step: ContractStreamStep[domain.ArchivedContract, (domain.ActiveContract[LfV], Pos)]) {
+      step: ContractStreamStep[domain.ArchivedContract, (domain.ActiveContract[LfVT], Pos)]) {
     import JsonProtocol._, spray.json._
 
-    def render(implicit lfv: LfV <~< JsValue, pos: Pos <~< Map[String, JsValue]): JsObject = {
+    def render(implicit lfv: LfVT <~< JsValue, pos: Pos <~< Map[String, JsValue]): JsObject = {
 
       def inj[V: JsonWriter](ctor: String, v: V) = JsObject(ctor -> v.toJson)
 
       val InsertDeleteStep(inserts, deletes) =
         Liskov
-          .lift2[StepAndErrors, Pos, Map[String, JsValue], LfV, JsValue](pos, lfv)(this)
+          .lift2[StepAndErrors, Pos, Map[String, JsValue], LfVT, JsValue](pos, lfv)(this)
           .step
           .toInsertDelete
 
@@ -84,13 +84,13 @@ object WebSocketService {
       renderEvents(events, offsetAfter)
     }
 
-    def append[P >: Pos, A >: LfV](o: StepAndErrors[P, A]): StepAndErrors[P, A] =
+    def append[P >: Pos, A >: LfVT](o: StepAndErrors[P, A]): StepAndErrors[P, A] =
       StepAndErrors(errors ++ o.errors, step append o.step)
 
-    def mapLfv[A](f: LfV => A): StepAndErrors[Pos, A] =
+    def mapLfv[A](f: LfVT => A): StepAndErrors[Pos, A] =
       copy(step = step mapPreservingIds (_ leftMap (_ map f)))
 
-    def mapPos[P](f: Pos => P): StepAndErrors[P, LfV] =
+    def mapPos[P](f: Pos => P): StepAndErrors[P, LfVT] =
       copy(step = step mapPreservingIds (_ rightMap f))
 
     def nonEmpty: Boolean = errors.nonEmpty || step.nonEmpty

--- a/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/domain.scala
+++ b/ledger-service/jwt/src/main/scala/com/digitalasset/jwt/domain.scala
@@ -8,7 +8,7 @@ import scalaz.{Applicative, Traverse}
 
 import scala.language.higherKinds
 
-package object domain {
+package domain {
 
   final case class KeyPair[A](publicKey: A, privateKey: A)
 

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/ApiCodecCompressed.scala
@@ -201,7 +201,7 @@ class ApiCodecCompressed[Cid](val encodeDecimalAsString: Boolean, val encodeInt6
   }
 
   @throws[DeserializationException]
-  private[this] def checkDups[K: Equal, V](decEntries: Seq[(K, V)]): Unit =
+  private[this] def checkDups[K: Equal](decEntries: Seq[(K, _)]): Unit =
     decEntries match {
       case (h, _) +: t =>
         val _ = t.foldLeft(h)((p, n) =>

--- a/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
+++ b/ledger-service/lf-value-json/src/main/scala/com/digitalasset/daml/lf/value/json/NavigatorModelAliases.scala
@@ -90,7 +90,7 @@ trait NavigatorModelAliases[Cid] {
     }
 
   import scala.language.higherKinds
-  type OfCid[V[_]] = V[Cid]
+  type OfCid[F[_]] = F[Cid]
   type ApiValue = OfCid[V]
   type ApiRecordField = (Option[DamlLfRef.Name], ApiValue)
   type ApiRecord = OfCid[V.ValueRecord]

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableFlatEventsRangeQueries.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableFlatEventsRangeQueries.scala
@@ -4,7 +4,6 @@
 package com.daml.platform.store.dao.events
 
 import anorm.{Row, SimpleSql, SqlStringInterpolation}
-import com.daml.ledger.participant.state.v1.Offset
 import com.daml.lf.data.Ref.{Identifier => ApiIdentifier}
 import com.daml.platform.store.Conversions._
 
@@ -112,6 +111,8 @@ private[events] sealed trait EventsTableFlatEventsRangeQueries[Offset] {
 }
 
 private[events] object EventsTableFlatEventsRangeQueries {
+
+  import com.daml.ledger.participant.state.v1.Offset
 
   final class GetTransactions(
       selectColumns: String,

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
@@ -11,7 +11,7 @@ import com.daml.lf.data.Ref
 import com.daml.lf.value.Value
 import com.daml.ledger.api.domain._
 
-package object v2 {
+package v2 {
 
   object AcsUpdateEvent {
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/console/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/console/package.scala
@@ -5,6 +5,12 @@ package com.daml.navigator
 
 import scala.util.Try
 
+package console {
+  case class CommandError(message: String, reason: Option[Throwable]) extends Throwable {
+    override def getMessage: String = message
+  }
+}
+
 package object console {
 
   /** Given old state and command arguments, what is the new state? */
@@ -12,10 +18,6 @@ package object console {
 
   /** Given the full commmand name, print some help */
   type Help = List[String] => Unit
-
-  case class CommandError(message: String, reason: Option[Throwable]) extends Throwable {
-    override def getMessage: String = message
-  }
 
   final implicit class CommandTryOps[T](val value: Try[T]) extends AnyVal {
     def ~>(msg: String): Either[CommandError, T] =

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/dotnot/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/dotnot/package.scala
@@ -19,7 +19,7 @@ package com.daml.navigator
   * - `path` or `property`: the list of all the pieces of the `Tree` from the `root` to a `leaf`
   * - `dotnot handler for k`: the set of all the paths and actions to be performed on an instance of `k`
   */
-package object dotnot {
+package dotnot {
 
   sealed trait DotNotFailure {
     def cursor: PropertyCursor
@@ -43,10 +43,6 @@ package object dotnot {
       extends DotNotFailure
   final case class UnknownType(name: String, cursor: PropertyCursor, value: String)
       extends DotNotFailure
-
-  type NameMatcher = String => Boolean
-  type ValueMatcher = String => Boolean
-  type Action[T, R, C] = (T, PropertyCursor, String, C) => Either[DotNotFailure, R]
 
   final case class NameMatcherToAction[T, R, C](matcher: NameMatcher, action: Action[T, R, C])
   final case class ValueMatcherToAction[T, R, C](matcher: ValueMatcher, action: Action[T, R, C])
@@ -237,6 +233,13 @@ package object dotnot {
     def const(r: R): OnLeafReady[T, R, C] =
       perform[String]((_: T, _: String) => r)
   }
+}
+
+package object dotnot {
+
+  type NameMatcher = String => Boolean
+  type ValueMatcher = String => Boolean
+  type Action[T, R, C] = (T, PropertyCursor, String, C) => Either[DotNotFailure, R]
 
   /**
     * Create a dot-notation handler for a type `T` with name `name` and with return

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/model/package.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/model/package.scala
@@ -17,7 +17,6 @@ package object model extends NavigatorModelAliases[String] {
     * An opaque identifier used for templates.
     * Templates are usually identified using a composite type (see [[DamlLfIdentifier]]).
     */
-  sealed trait TemplateStringIdTag
   type TemplateStringId = String @@ TemplateStringIdTag
   val TemplateStringId = Tag.of[TemplateStringIdTag]
 
@@ -101,4 +100,8 @@ package object model extends NavigatorModelAliases[String] {
   def parseOpaqueIdentifier(id: TemplateStringId): Option[DamlLfRef.Identifier] =
     parseOpaqueIdentifier(TemplateStringId.unwrap(id))
 
+}
+
+package model {
+  sealed trait TemplateStringIdTag
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/package.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/package.scala
@@ -11,7 +11,7 @@ import com.daml.platform.services.time.TimeProviderType
 
 import scala.concurrent.duration.FiniteDuration
 
-package object trigger {
+package trigger {
 
   case class LedgerConfig(
       host: String,


### PR DESCRIPTION
Sometimes codifying guidelines that have already come up in code review, sometimes checking probably-wrong constructs. I chose the lints to add based on [tpolecat's 2.12 list](https://tpolecat.github.io/2017/04/25/scalac-flags.html), picking the ones that either I was familiar with or sounded good, leaving out a couple. Examples fixed here:

```
package.scala:18: warning: it is not recommended to define classes/objects inside of package objects.
If possible, define trait NoCopy in package data instead.
  trait NoCopy {
        ^
```

Note that `package` is itself a scoping construct, so if your reason is the apparent aesthetic of placing a bunch of things in one `package object`, that is easily remedied by simply deleting the `object` keyword, such as I do in c5e8c3b3acd0593adced95d278f3318a670ea00e.

```
ContractsService.scala:197: warning: method searchDb in class ContractsService references private class ContractsFetch.
Classes which cannot access ContractsFetch may be unable to override searchDb.
  def searchDb(dao: dbbackend.ContractDao, fetch: ContractsFetch)(
      ^
```

This should be especially useful given modularization efforts such as @rautenrieth-da 's in #6695 and other PRs.

```
EventsTableFlatEventsRangeQueries.scala:11: warning: type parameter
 Offset defined in trait EventsTableFlatEventsRangeQueries shadows class
 Offset defined in package v1. You may want to rename your type
 parameter, or possibly remove it.
private[events] sealed trait EventsTableFlatEventsRangeQueries[Offset] {
                                                               ^
```

I noticed this in #6658. I'm generally in favor of sensible name-shadowing, following the "deliberately hide variables that should not be accessed here" school of thought.  But I think type name shadowing isn't quite as valuable and more likely to confuse than general variable shadowing, so have experimentally linted it out; see dad17ec4f7069e92faabe5af45997dc831a39aff for the results. We can easily revert that part of this PR if we don't like the rule, though.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
