### PR TITLE
Add a semantic test for updating a record field twice

### DIFF
--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -29,6 +29,7 @@
 -- @ERROR Aborted: EvExpRecUpdErr1 OK
 -- @ERROR Aborted: EvExpRecUpdErr2_1 OK
 -- @ERROR Aborted: EvExpRecUpdErr2_2 OK
+-- @ERROR Aborted: EvExpRecUpdErr2_3 OK
 -- @ERROR Aborted: EvExpUpPureErr OK
 -- @ERROR Aborted: EvExpUpBindErr OK
 -- @ERROR Aborted: EvExpUpCreateErr OK
@@ -147,6 +148,12 @@ evExpRecUpdErr2_2 = scenario do
     { b = error "EvExpRecUpdErr2_2 OK", a = error "EvExpRecUpdErr2_2 failed" }
   -- ^ Note that record update depends on the order the fields appear in
   -- code, rather than the order in which fields were defined.
+
+-- NOTE(MH): Make sure we don't swallow record field updates if a field is
+-- updated multiple times.
+evExpRecUpdErr2_3 = scenario do
+  pure (R1 {a=0, b=0})
+    { a = error "EvExpRecUpdErr2_3 OK", a = error "EvExpRecUpdErr2_3 failed" }
 
 -- Can't test LF struct evaluation order from DAML, since we purposely avoid
 -- evaluation of struct fields during typeclass desugaring, and we don't have


### PR DESCRIPTION
rhe new test ensures that we don't omit the first update in a record
update that updates the same field twice.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6901)
<!-- Reviewable:end -->
