### PR TITLE
LF: control of language version in the engine

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -401,19 +401,6 @@ class Engine(private[lf] val config: EngineConfig = EngineConfig.Stable) {
     */
   def compiledPackages(): CompiledPackages = compiledPackages
 
-  private[engine] def addPackage(pkgId: PackageId, pkg: Package): Result[Unit] =
-    pkg.modules.values
-      .collectFirst {
-        case Module(name, _, lv, _) if !config.languageVersions.contains(lv) =>
-          ResultError(
-            Error(
-              s"Disallowed language version in module $name of package $pkgId: " +
-                s"Expected value version between ${config.languageVersions.min} and ${config.languageVersions.max} but got $lv"
-            )
-          )
-      }
-      .getOrElse(compiledPackages.addPackage(pkgId, pkg))
-
   /** This function can be used to give a package to the engine pre-emptively,
     * rather than having the engine to ask about it through
     * [[ResultNeedPackage]].
@@ -439,6 +426,20 @@ class Engine(private[lf] val config: EngineConfig = EngineConfig.Stable) {
     compiledPackages.stackTraceMode =
       if (enable) speedy.Compiler.FullStackTrace else speedy.Compiler.NoStackTrace
   }
+
+  private[engine] def addPackage(pkgId: PackageId, pkg: Package): Result[Unit] =
+    pkg.modules.values
+      .collectFirst {
+        case Module(name, _, lv, _) if !config.languageVersions.contains(lv) =>
+          ResultError(
+            Error(
+              s"Disallowed language version in module $name of package $pkgId: " +
+                s"Expected value version between ${config.languageVersions.min} and ${config.languageVersions.max} but got $lv"
+            )
+          )
+      }
+      .getOrElse(compiledPackages.addPackage(pkgId, pkg))
+
 }
 
 object Engine {

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -428,17 +428,15 @@ class Engine(private[lf] val config: EngineConfig = EngineConfig.Stable) {
   }
 
   private[engine] def addPackage(pkgId: PackageId, pkg: Package): Result[Unit] =
-    pkg.modules.values
-      .collectFirst {
-        case Module(name, _, lv, _) if !config.languageVersions.contains(lv) =>
-          ResultError(
-            Error(
-              s"Disallowed language version in module $name of package $pkgId: " +
-                s"Expected value version between ${config.languageVersions.min} and ${config.languageVersions.max} but got $lv"
-            )
-          )
-      }
-      .getOrElse(compiledPackages.addPackage(pkgId, pkg))
+    if (config.languageVersions.contains(pkg.languageVersion))
+      compiledPackages.addPackage(pkgId, pkg)
+    else
+      ResultError(
+        Error(
+          s"Disallowed language version in package $pkgId: " +
+            s"Expected version between ${config.languageVersions.min} and ${config.languageVersions.max} but got ${pkg.languageVersion}"
+        )
+      )
 
 }
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -3,22 +3,21 @@
 
 package com.daml.lf.engine
 
-import com.daml.lf.data.NoCopy
-import com.daml.lf.{VersionRange, data}
+import com.daml.lf.VersionRange
 import com.daml.lf.language.{LanguageVersion => LV}
-import com.daml.lf.transaction.{TransactionVersion => TV, TransactionVersions}
+import com.daml.lf.transaction.{TransactionVersions, TransactionVersion => TV}
 
 // FIXME: https://github.com/digital-asset/daml/issues/5164
 // Currently only outputTransactionVersions is used.
 // languageVersions and outputTransactionVersions should be plug
-final case class EngineConfig private (
+final case class EngineConfig(
     // constrains the version of language accepted by the engine
     languageVersions: VersionRange[LV],
     // constrains the version of output transactions
     inputTransactionVersions: VersionRange[TV],
     // constrains the version of output transactions
     outputTransactionVersions: VersionRange[TV],
-) extends NoCopy
+)
 
 object EngineConfig {
 
@@ -56,39 +55,8 @@ object EngineConfig {
     )
   )
 
-  def build(
-      languageVersions: VersionRange[LV],
-      inputTransactionVersions: VersionRange[TV],
-      outputTransactionVersions: VersionRange[TV],
-  ): Either[String, EngineConfig] = {
-    val config = new EngineConfig(
-      languageVersions = languageVersions intersect Dev.languageVersions,
-      inputTransactionVersions = inputTransactionVersions intersect Dev.inputTransactionVersions,
-      outputTransactionVersions = outputTransactionVersions intersect Dev.outputTransactionVersions,
-    )
-
-    Either.cond(
-      config.languageVersions.nonEmpty && config.inputTransactionVersions.nonEmpty && config.outputTransactionVersions.nonEmpty,
-      config,
-      "invalid engine configuration"
-    )
-  }
-
-  def assertBuild(
-      languageVersions: VersionRange[LV],
-      inputTransactionVersions: VersionRange[TV],
-      outputTransactionVersions: VersionRange[TV],
-  ): EngineConfig =
-    data.assertRight(
-      build(
-        languageVersions: VersionRange[LV],
-        inputTransactionVersions: VersionRange[TV],
-        outputTransactionVersions: VersionRange[TV],
-      )
-    )
-
   // recommended configuration
-  val Stable: EngineConfig = assertBuild(
+  val Stable: EngineConfig = new EngineConfig(
     languageVersions = VersionRange(
       LV(LV.Major.V1, LV.Minor.Stable("6")),
       LV(LV.Major.V1, LV.Minor.Stable("8")),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -30,7 +30,7 @@ object SError {
   /** DAML exceptions that can be caught. These include
     * arithmetic errors, call to error builtin or update
     * errors. */
-  sealed trait SErrorDamlException extends SError
+  sealed abstract class SErrorDamlException extends SError
 
   /** Arithmetic error such as division by zero */
   final case class DamlEArithmeticError(message: String) extends SErrorDamlException {


### PR DESCRIPTION
This PR allows to control the language version accepted by the engine
following #5164.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
