### PR TITLE
Factor out reproducibility flags for tar and gzip

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -220,9 +220,6 @@ nixpkgs_package(
     fail_not_supported = False,
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,
-    # Remove once we upgrade to Bazel >=3.0. Until then `nix-build` output
-    # confuses the JAR query in `daml-sdk-head`.
-    quiet = True,
     repositories = dev_env_nix_repos,
 )
 
@@ -243,9 +240,6 @@ nixpkgs_package(
     fail_not_supported = False,
     nix_file = "//nix:bazel.nix",
     nix_file_deps = common_nix_file_deps,
-    # Remove once we upgrade to Bazel >=3.0. Until then `nix-build` output
-    # confuses the JAR query in `daml-sdk-head`.
-    quiet = True,
     repositories = dev_env_nix_repos,
 )
 

--- a/bazel_tools/packaging/BUILD.bazel
+++ b/bazel_tools/packaging/BUILD.bazel
@@ -1,7 +1,16 @@
 # Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-exports_files([
-    "packaging.bzl",
-    "package-app.sh",
-])
+load("@os_info//:os_info.bzl", "is_windows")
+
+sh_binary(
+    name = "package-app",
+    srcs = ["package-app.sh"],
+    data = [
+        "@gzip_dev_env//:gzip",
+        "@tar_dev_env//:tar",
+        "//bazel_tools/sh:mktgz",
+    ] + (["@patchelf_nix//:bin/patchelf"] if not is_windows else []),
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/bazel_tools/packaging/package-app.sh
+++ b/bazel_tools/packaging/package-app.sh
@@ -27,6 +27,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+# Make sure that runfiles and tools are still found after we change directory.
 case "$(uname -s)" in
   Darwin)
     abspath() { python -c 'import os.path, sys; sys.stdout.write(os.path.abspath(sys.argv[1]))' "$@"; }

--- a/bazel_tools/packaging/package-app.sh
+++ b/bazel_tools/packaging/package-app.sh
@@ -16,13 +16,54 @@
 # On Windows we only handle statically linked binaries
 # (Haskell binaries are linked statically on Windows) so we
 # just copy the binary and the resources and create a tarball from that.
+
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+case "$(uname -s)" in
+  Darwin)
+    abspath() { python -c 'import os.path, sys; sys.stdout.write(os.path.abspath(sys.argv[1]))' "$@"; }
+    ;;
+  *)
+    abspath() { realpath -s "$@"; }
+    ;;
+esac
+
+if [[ -n ${RUNFILES_DIR:-} ]]; then
+  export RUNFILES_DIR=$(abspath $RUNFILES_DIR)
+fi
+if [[ -n ${RUNFILES_MANIFEST_FILE:-} ]]; then
+  export RUNFILES_DIR=$(abspath $RUNFILES_MANIFEST_FILE)
+fi
+
+case "$(uname -s)" in
+  Darwin|Linux)
+    tar=$(abspath $(rlocation tar_dev_env/tar))
+    gzip=$(abspath $(rlocation gzip_dev_env/gzip))
+    mktgz=$(abspath $(rlocation com_github_digital_asset_daml/bazel_tools/sh/mktgz))
+    patchelf=$(abspath $(rlocation patchelf_nix/bin/patchelf))
+    ;;
+  CYGWIN*|MINGW*|MSYS*)
+    tar=$(abspath $(rlocation tar_dev_env/usr/bin/tar.exe))
+    gzip=$(abspath $(rlocation gzip_dev_env/usr/bin/gzip.exe))
+    mktgz=$(abspath $(rlocation com_github_digital_asset_daml/bazel_tools/sh/mktgz.exe))
+    ;;
+esac
+
 set -eou pipefail
 
 WORKDIR="$(mktemp -d)"
 trap "rm -rf $WORKDIR" EXIT
 
-SRC=$1
-OUT=$2
+SRC=$(abspath $1)
+OUT=$(abspath $2)
 shift 2
 NAME=$(basename $SRC)
 mkdir -p $WORKDIR/$NAME/lib
@@ -35,7 +76,7 @@ if [ $# -gt 0 ]; then
     if [[ "$res" == *.tar.gz ]]; then
       # If a resource is a tarball, e.g., because it originates from another
       # rule we extract it.
-      tar xf "$res" --strip-components=1 -C "$WORKDIR/$NAME/resources"
+      $tar xf "$res" --strip-components=1 -C "$WORKDIR/$NAME/resources"
     else
       cp -aL "$res" "$WORKDIR/$NAME/resources"
     fi
@@ -47,13 +88,13 @@ if [ "$(uname -s)" == "Linux" ]; then
   binary="$WORKDIR/$NAME/lib/$NAME"
   cp $SRC $binary
   chmod u+w $binary
-  rpaths_binary=$(patchelf --print-rpath "$binary"|tr ':' ' ')
+  rpaths_binary=$($patchelf --print-rpath "$binary"|tr ':' ' ')
   function copy_deps {
     local from target needed libOK rpaths
     from=$1
     target=$2
-    needed=$(patchelf --print-needed "$from")
-    rpaths="$(patchelf --print-rpath "$from"|tr ':' ' ') $rpaths_binary"
+    needed=$($patchelf --print-needed "$from")
+    rpaths="$($patchelf --print-rpath "$from"|tr ':' ' ') $rpaths_binary"
 
     for lib in $needed; do
       if [ ! -f "$target/$lib" ]; then
@@ -67,7 +108,7 @@ if [ "$(uname -s)" == "Linux" ]; then
             if [ "$lib" != "ld-linux-x86-64.so.2" ]; then
               # clear the old rpaths (silence stderr as it always warns
               # with "working around a Linux kernel bug".
-              patchelf --set-rpath '$ORIGIN' "$target/$lib" 2> /dev/null
+              $patchelf --set-rpath '$ORIGIN' "$target/$lib" 2> /dev/null
             fi
             copy_deps "$rpath/$lib" "$target"
             break
@@ -94,8 +135,8 @@ if [ "$(uname -s)" == "Linux" ]; then
    done
   )
 
-  patchelf --set-rpath '$ORIGIN/lib' "$binary"
-  patchelf --set-interpreter ld-undefined.so "$binary"
+  $patchelf --set-rpath '$ORIGIN/lib' "$binary"
+  $patchelf --set-interpreter ld-undefined.so "$binary"
 
   # Link resources directory to lib, as that'll be the actual
   # binary's location.
@@ -173,4 +214,4 @@ elif [[ "$(uname -s)" == "Darwin" ]]; then
 else
     cp "$SRC" "$WORKDIR/$NAME/$NAME"
 fi
-cd $WORKDIR && mktgz $OUT $NAME
+cd $WORKDIR && $mktgz $OUT $NAME

--- a/bazel_tools/packaging/package-app.sh
+++ b/bazel_tools/packaging/package-app.sh
@@ -173,6 +173,4 @@ elif [[ "$(uname -s)" == "Darwin" ]]; then
 else
     cp "$SRC" "$WORKDIR/$NAME/$NAME"
 fi
-cd $WORKDIR && tar c $NAME \
-    --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\ 00:00Z --sort=name \
-    | gzip -n > $OUT
+cd $WORKDIR && mktgz $OUT $NAME

--- a/bazel_tools/packaging/packaging.bzl
+++ b/bazel_tools/packaging/packaging.bzl
@@ -12,7 +12,13 @@ def _package_app_impl(ctx):
 
     args = ctx.actions.args()
     inputs = depset([], transitive = [files, runfiles, datafiles] + [r.files for r in ctx.attr.resources])
-    tools = [ctx.executable.tar, ctx.executable.gzip] if is_windows else [ctx.executable.patchelf, ctx.executable.tar, ctx.executable.gzip]
+    tools = [
+        ctx.executable.gzip,
+        ctx.executable.mktgz,
+        ctx.executable.tar,
+    ]
+    if not is_windows:
+        tools.append(ctx.executable.patchelf)
     ctx.actions.run_shell(
         outputs = [ctx.outputs.out],
         tools = [ctx.executable.package_app] + tools,
@@ -73,6 +79,12 @@ package_app = rule(
         ),
         "patchelf": attr.label(
             default = None if is_windows else Label("@patchelf_nix//:bin/patchelf"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+        "mktgz": attr.label(
+            default = Label("//bazel_tools/sh:mktgz"),
             cfg = "host",
             executable = True,
             allow_files = True,

--- a/bazel_tools/packaging/packaging.bzl
+++ b/bazel_tools/packaging/packaging.bzl
@@ -6,43 +6,19 @@
 load("@os_info//:os_info.bzl", "is_windows")
 
 def _package_app_impl(ctx):
-    files = depset(ctx.attr.binary.files)
-    runfiles = ctx.attr.binary.default_runfiles.files
-    datafiles = ctx.attr.binary[DefaultInfo].data_runfiles.files
-
     args = ctx.actions.args()
-    inputs = depset([], transitive = [files, runfiles, datafiles] + [r.files for r in ctx.attr.resources])
-    tools = [
-        ctx.executable.gzip,
-        ctx.executable.mktgz,
-        ctx.executable.tar,
-    ]
-    if not is_windows:
-        tools.append(ctx.executable.patchelf)
-    ctx.actions.run_shell(
+    args.add(ctx.executable.binary.path)
+    args.add(ctx.outputs.out.path)
+    args.add_all(ctx.attr.resources, map_each = _get_resource_path)
+    ctx.actions.run(
+        executable = ctx.executable.package_app,
         outputs = [ctx.outputs.out],
-        tools = [ctx.executable.package_app] + tools,
-        inputs = inputs.to_list(),
+        inputs = ctx.files.resources,
+        # Binaries are passed through tools so that Bazel can make the runfiles
+        # tree available to the action.
+        tools = [ctx.executable.binary],
         arguments = [args],
         progress_message = "Packaging " + ctx.attr.name,
-        command = """
-      set -eu
-      export PATH=$PATH:{path}
-      {package_app} \
-        "$PWD/{binary}" \
-        "$PWD/{output}" \
-        {resources}
-    """.format(
-            path = ":".join(["$PWD/`dirname {tool}`".format(tool = tool.path) for tool in tools]),
-            output = ctx.outputs.out.path,
-            name = ctx.attr.name,
-            package_app = ctx.executable.package_app.path,
-            binary = ctx.executable.binary.path,
-            resources = " ".join([
-                _get_resource_path(r)
-                for r in ctx.attr.resources
-            ]),
-        ),
     )
 
 def _get_resource_path(r):
@@ -77,32 +53,8 @@ package_app = rule(
         "resources": attr.label_list(
             allow_files = True,
         ),
-        "patchelf": attr.label(
-            default = None if is_windows else Label("@patchelf_nix//:bin/patchelf"),
-            cfg = "host",
-            executable = True,
-            allow_files = True,
-        ),
-        "mktgz": attr.label(
-            default = Label("//bazel_tools/sh:mktgz"),
-            cfg = "host",
-            executable = True,
-            allow_files = True,
-        ),
-        "tar": attr.label(
-            default = Label("@tar_dev_env//:tar"),
-            cfg = "host",
-            executable = True,
-            allow_files = True,
-        ),
-        "gzip": attr.label(
-            default = Label("@gzip_dev_env//:gzip"),
-            cfg = "host",
-            executable = True,
-            allow_files = True,
-        ),
         "package_app": attr.label(
-            default = Label("//bazel_tools/packaging:package-app.sh"),
+            default = Label("//bazel_tools/packaging:package-app"),
             cfg = "host",
             executable = True,
             allow_files = True,

--- a/bazel_tools/sh/BUILD.bazel
+++ b/bazel_tools/sh/BUILD.bazel
@@ -2,3 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 exports_files(["test.sh.tpl"])
+
+sh_binary(
+    name = "mktar",
+    srcs = ["mktar.sh"],
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "mktgz",
+    srcs = ["mktgz.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel_tools/sh/BUILD.bazel
+++ b/bazel_tools/sh/BUILD.bazel
@@ -6,11 +6,18 @@ exports_files(["test.sh.tpl"])
 sh_binary(
     name = "mktar",
     srcs = ["mktar.sh"],
+    data = ["@tar_dev_env//:tar"],
     visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_binary(
     name = "mktgz",
     srcs = ["mktgz.sh"],
+    data = [
+        "@gzip_dev_env//:gzip",
+        "@tar_dev_env//:tar",
+    ],
     visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/bazel_tools/sh/mktar.sh
+++ b/bazel_tools/sh/mktar.sh
@@ -2,6 +2,16 @@
 # Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
 set -euo pipefail
 usage() {
   cat >&2 <<'EOF'
@@ -14,7 +24,16 @@ EOF
 }
 trap usage ERR
 
-tar cf "$1" "${@:2}" \
+case "$(uname -s)" in
+  Darwin|Linux)
+    tar=$(rlocation tar_dev_env/tar)
+    ;;
+  CYGWIN*|MINGW*|MSYS*)
+    tar=$(rlocation tar_dev_env/usr/bin/tar.exe)
+    ;;
+esac
+
+$tar cf "$1" "${@:2}" \
   --owner="0" \
   --group="0" \
   --numeric-owner \

--- a/bazel_tools/sh/mktar.sh
+++ b/bazel_tools/sh/mktar.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+usage() {
+  cat >&2 <<'EOF'
+usage: mktar OUTPUT ARGS...
+
+Creates an uncompressed tarball in OUTPUT passing ARGS to tar. The created
+tarball is reproducible, i.e. it does not contain any timestamps or similar
+non-deterministic inputs. See https://reproducible-builds.org/docs/archives/
+EOF
+}
+trap usage ERR
+
+tar cf "$1" "${@:2}" \
+  --owner="0" \
+  --group="0" \
+  --numeric-owner \
+  --mtime="2000-01-01 00:00Z" \
+  --no-acls \
+  --no-xattrs \
+  --no-selinux \
+  --sort="name" \
+  --format=ustar

--- a/bazel_tools/sh/mktgz.sh
+++ b/bazel_tools/sh/mktgz.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+usage() {
+  cat >&2 <<'EOF'
+usage: mktgz OUTPUT ARGS...
+
+Creates a gzip compressed tarball in OUTPUT passing ARGS to tar. The created
+tarball is reproducible, i.e. it does not contain any timestamps or similar
+non-deterministic inputs. See https://reproducible-builds.org/docs/archives/
+EOF
+}
+trap usage ERR
+
+tar c "${@:2}" \
+  --owner="0" \
+  --group="0" \
+  --numeric-owner \
+  --mtime="2000-01-01 00:00Z" \
+  --no-acls \
+  --no-xattrs \
+  --no-selinux \
+  --sort="name" \
+  --format=ustar \
+  | gzip -n > "$1"

--- a/compatibility/WORKSPACE
+++ b/compatibility/WORKSPACE
@@ -123,6 +123,46 @@ haskell_register_ghc_nixpkgs(
 nixpkgs_python_configure(repository = "@nixpkgs")
 
 nixpkgs_package(
+    name = "tar_nix",
+    attribute_path = "gnutar",
+    fail_not_supported = False,
+    nix_file = "@daml//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    repositories = dev_env_nix_repos,
+)
+
+dev_env_tool(
+    name = "tar_dev_env",
+    nix_include = ["bin/tar"],
+    nix_label = "@tar_nix",
+    nix_paths = ["bin/tar"],
+    tools = ["tar"],
+    win_include = ["usr/bin/tar.exe"],
+    win_paths = ["usr/bin/tar.exe"],
+    win_tool = "msys2",
+)
+
+nixpkgs_package(
+    name = "gzip_nix",
+    attribute_path = "gzip",
+    fail_not_supported = False,
+    nix_file = "@daml//nix:bazel.nix",
+    nix_file_deps = common_nix_file_deps,
+    repositories = dev_env_nix_repos,
+)
+
+dev_env_tool(
+    name = "gzip_dev_env",
+    nix_include = ["bin/gzip"],
+    nix_label = "@gzip_nix",
+    nix_paths = ["bin/gzip"],
+    tools = ["gzip"],
+    win_include = ["usr/bin/gzip.exe"],
+    win_paths = ["usr/bin/gzip.exe"],
+    win_tool = "msys2",
+)
+
+nixpkgs_package(
     name = "postgresql_nix",
     attribute_path = "postgresql_9_6",
     build_file_content = """

--- a/compiler/daml-extension/BUILD.bazel
+++ b/compiler/daml-extension/BUILD.bazel
@@ -66,10 +66,9 @@ genrule(
             cp ../$$f $$dir/$$file
         done
         cd ..
-        tar c node_modules \\
-          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-          | gzip -n > $@
+        $(execpath //bazel_tools/sh:mktgz) $@ node_modules
     """,
+    tools = ["//bazel_tools/sh:mktgz"],
 )
 
 genrule(

--- a/compiler/daml-extension/BUILD.bazel
+++ b/compiler/daml-extension/BUILD.bazel
@@ -66,7 +66,9 @@ genrule(
             cp ../$$f $$dir/$$file
         done
         cd ..
-        $(execpath //bazel_tools/sh:mktgz) $@ node_modules
+        # Avoid file path too long errors on Windows of the form
+        #   .../tar_dev_env/usr/bin/tar: node_modules/.cache/terser-webpack-plugin/...: file name is too long (cannot be split); not dumped
+        $(execpath //bazel_tools/sh:mktgz) $@ --exclude="node_modules/.cache/*" node_modules
     """,
     tools = ["//bazel_tools/sh:mktgz"],
 )

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -277,11 +277,12 @@ genrule(
             --output-hoogle=$(location :daml-base-hoogle.txt) \\
             --output-anchor=$(location :daml-base-anchors.json) \\
             $(location :daml-stdlib.json) $(location :daml-prim.json)
-        tar c daml-base-rst \\
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-            | gzip -n > $(location :daml-base-rst.tar.gz)
+        $(execpath //bazel_tools/sh:mktgz) $(location :daml-base-rst.tar.gz) daml-base-rst
     """,
-    tools = ["//compiler/damlc"],
+    tools = [
+        "//bazel_tools/sh:mktgz",
+        "//compiler/damlc",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -65,9 +65,9 @@ genrule(
         $(location //ledger/ledger-api-auth-client:libledger-api-auth-client.jar) \\
         $(location //ledger/ledger-api-auth-client:ledger-api-auth-client_pom.xml)
       "$$MVN" -q -Dmaven.repo.local=$$MVN_DB -f "$$TMP_DIR/quickstart-java/pom.xml" dependency:resolve dependency:resolve-plugins
-      tar cf $(location integration-tests-mvn.tar) -C $$(dirname $$MVN_DB) $$(basename $$MVN_DB) \\
-        --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name
+      $(execpath //bazel_tools/sh:mktar) $@ -C $$(dirname $$MVN_DB) $$(basename $$MVN_DB)
     """.format(mvn = mvn_version),
+    tools = ["//bazel_tools/sh:mktar"],
 )
 
 ts_libraries = [

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -233,7 +233,7 @@ genrule(
         ln -s ../external/npm/node_modules .
 
         # Run sass and grunt
-        ../$(location @sass_nix//:bin/sass) \\
+        ../$(execpath @sass_nix//:bin/sass) \\
             -I bower_components_static/bourbon/dist \\
             -I bower_components_static/neat/app/assets/stylesheets \\
             -I bower_components_static/font-awesome/scss \\
@@ -242,20 +242,13 @@ genrule(
             --sourcemap=none \\
             --update \\
             sass:da_theme/static/css
-        ../$(location :grunt) build
+        ../$(execpath :grunt) build
 
-        tar c da_theme \\
-            --owner=1000 \\
-            --group=1000 \\
-            --mtime=2000-01-01\\ 00:00Z \\
-            --no-acls \\
-            --no-xattrs \\
-            --no-selinux \\
-            --sort=name \\
-            | gzip -n > ../$(location da_theme.tar.gz)
+        ../$(execpath //bazel_tools/sh:mktgz) ../$@ da_theme
     """,
     tools = [
         ":grunt",
+        "//bazel_tools/sh:mktgz",
         "@sass_nix//:bin/sass",
     ],
 ) if not is_windows else None
@@ -293,10 +286,9 @@ genrule(
         cp -L $(location //:LICENSE) source/LICENSE
         cp -L $(location //:NOTICES) source/NOTICES
 
-        tar c source \\
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-            | gzip -n > $(location source.tar.gz)
+        $(execpath //bazel_tools/sh:mktgz) $@ source
     """,
+    tools = ["//bazel_tools/sh:mktgz"],
 )
 
 genrule(
@@ -454,12 +446,11 @@ genrule(
         mkdir -p html/hoogle_db
         cp -rL ../$(location //compiler/damlc:daml-base-hoogle.txt) html/hoogle_db/base.txt
 
-        tar c html \\
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-            | gzip -n > ../$(location html-only.tar.gz)
+        ../$(execpath //bazel_tools/sh:mktgz) ../$@ html
         """.format(sdk = sdk_version),
     tools = [
         "@sphinx_nix//:bin/sphinx-build",
+        "//bazel_tools/sh:mktgz",
     ] + (["@glibc_locales//:locale-archive"] if is_linux else []),
 ) if not is_windows else None
 
@@ -482,10 +473,9 @@ genrule(
                 sed -i -e "s,__URL__,$${to}," redirects/$$from
             fi
         done <docs/redirects.map
-        tar c redirects \\
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-            | gzip -n > $(location redirects.tar.gz)
+        $(execpath //bazel_tools/sh:mktgz) $@ redirects
     """,
+    tools = ["//bazel_tools/sh:mktgz"],
 )
 
 genrule(
@@ -519,9 +509,7 @@ genrule(
         cp -L $(location :pdf-docs) html/_downloads
         # Remove Sphinx build products
         rm -rf .buildinfo .doctrees objects.inv
-        tar c html \\
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-            | gzip -n > $(location html.tar.gz)
+        $(execpath //bazel_tools/sh:mktgz) $@ html
     """.format(
         head = """<?xml version='1.0' encoding='UTF-8'?><urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd'>""",
         item = """<url><loc>%LOC%</loc><lastmod>%DATE%</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>""",
@@ -530,6 +518,7 @@ genrule(
     ),
     stamp = 1,
     tags = ["pdfdocs"],
+    tools = ["//bazel_tools/sh:mktgz"],
 ) if not is_windows else None
 
 filegroup(
@@ -554,10 +543,9 @@ genrule(
         mkdir -p quickstart-java
         cp -rL docs/source/app-dev/bindings-java/quickstart/template-root/* quickstart-java/
         sed -i "s/__VERSION__/{mvn}/" quickstart-java/pom.xml
-        tar c quickstart-java \\
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-            | gzip -n > $@
+        $(execpath //bazel_tools/sh:mktgz) $@ quickstart-java
     """.format(mvn = mvn_version),
+    tools = ["//bazel_tools/sh:mktgz"],
     visibility = ["//visibility:public"],
 )
 

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -99,12 +99,9 @@ genrule(
     cmd = """
         mkdir -p sandbox-classic-tarball/sandbox
         cp -L $(location :sandbox-classic-binary_deploy.jar) sandbox-classic-tarball/sandbox/sandbox-classic-{mvn}.jar
-        out=$$(realpath $@)
-        cd sandbox-classic-tarball
-        tar c sandbox \\
-          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-          | gzip -n > $$out
+        $(execpath //bazel_tools/sh:mktgz) $@ -C sandbox-classic-tarball sandbox
     """.format(mvn = mvn_version),
+    tools = ["//bazel_tools/sh:mktgz"],
     visibility = ["//visibility:public"],
 )
 

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -93,12 +93,9 @@ genrule(
     cmd = """
         mkdir -p sandbox-tarball/sandbox
         cp -L $(location :sandbox-binary_deploy.jar) sandbox-tarball/sandbox/sandbox-{mvn}.jar
-        out=$$(realpath $@)
-        cd sandbox-tarball
-        tar c sandbox \\
-          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-          | gzip -n > $$out
+        $(execpath //bazel_tools/sh:mktgz) $@ -C sandbox-tarball sandbox
     """.format(mvn = mvn_version),
+    tools = ["//bazel_tools/sh:mktgz"],
     visibility = ["//visibility:public"],
 )
 

--- a/navigator/frontend/BUILD.bazel
+++ b/navigator/frontend/BUILD.bazel
@@ -116,9 +116,7 @@ genrule(
     # Package result (.TGZ)
     # To debug, change 'c' to 'cv'.
     echo "Packaging result from $$OUT to $(@D)/frontend.tgz"
-    tar c -C $$OUT . \\
-        --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-        | gzip -n > "$(@D)/frontend.tgz"
+    $(execpath //bazel_tools/sh:mktgz) $(@D)/frontend.tgz -C $$OUT .
 
     # Package result (.JAR)
     echo "Packaging result from $$OUT to $(@D)/frontend.jar"
@@ -131,7 +129,10 @@ genrule(
         WP_OUT_ESCAPED = "'$$WP_OUT'" if is_windows else "$$WP_OUT",
     ),
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
-    tools = [":webpack"],
+    tools = [
+        ":webpack",
+        "//bazel_tools/sh:mktgz",
+    ],
     visibility = [
         "//navigator:__subpackages__",
     ],

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -31,6 +31,7 @@ def sdk_tarball(name, version):
             "//daml-assistant/daml-sdk:sdk_deploy.jar",
         ],
         outs = ["{}.tar.gz".format(name)],
+        tools = ["//bazel_tools/sh:mktgz"],
         cmd = """
           # damlc
           VERSION={version}
@@ -78,9 +79,7 @@ def sdk_tarball(name, version):
           cp -L $(location //triggers/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/trigger-logback.xml
           cp -L $(location //daml-script/runner:src/main/resources/logback.xml) $$OUT/daml-sdk/script-logback.xml
 
-          tar c --format=ustar $$OUT \\
-            --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-            | gzip -n > $@
+          $(execpath //bazel_tools/sh:mktgz) $@ $$OUT
         """.format(version = version),
         visibility = ["//visibility:public"],
     )

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -28,11 +28,12 @@ find $$OUT/ -name '*.template' -type f -exec sh -c 'mv "$$0" "$${0%.template}" &
 PATCH_TOOL=$$PWD/$(location @patch_dev_env//:patch)
 MESSAGING_PATCH=$$PWD/$(location //templates:create-daml-app-test-resources/messaging.patch)
 $$PATCH_TOOL -s -p1 < $$MESSAGING_PATCH
-tar c create-daml-app \\
-    --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-    | gzip -n >$(location :create-daml-app-docs.tar.gz)
+$(execpath //bazel_tools/sh:mktgz) $@ create-daml-app
 """,
-    tools = ["@patch_dev_env//:patch"],
+    tools = [
+        "//bazel_tools/sh:mktgz",
+        "@patch_dev_env//:patch",
+    ],
     visibility = ["//visibility:public"],
 ) if not is_windows else None
 
@@ -101,9 +102,8 @@ EOF
         mkdir -p $$OUT/daml-patterns
         tar xf $(location //docs:daml-patterns) --strip-components=1 -C $$OUT/daml-patterns
 
-        tar c templates-tarball \\
-          --owner=0 --group=0 --numeric-owner --mtime=2000-01-01\\ 00:00Z --sort=name \\
-          | gzip -n >$(location :templates-tarball.tar.gz)
+        $(execpath //bazel_tools/sh:mktgz) $@ templates-tarball
     """,
+    tools = ["//bazel_tools/sh:mktgz"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The results of `tar` and `gzip` are not reproducible by default due to file ordering or metadata like timestamps, see https://reproducible-builds.org/docs/archives/ for details. These issues can be avoided with the right set of command-line flags to `tar` and `gzip`. This PR factors these flags out into dedicated `sh_binary` targets that can be invoked by `genrules` and other rules producing archives. This way we don't need to repeat the same set of command line flags over and over and don't run the risk of accidentally forgetting a flag in some place.

Additionally, `package-app` is converted into a `sh_binary` target as well to ensure that runfiles are handled correctly.

I have compared the SDK release tarball before and after this change. The only differences were found in `daml-sdk/daml-sdk.jar` and `studio/daml-bundled.vsix` due to file ordering and differences in source maps in the navigator bundle. I've manually verified that the navigator and vscode extension work by going through the steps under point 13 in [`release/RELEASE.md`](https://github.com/digital-asset/daml/blob/91b174da9129a731028ccb0db7c2a77e007fa9fd/release/RELEASE.md). (`daml-sdk-head` and `sdk-version: 0.0.0`)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
