### PR TITLE
Expose type synonyms in data-dependencies.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -418,10 +418,6 @@ convertTypeDef env o@(ATyCon t) = withRange (convNameLoc t) $ if
     , n `elementOfUniqSet` consumingTypes
     -> pure []
 
-    -- Type synonyms get expanded out during conversion (see 'convertType').
-    | isTypeSynonymTyCon t
-    -> pure []
-
     -- Constraint tuples are represented by LF structs.
     | isConstraintTupleTyCon t
     -> pure []
@@ -434,6 +430,11 @@ convertTypeDef env o@(ATyCon t) = withRange (convNameLoc t) $ if
     -- Type classes
     | isClassTyCon t
     -> convertClassDef env t
+
+    -- Type synonyms get expanded out during conversion (see 'convertType'), but we also
+    -- convert the synonyms we can so that we can expose them via data-dependencies.
+    | isTypeSynonymTyCon t
+    -> convertTypeSynonym env t
 
     -- Simple record types. This includes newtypes, and
     -- single constructor algebraic types with no fields or with
@@ -474,6 +475,28 @@ convertSimpleRecordDef env tycon = do
         workerDef = defNewtypeWorker (envLFModuleName env) tycon tconName con tyVars fields
 
     pure $ typeDef : [workerDef | flavour == NewtypeFlavour]
+
+convertTypeSynonym :: Env -> TyCon -> ConvertM [Definition]
+convertTypeSynonym env tycon
+    | NameIn DA_Generics _ <- GHC.tyConName tycon
+    = pure []
+
+    | envLfVersion env `supports` featureTypeSynonyms
+    , Just (params, body) <- synTyConDefn_maybe tycon
+    , isLiftedTypeKind (tyConResKind tycon)
+    , not (isKindTyCon tycon)
+    = do
+        (env', tsynParams) <- bindTypeVars env params
+        tsynType <- convertType env' body
+        let tsynName = mkTypeSyn [getOccText tycon]
+        case tsynType of
+            TUnit -> pure []
+                -- ^ We avoid converting TUnit type synonyms because it
+                -- clashes with the conversion of empty typeclasses.
+            _ -> pure [ defTypeSyn tsynName tsynParams tsynType ]
+
+    | otherwise
+    = pure []
 
 convertClassDef :: Env -> TyCon -> ConvertM [Definition]
 convertClassDef env tycon = do

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -483,7 +483,7 @@ convertTypeSynonym env tycon
 
     | envLfVersion env `supports` featureTypeSynonyms
     , Just (params, body) <- synTyConDefn_maybe tycon
-    , isLiftedTypeKind (tyConResKind tycon)
+    , isLiftedTypeKind (tyConResKind tycon) -- accepts types and constraints
     , not (isKindTyCon tycon)
     = do
         (env', tsynParams) <- bindTypeVars env params
@@ -491,7 +491,7 @@ convertTypeSynonym env tycon
         let tsynName = mkTypeSyn [getOccText tycon]
         case tsynType of
             TUnit -> pure []
-                -- ^ We avoid converting TUnit type synonyms because it
+                -- We avoid converting TUnit type synonyms because it
                 -- clashes with the conversion of empty typeclasses.
             _ -> pure [ defTypeSyn tsynName tsynParams tsynType ]
 

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1124,7 +1124,11 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
               ]
           writeFileUTF8 (tmpDir </> "dep" </> "Foo.daml") $ unlines
               [ "module Foo where"
-              , "type MyInt = Int"
+              , "type MyInt' = Int"
+              , "type MyArrow a b = a -> b"
+              , "type MyUnit = ()"
+              , "type MyOptional = Optional"
+              , "type MyFunctor t = Functor t"
               ]
           withCurrentDirectory (tmpDir </> "dep") $ callProcessSilent damlc ["build", "-o", tmpDir </> "dep" </> "dep.dar", "--target=1.dev"]
           step "Building proj"
@@ -1140,8 +1144,20 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
           writeFileUTF8 (tmpDir </> "proj" </> "Bar.daml") $ unlines
               [ "module Bar where"
               , "import Foo"
-              , "x : MyInt"
+              , "x : MyInt'"
               , "x = 10"
+              , "f : MyArrow Int Int"
+              , "f a = a + 1"
+              , "type MyUnit = Int"
+              , "g : MyUnit -> MyUnit"
+                -- ^ this tests that MyUnit wasn't exported from Foo
+              , "g a = a"
+              , "type MyOptional t = Int"
+              , "h : MyOptional Int -> MyOptional Int"
+                  -- ^ this tests that MyOptional wasn't exported from Foo
+              , "h a = a"
+              , "myFmap : MyFunctor t => (a -> b) -> t a -> t b"
+              , "myFmap = fmap"
               ]
           withCurrentDirectory (tmpDir </> "proj") $ callProcessSilent damlc ["build", "-o", tmpDir </> "proj" </> "proj.dar", "--target=1.dev"]
 

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1112,6 +1112,39 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
               ]
           withCurrentDirectory (tmpDir </> "proj") $ callProcessSilent damlc ["build", "-o", tmpDir </> "proj" </> "proj.dar"]
 
+    , testCaseSteps "Type synonyms over data-dependencies" $ \step -> withTempDir $ \tmpDir -> do
+          step "Building dep"
+          createDirectoryIfMissing True (tmpDir </> "dep")
+          writeFileUTF8 (tmpDir </> "dep" </> "daml.yaml") $ unlines
+              [ "sdk-version: " <> sdkVersion
+              , "name: dep"
+              , "version: 0.1.0"
+              , "source: ."
+              , "dependencies: [daml-prim, daml-stdlib]"
+              ]
+          writeFileUTF8 (tmpDir </> "dep" </> "Foo.daml") $ unlines
+              [ "module Foo where"
+              , "type MyInt = Int"
+              ]
+          withCurrentDirectory (tmpDir </> "dep") $ callProcessSilent damlc ["build", "-o", tmpDir </> "dep" </> "dep.dar", "--target=1.dev"]
+          step "Building proj"
+          createDirectoryIfMissing True (tmpDir </> "proj")
+          writeFileUTF8 (tmpDir </> "proj" </> "daml.yaml") $ unlines
+              [ "sdk-version: " <> sdkVersion
+              , "name: proj"
+              , "version: 0.1.0"
+              , "source: ."
+              , "dependencies: [daml-prim, daml-stdlib]"
+              , "data-dependencies: [" <> show (tmpDir </> "dep" </> "dep.dar") <> "]"
+              ]
+          writeFileUTF8 (tmpDir </> "proj" </> "Bar.daml") $ unlines
+              [ "module Bar where"
+              , "import Foo"
+              , "x : MyInt"
+              , "x = 10"
+              ]
+          withCurrentDirectory (tmpDir </> "proj") $ callProcessSilent damlc ["build", "-o", tmpDir </> "proj" </> "proj.dar", "--target=1.dev"]
+
     , testCaseSteps "RankNTypes" $ \step -> withTempDir $ \tmpDir -> do
           step "Building dep"
           createDirectoryIfMissing True (tmpDir </> "dep")
@@ -1147,8 +1180,8 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
           writeFileUTF8 (tmpDir </> "proj" </> "Bar.daml") $ unlines
               [ "module Bar where"
               , "import Foo"
-              , "type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t"
               , "x : Lens s t a b -> Lens s t a b"
+                -- ^ This also tests Rank N type synonyms!
               , "x = lensIdentity"
               ]
           withCurrentDirectory (tmpDir </> "proj") $ callProcessSilent damlc ["build", "-o", tmpDir </> "proj" </> "proj.dar", "--target=1.dev"]


### PR DESCRIPTION
This PR converts (non-unit) type synonyms during LF conversion, and then
exposes them via data-dependencies. This is possible only when using an
LF version that supports type synonyms (LF version >= 1.7), the
type synonym isn't of unit type (because it clashes with empty
typeclasses, and the (fully applied) type synonym has kind *
(e.g. you can't define a * -> * synonym in LF).

This fixes issue #6306

changelog_begin

- [DAML Compiler] The DAML compiler will now compile type synonyms
  (``type X = Y``) into the DAR, whenever possible, and will expose
  these synonyms via data-dependencies.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
