### PR TITLE
Remove mentions of fidelity levels from the Ledger API test tool

### DIFF
--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -68,7 +68,7 @@ Run the tool with ``--help`` flag to obtain the list of options the tool provide
    $ java -jar ledger-api-test-tool.jar --help
 
 Selecting tests to run
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 Running the tool without any argument runs only the *default tests*.
 
@@ -128,6 +128,45 @@ Examples (hitting a single participant at ``localhost:6865``):
 
    $ java -jar ledger-api-test-tool.jar --exclude TestC
 
+Performance tests
+^^^^^^^^^^^^^^^^^
+
+The available performance tests allow to establish the "performance envelope"
+of the ledger under test (a term `borrowed from aeronautics <https://en.wikipedia.org/wiki/Flight_envelope>`__),
+which offers an indication of the amount of the parameters under which a
+ledger implementation is supposed to perform.
+
+Those tests include tail latency, throughput and maximum size of a single
+transaction. You can run the tool with the ``--list`` option to see a list
+of available test suites that includes individual performance envelope test
+cases. You can mix and match those tests to produce a test suite tailored
+to match the expected performance envelope of a given ledger implementation
+using a specific hardware setup.
+
+For example, the following will verify that the ledger under test can
+have a tail latency of one second when processing twenty pings, perform
+twenty pings per seconds and being able to process a transaction one
+megabyte in size:
+
+.. code-block:: console
+
+    $ java -jar ledger-api-test-tool.jar \
+      --perf-tests=PerformanceEnvelope.Latency.1000ms \
+      --perf-tests=PerformanceEnvelope.Throughput.TwentyOPS \
+      --perf-tests=PerformanceEnvelope.TransactionSize.1000KB \
+      localhost:6865
+
+.. note::
+
+  A "ping" is a collective name for two templates used to evaluate
+  the performance envelope. Each of the two templates, "Ping" and
+  "Pong", have a single choice allowing the controller to create
+  an instance of the complementary template, directed to the
+  original sender.
+
+The test run will also produce a short summary of statistics which is
+printed to standard output by default but that can be written to a
+specific file path using the ``--perf-tests-report`` command line option.
 
 Try out the Ledger API Test Tool against DAML Sandbox
 =====================================================

--- a/ledger/daml-on-sql/README.rst
+++ b/ledger/daml-on-sql/README.rst
@@ -680,13 +680,8 @@ In particular, the tests are run to ensure that *DAML on SQL* can:
 - have a tail latency no greater than 1 second when issuing 20 pings
 - have a throughput of 20 pings per second
 
-.. note::
-
-  A "ping" is a collective name for two templates used to evaluate
-  the performance envelope. Each of the two templates, "Ping" and
-  "Pong", have a single choice allowing the controller to create
-  an instance of the complementary template, directed to the
-  original sender.
+You can read more on performance tests in the documentation of the
+`Ledger API Test Tool <https://docs.daml.com/tools/ledger-api-test-tool/index.html#performance-tests>`__.
 
 Replicate performance envelope tests
 ====================================
@@ -710,9 +705,9 @@ zone to minimize the latency between the three.
 
 The tests run to evaluate the performance envelope are:
 
-- PerformanceEnvelope.Beta.Latency
-- PerformanceEnvelope.Beta.Throughput
-- PerformanceEnvelope.Beta.TransactionSize
+- PerformanceEnvelope.Latency.1000ms
+- PerformanceEnvelope.Throughput.TwentyOPS
+- PerformanceEnvelope.TransactionSize.1000KB
 
 Please refer to the documentation for the Ledger API Test Tool to learn
 how to run these tests.

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -150,7 +150,7 @@ object Cli {
       .text("""A comma-separated list of inclusion prefixes. If not specified, all default tests are included. If specified, only tests that match at least one of the given inclusion prefixes (and none of the given exclusion prefixes) will be run. Can be specified multiple times, i.e. `--include=a,b` is the same as `--include=a --include=b`.""")
 
     opt[Seq[String]]("perf-tests")
-      .validate(_.find(!Tests.PerformanceTestsKeySet(_)).fold(success)(invalidPerformanceTestName))
+      .validate(_.find(!Tests.PerformanceTestsKeys(_)).fold(success)(invalidPerformanceTestName))
       .action((inc, c) => c.copy(performanceTests = c.performanceTests ++ inc))
       .unbounded()
       .text("""A comma-separated list of performance tests that should be run.""")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -48,7 +48,7 @@ object LedgerApiTestTool {
     println("Alternatively, you can run performance tests.")
     println("They are not run by default, but can be run with `--perf-tests=TEST-NAME`.")
     println()
-    Tests.PerformanceTestsKeys.sorted.foreach(println(_))
+    Tests.PerformanceTestsKeys.foreach(println(_))
   }
   private def printAvailableTestSuites(config: Config): Unit = {
     println("Listing test suites. Run with --list-all to see individual tests.")
@@ -57,7 +57,7 @@ object LedgerApiTestTool {
 
   private def printAvailableTests(config: Config): Unit = {
     println("Listing all tests. Run with --list to only see test suites.")
-    printListOfTests(Tests.all.flatMap(_.tests).toSeq)(_.name)
+    printListOfTests(Tests.all.flatMap(_.tests))(_.name)
   }
 
   private def extractResources(resources: String*): Unit = {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Envelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Envelope.scala
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.infrastructure
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.Duration
+
+sealed abstract class Envelope(val name: String) extends Product with Serializable {
+  def this(names: Vector[String]) {
+    this(names.mkString(Envelope.Separator))
+  }
+}
+
+object Envelope {
+
+  private val Separator = "."
+
+  private val Prefix = Vector("PerformanceEnvelope")
+
+  val All = Latency.All ++ Throughput.All ++ TransactionSize.All
+
+  sealed abstract class Latency(name: String, val latency: Duration)
+      extends Envelope(Latency.Prefix :+ name)
+
+  object Latency {
+
+    private val Prefix = Envelope.Prefix :+ "Latency"
+
+    val All =
+      Vector(SixtySeconds, ThreeSeconds, OneSecond, HalfSecond)
+
+    case object SixtySeconds extends Latency("60000ms", latency = Duration(60, TimeUnit.SECONDS))
+    case object ThreeSeconds extends Latency("3000ms", latency = Duration(3, TimeUnit.SECONDS))
+    case object OneSecond extends Latency("1000ms", latency = Duration(1, TimeUnit.SECONDS))
+    case object HalfSecond extends Latency("500ms", latency = Duration(500, TimeUnit.MILLISECONDS))
+  }
+
+  sealed abstract class Throughput(name: String, val operationsPerSecond: Int)
+      extends Envelope(Throughput.Prefix :+ name)
+
+  object Throughput {
+
+    private val Prefix = Envelope.Prefix :+ "Throughput"
+
+    val All =
+      Vector(NoThroughput, FivePerSecond, TwentyPerSecond, FiftyPerSecond, FiveHundredPerSecond)
+
+    case object NoThroughput extends Throughput("ZeroOPS", operationsPerSecond = 0)
+    case object FivePerSecond extends Throughput("FiveOPS", operationsPerSecond = 5)
+    case object TwentyPerSecond extends Throughput("TwentyOPS", operationsPerSecond = 20)
+    case object FiftyPerSecond extends Throughput("FiftyOPS", operationsPerSecond = 50)
+    case object FiveHundredPerSecond extends Throughput("FiveHundredOPS", operationsPerSecond = 500)
+  }
+
+  sealed abstract class TransactionSize(name: String, val kilobytes: Int)
+      extends Envelope(TransactionSize.Prefix :+ name)
+
+  object TransactionSize {
+
+    private val Prefix = Envelope.Prefix :+ "TransactionSize"
+
+    val All =
+      Vector(OneKilobyte, OneHundredKilobytes, OneMegabyte, FiveMegabytes, TwentyFiveMegabytes)
+
+    case object OneKilobyte extends TransactionSize("1KB", kilobytes = 1)
+    case object OneHundredKilobytes extends TransactionSize("100KB", kilobytes = 100)
+    case object OneMegabyte extends TransactionSize("1000KB", kilobytes = 1000)
+    case object FiveMegabytes extends TransactionSize("5000KB", kilobytes = 5000)
+    case object TwentyFiveMegabytes extends TransactionSize("25000KB", kilobytes = 25000)
+  }
+
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
@@ -319,7 +319,7 @@ object PerformanceEnvelope {
     override protected val logger: Logger = LoggerFactory.getLogger(getClass)
 
     test(
-      envelope.name,
+      envelope.name.replace(".", ""),
       s"Verify that ledger passes the ${envelope.name} throughput envelope",
       allocate(SingleParty, SingleParty),
     )(implicit ec => { participants =>
@@ -364,7 +364,7 @@ object PerformanceEnvelope {
     require(numPings > 0 && numWarmupPings >= 0)
 
     test(
-      envelope.name,
+      envelope.name.replace(".", ""),
       s"Verify that ledger passes the ${envelope.name} latency envelope",
       allocate(SingleParty, SingleParty),
     )(implicit ec => { participants =>
@@ -409,7 +409,7 @@ object PerformanceEnvelope {
     override protected val maxInflight = 10
 
     test(
-      envelope.name,
+      envelope.name.replace(".", ""),
       s"Verify that ledger passes the ${envelope.name} transaction size envelope",
       allocate(SingleParty, SingleParty),
     )(implicit ec => { participants =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
@@ -9,7 +9,12 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
-import com.daml.ledger.api.testtool.infrastructure.{Allocation, Assertions, LedgerTestSuite}
+import com.daml.ledger.api.testtool.infrastructure.{
+  Allocation,
+  Assertions,
+  Envelope,
+  LedgerTestSuite
+}
 import com.daml.ledger.api.v1.command_completion_service.{
   CompletionEndRequest,
   CompletionStreamRequest,
@@ -25,58 +30,18 @@ import com.daml.ledger.client.binding.{Primitive => P}
 import com.daml.ledger.test.performance.{PingPong => PingPongModule}
 import io.grpc.stub.StreamObserver
 import io.grpc.{Context, Status}
-import org.slf4j.Logger
+import org.slf4j.{Logger, LoggerFactory}
 import scalaz.syntax.tag._
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future, Promise, blocking}
 import scala.util.{Failure, Random, Success, Try}
 
-sealed trait Envelope {
-  val name: String
-  val transactionSizeKb: Int
-  val throughput: Int
-  val latencyMs: Int
-}
+sealed trait PerformanceEnvelope[E <: Envelope] {
 
-object Envelope {
-
-  /** test will unlikely fail */
-  case object ProofOfConcept extends Envelope {
-    val name = "PoC"; val transactionSizeKb = 1; val throughput = 0; val latencyMs = 60000
-  }
-
-  /** test will fail if performance is lower than alpha envelope */
-  case object Alpha extends Envelope {
-    val name = "Alpha"; val transactionSizeKb = 100; val throughput = 5; val latencyMs = 3000
-  }
-
-  /** test will fail if performance is lower then beta envelope */
-  case object Beta extends Envelope {
-    val name = "Beta"; val transactionSizeKb = 1000; val throughput = 20; val latencyMs = 1000
-  }
-
-  case object Public extends Envelope {
-    val name = "Public"; val transactionSizeKb = 5000; val throughput = 50; val latencyMs = 1000
-  }
-
-  case object Enterprise extends Envelope {
-    val name = "Enterprise"
-    val transactionSizeKb = 25000
-    val throughput = 500
-    val latencyMs = 500
-  }
-
-  // [FT] Could use macros as in https://riptutorial.com/scala/example/26215/using-sealed-trait-and-case-objects-and-allvalues-macro
-  //   or even by pulling in https://github.com/lloydmeta/enumeratum  but https://github.com/bazelbuild/rules_scala/issues/445
-  val values: List[Envelope] = List[Envelope](ProofOfConcept, Alpha, Beta, Public, Enterprise)
-}
-
-trait PerformanceEnvelope {
-
-  def logger: Logger
-  def envelope: Envelope
-  def maxInflight: Int
+  protected def logger: Logger
+  protected def envelope: E
+  protected def maxInflight: Int
 
   protected def waitForParties(participants: Seq[Allocation.Participant]): Unit = {
     val (participantAlice, alice) = (participants.head.ledger, participants.head.parties.head)
@@ -326,68 +291,80 @@ trait PerformanceEnvelope {
 
 object PerformanceEnvelope {
 
+  def apply[E <: Envelope](
+      envelope: E,
+      reporter: (String, Double) => Unit,
+  ): LedgerTestSuite =
+    envelope match {
+      case e: Envelope.Latency => new LatencyTest(e, reporter = reporter)
+      case e: Envelope.Throughput => new ThroughputTest(e, reporter = reporter)
+      case e: Envelope.TransactionSize => new TransactionSizeScaleTest(e)
+    }
+
   /** Throughput test
     *
     * @param numPings  how many pings to run during the throughput test
     * @param maxInflight how many inflight commands we can have. set it high enough such that the system saturates, keep it low enough to not hit timeouts.
     * @param numWarmupPings how many pings to run before the perf test to warm up the system
     */
-  class ThroughputTest(
-      val logger: Logger,
-      val envelope: Envelope,
-      val numPings: Int = 200,
-      val maxInflight: Int = 40,
-      val numWarmupPings: Int = 40,
-      reporter: (String, Double) => Unit)
-      extends LedgerTestSuite
-      with PerformanceEnvelope {
+  private final class ThroughputTest(
+      override protected val envelope: Envelope.Throughput,
+      override protected val maxInflight: Int = 40,
+      numPings: Int = 200,
+      numWarmupPings: Int = 40,
+      reporter: (String, Double) => Unit,
+  ) extends LedgerTestSuite
+      with PerformanceEnvelope[Envelope.Throughput] {
+
+    override protected val logger: Logger = LoggerFactory.getLogger(getClass)
 
     test(
-      "perf-envelope-throughput",
+      envelope.name,
       s"Verify that ledger passes the ${envelope.name} throughput envelope",
       allocate(SingleParty, SingleParty),
-    )(implicit ec => {
-      case participants =>
-        waitForParties(participants.participants)
+    )(implicit ec => { participants =>
+      waitForParties(participants.participants)
 
-        def runTest(num: Int, description: String): Future[(Duration, List[Duration])] =
-          sendPings(
-            from = participants.participants.head,
-            to = participants.participants(1),
-            workflowIds = (1 to num).map(x => s"$description-$x").toList,
-            payload = description)
-        for {
-          _ <- runTest(numWarmupPings, "throughput-warmup")
-          timings <- runTest(numPings, "throughput-test")
-        } yield {
-          val (elapsed, latencies) = timings
-          val throughput = numPings / elapsed.toMillis.toDouble * 1000.0
-          logger.info(
-            s"Sending of $numPings succeeded after $elapsed, yielding a throughput of ${"%.2f" format throughput}.")
-          reporter("rate", throughput)
-          logger.info(
-            s"Throughput latency stats: ${genStats(latencies.map(_.toMillis), (_, _) => ())}")
-          assert(
-            throughput >= envelope.throughput,
-            s"Observed throughput of ${"%.2f" format throughput} is below the necessary envelope level ${envelope.throughput}")
-        }
+      def runTest(num: Int, description: String): Future[(Duration, List[Duration])] =
+        sendPings(
+          from = participants.participants.head,
+          to = participants.participants(1),
+          workflowIds = (1 to num).map(x => s"$description-$x").toList,
+          payload = description)
+      for {
+        _ <- runTest(numWarmupPings, "throughput-warmup")
+        timings <- runTest(numPings, "throughput-test")
+      } yield {
+        val (elapsed, latencies) = timings
+        val throughput = numPings / elapsed.toMillis.toDouble * 1000.0
+        logger.info(
+          s"Sending of $numPings succeeded after $elapsed, yielding a throughput of ${"%.2f" format throughput}.")
+        reporter("rate", throughput)
+        logger.info(
+          s"Throughput latency stats: ${genStats(latencies.map(_.toMillis), (_, _) => ())}")
+        assert(
+          throughput >= envelope.operationsPerSecond,
+          s"Observed throughput of ${"%.2f" format throughput} is below the necessary envelope level ${envelope.operationsPerSecond}"
+        )
+      }
     })
   }
 
-  class LatencyTest(
-      val logger: Logger,
-      val envelope: Envelope,
-      val numPings: Int = 20,
-      val numWarmupPings: Int = 10,
-      reporter: (String, Double) => Unit)
-      extends LedgerTestSuite
-      with PerformanceEnvelope {
+  private final class LatencyTest(
+      override protected val envelope: Envelope.Latency,
+      numPings: Int = 20,
+      numWarmupPings: Int = 10,
+      reporter: (String, Double) => Unit,
+  ) extends LedgerTestSuite
+      with PerformanceEnvelope[Envelope.Latency] {
 
-    val maxInflight = 1 // will only be one
+    override protected val logger: Logger = LoggerFactory.getLogger(getClass)
+
+    override protected val maxInflight = 1 // will only be one
     require(numPings > 0 && numWarmupPings >= 0)
 
     test(
-      "perf-envelope-latency",
+      envelope.name,
       s"Verify that ledger passes the ${envelope.name} latency envelope",
       allocate(SingleParty, SingleParty),
     )(implicit ec => { participants =>
@@ -402,7 +379,7 @@ object PerformanceEnvelope {
         case (_, latencies) =>
           val sample = latencies.drop(numWarmupPings).map(_.toMillis).sorted
           require(sample.length == numPings)
-          val tailCount = sample.count(_ > envelope.latencyMs)
+          val tailCount = sample.count(_ > envelope.latency.toMillis)
           val stats = genStats(sample, reporter)
           logger.info(s"Latency test finished: $stats")
           assert(
@@ -423,14 +400,16 @@ object PerformanceEnvelope {
     s"Sample size of ${sample.length}: avg=${"%.0f" format avg} ms, median=$med ms, stdev=${"%.0f" format stddev} ms"
   }
 
-  class TransactionSizeScaleTest(val logger: Logger, val envelope: Envelope)
-      extends LedgerTestSuite
-      with PerformanceEnvelope {
+  private final class TransactionSizeScaleTest(
+      override protected val envelope: Envelope.TransactionSize,
+  ) extends LedgerTestSuite
+      with PerformanceEnvelope[Envelope.TransactionSize] {
 
-    val maxInflight = 10
+    override protected val logger: Logger = LoggerFactory.getLogger(getClass)
+    override protected val maxInflight = 10
 
     test(
-      "perf-envelope-transaction-size",
+      envelope.name,
       s"Verify that ledger passes the ${envelope.name} transaction size envelope",
       allocate(SingleParty, SingleParty),
     )(implicit ec => { participants =>
@@ -440,7 +419,7 @@ object PerformanceEnvelope {
         from = participants.participants.head,
         to = participants.participants(1),
         workflowIds = List("transaction-size"),
-        payload = Random.alphanumeric.take(envelope.transactionSizeKb * 1024).mkString("")
+        payload = Random.alphanumeric.take(envelope.kilobytes * 1024).mkString("")
       ).map(_ => ())
     })
   }

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -155,9 +155,9 @@ conformance_test(
     ],
     test_tool_args = [
         "--verbose",
-        "--perf-tests=PerformanceEnvelope.Beta.Throughput",
-        "--perf-tests=PerformanceEnvelope.Beta.Latency",
-        "--perf-tests=PerformanceEnvelope.Beta.TransactionSize",
+        "--perf-tests=PerformanceEnvelope.Throughput.TwentyOPS",
+        "--perf-tests=PerformanceEnvelope.Latency.1000ms",
+        "--perf-tests=PerformanceEnvelope.TransactionSize.1000KB",
     ],
 )
 

--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -255,9 +255,9 @@ da_scala_test_suite(
             tags = db.get("benchmark_performance_envelope_tags", []),
             test_tool_args = db.get("benchmark_performance_envelope_tags", []) + [
                 "--verbose",
-                "--perf-tests=PerformanceEnvelope.Beta.Throughput",
-                "--perf-tests=PerformanceEnvelope.Beta.Latency",
-                "--perf-tests=PerformanceEnvelope.Beta.TransactionSize",
+                "--perf-tests=PerformanceEnvelope.Throughput.TwentyOPS",
+                "--perf-tests=PerformanceEnvelope.Latency.1000ms",
+                "--perf-tests=PerformanceEnvelope.TransactionSize.1000KB",
             ],
         ),
     )


### PR DESCRIPTION
Fixes #6868

changelog_begin
[Integration Kit] The performance test names have been changed.
To learn more about the available tests, consult the documentation
for the Ledger API Test Tool and run it with --list.
Docs: https://docs.daml.com/tools/ledger-api-test-tool/index.html#performance-tests
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
