### PR TITLE
Remove redundant clean --expunge

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,6 +1,7 @@
 .bazel-cache
 dev-env/var
 scratch/
+node_modules/
 compiler/daml-extension/node_modules/
 language-support/ts/node_modules/
 language-support/ts/packages/node_modules/

--- a/build.ps1
+++ b/build.ps1
@@ -48,9 +48,6 @@ function bazel() {
 # which later causes issues on Bazel init (source forest creation) on Windows. A shutdown closes workers,
 # which is a workaround for this problem.
 bazel shutdown
-# Temporary to workaround rules_nodejs update.
-bazel clean --expunge
-rm -Recurse -Force -ErrorAction Ignore node_modules
 
 # Prefetch nodejs_dev_env to avoid permission denied errors on external/nodejs_dev_env/nodejs_dev_env/node.exe
 # It isn’t clear where exactly those errors are coming from.

--- a/build.sh
+++ b/build.sh
@@ -27,10 +27,6 @@ if [ -n "$SANDBOX_PID" ]; then
     kill "$SANDBOX_PID"
 fi
 
-# Temporary to workaround rules_nodejs update.
-bazel clean --expunge
-rm -rf node_modules
-
 # Bazel test only builds targets that are dependencies of a test suite so do a full build first.
 bazel build //... --build_tag_filters "$tag_filter"
 

--- a/compatibility/build-release-artifacts-windows.ps1
+++ b/compatibility/build-release-artifacts-windows.ps1
@@ -37,9 +37,6 @@ function bazel() {
 
 
 bazel shutdown
-# Temporary to workaround rules_nodejs update.
-bazel clean --expunge
-rm -Recurse -Force -ErrorAction Ignore node_modules
 bazel fetch @nodejs_dev_env//...
 bazel build `
   `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution_windows.log `

--- a/compatibility/build-release-artifacts.sh
+++ b/compatibility/build-release-artifacts.sh
@@ -17,9 +17,6 @@ eval "$(./dev-env/bin/dade-assist)"
 # before fetching it in another step.
 HEAD_TARGET_DIR=${1:-compatibility/head_sdk}
 
-# Temporary to workaround rules_nodejs update.
-bazel clean --expunge
-rm -rf node_modules
 bazel build \
   //release:sdk-release-tarball \
   //ledger/ledger-api-test-tool:ledger-api-test-tool_deploy.jar


### PR DESCRIPTION
After the node resets this should hopefully not be necessary
anymore (we still had an issue this morning but I believe all nodes
that hit the issue also got the fix and if not, I’ll schedule a
targetted clean --expunge). I’ve also added node_modules to
.bazelignore to match the other node_modules directories.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
