### PR TITLE
daml2js: Add more tests for recursive types

### DIFF
--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -136,3 +136,8 @@ data Recursive = Recursive with
     recList: [Recursive]
     recTextMap : TextMap Recursive
   deriving (Eq, Show)
+
+data VoidRecord = VoidRecord with
+    inner: VoidRecord
+
+data VoidEnum = VoidEnum VoidEnum


### PR DESCRIPTION
I think testing that constructing the decoders doesn't loop deserves
its own very targeted test on top of the more intergration style test
we already have.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6871)
<!-- Reviewable:end -->
