### PR TITLE
Avoid dev-env for posting to slack

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -475,8 +475,6 @@ jobs:
         condition: not(eq(variables['skip-github'], 'TRUE'))
       - bash: |
           set -euo pipefail
-          eval "$(dev-env/bin/dade-assist)"
-
           curl -XPOST \
                -i \
                -H 'Content-Type: application/json' \


### PR DESCRIPTION
This is running on Azure’s agents and we just call curl so there is
really no need for dev-env (as evidenced by the fact that the message
got sent despite dev-env failing).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
