### PR TITLE
Pin rules_apple

### DIFF
--- a/bazel_tools/grpc-bazel-apple.patch
+++ b/bazel_tools/grpc-bazel-apple.patch
@@ -1,0 +1,18 @@
+diff --git a/bazel/grpc_deps.bzl b/bazel/grpc_deps.bzl
+index cce2f88fe8..ad7ecf0286 100644
+--- a/bazel/grpc_deps.bzl
++++ b/bazel/grpc_deps.bzl
+@@ -226,10 +226,10 @@ def grpc_deps():
+         )
+ 
+     if "build_bazel_rules_apple" not in native.existing_rules():
+-        git_repository(
++        http_archive(
+             name = "build_bazel_rules_apple",
+-            remote = "https://github.com/bazelbuild/rules_apple.git",
+-            tag = "0.17.2",
++            urls = ["https://github.com/bazelbuild/rules_apple/releases/download/0.17.2/rules_apple.0.17.2.tar.gz"],
++            sha256 = "6efdde60c91724a2be7f89b0c0a64f01138a45e63ba5add2dca2645d981d23a1",
+         )
+     
+ # TODO: move some dependencies from "grpc_deps" here?

--- a/deps.bzl
+++ b/deps.bzl
@@ -209,6 +209,7 @@ def daml_deps():
             urls = ["https://github.com/grpc/grpc/archive/v1.23.1.tar.gz"],
             sha256 = "dd7da002b15641e4841f20a1f3eb1e359edb69d5ccf8ac64c362823b05f523d9",
             patches = [
+                "@com_github_digital_asset_daml//bazel_tools:grpc-bazel-apple.patch",
                 "@com_github_digital_asset_daml//bazel_tools:grpc-bazel-mingw.patch",
             ],
             patch_args = ["-p1"],


### PR DESCRIPTION
This does not change the version of rules_apple, it only pins the http archive instead of fetching via git tag.

To avoid Bazel warnings of the following form since Bazel 3.3.1

```
DEBUG: Rule 'build_bazel_rules_apple' indicated that a canonical reproducible form can be obtained by modifying arguments commit = "ff6a37b24fcbbd525a5bf61692a12c810d0ee3c1", shallow_since = "1559833568 -0700" and dropping ["tag"]
DEBUG: Repository build_bazel_rules_apple instantiated at:
  no stack (--record_rule_instantiation_callstack not enabled)
Repository rule git_repository defined at:
  /home/aj/.cache/bazel/_bazel_aj/f66bee630c6a2cd906f92a0f5cdf8769/external/bazel_tools/tools/build_defs/repo/git.bzl:195:33: in <toplevel>
```

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
