### PR TITLE
Evaluation order specification and tests for exercise and other updates.

### DIFF
--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -50,12 +50,23 @@
 -- @ERROR Aborted: EvUpdCreateErr4_2 OK
 -- @ERROR Aborted: EvUpdCreateWithKeyErr1 OK
 -- @ERROR Aborted: EvUpdCreateWithKeyErr2 OK
+-- @ERROR Aborted: controllerCanAddsObserver OK
+-- @ERROR Aborted: choiceControllerDoesntAddObserver OK
+-- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrder:T_DoubleArchive)
+-- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrder:T_EvUpdExercConsumErr)
+-- @ERROR EvUpdExercNonConsumErr OK
+-- @ERROR EvUpdExercWithoutActorsErr_1 OK
+-- @ERROR EvUpdExercWithoutActorsErr_2 OK
+-- @ERROR exercise of C_BadActorCheck_1
+-- @ERROR Aborted: BadActorCheck_2 OK
+-- @ERROR Aborted: EvUpdFetchByKeyErr OK
+-- @ERROR Aborted: EvUpdLookupByKeyErr OK
 module SemanticsEvalOrder where
 
 evTyAbsErasableErr = scenario do
-    let x : forall a. a
-        x = error "EvTyAbsErasableErr OK"
-    error "EvTyAbsErasable failed"
+  let x : forall a. a
+      x = error "EvTyAbsErasableErr OK"
+  error "EvTyAbsErasable failed"
 
 overApply = scenario do
   let f x = error "overApply OK"
@@ -366,3 +377,200 @@ evUpdCreateWithKeyErr2 = scenario do
   submit p do
     create (T_EvUpdCreateWithKeyErr2 p)
     error "EvUpdCreateWithKeyErr2 failed"
+
+-- | `controller P can ...` syntax adds `P` to the observers,
+-- so if `P` causes an error, this is triggered on create,
+-- instead of on exercise.
+template T_ControllerCanAddsObserver
+  with
+    p : Party
+  where
+    signatory p
+    controller (error @Party "controllerCanAddsObserver OK") can
+      C_ControllerCanAddsObserver: ()
+        do pure ()
+
+controllerCanAddsObserver = scenario do
+  p <- getParty "Alice"
+  submit p do
+    create (T_ControllerCanAddsObserver p)
+    error "controllerCanAddsObserver failed"
+
+-- | `choice ... controller P ...` doesn't add `P` as observer.
+-- This test is here to contrast with the previous.
+template T_ChoiceControllerDoesntAddObserver
+  with
+    p : Party
+  where
+    signatory p
+    choice CY : ()
+      controller (error @Party "choiceControllerDoesntAddObserver failed")
+        do pure ()
+
+choiceControllerDoesntAddObserver = scenario do
+  p <- getParty "Alice"
+  submit p do
+    create (T_ChoiceControllerDoesntAddObserver p)
+    error "choiceControllerDoesntAddObserver OK"
+
+-- | Verify that contract inactivity is checked before interpreting
+-- the rest of the update.
+template T_DoubleArchive
+  with
+    p : Party
+  where
+    signatory p
+
+doubleArchive = scenario do
+  p <- getParty "Alice"
+  submit p do
+    c <- create (T_DoubleArchive p)
+    archive c
+    archive c
+    abort "doubleArchive failed"
+
+-- | Verify that a consuming choice's update is interpreted with a
+-- ledger state where the template has already been consumed.
+template T_EvUpdExercConsumErr
+  with
+    p : Party
+  where
+    signatory p
+    choice C_EvUpdExercConsumErr : ()
+      controller p
+        do
+          archive self
+          error "EvUpdExercConsumErr failed (1)"
+
+evUpdExercConsumErr = scenario do
+  p <- getParty "Alice"
+  submit p do
+    c <- create (T_EvUpdExercConsumErr p)
+    exercise c C_EvUpdExercConsumErr
+    abort "EvUpdExercConsumErr failed (2)"
+
+-- | Verify that a nonconsuming choice's update is interpreted with
+-- the original ledger state (template hasn't been consumed).
+template T_EvUpdExercNonConsumErr
+  with
+    p : Party
+  where
+    signatory p
+    nonconsuming choice C_EvUpdExercNonConsumErr : ()
+      controller p
+        do
+          archive self
+          error "EvUpdExercNonConsumErr OK"
+
+evUpdExercNonConsumErr = scenario do
+  p <- getParty "Alice"
+  submit p do
+    c <- create (T_EvUpdExercNonConsumErr p)
+    exercise c C_EvUpdExercNonConsumErr
+    abort "EvUpdExercNonConsumErr failed"
+
+-- | Verify that the exercising party is evaluated
+-- when the exercise is performed, not after.
+template T_EvUpdExercWithoutActorsErr_1
+  with
+    p : Party
+  where
+    signatory p
+    choice C_EvUpdExercWithoutActorsErr_1 : () with
+      controller (error @Party "EvUpdExercWithoutActorsErr_1 OK")
+        do abort "EvUpdExercWithoutActorsErr_1 failed (1)"
+
+evUpdExercWithoutActorsErr_1 = scenario do
+  p <- getParty "Alice"
+  submit p do
+    c <- create (T_EvUpdExercWithoutActorsErr_1 p)
+    exercise c C_EvUpdExercWithoutActorsErr_1
+    abort "EvUpdExercWithoutActorsErr_1 failed (2)"
+
+-- | Show that the exercising party is evaluated before
+-- we check that the contract is still active.
+template T_EvUpdExercWithoutActorsErr_2
+  with
+    p : Party
+  where
+    signatory p
+    choice C_EvUpdExercWithoutActorsErr_2 : () with
+      controller (error @Party "EvUpdExercWithoutActorsErr_2 OK")
+        do abort "EvUpdExercWithoutActorsErr_2 failed (1)"
+
+evUpdExercWithoutActorsErr_2 = scenario do
+  p <- getParty "Alice"
+  submit p do
+    c <- create (T_EvUpdExercWithoutActorsErr_2 p)
+    archive c
+    exercise c C_EvUpdExercWithoutActorsErr_2
+    abort "EvUpdExercWithoutActorsErr_2 failed (2)"
+
+-- | Checks that an authorization / bad actor check occurs
+-- at some point during submission.
+template T_BadActorCheck_1
+  with
+    p1 : Party
+    p2 : Party
+  where
+    signatory p1
+    controller p2 can
+      C_BadActorCheck_1 : ()
+        do pure ()
+
+badActorCheck_1 = scenario do
+  p1 <- getParty "Alice"
+  p2 <- getParty "Bob"
+  submit p1 do
+    c <- create (T_BadActorCheck_1 p1 p2)
+    exercise c C_BadActorCheck_1
+  error "BadActorCheck_1 failed"
+
+-- | Checks that the bad actor does not occur before running the update,
+-- for an 'exercise_without_actor', since the exercis actor is always
+-- "correct" with respect to the choic, but there is no authorization.
+template T_BadActorCheck_2
+  with
+    p1 : Party
+    p2 : Party
+  where
+    signatory p1
+    controller p2 can
+      C_BadActorCheck_2 : ()
+        do error "BadActorCheck_2 OK"
+
+badActorCheck_2 = scenario do
+  p1 <- getParty "Alice"
+  p2 <- getParty "Bob"
+  submit p1 do
+    c <- create (T_BadActorCheck_2 p1 p2)
+    exercise c C_BadActorCheck_2
+  error "BadActorCheck_2 failed"
+
+template T_EvUpdFetchByKeyErr
+  with
+    p : Party
+  where
+    signatory p
+    key () : ()
+    maintainer (error @Party "EvUpdFetchByKeyErr OK")
+
+evUpdFetchByKeyErr = scenario do
+  p <- getParty "Alice"
+  submit p do
+    fetchByKey @T_EvUpdFetchByKeyErr ()
+    abort "EvUpdFetchByKeyErr failed"
+
+template T_EvUpdLookupByKeyErr
+  with
+    p : Party
+  where
+    signatory p
+    key () : ()
+    maintainer (error @Party "EvUpdLookupByKeyErr OK")
+
+evUpdLookupByKeyErr = scenario do
+  p <- getParty "Alice"
+  submit p do
+    fetchByKey @T_EvUpdLookupByKeyErr ()
+    abort "EvUpdLookupByKeyErr failed"

--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -53,7 +53,8 @@
 -- @ERROR Aborted: controllerCanAddsObserver OK
 -- @ERROR Aborted: choiceControllerDoesntAddObserver OK
 -- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrder:T_DoubleArchive)
--- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrder:T_EvUpdExercConsumErr)
+-- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrder:T_EvUpdExercConsumErr_1)
+-- @ERROR Attempt to exercise a contract that was consumed in same transaction. Contract: #0:0 (SemanticsEvalOrder:T_EvUpdExercConsumErr_2)
 -- @ERROR EvUpdExercNonConsumErr OK
 -- @ERROR EvUpdExercWithoutActorsErr_1 OK
 -- @ERROR EvUpdExercWithoutActorsErr_2 OK
@@ -431,23 +432,43 @@ doubleArchive = scenario do
 
 -- | Verify that a consuming choice's update is interpreted with a
 -- ledger state where the template has already been consumed.
-template T_EvUpdExercConsumErr
+template T_EvUpdExercConsumErr_1
   with
     p : Party
   where
     signatory p
-    choice C_EvUpdExercConsumErr : ()
+    choice C_EvUpdExercConsumErr_1 : ()
       controller p
         do
           archive self
-          error "EvUpdExercConsumErr failed (1)"
+          error "EvUpdExercConsumErr_1 failed (1)"
 
-evUpdExercConsumErr = scenario do
+evUpdExercConsumErr_1 = scenario do
   p <- getParty "Alice"
   submit p do
-    c <- create (T_EvUpdExercConsumErr p)
-    exercise c C_EvUpdExercConsumErr
-    abort "EvUpdExercConsumErr failed (2)"
+    c <- create (T_EvUpdExercConsumErr_1 p)
+    exercise c C_EvUpdExercConsumErr_1
+    abort "EvUpdExercConsumErr_1 failed (2)"
+
+
+-- | Similar to `T_EvUpdExercConsumErr_1` but using fetch instead of archive.
+template T_EvUpdExercConsumErr_2
+  with
+    p : Party
+  where
+    signatory p
+    choice C_EvUpdExercConsumErr_2 : ()
+      controller p
+        do
+          fetch self
+          error "EvUpdExercConsumErr_2 failed (1)"
+
+evUpdExercConsumErr_2 = scenario do
+  p <- getParty "Alice"
+  submit p do
+    c <- create (T_EvUpdExercConsumErr_2 p)
+    exercise c C_EvUpdExercConsumErr_2
+    abort "EvUpdExercConsumErr_2 failed (2)"
 
 -- | Verify that a nonconsuming choice's update is interpreted with
 -- the original ledger state (template hasn't been consumed).

--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -527,8 +527,8 @@ badActorCheck_1 = scenario do
   error "BadActorCheck_1 failed"
 
 -- | Checks that the bad actor does not occur before running the update,
--- for an 'exercise_without_actor', since the exercis actor is always
--- "correct" with respect to the choic, but there is no authorization.
+-- for an 'exercise_without_actor', since the exercise actor is always
+-- "correct" with respect to the choice, but there is no authorization.
 template T_BadActorCheck_2
   with
     p1 : Party

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2673,12 +2673,67 @@ as described by the ledger model::
      Ok (cid, tr) ‖ (st₁, keys₁)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+     cid ∈ dom(st₀)
+     st₀(cid) = (Mod:T, vₜ, 'inactive')
+   —————————————————————————————————————————————————————————————————————— EvUpdExercInactive
+     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀; keys₀)
+       ⇓ᵤ
+     Err "Exercise on inactive contract"
+
+     'tpl' (x : T)
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
-     eₚ[y ↦ v₂, x ↦ vₜ]  ⇓  Ok vₚ
+     eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Err t
+   —————————————————————————————————————————————————————————————————————— EvUpdExercErr1
+     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)  ⇓ᵤ  Err t
+
+     'tpl' (x : T)
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+     cid ∈ dom(st₀)
+     st₀(cid) = (Mod:T, vₜ, 'active')
+     eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
+     v₁ ≠ₛ vₚ
+   —————————————————————————————————————————————————————————————————————— EvUpdExercBadActors
+     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st; keys)
+       ⇓ᵤ
+     Err "Exercise actors do not match"
+
+     'tpl' (x : T)
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+     cid ∈ dom(st₀)
+     st₀(cid) = (Mod:T, vₜ, 'active')
+     eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
      v₁ =ₛ vₚ
-     eₐ[y ↦ cid, z ↦ v₂, x ↦ vₜ]  ⇓  Ok uₐ
+     eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Err t
+   —————————————————————————————————————————————————————————————————————— EvUpdExercErr2
+     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)
+       ⇓ᵤ
+     Err t
+
+     'tpl' (x : T)
+         ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+     cid ∈ dom(st₀)
+     st₀(cid) = (Mod:T, vₜ, 'active')
+     eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
+     v₁ =ₛ vₚ
+     eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Ok uₐ
+     keys₁ = keys₀ - keys₀⁻¹(cid)
+     st₁ = st₀[cid ↦ (Mod:T, vₜ, 'inactive')]
+     uₐ ‖ (st₁, keys₁)  ⇓ᵤ  Err t
+   —————————————————————————————————————————————————————————————————————— EvUpdExercConsumErr
+     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)
+       ⇓ᵤ
+     Err t
+
+     'tpl' (x : T)
+         ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+     cid ∈ dom(st₀)
+     st₀(cid) = (Mod:T, vₜ, 'active')
+     eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
+     v₁ =ₛ vₚ
+     eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Ok uₐ
      keys₁ = keys₀ - keys₀⁻¹(cid)
      st₁ = st₀[cid ↦ (Mod:T, vₜ, 'inactive')]
      uₐ ‖ (st₁, keys₁)  ⇓ᵤ  Ok (vₐ, trₐ) ‖ (st₂, keys₂)
@@ -2688,12 +2743,25 @@ as described by the ledger model::
      Ok (vₐ, 'exercise' v₁ (cid, Mod:T, vₜ) 'consuming' trₐ) ‖ (st₂, keys₂)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' 'non-consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' 'non-consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
-     eₚ[z ↦ v₂, x ↦ vₜ]  ⇓  Ok vₚ
+     eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
      v₁ =ₛ vₚ
-     eₐ[y ↦ cid, z ↦ v₂, x ↦ vₜ]  ⇓  Ok uₐ
+     eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Ok uₐ
+     uₐ ‖ (st₀; keys₀)  ⇓ᵤ  Err t
+   —————————————————————————————————————————————————————————————————————— EvUpdExercNonConsumErr
+     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)
+       ⇓ᵤ
+     Err t
+
+     'tpl' (x : T)
+         ↦ { 'choices' { …, 'choice' 'non-consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+     cid ∈ dom(st₀)
+     st₀(cid) = (Mod:T, vₜ, 'active')
+     eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
+     v₁ =ₛ vₚ
+     eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Ok uₐ
      uₐ ‖ (st₀; keys₀)  ⇓ᵤ  Ok (vₐ, trₐ) ‖ (st₁, keys₁)
    —————————————————————————————————————————————————————————————————————— EvUpdExercNonConsum
      'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)
@@ -2701,35 +2769,29 @@ as described by the ledger model::
      Ok (vₐ, 'exercise' v₁ (cid, Mod:T, vₜ) 'non-consuming' trₐ) ‖ (st₁, keys₁)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (z : 'ContractId' Mod:T) (y : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
-     cid ∈ dom(st₀)
-     st₀(cid) = (Mod:T, vₜ, 'inactive')
-   —————————————————————————————————————————————————————————————————————— EvUpdExercInactive
-     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀; keys₀)
-       ⇓ᵤ
-     Err "Exercise on inactive contract" ‖ (st₀; keys₀)
-
-     'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (z : 'ContractId' Mod:T) (y : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
-     eₚ[x ↦ vₜ]  ⇓  Ok vₚ
-     v₁ ≠ₛ vₚ
-   —————————————————————————————————————————————————————————————————————— EvUpdExercBadActors
-     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st; keys)
-       ⇓ᵤ
-     Err "Exercise actors do not match"  ‖ (st; keys)
+     eₚ[x ↦ vₜ, z ↦ v₁]  ⇓  Err t
+   —————————————————————————————————————————————————————————————————————— EvUpdExercWithoutActorsErr
+     'exercise_without_actors' Mod:T.Ch cid v₁ ‖ (st₀, keys₀)  ⇓ᵤ  Err t
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (z : 'ContractId' Mod:T) (y : τ) : σ  'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
-     eₚ[y ↦ cid, z ↦ v₂, x ↦ vₜ]  ⇓  Ok vₚ
-     'exercise' Mod:T.Ch cid vₚ v₁ ‖ (st₀, keys₀)  ⇓ᵤ  ur ‖ (st₁, keys₁)
+     eₚ[x ↦ vₜ, z ↦ v₁]  ⇓  Ok vₚ
+     'exercise' Mod:T.Ch cid vₚ v₁ ‖ (st₀, keys₀)  ⇓ᵤ  ur
    —————————————————————————————————————————————————————————————————————— EvUpdExercWithoutActors
-     'exercise_without_actors' Mod:T.Ch cid v₁ ‖ (st₀, keys₀)
+     'exercise_without_actors' Mod:T.Ch cid v₁ ‖ (st₀, keys₀)  ⇓ᵤ  ur
+
+     'tpl' (x : T) ↦ …  ∈  〚Ξ〛Mod
+     cid ∈ dom(st)
+     st(cid) = (Mod:T, vₜ, 'inactive')
+   —————————————————————————————————————————————————————————————————————— EvUpdFetchInactive
+     'fetch' @Mod:T cid ‖ (st; keys)
        ⇓ᵤ
-     ur ‖ (st₁, keys₁)
+     Err "Exercise on inactive contract"
 
      'tpl' (x : T) ↦ …  ∈  〚Ξ〛Mod
      cid ∈ dom(st)
@@ -2739,57 +2801,61 @@ as described by the ledger model::
        ⇓ᵤ
      Ok (vₜ, ε) ‖ (st; keys)
 
-      e  ⇓  Ok vₖ
-      (Mod:T, vₖ) ∈ dom(keys₀)      cid = keys((Mod:T, v))
-      st(cid) = (Mod:T, vₜ, 'active')
+     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈ 〚Ξ〛Mod
+     (eₘ vₖ)  ⇓  Err t
+     (Mod:T, vₖ) ∉ dom(keys₀)
+    —————————————————————————————————————————————————————————————————————— EvUpdFetchByKeyErr
+     'fetch_by_key' @Mod:T vₖ ‖ (st; keys)  ⇓ᵤ  Err t
+
+     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
+     (eₘ vₖ)  ⇓  Ok  vₘ
+     (Mod:T, vₖ) ∉ dom(keys₀)
+    —————————————————————————————————————————————————————————————————————— EvUpdFetchByKeyNotFound
+     'fetch_by_key' @Mod:T vₖ ‖ (st; keys)
+        ⇓ᵤ
+     Err "Lookup key not found"
+
+     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
+     (eₘ vₖ)  ⇓  Ok  vₘ
+     (Mod:T, vₖ) ∈ dom(keys)
+     cid = keys((Mod:T, v))
+     st(cid) = (Mod:T, vₜ, 'inactive')
+   —————————————————————————————————————————————————————————————————————— EvUpdFetchByKeyInactive
+     'fetch_by_key' @Mod:T vₖ ‖ (st; keys)
+        ⇓ᵤ
+     Err "Exercise on inactive contract"
+
+     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
+     (eₘ vₖ)  ⇓  Ok  vₘ
+     (Mod:T, vₖ) ∈ dom(keys)
+     cid = keys((Mod:T, v))
+     st(cid) = (Mod:T, vₜ, 'active')
    —————————————————————————————————————————————————————————————————————— EvUpdFetchByKeyFound
-     'fetch_by_key' @Mod:T e ‖ (st; keys)
+     'fetch_by_key' @Mod:T vₖ ‖ (st; keys)
         ⇓ᵤ
      Ok ⟨'contractId': cid, 'contract': vₜ⟩ ‖ (st; keys)
 
      'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
-     e  ⇓  Ok vₖ
+     (eₘ vₖ)  ⇓  Err t
+   —————————————————————————————————————————————————————————————————————— EvUpdLookupByKeyErr
+     'lookup_by_key' @Mod:T vₖ ‖ (st; keys)  ⇓ᵤ  Err t
+
+     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
      (eₘ vₖ)  ⇓  vₘ
-     (Mod:T, vₖ) ∉ dom(keys₀)
-    —————————————————————————————————————————————————————————————————————— EvUpdFetchByKeyNotFound
-     'fetch_by_key' @Mod:T e ‖ (st; keys)
-        ⇓ᵤ
-     Err "Lookup key not found"  ‖ (st; keys)
-
-     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
-     e  ⇓  Ok vₖ
-     (eₘ vₖ)  ⇓  vₘ
-     (Mod:T, vₖ) ∈ dom(keys)   cid = keys((Mod:T, v))
-   —————————————————————————————————————————————————————————————————————— EvUpdLookupByKeyErr1
-     'lookup_by_key' @Mod:T e ‖ (st; keys) ⇓ᵤ Err t
-
-     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
-     e  ⇓  Ok vₖ
-     (eₘ vₖ)  ⇓  vₘ
-     (Mod:T, vₖ) ∈ dom(keys)   cid = keys((Mod:T, v))
-   —————————————————————————————————————————————————————————————————————— EvUpdLookupByKeyErr2
-     'lookup_by_key' @Mod:T e ‖ (st; keys)
-       ⇓ᵤ
-     Ok ('Some' @(Contract:Id Mod:T) cid, ε) ‖ (st; keys)
-
-
-     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
-     e  ⇓  Ok vₖ
-     (eₘ vₖ)  ⇓  Ok vₘ
-     (Mod:T, vₖ) ∈ dom(keys)   cid = keys((Mod:T, v))
-   —————————————————————————————————————————————————————————————————————— EvUpdLookupByKeyFound
-     'lookup_by_key' @Mod:T e ‖ (st; keys)
-       ⇓ᵤ
-     Ok ('Some' @(Contract:Id Mod:T) cid, ε) ‖ (st; keys)
-
-     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
-     e  ⇓  Ok vₖ
-     (eₘ vₖ)  ⇓  Ok vₘ
      (Mod:T, vₖ) ∉ dom(keys)
    —————————————————————————————————————————————————————————————————————— EvUpdLookupByKeyNotFound
-     'lookup_by_key' @Mod:T e ‖ (st; keys)
-         ⇓ᵤ
+     'lookup_by_key' @Mod:T vₖ ‖ (st; keys)
+       ⇓ᵤ
      Ok ('None' @(Contract:Id Mod:T), ε) ‖ (st; keys)
+
+     'tpl' (x : T) ↦ { …, 'key' @σ eₖ eₘ }  ∈  〚Ξ〛Mod
+     (eₘ vₖ)  ⇓  vₘ
+     (Mod:T, vₖ) ∈ dom(keys)
+     cid = keys((Mod:T, v))
+   —————————————————————————————————————————————————————————————————————— EvUpdLookupByKeyFound
+     'lookup_by_key' @Mod:T vₖ ‖ (st; keys)
+       ⇓ᵤ
+     Ok ('Some' @(Contract:Id Mod:T) cid, ε) ‖ (st; keys)
 
      LitTimestamp is the current ledger time
    —————————————————————————————————————————————————————————————————————— EvUpdGetTime

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2686,7 +2686,7 @@ as described by the ledger model::
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Err t
-   —————————————————————————————————————————————————————————————————————— EvUpdExercErr1
+   —————————————————————————————————————————————————————————————————————— EvUpdExercActorEvalErr
      'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)  ⇓ᵤ  Err t
 
      'tpl' (x : T)
@@ -2707,7 +2707,7 @@ as described by the ledger model::
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
      v₁ =ₛ vₚ
      eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Err t
-   —————————————————————————————————————————————————————————————————————— EvUpdExercErr2
+   —————————————————————————————————————————————————————————————————————— EvUpdExercBodyEvalErr
      'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)
        ⇓ᵤ
      Err t


### PR DESCRIPTION
This adds more DAML tests and error cases in the specification, finishing
off the update interpretation for now. I believe this is roughly the limit of what we
can test directly in DAML, and the rest is up to DAML-LF testing.

For example, there's no way to test that the contract inactivity check
in EvUpdExercInactive happens before the evaluation of the controller
expression, since there is no way to generate an 'exercise' with actors
from DAML, as far as I could tell, and 'exercise_without_actor' always
evaluates the controller before passing it off to 'exercise'.

For the same reason, the EvUpdExercBadActor check seems impossible to
trigger from DAML itself. The closest is an authorization test that
happens during submit (which I added a test for, because it is kinda
relevant to evaluation order of scenarios, even though scenario
interpretation isn't really important to the spec).

So at the very least we should add LF tests for those two cases.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
