### PR TITLE
better release triggers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -373,7 +373,7 @@ jobs:
       - checkout: self
         persistCredentials: true
       - bash: |
-          set -euxo pipefail
+          set -euo pipefail
           if git tag v$(release_tag) $(release_sha); then
             git push origin v$(release_tag)
             mkdir $(Build.StagingDirectory)/release
@@ -478,6 +478,17 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
         condition: not(eq(variables['skip-github'], 'TRUE'))
+      - bash: |
+          set -euo pipefail
+          eval "$(dev-env/bin/dade-assist)"
+
+          curl -XPOST \
+               -i \
+               -H 'Content-Type: application/json' \
+               --data "{\"text\":\"Release \`$(release_tag)\` is ready for testing. (<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|build>, <https://github.com/digital-asset/daml/commit/$(trigger_sha)|trigger commit>, <https://github.com/digital-asset/daml/commit/$(release_sha)|target commit>)\"}" \
+               $(Slack.team-daml)
+          }
+
       - template: ci/tell-slack-failed.yml
         parameters:
           trigger_sha: '$(trigger_sha)'
@@ -536,7 +547,7 @@ jobs:
         git -c user.name="Azure Pipelines DAML Build" \
             -c user.email="support@digitalasset.com" \
             commit \
-            -m "$(printf "update compat versions for $(release_tag)\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n"))"
+            -m "$(printf "update compat versions for $(release_tag)\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n")"
         git push origin $BRANCH:$BRANCH
         curl -H "Content-Type: application/json" \
              -u $AUTH \
@@ -777,6 +788,7 @@ jobs:
     dependsOn:
       - git_sha
       - collect_build_data
+      - check_for_release
     pool:
       name: 'linux-pool'
       demands: assignment -equals default
@@ -784,6 +796,7 @@ jobs:
       pr.num: $[ variables['System.PullRequest.PullRequestNumber'] ]
       branch_sha: $[ dependencies.git_sha.outputs['out.branch'] ]
       status: $[ dependencies.collect_build_data.result ]
+      is_release: $[ dependencies.check_for_release.outputs['out.is_release'] ]
     steps:
       - bash: |
           set -euo pipefail
@@ -797,6 +810,22 @@ jobs:
                    --data "{\"text\":\"<@${USER_ID}> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for <https://github.com/digital-asset/daml/pull/$(pr.num)|PR $(pr.num)> has completed with status ${MESSAGE}.\"}" \
                    $(Slack.team-daml-ci)
           }
+
+          tell_daml() {
+              local message
+              message=$1
+              curl -XPOST \
+                   -i \
+                   -H 'Content-Type: application/json' \
+                   --data "{\"text\":\"<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for release PR <https://github.com/digital-asset/daml/pull/$(pr.num)|#$(pr.num)> has completed with status ${message}.\"}" \
+                   $(Slack.team-daml)
+          }
+
+          if [ "$(is_release)" == "true" ]; then
+              # releases matter to everyone
+              tell_daml "$(status)"
+              exit 0
+          fi
 
           EMAIL=$(git log -n 1 --format=%ae $(branch_sha))
           user_registered() {

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -1,0 +1,48 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+pr: none
+trigger: none
+
+schedules:
+- cron: "0 6 * * Wed"
+  displayName: weekly snapshot
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- job: open_release_pr
+  timeoutInMinutes: 60
+  pool:
+    name: linux-pool
+    demands: assignment -equals default
+  steps:
+  - checkout: self
+    persistCredentials: true
+  - bash: ci/dev-env-install.sh
+  - bash: |
+      set -euo pipefail
+      eval "$(./dev-env/bin/dade-assist)"
+
+      AUTH="$(git config remote.origin.url | grep -o "://.*:.*@" | cut -c4- | rev | cut -c2- | rev)"
+
+      BRANCH=auto-release-pr-$(date -I)
+      git branch -D $BRANCH || true
+      git checkout -b $BRANCH
+      ./release.sh new snapshot
+      git add LATEST
+      RELEASE=$(head -1 LATEST | awk '{print $2}')
+      git -c user.name="Azure Pipelines DAML Build" \
+          -c user.email="support@digitalasset.com" \
+          commit \
+          -m "$(printf "release $RELEASE\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n")"
+      git push origin $BRANCH:$BRANCH
+      curl -H "Content-Type: application/json" \
+           -u $AUTH \
+           --silent \
+           --include \
+           --location \
+           -d "{\"title\": \"release $RELEASE\", \"head\": \"$BRANCH\", \"base\": \"master\", \"body\": \"This PR has been created by a script, which is not very smart and does not have all the context. Please do double-check that the version prefix is correct before merging.\"}" \
+           https://api.github.com/repos/digital-asset/daml/pulls


### PR DESCRIPTION
Based on feedback from @nickchapman-da, this PR aims at making the release process easier by:

- Automatically opening a release PR on Wednesday morning. The goal here is that by the time we start working, there is a release already built, so we save about an hour on waiting for that. This obviously doesn't help with ad-hoc releases.
- On a release PR build, posting to Slack when the release is ready to merge.
- On a release master build, posting to Slack when a release is ready to be tested.

My hope is that this makes the release process less tedious. This is not trying to address the actual release testing, but hopefully should reduce the annoyance of having to constantly go and check if the release is ready.

CHANGELOG_BEGIN
CHANGELOG_END