### PR TITLE
remove clean --expunge from Windows builds

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -48,7 +48,6 @@ function bazel() {
 # which later causes issues on Bazel init (source forest creation) on Windows. A shutdown closes workers,
 # which is a workaround for this problem.
 bazel shutdown
-bazel clean --expunge
 
 # Prefetch nodejs_dev_env to avoid permission denied errors on external/nodejs_dev_env/nodejs_dev_env/node.exe
 # It isn’t clear where exactly those errors are coming from.

--- a/compatibility/build-release-artifacts-windows.ps1
+++ b/compatibility/build-release-artifacts-windows.ps1
@@ -37,7 +37,6 @@ function bazel() {
 
 
 bazel shutdown
-bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build `
   `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution_windows.log `

--- a/compatibility/test-windows.ps1
+++ b/compatibility/test-windows.ps1
@@ -45,7 +45,6 @@ cd compatibility
 cp ../.bazelrc .bazelrc
 
 bazel shutdown
-bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build //...
 bazel shutdown


### PR DESCRIPTION
Following #6761, all nodes have been reset, so we can get back to fast, cached builds.

CHANGELOG_BEGIN
CHANGELOG_END