### PR TITLE
participant-integration-api: Increase the DAR upload timeout.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -23,13 +23,13 @@ import com.daml.platform.apiserver.execution.{
   StoreBackedCommandExecutor,
   TimedCommandExecutor
 }
+import com.daml.platform.apiserver.services._
 import com.daml.platform.apiserver.services.admin.{
   ApiConfigManagementService,
   ApiPackageManagementService,
   ApiPartyManagementService
 }
 import com.daml.platform.apiserver.services.transaction.ApiTransactionService
-import com.daml.platform.apiserver.services._
 import com.daml.platform.configuration.{
   CommandConfiguration,
   LedgerConfiguration,
@@ -248,7 +248,7 @@ private[daml] object ApiServices {
 
         val apiPackageManagementService =
           ApiPackageManagementService
-            .createApiService(indexService, transactionsService, writeService, timeProvider)
+            .createApiService(indexService, transactionsService, writeService)
 
         val apiConfigManagementService =
           ApiConfigManagementService

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -7,18 +7,16 @@ import java.io.ByteArrayInputStream
 import java.util.UUID
 import java.util.zip.ZipInputStream
 
-import akka.actor.Scheduler
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
-import com.daml.ledger.participant.state.index.v2.{IndexPackagesService, IndexTransactionsService}
-import com.daml.ledger.participant.state.v1.{SubmissionId, SubmissionResult, WritePackagesService}
-import com.daml.api.util.TimeProvider
-import com.daml.lf.archive.DarReader
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.dec.{DirectExecutionContext => DE}
 import com.daml.ledger.api.domain.{LedgerOffset, PackageEntry}
 import com.daml.ledger.api.v1.admin.package_management_service.PackageManagementServiceGrpc.PackageManagementService
 import com.daml.ledger.api.v1.admin.package_management_service._
+import com.daml.ledger.participant.state.index.v2.{IndexPackagesService, IndexTransactionsService}
+import com.daml.ledger.participant.state.v1.{SubmissionId, SubmissionResult, WritePackagesService}
+import com.daml.lf.archive.DarReader
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.validation.ErrorFactories
@@ -34,9 +32,8 @@ private[apiserver] final class ApiPackageManagementService private (
     packagesIndex: IndexPackagesService,
     transactionsService: IndexTransactionsService,
     packagesWrite: WritePackagesService,
-    timeProvider: TimeProvider,
     materializer: Materializer,
-    scheduler: Scheduler)(implicit logCtx: LoggingContext)
+)(implicit logCtx: LoggingContext)
     extends PackageManagementService
     with GrpcApiService {
 
@@ -134,13 +131,7 @@ private[apiserver] object ApiPackageManagementService {
       readBackend: IndexPackagesService,
       transactionsService: IndexTransactionsService,
       writeBackend: WritePackagesService,
-      timeProvider: TimeProvider)(implicit mat: Materializer, logCtx: LoggingContext)
+  )(implicit mat: Materializer, logCtx: LoggingContext)
     : PackageManagementServiceGrpc.PackageManagementService with GrpcApiService =
-    new ApiPackageManagementService(
-      readBackend,
-      transactionsService,
-      writeBackend,
-      timeProvider,
-      mat,
-      mat.system.scheduler)
+    new ApiPackageManagementService(readBackend, transactionsService, writeBackend, mat)
 }


### PR DESCRIPTION
Many DARs take longer than 30 seconds to process, leading to a false timeout before it shows up on the package entry stream.

Increasing this to 15 minutes should cover any use case we can imagine. The client can always terminate the request early if they like; we'll keep polling for a while, but we'll time out on the server too eventually.

This is a workaround for #6880 until we can do it properly.

### Changelog

- **[Ledger API Specification]** The server-side timeout for the `PackageManagementService.UploadDarFile` endpoint has been increased from 30 seconds to 15 minutes. Many DARs take longer than 30 seconds to process, leading to a false timeout before it shows up on the package entry stream.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
