### PR TITLE
DAML REPL :module command

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -74,6 +74,7 @@ import Type (splitTyConApp)
 data Error
     = ParseError MsgDoc
     | UnsupportedStatement String -- ^ E.g., pattern on the LHS
+    | UnknownModules [ModuleName]
     | TypeError -- ^ The actual error will be in the diagnostics
     | ScriptError ReplClient.BackendError
 
@@ -83,6 +84,8 @@ renderError dflags err = case err of
         putStrLn (showSDoc dflags err)
     (UnsupportedStatement str) ->
         putStrLn ("Unsupported statement: " <> str)
+    (UnknownModules names) ->
+        putStrLn ("Unknown modules: " <> intercalate ", " (map moduleNameString names))
     TypeError ->
         -- The error will be displayed via diagnostics.
         pure ()
@@ -325,8 +328,8 @@ runRepl importPkgs opts replClient logger ideState = do
           where
             banner = pure "daml> "
             command = replLine
-            options = []
-            prefix = Nothing
+            options = replOptions
+            prefix = Just ':'
             tabComplete = Repl.Cursor $ \_ _ -> pure []
             initialiser = pure ()
     State.evalStateT replM initReplState
@@ -393,17 +396,7 @@ runRepl importPkgs opts replClient logger ideState = do
         :: DynFlags
         -> ImportDecl GhcPs
         -> ExceptT Error ReplM ()
-    handleImport dflags imp = do
-        ReplState {imports, lineNumber} <- State.get
-        -- TODO[AH] Deduplicate imports.
-        let newImports = imp : imports
-        -- TODO[AH] Factor out the module render and typecheck step.
-        liftIO $ setBufferModified ideState (lineFilePath lineNumber)
-            $ Just $ T.pack (unlines $ moduleHeader dflags newImports lineNumber)
-        _ <- maybe (throwError TypeError) pure =<< liftIO (runAction ideState $ runMaybeT $
-            (,) <$> useE GenerateDalf (lineFilePath lineNumber)
-                <*> useE TypeCheck (lineFilePath lineNumber))
-        State.modify $ \s -> s { imports = newImports }
+    handleImport dflags imp = addImports dflags [imp]
     replLine :: String -> ReplM ()
     replLine line = do
         ReplState {lineNumber} <- State.get
@@ -418,6 +411,64 @@ runRepl importPkgs opts replClient logger ideState = do
         case r of
             Left err -> liftIO $ renderError dflags err
             Right () -> pure ()
+
+    mkReplOption
+        :: (DynFlags -> [String] -> ExceptT Error ReplM ())
+        -> [String] -> ReplM ()
+    mkReplOption option args = do
+        ReplState {lineNumber} <- State.get
+        dflags <- liftIO $
+            hsc_dflags . hscEnv <$>
+            runAction ideState (use_ GhcSession $ lineFilePath lineNumber)
+        r <- runExceptT $ option dflags args
+        case r of
+            Left err -> liftIO $ renderError dflags err
+            Right () -> pure ()
+    replOptions :: [(String, [String] -> ReplM ())]
+    replOptions =
+      [ ("help", mkReplOption optHelp)
+      , ("module", mkReplOption optModule)
+      ]
+    optHelp _dflags _args = liftIO $ T.putStrLn $ T.unlines
+      [ " Commands available from the prompt:"
+      , ""
+      , "   <statement>                 evaluate/run <statement>"
+      , "   :module [+/-] <mod> ...     add or remove the modules from the import list"
+      ]
+    optModule _dflags ("-" : modules) = do
+        ReplState {imports} <- lift State.get
+        -- TODO[AH] Use a more appropriate data structure to track imports.
+        let unknown =
+              [ removed
+              | removed <- map mkModuleName modules
+              , removed `notElem` map (unLoc . ideclName) imports
+              ]
+            newImports =
+              [ simpleImportDecl imported
+              | imported <- map (unLoc . ideclName) imports
+              , imported `notElem` map mkModuleName modules
+              ]
+        unless (null unknown) $
+            throwError $ UnknownModules unknown
+        lift $ State.modify $ \s -> s { imports = newImports }
+    optModule dflags ("+" : modules) = do
+        let imports = map (simpleImportDecl . mkModuleName) modules
+        addImports dflags imports
+    optModule dflags modules = do
+        let imports = map (simpleImportDecl . mkModuleName) modules
+        addImports dflags imports
+
+    addImports
+        :: DynFlags
+        -> [ImportDecl GhcPs]
+        -> ExceptT Error ReplM ()
+    addImports dflags additional = do
+        ReplState {imports, lineNumber} <- State.get
+        -- TODO[AH] Deduplicate imports.
+        let newImports = additional ++ imports
+        _ <- printDelayedDiagnostics $ tryTypecheck lineNumber $
+            T.pack (unlines $ moduleHeader dflags newImports lineNumber)
+        State.modify $ \s -> s { imports = newImports }
 
 exprTy :: LHsBinds GhcTc -> Maybe Type
 exprTy binds = listToMaybe

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -74,7 +74,7 @@ import Type (splitTyConApp)
 data Error
     = ParseError MsgDoc
     | UnsupportedStatement String -- ^ E.g., pattern on the LHS
-    | UnknownModules [ModuleName]
+    | NotImportedModules [ModuleName]
     | TypeError -- ^ The actual error will be in the diagnostics
     | ScriptError ReplClient.BackendError
 
@@ -84,8 +84,8 @@ renderError dflags err = case err of
         putStrLn (showSDoc dflags err)
     (UnsupportedStatement str) ->
         putStrLn ("Unsupported statement: " <> str)
-    (UnknownModules names) ->
-        putStrLn ("Unknown modules: " <> intercalate ", " (map moduleNameString names))
+    (NotImportedModules names) ->
+        putStrLn ("Not imported, cannot remove: " <> intercalate ", " (map moduleNameString names))
     TypeError ->
         -- The error will be displayed via diagnostics.
         pure ()
@@ -449,7 +449,7 @@ runRepl importPkgs opts replClient logger ideState = do
               , imported `notElem` map mkModuleName modules
               ]
         unless (null unknown) $
-            throwError $ UnknownModules unknown
+            throwError $ NotImportedModules unknown
         lift $ State.modify $ \s -> s { imports = newImports }
     optModule dflags ("+" : modules) = do
         let imports = map (simpleImportDecl . mkModuleName) modules

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -214,6 +214,18 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , input "debug (days 1)"
           , matchServiceOutput "^.*: RelTime {microseconds = 86400000000}$"
           ]
+    , testInteraction' ":module"
+          [ input ":module + DA.Time DA.Assert"
+          , input "assertEq (days 1) (days 1)"
+          , input ":module - DA.Time"
+          , input "assertEq (days 1) (days 1)"
+          , matchOutput "^File:.*$"
+          , matchOutput "^Hidden:.*$"
+          , matchOutput "^Range:.*$"
+          , matchOutput "^Source:.*$"
+          , matchOutput "^Severity:.*$"
+          , matchOutput "^Message:.*error: Variable not in scope: days.*$"
+          ]
     , testInteraction' "error call"
           [ input "error \"foobar\""
           , matchServiceOutput "^Error: User abort: foobar$"

--- a/docs/source/daml-repl/index.rst
+++ b/docs/source/daml-repl/index.rst
@@ -132,9 +132,8 @@ In the prompt, all modules from DALFs specified in ``--import`` are
 imported automatically. In addition to that, the ``DAML.Script``
 module is also imported and gives you access to the DAML Script API.
 
-You can use the commands ``:module +`` and ``:module -`` to control which
-modules are imported. You can also use import declarations at the prompt to
-import additional modules.
+```suggestion
+You can use the commands ``:module + ModA ModB …`` to import additional modules and ``:module - ModA ModB …`` to remove previously added imports. Modules can also be imported using regular import declarations instead of ``module +``.
 
 .. code-block:: none
 

--- a/docs/source/daml-repl/index.rst
+++ b/docs/source/daml-repl/index.rst
@@ -76,6 +76,9 @@ two forms:
    and ``y`` is a pure expression or ``let f x = y`` to define a function.
    The bound variables can be used on subsequent lines.
 
+5. Next to DAML code the REPL also understands REPL commands which are prefixed
+   by ``:``. Enter ``:help`` to see a list of supported REPL commands.
+
 First create two parties: A party with the display name ``"Alice"``
 and the party id ``"alice"`` and a party with the display name
 ``"Bob"`` and the party id ``"bob"``.
@@ -129,7 +132,9 @@ In the prompt, all modules from DALFs specified in ``--import`` are
 imported automatically. In addition to that, the ``DAML.Script``
 module is also imported and gives you access to the DAML Script API.
 
-You can use import declarations at the prompt to import additional modules.
+You can use the commands ``:module +`` and ``:module -`` to control which
+modules are imported. You can also use import declarations at the prompt to
+import additional modules.
 
 .. code-block:: none
 


### PR DESCRIPTION
Adds commands `:help` and `:module` to DAML REPL.
Adds a REPL functest for the `:module` command

Module imports are currently tracked as a list of `ImportDecl`. That's not very efficient for deletion and doesn't deduplicate imports. Improving this is deferred to a separate PR as it's not immediately to this feature.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
