### PR TITLE
daml2js: Use jtv.lazy as the only loop break

### DIFF
--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -46,6 +46,8 @@ template AllTypes with
     n5 : Numeric 5
     n10 : Decimal
     rec : Recursive
+    voidRecord: Optional VoidRecord
+    voidEnum: Optional VoidEnum
   where
     signatory party
 
@@ -72,6 +74,14 @@ template Person with
       do
         archive self
         create this with name = newName
+
+    nonconsuming choice AddOthersFriends: ContractId Person with
+        otherCid: ContractId Person
+      controller party
+      do
+        other <- fetch otherCid
+        archive self
+        create this with friends = friends ++ other.friends
 
 data Pair a b = Pair {
   one: a;
@@ -139,5 +149,7 @@ data Recursive = Recursive with
 
 data VoidRecord = VoidRecord with
     inner: VoidRecord
+  deriving (Eq, Show)
 
 data VoidEnum = VoidEnum VoidEnum
+  deriving (Eq, Show)

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -108,11 +108,11 @@ function promisifyStream<T extends object, K, I extends string, State>(
 
 describe('decoders for recursive types do not loop', () => {
   test('recursive enum', () => {
-    expect(buildAndLint.Main.Expr(Int).decoder().run(undefined).ok).toBe(false);
+    expect(buildAndLint.Main.Expr(Int).decoder.run(undefined).ok).toBe(false);
   });
 
   test('recursive record with guards', () => {
-    expect(buildAndLint.Main.Recursive.decoder().run(undefined).ok).toBe(false);
+    expect(buildAndLint.Main.Recursive.decoder.run(undefined).ok).toBe(false);
   });
 
   // FIXME(MH): This test does not pass yet, see https://github.com/digital-asset/daml/issues/6840
@@ -121,7 +121,7 @@ describe('decoders for recursive types do not loop', () => {
   // });
 
   test('uninhabited enum', () => {
-    expect(buildAndLint.Main.VoidEnum.decoder().run(undefined).ok).toBe(false);
+    expect(buildAndLint.Main.VoidEnum.decoder.run(undefined).ok).toBe(false);
   });
 });
 
@@ -296,6 +296,8 @@ test('create + fetch & exercise', async () => {
     n5:  '3.14159',      // Numeric 5
     n10: '3.1415926536', // Numeric 10
     rec: {'recOptional': null, 'recList': [], 'recTextMap': {}},
+    voidRecord: null,
+    voidEnum: null,
   };
   const allTypesContract = await aliceLedger.create(buildAndLint.Main.AllTypes, allTypes);
   expect(allTypesContract.payload).toEqual(allTypes);

--- a/language-support/ts/daml-ledger/index.test.ts
+++ b/language-support/ts/daml-ledger/index.test.ts
@@ -68,8 +68,8 @@ jest.mock('isomorphic-ws', () => class {
 
 const Foo: Template<Foo, string, "foo-id"> = {
   templateId: "foo-id",
-  keyDecoder: () => jtv.string(),
-  decoder: () => jtv.object({key: jtv.string()}),
+  keyDecoder: jtv.string(),
+  decoder: jtv.object({key: jtv.string()}),
   Archive: {} as unknown as Choice<Foo, {}, {}, string>,
 };
 

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -51,12 +51,12 @@ export type Event<T extends object, K = unknown, I extends string = string> =
  */
 const decodeCreateEvent = <T extends object, K, I extends string>(template: Template<T, K, I>): jtv.Decoder<CreateEvent<T, K, I>> => jtv.object({
   templateId: jtv.constant(template.templateId),
-  contractId: ContractId(template).decoder(),
-  signatories: List(Party).decoder(),
-  observers: List(Party).decoder(),
-  agreementText: Text.decoder(),
-  key: template.keyDecoder(),
-  payload: template.decoder(),
+  contractId: ContractId(template).decoder,
+  signatories: List(Party).decoder,
+  observers: List(Party).decoder,
+  agreementText: Text.decoder,
+  key: template.keyDecoder,
+  payload: template.decoder,
 });
 
 /**
@@ -72,7 +72,7 @@ const decodeCreateEventUnknown: jtv.Decoder<CreateEvent<object>> =
  */
 const decodeArchiveEvent = <T extends object, K, I extends string>(template: Template<T, K, I>): jtv.Decoder<ArchiveEvent<T, I>> => jtv.object({
   templateId: jtv.constant(template.templateId),
-  contractId: ContractId(template).decoder(),
+  contractId: ContractId(template).decoder,
 });
 
 /**
@@ -400,7 +400,7 @@ class Ledger {
     const json = await this.submit('v1/exercise', payload);
     // Decode the server response into a tuple.
     const responseDecoder: jtv.Decoder<{exerciseResult: R; events: Event<object>[]}> = jtv.object({
-      exerciseResult: choice.resultDecoder(),
+      exerciseResult: choice.resultDecoder,
       events: jtv.array(decodeEventUnknown),
     });
     const {exerciseResult, events} = jtv.Result.withException(responseDecoder.run(json));
@@ -438,7 +438,7 @@ class Ledger {
     const json = await this.submit('v1/exercise', payload);
     // Decode the server response into a tuple.
     const responseDecoder: jtv.Decoder<{exerciseResult: R; events: Event<object>[]}> = jtv.object({
-      exerciseResult: choice.resultDecoder(),
+      exerciseResult: choice.resultDecoder,
       events: jtv.array(decodeEventUnknown),
     });
     const {exerciseResult, events} = jtv.Result.withException(responseDecoder.run(json));

--- a/language-support/ts/daml-types/index.test.ts
+++ b/language-support/ts/daml-types/index.test.ts
@@ -5,21 +5,21 @@ import { Optional, Text, memo } from './index';
 describe('@daml/types', () => {
   it('optional', () => {
     const dict = Optional(Text);
-    expect(dict.decoder().run(null).ok).toBe(true);
-    expect(dict.decoder().run('X').ok).toBe(true);
-    expect(dict.decoder().run([]).ok).toBe(false);
-    expect(dict.decoder().run(['X']).ok).toBe(false);
+    expect(dict.decoder.run(null).ok).toBe(true);
+    expect(dict.decoder.run('X').ok).toBe(true);
+    expect(dict.decoder.run([]).ok).toBe(false);
+    expect(dict.decoder.run(['X']).ok).toBe(false);
   });
 
   it('nested optionals', () => {
     const dict = Optional(Optional(Text));
-    expect(dict.decoder().run(null).ok).toBe(true);
-    expect(dict.decoder().run([]).ok).toBe(true);
-    expect(dict.decoder().run(['X']).ok).toBe(true);
-    expect(dict.decoder().run('X').ok).toBe(false);
-    expect(dict.decoder().run([['X']]).ok).toBe(false);
-    expect(dict.decoder().run([[]]).ok).toBe(false);
-    expect(dict.decoder().run([null]).ok).toBe(false);
+    expect(dict.decoder.run(null).ok).toBe(true);
+    expect(dict.decoder.run([]).ok).toBe(true);
+    expect(dict.decoder.run(['X']).ok).toBe(true);
+    expect(dict.decoder.run('X').ok).toBe(false);
+    expect(dict.decoder.run([['X']]).ok).toBe(false);
+    expect(dict.decoder.run([[]]).ok).toBe(false);
+    expect(dict.decoder.run([null]).ok).toBe(false);
   });
 });
 

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -10,11 +10,9 @@ import * as jtv from '@mojotech/json-type-validation';
  */
 export interface Serializable<T> {
   /**
-   * The decoder for a contract of template T.
-   *
-   * NB: This is a function to allow for mutually recursive decoders.
+   * @internal The decoder for a contract of template T.
    */
-  decoder: () => jtv.Decoder<T>;
+  decoder: jtv.Decoder<T>;
 }
 
 /**
@@ -28,7 +26,10 @@ export interface Serializable<T> {
  */
 export interface Template<T extends object, K = unknown, I extends string = string> extends Serializable<T> {
   templateId: I;
-  keyDecoder: () => jtv.Decoder<K>;
+  /**
+   * @internal
+   */
+  keyDecoder: jtv.Decoder<K>;
   Archive: Choice<T, {}, {}, K>;
 }
 
@@ -47,13 +48,13 @@ export interface Choice<T extends object, C, R, K = unknown> {
    */
   template: () => Template<T, K>;
   /**
-   * Returns a decoder to decode the choice arguments.
+   * @internal Returns a decoder to decode the choice arguments.
    */
-  argumentDecoder: () => jtv.Decoder<C>;
+  argumentDecoder: jtv.Decoder<C>;
   /**
-   * Returns a deocoder to decode the return value.
+   * @internal Returns a deocoder to decode the return value.
    */
-  resultDecoder: () => jtv.Decoder<R>;
+  resultDecoder: jtv.Decoder<R>;
   /**
    * The choice name.
    */
@@ -125,7 +126,7 @@ export type Unit = {};
  * Companion obect of the [[Unit]] type.
  */
 export const Unit: Serializable<Unit> = {
-  decoder: () => jtv.object({}),
+  decoder: jtv.object({}),
 }
 
 /**
@@ -137,7 +138,7 @@ export type Bool = boolean;
  * Companion object of the [[Bool]] type.
  */
 export const Bool: Serializable<Bool> = {
-  decoder: jtv.boolean,
+  decoder: jtv.boolean(),
 }
 
 /**
@@ -151,7 +152,7 @@ export type Int = string;
  * Companion object of the [[Int]] type.
  */
 export const Int: Serializable<Int> = {
-  decoder: jtv.string,
+  decoder: jtv.string(),
 }
 
 /**
@@ -176,7 +177,7 @@ export type Decimal = Numeric;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const Numeric = (_: number): Serializable<Numeric> =>
   ({
-    decoder: jtv.string,
+    decoder: jtv.string(),
   })
 
 /**
@@ -193,7 +194,7 @@ export type Text = string;
  * Companion object of the [[Text]] type.
  */
 export const Text: Serializable<Text> = {
-  decoder: jtv.string,
+  decoder: jtv.string(),
 }
 
 /**
@@ -207,7 +208,7 @@ export type Time = string;
  * Companion object of the [[Time]] type.
  */
 export const Time: Serializable<Time> = {
-  decoder: jtv.string,
+  decoder: jtv.string(),
 }
 
 /**
@@ -221,7 +222,7 @@ export type Party = string;
  * Companion object of the [[Party]] type.
  */
 export const Party: Serializable<Party> = {
-  decoder: jtv.string,
+  decoder: jtv.string(),
 }
 
 /**
@@ -237,7 +238,7 @@ export type List<T> = T[];
  * Companion object of the [[List]] type.
  */
 export const List = <T>(t: Serializable<T>): Serializable<T[]> => ({
-  decoder: (): jtv.Decoder<T[]> => lazyMemo(() => jtv.array(t.decoder())),
+  decoder: jtv.array(t.decoder),
 });
 
 /**
@@ -251,7 +252,7 @@ export type Date = string;
  * Companion object of the [[Date]] type.
  */
 export const Date: Serializable<Date> = {
-  decoder: jtv.string,
+  decoder: jtv.string(),
 }
 
 /**
@@ -279,7 +280,7 @@ export type ContractId<T> = string & { [ContractIdBrand]: T }
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const ContractId = <T>(_t: Serializable<T>): Serializable<ContractId<T>> => ({
-  decoder: jtv.string as () => jtv.Decoder<ContractId<T>>,
+  decoder: jtv.string() as jtv.Decoder<ContractId<T>>,
 });
 
 /**
@@ -302,14 +303,11 @@ type OptionalInner<T> = null extends T ? [] | [Exclude<T, null>] : T
  * @typeparam T The type of the optionally present value.
  */
 class OptionalWorker<T> implements Serializable<Optional<T>> {
-  constructor(private payload: Serializable<T>) { }
+  decoder: jtv.Decoder<Optional<T>>;
+  private innerDecoder: jtv.Decoder<OptionalInner<T>>;
 
-  decoder(): jtv.Decoder<Optional<T>> {
-      return jtv.oneOf(jtv.constant(null), lazyMemo(() => this.innerDecoder()));
-  }
-
-  private innerDecoder(): jtv.Decoder<OptionalInner<T>> {
-    if (this.payload instanceof OptionalWorker) {
+  constructor(payload: Serializable<T>) {
+    if (payload instanceof OptionalWorker) {
       // NOTE(MH): `T` is of the form `Optional<U>` for some `U` here, that is
       // `T = Optional<U> = null | OptionalInner<U>`. Since `null` does not
       // extend `OptionalInner<V>` for any `V`, this implies
@@ -317,16 +315,17 @@ class OptionalWorker<T> implements Serializable<Optional<T>> {
       // `OptionalInner<T> = [] | [Exclude<T, null>]`.
       type OptionalInnerU = Exclude<T, null>
       const payloadInnerDecoder =
-        this.payload.innerDecoder() as jtv.Decoder<unknown> as jtv.Decoder<OptionalInnerU>;
-      return jtv.oneOf<[] | [Exclude<T, null>]>(
+        payload.innerDecoder as jtv.Decoder<unknown> as jtv.Decoder<OptionalInnerU>;
+      this.innerDecoder = jtv.oneOf<[] | [Exclude<T, null>]>(
         jtv.constant<[]>([]),
         jtv.tuple([payloadInnerDecoder]),
       ) as jtv.Decoder<OptionalInner<T>>;
     } else {
       // NOTE(MH): `T` is not of the form `Optional<U>` here and hence `null`
       // does not extend `T`. Thus, `OptionalInner<T> = T`.
-      return this.payload.decoder() as jtv.Decoder<OptionalInner<T>>;
+      this.innerDecoder = payload.decoder as jtv.Decoder<OptionalInner<T>>;
     }
+    this.decoder = jtv.oneOf(jtv.constant(null), this.innerDecoder);
   }
 }
 
@@ -349,7 +348,7 @@ export type TextMap<T> = { [key: string]: T };
  * Companion object of the [[TextMap]] type.
  */
 export const TextMap = <T>(t: Serializable<T>): Serializable<TextMap<T>> => ({
-    decoder: (): jtv.Decoder<TextMap<T>> => lazyMemo(() => jtv.dict(t.decoder())),
+    decoder: jtv.dict(t.decoder),
 });
 
 // TODO(MH): `Map` type.


### PR DESCRIPTION
We currently use two different mechanisms for breaking loops in the
`Serializable` companion objects generated for each type:

1. Explicit thunks of the form `() => Decoder<A>`, e.g., in the
   definition of the `Serializable` interface itself.
2. the `lazyMemo` combinator, e.g. in enum types, `Optional`s and lists.

This is inconsistent and leads to the introduction of more loop
breakers than actually needed.

This PR changes the situation to use the `lazyMemo` combinator as the
only loop breaker. To this end, we change the definition of the
`Serializable` interface and related similar interfaces to use `Decoder`
directly rather than the thunked up version. This is a *breaking change*
of the affected interfaces. However, the libraries `@daml/ledger` and
`@daml/react` are updated accordingly and hence nothing breaks when
using `daml2js` in combination with these libraries. Furthermore, the
exact definition of the decoder types is considered an implementation
detail since we don't want to tie ourselves long-term to the use of the
`json-type-validation` library, which is mostly unmaintained.

Using `lazy` as the only loop breaker effectively pushes all loop
breakers to the top-level and allows for removing those nested more
deeply in types.

This change should not negatively impact the performance of the
decoding process since it only replaces thunks by memoized thunks and
removes a few calls to `lazyMemo` completely. In fact, we should gain
performance since the decoders in the companion objects are now
memoized.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6898)
<!-- Reviewable:end -->
