### PR TITLE
Fix populating out-of-time-bounds log entry for pre-execution

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -127,21 +127,6 @@ conformance_test(
 )
 
 conformance_test(
-    name = "conformance-test-pre-execution",
-    ports = [6865],
-    server = ":app",
-    server_args = [
-        "--contract-id-seeding=testing-weak",
-        "--participant participant-id=example,port=6865",
-        "--batching enable=false",
-        "--pre-execute true",
-    ],
-    test_tool_args = [
-        "--verbose",
-    ],
-)
-
-conformance_test(
     name = "conformance-test-multi-participant",
     ports = [
         6865,

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -127,6 +127,21 @@ conformance_test(
 )
 
 conformance_test(
+    name = "conformance-test-pre-execution",
+    ports = [6865],
+    server = ":app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant participant-id=example,port=6865",
+        "--batching enable=false",
+        "--pre-execute true",
+    ],
+    test_tool_args = [
+        "--verbose",
+    ],
+)
+
+conformance_test(
     name = "conformance-test-multi-participant",
     ports = [
         6865,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -84,15 +84,15 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
       inputState: DamlStateMap,
   ): (DamlLogEntry, Map[DamlStateKey, DamlStateValue]) =
     runTimer.time { () =>
-      val ctx = new CommitContext {
+      val commitContext: CommitContext = new CommitContext {
         override def getRecordTime: Option[Time.Timestamp] = recordTime
 
         override def getParticipantId: ParticipantId = participantId
 
         override val inputs: DamlStateMap = inputState
       }
-      val logEntry = runSteps(ctx, submission)
-      logEntry -> ctx.getOutputs.toMap
+      val logEntry = runSteps(commitContext, submission)
+      logEntry -> commitContext.getOutputs.toMap
     }
 
   def runWithPreExecution(
@@ -101,7 +101,7 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
       inputState: DamlStateMap,
   ): PreExecutionResult =
     preExecutionRunTimer.time { () =>
-      val commitContext = new CommitContext {
+      val commitContext: CommitContext = new CommitContext {
         override def getRecordTime: Option[Time.Timestamp] = None
 
         override def getParticipantId: ParticipantId = participantId

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -148,6 +148,13 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
           .setOutOfTimeBoundsEntry(builder)
           .build
       }
+      .orElse {
+        // In case no min & max record time is set we won't be checking time bounds at post-execution
+        // so the contents of this log entry does not matter.
+        PartialFunction.condOpt((commitContext.minimumRecordTime, commitContext.maximumRecordTime)) {
+          case (None, None) => DamlLogEntry.getDefaultInstance
+        }
+      }
       .getOrElse(throw new IllegalArgumentException(
         "Committer did not set an out-of-time-bounds log entry"))
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -52,6 +52,7 @@ private[kvutils] class ConfigCommitter(
       if (ctx.preExecute) {
         // Propagate the time bounds and defer the checks to post-execution.
         ctx.maximumRecordTime = Some(maximumRecordTime.toInstant)
+        setOutOfTimeBoundsLogEntry(result.submission, ctx)
       }
       StepContinue(result)
     }
@@ -165,9 +166,6 @@ private[kvutils] class ConfigCommitter(
     val successLogEntry = buildLogEntryWithOptionalRecordTime(
       ctx.getRecordTime,
       _.setConfigurationEntry(configurationEntry))
-    if (ctx.preExecute) {
-      setOutOfTimeBoundsLogEntry(result.submission, ctx)
-    }
     StepStop(successLogEntry)
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -178,22 +178,31 @@ private[kvutils] class TransactionCommitter(
                     RejectionReason.InvalidLedgerTime(reason))),
               _ => StepContinue(transactionEntry)
             )
-        case None => // Pre-execution: propagate the time bounds and defer the checks to post-execution
+        case None => // Pre-execution: propagate the time bounds and defer the checks to post-execution.
           val maybeDeduplicateUntil =
             getLedgerDeduplicateUntil(transactionEntry, commitContext)
-
-          commitContext.minimumRecordTime = Some(
-            transactionMinRecordTime(
-              transactionEntry.submissionTime.toInstant,
-              transactionEntry.ledgerEffectiveTime.toInstant,
-              maybeDeduplicateUntil,
-              timeModel))
-          commitContext.maximumRecordTime = Some(
-            transactionMaxRecordTime(
-              transactionEntry.submissionTime.toInstant,
-              transactionEntry.ledgerEffectiveTime.toInstant,
-              timeModel))
+          val minimumRecordTime = transactionMinRecordTime(
+            transactionEntry.submissionTime.toInstant,
+            transactionEntry.ledgerEffectiveTime.toInstant,
+            maybeDeduplicateUntil,
+            timeModel)
+          val maximumRecordTime = transactionMaxRecordTime(
+            transactionEntry.submissionTime.toInstant,
+            transactionEntry.ledgerEffectiveTime.toInstant,
+            timeModel)
+          commitContext.minimumRecordTime = Some(minimumRecordTime)
+          commitContext.maximumRecordTime = Some(maximumRecordTime)
           commitContext.deduplicateUntil = maybeDeduplicateUntil
+          val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
+            .setTransactionRejectionEntry(
+              buildRejectionLogEntry(
+                transactionEntry,
+                RejectionReason.InvalidLedgerTime(
+                  s"Record time is outside of valid range [$minimumRecordTime, $maximumRecordTime]")
+              )
+            )
+            .build
+          commitContext.outOfTimeBoundsLogEntry = Some(outOfTimeBoundsLogEntry)
           StepContinue(transactionEntry)
       }
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -190,9 +190,9 @@ private[kvutils] class TransactionCommitter(
             transactionEntry.submissionTime.toInstant,
             transactionEntry.ledgerEffectiveTime.toInstant,
             timeModel)
+          commitContext.deduplicateUntil = maybeDeduplicateUntil
           commitContext.minimumRecordTime = Some(minimumRecordTime)
           commitContext.maximumRecordTime = Some(maximumRecordTime)
-          commitContext.deduplicateUntil = maybeDeduplicateUntil
           val outOfTimeBoundsLogEntry = DamlLogEntry.newBuilder
             .setTransactionRejectionEntry(
               buildRejectionLogEntry(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -93,7 +93,7 @@ class CommitterSpec
       actualOutOfTimeBoundsLogEntry.getEntry shouldBe aRejectionLogEntry
     }
 
-    "do not throw in case no out-of-time-bounds log entry and min/max record time is set" in {
+    "do not throw in case neither out-of-time-bounds log entry nor min/max record time are set" in {
       val mockContext = mock[CommitContext]
       when(mockContext.outOfTimeBoundsLogEntry).thenReturn(None)
       when(mockContext.getOutputs).thenReturn(Iterable.empty)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -15,9 +15,14 @@ import com.daml.lf.data.Time.Timestamp
 import com.daml.metrics.Metrics
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
+import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Matchers, WordSpec}
 
-class CommitterSpec extends WordSpec with Matchers with MockitoSugar {
+class CommitterSpec
+    extends WordSpec
+    with TableDrivenPropertyChecks
+    with Matchers
+    with MockitoSugar {
   "preExecute" should {
     "set pre-execution results from context" in {
       val mockContext = mock[CommitContext]
@@ -88,7 +93,7 @@ class CommitterSpec extends WordSpec with Matchers with MockitoSugar {
       actualOutOfTimeBoundsLogEntry.getEntry shouldBe aRejectionLogEntry
     }
 
-    "throw in case no out-of-time-bounds log entry is set" in {
+    "do not throw in case no out-of-time-bounds log entry and min/max record time is set" in {
       val mockContext = mock[CommitContext]
       when(mockContext.outOfTimeBoundsLogEntry).thenReturn(None)
       when(mockContext.getOutputs).thenReturn(Iterable.empty)
@@ -97,8 +102,32 @@ class CommitterSpec extends WordSpec with Matchers with MockitoSugar {
       when(mockContext.maximumRecordTime).thenReturn(None)
       val instance = createCommitter()
 
-      assertThrows[IllegalArgumentException](
-        instance.preExecute(aDamlSubmission, aParticipantId, Map.empty, mockContext))
+      instance.preExecute(aDamlSubmission, aParticipantId, Map.empty, mockContext)
+      succeed
+    }
+
+    "throw in case out-of-time-bounds log entry is not set but min/max record time is" in {
+      val anInstant = Instant.ofEpochSecond(1234)
+      val combinations = Table(
+        "min/max record time",
+        Some(anInstant) -> Some(anInstant),
+        Some(anInstant) -> None,
+        None -> Some(anInstant)
+      )
+
+      forAll(combinations) {
+        case (minRecordTimeMaybe, maxRecordTimeMaybe) =>
+          val mockContext = mock[CommitContext]
+          when(mockContext.outOfTimeBoundsLogEntry).thenReturn(None)
+          when(mockContext.getOutputs).thenReturn(Iterable.empty)
+          when(mockContext.getAccessedInputKeys).thenReturn(Set.empty[DamlStateKey])
+          when(mockContext.minimumRecordTime).thenReturn(minRecordTimeMaybe)
+          when(mockContext.maximumRecordTime).thenReturn(maxRecordTimeMaybe)
+          val instance = createCommitter()
+
+          assertThrows[IllegalArgumentException](
+            instance.preExecute(aDamlSubmission, aParticipantId, Map.empty, mockContext))
+      }
     }
   }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
@@ -76,9 +76,10 @@ class ConfigCommitterSpec extends WordSpec with Matchers {
       context.outOfTimeBoundsLogEntry.foreach { actual =>
         actual.hasRecordTime shouldBe false
         actual.hasConfigurationRejectionEntry shouldBe true
-        actual.getConfigurationRejectionEntry.getSubmissionId shouldBe aConfigurationSubmission.getSubmissionId
-        actual.getConfigurationRejectionEntry.getParticipantId shouldBe aConfigurationSubmission.getParticipantId
-        actual.getConfigurationRejectionEntry.getConfiguration shouldBe aConfigurationSubmission.getConfiguration
+        val actualConfigurationRejectionEntry = actual.getConfigurationRejectionEntry
+        actualConfigurationRejectionEntry.getSubmissionId shouldBe aConfigurationSubmission.getSubmissionId
+        actualConfigurationRejectionEntry.getParticipantId shouldBe aConfigurationSubmission.getParticipantId
+        actualConfigurationRejectionEntry.getConfiguration shouldBe aConfigurationSubmission.getConfiguration
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
@@ -126,7 +126,7 @@ class TransactionCommitterSpec extends WordSpec with Matchers with MockitoSugar 
         }
       }
 
-      "compute and correctly set the min/max ledger time without deduplicateUntil" in {
+      "compute and correctly set the min/max ledger time and out-of-time-bounds log entry without deduplicateUntil" in {
         val context = contextWithTimeModelAndEmptyCommandDeduplication()
         instance.validateLedgerTime(
           context,
@@ -141,7 +141,7 @@ class TransactionCommitterSpec extends WordSpec with Matchers with MockitoSugar 
         }
       }
 
-      "compute and correctly set the min/max ledger time with deduplicateUntil" in {
+      "compute and correctly set the min/max ledger time and out-of-time-bounds log entry with deduplicateUntil" in {
         val context = contextWithTimeModelAndCommandDeduplication()
         instance.validateLedgerTime(
           context,


### PR DESCRIPTION
Summary of changes:
* Populate out-of-time-bounds log entry at the committer step when normally checks against record time would be performed in `TransactionCommitter` and `ConfigCommitter`.
* Do not throw in `Committer.preExecute` in case out-of-time-bounds log entry isn't set and min/max record time isn't either.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
