### PR TITLE
Support let-bindings in DAML REPL

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -264,6 +264,19 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , matchOutput "^.*"
           , matchOutput "^.*"
           ]
+    , testInteraction' "let bindings"
+          [ input "let x = 1 + 1"
+          , input "x"
+          , matchOutput "2"
+          , input "let Some (x, y) = Some (23, 42)"
+          , input "x"
+          , matchOutput "23"
+          , input "y"
+          , matchOutput "42"
+          , input "let f x = x + 1"
+          , input "f 42"
+          , matchOutput "43"
+          ]
     ]
   where
     testInteraction' testName steps =

--- a/docs/source/daml-repl/index.rst
+++ b/docs/source/daml-repl/index.rst
@@ -72,6 +72,10 @@ two forms:
    the pattern ``pat`` bindings the matches to the variables in the pattern.
    You can then use those variables on subsequent lines.
 
+4. A ``let`` binding of the form ``let pat = y``, where ``pat`` is a pattern
+   and ``y`` is a pure expression or ``let f x = y`` to define a function.
+   The bound variables can be used on subsequent lines.
+
 First create two parties: A party with the display name ``"Alice"``
 and the party id ``"alice"`` and a party with the display name
 ``"Bob"`` and the party id ``"bob"``.


### PR DESCRIPTION
This PR extends DAML REPL to also support `let` bindings which plays
well with the improved support for pure expressions. We support both
pattern bindings and function bindings.

changelog_begin

- [DAML REPL] DAML REPL can now run without a ledger. Take a look at
  the documentation for details.

- [DAML REPL] DAML REPL now supports ``let`` bindings to bind pure
  expressions. Take a look at the documentation for details.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
