### PR TITLE
Trigger service: attempt to integrate auth workflow and run authenticated sandbox in tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -975,6 +975,6 @@ java_import(
 http_file(
     name = "ref-ledger-authentication",
     downloaded_file_path = "ref-ledger-authentication.jar",
-    sha256 = "761b1731339acea3370baf98a3242714e0c81789d8cbb26b623bbf93ce6f80ef",
-    urls = ["https://github.com/digital-asset/ref-ledger-authenticator/releases/download/v0.0.0-snapshot-20200716.15.2b46f9f5/ref-ledger-authenticator-0.0.0-snapshot-20200716.15.2b46f9f5.jar"],
+    sha256 = "2883ec91884bcde97e65b81f8144747c289ab3facc61f614c4ffcfa57895ca45",
+    urls = ["https://github.com/digital-asset/ref-ledger-authenticator/releases/download/v0.0.0-snapshot-20200804.16.3d005359/ref-ledger-authenticator-0.0.0-snapshot-20200804.16.3d005359.jar"],
 )

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -105,6 +105,8 @@ da_scala_test(
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
         "//ledger/caching",
+        "//ledger/ledger-api-auth",
+        "//ledger-service/jwt",
         "//ledger/ledger-api-common",
         "//ledger/participant-integration-api",
         "//ledger/participant-state",

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -89,6 +89,7 @@ da_scala_test(
     srcs = glob(["src/test/scala/com/digitalasset/daml/lf/engine/trigger/*.scala"]),
     data = [
         ":test-model.dar",
+        "//triggers/service:ref-ledger-authentication-binary",
     ] + (
         [
             "@toxiproxy_dev_env//:bin/toxiproxy-cmd",

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -35,6 +35,7 @@ da_scala_library(
         "//ledger-api/rs-grpc-bridge",
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
+        "//ledger/ledger-api-domain",
         "//libs-scala/timer-utils",
         "//triggers/runner:trigger-runner-lib",
         "@maven//:com_chuusai_shapeless_2_12",

--- a/triggers/service/daml-platform.sh
+++ b/triggers/service/daml-platform.sh
@@ -44,7 +44,7 @@ $LEDGER_TRIGGER_SERVICE_PID=$!
 #  curl -X POST localhost:$TRIGGER_SERVICE_HTTP_PORT/v1/start \
 #    -H "Content-type: application/json" -H "Accept: application/json" \
 #    -H "Authorization: Basic YWxpY2U6JmFsQzJsM1NEUypW" \
-#    -d '{"triggerName":"d2c239382d4875c65d03435ec9da5a349cfd7055dbf348527acfe34ca99f5eb1:TestTrigger:trigger"}'
+#    -d '{"triggerName":"eaccf634dca6887f737d1efb254c536c55288a24ced77f3036549db08f14b8c2:TestTrigger:trigger"}'
 #
 # You can get the package ID from a .dar with `damlc
 # -inspect-dar`. You can "seed" the trigger service with a DAR using

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -153,7 +153,7 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
           for {
             sa <- getServiceAccount(authServiceToken)
             _ = if (sa.creds.length <= initialNumCreds) throw new NoSuchElementException
-          } yield sa.creds.head
+          } yield sa.creds.head // new credential is added to the front of the list
       }
     } yield newCred
 

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -181,7 +181,7 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
     runRequest(req)(Unmarshal(_).to[LedgerAccessToken])
   }
 
-  def theWholeThing(
+  def getLedgerToken(
       username: String,
       password: String,
       ledgerId: String): Future[LedgerAccessToken] =

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -148,11 +148,11 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
       sa <- getServiceAccount(authServiceToken)
       initialNumCreds = sa.creds.length
       () <- requestCredential(authServiceToken, sa.serviceAccount)
-      newCred <- RetryStrategy.constant(attempts = Some(3), waitTime = 4.seconds)(notFound) {
+      newCred <- RetryStrategy.constant(attempts = Some(5), waitTime = 4.seconds)(notFound) {
         (_, _) =>
           for {
             sa <- getServiceAccount(authServiceToken)
-            _ = if (sa.creds.length <= initialNumCreds) throw new NoSuchElementException
+            _ = if (sa.creds.length <= 0) throw new NoSuchElementException
           } yield sa.creds.head // new credential is added to the front of the list
       }
     } yield newCred

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -180,6 +180,20 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
     )
     runRequest(req)(Unmarshal(_).to[LedgerAccessToken])
   }
+
+  def theWholeThing(
+      username: String,
+      password: String,
+      ledgerId: String): Future[LedgerAccessToken] =
+    for {
+      token <- authorize(username, password)
+      () <- requestServiceAccount(token, ledgerId)
+      sa <- getServiceAccount(token)
+      () <- requestCredential(token, sa.serviceAccount)
+      credId <- getNewCredentialId(token, sa.serviceAccount)
+      cred <- getCredential(token, credId)
+      accessTok <- login(cred)
+    } yield accessTok
 }
 
 object AuthServiceClient {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -66,7 +66,7 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
 
   private val http: HttpExt = Http(system)
   private val saSecure = Path("/sa/secure")
-  private val saLogin = Path("/sa/login")
+  private val saLogin = Path("/sa/loginWithUserId")
 
   // Send an HTTP request and convert an error response into a failed future.
   // Run the given function on a successful response only.

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -119,7 +119,7 @@ class Server(
       existingInstance: Option[UUID] = None): Either[String, JsValue] = {
     val credentials = UserCredentials(encrypt(secretKey, userpass._1, userpass._2))
     val ledgerAccessToken: Option[LedgerAccessToken] = authServiceClient.map(client =>
-      Await.result(client.getLedgerToken(userpass._1, userpass._2, LedgerId.unwrap(ledgerConfig.ledgerId)), 30.seconds))
+      Await.result(client.getLedgerToken(userpass._1, userpass._2, LedgerId.unwrap(ledgerConfig.ledgerId)), 60.seconds))
     for {
       trigger <- Trigger.fromIdentifier(compiledPackages, triggerName)
       triggerInstance <- existingInstance match {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -19,6 +19,7 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import spray.json.DefaultJsonProtocol._
 import spray.json._
+import com.daml.ledger.api.domain.LedgerId
 import com.daml.lf.archive.{Dar, DarReader, Decode}
 import com.daml.lf.archive.Reader.ParseError
 import com.daml.lf.data.Ref.{Identifier, PackageId}
@@ -118,7 +119,7 @@ class Server(
       existingInstance: Option[UUID] = None): Either[String, JsValue] = {
     val credentials = UserCredentials(encrypt(secretKey, userpass._1, userpass._2))
     val ledgerAccessToken: Option[LedgerAccessToken] = authServiceClient.map(client =>
-      Await.result(client.getLedgerToken(userpass._1, userpass._2, ""), 10.seconds))
+      Await.result(client.getLedgerToken(userpass._1, userpass._2, LedgerId.unwrap(ledgerConfig.ledgerId)), 10.seconds))
     for {
       trigger <- Trigger.fromIdentifier(compiledPackages, triggerName)
       triggerInstance <- existingInstance match {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -98,12 +98,10 @@ class Server(
 
   private def restartTriggers(triggers: Vector[RunningTrigger]): Either[String, Unit] = {
     import cats.implicits._ // needed for traverse
-    triggers.traverse_(t =>
-      {
-        val userpass = TokenManagement.decodeCredentials(secretKey, t.credentials)
-        startTrigger(userpass, t.triggerName, Some(t.triggerInstance))
-      }
-    )
+    triggers.traverse_(t => {
+      val userpass = TokenManagement.decodeCredentials(secretKey, t.credentials)
+      startTrigger(userpass, t.triggerName, Some(t.triggerInstance))
+    })
   }
 
   private def triggerRunnerName(triggerInstance: UUID): String =

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -118,8 +118,11 @@ class Server(
       triggerName: Identifier,
       existingInstance: Option[UUID] = None): Either[String, JsValue] = {
     val credentials = UserCredentials(encrypt(secretKey, userpass._1, userpass._2))
-    val ledgerAccessToken: Option[LedgerAccessToken] = authServiceClient.map(client =>
-      Await.result(client.getLedgerToken(userpass._1, userpass._2, LedgerId.unwrap(ledgerConfig.ledgerId)), 60.seconds))
+    val ledgerAccessToken: Option[LedgerAccessToken] = authServiceClient.map(
+      client =>
+        Await.result(
+          client.getLedgerToken(userpass._1, userpass._2, LedgerId.unwrap(ledgerConfig.ledgerId)),
+          60.seconds))
     for {
       trigger <- Trigger.fromIdentifier(compiledPackages, triggerName)
       triggerInstance <- existingInstance match {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -120,7 +120,7 @@ class Server(
       existingInstance: Option[UUID] = None): Either[String, JsValue] = {
     val credentials = UserCredentials(encrypt(secretKey, userpass._1, userpass._2))
     val ledgerAccessToken: Option[LedgerAccessToken] = authServiceClient.map(client =>
-      Await.result(client.theWholeThing(userpass._1, userpass._2, ""), 10.seconds))
+      Await.result(client.getLedgerToken(userpass._1, userpass._2, ""), 10.seconds))
     for {
       trigger <- Trigger.fromIdentifier(compiledPackages, triggerName)
       triggerInstance <- existingInstance match {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -119,7 +119,8 @@ class Server(
       existingInstance: Option[UUID] = None): Either[String, JsValue] = {
     val credentials = UserCredentials(encrypt(secretKey, userpass._1, userpass._2))
     val ledgerAccessToken: Option[LedgerAccessToken] = authServiceClient.map(client =>
-      Await.result(client.getLedgerToken(userpass._1, userpass._2, LedgerId.unwrap(ledgerConfig.ledgerId)), 10.seconds))
+      Await.result(client.getLedgerToken(userpass._1, userpass._2, LedgerId.unwrap(ledgerConfig.ledgerId)), 30.seconds))
+    ctx.system.log.debug(s"Got access token ${ledgerAccessToken.get.token}")
     for {
       trigger <- Trigger.fromIdentifier(compiledPackages, triggerName)
       triggerInstance <- existingInstance match {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -120,7 +120,6 @@ class Server(
     val credentials = UserCredentials(encrypt(secretKey, userpass._1, userpass._2))
     val ledgerAccessToken: Option[LedgerAccessToken] = authServiceClient.map(client =>
       Await.result(client.getLedgerToken(userpass._1, userpass._2, LedgerId.unwrap(ledgerConfig.ledgerId)), 30.seconds))
-    ctx.system.log.debug(s"Got access token ${ledgerAccessToken.get.token}")
     for {
       trigger <- Trigger.fromIdentifier(compiledPackages, triggerName)
       triggerInstance <- existingInstance match {

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -100,8 +100,8 @@ class Server(
     import cats.implicits._ // needed for traverse
     triggers.traverse_(t =>
       {
-//        val userpass = TokenManagement.decodeCredentials(secretKey, t.credentials)
-        startTrigger(("", ""), t.triggerName, Some(t.triggerInstance)).map(_ => ())
+        val userpass = TokenManagement.decodeCredentials(secretKey, t.credentials)
+        startTrigger(userpass, t.triggerName, Some(t.triggerInstance))
       }
     )
   }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -7,6 +7,7 @@ import java.nio.file.{Path, Paths}
 import java.time.Duration
 
 import akka.http.scaladsl.model.Uri
+import com.daml.ledger.api.domain.LedgerId
 import com.daml.platform.services.time.TimeProviderType
 import scalaz.Show
 
@@ -20,6 +21,7 @@ case class ServiceConfig(
     httpPort: Int,
     ledgerHost: String,
     ledgerPort: Int,
+    ledgerId: LedgerId,
     maxInboundMessageSize: Int,
     minRestartInterval: FiniteDuration,
     maxRestartInterval: FiniteDuration,
@@ -105,6 +107,10 @@ object ServiceConfig {
       .action((t, c) => c.copy(ledgerPort = t))
       .text("Ledger port.")
 
+    opt[String]("ledger-id")
+      .action((t, c) => c.copy(ledgerId = LedgerId(t)))
+      .text("Ledger ID.")
+
     opt[Int]("max-inbound-message-size")
       .action((x, c) => c.copy(maxInboundMessageSize = x))
       .optional()
@@ -165,6 +171,7 @@ object ServiceConfig {
         httpPort = DefaultHttpPort,
         ledgerHost = null,
         ledgerPort = 0,
+        ledgerId = null,
         maxInboundMessageSize = DefaultMaxInboundMessageSize,
         minRestartInterval = DefaultMinRestartInterval,
         maxRestartInterval = DefaultMaxRestartInterval,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -44,6 +44,7 @@ object ServiceMain {
           jdbcConfig,
           initDb = false, // for tests we initialize the database in beforeEach clause
           noSecretKey,
+          authServiceBaseUrl = None,
         ),
         "TriggerService"
       )
@@ -89,7 +90,8 @@ object ServiceMain {
               encodedDar,
               config.jdbcConfig,
               config.init,
-              config.noSecretKey
+              config.noSecretKey,
+              config.authServiceBaseUrl,
             ),
             "TriggerService"
           )

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -6,8 +6,8 @@ package com.daml.lf.engine.trigger
 import akka.actor.typed.{ActorRef, ActorSystem, Scheduler}
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.model.Uri
 import akka.util.Timeout
-
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.lf.archive.{Dar, DarReader}
 import com.daml.lf.data.Ref.PackageId
@@ -31,6 +31,7 @@ object ServiceMain {
       encodedDar: Option[Dar[(PackageId, DamlLf.ArchivePayload)]],
       jdbcConfig: Option[JdbcConfig],
       noSecretKey: Boolean,
+      authServiceBaseUrl: Option[Uri],
   ): Future[(ServerBinding, ActorSystem[Message])] = {
 
     val system: ActorSystem[Message] =
@@ -44,7 +45,7 @@ object ServiceMain {
           jdbcConfig,
           initDb = false, // for tests we initialize the database in beforeEach clause
           noSecretKey,
-          authServiceBaseUrl = None,
+          authServiceBaseUrl,
         ),
         "TriggerService"
       )

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -73,6 +73,7 @@ object ServiceMain {
           LedgerConfig(
             config.ledgerHost,
             config.ledgerPort,
+            config.ledgerId,
             config.timeProviderType,
             config.commandTtl,
             config.maxInboundMessageSize,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TokenManagement.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TokenManagement.scala
@@ -4,7 +4,7 @@
 package com.daml.lf.engine.trigger
 
 import com.daml.lf.data.Ref
-import com.daml.ledger.api.refinements.ApiTypes.Party
+//import com.daml.ledger.api.refinements.ApiTypes.Party
 import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
 import akka.http.scaladsl.model.HttpRequest
 import java.nio.charset.StandardCharsets
@@ -64,9 +64,9 @@ object TokenManagement {
   // token. By construction we ensure that there will always be two
   // components and that the first component is a syntactically valid
   // party identifier (see 'findCredentials').
-  def decodeCredentials(key: SecretKey, creds: UserCredentials): (Party, Password) = {
+  def decodeCredentials(key: SecretKey, creds: UserCredentials): (String, String) = {
     val segments = decrypt(key, creds.token).token.split(":")
-    (Party(segments(0)), Password(segments(1)))
+    (segments(0), segments(1))
   }
 
   // Get the unencrypted basic credentials from the request header.

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunnerImpl.scala
@@ -18,7 +18,11 @@ import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.v1.event.CreatedEvent
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.client.LedgerClient
-import com.daml.ledger.client.configuration.{CommandClientConfiguration, LedgerClientConfiguration, LedgerIdRequirement}
+import com.daml.ledger.client.configuration.{
+  CommandClientConfiguration,
+  LedgerClientConfiguration,
+  LedgerIdRequirement
+}
 import java.util.UUID
 
 import com.daml.lf.engine.trigger.AuthServiceDomain.LedgerAccessToken

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/package.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/package.scala
@@ -7,6 +7,7 @@ import java.time.Duration
 import java.util.UUID
 
 import com.daml.lf.data.Ref.Identifier
+import com.daml.ledger.api.domain.LedgerId
 import com.daml.platform.services.time.TimeProviderType
 
 import scala.concurrent.duration.FiniteDuration
@@ -16,6 +17,7 @@ package trigger {
   case class LedgerConfig(
       host: String,
       port: Int,
+      ledgerId: LedgerId,
       timeProvider: TimeProviderType,
       commandTtl: Duration,
       maxInboundMessageSize: Int,
@@ -34,7 +36,5 @@ package trigger {
       triggerInstance: UUID,
       triggerName: Identifier,
       credentials: UserCredentials,
-      // TODO(SF, 2020-0610): Add access token field here in the
-      // presence of authentication.
   )
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -20,7 +20,7 @@ import com.daml.jwt.JwksVerifier
 import com.daml.ledger.api.auth.AuthServiceJWT
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
-import com.daml.ledger.client.LedgerClient
+//import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
   LedgerClientConfiguration,
@@ -53,7 +53,7 @@ object TriggerServiceFixture {
       encodedDar: Option[Dar[(PackageId, DamlLf.ArchivePayload)]],
       jdbcConfig: Option[JdbcConfig],
       auth: Boolean,
-  )(testFn: (Uri, LedgerClient, Proxy) => Future[A])(
+  )(testFn: (Uri, Proxy) => Future[A])(
       implicit asys: ActorSystem,
       mat: Materializer,
       aesf: ExecutionSequencerFactory,
@@ -148,14 +148,14 @@ object TriggerServiceFixture {
     // forwards to the real sandbox port.
 
     // Configure this client with the ledger's *actual* port.
-    val clientF: Future[LedgerClient] = for {
-      (_, ledgerPort, _, _, _) <- ledgerF
-      client <- LedgerClient.singleHost(
-        host.getHostName,
-        ledgerPort.value,
-        clientConfig(applicationId),
-      )
-    } yield client
+    // val clientF: Future[LedgerClient] = for {
+    //   (_, ledgerPort, _, _, _) <- ledgerF
+    //   client <- LedgerClient.singleHost(
+    //     host.getHostName,
+    //     ledgerPort.value,
+    //     clientConfig(applicationId),
+    //   )
+    // } yield client
 
     // Configure the service with the ledger's *proxy* port.
     val serviceF: Future[(ServerBinding, TypedActorSystem[Message])] = for {
@@ -191,11 +191,11 @@ object TriggerServiceFixture {
     } yield ledgerProxy
 
     val fa: Future[A] = for {
-      client <- clientF
+//      client <- clientF
       binding <- serviceF
       ledgerProxy <- ledgerProxyF
       uri = Uri.from(scheme = "http", host = "localhost", port = binding._1.localAddress.getPort)
-      a <- testFn(uri, client, ledgerProxy)
+      a <- testFn(uri, ledgerProxy)
     } yield a
 
     fa.transformWith { ta =>

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -119,7 +119,7 @@ object TriggerServiceFixture {
         restartConfig,
         encodedDar,
         jdbcConfig,
-        noSecretKey = true // That's ok, use the default.
+        noSecretKey = true,
       )
     } yield service
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -163,6 +163,7 @@ object TriggerServiceFixture {
       ledgerConfig = LedgerConfig(
         host.getHostName,
         ledgerProxyPort.port.value,
+        ledgerId,
         TimeProviderType.Static,
         Duration.ofSeconds(30),
         ServiceConfig.DefaultMaxInboundMessageSize,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -104,7 +104,7 @@ object TriggerServiceFixture {
               ).run()
             }
             // Wait for the auth service instance to be ready to accept connections.
-            _ <- RetryStrategy.constant(attempts = 10, waitTime = 4.seconds) ((_, _) =>
+            _ <- RetryStrategy.constant(attempts = 10, waitTime = 4.seconds)((_, _) =>
               Future(authServicePort.testAndUnlock(host)))
             authServiceBaseUrl = Uri.from(
               scheme = "http",

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -69,7 +69,7 @@ object TriggerServiceFixture {
         for {
           ledger <- Future(
             new SandboxServer(
-              SandboxServer.defaultConfig.copy(
+              SandboxConfig.defaultConfig.copy(
                 port = Port.Dynamic,
                 ledgerIdMode = LedgerIdMode.Static(adminLedgerId),
               ),

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -65,7 +65,7 @@ object TriggerServiceFixture {
     val authServiceAdminLedger: Future[Option[(SandboxServer, Port)]] =
       if (!auth) Future(None)
       else {
-        val adminLedgerId = LedgerId("admin-ledger")
+        val adminLedgerId = LedgerId("auth-service-admin-ledger")
         for {
           ledger <- Future(
             new SandboxServer(
@@ -86,13 +86,13 @@ object TriggerServiceFixture {
     val authServiceInstanceF: Future[Option[(Process, Uri)]] =
       authServiceAdminLedger.flatMap {
         case None => Future(None)
-        case Some(adminLedger) =>
+        case Some((_, adminLedgerPort)) =>
           for {
             authServicePort <- Future(LockedFreePort.find())
             ledgerUri = Uri.from(
               scheme = "http",
               host = host.getHostAddress,
-              port = adminLedger._2.value)
+              port = adminLedgerPort.value)
             process <- Future {
               Process(
                 Seq(authServiceBinaryLoc),
@@ -240,7 +240,7 @@ object TriggerServiceFixture {
       authService = authServiceJwksUrl.map(url => AuthServiceJWT(JwksVerifier(url.toString))),
     )
 
-  private def clientConfig[A](
+  private def clientConfig(
       applicationId: ApplicationId,
       token: Option[String] = None): LedgerClientConfiguration =
     LedgerClientConfiguration(

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -42,6 +42,8 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   // Abstract member for testing with and without a database
   def jdbcConfig: Option[JdbcConfig]
 
+  def auth: Boolean
+
   // Default retry config for `eventually`
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(15, Seconds)), interval = scaled(Span(1, Seconds)))
@@ -82,7 +84,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
 
   def withTriggerService[A](encodedDar: Option[Dar[(PackageId, DamlLf.ArchivePayload)]])
     : ((Uri, LedgerClient, Proxy) => Future[A]) => Future[A] =
-    TriggerServiceFixture.withTriggerService(testId, List(darPath), encodedDar, jdbcConfig)
+    TriggerServiceFixture.withTriggerService(testId, List(darPath), encodedDar, jdbcConfig, auth)
 
   def startTrigger(uri: Uri, triggerName: String, party: User): Future[HttpResponse] = {
     val req = HttpRequest(
@@ -479,6 +481,7 @@ object AbstractTriggerServiceTest {
 class TriggerServiceTestInMem extends AbstractTriggerServiceTest {
 
   override def jdbcConfig: Option[JdbcConfig] = None
+  override def auth: Boolean = false
 
 }
 
@@ -489,6 +492,7 @@ class TriggerServiceTestWithDb
     with PostgresAroundAll {
 
   override def jdbcConfig: Option[JdbcConfig] = Some(jdbcConfig_)
+  override def auth: Boolean = false
 
   // Lazy because the postgresDatabase is only available once the tests start
   private lazy val jdbcConfig_ = JdbcConfig(postgresDatabase.url, "operator", "password")
@@ -560,5 +564,13 @@ class TriggerServiceTestWithDb
       } yield succeed
     }
   } yield succeed)
+
+}
+
+// Tests with ledger authentication enabled
+class TriggerServiceTestWithAuth extends AbstractTriggerServiceTest {
+
+  override def jdbcConfig: Option[JdbcConfig] = None
+  override def auth: Boolean = true
 
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -355,7 +355,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
       aliceTrigger <- parseTriggerId(resp)
       _ <- assertTriggerIds(uri, alice, Vector(aliceTrigger))
       // Proceed when it's confirmed to be running.
-      _ <- assertTriggerStatus(uri, aliceTrigger, _.last == "running")
+      _ <- assertTriggerStatus(uri, aliceTrigger, _.last == "running", 30)
       // Simulate brief network connectivity loss and observe the trigger fail.
       _ <- Future(ledgerProxy.disable())
       _ <- assertTriggerStatus(uri, aliceTrigger, _.contains("stopped: runtime failure"))

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -535,7 +535,7 @@ class TriggerServiceTestWithDb
   } yield succeed)
 
   it should "restart triggers after shutdown" in (for {
-  _ <- withTriggerService(Some(dar)) { (uri: Uri, ledgerProxy: Proxy) =>
+    _ <- withTriggerService(Some(dar)) { (uri: Uri, ledgerProxy: Proxy) =>
       for {
         // Start a trigger in the first run of the service.
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -56,6 +56,7 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         token2 <- client.getLedgerToken("username", "password", testLedgerId)
         _ <- token1.token should not be empty
         _ <- token2.token should not be empty
+        // FIXME: These tokens are equal sometimes. Why?
         _ <- token1 should not equal token2
       } yield succeed
     }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -48,4 +48,15 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         _ <- assert(error.isInstanceOf[NoSuchElementException])
       } yield succeed
     }
+
+  it should "get access tokens for the same user with different service accounts" in
+    AuthServiceFixture.withAuthServiceClient(testId) { client =>
+      for {
+        token1 <- client.getLedgerToken("username", "password", testLedgerId)
+        token2 <- client.getLedgerToken("username", "password", testLedgerId)
+        _ <- token1.token should not be empty
+        _ <- token2.token should not be empty
+        _ <- token1 should not equal token2
+      } yield succeed
+    }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -28,7 +28,7 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         sa <- authServiceClient.getServiceAccount(authServiceToken)
         _ <- sa.serviceAccount should not be empty
         _ <- sa.creds should equal(List())
-        credId <- authServiceClient.getNewCredentialId(authServiceToken, sa.serviceAccount)
+        credId <- authServiceClient.getNewCredentialId(authServiceToken)
         _ <- credId.credId should not be empty
         cred <- authServiceClient.getCredential(authServiceToken, credId)
         _ <- cred.cred should not be empty


### PR DESCRIPTION
Fairly rough at the moment. My goal is to
1. Run tests with auth turned on in the sandbox, running the auth service against it.
2. Execute the auth workflow in the most naive way possible (creating as many service accounts and credentials as we want) to get an access token to use when starting a trigger (which should eventually fail due to the token expiring).

Open to feedback on the direction.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
