### PR TITLE
Limit JVM memory in a few tests

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Repl.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
+import DA.Test.Util
 import System.Environment.Blank
 import System.FilePath
 import System.IO.Extra
@@ -30,6 +31,7 @@ testLedgerId = "replledger"
 main :: IO ()
 main = do
     setEnv "TASTY_NUM_THREADS" "1" True
+    limitJvmMemory defaultJvmMemoryLimits
     damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
     scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml" </> "daml-script.dar")
     testDar <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> "repl-test.dar")

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -45,6 +45,7 @@ import Text.Regex.TDFA
 main :: IO ()
 main = do
     setNumCapabilities 1
+    limitJvmMemory defaultJvmMemoryLimits
     scriptDar <- locateRunfiles (mainWorkspace </> "daml-script" </> "daml" </> "daml-script.dar")
     testDars <- forM ["repl-test", "repl-test-two"] $ \name ->
         locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "tests" </> name <.> "dar")

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
@@ -38,6 +38,7 @@ instance IsOption ProjectName where
 main :: IO ()
 main = withTempDir $ \yarnCache -> do
     setEnv "YARN_CACHE_FOLDER" yarnCache True
+    limitJvmMemory defaultJvmMemoryLimits
     yarn : args <- getArgs
     javaPath <- locateRunfiles "local_jdk/bin"
     oldPath <- getSearchPath

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -53,6 +53,7 @@ main = do
     -- on the PATH as mvn.cmd executes cmd.exe
     mbComSpec <- getEnv "COMSPEC"
     let mbCmdDir = takeDirectory <$> mbComSpec
+    limitJvmMemory defaultJvmMemoryLimits
     withArgs args (withEnv
         [ ("PATH", Just $ intercalate [searchPathSeparator] $ (tarPath : javaPath : mvnPath : yarnPath : oldPath) ++ maybeToList mbCmdDir)
         , ("TASTY_NUM_THREADS", Just "1")

--- a/libs-haskell/test-utils/DA/Test/Util.hs
+++ b/libs-haskell/test-utils/DA/Test/Util.hs
@@ -13,6 +13,9 @@ module DA.Test.Util (
     withDevNull,
     assertFileExists,
     assertFileDoesNotExist,
+    limitJvmMemory,
+    defaultJvmMemoryLimits,
+    JvmMemoryLimits(..),
 ) where
 
 import Control.Monad
@@ -96,3 +99,23 @@ assertFileExists file = doesFileExist file >>= assertBool (file ++ " was expecte
 
 assertFileDoesNotExist :: FilePath -> IO ()
 assertFileDoesNotExist file = doesFileExist file >>= assertBool (file ++ " was expected to not exist, but does exist") . not
+
+data JvmMemoryLimits = JvmMemoryLimits
+  { initialHeapSize :: String
+  , maxHeapSize :: String
+  }
+
+defaultJvmMemoryLimits :: JvmMemoryLimits
+defaultJvmMemoryLimits = JvmMemoryLimits
+  { initialHeapSize = "128m"
+  , maxHeapSize = "256m"
+  }
+
+limitJvmMemory :: JvmMemoryLimits -> IO ()
+limitJvmMemory JvmMemoryLimits{..} = do
+    setEnv "_JAVA_OPTIONS" limits True
+  where
+    limits = unwords
+      [ "-Xms" <> initialHeapSize
+      , "-Xmx" <> maxHeapSize
+      ]


### PR DESCRIPTION
This limits the JVM max memory and initial memory in a few tests that
look like they might be using more than they have two and that run for
a long time so there is a high chance they end up running in parallel
with something else.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
