### PR TITLE
Fix decoding of recursive types in daml-types

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -478,7 +478,9 @@ data Decoder
     | DecoderObject [(T.Text, Decoder)]
     | DecoderConstant DecoderConstant
     | DecoderRef TypeRef -- ^ Reference to an object with a .decoder() method
-    | DecoderLazy Decoder
+    | DecoderLazy Decoder -- ^ Lazy decoder, we need this to avoid infinite loops
+    -- on recursive types. We insert this in every variant, Optional, List and TextMap
+    -- which are the only ways to construct terminating recursive types.
 
 data DecoderConstant
     = ConstantUndefined

--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -45,6 +45,7 @@ template AllTypes with
     n0 : Numeric 0
     n5 : Numeric 5
     n10 : Decimal
+    rec : Recursive
   where
     signatory party
 
@@ -129,3 +130,9 @@ template U with
       C: ContractId T with
         do
           create T with party
+
+data Recursive = Recursive with
+    recOptional : Optional Recursive
+    recList: [Recursive]
+    recTextMap : TextMap Recursive
+  deriving (Eq, Show)

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -275,6 +275,7 @@ test('create + fetch & exercise', async () => {
     n0:  '3.0',          // Numeric 0
     n5:  '3.14159',      // Numeric 5
     n10: '3.1415926536', // Numeric 10
+    rec: {'recOptional': null, 'recList': [], 'recTextMap': {}},
   };
   const allTypesContract = await aliceLedger.create(buildAndLint.Main.AllTypes, allTypes);
   expect(allTypesContract.payload).toEqual(allTypes);

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -211,7 +211,7 @@ export type List<T> = T[];
  * Companion object of the [[List]] type.
  */
 export const List = <T>(t: Serializable<T>): Serializable<T[]> => ({
-  decoder: (): jtv.Decoder<T[]> => jtv.array(t.decoder()),
+  decoder: (): jtv.Decoder<T[]> => jtv.array(jtv.lazy(() => t.decoder())),
 });
 
 /**
@@ -279,7 +279,7 @@ class OptionalWorker<T> implements Serializable<Optional<T>> {
   constructor(private payload: Serializable<T>) { }
 
   decoder(): jtv.Decoder<Optional<T>> {
-    return jtv.oneOf(jtv.constant(null), this.innerDecoder());
+      return jtv.oneOf(jtv.constant(null), jtv.lazy(() => this.innerDecoder()));
   }
 
   private innerDecoder(): jtv.Decoder<OptionalInner<T>> {
@@ -323,7 +323,7 @@ export type TextMap<T> = { [key: string]: T };
  * Companion object of the [[TextMap]] type.
  */
 export const TextMap = <T>(t: Serializable<T>): Serializable<TextMap<T>> => ({
-  decoder: (): jtv.Decoder<TextMap<T>> => jtv.dict(t.decoder()),
+    decoder: (): jtv.Decoder<TextMap<T>> => jtv.dict(jtv.lazy(() => t.decoder())),
 });
 
 // TODO(MH): `Map` type.


### PR DESCRIPTION
The examples and the comment are hopefully obvious enough. Builtin
types can also produce terminating recursion so we need to make them
lazy.

changelog_begin

- [@daml/daml-types library] Fix an issue where some recursive types
  resulted in a stackoverflow.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
