### PR TITLE
Introduce time update log entry type

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -79,7 +79,7 @@ message DamlSubmissionBatch {
 // A log entry for a committed DAML submission.
 // Produced by [[KeyValueCommitting]] from the `DamlSubmission` message.
 // Each entry can be converted into a participant state `Update` event
-// with [[KeyValueConsumption]].
+// with [[KeyValueConsumption]], except for a time update entry.
 //
 // Please read comments in [[com.daml.ledger.participant.state.v1.package]]
 // and  [[com.daml.ledger.participant.state.kvutils.package]] for background
@@ -116,6 +116,9 @@ message DamlLogEntry {
 
     // A rejection of a pre-executed submission because of out-of-time-bounds.
     DamlOutOfTimeBoundsEntry out_of_time_bounds_entry = 10;
+
+    // A log entry whose purpose is to transmit a current record time for pre-executed submissions.
+    google.protobuf.Empty time_update_entry = 101;
   }
 }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -185,6 +185,9 @@ object KeyValueConsumption {
       case DamlLogEntry.PayloadCase.OUT_OF_TIME_BOUNDS_ENTRY =>
         outOfTimeBoundsEntryToUpdate(recordTime, entry.getOutOfTimeBoundsEntry).toList
 
+      case DamlLogEntry.PayloadCase.TIME_UPDATE_ENTRY =>
+        List.empty
+
       case DamlLogEntry.PayloadCase.PAYLOAD_NOT_SET =>
         throw Err.InternalError("logEntryToUpdate: PAYLOAD_NOT_SET!")
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/ConflictDetection.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/ConflictDetection.scala
@@ -82,7 +82,7 @@ class ConflictDetection(val damlMetrics: Metrics) {
       case PARTY_ALLOCATION_ENTRY | PACKAGE_UPLOAD_ENTRY | CONFIGURATION_ENTRY |
           TRANSACTION_REJECTION_ENTRY | CONFIGURATION_REJECTION_ENTRY |
           PACKAGE_UPLOAD_REJECTION_ENTRY | PARTY_ALLOCATION_REJECTION_ENTRY |
-          OUT_OF_TIME_BOUNDS_ENTRY =>
+          OUT_OF_TIME_BOUNDS_ENTRY | TIME_UPDATE_ENTRY =>
         logger.trace(s"Dropping conflicting submission (${logEntry.getPayloadCase})")
         metrics.dropped.inc()
         None

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
@@ -16,6 +16,7 @@ import com.daml.ledger.participant.state.kvutils.KeyValueConsumption.{
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
 import com.daml.ledger.participant.state.v1.{Configuration, RejectionReason, Update}
 import com.daml.lf.data.Time.Timestamp
+import com.google.protobuf.Empty
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.TableFor4
 import org.scalatest.prop.Tables.Table
@@ -54,6 +55,14 @@ class KeyValueConsumptionSpec extends WordSpec with Matchers {
         logEntryToUpdate(aLogEntryId, aLogEntryWithRecordTime, recordTimeForUpdate = None)
 
       actual.recordTime shouldBe Timestamp.assertFromInstant(Instant.ofEpochSecond(100))
+    }
+
+    "not generate an update from a time update entry" in {
+      val timeUpdateEntry = DamlLogEntry.newBuilder
+        .setRecordTime(Conversions.buildTimestamp(aRecordTime))
+        .setTimeUpdateEntry(Empty.getDefaultInstance)
+        .build
+      logEntryToUpdate(aLogEntryId, timeUpdateEntry, recordTimeForUpdate = None) shouldBe Nil
     }
   }
 
@@ -297,6 +306,8 @@ class KeyValueConsumptionSpec extends WordSpec with Matchers {
           DamlPartyAllocationRejectionEntry.getDefaultInstance)
       case OUT_OF_TIME_BOUNDS_ENTRY =>
         builder.setOutOfTimeBoundsEntry(DamlOutOfTimeBoundsEntry.getDefaultInstance)
+      case TIME_UPDATE_ENTRY =>
+        builder.setTimeUpdateEntry(Empty.getDefaultInstance)
       case PAYLOAD_NOT_SET =>
         ()
     }


### PR DESCRIPTION
Summary of changes:
* Introduced new log entry type `time_update_entry` to be used for pre-execution.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
