### PR TITLE
Enable assertions in Haskell builds

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -118,7 +118,10 @@ haskell_library(
 )
 """.format(version = GHCIDE_VERSION),
         patch_args = ["-p1"],
-        patches = ["@com_github_digital_asset_daml//bazel_tools:haskell-ghcide-expose-compat.patch"],
+        patches = [
+            "@com_github_digital_asset_daml//bazel_tools:haskell-ghcide-binary-q.patch",
+            "@com_github_digital_asset_daml//bazel_tools:haskell-ghcide-expose-compat.patch",
+        ],
         sha256 = GHCIDE_SHA256,
         strip_prefix = "ghcide-%s" % GHCIDE_REV,
         urls = ["https://github.com/digital-asset/ghcide/archive/%s.tar.gz" % GHCIDE_REV],

--- a/bazel_tools/haskell-ghcide-binary-q.patch
+++ b/bazel_tools/haskell-ghcide-binary-q.patch
@@ -1,0 +1,20 @@
+diff --git a/src/Development/IDE/Core/Shake.hs b/src/Development/IDE/Core/Shake.hs
+index a471070..a2b3183 100644
+--- a/src/Development/IDE/Core/Shake.hs
++++ b/src/Development/IDE/Core/Shake.hs
+@@ -503,7 +503,14 @@ isBadDependency x
+ newtype Q k = Q (k, NormalizedFilePath)
+     deriving (Eq,Hashable,NFData, Generic)
+ 
+-instance Binary k => Binary (Q k)
++instance Binary k => Binary (Q k) where
++    put (Q (k, fp)) = put (k, fp)
++    get = do
++        (k, fp) <- get
++        -- The `get` implementation of NormalizedFilePath
++        -- does not handle empty file paths so we
++        -- need to handle this ourselves here.
++        pure (Q (k, toNormalizedFilePath' fp))
+ 
+ instance Show k => Show (Q k) where
+     show (Q (k, file)) = show k ++ "; " ++ fromNormalizedFilePath file

--- a/bazel_tools/haskell.bzl
+++ b/bazel_tools/haskell.bzl
@@ -53,6 +53,7 @@ common_haskell_flags = [
     "-Wincomplete-uni-patterns",
     "-Wno-name-shadowing",
     "-fno-omit-yields",
+    "-fno-ignore-asserts",
     "-threaded",
     "-rtsopts",
 

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -253,7 +253,7 @@ loadPackages :: [(LF.PackageName, Maybe LF.PackageVersion)] -> ReplClient.Handle
 loadPackages importPkgs replClient ideState = do
     -- Load packages
     Just (PackageMap pkgs) <- runAction ideState (use GeneratePackageMap "Dummy.daml")
-    Just stablePkgs <- runAction ideState (use GenerateStablePackages "Dummy.daml")
+    Just stablePkgs <- runAction ideState (useNoFile GenerateStablePackages)
     for_ (topologicalSort (toList pkgs <> toList stablePkgs)) $ \pkg -> do
         r <- ReplClient.loadPackage replClient (LF.dalfPackageBytes pkg)
         case r of

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -716,7 +716,7 @@ contextForFile file = do
     lfVersion <- getDamlLfVersion
     WhnfPackage pkg <- use_ GeneratePackage file
     PackageMap pkgMap <- use_ GeneratePackageMap file
-    stablePackages <- use_ GenerateStablePackages file
+    stablePackages <- useNoFile_ GenerateStablePackages
     encodedModules <-
         mapM (\m -> fmap (\(hash, bs) -> (hash, (LF.moduleName m, bs))) (encodeModule lfVersion m)) $
         NM.toList $ LF.packageModules pkg


### PR DESCRIPTION
GHC hates its users and defaults to optimizing out assertions. We
fixed that in Buck at some point but clearly that got lost when
migrating to Bazel.

Turns out enabling assertions catches bugs. This insight was brought to
you from the people that also brought you “Turns out writing tests
catches bugs”.

fixes #5624

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
