### PR TITLE
Document required nodejs version

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -35,6 +35,11 @@ You will also need some common software tools to build and interact with the tem
 - `Yarn <https://classic.yarnpkg.com/en/docs/install/>`_ package manager for JavaScript. You have to have yarn version 1.10.0 or higher.
 
   Note: Ubuntu 17.04 and higher come with ``cmdtest`` package installed by default. If you are getting errors when installing yarn, you may want to run ``sudo apt remove cmdtest`` first and then install yarn. More information can be found `here <https://github.com/yarnpkg/yarn/issues/2821>`_ as well as in the official `yarn installation docs for Debian / Ubuntu <https://classic.yarnpkg.com/en/docs/install/#debian-stable>`_
+- `NodeJS <https://nodejs.org/en/download/>`_ in version 8.16 or higher. This will usually be
+  installed automatically as part of installing Yarn.
+
+  Note: On Ubuntu 18.04, NodeJS 8.10 will be installed as part of installing Yarn which is too old.
+  You can find instructions for installing newer versions at `NodeSource <https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions>`_.
 - A terminal application for command line interaction
 
 


### PR DESCRIPTION
We’ve had a few confused users run into issues because of
this. `fsevents` (which is basically impossible to avoid as a
dependency) requires NodeJS 8.16 but for some reason Ubuntu 18.04
sticks to the unsupported 8.10.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
