### PR TITLE
Fix flakiness in build-and-lint tests (again)

### DIFF
--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -103,7 +103,11 @@ sh_test(
             "ts/**/lib/**",
         ],
     ),
-    flaky = True,
+    # Spinning up jest, Sandbox and the JSON API is expensive.
+    # The expensive stuff should be Sandbox and the JSON API so we
+    # go for 2 CPUs. Feel free to change this to something more adequate
+    # if needed.
+    tags = ["cpu:2"],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
     ],

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -44,38 +44,37 @@ const getEnv = (variable: string): string => {
   return result;
 }
 
-const spawnJvmAndWaitOn = async (jar: string, args: string[], resource: string, jvmArgs: string[] = []): Promise<ChildProcess> => {
+const spawnJvm = (jar: string, args: string[], jvmArgs: string[] = []): ChildProcess => {
   const java = getEnv('JAVA');
   const proc = spawn(java, [...jvmArgs, '-jar', jar, ...args], {stdio: "inherit",});
-  await waitOn({resources: [resource]})
   return proc;
 }
 
 beforeAll(async () => {
   console.log ('build-and-lint-1.0.0 (' + buildAndLint.packageId + ") loaded");
   const darPath = getEnv('DAR');
-  sandboxProcess = await spawnJvmAndWaitOn(
+  sandboxProcess = spawnJvm(
     getEnv('SANDBOX'),
     ['--port', "0", '--port-file', SANDBOX_PORT_FILE, '--ledgerid', LEDGER_ID, '--wall-clock-time', darPath],
-    `file:${SANDBOX_PORT_FILE}`,
   );
+  await waitOn({resources: [`file:${SANDBOX_PORT_FILE}`]})
   const sandboxPortData = await fs.readFile(SANDBOX_PORT_FILE, { encoding: 'utf8' });
   sandboxPort = parseInt(sandboxPortData);
   console.log('Sandbox listening on port ' + sandboxPort.toString());
 
-  jsonApiProcess = await spawnJvmAndWaitOn(
+  jsonApiProcess = spawnJvm(
     getEnv('JSON_API'),
     ['--ledger-host', 'localhost', '--ledger-port', `${sandboxPort}`,
      '--port-file', JSON_API_PORT_FILE, '--http-port', "0",
      '--allow-insecure-tokens', '--websocket-config', 'heartBeatPer=1'],
-    `file:${JSON_API_PORT_FILE}`,
     ['-Dakka.http.server.request-timeout=60s',
      '-Dlogback.configurationFile=' + getEnv("JSON_API_LOGBACK")],
   )
+  await waitOn({resources: [`file:${JSON_API_PORT_FILE}`]})
   const jsonApiPortData = await fs.readFile(JSON_API_PORT_FILE, { encoding: 'utf8' });
   jsonApiPort = parseInt(jsonApiPortData);
   console.log('JSON API listening on port ' + jsonApiPort.toString());
-});
+}, 120_000);
 
 afterAll(() => {
   if (sandboxProcess) {


### PR DESCRIPTION
This fixes 3 issues:

1. Switch the order in which we assign to `$proc` and
   `waitOn`. Without this the cleanup will not do anthing if `beforeAll`
   fails since the variable has not been assigned. This results in jest
   hanging forever until we hit the Bazel timeout.

2. Increase the timeout on `beforeAll` since we occasionally hit this
   on CI.

3. Allocate 2 CPUs to reflect the number of resources required by this test.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
