### PR TITLE
triggers + ports: Lock free ports before binding.

### DIFF
--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/LockedFreePort.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/LockedFreePort.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.testing.postgresql
+package com.daml.ports
 
 import com.daml.ports
 
 import scala.annotation.tailrec
 
-private[postgresql] object LockedFreePort {
+object LockedFreePort {
 
   @tailrec
   def find(tries: Int = 10): PortLock.Locked = {

--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/Port.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/Port.scala
@@ -3,10 +3,17 @@
 
 package com.daml.ports
 
+import java.net.{InetAddress, Socket}
+
 import scala.util.{Failure, Success, Try}
 
 final case class Port private (value: Int) extends AnyVal {
   override def toString: String = value.toString
+
+  def test(host: InetAddress): Unit = {
+    val socket = new Socket(host, value)
+    socket.close()
+  }
 }
 
 object Port {

--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortLock.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortLock.scala
@@ -59,6 +59,8 @@ object PortLock {
       channel.close()
       file.close()
     }
+
+    override def toString: String = s"locked port $port"
   }
 
   case class FailedToLock(port: Port) extends RuntimeException(s"Failed to lock port $port.")

--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortLock.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortLock.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.testing.postgresql
+package com.daml.ports
 
 import java.io.RandomAccessFile
 import java.nio.channels.{
@@ -12,9 +12,7 @@ import java.nio.channels.{
 }
 import java.nio.file.{Files, Path, Paths}
 
-import com.daml.ports.Port
-
-private[postgresql] object PortLock {
+object PortLock {
 
   // We can't use `sys.props("java.io.tmpdir")` because Bazel changes this for each test run.
   // For this to be useful, it needs to be shared across concurrent runs.

--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortLock.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortLock.scala
@@ -4,6 +4,7 @@
 package com.daml.ports
 
 import java.io.RandomAccessFile
+import java.net.InetAddress
 import java.nio.channels.{
   ClosedChannelException,
   FileChannel,
@@ -58,6 +59,11 @@ object PortLock {
       }
       channel.close()
       file.close()
+    }
+
+    def testAndUnlock(host: InetAddress): Unit = {
+      port.test(host)
+      unlock()
     }
 
     override def toString: String = s"locked port $port"

--- a/libs-scala/ports/src/test/suite/scala/com/digitalasset/ports/LockedFreePortSpec.scala
+++ b/libs-scala/ports/src/test/suite/scala/com/digitalasset/ports/LockedFreePortSpec.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.testing.postgresql
+package com.daml.ports
 
 import org.scalatest.{Matchers, WordSpec}
 

--- a/libs-scala/postgresql-testing/BUILD.bazel
+++ b/libs-scala/postgresql-testing/BUILD.bazel
@@ -26,12 +26,3 @@ da_scala_library(
         "@maven//:org_scalatest_scalatest_2_12",
     ],
 )
-
-da_scala_test(
-    name = "postgresql-testing-tests",
-    srcs = glob(["src/test/suite/scala/**/*.scala"]),
-    deps = [
-        ":postgresql-testing",
-        "//libs-scala/ports",
-    ],
-)

--- a/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
+++ b/libs-scala/postgresql-testing/src/main/scala/com/digitalasset/testing/postgresql/PostgresAround.scala
@@ -10,7 +10,7 @@ import java.nio.file.{Files, Path}
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 
-import com.daml.ports.Port
+import com.daml.ports.{LockedFreePort, Port}
 import com.daml.testing.postgresql.PostgresAround._
 import org.apache.commons.io.{FileUtils, IOUtils}
 import org.slf4j.LoggerFactory


### PR DESCRIPTION
This came out of trying to figure out why the `AuthServiceFixture` sometimes fails to establish a connection to the auth service. I didn't work that out, but I did see some duplication.

This changes `AuthServiceFixture` and `TriggerServiceFixture` to use `LockedFreePort` to find a free port, which ensures that the port will not be grabbed by another process in parallel. It might fix the aforementioned flake, but I doubt it.

It also moves some of the logic in testing whether a port is open into the ports library.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
