### PR TITLE
ledger-api-client + participant-integration-api: Increase the default maximum inbound error size, and truncate errors well before that.

### DIFF
--- a/ledger-api/sample-service/src/main/protobuf/hello.proto
+++ b/ledger-api/sample-service/src/main/protobuf/hello.proto
@@ -19,6 +19,7 @@ message HelloResponse {
 }
 
 service HelloService {
-    rpc Single (HelloRequest) returns (HelloResponse);
-    rpc ServerStreaming (HelloRequest) returns (stream HelloResponse);
+  rpc Single (HelloRequest) returns (HelloResponse);
+  rpc ServerStreaming (HelloRequest) returns (stream HelloResponse);
+  rpc Fails (HelloRequest) returns (HelloResponse);
 }

--- a/ledger-api/sample-service/src/main/scala/com/digitalasset/grpc/sampleservice/Responding.scala
+++ b/ledger-api/sample-service/src/main/scala/com/digitalasset/grpc/sampleservice/Responding.scala
@@ -13,6 +13,9 @@ trait Responding extends HelloService {
   override def single(request: HelloRequest): Future[HelloResponse] =
     Future.successful(response(request))
 
+  override def fails(request: HelloRequest): Future[HelloResponse] =
+    Future.failed(new IllegalStateException(request.payload.toStringUtf8))
+
   protected def response(request: HelloRequest): HelloResponse =
     HelloResponse(request.reqInt * 2, request.payload)
 

--- a/ledger/ledger-api-client/BUILD.bazel
+++ b/ledger/ledger-api-client/BUILD.bazel
@@ -23,6 +23,8 @@ da_scala_library(
         "//ledger/ledger-api-domain",
         "//libs-scala/direct-execution-context",
         "//libs-scala/grpc-utils",
+        "//libs-scala/ports",
+        "//libs-scala/resources",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_grpc_grpc_netty",

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/GrpcChannel.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/GrpcChannel.scala
@@ -30,6 +30,7 @@ object GrpcChannel {
           configuration.sslContext
             .fold(builder.usePlaintext())(
               builder.sslContext(_).negotiationType(NegotiationType.TLS))
+          builder.maxInboundMetadataSize(configuration.maxInboundMessageSize)
           builder.build()
         }
       )(channel =>

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/GrpcChannel.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/GrpcChannel.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.client
+
+import java.net.{InetAddress, InetSocketAddress}
+
+import com.daml.ledger.client.configuration.LedgerClientConfiguration
+import com.daml.ports.Port
+import com.daml.resources.{Resource, ResourceOwner}
+import io.grpc.ManagedChannel
+import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object GrpcChannel {
+
+  final class Owner(builder: NettyChannelBuilder, configuration: LedgerClientConfiguration)
+      extends ResourceOwner[ManagedChannel] {
+    def this(port: Port, configuration: LedgerClientConfiguration) =
+      this(
+        NettyChannelBuilder
+          .forAddress(new InetSocketAddress(InetAddress.getLoopbackAddress, port.value)),
+        configuration,
+      )
+
+    override def acquire()(implicit executionContext: ExecutionContext): Resource[ManagedChannel] =
+      Resource(
+        Future {
+          configuration.sslContext
+            .fold(builder.usePlaintext())(
+              builder.sslContext(_).negotiationType(NegotiationType.TLS))
+          builder.build()
+        }
+      )(channel =>
+        Future {
+          channel.shutdownNow()
+          ()
+      })
+  }
+
+}

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
@@ -3,18 +3,32 @@
 
 package com.daml.ledger.client.configuration
 
+import com.daml.ledger.client.configuration.LedgerClientConfiguration._
 import io.netty.handler.ssl.SslContext
 
 /**
-  * @param applicationId The string that will be used as an application identifier when issuing commands and retrieving transactions
-  * @param ledgerIdRequirement A [[LedgerIdRequirement]] specifying how the ledger identifier must be checked against the one returned by the LedgerIdentityService
-  * @param commandClient The [[CommandClientConfiguration]] that defines how the command client should be setup with regards to timeouts, commands in flight and command TTL
-  * @param sslContext If defined, the context will be passed on to the underlying gRPC code to ensure the communication channel is secured by TLS
-  * @param token If defined, the access token that will be passed by default, unless overridden in individual calls (mostly useful for short-lived applications)
+  * @param applicationId         The string that will be used as an application identifier when issuing commands and retrieving transactions
+  * @param ledgerIdRequirement   A [[LedgerIdRequirement]] specifying how the ledger identifier must be checked against the one returned by the LedgerIdentityService
+  * @param commandClient         The [[CommandClientConfiguration]] that defines how the command client should be setup with regards to timeouts, commands in flight and command TTL
+  * @param sslContext            If defined, the context will be passed on to the underlying gRPC code to ensure the communication channel is secured by TLS
+  * @param token                 If defined, the access token that will be passed by default, unless overridden in individual calls (mostly useful for short-lived applications)
+  * @param maxInboundMessageSize The maximum size of the response headers.
   */
 final case class LedgerClientConfiguration(
     applicationId: String,
     ledgerIdRequirement: LedgerIdRequirement,
     commandClient: CommandClientConfiguration,
     sslContext: Option[SslContext],
-    token: Option[String] = None)
+    token: Option[String] = None,
+    maxInboundMessageSize: Int = DefaultMaxInboundMessageSize,
+)
+
+object LedgerClientConfiguration {
+
+  // This needs to be large because we often include parts of the request in GRPC errors, which are
+  // returned in the response headers. A large request could lead to the client choking on the
+  // response headers if the limit is too low.
+  // The default limit set by Netty is 8 KB, which often leads to errors.
+  val DefaultMaxInboundMessageSize: Int = 1024 * 1024 // 1 MB
+
+}

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.client.configuration
 
-import com.daml.ledger.client.configuration.LedgerClientConfiguration._
+import io.grpc.internal.GrpcUtil
 import io.netty.handler.ssl.SslContext
 
 /**
@@ -20,15 +20,5 @@ final case class LedgerClientConfiguration(
     commandClient: CommandClientConfiguration,
     sslContext: Option[SslContext],
     token: Option[String] = None,
-    maxInboundMessageSize: Int = DefaultMaxInboundMessageSize,
+    maxInboundMessageSize: Int = GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
 )
-
-object LedgerClientConfiguration {
-
-  // This needs to be large because we often include parts of the request in GRPC errors, which are
-  // returned in the response headers. A large request could lead to the client choking on the
-  // response headers if the limit is too low.
-  // The default limit set by Netty is 8 KB, which often leads to errors.
-  val DefaultMaxInboundMessageSize: Int = 1024 * 1024 // 1 MB
-
-}

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
@@ -8,55 +8,63 @@ import java.net.{BindException, InetAddress, InetSocketAddress}
 import java.util.concurrent.TimeUnit.SECONDS
 
 import com.daml.metrics.Metrics
-import com.daml.platform.apiserver.GrpcServerOwner._
 import com.daml.ports.Port
 import com.daml.resources.{Resource, ResourceOwner}
 import com.google.protobuf.Message
-import io.grpc.netty.NettyServerBuilder
 import io.grpc._
+import io.grpc.netty.NettyServerBuilder
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.ssl.SslContext
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
 
-final class GrpcServerOwner(
-    address: Option[String],
-    desiredPort: Port,
-    maxInboundMessageSize: Int,
-    sslContext: Option[SslContext] = None,
-    interceptors: List[ServerInterceptor] = List.empty,
-    metrics: Metrics,
-    eventLoopGroups: ServerEventLoopGroups,
-    services: Iterable[BindableService],
-) extends ResourceOwner[Server] {
-  override def acquire()(implicit executionContext: ExecutionContext): Resource[Server] = {
-    val host = address.map(InetAddress.getByName).getOrElse(InetAddress.getLoopbackAddress)
-    Resource(Future {
-      val builder = NettyServerBuilder.forAddress(new InetSocketAddress(host, desiredPort.value))
-      builder.sslContext(sslContext.orNull)
-      builder.channelType(classOf[NioServerSocketChannel])
-      builder.permitKeepAliveTime(10, SECONDS)
-      builder.permitKeepAliveWithoutCalls(true)
-      builder.directExecutor()
-      builder.maxInboundMessageSize(maxInboundMessageSize)
-      interceptors.foreach(builder.intercept)
-      builder.intercept(new MetricsInterceptor(metrics))
-      eventLoopGroups.populate(builder)
-      services.foreach { service =>
-        builder.addService(service)
-        toLegacyService(service).foreach(builder.addService)
-      }
-      val server = builder.build()
-      try {
-        server.start()
-      } catch {
-        case e: IOException if e.getCause != null && e.getCause.isInstanceOf[BindException] =>
-          throw new UnableToBind(desiredPort, e.getCause)
-      }
-      server
-    })(server => Future(server.shutdown().awaitTermination()))
+object GrpcServer {
+
+  final class Owner(
+      address: Option[String],
+      desiredPort: Port,
+      maxInboundMessageSize: Int,
+      sslContext: Option[SslContext] = None,
+      interceptors: List[ServerInterceptor] = List.empty,
+      metrics: Metrics,
+      eventLoopGroups: ServerEventLoopGroups,
+      services: Iterable[BindableService],
+  ) extends ResourceOwner[Server] {
+    override def acquire()(implicit executionContext: ExecutionContext): Resource[Server] = {
+      val host = address.map(InetAddress.getByName).getOrElse(InetAddress.getLoopbackAddress)
+      Resource(Future {
+        val builder = NettyServerBuilder.forAddress(new InetSocketAddress(host, desiredPort.value))
+        builder.sslContext(sslContext.orNull)
+        builder.channelType(classOf[NioServerSocketChannel])
+        builder.permitKeepAliveTime(10, SECONDS)
+        builder.permitKeepAliveWithoutCalls(true)
+        builder.directExecutor()
+        builder.maxInboundMessageSize(maxInboundMessageSize)
+        interceptors.foreach(builder.intercept)
+        builder.intercept(new MetricsInterceptor(metrics))
+        eventLoopGroups.populate(builder)
+        services.foreach { service =>
+          builder.addService(service)
+          toLegacyService(service).foreach(builder.addService)
+        }
+        val server = builder.build()
+        try {
+          server.start()
+        } catch {
+          case e: IOException if e.getCause != null && e.getCause.isInstanceOf[BindException] =>
+            throw new UnableToBind(desiredPort, e.getCause)
+        }
+        server
+      })(server => Future(server.shutdown().awaitTermination()))
+    }
   }
+
+  final class UnableToBind(port: Port, cause: Throwable)
+      extends RuntimeException(
+        s"The API server was unable to bind to port $port. Terminate the process occupying the port, or choose a different one.",
+        cause)
+      with NoStackTrace
 
   // This exposes the existing services under com.daml also under com.digitalasset.
   // This is necessary to allow applications built with an earlier version of the SDK
@@ -88,14 +96,5 @@ final class GrpcServerOwner(
       Option(digitalassetDef.build())
     } else None
   }
-}
-
-object GrpcServerOwner {
-
-  final class UnableToBind(port: Port, cause: Throwable)
-      extends RuntimeException(
-        s"The API server was unable to bind to port $port. Terminate the process occupying the port, or choose a different one.",
-        cause)
-      with NoStackTrace
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
@@ -24,7 +24,9 @@ object GrpcServer {
   // Unfortunately, we can't get the maximum inbound message size from the client, so we don't know
   // how big this should be. This seems long enough to contain useful data, but short enough that it
   // won't break most well-configured clients.
-  private val MaximumStatusDescriptionLength = 256 * 1024 // 256 KB
+  // As the default response header limit for a Netty client is 8 KB, we set our limit to 4 KB to
+  // allow for extra information such as the exception stack trace.
+  private val MaximumStatusDescriptionLength = 4 * 1024 // 4 KB
 
   final class Owner(
       address: Option[String],

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
@@ -38,7 +38,7 @@ final class LedgerApiServer(
       ).acquire()
       apiServicesResource = apiServicesOwner.acquire()
       apiServices <- apiServicesResource
-      server <- new GrpcServerOwner(
+      server <- new GrpcServer.Owner(
         address,
         desiredPort,
         maxInboundMessageSize,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TruncatedStatusInterceptor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TruncatedStatusInterceptor.scala
@@ -23,12 +23,8 @@ class TruncatedStatusInterceptor(maximumDescriptionLength: Int) extends ServerIn
     )
 
   private def truncate(description: String): String =
-    Option(description)
-      .map(
-        s =>
-          if (s.length > maximumDescriptionLength)
-            s.substring(0, maximumDescriptionLength - 3) + "..."
-          else
-          s)
-      .orNull
+    if (description != null && description.length > maximumDescriptionLength)
+      description.substring(0, maximumDescriptionLength - 3) + "..."
+    else
+      description
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
@@ -45,6 +45,21 @@ final class GrpcServerSpec extends AsyncWordSpec with Matchers {
         }
       }
     }
+
+    "fail with a nice exception, even when the text is very long" in {
+      val length = 64 * 1024
+      val exceptionMessage = Stream.continually("x").take(length).mkString
+      resources().use { channel =>
+        val helloService = HelloServiceGrpc.stub(channel)
+        for {
+          exception <- helloService
+            .fails(HelloRequest(7, ByteString.copyFromUtf8(exceptionMessage)))
+            .failed
+        } yield {
+          exception.getMessage shouldBe s"INTERNAL: $exceptionMessage"
+        }
+      }
+    }
   }
 }
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
@@ -46,8 +46,8 @@ final class GrpcServerSpec extends AsyncWordSpec with Matchers {
       }
     }
 
-    "fail with a nice exception, even when the text is very long" in {
-      val length = 64 * 1024
+    "fail with a nice exception, even when the text is quite long" in {
+      val length = 2 * 1024
       val exceptionMessage = "There was an error. " + Stream.continually("x").take(length).mkString
 
       resources().use { channel =>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.apiserver
+
+import java.net.{InetAddress, InetSocketAddress}
+import java.util.concurrent.TimeUnit
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.grpc.sampleservice.implementations.ReferenceImplementation
+import com.daml.metrics.Metrics
+import com.daml.platform.apiserver.GrpcServerSpec._
+import com.daml.platform.hello.{HelloRequest, HelloServiceGrpc}
+import com.daml.ports.{FreePort, Port}
+import com.daml.resources.{Resource, ResourceOwner}
+import com.google.protobuf.ByteString
+import io.grpc.ManagedChannel
+import io.grpc.netty.NettyChannelBuilder
+import org.scalatest.{AsyncWordSpec, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+final class GrpcServerSpec extends AsyncWordSpec with Matchers {
+  "a GRPC server" should {
+    "handle a request to a valid service" in {
+      resources().use { channel =>
+        val helloService = HelloServiceGrpc.stub(channel)
+        for {
+          response <- helloService.single(HelloRequest(7))
+        } yield {
+          response.respInt shouldBe 14
+        }
+      }
+    }
+
+    "fail with a nice exception" in {
+      resources().use { channel =>
+        val helloService = HelloServiceGrpc.stub(channel)
+        for {
+          exception <- helloService
+            .fails(HelloRequest(7, ByteString.copyFromUtf8("This is some text.")))
+            .failed
+        } yield {
+          exception.getMessage shouldBe "INTERNAL: This is some text."
+        }
+      }
+    }
+  }
+}
+
+object GrpcServerSpec {
+
+  private def resources(): ResourceOwner[ManagedChannel] = {
+    for {
+      eventLoopGroups <- new ServerEventLoopGroups.Owner(
+        classOf[GrpcServerSpec].getSimpleName,
+        workerParallelism = sys.runtime.availableProcessors(),
+        bossParallelism = 1,
+      )
+      port = FreePort.find()
+      _ <- new GrpcServer.Owner(
+        address = None,
+        desiredPort = port,
+        maxInboundMessageSize = 4 * 1024 * 1024,
+        metrics = new Metrics(new MetricRegistry),
+        eventLoopGroups = eventLoopGroups,
+        services = Seq(new ReferenceImplementation),
+      )
+      channel <- new ChannelOwner(port)
+    } yield channel
+  }
+
+  final class ChannelOwner(port: Port) extends ResourceOwner[ManagedChannel] {
+    override def acquire()(implicit executionContext: ExecutionContext): Resource[ManagedChannel] =
+      Resource(
+        Future {
+          NettyChannelBuilder
+            .forAddress(new InetSocketAddress(InetAddress.getLoopbackAddress, port.value))
+            .usePlaintext()
+            .build()
+        }
+      )(channel =>
+        Future {
+          channel.shutdown().awaitTermination(Long.MaxValue, TimeUnit.SECONDS)
+          ()
+      })
+  }
+
+}

--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/FreePort.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/FreePort.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ports
+
+import java.net.{InetAddress, ServerSocket}
+
+object FreePort {
+
+  def find(): Port = {
+    val socket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
+    try {
+      Port(socket.getLocalPort)
+    } finally {
+      socket.close()
+    }
+  }
+
+}

--- a/libs-scala/ports/src/test/suite/scala/com/digitalasset/ports/FreePortSpec.scala
+++ b/libs-scala/ports/src/test/suite/scala/com/digitalasset/ports/FreePortSpec.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ports
+
+import org.scalatest.{Matchers, WordSpec}
+
+class FreePortSpec extends WordSpec with Matchers {
+  "a free port" should {
+    "always be available" in {
+      val port = FreePort.find()
+      port.value should (be >= 1024 and be < 65536)
+    }
+  }
+}

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/LockedFreePort.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/LockedFreePort.scala
@@ -3,29 +3,19 @@
 
 package com.daml.testing.postgresql
 
-import java.net.{InetAddress, ServerSocket}
-
-import com.daml.ports.Port
+import com.daml.ports
 
 import scala.annotation.tailrec
 
-private[postgresql] object FreePort {
+private[postgresql] object LockedFreePort {
 
   @tailrec
   def find(tries: Int = 10): PortLock.Locked = {
-    val socket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress)
-    val portLock = try {
-      val port = Port(socket.getLocalPort)
-      PortLock.lock(port)
-    } finally {
-      socket.close()
-    }
-    portLock match {
+    val port = ports.FreePort.find()
+    PortLock.lock(port) match {
       case Right(locked) =>
-        socket.close()
         locked
       case Left(failure) =>
-        socket.close()
         if (tries <= 1) {
           throw failure
         } else {

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -55,7 +55,7 @@ trait PostgresAround {
     val dataDir = root.resolve("data")
     val configPath = dataDir.resolve("postgresql.conf")
     val logFile = Files.createFile(root.resolve("postgresql.log"))
-    val lockedPort = FreePort.find()
+    val lockedPort = LockedFreePort.find()
     val hostName = InetAddress.getLoopbackAddress.getHostAddress
     val port = lockedPort.port
     val userName = "test"

--- a/libs-scala/postgresql-testing/src/test/suite/scala/com/digitalasset/testing/postgresql/LockedFreePortSpec.scala
+++ b/libs-scala/postgresql-testing/src/test/suite/scala/com/digitalasset/testing/postgresql/LockedFreePortSpec.scala
@@ -5,10 +5,10 @@ package com.daml.testing.postgresql
 
 import org.scalatest.{Matchers, WordSpec}
 
-class FreePortSpec extends WordSpec with Matchers {
+class LockedFreePortSpec extends WordSpec with Matchers {
   "a free port" should {
     "always be available" in {
-      val lockedPort = FreePort.find()
+      val lockedPort = LockedFreePort.find()
       try {
         lockedPort.port.value should (be >= 1024 and be < 65536)
       } finally {
@@ -17,7 +17,7 @@ class FreePortSpec extends WordSpec with Matchers {
     }
 
     "lock, to prevent race conditions" in {
-      val lockedPort = FreePort.find()
+      val lockedPort = LockedFreePort.find()
       try {
         PortLock.lock(lockedPort.port) should be(Left(PortLock.FailedToLock(lockedPort.port)))
       } finally {
@@ -26,7 +26,7 @@ class FreePortSpec extends WordSpec with Matchers {
     }
 
     "unlock when the server's started" in {
-      val lockedPort = FreePort.find()
+      val lockedPort = LockedFreePort.find()
       lockedPort.unlock()
 
       val locked = PortLock
@@ -36,8 +36,8 @@ class FreePortSpec extends WordSpec with Matchers {
       succeed
     }
 
-    "can be unlocked twice" in {
-      val lockedPort = FreePort.find()
+    "not error if it's unlocked twice" in {
+      val lockedPort = LockedFreePort.find()
       lockedPort.unlock()
       lockedPort.unlock()
       succeed


### PR DESCRIPTION
Tested with the _HelloService_.

Fixes #5738.

### Changelog

- **[Integration Kit]** Truncate GPRC error messages at 4 KB. This ensures that we won't trigger a protocol error when sending errors to the client.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
