### PR TITLE
daml2js: Memoize lazily constructed decoders

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -505,7 +505,7 @@ renderDecoder = \case
         "})"
     DecoderConstant c -> "jtv.constant(" <> renderDecoderConstant c <> ")"
     DecoderRef t -> snd (genType t) <> ".decoder()"
-    DecoderLazy d -> "jtv.lazy(function () { return " <> renderDecoder d <> "; })"
+    DecoderLazy d -> "damlTypes.lazyMemo(function () { return " <> renderDecoder d <> "; })"
 
 data TypeDef
     = UnionDef T.Text [T.Text] [(T.Text, TypeRef)]

--- a/language-support/ts/daml-types/index.test.ts
+++ b/language-support/ts/daml-types/index.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Optional, Text } from './index';
+import { Optional, Text, memo } from './index';
 
 describe('@daml/types', () => {
   it('optional', () => {
@@ -21,4 +21,15 @@ describe('@daml/types', () => {
     expect(dict.decoder().run([[]]).ok).toBe(false);
     expect(dict.decoder().run([null]).ok).toBe(false);
   });
+});
+
+test('memo', () => {
+  let x = 0;
+  const f = memo(() => {
+    x += 1;
+    return x;
+  });
+  expect(f()).toBe(1);
+  expect(f()).toBe(1);
+  expect(x).toBe(1);
 });


### PR DESCRIPTION
Currently, if you have a record type `T` with a field of type, say,
`Optional S` and you're decoding a list of type `[T]`, then the decoder
for `S` has to be reconstructed for each element of the list. This is
because the `lazy` combinator from the `json-type-validation` does not
memoize the decoder it receives as a thunk.

This PR adds a new combinator `lazyMemo` which behaves like `lazy` but
also memoizes the decoder on its first invocation. All use sites of the
old `lazy` combinator are then replaced with `lazyMemo`.

We could consider upstreaming `lazyMemo` but I'm not sure how much
effort this is given that `json-type-validation` seems to be in
maintenance mode rather than active development.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6892)
<!-- Reviewable:end -->
