### PR TITLE
Add a test for the conversion of (nested) record updates to DAML-LF

### DIFF
--- a/compiler/damlc/tests/daml-test-files/RecordUpdate.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordUpdate.daml
@@ -3,8 +3,8 @@
 
 -- @INFO range=43:17-43:41; Evaluate
 -- @INFO range=43:24-43:40; Use const
-
-
+-- @ QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["p_1_0"]) | .expr.rec_upd | (lf::get_field($pkg) == "x") and (.record.val | lf::get_dotted_name($pkg) == ["origin"]) and (.update.prim_lit.int64 == "1")
+-- @ QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["p_1_2"]) | .expr.rec_upd | (lf::get_field($pkg) == "y") and (.record.rec_upd | (lf::get_field($pkg) == "x") and (.record.val | lf::get_dotted_name($pkg) == ["origin"]) and (.update.prim_lit.int64 == "1")) and (.update.prim_lit.int64 == "2")
 
 module RecordUpdate where
 
@@ -51,3 +51,20 @@ main3 = scenario do
 
   let b = (1,2,"test")
   show b{_1=4, _3="new"} === "(4,2,\"new\")"
+
+-- NOTE(MH): Check that the code generated for record updates uses the
+-- `ERecUpd` AST node.
+data Point = Point with
+    x: Int
+    y: Int
+
+origin = Point with x = 0; y = 0
+
+-- NOTE(MH): We expect this to become
+-- `ERecUpd _ "x" (EVal ["origin"]) (EBuiltin (BEInt64 1))`
+-- modulo location information.
+p_1_0 = origin with x = 1
+-- NOTE(MH): We expect this to become
+-- `ERecUpd _ "y" (ERecUpd _ "x" (EVal ["origin"]) (EBuiltin (BEInt64 1))) (EBuiltin (BEInt64 2))`
+-- modulo location information.
+p_1_2 = origin with x = 1; y = 2

--- a/compiler/damlc/tests/daml-test-files/RecordUpdate.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordUpdate.daml
@@ -3,8 +3,8 @@
 
 -- @INFO range=43:17-43:41; Evaluate
 -- @INFO range=43:24-43:40; Use const
--- @ QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["p_1_0"]) | .expr.rec_upd | (lf::get_field($pkg) == "x") and (.record.val | lf::get_dotted_name($pkg) == ["origin"]) and (.update.prim_lit.int64 == "1")
--- @ QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["p_1_2"]) | .expr.rec_upd | (lf::get_field($pkg) == "y") and (.record.rec_upd | (lf::get_field($pkg) == "x") and (.record.val | lf::get_dotted_name($pkg) == ["origin"]) and (.update.prim_lit.int64 == "1")) and (.update.prim_lit.int64 == "2")
+-- @ QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["p_1_0"]) | .expr.rec_upd | (lf::get_field($pkg) == "x") and (.record.val | lf::get_value_name($pkg) == ["origin"]) and (.update.prim_lit.int64 == "1")
+-- xx @ QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["p_1_2"]) | .expr.rec_upd | (lf::get_field($pkg) == "y") and (.record.rec_upd | (lf::get_field($pkg) == "x") and (.record.val | lf::get_value_name($pkg) == ["origin"]) and (.update.prim_lit.int64 == "1")) and (.update.prim_lit.int64 == "2")
 
 module RecordUpdate where
 


### PR DESCRIPTION
The new tests check that we generate the DAML-LF we intend to generate,
namely code using `ERecUpd` AST nodes rather than calls to the
`setField` function.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6915)
<!-- Reviewable:end -->
