### PR TITLE
Print results in DAML REPL and support pure expressions

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Output.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Output.hs
@@ -1,11 +1,12 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module DA.Cli.Output
+module DA.Daml.Compiler.Output
   ( writeOutput
   , writeOutputBSL
   , diagnosticsLogger
   , hDiagnosticsLogger
+  , printDiagnostics
   ) where
 
 import qualified Data.ByteString.Char8 as BS

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 module DA.Daml.Compiler.Repl
-    ( getReplLogger
+    ( newReplLogger
     , runRepl
     , ReplLogger(..)
     ) where
@@ -244,8 +244,8 @@ data ReplLogger = ReplLogger
   }
 
 
-getReplLogger :: IO ReplLogger
-getReplLogger = do
+newReplLogger :: IO ReplLogger
+newReplLogger = do
     lock <- newLock
     diagsRef <- newIORef $ \diags -> printDiagnostics stdout diags
     let replEventLogger = \case

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -632,7 +632,7 @@ execRepl projectOpts opts scriptDar dars importPkgs ledgerHost ledgerPort mbAuth
                     , "data-dependencies:"
                     ] ++ ["- " <> show dar | dar <- dars]
                 initPackageDb opts (InitPkgDb True)
-                replLogger <- Repl.getReplLogger
+                replLogger <- Repl.newReplLogger
                 withDamlIdeState opts logger (Repl.replEventLogger replLogger)
                     (Repl.runRepl importPkgs opts replHandle replLogger)
 

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -632,9 +632,9 @@ execRepl projectOpts opts scriptDar dars importPkgs ledgerHost ledgerPort mbAuth
                     , "data-dependencies:"
                     ] ++ ["- " <> show dar | dar <- dars]
                 initPackageDb opts (InitPkgDb True)
-                -- We want diagnostics to go to stdout in the repl.
-                withDamlIdeState opts logger (hDiagnosticsLogger stdout)
-                    (Repl.runRepl importPkgs opts replHandle)
+                replLogger <- Repl.getReplLogger
+                withDamlIdeState opts logger (Repl.replEventLogger replLogger)
+                    (Repl.runRepl importPkgs opts replHandle replLogger)
 
 -- | Remove any build artifacts if they exist.
 execClean :: ProjectOpts -> Command

--- a/compiler/damlc/lib/DA/Cli/Damlc/Base.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Base.hs
@@ -3,12 +3,12 @@
 
 module DA.Cli.Damlc.Base
     ( module DA.Cli.Options
-    , module DA.Cli.Output
+    , module DA.Daml.Compiler.Output
     , getLogger
     )
 where
 import           DA.Cli.Options
-import           DA.Cli.Output
+import           DA.Daml.Compiler.Output
 import DA.Daml.Options.Types
 import qualified Data.Text as T
 import qualified DA.Service.Logger                 as Logger

--- a/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Command/Damldoc.hs
@@ -5,7 +5,7 @@
 module DA.Cli.Damlc.Command.Damldoc(cmd, exec) where
 
 import DA.Cli.Options
-import DA.Cli.Output
+import DA.Daml.Compiler.Output
 import DA.Daml.Doc.Driver
 import DA.Daml.Doc.Extract
 import DA.Daml.Options.Types

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -120,6 +120,7 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , input "debug props"
           , matchServiceOutput "^.*: \\[\\(<contract-id>,TProposal {proposer = '[^']+', accepter = '[^']+'}.*\\)\\]$"
           , input "forA props $ \\(prop, _) -> submit bob $ exerciseCmd prop Accept"
+          -- Allow for trailing \r because Windows
           , matchOutput "^\\[<contract-id>\\].?$"
           , input "debug =<< query @T bob"
           , matchServiceOutput "^.*: \\[\\(<contract-id>,T {proposer = '[^']+', accepter = '[^']+'}.*\\)\\]$"
@@ -241,9 +242,11 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
     , testInteraction' "repl output"
           [ input "pure ()" -- no output
           , input "pure (1 + 1)"
+          -- Allow for trailing \r because Windows
           , matchOutput "^2.?$"
           , input "pure (\\x -> x)" -- no output
           , input "1 + 2"
+          -- Allow for trailing \r because Windows
           , matchOutput "^3.?$"
           , input "\\x -> x"
           , matchOutput "^File:.*$"

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -120,7 +120,7 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , input "debug props"
           , matchServiceOutput "^.*: \\[\\(<contract-id>,TProposal {proposer = '[^']+', accepter = '[^']+'}.*\\)\\]$"
           , input "forA props $ \\(prop, _) -> submit bob $ exerciseCmd prop Accept"
-          , matchOutput "^\\[<contract-id>\\]$"
+          , matchOutput "^\\[<contract-id>\\].?$"
           , input "debug =<< query @T bob"
           , matchServiceOutput "^.*: \\[\\(<contract-id>,T {proposer = '[^']+', accepter = '[^']+'}.*\\)\\]$"
           , input "debug =<< query @TProposal bob"
@@ -241,10 +241,10 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
     , testInteraction' "repl output"
           [ input "pure ()" -- no output
           , input "pure (1 + 1)"
-          , matchOutput "^2$"
+          , matchOutput "^2.?$"
           , input "pure (\\x -> x)" -- no output
           , input "1 + 2"
-          , matchOutput "^3$"
+          , matchOutput "^3.?$"
           , input "\\x -> x"
           , matchOutput "^File:.*$"
           , matchOutput "^Hidden:.*$"

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -71,7 +71,7 @@ main = do
         withAsync (drainHandle serviceOut serviceLineChan) $ \_ -> do
             initPackageConfig scriptDar testDars
             logger <- Logger.newStderrLogger Logger.Warning "repl-tests"
-            replLogger <- getReplLogger
+            replLogger <- newReplLogger
             withDamlIdeState options logger (replEventLogger replLogger) $ \ideState ->
                 (hspec $ functionalTests replHandle replLogger serviceLineChan options ideState) `finally`
                     -- We need to kill the process to avoid getting stuck in hGetLine on Windows.

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -4,12 +4,10 @@ module DA.Test.Repl.FuncTests (main) where
 
 import Control.Concurrent
 import Control.Concurrent.Async
--- import Control.Concurrent.Chan
 import Control.Exception
 import Control.Monad.Extra
 import DA.Bazel.Runfiles
 import DA.Cli.Damlc.Packaging
-import DA.Cli.Output
 import DA.Daml.Compiler.Repl
 import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.ReplClient as ReplClient
@@ -73,8 +71,9 @@ main = do
         withAsync (drainHandle serviceOut serviceLineChan) $ \_ -> do
             initPackageConfig scriptDar testDars
             logger <- Logger.newStderrLogger Logger.Warning "repl-tests"
-            withDamlIdeState options logger (hDiagnosticsLogger stdout) $ \ideState ->
-                (hspec $ functionalTests replHandle serviceLineChan options ideState) `finally`
+            replLogger <- getReplLogger
+            withDamlIdeState options logger (replEventLogger replLogger) $ \ideState ->
+                (hspec $ functionalTests replHandle replLogger serviceLineChan options ideState) `finally`
                     -- We need to kill the process to avoid getting stuck in hGetLine on Windows.
                     terminateProcess processHandle
 
@@ -103,24 +102,25 @@ drainHandle handle chan = forever $ do
 options :: Options
 options = (defaultOptions Nothing) { optScenarioService = EnableScenarioService False }
 
-functionalTests :: ReplClient.Handle -> Chan String -> Options -> IdeState -> Spec
-functionalTests replClient serviceOut options ideState = describe "repl func tests" $ sequence_
+functionalTests :: ReplClient.Handle -> ReplLogger -> Chan String -> Options -> IdeState -> Spec
+functionalTests replClient replLogger serviceOut options ideState = describe "repl func tests" $ sequence_
     [ testInteraction' "create and query"
           [ input "alice <- allocateParty \"Alice\""
           , input "debug =<< query @T alice"
           , matchServiceOutput "^.*: \\[\\]$"
-          , input "submit alice $ createCmd (T alice alice)"
+          , input "_ <- submit alice $ createCmd (T alice alice)"
           , input "debug =<< query @T alice"
           , matchServiceOutput "^.*: \\[\\(<contract-id>,T {proposer = '[^']+', accepter = '[^']+'}.*\\)\\]$"
           ]
     , testInteraction' "propose and accept"
           [ input "alice <- allocateParty \"Alice\""
           , input "bob <- allocateParty \"Bob\""
-          , input "submit alice $ createCmd (TProposal alice bob)"
+          , input "_ <- submit alice $ createCmd (TProposal alice bob)"
           , input "props <- query @TProposal bob"
           , input "debug props"
           , matchServiceOutput "^.*: \\[\\(<contract-id>,TProposal {proposer = '[^']+', accepter = '[^']+'}.*\\)\\]$"
           , input "forA props $ \\(prop, _) -> submit bob $ exerciseCmd prop Accept"
+          , matchOutput "^\\[<contract-id>\\]$"
           , input "debug =<< query @T bob"
           , matchServiceOutput "^.*: \\[\\(<contract-id>,T {proposer = '[^']+', accepter = '[^']+'}.*\\)\\]$"
           , input "debug =<< query @TProposal bob"
@@ -160,7 +160,7 @@ functionalTests replClient serviceOut options ideState = describe "repl func tes
           , matchServiceOutput "^.*: 2"
           ]
     , testInteraction' "type error"
-          [ input "1"
+          [ input "1 + \"\""
           -- TODO Make this less noisy
           , matchOutput "^File:.*$"
           , matchOutput "^Hidden:.*$"
@@ -169,12 +169,7 @@ functionalTests replClient serviceOut options ideState = describe "repl func tes
           , matchOutput "^Severity:.*$"
           , matchOutput "^Message:.*$"
           , matchOutput "^.*error.*$"
-          , matchOutput "^.*expected type .*Script .* with actual type .*Int.*$"
-          , matchOutput "^.*$"
-          , matchOutput "^.*$"
-          , matchOutput "^.*$"
-          , matchOutput "^.*$"
-          , matchOutput "^.*$"
+          , matchOutput "^.*expected type .*Int.* with actual type .*Text.*$"
           , matchOutput "^.*$"
           , matchOutput "^.*$"
           , matchOutput "^.*$"
@@ -243,20 +238,43 @@ functionalTests replClient serviceOut options ideState = describe "repl func tes
           , input "debug t2"
           , matchServiceOutput "^.*: T2 {owner = 'two_dars_party'}"
           ]
+    , testInteraction' "repl output"
+          [ input "pure ()" -- no output
+          , input "pure (1 + 1)"
+          , matchOutput "^2$"
+          , input "pure (\\x -> x)" -- no output
+          , input "1 + 2"
+          , matchOutput "^3$"
+          , input "\\x -> x"
+          , matchOutput "^File:.*$"
+          , matchOutput "^Hidden:.*$"
+          , matchOutput "^Range:.*$"
+          , matchOutput "^Source:.*$"
+          , matchOutput "^Severity:.*$"
+          , matchOutput "^Message:.*$"
+          , matchOutput "^.*error.*$"
+          , matchOutput "^.*No instance for \\(Show.*$"
+          , matchOutput "^.*"
+          , matchOutput "^.*"
+          , matchOutput "^.*"
+          , matchOutput "^.*"
+          , matchOutput "^.*"
+          ]
     ]
   where
     testInteraction' testName steps =
         it testName $
-        testInteraction replClient serviceOut options ideState steps
+        testInteraction replClient replLogger serviceOut options ideState steps
 
 testInteraction
     :: ReplClient.Handle
+    -> ReplLogger
     -> Chan String
     -> Options
     -> IdeState
     -> [Step]
     -> Expectation
-testInteraction replClient serviceOut options ideState steps = do
+testInteraction replClient replLogger serviceOut options ideState steps = do
     let (inLines, outAssertions) = processSteps steps
     -- On Windows we cannot dup2 between a file handle and a pipe.
     -- Therefore, we redirect to files, run the action and assert afterwards.
@@ -266,7 +284,7 @@ testInteraction replClient serviceOut options ideState steps = do
             redirectingHandle stdin readIn $ do
             Right () <- ReplClient.clearResults replClient
             let imports = [(LF.PackageName name, Nothing) | name <- ["repl-test", "repl-test-two"]]
-            capture_ $ runRepl imports options replClient ideState
+            capture_ $ runRepl imports options replClient replLogger ideState
     -- Write output to a file so we can conveniently read individual characters.
     withTempFile $ \clientOutFile -> do
         writeFileUTF8 clientOutFile out

--- a/compiler/repl-service/protos/repl_service.proto
+++ b/compiler/repl-service/protos/repl_service.proto
@@ -28,6 +28,8 @@ message RunScriptRequest {
 }
 
 message RunScriptResponse {
+  // Optional result, we render this on the client side.
+  string result = 1;
 }
 
 message ClearResultsRequest {

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -265,7 +265,11 @@ class ReplService(
         respObs.onError(e)
       case Success(v) =>
         results = results ++ Seq(v)
-        respObs.onNext(RunScriptResponse.newBuilder.build)
+        val result = v match {
+          case SValue.SText(t) => t
+          case _ => ""
+        }
+        respObs.onNext(RunScriptResponse.newBuilder.setResult(result).build)
         respObs.onCompleted
     }
   }

--- a/docs/source/daml-repl/index.rst
+++ b/docs/source/daml-repl/index.rst
@@ -56,9 +56,14 @@ You can think of this prompt like a line in a ``do``-block of the
 two forms:
 
 1. An expression ``expr`` of type ``Script a`` for some type ``a``. This
-   will execute the script ignoring the result.
+   will execute the script and print the result if ``a`` is an
+   instance of ``Show`` and not ``()``.
 
-2. A binding of the form ``pat <- expr`` where ``pat`` is pattern, e.g.,
+2. A pure expression ``expr`` of type ``a`` for some type ``a`` where
+   ``a`` is an instance of ``Show``. This will evaluate ``expr``
+   and print the result.
+
+3. A binding of the form ``pat <- expr`` where ``pat`` is pattern, e.g.,
    a variable name ``x`` to bind the result to
    and ``expr`` is an expression of type ``Script a``.
    This will execute the script and match the result against


### PR DESCRIPTION
This extends DAML REPL to behave similar to GHCi in that it prints
results if the result is an instance of `Show` and it also supports
pure, non-script expressions now. We copy the same hack from GHCi and
typecheck multiple times. This doesn’t seem to have any noticeable
performance impact (which makes sense, the expressions are tiny and
the overhead of grpc is much much bigger).

Docs and tests are updated.

fixes #6780

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
