### PR TITLE
Validate performance test keys

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -150,7 +150,7 @@ object Cli {
         if (tests.forall(Tests.PerformanceTestsKeySet)) {
           success
         } else {
-          failure("Invalid performance test name, use --list to see valid performance test names")
+          failure("Invalid performance test name. Use `--list` to see valid names.")
       })
       .action((inc, c) => c.copy(performanceTests = c.performanceTests ++ inc))
       .unbounded()

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -146,6 +146,12 @@ object Cli {
       .text("""A comma-separated list of inclusion prefixes. If not specified, all default tests are included. If specified, only tests that match at least one of the given inclusion prefixes (and none of the given exclusion prefixes) will be run. Can be specified multiple times, i.e. `--include=a,b` is the same as `--include=a --include=b`.""")
 
     opt[Seq[String]]("perf-tests")
+      .validate(tests =>
+        if (tests.forall(Tests.PerformanceTestsKeySet)) {
+          success
+        } else {
+          failure("Invalid performance test name, use --list to see valid performance test names")
+      })
       .action((inc, c) => c.copy(performanceTests = c.performanceTests ++ inc))
       .unbounded()
       .text("""A comma-separated list of performance tests that should be run.""")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -92,4 +92,6 @@ object Tests {
         performanceEnvelopeLatencyTestKey(envelope),
         performanceEnvelopeTransactionSizeTestKey(envelope)),
     }
+
+  private[testtool] val PerformanceTestsKeySet = PerformanceTestsKeys.toSet
 }


### PR DESCRIPTION
Fixes #6823

changelog_begin
[Integration Kit] Fixed a bug in the Ledger API test tool that caused
the full conformance test suite to be run when trying to run performance
tests but using a wrong name. See https://github.com/digital-asset/daml/issues/6823
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
