### PR TITLE
daml2js: Push the lazy combinator further outward

### DIFF
--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -211,7 +211,7 @@ export type List<T> = T[];
  * Companion object of the [[List]] type.
  */
 export const List = <T>(t: Serializable<T>): Serializable<T[]> => ({
-  decoder: (): jtv.Decoder<T[]> => jtv.array(jtv.lazy(() => t.decoder())),
+  decoder: (): jtv.Decoder<T[]> => jtv.lazy(() => jtv.array(t.decoder())),
 });
 
 /**
@@ -323,7 +323,7 @@ export type TextMap<T> = { [key: string]: T };
  * Companion object of the [[TextMap]] type.
  */
 export const TextMap = <T>(t: Serializable<T>): Serializable<TextMap<T>> => ({
-    decoder: (): jtv.Decoder<TextMap<T>> => jtv.dict(jtv.lazy(() => t.decoder())),
+    decoder: (): jtv.Decoder<TextMap<T>> => jtv.lazy(() => jtv.dict(t.decoder())),
 });
 
 // TODO(MH): `Map` type.


### PR DESCRIPTION
Currently, the decoders for the container types `List` and `TextMap` use
`jtv.lazy` _within_ their container decoders `jtv.array` and `jtv.dict`.
Since `jtv.lazy` does not memoize its result, this has the disadvantage
that the thunk producing the decoder for the element type is invoked
for each element of the container rather than once for the whole
container. This is a potential performance bottleneck.

This PR moves the use of `jtv.lazy` one level further out in oder to
avoid the potential performance issues without adding any further
downsides.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6878)
<!-- Reviewable:end -->
