### PR TITLE
LF: adapt TransactionBuilder to the new version inference

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -153,7 +153,7 @@ class Context(val contextId: Context.ContextId) {
         compiledPackages,
         txSeeding,
         defn,
-        TransactionVersions.SupportedOutputDevVersions,
+        TransactionVersions.SupportedDevOutputVersions,
       )
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -610,7 +610,7 @@ private[lf] object Speedy {
         expr = expr,
         globalCids = Set.empty,
         committers = Set.empty,
-        outputTransactionVersions = TransactionVersions.SupportedOutputDevVersions,
+        outputTransactionVersions = TransactionVersions.SupportedDevOutputVersions,
       )
 
     @throws[PackageNotFound]

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -187,9 +187,9 @@ object Repl {
 
     val txVersions =
       if (devMode)
-        TransactionVersions.SupportedOutputDevVersions
+        TransactionVersions.SupportedDevOutputVersions
       else
-        TransactionVersions.SupportedOutputStableVersions
+        TransactionVersions.SupportedStableOutputVersions
 
     def run(expr: Expr): (
         Speedy.Machine,

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -57,7 +57,7 @@ class CollectAuthorityState {
       compiledPackages,
       seeding(),
       expr,
-      TransactionVersions.SupportedOutputDevVersions,
+      TransactionVersions.SupportedDevOutputVersions,
     )
     the_sexpr = machine.ctrl
 

--- a/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
+++ b/daml-lf/scenario-interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ScenarioRunnerTest.scala
@@ -22,7 +22,7 @@ class ScenarioRunnerTest extends AsyncWordSpec with Matchers with ScalaFutures {
         compiledPackages,
         txSeed,
         e,
-        TransactionVersions.SupportedOutputDevVersions,
+        TransactionVersions.SupportedDevOutputVersions,
       )
       val sr = ScenarioRunner(m, _ + "-XXX")
       sr.run() match {

--- a/daml-lf/transaction-test-lib/BUILD.bazel
+++ b/daml-lf/transaction-test-lib/BUILD.bazel
@@ -20,6 +20,7 @@ da_scala_library(
         "//daml-lf/data",
         "//daml-lf/data-scalacheck",
         "//daml-lf/interface",
+        "//daml-lf/language",
         "//daml-lf/transaction",
         "@maven//:com_chuusai_shapeless_2_12",
         "@maven//:com_google_protobuf_protobuf_java",

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -62,7 +62,7 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
         .toSeq
     val txVersion =
       VersionTimeline
-        .latestWhenAllPresent(TransactionVersions.SupportedStableVersions.min, nodesVersions: _*)
+        .latestWhenAllPresent(TransactionVersions.SupportedStableOutputVersions.min, nodesVersions: _*)
     VersionedTransaction(txVersion, GenTransaction(nodes.result(), roots.result()))
   }
 
@@ -122,7 +122,7 @@ object TransactionBuilder {
   private val KeyWithMaintainers = transaction.Node.KeyWithMaintainers
 
   def apply(): TransactionBuilder =
-    TransactionBuilder(TransactionVersions.SupportedStableVersions.min)
+    TransactionBuilder(TransactionVersions.SupportedStableOutputVersions.min)
 
   def apply(txVersion: TransactionVersion): TransactionBuilder =
     new TransactionBuilder(_ => txVersion)
@@ -131,7 +131,7 @@ object TransactionBuilder {
     def pkgTxVersion(pkgId: Ref.PackageId) = {
       import VersionTimeline.Implicits._
       VersionTimeline.latestWhenAllPresent(
-        TransactionVersions.SupportedStableVersions.min,
+        TransactionVersions.SupportedStableOutputVersions.min,
         pkgLangVersion(pkgId)
       )
     }
@@ -238,7 +238,7 @@ object TransactionBuilder {
   // not valid transactions.
   val Empty: Tx.Transaction =
     VersionedTransaction(
-      TransactionVersions.SupportedStableVersions.min,
+      TransactionVersions.SupportedStableOutputVersions.min,
       GenTransaction(HashMap.empty, ImmArray.empty),
     )
   val EmptySubmitted: SubmittedTransaction = SubmittedTransaction(Empty)

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -62,7 +62,9 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
         .toSeq
     val txVersion =
       VersionTimeline
-        .latestWhenAllPresent(TransactionVersions.SupportedStableOutputVersions.min, nodesVersions: _*)
+        .latestWhenAllPresent(
+          TransactionVersions.SupportedStableOutputVersions.min,
+          nodesVersions: _*)
     VersionedTransaction(txVersion, GenTransaction(nodes.result(), roots.result()))
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -36,14 +36,14 @@ private[lf] object TransactionVersions
   // Older versions are deprecated https://github.com/digital-asset/daml/issues/5220
   // We force output of recent version, but keep reading older version as long as
   // Sandbox is alive.
-  val SupportedOutputStableVersions =
+  val SupportedStableOutputVersions =
     VersionRange(TransactionVersion("10"), TransactionVersion("10"))
 
-  val SupportedOutputDevVersions = SupportedOutputStableVersions.copy(max = acceptedVersions.last)
+  val SupportedDevOutputVersions = SupportedStableOutputVersions.copy(max = acceptedVersions.last)
 
   def assignVersion(
       a: GenTransaction.WithTxValue[_, Value.ContractId],
-      supportedVersions: VersionRange[TransactionVersion] = SupportedOutputDevVersions,
+      supportedVersions: VersionRange[TransactionVersion] = SupportedDevOutputVersions,
   ): Either[String, TransactionVersion] = {
     require(a != null)
     import VersionTimeline.Implicits._
@@ -117,8 +117,8 @@ private[lf] object TransactionVersions
   }
 
   def asVersionedTransaction(
-      tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
-      supportedVersions: VersionRange[TransactionVersion] = SupportedOutputDevVersions,
+    tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
+    supportedVersions: VersionRange[TransactionVersion] = SupportedDevOutputVersions,
   ): Either[String, Transaction.Transaction] =
     for {
       v <- assignVersion(tx, supportedVersions)
@@ -126,8 +126,8 @@ private[lf] object TransactionVersions
 
   @throws[IllegalArgumentException]
   def assertAsVersionedTransaction(
-      tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
-      supportedVersions: VersionRange[TransactionVersion] = SupportedOutputDevVersions,
+    tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
+    supportedVersions: VersionRange[TransactionVersion] = SupportedDevOutputVersions,
   ): Transaction.Transaction =
     data.assertRight(asVersionedTransaction(tx, supportedVersions))
 
@@ -145,7 +145,7 @@ private[lf] object TransactionVersions
     val transactionVersion =
       VersionTimeline.latestWhenAllPresent(
         supportedTxVersions.min,
-        (SupportedOutputStableVersions.min: SpecifiedVersion) +: as: _*,
+        (SupportedStableOutputVersions.min: SpecifiedVersion) +: as: _*,
       )
 
     Either.cond(

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -117,8 +117,8 @@ private[lf] object TransactionVersions
   }
 
   def asVersionedTransaction(
-    tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
-    supportedVersions: VersionRange[TransactionVersion] = SupportedDevOutputVersions,
+      tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
+      supportedVersions: VersionRange[TransactionVersion] = SupportedDevOutputVersions,
   ): Either[String, Transaction.Transaction] =
     for {
       v <- assignVersion(tx, supportedVersions)
@@ -126,8 +126,8 @@ private[lf] object TransactionVersions
 
   @throws[IllegalArgumentException]
   def assertAsVersionedTransaction(
-    tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
-    supportedVersions: VersionRange[TransactionVersion] = SupportedDevOutputVersions,
+      tx: GenTransaction.WithTxValue[NodeId, Value.ContractId],
+      supportedVersions: VersionRange[TransactionVersion] = SupportedDevOutputVersions,
   ): Transaction.Transaction =
     data.assertRight(asVersionedTransaction(tx, supportedVersions))
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
@@ -21,7 +21,7 @@ class TransactionVersionSpec extends WordSpec with Matchers with TableDrivenProp
   private[this] val supportedValVersions =
     ValueVersions.SupportedDevVersions.copy(min = ValueVersion("1"))
   private[this] val supportedTxVersions =
-    TransactionVersions.SupportedOutputDevVersions.copy(min = TransactionVersion("1"))
+    TransactionVersions.SupportedDevOutputVersions.copy(min = TransactionVersion("1"))
 
   "assignVersion" should {
     "prefer picking an older version" in {

--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -119,6 +119,7 @@ da_scala_library(
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
+        "//daml-lf/language",
         "//daml-lf/transaction",
         "//daml-lf/transaction-test-lib",
         "//language-support/scala/bindings",

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
@@ -21,7 +21,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
 
   it should "preserve divulged contracts" in {
     val (create1, tx1) = {
-      val builder = new TransactionBuilder
+      val builder = TransactionBuilder()
       val contractId = builder.newCid
       builder.add(
         NodeCreate(
@@ -36,7 +36,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
       contractId -> builder.buildCommitted()
     }
     val (create2, tx2) = {
-      val builder = new TransactionBuilder
+      val builder = TransactionBuilder()
       val contractId = builder.newCid
       builder.add(
         NodeCreate(
@@ -53,7 +53,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
       contractId -> builder.buildCommitted()
     }
     val tx3 = {
-      val builder = new TransactionBuilder
+      val builder = TransactionBuilder()
       val rootExercise = builder.add(
         NodeExercises(
           targetCoid = create1,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -145,7 +145,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
 
   protected final def singleCreateP(create: ContractId => NodeCreate[ContractId, Value[ContractId]])
     : (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder()
+    val txBuilder = TransactionBuilder()
     val cid = txBuilder.newCid
     val creation = create(cid)
     val eid = txBuilder.add(creation)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -77,7 +77,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
     someAgreement
   )
   protected final val someVersionedContractInstance =
-    TransactionBuilder.version(someContractInstance)
+    TransactionBuilder().versionContract(someContractInstance)
 
   protected final val defaultConfig = v1.Configuration(
     generation = 0,
@@ -145,7 +145,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
 
   protected final def singleCreateP(create: ContractId => NodeCreate[ContractId, Value[ContractId]])
     : (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = new TransactionBuilder()
     val cid = txBuilder.newCid
     val creation = create(cid)
     val eid = txBuilder.add(creation)
@@ -172,7 +172,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       id: ContractId,
       divulgees: Set[Party],
   ): (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val exerciseId = txBuilder.add(
       NodeExercises(
         targetCoid = id,
@@ -218,7 +218,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
   protected def singleExercise(
       targetCid: ContractId,
   ): (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val nid = txBuilder.add(exercise(targetCid))
     val offset = nextOffset()
     val id = offset.toLong
@@ -239,7 +239,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
   protected def singleNonConsumingExercise(
       targetCid: ContractId,
   ): (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val nid = txBuilder.add(exercise(targetCid).copy(consuming = false))
     val offset = nextOffset()
     val id = offset.toLong
@@ -260,7 +260,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
   protected def exerciseWithChild(
       targetCid: ContractId,
   ): (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val exerciseId = txBuilder.add(exercise(targetCid))
     val childId = txBuilder.add(create(txBuilder.newCid), exerciseId)
     val tx = CommittedTransaction(txBuilder.build())
@@ -282,7 +282,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
   }
 
   protected def fullyTransient: (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val cid = txBuilder.newCid
     val createId = txBuilder.add(create(cid))
     val exerciseId = txBuilder.add(exercise(cid))
@@ -306,7 +306,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
   // The transient contract is divulged to `charlie` as a non-stakeholder actor on the
   // root exercise node that causes the creation of a transient contract
   protected def fullyTransientWithChildren: (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val root = txBuilder.newCid
     val transient = txBuilder.newCid
     val rootCreateId = txBuilder.add(create(root))
@@ -347,7 +347,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
     *
     */
   protected def partiallyVisible: (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val createId = txBuilder.add(
       create(txBuilder.newCid).copy(
         signatories = Set(charlie),
@@ -400,7 +400,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       signatoriesAndTemplates: Seq[(String, String)],
   ): (Offset, LedgerEntry.Transaction) = {
     require(signatoriesAndTemplates.nonEmpty, "multipleCreates cannot create empty transactions")
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val disclosure = for {
       entry <- signatoriesAndTemplates
       (signatory, template) = entry
@@ -475,7 +475,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       party: Party,
       key: String,
   ): (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val createNodeId = txBuilder.add(
       NodeCreate(
         coid = txBuilder.newCid,
@@ -505,7 +505,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       contract: (ContractId, Option[String]),
   ): (Offset, LedgerEntry.Transaction) = {
     val (contractId, maybeKey) = contract
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val archiveNodeId = txBuilder.add(
       NodeExercises(
         targetCoid = contractId,
@@ -541,7 +541,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       key: String,
       result: Option[ContractId],
   ): (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val lookupByKeyNodeId = txBuilder.add(
       NodeLookupByKey(
         someTemplateId,
@@ -566,7 +566,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       party: Party,
       contractId: ContractId,
   ): (Offset, LedgerEntry.Transaction) = {
-    val txBuilder = new TransactionBuilder
+    val txBuilder = TransactionBuilder()
     val fetchNodeId = txBuilder.add(
       NodeFetch(
         coid = contractId,

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
@@ -7,6 +7,7 @@ import java.sql.Connection
 import java.time.Instant
 import java.util.UUID
 
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
 import org.scalatest.{Matchers, WordSpec}
 
@@ -213,7 +214,7 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
             id = committedContract.coid.coid,
             ledgerEffectiveTime = committedContractLedgerEffectiveTime,
             key = committedContract.key.map(x =>
-              convert(committedContract.coinst.template, TxBuilder.version(x)))
+              GlobalKey.assertBuild(committedContract.coinst.template, x.key))
           )
         )
       )

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -69,7 +69,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
     }
 
     "yield two projection roots for single root transaction with two parties" in {
-      val builder = new TransactionBuilder
+      val builder = TransactionBuilder()
       val nid = builder.add(
         makeCreateNode(
           builder.newCid,
@@ -85,7 +85,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
     }
 
     "yield proper projection roots in complex transaction" in {
-      val builder = new TransactionBuilder
+      val builder = TransactionBuilder()
 
       // Alice creates an "offer contract" to Bob as part of her workflow.
       // Alice sees both the exercise and the create, and Bob only

--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -72,6 +72,7 @@ da_scala_benchmark_jmh(
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
         "//daml-lf/engine",
+        "//daml-lf/interpreter",
         "//daml-lf/language",
         "//daml-lf/transaction",
         "//daml-lf/transaction:transaction_java_proto",

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Adapter.scala
@@ -4,18 +4,20 @@
 package com.daml.ledger.participant.state.kvutils.test
 
 import com.daml.lf.data._
-import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{Transaction => Tx, GlobalKey, Node, NodeId, SubmittedTransaction}
+import com.daml.lf.language.{Ast, LanguageVersion}
+import com.daml.lf.transaction.{GlobalKey, Node, NodeId, SubmittedTransaction, Transaction => Tx}
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 
 import scala.collection.mutable
 
-private[test] final class Adapter(packages: Map[Ref.PackageId, Ast.Package]) {
+private[test] final class Adapter(
+    packages: Map[Ref.PackageId, Ast.Package],
+    pkgLangVersion: Ref.PackageId => LanguageVersion) {
 
   def adapt(tx: Tx.Transaction): SubmittedTransaction =
-    tx.foldWithPathState(new TxBuilder, Option.empty[NodeId])(
+    tx.foldWithPathState(TxBuilder(pkgLangVersion), Option.empty[NodeId])(
         (builder, parent, _, node) =>
           (builder, Some(parent.fold(builder.add(adapt(node)))(builder.add(adapt(node), _))))
       )


### PR DESCRIPTION
This PR changes `TransactionBuilder` according the new version inference
algorithm implemented in #6756

This advances the state of #5164.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
