### PR TITLE
Support participant node failover

### DIFF
--- a/docs/source/app-dev/app-arch.rst
+++ b/docs/source/app-dev/app-arch.rst
@@ -154,17 +154,22 @@ For more details on command deduplication, see the :ref:`Ledger API Services <co
 Handling participant node failover
 **********************************
 
-Some DAML Ledgers support exposing multiple eventually consistent Ledger API endpoints hosted by separate participant nodes.
+Some DAML Ledgers support exposing multiple eventually consistent Ledger API endpoints
+where command deduplication works across the Ledger API endpoints,
+e.g., by hosting separate participant nodes that expose the same view onto the ledger.
+Contact your ledger operator to find out whether this applies to your ledger.
 
-To support switching to a different participant node at run time,
+On such ledgers, applications can easily switch between Ledger API endpoints to handle participant node failovers.
+To support switching to a different ledger API endpoint at run time,
 your application should keep track of the last ledger offset received from the :ref:`transaction service <transaction-service>`.
-After switching to a new participant node, subscribe to the transaction stream using the last received offset.
-If you receive the OUT_OF_RANGE error, it means the new participant node hasn't caught up with the state on the previous participant yet
-and your application should retry subscribing to the transaction stream until successful.
+After switching to a new Ledger API endpoint, subscribe to the transaction stream using the last received offset.
 
-Note that command deduplication is not guaranteed to work across participants.
-Contanct your ledger operator to find out whether you can safely resubmit all outstanding commands to the new participant.
+The subscription may return a OUT_OF_RANGE error.
+As per the gRCP error code definition, this means the subscription was attempted past the valid range, and the problem may be fixed if the system state changes.
+In practice, it means the new participant node hasn't caught up with the state on the previous participant yet.
+If you receive such an error, your application should retry subscribing to the transaction stream until successful.
 
+Once you successfully subscribe to the new transaction stream, your application can resume normal operation.
 
 .. _dealing-with-time:
 

--- a/docs/source/app-dev/app-arch.rst
+++ b/docs/source/app-dev/app-arch.rst
@@ -124,10 +124,10 @@ typical DAML developer workflow is to
 
 .. image:: ./developer_workflow.svg
 
-.. _handling-submission-failures:
+.. _command-deduplication:
 
-Handle failures when submitting commands
-****************************************
+Command deduplication
+*********************
 
 The interaction of a DAML application with the ledger is inherently asynchronous: applications send commands to the ledger, and some time later they see the effect of that command on the ledger.
 
@@ -147,6 +147,24 @@ To use command deduplication, you should:
 
 
 For more details on command deduplication, see the :ref:`Ledger API Services <command-submission-service-deduplication>` documentation.
+
+
+.. _handling-participant-node-failover:
+
+Handling participant node failover
+**********************************
+
+Some DAML Ledgers support exposing multiple eventually consistent Ledger API endpoints hosted by separate participant nodes.
+
+To support switching to a different participant node at run time,
+your application should keep track of the last ledger offset received from the :ref:`transaction service <transaction-service>`.
+After switching to a new participant node, subscribe to the transaction stream using the last received offset.
+If you receive the OUT_OF_RANGE error, it means the new participant node hasn't caught up with the state on the previous participant yet
+and your application should retry subscribing to the transaction stream until successful.
+
+Note that command deduplication is not guaranteed to work across participants.
+Contanct your ledger operator to find out whether you can safely resubmit all outstanding commands to the new participant.
+
 
 .. _dealing-with-time:
 

--- a/docs/source/app-dev/services.rst
+++ b/docs/source/app-dev/services.rst
@@ -77,7 +77,7 @@ The command submission service deduplicates submitted commands based on the subm
 
 - If the ledger provides additional command deduplication across participants, the initial command submission might be successful, but ultimately the command can be rejected if the deduplication check fails on the ledger.
 
-For details on how to use command deduplication, see the :ref:`Application Architecture Guide <handling-submission-failures>`.
+For details on how to use command deduplication, see the :ref:`Application Architecture Guide <command-deduplication>`.
 
 .. _command-completion-service:
 

--- a/docs/source/support/release-notes.rst
+++ b/docs/source/support/release-notes.rst
@@ -1267,7 +1267,7 @@ Specific Changes
 Impact and Migration
 >>>>>>>>>>>>>>>>>>>>
 
-The maximum record time based mechanism for command deduplication is now deprecated and will be removed with the next SDK release. We recommend switching from the MRT-based mechanism to ``deduplication_time`` based one. Detailed documentation :ref:`here <handling-submission-failures>`.
+The maximum record time based mechanism for command deduplication is now deprecated and will be removed with the next SDK release. We recommend switching from the MRT-based mechanism to ``deduplication_time`` based one. Detailed documentation :ref:`here <command-deduplication>`.
 
 Minor Improvements
 ^^^^^^^^^^^^^^^^^^

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
@@ -70,9 +70,7 @@ class TransactionServiceRequestValidator(
       offsetOrdering: Ordering[LedgerOffset.Absolute]): Result[Unit] =
     ledgerOffset match {
       case abs: LedgerOffset.Absolute if offsetOrdering.gt(abs, ledgerEnd) =>
-        Left(
-          invalidArgument(
-            s"$offsetType offset ${abs.value} is after ledger end ${ledgerEnd.value}"))
+        Left(outOfRange(s"$offsetType offset ${abs.value} is after ledger end ${ledgerEnd.value}"))
       case _ => Right(())
     }
 

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandCompletionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/domain/CommandCompletionService.scala
@@ -19,4 +19,6 @@ trait CommandCompletionService {
 
   def getLedgerEnd(ledgerId: domain.LedgerId): Future[LedgerOffset.Absolute]
 
+  def offsetOrdering: Ordering[LedgerOffset.Absolute]
+
 }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/validation/ErrorFactories.scala
@@ -25,6 +25,9 @@ trait ErrorFactories {
   def invalidField(fieldName: String, message: String) =
     grpcError(Status.INVALID_ARGUMENT.withDescription(s"Invalid field $fieldName: $message"))
 
+  def outOfRange(description: String): StatusRuntimeException =
+    grpcError(Status.OUT_OF_RANGE.withDescription(description))
+
   def notFound(target: String): StatusRuntimeException =
     grpcError(Status.NOT_FOUND.withDescription(s"$target not found."))
 

--- a/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
+++ b/ledger/ledger-api-common/src/test/lib/scala/com/digitalasset/ledger/api/validation/ValidatorTestUtils.scala
@@ -23,6 +23,7 @@ trait ValidatorTestUtils extends Matchers with Inside with OptionValues { self: 
   protected val includedModule = "includedModule"
   protected val includedTemplate = "includedTemplate"
   protected val expectedLedgerId = "expectedLedgerId"
+  protected val expectedApplicationId = "expectedApplicationId"
   protected val packageId = Ref.PackageId.assertFromString("packageId")
   protected val absoluteOffset = Ref.LedgerString.assertFromString("42")
   protected val party = Ref.Party.assertFromString("party")

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/CompletionServiceRequestValidatorTest.scala
@@ -1,0 +1,176 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.validation
+
+import com.daml.ledger.api.domain
+import com.daml.ledger.api.v1.command_completion_service.{
+  CompletionEndRequest,
+  CompletionStreamRequest
+}
+import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
+import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.LedgerBoundary
+import com.daml.ledger.api.v1.trace_context.TraceContext
+import io.grpc.Status.Code._
+import org.scalatest.WordSpec
+
+class CompletionServiceRequestValidatorTest extends WordSpec with ValidatorTestUtils {
+
+  private val traceContext = TraceContext(traceIdHigh, traceId, spanId, parentSpanId, sampled)
+
+  private val completionReq = CompletionStreamRequest(
+    expectedLedgerId,
+    expectedApplicationId,
+    List(party),
+    Some(LedgerOffset(LedgerOffset.Value.Absolute(absoluteOffset))),
+  )
+
+  private val endReq = CompletionEndRequest(expectedLedgerId, Some(traceContext))
+
+  val validator = new CompletionServiceRequestValidator(
+    domain.LedgerId(expectedLedgerId),
+    PartyNameChecker.AllowAllParties
+  )
+
+  "CompletionRequestValidation" when {
+
+    "validating regular requests" should {
+
+      "reject requests with empty ledger ID" in {
+        requestMustFailWith(
+          validator.validateCompletionStreamRequest(
+            completionReq.withLedgerId(""),
+            ledgerEnd,
+            offsetOrdering),
+          NOT_FOUND,
+          "Ledger ID '' not found. Actual Ledger ID is 'expectedLedgerId'."
+        )
+      }
+
+      "return the correct error on missing application ID" in {
+        requestMustFailWith(
+          validator.validateCompletionStreamRequest(
+            completionReq.withApplicationId(""),
+            ledgerEnd,
+            offsetOrdering),
+          INVALID_ARGUMENT,
+          "Missing field: application_id"
+        )
+      }
+
+      "return the correct error on missing party" in {
+        requestMustFailWith(
+          validator.validateCompletionStreamRequest(
+            completionReq.withParties(Seq()),
+            ledgerEnd,
+            offsetOrdering),
+          INVALID_ARGUMENT,
+          "Missing field: parties")
+      }
+
+      "return the correct error on unknown begin boundary" in {
+        requestMustFailWith(
+          validator.validateCompletionStreamRequest(
+            completionReq.withOffset(
+              LedgerOffset(LedgerOffset.Value.Boundary(LedgerBoundary.Unrecognized(7)))),
+            ledgerEnd,
+            offsetOrdering),
+          INVALID_ARGUMENT,
+          "Invalid argument: Unknown ledger boundary value '7' in field offset.boundary"
+        )
+      }
+
+      "return the correct error when offset is after ledger end" in {
+        requestMustFailWith(
+          validator.validateCompletionStreamRequest(
+            completionReq.withOffset(
+              LedgerOffset(LedgerOffset.Value.Absolute((ledgerEnd.value.toInt + 1).toString))),
+            ledgerEnd,
+            offsetOrdering),
+          OUT_OF_RANGE,
+          "Begin offset 1001 is after ledger end 1000"
+        )
+      }
+
+      "tolerate missing end" in {
+        inside(
+          validator.validateCompletionStreamRequest(
+            completionReq.update(_.optionalOffset := None),
+            ledgerEnd,
+            offsetOrdering)) {
+          case Right(req) =>
+            req.ledgerId shouldEqual expectedLedgerId
+            req.applicationId shouldEqual expectedApplicationId
+            req.parties shouldEqual Set(party)
+            req.offset shouldEqual None
+        }
+      }
+
+      "tolerate all fields filled out" in {
+        inside(validator.validateCompletionStreamRequest(completionReq, ledgerEnd, offsetOrdering)) {
+          case Right(req) =>
+            req.ledgerId shouldEqual expectedLedgerId
+            req.applicationId shouldEqual expectedApplicationId
+            req.parties shouldEqual Set(party)
+            req.offset shouldEqual Some(domain.LedgerOffset.Absolute(absoluteOffset))
+        }
+      }
+    }
+
+    "validating completions end requests" should {
+
+      "fail on ledger ID mismatch" in {
+        requestMustFailWith(
+          validator.validateCompletionEndRequest(endReq.withLedgerId("")),
+          NOT_FOUND,
+          "Ledger ID '' not found. Actual Ledger ID is 'expectedLedgerId'.")
+      }
+
+      "work with missing traceContext" in {
+        inside(
+          validator.validateCompletionEndRequest(endReq.update(_.optionalTraceContext := None))) {
+          case Right(out) =>
+            out should have('ledgerId (expectedLedgerId))
+            out.traceContext shouldBe empty
+        }
+      }
+
+      "work with present traceContext" in {
+        inside(validator.validateCompletionEndRequest(endReq)) {
+          case Right(out) =>
+            out should have('ledgerId (expectedLedgerId))
+            isExpectedTraceContext(out.traceContext.value)
+        }
+      }
+    }
+
+    "applying party name checks" should {
+
+      val knowsPartyOnly =
+        new CompletionServiceRequestValidator(
+          domain.LedgerId(expectedLedgerId),
+          PartyNameChecker.AllowPartySet(Set(party)))
+
+      val unknownParties = List("party", "Alice", "Bob")
+      val knownParties = List("party")
+
+      "reject completion requests for unknown parties" in {
+        requestMustFailWith(
+          knowsPartyOnly.validateCompletionStreamRequest(
+            completionReq.withParties(unknownParties),
+            ledgerEnd,
+            offsetOrdering),
+          INVALID_ARGUMENT,
+          "Invalid argument: Unknown parties: [Alice, Bob]"
+        )
+      }
+
+      "accept transaction requests for known parties" in {
+        knowsPartyOnly.validateCompletionStreamRequest(
+          completionReq.withParties(knownParties),
+          ledgerEnd,
+          offsetOrdering) shouldBe a[Right[_, _]]
+      }
+    }
+  }
+}

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidatorTest.scala
@@ -139,8 +139,8 @@ class TransactionServiceRequestValidatorTest extends WordSpec with ValidatorTest
               LedgerOffset(LedgerOffset.Value.Absolute((ledgerEnd.value.toInt + 1).toString))),
             ledgerEnd,
             offsetOrdering),
-          INVALID_ARGUMENT,
-          "Invalid argument: Begin offset 1001 is after ledger end 1000"
+          OUT_OF_RANGE,
+          "Begin offset 1001 is after ledger end 1000"
         )
       }
 
@@ -151,8 +151,8 @@ class TransactionServiceRequestValidatorTest extends WordSpec with ValidatorTest
               LedgerOffset(LedgerOffset.Value.Absolute((ledgerEnd.value.toInt + 1).toString))),
             ledgerEnd,
             offsetOrdering),
-          INVALID_ARGUMENT,
-          "Invalid argument: End offset 1001 is after ledger end 1000"
+          OUT_OF_RANGE,
+          "End offset 1001 is after ledger end 1000"
         )
       }
 
@@ -274,8 +274,8 @@ class TransactionServiceRequestValidatorTest extends WordSpec with ValidatorTest
               LedgerOffset(LedgerOffset.Value.Absolute((ledgerEnd.value.toInt + 1).toString))),
             ledgerEnd,
             offsetOrdering),
-          INVALID_ARGUMENT,
-          "Invalid argument: Begin offset 1001 is after ledger end 1000"
+          OUT_OF_RANGE,
+          "Begin offset 1001 is after ledger end 1000"
         )
       }
 
@@ -286,8 +286,8 @@ class TransactionServiceRequestValidatorTest extends WordSpec with ValidatorTest
               LedgerOffset(LedgerOffset.Value.Absolute((ledgerEnd.value.toInt + 1).toString))),
             ledgerEnd,
             offsetOrdering),
-          INVALID_ARGUMENT,
-          "Invalid argument: End offset 1001 is after ledger end 1000"
+          OUT_OF_RANGE,
+          "End offset 1001 is after ledger end 1000"
         )
       }
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -54,6 +54,9 @@ private[apiserver] final class ApiCommandCompletionService private (
   override def getLedgerEnd(ledgerId: domain.LedgerId): Future[LedgerOffset.Absolute] =
     completionsService.currentLedgerEnd().andThen(logger.logErrorsOnCall[LedgerOffset.Absolute])
 
+  override lazy val offsetOrdering: Ordering[LedgerOffset.Absolute] =
+    Ordering.by[LedgerOffset.Absolute, String](_.value)
+
 }
 
 private[apiserver] object ApiCommandCompletionService {


### PR DESCRIPTION
Fixes #6842.

CHANGELOG_BEGIN
- [Ledger API] The error code for requesting a transaction stream
  with an offset beyond the ledger end changed from INVALID_ARGUMENT
  to OUT_OF_RANGE. This makes it easier to handle scenarios where
  an application fails over to a backup participant which hasn't
  caught up with the ledger yet.
- [Ledger API] The command completion service now validates the offset and
  returns the OUT_OF_RANGE error if the request offset is beyond the ledger end.
- [Application Architecture] Added a section on how to write DAML applications
  that can fail over between multiple eventually consistent Ledger API endpoints
  where command deduplication works across these Ledger API endpoints, which
  can be useful for addressing HA and/or DR scenarios.
CHANGELOG_END
