### PR TITLE
Fix flakiness in TS build-and-lint tests

### DIFF
--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -84,6 +84,7 @@ sh_test(
         "$(location //language-support/ts/daml-types:npm_package)",
         "$(location //language-support/ts/daml-ledger:npm_package)",
         sdk_version,
+        "$(location //ledger-service/http-json:release/json-api-logback.xml)",
     ],
     data = [
         "//:java",
@@ -91,6 +92,7 @@ sh_test(
         "//:daml2js",
         "//ledger/sandbox-classic:sandbox-classic-binary_deploy.jar",
         "//ledger-service/http-json:http-json-binary_deploy.jar",
+        "//ledger-service/http-json:release/json-api-logback.xml",
         ":build-and-lint.dar",
         "//language-support/ts/daml-types:npm_package",
         "//language-support/ts/daml-ledger:npm_package",

--- a/language-support/ts/codegen/tests/build-and-lint.sh
+++ b/language-support/ts/codegen/tests/build-and-lint.sh
@@ -46,6 +46,7 @@ TS_DIR=$(dirname $PACKAGE_JSON)
 DAML_TYPES=$(rlocation "$TEST_WORKSPACE/$8")
 DAML_LEDGER=$(rlocation "$TEST_WORKSPACE/$9")
 SDK_VERSION=${10}
+JSON_API_LOGBACK=$(rlocation "$TEST_WORKSPACE/${11}")
 
 TMP_DAML_TYPES=$TMP_DIR/daml-types
 TMP_DAML_LEDGER=$TMP_DIR/daml-ledger
@@ -69,4 +70,4 @@ $YARN run build
 $YARN run lint
 # Invoke 'yarn test'. Control is thereby passed to
 # 'language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts'.
-JAVA=$JAVA SANDBOX=$SANDBOX JSON_API=$JSON_API DAR=$DAR $YARN test
+JAVA=$JAVA SANDBOX=$SANDBOX JSON_API=$JSON_API DAR=$DAR JSON_API_LOGBACK=$JSON_API_LOGBACK $YARN test


### PR DESCRIPTION
This PR bumps the akka request timeout in the JSON API which we hit
occasionally in the tests which leads to a 503 error
and the tests timing out.

In addition to bumping the timeout, I’ve also changed the logback file
of the JSON API so we don’t get tons and tons of netty debugging
output and updated the token format since the JSON API warns about the
outdated one.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
