### PR TITLE
Trigger service: auth service client methods to request, list and poll for service accounts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,8 @@ if [ -n "$SANDBOX_PID" ]; then
     kill "$SANDBOX_PID"
 fi
 
+bazel test //triggers/service:auth-client-tests --runs_per_test=20
+
 # Bazel test only builds targets that are dependencies of a test suite so do a full build first.
 bazel build //... --build_tag_filters "$tag_filter"
 

--- a/build.sh
+++ b/build.sh
@@ -27,8 +27,6 @@ if [ -n "$SANDBOX_PID" ]; then
     kill "$SANDBOX_PID"
 fi
 
-bazel test //triggers/service:auth-client-tests --runs_per_test=20
-
 # Bazel test only builds targets that are dependencies of a test suite so do a full build first.
 bazel build //... --build_tag_filters "$tag_filter"
 

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -35,6 +35,7 @@ da_scala_library(
         "//ledger-api/rs-grpc-bridge",
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
+        "//libs-scala/timer-utils",
         "//triggers/runner:trigger-runner-lib",
         "@maven//:com_chuusai_shapeless_2_12",
         "@maven//:com_github_scopt_scopt_2_12",

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -37,6 +37,7 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         _ <- assert(saReqSuccess)
         Some(sa) <- authServiceClient.getServiceAccount(authServiceToken)
         _ <- sa.serviceAccount should not be empty
+        _ <- sa.creds should equal(List())
       } yield succeed
     }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -19,12 +19,24 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
 
   private val testLedgerId = "test-ledger-id"
 
-  it should "authorize a user and request a service account" in AuthServiceFixture
-    .withAuthServiceClient(testId) { authServiceClient =>
+  it should "authorize a user and request a service account" in
+    AuthServiceFixture.withAuthServiceClient(testId) { authServiceClient =>
       for {
         authServiceToken <- authServiceClient.authorize("username", "password")
         _ <- authServiceToken.token should not be empty
         success <- authServiceClient.requestServiceAccount(authServiceToken, testLedgerId)
       } yield assert(success)
+    }
+
+  it should "retrieve a service account" in
+    AuthServiceFixture.withAuthServiceClient(testId) { authServiceClient =>
+      for {
+        authServiceToken <- authServiceClient.authorize("username", "password")
+        _ <- authServiceToken.token should not be empty
+        saReqSuccess <- authServiceClient.requestServiceAccount(authServiceToken, testLedgerId)
+        _ <- assert(saReqSuccess)
+        Some(sa) <- authServiceClient.getServiceAccount(authServiceToken)
+        _ <- sa.serviceAccount should not be empty
+      } yield succeed
     }
 }


### PR DESCRIPTION
Uses `RetryStrategy` to poll for service account after making request. Client tests passed 20 times in CI using `--runs_per_test=20` in `build.sh`.

Thinking about encapsulating things like the `authServiceToken` and ledger id in the AuthServiceClient object, but can tweak this later.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
