### PR TITLE
Privatize participant API

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/ApiOffset.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/ApiOffset.scala
@@ -10,7 +10,7 @@ import scala.util.{Failure, Success, Try}
 
 // This utility object is used as a single point to encode and decode
 // offsets sent over the API and received from the API.
-object ApiOffset {
+private[daml] object ApiOffset {
 
   val begin: Offset = Offset.fromByteArray(Array(0: Byte))
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -49,7 +49,7 @@ import scalaz.syntax.tag._
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 
-trait ApiServices {
+private[daml] trait ApiServices {
   val services: Iterable[BindableService]
 
   def withServices(otherServices: immutable.Seq[BindableService]): ApiServices
@@ -62,7 +62,7 @@ private case class ApiServicesBundle(services: immutable.Seq[BindableService]) e
 
 }
 
-object ApiServices {
+private[daml] object ApiServices {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/EventLoopGroupOwner.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/EventLoopGroupOwner.scala
@@ -15,7 +15,7 @@ import io.netty.util.concurrent.DefaultThreadFactory
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try
 
-final class EventLoopGroupOwner(threadPoolName: String, parallelism: Int)
+private[apiserver] final class EventLoopGroupOwner(threadPoolName: String, parallelism: Int)
     extends ResourceOwner[EventLoopGroup] {
 
   override def acquire()(implicit executionContext: ExecutionContext): Resource[EventLoopGroup] =
@@ -33,7 +33,7 @@ final class EventLoopGroupOwner(threadPoolName: String, parallelism: Int)
     )
 }
 
-object EventLoopGroupOwner {
+private[apiserver] object EventLoopGroupOwner {
 
   val clientChannelType: Class[_ <: Channel] = classOf[NioSocketChannel]
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ExecutionSequencerFactoryOwner.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ExecutionSequencerFactoryOwner.scala
@@ -11,7 +11,7 @@ import com.daml.resources.{Resource, ResourceOwner}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class ExecutionSequencerFactoryOwner(implicit actorSystem: ActorSystem)
+private[daml] final class ExecutionSequencerFactoryOwner(implicit actorSystem: ActorSystem)
     extends ResourceOwner[ExecutionSequencerFactory] {
   // NOTE: Pick a unique pool name as we want to allow multiple LedgerApiServer instances,
   // and it's pretty difficult to wait for the name to become available again.

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
@@ -19,7 +19,7 @@ import io.netty.handler.ssl.SslContext
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
 
-object GrpcServer {
+private[apiserver] object GrpcServer {
 
   // Unfortunately, we can't get the maximum inbound message size from the client, so we don't know
   // how big this should be. This seems long enough to contain useful data, but short enough that it

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
@@ -14,7 +14,7 @@ import io.netty.handler.ssl.SslContext
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
-final class LedgerApiServer(
+private[daml] final class LedgerApiServer(
     apiServicesOwner: ResourceOwner[ApiServices],
     desiredPort: Port,
     maxInboundMessageSize: Int,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/MetricsInterceptor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/MetricsInterceptor.scala
@@ -27,7 +27,7 @@ import scala.collection.concurrent.TrieMap
   *
   * e.g. "org.example.SomeService/someMethod" becomes "daml.lapi.some_service.some_method"
   */
-final class MetricsInterceptor(metrics: Metrics) extends ServerInterceptor {
+private[apiserver] final class MetricsInterceptor(metrics: Metrics) extends ServerInterceptor {
 
   // Cache the result of calling MetricsInterceptor.nameFor, which practically has a
   // limited co-domain and whose cost we don't want to pay every time an endpoint is hit

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ServerEventLoopGroups.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ServerEventLoopGroups.scala
@@ -9,7 +9,7 @@ import io.netty.channel.{EventLoopGroup, ServerChannel}
 
 import scala.concurrent.ExecutionContext
 
-case class ServerEventLoopGroups(
+private[apiserver] case class ServerEventLoopGroups(
     worker: EventLoopGroup,
     boss: EventLoopGroup,
     channelType: Class[_ <: ServerChannel],
@@ -23,7 +23,7 @@ case class ServerEventLoopGroups(
 
 }
 
-object ServerEventLoopGroups {
+private[apiserver] object ServerEventLoopGroups {
 
   final class Owner(name: String, workerParallelism: Int, bossParallelism: Int)
       extends ResourceOwner[ServerEventLoopGroups] {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -37,7 +37,8 @@ import com.daml.metrics.{Metrics, Timed}
 
 import scala.concurrent.Future
 
-final class TimedIndexService(delegate: IndexService, metrics: Metrics) extends IndexService {
+private[daml] final class TimedIndexService(delegate: IndexService, metrics: Metrics)
+    extends IndexService {
 
   override def listLfPackages(): Future[Map[PackageId, v2.PackageDetails]] =
     Timed.future(metrics.daml.services.index.listLfPackages, delegate.listLfPackages())

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutionResult.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutionResult.scala
@@ -20,7 +20,7 @@ import com.daml.lf.transaction.SubmittedTransaction
   *                                 changed after command interpretation.
   * @param interpretationTimeNanos  Wall-clock time that interpretation took for the engine.
   */
-final case class CommandExecutionResult(
+private[apiserver] final case class CommandExecutionResult(
     submitterInfo: SubmitterInfo,
     transactionMeta: TransactionMeta,
     transaction: SubmittedTransaction,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutor.scala
@@ -10,7 +10,7 @@ import com.daml.platform.store.ErrorCause
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait CommandExecutor {
+private[apiserver] trait CommandExecutor {
   def execute(
       commands: ApiCommands,
       submissionSeed: crypto.Hash,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
@@ -14,7 +14,7 @@ import com.daml.platform.store.ErrorCause
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class LedgerTimeAwareCommandExecutor(
+private[apiserver] final class LedgerTimeAwareCommandExecutor(
     delegate: CommandExecutor,
     contractStore: ContractStore,
     maxRetries: Int,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -31,7 +31,7 @@ import scalaz.syntax.tag._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-final class StoreBackedCommandExecutor(
+private[apiserver] final class StoreBackedCommandExecutor(
     engine: Engine,
     participant: Ref.ParticipantId,
     packagesService: IndexPackagesService,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/TimedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/TimedCommandExecutor.scala
@@ -11,7 +11,7 @@ import com.daml.platform.store.ErrorCause
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class TimedCommandExecutor(
+private[apiserver] class TimedCommandExecutor(
     delegate: CommandExecutor,
     metrics: Metrics,
 ) extends CommandExecutor {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
@@ -20,7 +20,7 @@ import io.grpc.{BindableService, ServerServiceDefinition}
 
 import scala.concurrent.ExecutionContext
 
-final class ApiActiveContractsService private (
+private[apiserver] final class ApiActiveContractsService private (
     backend: ACSBackend,
 )(
     implicit executionContext: ExecutionContext,
@@ -46,7 +46,7 @@ final class ApiActiveContractsService private (
     ActiveContractsServiceGrpc.bindService(this, DirectExecutionContext)
 }
 
-object ApiActiveContractsService {
+private[apiserver] object ApiActiveContractsService {
 
   def create(ledgerId: LedgerId, backend: ACSBackend)(
       implicit ec: ExecutionContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -25,7 +25,8 @@ import io.grpc.ServerServiceDefinition
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class ApiCommandCompletionService private (completionsService: IndexCompletionsService)(
+private[apiserver] final class ApiCommandCompletionService private (
+    completionsService: IndexCompletionsService)(
     implicit ec: ExecutionContext,
     protected val mat: Materializer,
     protected val esf: ExecutionSequencerFactory,
@@ -55,7 +56,7 @@ final class ApiCommandCompletionService private (completionsService: IndexComple
 
 }
 
-object ApiCommandCompletionService {
+private[apiserver] object ApiCommandCompletionService {
 
   def create(ledgerId: LedgerId, completionsService: IndexCompletionsService)(
       implicit ec: ExecutionContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -45,7 +45,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try
 
-final class ApiCommandService private (
+private[apiserver] final class ApiCommandService private (
     services: LocalServices,
     configuration: ApiCommandService.Configuration,
     ledgerConfigProvider: LedgerConfigProvider,
@@ -157,7 +157,7 @@ final class ApiCommandService private (
   override def toString: String = ApiCommandService.getClass.getSimpleName
 }
 
-object ApiCommandService {
+private[apiserver] object ApiCommandService {
 
   def create(
       configuration: Configuration,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
@@ -19,7 +19,8 @@ import io.grpc.{BindableService, ServerServiceDefinition}
 
 import scala.concurrent.ExecutionContext
 
-final class ApiLedgerConfigurationService private (configurationService: IndexConfigurationService)(
+private[apiserver] final class ApiLedgerConfigurationService private (
+    configurationService: IndexConfigurationService)(
     implicit protected val esf: ExecutionSequencerFactory,
     protected val mat: Materializer,
     logCtx: LoggingContext)
@@ -44,7 +45,7 @@ final class ApiLedgerConfigurationService private (configurationService: IndexCo
     LedgerConfigurationServiceGrpc.bindService(this, DirectExecutionContext)
 }
 
-object ApiLedgerConfigurationService {
+private[apiserver] object ApiLedgerConfigurationService {
   def create(ledgerId: LedgerId, configurationService: IndexConfigurationService)(
       implicit ec: ExecutionContext,
       esf: ExecutionSequencerFactory,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerIdentityService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerIdentityService.scala
@@ -21,8 +21,8 @@ import scalaz.syntax.tag._
 
 import scala.concurrent.Future
 
-final class ApiLedgerIdentityService private (getLedgerId: () => Future[LedgerId])(
-    implicit logCtx: LoggingContext)
+private[apiserver] final class ApiLedgerIdentityService private (
+    getLedgerId: () => Future[LedgerId])(implicit logCtx: LoggingContext)
     extends GrpcLedgerIdentityService
     with GrpcApiService {
 
@@ -49,7 +49,7 @@ final class ApiLedgerIdentityService private (getLedgerId: () => Future[LedgerId
     LedgerIdentityServiceGrpc.bindService(this, DirectExecutionContext)
 }
 
-object ApiLedgerIdentityService {
+private[apiserver] object ApiLedgerIdentityService {
   def create(getLedgerId: () => Future[LedgerId])(
       implicit logCtx: LoggingContext): ApiLedgerIdentityService with BindableService = {
     new ApiLedgerIdentityService(getLedgerId)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiPackageService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiPackageService.scala
@@ -21,7 +21,7 @@ import io.grpc.{BindableService, ServerServiceDefinition, Status}
 
 import scala.concurrent.Future
 
-final class ApiPackageService private (backend: IndexPackagesService)(
+private[apiserver] final class ApiPackageService private (backend: IndexPackagesService)(
     implicit logCtx: LoggingContext)
     extends PackageService
     with GrpcApiService {
@@ -90,7 +90,7 @@ final class ApiPackageService private (backend: IndexPackagesService)(
 
 }
 
-object ApiPackageService {
+private[platform] object ApiPackageService {
   def create(ledgerId: LedgerId, backend: IndexPackagesService)(
       implicit logCtx: LoggingContext): PackageService with GrpcApiService =
     new PackageServiceValidation(new ApiPackageService(backend), ledgerId) with BindableService {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -45,7 +45,7 @@ import scala.compat.java8.FutureConverters.CompletionStageOps
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-object ApiSubmissionService {
+private[apiserver] object ApiSubmissionService {
 
   def create(
       ledgerId: LedgerId,
@@ -93,7 +93,7 @@ object ApiSubmissionService {
 
 }
 
-final class ApiSubmissionService private (
+private[apiserver] final class ApiSubmissionService private (
     contractStore: ContractStore,
     writeService: WriteService,
     submissionService: IndexSubmissionService,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
@@ -26,7 +26,7 @@ import scalaz.syntax.tag._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
 
-final class ApiTimeService private (
+private[apiserver] final class ApiTimeService private (
     val ledgerId: LedgerId,
     backend: TimeServiceBackend,
 )(
@@ -121,7 +121,7 @@ final class ApiTimeService private (
   }
 }
 
-object ApiTimeService {
+private[apiserver] object ApiTimeService {
   def create(ledgerId: LedgerId, backend: TimeServiceBackend)(
       implicit grpcExecutionContext: ExecutionContext,
       mat: Materializer,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/LedgerConfigProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/LedgerConfigProvider.scala
@@ -35,7 +35,7 @@ import scala.concurrent.duration.{DurationInt, DurationLong}
   * This class helps avoiding code duplication and limiting the number of
   * database lookups, as multiple services and validators require the latest ledger config.
   */
-final class LedgerConfigProvider private (
+private[apiserver] final class LedgerConfigProvider private (
     index: IndexConfigManagementService,
     optWriteService: Option[WriteService],
     timeProvider: TimeProvider,
@@ -166,7 +166,7 @@ final class LedgerConfigProvider private (
   }
 }
 
-object LedgerConfigProvider {
+private[apiserver] object LedgerConfigProvider {
 
   def create(
       index: IndexConfigManagementService,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -32,7 +32,7 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import scala.util.{Failure, Success}
 
-final class ApiConfigManagementService private (
+private[apiserver] final class ApiConfigManagementService private (
     index: IndexConfigManagementService,
     writeService: WriteConfigService,
     timeProvider: TimeProvider,
@@ -191,7 +191,7 @@ final class ApiConfigManagementService private (
 
 }
 
-object ApiConfigManagementService {
+private[apiserver] object ApiConfigManagementService {
   def createApiService(
       readBackend: IndexConfigManagementService,
       writeBackend: WriteConfigService,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-final class ApiPackageManagementService private (
+private[apiserver] final class ApiPackageManagementService private (
     packagesIndex: IndexPackagesService,
     transactionsService: IndexTransactionsService,
     packagesWrite: WritePackagesService,
@@ -126,7 +126,7 @@ final class ApiPackageManagementService private (
   }
 }
 
-object ApiPackageManagementService {
+private[apiserver] object ApiPackageManagementService {
   def createApiService(
       readBackend: IndexPackagesService,
       transactionsService: IndexTransactionsService,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -31,7 +31,7 @@ import scala.compat.java8.FutureConverters
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
-final class ApiPartyManagementService private (
+private[apiserver] final class ApiPartyManagementService private (
     partyManagementService: IndexPartyManagementService,
     transactionService: IndexTransactionsService,
     writeService: WritePartyService,
@@ -132,7 +132,7 @@ final class ApiPartyManagementService private (
   }
 }
 
-object ApiPartyManagementService {
+private[apiserver] object ApiPartyManagementService {
   def createApiService(
       partyManagementServiceBackend: IndexPartyManagementService,
       transactionsService: IndexTransactionsService,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
@@ -26,7 +26,8 @@ import scala.util.{Failure, Success}
   * Tracks SubmitAndWaitRequests.
   * @param queue The input queue to the tracking flow.
   */
-final class TrackerImpl(queue: SourceQueueWithComplete[TrackerImpl.QueueInput]) extends Tracker {
+private[services] final class TrackerImpl(queue: SourceQueueWithComplete[TrackerImpl.QueueInput])
+    extends Tracker {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -64,7 +65,7 @@ final class TrackerImpl(queue: SourceQueueWithComplete[TrackerImpl.QueueInput]) 
   }
 }
 
-object TrackerImpl {
+private[services] object TrackerImpl {
 
   private val logger = LoggerFactory.getLogger(this.getClass.getName)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
@@ -20,7 +20,8 @@ import scala.util.{Failure, Success}
   * A map for [[Tracker]]s with thread-safe tracking methods and automatic cleanup. A tracker tracker, if you will.
   * @param retentionPeriod The minimum finite duration for which to retain idle trackers.
   */
-final class TrackerMap(retentionPeriod: FiniteDuration)(implicit logCtx: LoggingContext)
+private[services] final class TrackerMap(retentionPeriod: FiniteDuration)(
+    implicit logCtx: LoggingContext)
     extends AutoCloseable {
 
   private val logger = ContextualizedLogger.get(this.getClass)
@@ -91,7 +92,7 @@ final class TrackerMap(retentionPeriod: FiniteDuration)(implicit logCtx: Logging
   }
 }
 
-object TrackerMap {
+private[services] object TrackerMap {
 
   final case class Key(application: String, party: String)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -32,7 +32,7 @@ import scalaz.syntax.tag._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object ApiTransactionService {
+private[apiserver] object ApiTransactionService {
 
   def create(
       ledgerId: LedgerId,
@@ -49,7 +49,7 @@ object ApiTransactionService {
     )
 }
 
-final class ApiTransactionService private (
+private[apiserver] final class ApiTransactionService private (
     transactionsService: IndexTransactionsService,
     parallelism: Int = 4)(
     implicit executionContext: ExecutionContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/index/EventFilter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/EventFilter.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.api.v1.value.Identifier
 import com.daml.platform.store.Contract.ActiveContract
 import com.daml.platform.api.v1.event.EventOps.EventOps
 
-object EventFilter {
+private[platform] object EventFilter {
 
   // TODO Remove all usages of domain objects
   private def toLfIdentifier(id: Identifier): Ref.Identifier =

--- a/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
@@ -13,7 +13,7 @@ import com.daml.platform.configuration.ServerRole
 import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.resources.ResourceOwner
 
-object JdbcIndex {
+private[platform] object JdbcIndex {
   def owner(
       serverRole: ServerRole,
       ledgerId: LedgerId,

--- a/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
@@ -49,7 +49,7 @@ import scalaz.syntax.tag.ToTagOps
 
 import scala.concurrent.Future
 
-final class LedgerBackedIndexService(
+private[platform] final class LedgerBackedIndexService(
     ledger: ReadOnlyLedger,
     participantId: ParticipantId,
 )(implicit mat: Materializer)

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -33,7 +33,8 @@ import com.daml.platform.store.entries.{ConfigurationEntry, PackageLedgerEntry, 
 
 import scala.concurrent.Future
 
-private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: Metrics) extends ReadOnlyLedger {
+private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: Metrics)
+    extends ReadOnlyLedger {
 
   override def ledgerId: LedgerId = ledger.ledgerId
 

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -33,7 +33,7 @@ import com.daml.platform.store.entries.{ConfigurationEntry, PackageLedgerEntry, 
 
 import scala.concurrent.Future
 
-class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: Metrics) extends ReadOnlyLedger {
+private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: Metrics) extends ReadOnlyLedger {
 
   override def ledgerId: LedgerId = ledger.ledgerId
 
@@ -160,7 +160,7 @@ class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: Metrics) extends Re
       ledger.stopDeduplicatingCommand(commandId, submitter))
 }
 
-object MeteredReadOnlyLedger {
+private[platform] object MeteredReadOnlyLedger {
   def apply(ledger: ReadOnlyLedger, metrics: Metrics): ReadOnlyLedger =
     new MeteredReadOnlyLedger(ledger, metrics)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -27,7 +27,7 @@ import com.daml.timer.RetryStrategy
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-object ReadOnlySqlLedger {
+private[platform] object ReadOnlySqlLedger {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/index/TransactionConversion.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/TransactionConversion.scala
@@ -30,7 +30,7 @@ import com.daml.platform.store.entries.LedgerEntry
 
 import scala.annotation.tailrec
 
-object TransactionConversion {
+private[platform] object TransactionConversion {
 
   private type ContractId = lf.value.Value.ContractId
   private type Transaction = CommittedTransaction

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -28,7 +28,7 @@ import com.daml.resources.{Resource, ResourceOwner}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-final class JdbcIndexerFactory(
+private[indexer] final class JdbcIndexerFactory(
     serverRole: ServerRole,
     config: IndexerConfig,
     readService: ReadService,
@@ -116,7 +116,7 @@ final class JdbcIndexerFactory(
 /**
   * @param startExclusive The last offset received from the read service.
   */
-class JdbcIndexer private[indexer] (
+private[indexer] class JdbcIndexer private[indexer] (
     startExclusive: Option[Offset],
     participantId: ParticipantId,
     ledgerDao: LedgerDao,

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
@@ -23,7 +23,7 @@ import scala.util.{Failure, Success}
   * @param scheduler    Used to schedule the restart operation.
   * @param restartDelay Time to wait before restarting the indexer after a failure
   */
-final class RecoveringIndexer(
+private[indexer] final class RecoveringIndexer(
     scheduler: Scheduler,
     restartDelay: FiniteDuration,
 )(implicit logCtx: LoggingContext) {

--- a/ledger/participant-integration-api/src/main/scala/platform/packages/InMemoryPackageStore.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/packages/InMemoryPackageStore.scala
@@ -21,11 +21,11 @@ import scala.collection.immutable.Map
 import scala.concurrent.Future
 import scala.util.Try
 
-object InMemoryPackageStore {
+private[platform] object InMemoryPackageStore {
   def empty: InMemoryPackageStore = new InMemoryPackageStore(Map.empty, Map.empty, Map.empty)
 }
 
-case class InMemoryPackageStore(
+private[platform] case class InMemoryPackageStore(
     packageInfos: Map[PackageId, PackageDetails],
     packages: Map[PackageId, Ast.Package],
     archives: Map[PackageId, Archive]) {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerState.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerState.scala
@@ -14,13 +14,13 @@ import com.daml.lf.value.Value.ContractId
 import com.daml.ledger.TransactionId
 import com.daml.platform.store.Contract.ActiveContract
 
-sealed abstract class LetLookup
+private[platform] sealed abstract class LetLookup
 
 /** Contract exists, but contract LET is unknown (e.g., a divulged contract) */
-case object LetUnknown extends LetLookup
+private[platform] case object LetUnknown extends LetLookup
 
 /** Contract exists with the given LET */
-final case class Let(instant: Instant) extends LetLookup
+private[platform] final case class Let(instant: Instant) extends LetLookup
 
 /**
   * An abstract representation of the active ledger state:
@@ -35,7 +35,7 @@ final case class Let(instant: Instant) extends LetLookup
   * The active ledger state could be derived from the transaction stream,
   * we keep track of it explicitly for performance reasons.
   */
-trait ActiveLedgerState[ALS <: ActiveLedgerState[ALS]] {
+private[platform] trait ActiveLedgerState[ALS <: ActiveLedgerState[ALS]] {
 
   /** Callback to query an active or divulged contract, used for transaction validation
     * Returns:

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
@@ -22,7 +22,8 @@ import com.daml.platform.store.Contract.ActiveContract
   * - Validates the transaction against the [[ActiveLedgerState]].
   * - Updates the [[ActiveLedgerState]].
   */
-private[platform] class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => ALS) {
+private[platform] class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](
+    initialState: => ALS) {
 
   private case class AddTransactionState(
       acc: Option[ALS],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ActiveLedgerStateManager.scala
@@ -22,7 +22,7 @@ import com.daml.platform.store.Contract.ActiveContract
   * - Validates the transaction against the [[ActiveLedgerState]].
   * - Updates the [[ActiveLedgerState]].
   */
-class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => ALS) {
+private[platform] class ActiveLedgerStateManager[ALS <: ActiveLedgerState[ALS]](initialState: => ALS) {
 
   private case class AddTransactionState(
       acc: Option[ALS],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -40,7 +40,7 @@ import scalaz.syntax.tag.ToTagOps
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-abstract class BaseLedger(
+private[platform] abstract class BaseLedger(
     val ledgerId: LedgerId,
     ledgerDao: LedgerReadDao,
     dispatcher: Dispatcher[Offset],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/Contract.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/Contract.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.{TransactionId, WorkflowId}
 /** A contract that is part of the [[ActiveLedgerState]].
   * Depending on where the contract came from, other metadata may be available.
   */
-sealed abstract class Contract {
+private[platform] sealed abstract class Contract {
   def id: Value.ContractId
 
   def contract: ContractInst[VersionedValue[ContractId]]
@@ -31,7 +31,7 @@ sealed abstract class Contract {
     parties.foldLeft(divulgences)((m, e) => if (m.contains(e)) m else m + (e -> transactionId))
 }
 
-object Contract {
+private[platform] object Contract {
 
   /**
     * For divulged contracts, we only know their contract argument, but no other metadata.

--- a/ledger/participant-integration-api/src/main/scala/platform/store/Conversions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/Conversions.scala
@@ -14,7 +14,7 @@ import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref
 import com.daml.lf.value.Value
 
-object Conversions {
+private[platform] object Conversions {
 
   private def stringColumnToX[X](f: String => Either[String, X]): Column[X] =
     Column.nonNull((value: Any, meta) =>

--- a/ledger/participant-integration-api/src/main/scala/platform/store/DbType.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/DbType.scala
@@ -3,12 +3,12 @@
 
 package com.daml.platform.store
 
-sealed abstract class DbType(
+private[platform] sealed abstract class DbType(
     val name: String,
     val driver: String,
     val supportsParallelWrites: Boolean)
 
-object DbType {
+private[platform] object DbType {
   object Postgres extends DbType("postgres", "org.postgresql.Driver", true)
 
   // H2 does not support concurrent, conditional updates to the ledger_end at read committed isolation

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ErrorCause.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ErrorCause.scala
@@ -5,10 +5,11 @@ package com.daml.platform.store
 
 import com.daml.lf.engine.{Error => LfError}
 
-sealed abstract class ErrorCause extends Product with Serializable {
+private[platform] sealed abstract class ErrorCause extends Product with Serializable {
   def explain: String
 }
-object ErrorCause {
+
+private[platform] object ErrorCause {
 
   final case class DamlLf(error: LfError) extends ErrorCause {
     override def explain: String = {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
@@ -16,7 +16,7 @@ import org.flywaydb.core.api.configuration.FluentConfiguration
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
-class FlywayMigrations(jdbcUrl: String)(implicit logCtx: LoggingContext) {
+private[platform] class FlywayMigrations(jdbcUrl: String)(implicit logCtx: LoggingContext) {
   private val logger = ContextualizedLogger.get(this.getClass)
 
   private val dbType = DbType.jdbcType(jdbcUrl)
@@ -68,7 +68,7 @@ class FlywayMigrations(jdbcUrl: String)(implicit logCtx: LoggingContext) {
     )
 }
 
-object FlywayMigrations {
+private[platform] object FlywayMigrations {
   def configurationBase(dbType: DbType): FluentConfiguration =
     Flyway
       .configure()

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
@@ -32,7 +32,7 @@ import com.daml.platform.store.entries.{ConfigurationEntry, PackageLedgerEntry, 
 import scala.concurrent.Future
 
 /** Defines all the functionalities a Ledger needs to provide */
-trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
+private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable {
 
   def ledgerId: LedgerId
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/SimpleSqlAsVectorOf.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/SimpleSqlAsVectorOf.scala
@@ -9,7 +9,7 @@ import anorm.{Cursor, Row, RowParser, SimpleSql}
 
 import scala.util.{Failure, Success, Try}
 
-object SimpleSqlAsVectorOf {
+private[platform] object SimpleSqlAsVectorOf {
 
   implicit final class SimpleSqlAsVectorOf(val sql: SimpleSql[Row]) extends AnyVal {
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsTable.scala
@@ -17,7 +17,7 @@ import com.daml.platform.store.Conversions._
 import io.grpc.Status.Code
 import com.google.rpc.status.Status
 
-object CommandCompletionsTable {
+private[platform] object CommandCompletionsTable {
 
   import SqlParser.{int, str}
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
@@ -17,7 +17,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-final class DbDispatcher private (
+private[platform] final class DbDispatcher private (
     val maxConnections: Int,
     connectionProvider: HikariJdbcConnectionProvider,
     executor: Executor,
@@ -83,7 +83,7 @@ final class DbDispatcher private (
   }
 }
 
-object DbDispatcher {
+private[platform] object DbDispatcher {
   private val logger = ContextualizedLogger.get(this.getClass)
 
   def owner(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
@@ -96,7 +96,9 @@ private[platform] object HikariConnection {
     )
 }
 
-private[platform] class HikariJdbcConnectionProvider(dataSource: HikariDataSource, healthPoller: Timer)(
+private[platform] class HikariJdbcConnectionProvider(
+    dataSource: HikariDataSource,
+    healthPoller: Timer)(
     implicit logCtx: LoggingContext
 ) extends JdbcConnectionProvider {
   private val transientFailureCount = new AtomicInteger(0)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
@@ -22,7 +22,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.control.NonFatal
 
-final class HikariConnection(
+private[platform] final class HikariConnection(
     serverRole: ServerRole,
     jdbcUrl: String,
     minimumIdle: Int,
@@ -70,7 +70,7 @@ final class HikariConnection(
   }
 }
 
-object HikariConnection {
+private[platform] object HikariConnection {
   private val MaxInitialConnectRetryAttempts = 600
   private val ConnectionPoolPrefix: String = "daml.index.db.connection"
 
@@ -96,7 +96,7 @@ object HikariConnection {
     )
 }
 
-class HikariJdbcConnectionProvider(dataSource: HikariDataSource, healthPoller: Timer)(
+private[platform] class HikariJdbcConnectionProvider(dataSource: HikariDataSource, healthPoller: Timer)(
     implicit logCtx: LoggingContext
 ) extends JdbcConnectionProvider {
   private val transientFailureCount = new AtomicInteger(0)
@@ -148,7 +148,7 @@ class HikariJdbcConnectionProvider(dataSource: HikariDataSource, healthPoller: T
   }
 }
 
-object HikariJdbcConnectionProvider {
+private[platform] object HikariJdbcConnectionProvider {
   private val MaxTransientFailureCount: Int = 5
   private val HealthPollingSchedule: FiniteDuration = 1.second
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
@@ -98,7 +98,8 @@ private[platform] object HikariConnection {
 
 private[platform] class HikariJdbcConnectionProvider(
     dataSource: HikariDataSource,
-    healthPoller: Timer)(
+    healthPoller: Timer,
+)(
     implicit logCtx: LoggingContext
 ) extends JdbcConnectionProvider {
   private val transientFailureCount = new AtomicInteger(0)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcConnectionProvider.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.api.health.ReportsHealth
 import com.daml.metrics.DatabaseMetrics
 
 /** A helper to run JDBC queries using a pool of managed connections */
-trait JdbcConnectionProvider extends ReportsHealth {
+private[platform] trait JdbcConnectionProvider extends ReportsHealth {
 
   /** Blocks are running in a single transaction as the commit happens when the connection
     * is returned to the pool.

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -916,7 +916,7 @@ private class JdbcLedgerDao(
   }
 }
 
-object JdbcLedgerDao {
+private[platform] object JdbcLedgerDao {
 
   private val DefaultNumberOfShortLivedConnections = 16
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -37,7 +37,7 @@ import com.daml.platform.store.entries.{
 
 import scala.concurrent.Future
 
-trait LedgerReadDao extends ReportsHealth {
+private[platform] trait LedgerReadDao extends ReportsHealth {
 
   def maxConcurrentConnections: Int
 
@@ -151,7 +151,7 @@ trait LedgerReadDao extends ReportsHealth {
   ): Future[Unit]
 }
 
-trait LedgerWriteDao extends ReportsHealth {
+private[platform] trait LedgerWriteDao extends ReportsHealth {
 
   def maxConcurrentConnections: Int
 
@@ -227,4 +227,4 @@ trait LedgerWriteDao extends ReportsHealth {
 
 }
 
-trait LedgerDao extends LedgerReadDao with LedgerWriteDao
+private[platform] trait LedgerDao extends LedgerReadDao with LedgerWriteDao

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -29,7 +29,7 @@ import com.daml.platform.store.entries.{
 
 import scala.concurrent.Future
 
-class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: Metrics) extends LedgerReadDao {
+private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: Metrics) extends LedgerReadDao {
 
   override def maxConcurrentConnections: Int = ledgerDao.maxConcurrentConnections
 
@@ -120,7 +120,7 @@ class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: Metrics) extends L
       ledgerDao.stopDeduplicatingCommand(commandId, submitter))
 }
 
-class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
+private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
     extends MeteredLedgerReadDao(ledgerDao, metrics)
     with LedgerDao {
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -29,7 +29,8 @@ import com.daml.platform.store.entries.{
 
 import scala.concurrent.Future
 
-private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: Metrics) extends LedgerReadDao {
+private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: Metrics)
+    extends LedgerReadDao {
 
   override def maxConcurrentConnections: Int = ledgerDao.maxConcurrentConnections
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/PaginatingAsyncStream.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/PaginatingAsyncStream.scala
@@ -9,7 +9,7 @@ import com.daml.dec.DirectExecutionContext
 
 import scala.concurrent.Future
 
-object PaginatingAsyncStream {
+private[platform] object PaginatingAsyncStream {
 
   /**
     * Concatenates the results of multiple asynchronous calls into

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/PersistenceResponse.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/PersistenceResponse.scala
@@ -3,9 +3,9 @@
 
 package com.daml.platform.store.dao
 
-sealed abstract class PersistenceResponse extends Product with Serializable
+private[platform] sealed abstract class PersistenceResponse extends Product with Serializable
 
-object PersistenceResponse {
+private[platform] object PersistenceResponse {
 
   case object Ok extends PersistenceResponse
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -114,7 +114,7 @@ private[dao] sealed abstract class ContractsReader(
 
 }
 
-object ContractsReader {
+private[dao] object ContractsReader {
 
   private[dao] def apply(
       dispatcher: DbDispatcher,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsRange.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsRange.scala
@@ -7,9 +7,9 @@ import anorm.SqlStringInterpolation
 import com.daml.ledger.participant.state.v1.Offset
 
 // (startExclusive, endInclusive]
-final case class EventsRange[A](startExclusive: A, endInclusive: A)
+private[events] final case class EventsRange[A](startExclusive: A, endInclusive: A)
 
-object EventsRange {
+private[events] object EventsRange {
   private val EmptyLedgerEventSeqId = 0L
 
   // (0, 0] -- non-existent range

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableQueries.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/EventsTableQueries.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.store.dao.events
 
-object EventsTableQueries {
+private[events] object EventsTableQueries {
   def format(ps: Set[Party]): String =
     ps.view.map(p => s"'$p'").mkString(",")
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/Raw.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/Raw.scala
@@ -20,7 +20,7 @@ import com.daml.platform.participant.util.LfEngineToApi
   * wrap events from the database while delaying deserialization
   * so that it doesn't happen on the database thread pool.
   */
-sealed trait Raw[+E] {
+private[events] sealed trait Raw[+E] {
 
   /**
     * Fill the blanks left in the raw event by running
@@ -33,7 +33,7 @@ sealed trait Raw[+E] {
 
 }
 
-object Raw {
+private[events] object Raw {
 
   /**
     * Since created events can be both a flat event or a tree event

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/SqlFunctions.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/SqlFunctions.scala
@@ -6,7 +6,7 @@ package com.daml.platform.store.dao.events
 import com.daml.platform.store.DbType
 import com.daml.platform.store.dao.events.EventsTableQueries.format
 
-trait SqlFunctions {
+private[events] trait SqlFunctions {
   def arrayIntersectionWhereClause(arrayColumn: String, party: Party): String =
     arrayIntersectionWhereClause(arrayColumn: String, Set(party))
 
@@ -15,7 +15,7 @@ trait SqlFunctions {
   def arrayIntersectionValues(arrayColumn: String, parties: Set[Party]): String
 }
 
-object SqlFunctions {
+private[events] object SqlFunctions {
   def arrayIntersection(a: Array[String], b: Array[String]): Array[String] =
     a.toSet.intersect(b.toSet).toArray
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/entries/ConfigurationEntry.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/entries/ConfigurationEntry.scala
@@ -6,11 +6,11 @@ package com.daml.platform.store.entries
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId}
 import com.daml.ledger.api.domain
 
-sealed abstract class ConfigurationEntry extends Product with Serializable {
+private[platform] sealed abstract class ConfigurationEntry extends Product with Serializable {
   def toDomain: domain.ConfigurationEntry
 }
 
-object ConfigurationEntry {
+private[platform] object ConfigurationEntry {
 
   final case class Accepted(
       submissionId: String,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/entries/LedgerEntry.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/entries/LedgerEntry.scala
@@ -11,9 +11,9 @@ import com.daml.lf.transaction.{CommittedTransaction, NodeId}
 import com.daml.ledger._
 import com.daml.ledger.api.domain.RejectionReason
 
-sealed abstract class LedgerEntry extends Product with Serializable
+private[platform] sealed abstract class LedgerEntry extends Product with Serializable
 
-object LedgerEntry {
+private[platform] object LedgerEntry {
 
   final case class Rejection(
       recordTime: Instant,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/entries/PackageLedgerEntry.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/entries/PackageLedgerEntry.scala
@@ -8,12 +8,12 @@ import java.time.Instant
 import com.daml.ledger.participant.state.v1.SubmissionId
 import com.daml.ledger.api.domain.PackageEntry
 
-sealed abstract class PackageLedgerEntry extends Product with Serializable {
+private[platform] sealed abstract class PackageLedgerEntry extends Product with Serializable {
   def submissionId: SubmissionId
   def toDomain: PackageEntry
 }
 
-object PackageLedgerEntry {
+private[platform] object PackageLedgerEntry {
 
   final case class PackageUploadAccepted(
       submissionId: SubmissionId,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/entries/PartyLedgerEntry.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/entries/PartyLedgerEntry.scala
@@ -8,12 +8,12 @@ import java.time.Instant
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionId}
 import com.daml.ledger.api.domain.PartyDetails
 
-sealed abstract class PartyLedgerEntry() extends Product with Serializable {
+private[platform] sealed abstract class PartyLedgerEntry() extends Product with Serializable {
   val submissionIdOpt: Option[SubmissionId]
   val recordTime: Instant
 }
 
-object PartyLedgerEntry {
+private[platform] object PartyLedgerEntry {
 
   final case class AllocationAccepted(
       submissionIdOpt: Option[SubmissionId],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/serialization/ValueSerializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/serialization/ValueSerializer.scala
@@ -9,7 +9,7 @@ import com.daml.lf.archive.{Decode, Reader}
 import com.daml.lf.value.Value.{ContractId, VersionedValue}
 import com.daml.lf.value.{ValueCoder, ValueOuterClass}
 
-object ValueSerializer {
+private[platform] object ValueSerializer {
 
   def serializeValue(
       value: VersionedValue[ContractId],


### PR DESCRIPTION
This PR makes many classes in `//ledger/participant-integration-api` private.

It should not affect any existing ledger integrations, as all changed classes are not useful for ledger integrations. Nevertheless, we should manually check whether this breaks any existing integration. 