### PR TITLE
Trigger service: rest of auth service client

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,8 @@ if [ -n "$SANDBOX_PID" ]; then
     kill "$SANDBOX_PID"
 fi
 
+bazel test //triggers/service:auth-client-tests --runs_per_test=20
+
 # Bazel test only builds targets that are dependencies of a test suite so do a full build first.
 bazel build //... --build_tag_filters "$tag_filter"
 

--- a/build.sh
+++ b/build.sh
@@ -27,8 +27,6 @@ if [ -n "$SANDBOX_PID" ]; then
     kill "$SANDBOX_PID"
 fi
 
-bazel test //triggers/service:auth-client-tests --runs_per_test=20
-
 # Bazel test only builds targets that are dependencies of a test suite so do a full build first.
 bazel build //... --build_tag_filters "$tag_filter"
 

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -35,6 +35,7 @@ da_scala_library(
         "//ledger-api/rs-grpc-bridge",
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
+        "//libs-scala/timer-utils",
         "//triggers/runner:trigger-runner-lib",
         "@maven//:com_chuusai_shapeless_2_12",
         "@maven//:com_github_scopt_scopt_2_12",

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -61,16 +61,13 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
   private val saLogin = Path("/sa/login")
 
   def authorize(username: String, password: String): Future[AuthServiceToken] = {
-    val authorizeUri = authServiceBaseUri.withPath(saSecure./("authorize"))
-    val request = HttpRequest(
+    val uri = authServiceBaseUri.withPath(saSecure./("authorize"))
+    val req = HttpRequest(
       method = HttpMethods.POST,
-      uri = authorizeUri,
+      uri,
       headers = List(Authorization(BasicHttpCredentials(username, password)))
     )
-    for {
-      authResponse <- http.singleRequest(request)
-      authServiceToken <- Unmarshal(authResponse).to[AuthServiceToken]
-    } yield authServiceToken
+    http.singleRequest(req).flatMap(Unmarshal(_).to[AuthServiceToken])
   }
 
   def requestServiceAccount(

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -36,6 +36,15 @@ object AuthServiceDomain extends DefaultJsonProtocol {
 
   case class ServiceAccountList(serviceAccounts: List[ServiceAccount])
   implicit val serviceAccountListFormat = jsonFormat1(ServiceAccountList)
+
+  case class Credential(
+      cred: String,
+      credId: String,
+      nonce: String,
+      validFrom: String,
+      validTo: String
+  )
+  implicit val credentialFormat = jsonFormat5(Credential)
 }
 
 class AuthServiceClient(authServiceBaseUri: Uri)(
@@ -133,6 +142,17 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
             }
         }
     }
+
+  def getCredential(authServiceToken: AuthServiceToken, credentialId: CredentialId): Future[Credential] = {
+    val uri = authServiceBaseUri.withPath(saSecure./("cred")./(credentialId.credId))
+    val authHeader = Authorization(OAuth2BearerToken(authServiceToken.token))
+    val req = HttpRequest(
+      method = HttpMethods.GET,
+      uri,
+      headers = List(authHeader),
+    )
+    http.singleRequest(req).flatMap(Unmarshal(_).to[Credential])
+  }
 }
 
 object AuthServiceClient {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -9,7 +9,15 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.{Http, HttpExt}
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, HttpResponse, StatusCodes, Uri}
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpMethods,
+  HttpRequest,
+  HttpResponse,
+  StatusCodes,
+  Uri
+}
 import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, OAuth2BearerToken}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
@@ -140,11 +148,12 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
       sa <- getServiceAccount(authServiceToken)
       initialNumCreds = sa.creds.length
       () <- requestCredential(authServiceToken, sa.serviceAccount)
-      newCred <- RetryStrategy.constant(attempts = Some(3), waitTime = 4.seconds)(notFound) { (_, _) =>
-        for {
-          sa <- getServiceAccount(authServiceToken)
-          _ = if (sa.creds.length <= initialNumCreds) throw new NoSuchElementException
-        } yield sa.creds.head
+      newCred <- RetryStrategy.constant(attempts = Some(3), waitTime = 4.seconds)(notFound) {
+        (_, _) =>
+          for {
+            sa <- getServiceAccount(authServiceToken)
+            _ = if (sa.creds.length <= initialNumCreds) throw new NoSuchElementException
+          } yield sa.creds.head
       }
     } yield newCred
 

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -97,6 +97,19 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
     } catch {
       case e: Throwable => Future(None)
     }
+
+  def requestCredential(
+      authServiceToken: AuthServiceToken,
+      serviceAccountId: String): Future[Boolean] = {
+    val uri = authServiceBaseUri.withPath(saSecure./(serviceAccountId)./("credRequest"))
+    val authHeader = Authorization(OAuth2BearerToken(authServiceToken.token))
+    val req = HttpRequest(
+      method = HttpMethods.POST,
+      uri,
+      headers = List(authHeader),
+    )
+    http.singleRequest(req).map(_.status.isSuccess)
+  }
 }
 
 object AuthServiceClient {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -3,13 +3,13 @@
 
 package com.daml.lf.engine.trigger
 
-import java.util.UUID
+import java.util.{NoSuchElementException, UUID}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.{Http, HttpExt}
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, Uri}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, HttpResponse, StatusCodes, Uri}
 import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, OAuth2BearerToken}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
@@ -60,6 +60,25 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
   private val saSecure = Path("/sa/secure")
   private val saLogin = Path("/sa/login")
 
+  // Send an HTTP request and convert an error response into a failed future.
+  // Run the given function on a successful response only.
+  private def runRequest[A](req: HttpRequest)(ifOk: HttpResponse => Future[A]): Future[A] =
+    http.singleRequest(req) flatMap { resp =>
+      resp.status match {
+        case StatusCodes.OK => ifOk(resp)
+        case errorCode =>
+          val errorMessage =
+            s"""${req.method.value} request to ${req.uri} failed with status code ${errorCode.value}.
+          |Response body: ${resp.entity.dataBytes}""".stripMargin
+          Future.failed(new RuntimeException(errorMessage))
+      }
+    }
+
+  // Used to identify a failure condition in a retry strategy
+  private val notFound: PartialFunction[Throwable, Boolean] = {
+    case e if e.isInstanceOf[NoSuchElementException] => true
+  }
+
   def authorize(username: String, password: String): Future[AuthServiceToken] = {
     val uri = authServiceBaseUri.withPath(saSecure./("authorize"))
     val req = HttpRequest(
@@ -67,12 +86,10 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
       uri,
       headers = List(Authorization(BasicHttpCredentials(username, password)))
     )
-    http.singleRequest(req).flatMap(Unmarshal(_).to[AuthServiceToken])
+    runRequest(req)(Unmarshal(_).to[AuthServiceToken])
   }
 
-  def requestServiceAccount(
-      authServiceToken: AuthServiceToken,
-      ledgerId: String): Future[Boolean] = {
+  def requestServiceAccount(authServiceToken: AuthServiceToken, ledgerId: String): Future[Unit] = {
     val uri = authServiceBaseUri.withPath(saSecure./("request")./(ledgerId))
     val authHeader = Authorization(OAuth2BearerToken(authServiceToken.token))
     val nonce = Nonce(UUID.randomUUID.toString)
@@ -83,7 +100,7 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
       headers = List(authHeader),
       entity
     )
-    http.singleRequest(req).map(_.status.isSuccess)
+    runRequest(req)(_ => Future(()))
   }
 
   def listServiceAccounts(authServiceToken: AuthServiceToken): Future[ServiceAccountList] = {
@@ -94,23 +111,18 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
       uri,
       headers = List(authHeader),
     )
-    http.singleRequest(req).flatMap(Unmarshal(_).to[ServiceAccountList])
+    runRequest(req)(Unmarshal(_).to[ServiceAccountList])
   }
 
-  def getServiceAccount(authServiceToken: AuthServiceToken): Future[Option[ServiceAccount]] =
-    try {
-      RetryStrategy.constant(attempts = 3, waitTime = 4.seconds) { (_, _) =>
-        for {
-          ServiceAccountList(sa :: _) <- listServiceAccounts(authServiceToken)
-        } yield Some(sa)
-      }
-    } catch {
-      case e: Throwable => Future(None)
+  def getServiceAccount(authServiceToken: AuthServiceToken): Future[ServiceAccount] = {
+    RetryStrategy.constant(attempts = Some(3), waitTime = 4.seconds)(notFound) { (_, _) =>
+      listServiceAccounts(authServiceToken).map(_.serviceAccounts.head)
     }
+  }
 
   def requestCredential(
       authServiceToken: AuthServiceToken,
-      serviceAccountId: String): Future[Boolean] = {
+      serviceAccountId: String): Future[Unit] = {
     val uri = authServiceBaseUri.withPath(saSecure./(serviceAccountId)./("credRequest"))
     val authHeader = Authorization(OAuth2BearerToken(authServiceToken.token))
     val req = HttpRequest(
@@ -118,31 +130,23 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
       uri,
       headers = List(authHeader),
     )
-    http.singleRequest(req).map(_.status.isSuccess)
+    runRequest(req)(_ => Future(()))
   }
 
   def getNewCredentialId(
       authServiceToken: AuthServiceToken,
-      serviceAccountId: String): Future[Option[CredentialId]] =
-    getServiceAccount(authServiceToken) flatMap {
-      case None => Future(None)
-      case Some(sa) =>
-        val numCreds = sa.creds.length
-        requestCredential(authServiceToken, sa.serviceAccount) flatMap { reqSuccess =>
-          if (!reqSuccess) Future(None)
-          else
-            try {
-              RetryStrategy.constant(attempts = 3, waitTime = 4.seconds) { (_, _) =>
-                for {
-                  ServiceAccountList(sa :: _) <- listServiceAccounts(authServiceToken)
-                  if sa.creds.length > numCreds
-                } yield Some(sa.creds.head)
-              }
-            } catch {
-              case e: Throwable => Future(None)
-            }
-        }
-    }
+      serviceAccountId: String): Future[CredentialId] =
+    for {
+      sa <- getServiceAccount(authServiceToken)
+      initialNumCreds = sa.creds.length
+      () <- requestCredential(authServiceToken, sa.serviceAccount)
+      newCred <- RetryStrategy.constant(attempts = Some(3), waitTime = 4.seconds)(notFound) { (_, _) =>
+        for {
+          sa <- getServiceAccount(authServiceToken)
+          _ = if (sa.creds.length <= initialNumCreds) throw new NoSuchElementException
+        } yield sa.creds.head
+      }
+    } yield newCred
 
   def getCredential(
       authServiceToken: AuthServiceToken,
@@ -154,7 +158,7 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
       uri,
       headers = List(authHeader),
     )
-    http.singleRequest(req).flatMap(Unmarshal(_).to[Credential])
+    runRequest(req)(Unmarshal(_).to[Credential])
   }
 
   def login(credential: Credential): Future[LedgerAccessToken] = {
@@ -165,7 +169,7 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
       uri,
       headers = List(authHeader),
     )
-    http.singleRequest(req).flatMap(Unmarshal(_).to[LedgerAccessToken])
+    runRequest(req)(Unmarshal(_).to[LedgerAccessToken])
   }
 }
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -5,12 +5,12 @@ package com.daml.lf.engine.trigger.auth.client
 
 import akka.actor.ActorSystem
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
-import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext
 
-class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers {
+class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers with ScalaFutures {
 
   def testId: String = this.getClass.getSimpleName
   implicit val system: ActorSystem = ActorSystem(testId)
@@ -35,6 +35,17 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         _ <- cred.credId should equal(credId.credId)
         ledgerAccessToken <- authServiceClient.login(cred)
         _ <- ledgerAccessToken.token should not be empty
+      } yield succeed
+    }
+
+  it should "fail to get service account without a request" in
+    AuthServiceFixture.withAuthServiceClient(testId) { authServiceClient =>
+      for {
+        authServiceToken <- authServiceClient.authorize("username", "password")
+        _ <- authServiceToken.token should not be empty
+        getSa = authServiceClient.getServiceAccount(authServiceToken)
+        error <- getSa.failed
+        _ <- assert(error.isInstanceOf[NoSuchElementException])
       } yield succeed
     }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -40,6 +40,9 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         _ <- sa.creds should equal(List())
         Some(credId) <- authServiceClient.getNewCredentialId(authServiceToken, sa.serviceAccount)
         _ <- credId.credId should not be empty
+        cred <- authServiceClient.getCredential(authServiceToken, credId)
+        _ <- cred.cred should not be empty
+        _ <- cred.credId should equal(credId.credId)
       } yield succeed
     }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -28,7 +28,7 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
       } yield assert(success)
     }
 
-  it should "retrieve a service account" in
+  it should "get a service account and a new credential" in
     AuthServiceFixture.withAuthServiceClient(testId) { authServiceClient =>
       for {
         authServiceToken <- authServiceClient.authorize("username", "password")
@@ -38,6 +38,8 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         Some(sa) <- authServiceClient.getServiceAccount(authServiceToken)
         _ <- sa.serviceAccount should not be empty
         _ <- sa.creds should equal(List())
+        Some(credId) <- authServiceClient.getNewCredentialId(authServiceToken, sa.serviceAccount)
+        _ <- credId.credId should not be empty
       } yield succeed
     }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -19,16 +19,7 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
 
   private val testLedgerId = "test-ledger-id"
 
-  it should "authorize a user and request a service account" in
-    AuthServiceFixture.withAuthServiceClient(testId) { authServiceClient =>
-      for {
-        authServiceToken <- authServiceClient.authorize("username", "password")
-        _ <- authServiceToken.token should not be empty
-        success <- authServiceClient.requestServiceAccount(authServiceToken, testLedgerId)
-      } yield assert(success)
-    }
-
-  it should "get a service account, credential and ledger access token" in
+  it should "complete auth flow from service account to ledger access token" in
     AuthServiceFixture.withAuthServiceClient(testId) { authServiceClient =>
       for {
         authServiceToken <- authServiceClient.authorize("username", "password")

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -37,6 +37,7 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         _ <- assert(saReqSuccess)
         Some(sa) <- authServiceClient.getServiceAccount(authServiceToken)
         _ <- sa.serviceAccount should not be empty
+        _ <- sa.creds should equal(List())
       } yield succeed
     }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -19,12 +19,24 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
 
   private val testLedgerId = "test-ledger-id"
 
-  it should "authorize a user and request a service account" in AuthServiceFixture
-    .withAuthServiceClient(testId) { authServiceClient =>
+  it should "authorize a user and request a service account" in
+    AuthServiceFixture.withAuthServiceClient(testId) { authServiceClient =>
       for {
         authServiceToken <- authServiceClient.authorize("username", "password")
         _ <- authServiceToken.token should not be empty
         success <- authServiceClient.requestServiceAccount(authServiceToken, testLedgerId)
       } yield assert(success)
+    }
+
+  it should "retrieve a service account" in
+    AuthServiceFixture.withAuthServiceClient(testId) { authServiceClient =>
+      for {
+        authServiceToken <- authServiceClient.authorize("username", "password")
+        _ <- authServiceToken.token should not be empty
+        saReqSuccess <- authServiceClient.requestServiceAccount(authServiceToken, testLedgerId)
+        _ <- assert(saReqSuccess)
+        Some(sa) <- authServiceClient.getServiceAccount(authServiceToken)
+        _ <- sa.serviceAccount should not be empty
+      } yield succeed
     }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -24,12 +24,11 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
       for {
         authServiceToken <- authServiceClient.authorize("username", "password")
         _ <- authServiceToken.token should not be empty
-        saReqSuccess <- authServiceClient.requestServiceAccount(authServiceToken, testLedgerId)
-        _ <- assert(saReqSuccess)
-        Some(sa) <- authServiceClient.getServiceAccount(authServiceToken)
+        () <- authServiceClient.requestServiceAccount(authServiceToken, testLedgerId)
+        sa <- authServiceClient.getServiceAccount(authServiceToken)
         _ <- sa.serviceAccount should not be empty
         _ <- sa.creds should equal(List())
-        Some(credId) <- authServiceClient.getNewCredentialId(authServiceToken, sa.serviceAccount)
+        credId <- authServiceClient.getNewCredentialId(authServiceToken, sa.serviceAccount)
         _ <- credId.credId should not be empty
         cred <- authServiceClient.getCredential(authServiceToken, credId)
         _ <- cred.cred should not be empty

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -28,7 +28,7 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
       } yield assert(success)
     }
 
-  it should "get a service account and a new credential" in
+  it should "get a service account, credential and ledger access token" in
     AuthServiceFixture.withAuthServiceClient(testId) { authServiceClient =>
       for {
         authServiceToken <- authServiceClient.authorize("username", "password")
@@ -43,6 +43,8 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         cred <- authServiceClient.getCredential(authServiceToken, credId)
         _ <- cred.cred should not be empty
         _ <- cred.credId should equal(credId.credId)
+        ledgerAccessToken <- authServiceClient.login(cred)
+        _ <- ledgerAccessToken.token should not be empty
       } yield succeed
     }
 }


### PR DESCRIPTION
This fills out the rest of the methods needed for use of the auth service in the trigger service. The auth service client methods return `Future`s with failed requests becoming failed futures. A retry strategy is used to poll the "list" command for new service accounts and credential ids.

In the future I will likely encapsulate the auth service bearer token in the client object.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
