### PR TITLE
remove click-to-zoom instruction

### DIFF
--- a/docs/source/daml/daml-studio.rst
+++ b/docs/source/daml/daml-studio.rst
@@ -116,7 +116,7 @@ For example a scenario for the :download:`Iou<daml-studio/daml/Iou.daml>` module
    :scale: 40%
    :align: center
 
-   Scenario results (click to zoom)
+   Scenario results
 
 Each transaction is the result of executing a step in the scenario. In the
 image below, the transaction ``#0`` is the result of executing the first


### PR DESCRIPTION
The ability to click on images to zoom was removed in #5233. This removes the instruction to clic, as it doesn't do anything anymore.

Note: `git grep zoom docs` did not turn up any other instance, though the lack of structure for the caption makes it hard to be sure.

CHANGELOG_BEGIN
CHANGELOG_END