### PR TITLE
Add previous/next buttons to the documentation

### DIFF
--- a/docs/configs/html/conf.py
+++ b/docs/configs/html/conf.py
@@ -105,6 +105,8 @@ html_static_path = []
 # Don't show "powered by sphinx"
 html_show_sphinx = False
 
+html_show_copyright = False
+
 # Don't display the link to the sources
 html_show_sourcelink = False
 

--- a/docs/configs/pdf/conf.py
+++ b/docs/configs/pdf/conf.py
@@ -107,6 +107,8 @@ html_static_path = ['_static']
 # Don't show "powered by sphinx"
 html_show_sphinx = False
 
+html_show_copyright = False
+
 # Don't display the link to the sources
 html_show_sourcelink = False
 

--- a/docs/theme/da_theme_skeleton/footer.html
+++ b/docs/theme/da_theme_skeleton/footer.html
@@ -5,10 +5,10 @@
   {% if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       {% if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
+        <a href="{{ next.link|e }}" class="btn btn-neutral float-right btn-next" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
       {% endif %}
       {% if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
+        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left btn-prev" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
       {% endif %}
     </div>
   {% endif %}

--- a/docs/theme/da_theme_skeleton/layout.html
+++ b/docs/theme/da_theme_skeleton/layout.html
@@ -225,6 +225,9 @@
               {% block comments %}{% endblock %}
             </div>
             {% endif%}
+            {% if url_root != './' %}
+              {% include "footer.html" %}
+            {% endif %}
           </div>
           {%- endblock %}
         </div>
@@ -265,8 +268,6 @@
   {% else %}
   <div id="inpageContent" style="display: none;"></div>
   {% endif %}
-
-  {%- block footer %} {% endblock %}
 
 </body>
 </html>

--- a/docs/theme/sass/_theme_layout.sass
+++ b/docs/theme/sass/_theme_layout.sass
@@ -2366,3 +2366,6 @@ a.copybtn.o-tooltip--left
 
   img
     position: absolute
+
+.btn.btn-next, .btn.btn-prev
+    padding: .4em .8em


### PR DESCRIPTION
fixes #6701

Clicked through a bunch of pages and it looks fine. Also verified that it doesn’t end up in the PDF docs.

Not quite sure about the copyright thing but we didn’t display it before so if we want to display it, let’s do that separately.

![Screenshot_2020-07-21 Getting Started with DAML — DAML SDK 0 0 0 documentation](https://user-images.githubusercontent.com/1313584/88058483-d12fe800-cb63-11ea-989b-cdae491dc4ac.png)


changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
