### PR TITLE
Partial ANF transformation for Speedy.

### DIFF
--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -53,6 +53,7 @@ da_scala_test_suite(
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_scalaz_scalaz_scalacheck_binding_2_12",
         "@maven//:org_slf4j_slf4j_api",
+        "@maven//:org_typelevel_paiges_core_2_12",
     ],
 )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -1,0 +1,443 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+
+/**
+  Transformation to ANF based AST for the speedy interpreter.
+
+  "ANF" stands for A-normal form.
+  In essence it means that sub-expressions of most expression nodes are in atomic-form.
+  The one exception is the let-expression.
+
+  Atomic mean: a variable reference (ELoc), a (literal) value, or a builtin.
+  This is captured by any speedy-expression which `extends SExprAtomic`.
+
+  The reason we convert to ANF is to improve the efficiency of speedy execution: the
+  execution engine can take advantage of the atomic assumption, and often removes
+  additional execution steps - in particular the pushing of continuations to allow
+  execution to continue after a compound expression is reduced to a value.
+
+  The speedy machine now expects that it will never have to execute a non-ANF expression,
+  crashing at runtime if one is encountered. In particular we must ensure that the
+  expression forms: SEAppGeneral and SECase are removed, and replaced by the simpler
+  SEAppAtomic and SECaseAtomic (plus SELet as required).
+
+  */
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.Compiler.CompilationError
+
+import scala.annotation.tailrec
+
+private[lf] object Anf {
+
+  /*** Entry point for the ANF transformation phase */
+  @throws[CompilationError]
+  def flattenToAnf(exp: SExpr): SExpr = {
+    flattenToAnfInternal(exp).wrapped
+  }
+
+  /** `AExpr` tracks when an expression has been transformed. It is
+    * private to this file. */
+  private final case class AExpr(wrapped: SExpr) extends Serializable
+
+  @throws[CompilationError]
+  private def flattenToAnfInternal(exp: SExpr): AExpr = {
+    val depth = DepthA(0)
+    val env = initEnv
+    flattenExp(depth, env, exp) { anf =>
+      Land(anf)
+    }.bounce
+  }
+
+  /**
+    The transformation code is implemented using a what looks like
+    continuation-passing style; the code routinely creates new functions to
+    pass down the stack as it explores the expression tree. This is quite
+    common for translation to ANF. In general, naming nested compound
+    expressions requires turning an expression kind of inside out, lifting the
+    introduced let-expression up to the the nearest enclosing abstraction or
+    case-branch.
+
+    For speedy, the ANF pass occurs after translation to De Brujin and closure
+    conversions, which adds the additional complication of re-indexing the
+    variable indexes. This is achieved by tracking the old and new depth & the
+    mapping between them. See the types: DepthE, DepthA and Env.
+
+    Using a coding style that looks like CPS is a natural way to express the
+    ANF transformation. However, this means the transformation is very
+    stack-intensive. To address that, we need the code to be in "true" CPS
+    form, which is not quite the same as the semantics required by the ANF
+    transform. Having the code in ANF form allows us to use the trampoline
+    technique to execute the computation in constant stack space.
+
+    This means that, in some sense, the following code has two (interleaved)
+    levels of CPS-looking style. For the sake of clarity, in further comments
+    as well as in the code, we will use the term "continuation" and the
+    variable names "k", "txK" strictly for the "true" continuations that have
+    been added to achieve constant stack space, and use the term
+    "transformation function" and the variable names "transform", "tx" for
+    the functions that express the semantics of the ANF transformation.
+
+    Things are further muddied by the following:
+    1. A number of top-level functions defined in this object also qualify as
+       "transformation functions", even though they themselves receive
+       transformation functions as arguments and/or define new ones on the fly
+       (flattenExp, transformLet1, flattenAlts, transformExp, atomizeExp,
+       atomizeExps).
+    2. To achieve full CPS, transformation functions themselves need to accept
+       (and apply) a continuation.
+
+    Not all functions in this object are in CPS (only the ones that are part of
+    the main recursive loop), but those that do always take the continuation as
+    their last argument.
+
+    */
+  /** `DepthE` tracks the stack-depth of the original expression being traversed */
+  private[this] final case class DepthE(n: Int) {
+    def incr(m: Int): DepthE = DepthE(n + m)
+  }
+
+  /** `DepthA` tracks the stack-depth of the ANF expression being constructed */
+  private[this] final case class DepthA(n: Int) {
+    def incr(m: Int): DepthA = DepthA(n + m)
+  }
+
+  /** `Env` contains the mapping from old to new depth, as well as the old-depth as these
+    * components always travel together */
+  private[this] final case class Env(absMap: Map[DepthE, DepthA], oldDepth: DepthE)
+
+  private[this] val initEnv: Env = Env(absMap = Map.empty, oldDepth = DepthE(0))
+
+  private[this] def trackBindings(depth: DepthA, env: Env, n: Int): Env = {
+    val extra = (0 until n).map(i => (env.oldDepth.incr(i), depth.incr(i)))
+    Env(absMap = env.absMap ++ extra, oldDepth = env.oldDepth.incr(n))
+  }
+
+  // Returning a Bounce object allows a function to evict itself from the
+  // current stack.
+  private[this] sealed abstract class Trampoline[T] {
+    @tailrec
+    final def bounce: T = this match {
+      case Land(x) => x
+      case Bounce(continue) => continue().bounce
+    }
+  }
+
+  private[this] final case class Land[T](x: T) extends Trampoline[T]
+  private[this] final case class Bounce[T](continue: () => Trampoline[T]) extends Trampoline[T]
+
+  /**
+    * Tx is the type for the stacked transformation functions managed by the ANF
+    * transformation, mainly transformExp.
+    *
+    * All of the transformation functions would, without CPS, return an AExpr,
+    * so that is the input type of the continuation.
+    *
+    * Both type parameters are ultimately needed because SCaseAlt does not
+    * extend SExpr. If it did, T would always be SExpr and A would always be
+    * AExpr.
+    *
+    * Note that Scala does not seem to be able to generate anonymous function of
+    * a parameterized type, so we use nested `defs` instead.
+    *
+    * @tparam T The type of expression this will be applied to.
+    * @tparam A The return type of the continuation (minus the Trampoline
+    *           wrapping).
+    */
+  private[this] type Tx[T, A] = (DepthA, T, K[AExpr, A]) => Trampoline[A]
+
+  /**
+    * K Is the type for contiunations.
+    *
+    * @tparam T Type the function would have returned had it not been in CPS.
+    * @tparam A The return type of the continuation (minus the Trampoline
+    *           wrapping).
+    */
+  private[this] type K[T, A] = T => Trampoline[A]
+
+  /** During conversion we need to deal with bindings which are made/found at a given
+    absolute stack depth. These are represented using `AbsBinding`. An absolute stack
+    depth is the offset from the depth of the stack when the function is entered. We call
+    it absolute because an offset doesn't change as new bindings are pushed onto the
+    stack.
+
+    Note the contrast with the expression form `ELocS` which contains a relative offset
+    from the end of the stack. This relative-position is used in both the original
+    expression which we traverse AND the new ANF expression we are constructing. The
+    relative-offset to a binding varies as new bindings are pushed on the stack.
+    */
+  private[this] case class AbsBinding(abs: DepthA)
+
+  private[this] def makeAbsoluteB(env: Env, rel: Int): AbsBinding = {
+    val oldAbs = env.oldDepth.incr(-rel)
+    env.absMap.get(oldAbs) match {
+      case None => throw CompilationError(s"makeAbsoluteB(env=$env,rel=$rel)")
+      case Some(abs) => AbsBinding(abs)
+    }
+  }
+
+  private[this] def makeRelativeB(depth: DepthA, binding: AbsBinding): Int = {
+    (depth.n - binding.abs.n)
+  }
+
+  private[this] type AbsAtom = Either[SExprAtomic, AbsBinding]
+
+  private[this] def makeAbsoluteA(env: Env, atom: SExprAtomic): AbsAtom = atom match {
+    case SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case x => Left(x)
+  }
+
+  private[this] def makeRelativeA(depth: DepthA)(atom: AbsAtom): SExprAtomic = atom match {
+    case Left(x: SELocS) => throw CompilationError(s"makeRelativeA: unexpected: $x")
+    case Left(atom) => atom
+    case Right(binding) => SELocS(makeRelativeB(depth, binding))
+  }
+
+  private[this] type AbsLoc = Either[SELoc, AbsBinding]
+
+  private[this] def makeAbsoluteL(env: Env, loc: SELoc): AbsLoc = loc match {
+    case SELocS(rel) => Right(makeAbsoluteB(env, rel))
+    case x: SELocA => Left(x)
+    case x: SELocF => Left(x)
+  }
+
+  private[this] def makeRelativeL(depth: DepthA)(loc: AbsLoc): SELoc = loc match {
+    case Left(x: SELocS) => throw CompilationError(s"makeRelativeL: unexpected: $x")
+    case Left(loc) => loc
+    case Right(binding) => SELocS(makeRelativeB(depth, binding))
+  }
+
+  private[this] def flattenExp[A](depth: DepthA, env: Env, exp: SExpr)(
+      k: K[AExpr, A]): Trampoline[A] = {
+    Bounce(() =>
+      transformExp[A](depth, env, exp, k) { (_, sexpr, txK) =>
+        Bounce(() => txK(AExpr(sexpr)))
+    })
+  }
+
+  private[this] def transformLet1[A](
+      depth: DepthA,
+      env: Env,
+      rhs: SExpr,
+      body: SExpr,
+      k: K[AExpr, A],
+      transform: Tx[SExpr, A]): Trampoline[A] = {
+    Bounce(() =>
+      transformExp(depth, env, rhs, k) { (depth, rhs, txK) =>
+        val depth1 = depth.incr(1)
+        val env1 = trackBindings(depth, env, 1)
+        Bounce(() =>
+          transformExp(depth1, env1, body, { body1 =>
+            Bounce(() => txK(AExpr(SELet1(rhs, body1.wrapped))))
+          })(transform))
+    })
+  }
+
+  private[this] def flattenAlts[A](depth: DepthA, env: Env, alts: Array[SCaseAlt])(
+      k: K[Array[SCaseAlt], A]): Trampoline[A] = {
+    // Note: this could be made properly CPS and thus constant stack through
+    // trampoline by implementing a CPS version of map. However, map on an
+    // array is implemented as a loop so this should be fine.
+    Bounce(() =>
+      k(alts.map {
+        case SCaseAlt(pat, body0) =>
+          val n = patternNArgs(pat)
+          val env1 = trackBindings(depth, env, n)
+          flattenExp(depth.incr(n), env1, body0)(body => {
+            Land(SCaseAlt(pat, body.wrapped))
+          }).bounce
+      }))
+  }
+
+  private[this] def patternNArgs(pat: SCasePat): Int = pat match {
+    case _: SCPEnum | _: SCPPrimCon | SCPNil | SCPDefault | SCPNone => 0
+    case _: SCPVariant | SCPSome => 1
+    case SCPCons => 2
+  }
+
+  /** `transformExp` is the function at the heart of the ANF transformation.
+    *  You can read its type as saying: "Caller, give me a general expression
+    *  `exp`, (& depth/env info), and a transformation function `transform`
+    *  which says what you want to do with the transformed expression. Then I
+    *  will do the transform, and call `transform` with it. I reserve the right
+    *  to wrap further expression-AST around the expression returned by
+    *  `transform`.
+    *
+    *  See: `atomizeExp` for an instance where this wrapping occurs.
+    *
+    *  Note: this wrapping is the reason why we need a "second" CPS transform to
+    *  achieve constant stack through trampoline.
+    */
+  private[this] def transformExp[A](depth: DepthA, env: Env, exp: SExpr, k: K[AExpr, A])(
+      transform: Tx[SExpr, A]): Trampoline[A] =
+    exp match {
+      case atom0: SExprAtomic =>
+        val atom = makeRelativeA(depth)(makeAbsoluteA(env, atom0))
+        Bounce(() => transform(depth, atom, k))
+
+      case x: SEVal => Bounce(() => transform(depth, x, k))
+      case x: SEImportValue => Bounce(() => transform(depth, x, k))
+
+      case SEAppGeneral(func, args) =>
+        // It's safe to perform ANF if the func-expression has no effects when evaluated.
+        val safeFunc =
+          func match {
+            // we know that trivially in these two cases
+            case SEBuiltin(b) => (args.size <= b.arity)
+            case _ => false
+          }
+        // It's also safe to perform ANF for applications of a single argument.
+        if (safeFunc || args.size == 1) {
+          transformMultiApp[A](depth, env, func, args, k)(transform)
+        } else {
+          transformMultiAppSafely[A](depth, env, func, args, k)(transform)
+        }
+
+      case SEMakeClo(fvs0, arity, body0) =>
+        val fvs = fvs0.map((loc) => makeRelativeL(depth)(makeAbsoluteL(env, loc)))
+        val body = flattenToAnfInternal(body0).wrapped
+        Bounce(() => transform(depth, SEMakeClo(fvs, arity, body), k))
+
+      case SECase(scrut, alts0) => {
+        Bounce(() =>
+          atomizeExp(depth, env, scrut, k) { (depth, scrut, txK) =>
+            val scrut1 = makeRelativeA(depth)(scrut)
+            Bounce(() =>
+              flattenAlts(depth, env, alts0) { alts =>
+                Bounce(() => transform(depth, SECaseAtomic(scrut1, alts), txK))
+            })
+        })
+      }
+
+      case SELet(rhss, body) =>
+        val expanded = expandMultiLet(rhss.toList, body)
+        Bounce(() => transformExp(depth, env, expanded, k)(transform))
+
+      case SELet1General(rhs, body) =>
+        Bounce(() => transformLet1(depth, env, rhs, body, k, transform))
+
+      case SECatch(body0, handler0, fin0) =>
+        Bounce(() =>
+          flattenExp(depth, env, body0) { body =>
+            Bounce(() =>
+              flattenExp(depth, env, handler0) { handler =>
+                Bounce(() =>
+                  flattenExp(depth, env, fin0) { fin =>
+                    Bounce(() =>
+                      transform(depth, SECatch(body.wrapped, handler.wrapped, fin.wrapped), k))
+                })
+            })
+        })
+
+      case SELocation(loc, body) => {
+        Bounce(() =>
+          transformExp(depth, env, body, k) { (depth, body, txK) =>
+            Bounce(() => transform(depth, SELocation(loc, body), txK))
+        })
+      }
+
+      case SELabelClosure(label, exp) => {
+        Bounce(() =>
+          transformExp(depth, env, exp, k) { (depth, exp, txK) =>
+            Bounce(() => transform(depth, SELabelClosure(label, exp), txK))
+        })
+      }
+
+      case x: SEAbs => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SEWronglyTypeContractId => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SEAppAtomicFun => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SEAppAtomicGeneral => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SEAppAtomicSaturatedBuiltin => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SELet1Builtin => throw CompilationError(s"flatten: unexpected: $x")
+      case x: SECaseAtomic => throw CompilationError(s"flatten: unexpected: $x")
+    }
+
+  private[this] def atomizeExps[A](depth: DepthA, env: Env, exps: List[SExpr], k: K[AExpr, A])(
+      transform: Tx[List[AbsAtom], A]): Trampoline[A] =
+    exps match {
+      case Nil => Bounce(() => transform(depth, Nil, k))
+      case exp :: exps =>
+        Bounce(() =>
+          atomizeExp(depth, env, exp, k) { (depth, atom, txK1) =>
+            Bounce(() =>
+              atomizeExps(depth, env, exps, txK1) { (depth, atoms, txK2) =>
+                Bounce(() => transform(depth, atom :: atoms, txK2))
+            })
+        })
+    }
+
+  private[this] def atomizeExp[A](depth: DepthA, env: Env, exp: SExpr, k: K[AExpr, A])(
+      transform: Tx[AbsAtom, A]): Trampoline[A] = {
+    exp match {
+      case ea: SExprAtomic => Bounce(() => transform(depth, makeAbsoluteA(env, ea), k))
+      case _ => {
+        Bounce(() =>
+          transformExp(depth, env, exp, k) { (depth, anf, txK) =>
+            val atom = Right(AbsBinding(depth))
+            Bounce(() =>
+              transform(depth.incr(1), atom, { body =>
+                Bounce(() => txK(AExpr(SELet1(anf, body.wrapped))))
+              }))
+        })
+      }
+    }
+  }
+
+  private[this] def expandMultiLet(rhss: List[SExpr], body: SExpr): SExpr = {
+    //loop over rhss in reverse order
+    @tailrec
+    def loop(acc: SExpr, xs: List[SExpr]): SExpr = {
+      xs match {
+        case Nil => acc
+        case rhs :: xs => loop(SELet1General(rhs, acc), xs)
+      }
+    }
+    loop(body, rhss.reverse)
+  }
+
+  /* This function is used when transforming known functions.  And so we can we sure that
+   the ANF transform is safe, and will not change the evaluation order
+   */
+  private[this] def transformMultiApp[A](
+      depth: DepthA,
+      env: Env,
+      func: SExpr,
+      args: Array[SExpr],
+      k: K[AExpr, A])(transform: Tx[SExpr, A]): Trampoline[A] = {
+    Bounce(() =>
+      atomizeExp(depth, env, func, k) { (depth, func, txK1) =>
+        Bounce(() =>
+          atomizeExps(depth, env, args.toList, txK1) { (depth, args, txK) =>
+            val func1 = makeRelativeA(depth)(func)
+            val args1 = args.map(makeRelativeA(depth))
+            Bounce(() => transform(depth, SEAppAtomic(func1, args1.toArray), txK))
+        })
+    })
+  }
+
+  /* This function must be used when transforming an application of unknown function.  The
+   translated application is *not* in proper ANF form.
+   */
+
+  private[this] def transformMultiAppSafely[A](
+      depth: DepthA,
+      env: Env,
+      func: SExpr,
+      args: Array[SExpr],
+      k: K[AExpr, A])(transform: Tx[SExpr, A]): Trampoline[A] = {
+
+    Bounce(() =>
+      atomizeExp(depth, env, func, k) { (depth, func, txK) =>
+        val func1 = makeRelativeA(depth)(func)
+        // we dont atomize the args here
+        val args1 = args.map(arg => flattenExp(depth, env, arg)(anf => Land(anf)).bounce.wrapped)
+        Bounce(
+          () =>
+            // we build a non-atomic application here (only the function is atomic)
+            transform(depth, SEAppAtomicFun(func1, args1.toArray), txK))
+    })
+
+  }
+
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -10,6 +10,7 @@ import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.Anf.flattenToAnf
 import com.daml.lf.validation.{EUnknownDefinition, LEPackage, Validation, ValidationError}
 import org.slf4j.LoggerFactory
 
@@ -171,17 +172,29 @@ private[lf] final case class Compiler(
   @throws[PackageNotFound]
   @throws[CompilationError]
   def unsafeCompile(cmds: ImmArray[Command]): SExpr =
-    validate(closureConvert(Map.empty, translateCommands(cmds)))
+    validate(compilationPipeline(translateCommands(cmds)))
 
   @throws[PackageNotFound]
   @throws[CompilationError]
   def unsafeCompile(expr: Expr): SExpr =
-    validate(closureConvert(Map.empty, translate(expr)))
+    validate(compilationPipeline(translate(expr)))
 
   @throws[PackageNotFound]
   @throws[CompilationError]
   def unsafeClosureConvert(sexpr: SExpr): SExpr =
-    validate(closureConvert(Map.empty, sexpr))
+    validate(compilationPipeline(sexpr))
+
+  // Run the compilation pipeline phases:
+  // (1) closure conversion
+  // (2) transform to ANF
+  private[this] def compilationPipeline(sexpr: SExpr): SExpr = {
+    val doANF = true
+    if (doANF) {
+      flattenToAnf(closureConvert(Map.empty, sexpr))
+    } else {
+      closureConvert(Map.empty, sexpr)
+    }
+  }
 
   @throws[PackageNotFound]
   @throws[CompilationError]
@@ -1084,10 +1097,6 @@ private[lf] final case class Compiler(
         val newArgs = args.map(closureConvert(remaps, _))
         SEApp(newFun, newArgs)
 
-      case SEAppSaturatedBuiltinFun(builtin, args) =>
-        val newArgs = args.map(closureConvert(remaps, _))
-        SEAppSaturatedBuiltinFun(builtin, newArgs)
-
       case SECase(scrut, alts) =>
         SECase(
           closureConvert(remaps, scrut),
@@ -1122,6 +1131,13 @@ private[lf] final case class Compiler(
 
       case x: SEImportValue =>
         throw CompilationError(s"unexpected SEImportValue: $x")
+
+      case x: SEAppAtomicGeneral => throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SEAppAtomicSaturatedBuiltin =>
+        throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SELet1General => throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SELet1Builtin => throw CompilationError(s"closureConvert: unexpected: $x")
+      case x: SECaseAtomic => throw CompilationError(s"closureConvert: unexpected: $x")
     }
   }
 
@@ -1166,8 +1182,6 @@ private[lf] final case class Compiler(
           args.foldLeft(go(fun, bound, free))((acc, arg) => go(arg, bound, acc))
         case SEAppAtomicFun(fun, args) =>
           args.foldLeft(go(fun, bound, free))((acc, arg) => go(arg, bound, acc))
-        case SEAppSaturatedBuiltinFun(_, args) =>
-          args.foldLeft(free)((acc, arg) => go(arg, bound, acc))
         case SEAbs(n, body) =>
           go(body, bound + n, free)
         case x: SELoc =>
@@ -1190,6 +1204,12 @@ private[lf] final case class Compiler(
           throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
         case x: SEImportValue =>
           throw CompilationError(s"unexpected SEImportValue: $x")
+
+        case x: SEAppAtomicGeneral => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SEAppAtomicSaturatedBuiltin => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SELet1General => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SELet1Builtin => throw CompilationError(s"freeVars: unexpected: $x")
+        case x: SECaseAtomic => throw CompilationError(s"freeVars: unexpected: $x")
       }
     go(expr, initiallyBound, Set.empty)
   }
@@ -1240,13 +1260,16 @@ private[lf] final case class Compiler(
         case _: SEBuiltin => ()
         case _: SEBuiltinRecursiveDefinition => ()
         case SEValue(v) => goV(v)
+        case SEAppAtomicGeneral(fun, args) =>
+          go(fun)
+          args.foreach(go)
+        case SEAppAtomicSaturatedBuiltin(_, args) =>
+          args.foreach(go)
         case SEAppGeneral(fun, args) =>
           go(fun)
           args.foreach(go)
         case SEAppAtomicFun(fun, args) =>
           go(fun)
-          args.foreach(go)
-        case SEAppSaturatedBuiltinFun(_, args) =>
           args.foreach(go)
         case x: SEVar =>
           throw CompilationError(s"validate: SEVar encountered: $x")
@@ -1255,6 +1278,7 @@ private[lf] final case class Compiler(
         case SEMakeClo(fvs, n, body) =>
           fvs.foreach(goLoc)
           goBody(0, n, fvs.length)(body)
+        case SECaseAtomic(scrut, alts) => go(SECase(scrut, alts))
         case SECase(scrut, alts) =>
           go(scrut)
           alts.foreach {
@@ -1268,6 +1292,8 @@ private[lf] final case class Compiler(
               goBody(maxS + i, maxA, maxF)(rhs)
           }
           goBody(maxS + bounds.length, maxA, maxF)(body)
+        case _: SELet1General => goLets(maxS)(expr)
+        case _: SELet1Builtin => goLets(maxS)(expr)
         case SECatch(body, handler, fin) =>
           go(body)
           go(handler)
@@ -1280,6 +1306,20 @@ private[lf] final case class Compiler(
           throw CompilationError(s"unexpected SEWronglyTypeContractId: $x")
         case x: SEImportValue =>
           throw CompilationError(s"unexpected SEImportValue: $x")
+      }
+      @tailrec
+      def goLets(maxS: Int)(expr: SExpr): Unit = {
+        def go = goBody(maxS, maxA, maxF)
+        expr match {
+          case SELet1General(rhs, body) =>
+            go(rhs)
+            goLets(maxS + 1)(body)
+          case SELet1Builtin(_, args, body) =>
+            args.foreach(go)
+            goLets(maxS + 1)(body)
+          case expr =>
+            go(expr)
+        }
       }
       go
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -492,6 +492,7 @@ private[lf] object Pretty {
             case other => str(other)
           }
 
+        case SECaseAtomic(scrut, alts) => prettySExpr(index)(SECase(scrut, alts))
         case SECase(scrut, alts) =>
           (text("case") & prettySExpr(index)(scrut) & text("of") +
             line +
@@ -524,15 +525,19 @@ private[lf] object Pretty {
             case _ => str(x)
           }
         case SEAppGeneral(fun, args) =>
-          val prefix = prettySExpr(index)(fun) + char('(')
+          val prefix = prettySExpr(index)(fun) + text("@E(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))
         case SEAppAtomicFun(fun, args) =>
-          val prefix = prettySExpr(index)(fun) + char('(')
+          val prefix = prettySExpr(index)(fun) + text("@N(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))
-        case SEAppSaturatedBuiltinFun(builtin, args) =>
-          val prefix = prettySExpr(index)(SEBuiltin(builtin)) + char('(')
+        case SEAppAtomicGeneral(fun, args) =>
+          val prefix = prettySExpr(index)(fun) + text("@A(")
+          intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
+            .tightBracketBy(prefix, char(')'))
+        case SEAppAtomicSaturatedBuiltin(builtin, args) =>
+          val prefix = prettySExpr(index)(SEBuiltin(builtin)) + text("@B(")
           intercalate(comma + lineOrSpace, args.map(prettySExpr(index)))
             .tightBracketBy(prefix, char(')'))
         case SEAbs(n, body) =>
@@ -565,6 +570,10 @@ private[lf] object Pretty {
               str(index + n) & char('=') & prettySExpr(index + n)(x)
           })).tightBracketBy(text("let ["), char(']')) +
             lineOrSpace + text("in") & prettySExpr(index + bounds.length)(body)
+        case SELet1General(rhs, body) =>
+          prettySExpr(index)(SELet(Array(rhs), body))
+        case SELet1Builtin(builtin, args, body) =>
+          prettySExpr(index)(SELet1General(SEAppAtomicSaturatedBuiltin(builtin, args), body))
 
         case x: SEBuiltinRecursiveDefinition => str(x)
         case x: SEImportValue => str(x)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -49,13 +49,18 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     case SEVar(n) => s"D#$n" //dont expect these at runtime
     case loc: SELoc => pp(loc)
     case SEAppGeneral(func, args) => s"@E(${pp(func)},${commas(args.map(pp))})"
-    case SEAppAtomicFun(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
-    case SEAppSaturatedBuiltinFun(builtin, args) => s"@B($builtin,${commas(args.map(pp))})"
+    case SEAppAtomicFun(func, args) => s"@N(${pp(func)},${commas(args.map(pp))})"
+    case SEAppAtomicGeneral(func, args) => s"@A(${pp(func)},${commas(args.map(pp))})"
+    case SEAppAtomicSaturatedBuiltin(b, args) => s"@B(${pp(SEBuiltin(b))},${commas(args.map(pp))})"
     case SEMakeClo(fvs, arity, body) => s"[${commas(fvs.map(pp))}]\\$arity.${pp(body)}"
     case SEBuiltin(b) => s"(BUILTIN)$b"
     case SEVal(ref) => s"(DEF)${pp(ref)}"
     case SELocation(_, exp) => s"LOC(${pp(exp)})"
-    case SELet(rhss, body) => s"let (${commas(rhss.map(pp))}) in ${pp(body)}"
+    case SELet(rhss, body) => s"letG (${commas(rhss.map(pp))}) in ${pp(body)}"
+    case SELet1General(rhs, body) => s"let ${pp(rhs)} in ${pp(body)}"
+    case SELet1Builtin(builtin, args, body) =>
+      s"letB (${pp(SEBuiltin(builtin))},${commas(args.map(pp))}) in ${pp(body)}"
+    case SECaseAtomic(scrut, _) => s"case(atomic) ${pp(scrut)} of..."
     case SECase(scrut, _) => s"case ${pp(scrut)} of..."
     case _ => "<" + e.getClass.getSimpleName + "...>"
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -125,45 +125,47 @@ object SExpr {
     }
   }
 
-  /** Function application:
-    Special case: 'fun' is a builtin; size of `args' matches the builtin arity.
-    */
-  // A fully saturated builtin application
-  final case class SEAppSaturatedBuiltinFun(builtin: SBuiltin, args: Array[SExpr])
-      extends SExpr
-      with SomeArrayEquals {
-    if (args.size != builtin.arity) {
-      throw SErrorCrash(s"SEAppB: arg.size != builtin.arity")
-    }
-    def execute(machine: Machine): Unit = {
-      val arity = builtin.arity
-      val actuals = new util.ArrayList[SValue](arity)
-      machine.pushKont(KBuiltin(builtin, actuals, machine.env.size))
-      evaluateArguments(machine, actuals, args, args.length);
+  object SEApp {
+    def apply(fun: SExpr, args: Array[SExpr]): SExpr = {
+      SEAppGeneral(fun, args)
     }
   }
 
-  object SEApp {
+  /** Function application: ANF case: 'fun' and 'args' are atomic expressions */
+  final case class SEAppAtomicGeneral(fun: SExprAtomic, args: Array[SExprAtomic])
+      extends SExpr
+      with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      val vfun = fun.lookupValue(machine)
+      enterApplication(machine, vfun, args)
+    }
+  }
 
-    def apply(fun: SExpr, args: Array[SExpr]): SExpr = {
-      fun match {
-        // Detect special cases of function-application which can we executed more efficiently
+  /** Function application: ANF case: 'fun' is builtin; 'args' are atomic expressions.  Size
+    * of `args' matches the builtin arity. */
+  final case class SEAppAtomicSaturatedBuiltin(builtin: SBuiltin, args: Array[SExprAtomic])
+      extends SExpr
+      with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      val arity = builtin.arity
+      val actuals = new util.ArrayList[SValue](arity)
+      for (i <- 0 to arity - 1) {
+        val arg = args(i)
+        val v = arg.lookupValue(machine)
+        actuals.add(v)
+      }
+      builtin.execute(actuals, machine)
+    }
+  }
 
+  object SEAppAtomic {
+    // smart constructor: detect special case of saturated builtin application
+    def apply(func: SExprAtomic, args: Array[SExprAtomic]): SExpr = {
+      func match {
         case SEBuiltin(builtin) if builtin.arity == args.length =>
-          SEAppSaturatedBuiltinFun(builtin, args)
-
-        case SEBuiltin(builtin) if builtin.arity < args.length =>
-          val arity = builtin.arity
-          val extra = args.length - arity
-          val arityArgs = new Array[SExpr](arity)
-          val extraArgs = new Array[SExpr](extra)
-          System.arraycopy(args, 0, arityArgs, 0, arity)
-          System.arraycopy(args, arity, extraArgs, 0, extra)
-          SEApp(SEAppSaturatedBuiltinFun(builtin, arityArgs), extraArgs)
-
-        case vfun: SExprAtomic => SEAppAtomicFun(vfun, args)
-
-        case _ => SEAppGeneral(fun, args) // fall back to the general case
+          SEAppAtomicSaturatedBuiltin(builtin, args)
+        case _ =>
+          SEAppAtomicGeneral(func, args) // general case
       }
     }
   }
@@ -254,6 +256,51 @@ object SExpr {
     }
 
     def apply(scrut: SExpr) = PartialSECase(scrut)
+  }
+
+  final case class SECaseAtomic(scrut: SExprAtomic, alts: Array[SCaseAlt])
+      extends SExpr
+      with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      val vscrut = scrut.lookupValue(machine)
+      executeMatchAlts(machine, alts, vscrut)
+    }
+  }
+
+  /** A let-expression with a single RHS */
+  final case class SELet1General(rhs: SExpr, body: SExpr) extends SExpr with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      machine.pushKont(KPushTo(machine.env, body, machine.frame, machine.actuals, machine.env.size))
+      machine.ctrl = rhs
+    }
+  }
+
+  /** A (single) let-expression with an unhungry,saturated builtin-application as RHS */
+  final case class SELet1Builtin(builtin: SBuiltinPure, args: Array[SExprAtomic], body: SExpr)
+      extends SExpr
+      with SomeArrayEquals {
+    def execute(machine: Machine): Unit = {
+      val arity = builtin.arity
+      val actuals = new util.ArrayList[SValue](arity)
+      for (i <- 0 to arity - 1) {
+        val arg = args(i)
+        val v = arg.lookupValue(machine)
+        actuals.add(v)
+      }
+      val v = builtin.executePure(actuals)
+      machine.env.add(v)
+      machine.ctrl = body
+    }
+  }
+
+  object SELet1 {
+    def apply(rhs: SExpr, body: SExpr): SExpr = {
+      rhs match {
+        case SEAppAtomicSaturatedBuiltin(builtin: SBuiltinPure, args) =>
+          SELet1Builtin(builtin, args, body)
+        case _ => SELet1General(rhs, body)
+      }
+    }
   }
 
   /** A non-recursive, non-parallel let block. Each bound expression
@@ -433,43 +480,57 @@ object SExpr {
 
     val EqualList: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.EqualList)
 
-    private val equalListBody: SExpr =
-      // equalList f xs ys =
-      // case xs of
-      SECase(SELocA(1) /* xs */ ) of (
-        // nil ->
-        SCaseAlt(
-          SCPNil,
-          // case ys of
-          //   nil -> True
-          //   default -> False
-          SECase(SELocA(2)) of (SCaseAlt(SCPNil, SEValue.True),
-          SCaseAlt(SCPDefault, SEValue.False))
-        ),
-        // cons x xss ->
-        SCaseAlt(
-          SCPCons,
-          // case ys of
-          //       True -> listEqual f xss yss
-          //       False -> False
-          SECase(SELocA(2) /* ys */ ) of (
-            // nil -> False
-            SCaseAlt(SCPNil, SEValue.False),
-            // cons y yss ->
-            SCaseAlt(
-              SCPCons,
-              // case f x y of
-              SECase(SEApp(SELocA(0), Array(SELocS(2), SELocS(4)))) of (
-                SCaseAlt(
-                  SCPPrimCon(PCTrue),
-                  SEApp(EqualList, Array(SELocA(0), SELocS(1), SELocS(3))),
-                ),
-                SCaseAlt(SCPPrimCon(PCFalse), SEValue.False)
+    // The body of an expanded recursive-builtin will always be in ANF form.
+    // The comments show where variables are to be found at runtime.
+
+    private def equalListBody: SExpr =
+      SECaseAtomic( // case xs of
+        SELocA(1),
+        Array(
+          SCaseAlt(
+            SCPNil, // nil ->
+            SECaseAtomic( // case ys of
+              SELocA(2),
+              Array(
+                SCaseAlt(SCPNil, SEValue.True), // nil -> True
+                SCaseAlt(SCPDefault, SEValue.False))) // default -> False
+          ),
+          SCaseAlt( // cons x xss ->
+            SCPCons,
+            SECaseAtomic( // case ys of
+              SELocA(2),
+              Array(
+                SCaseAlt(SCPNil, SEValue.False), // nil -> False
+                SCaseAlt( // cons y yss ->
+                  SCPCons,
+                  SELet1( // let sub = (f y x) in
+                    SEAppAtomicGeneral(
+                      SELocA(0), // f
+                      Array(
+                        SELocS(2), // y
+                        SELocS(4))), // x
+                    SECaseAtomic( // case (f y x) of
+                      SELocS(1),
+                      Array(
+                        SCaseAlt(
+                          SCPPrimCon(PCTrue), // True ->
+                          SEAppAtomicGeneral(
+                            EqualList,
+                            Array(
+                              SELocA(0), // f
+                              SELocS(2), // yss
+                              SELocS(4))) // xss
+                        ),
+                        SCaseAlt(SCPPrimCon(PCFalse), SEValue.False) // False -> False
+                      )
+                    )
+                  )
+                )
               )
             )
           )
         )
-    )
+      )
   }
 
   final case object AnonymousClosure

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/AnfTest.scala
@@ -1,0 +1,247 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+
+import org.scalatest.{Assertion, WordSpec, Matchers}
+
+import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.SValue._
+import com.daml.lf.speedy.SBuiltin._
+import com.daml.lf.speedy.Anf.flattenToAnf
+import com.daml.lf.speedy.Pretty.SExpr._
+import com.daml.lf.data.Ref._
+
+class AnfTest extends WordSpec with Matchers {
+
+  "identity: [\\x. x]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(1, arg0)
+      val expected = original
+      testTransform(original, expected)
+    }
+  }
+
+  "twice: [\\f x. f (f x)]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(2, app(arg0, app(arg0, arg1)))
+      val expected = lam(2, let1(appa(arg0, arg1), appa(arg0, stack1)))
+      testTransform(original, expected)
+    }
+  }
+
+  "thrice: [\\f x. f (f (f x))]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(2, app(arg0, app(arg0, app(arg0, arg1))))
+      val expected =
+        lam(2, let1(appa(arg0, arg1), let1(appa(arg0, stack1), appa(arg0, stack1))))
+      testTransform(original, expected)
+    }
+  }
+
+  "arithmetic non-atomic: [\\f x. f (x+1)]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(2, app(arg0, binop(SBAddInt64, arg1, num1)))
+      val expected = lam(2, let1b2(SBAddInt64, arg1, num1, appa(arg0, stack1)))
+      testTransform(original, expected)
+    }
+  }
+
+  "nested (4x non-atomic): [\\f x. f(x+1) - f(x+2)]" should {
+    "be transformed to ANF as expected" in {
+      val original =
+        lam(
+          2,
+          binop(
+            SBSubInt64,
+            app(arg0, binop(SBAddInt64, arg1, num1)),
+            app(arg0, binop(SBAddInt64, arg1, num2))))
+      val expected =
+        lam(
+          2,
+          let1b2(
+            SBAddInt64,
+            arg1,
+            num1,
+            let1(
+              appa(arg0, stack1),
+              let1b2(
+                SBAddInt64,
+                arg1,
+                num2,
+                let1(appa(arg0, stack1), binopa(SBSubInt64, stack3, stack1))))))
+      testTransform(original, expected)
+    }
+  }
+
+  "builtin multi-arg fun: [\\g. (g 1) - (g 2)]" should {
+    "be transformed to ANF as expected" in {
+      val original =
+        lam(1, binop(SBSubInt64, app(arg1, num1), app(arg1, num2)))
+      val expected =
+        lam(1, let1(appa(arg1, num1), let1(appa(arg1, num2), binopa(SBSubInt64, stack2, stack1))))
+      testTransform(original, expected)
+    }
+  }
+
+  "unknown multi-arg fun: [\\f g. f (g 1) (g 2)]" should {
+    "be transformed to ANF as expected (safely)" in {
+      val original =
+        lam(2, app2(arg0, app(arg1, num1), app(arg1, num2)))
+      val expected =
+        lam(2, app2n(arg0, appa(arg1, num1), appa(arg1, num2)))
+      testTransform(original, expected)
+    }
+  }
+
+  "known apps nested in unknown: [\\f g x. f (g (x+1)) (g (x+2))]" should {
+    "be transformed to ANF as expected (safely)" in {
+      val original =
+        lam(
+          2,
+          app2(
+            arg0,
+            app(arg1, binop(SBSubInt64, arg3, num1)),
+            app(arg1, binop(SBSubInt64, arg3, num2))))
+      val expected =
+        lam(
+          2,
+          app2n(
+            arg0,
+            let1b2(SBSubInt64, arg3, num1, appa(arg1, stack1)),
+            let1b2(SBSubInt64, arg3, num2, appa(arg1, stack1))))
+      testTransform(original, expected)
+    }
+  }
+
+  "error applied to 1 arg" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(1, SEApp(SEBuiltin(SBError), Array(arg0)))
+      val expected = lam(1, SEAppAtomicSaturatedBuiltin(SBError, Array(arg0)))
+      testTransform(original, expected)
+    }
+  }
+
+  "error (over) applied to 2 arg" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(2, SEApp(SEBuiltin(SBError), Array(arg0, arg1)))
+      val expected = lam(2, SEAppAtomicFun(SEBuiltin(SBError), Array(arg0, arg1)))
+      testTransform(original, expected)
+    }
+  }
+
+  "case expression: [\\a b c. if a then b else c]" should {
+    "be transformed to ANF as expected" in {
+      val original = lam(3, ite(arg0, arg1, arg2))
+      val expected = lam(3, itea(arg0, arg1, arg2))
+      testTransform(original, expected)
+    }
+  }
+
+  "non-atomic in branch: [\\f x. if x==0 then 1 else f (div(1,x))]" should {
+    "be transformed to ANF as expected" in {
+      val original =
+        lam(2, ite(binop(SBEqual, arg1, num0), num1, app(arg0, binop(SBDivInt64, num1, arg1))))
+      val expected =
+        lam(
+          2,
+          let1b2(
+            SBEqual,
+            arg1,
+            num0,
+            itea(stack1, num1, let1b2(SBDivInt64, num1, arg1, appa(arg0, stack1)))))
+      testTransform(original, expected)
+    }
+  }
+
+  "nested lambda: [\\f g. g (\\y. f (f y))]" should {
+    "be transformed to ANF as expected" in {
+      val original =
+        lam(2, app(arg1, clo1(arg0, 1, app(free0, app(free0, arg0)))))
+      val expected =
+        lam(
+          2,
+          let1(clo1(arg0, 1, let1(appa(free0, arg0), appa(free0, stack1))), appa(arg1, stack1)))
+      testTransform(original, expected)
+    }
+  }
+
+  "issue 6535: [\\x. x + x]" should {
+    "be transformed to ANF as expected (with no redundant lets)" in {
+      val original = lam(1, binop(SBAddInt64, arg1, arg1))
+      val expected = lam(1, binopa(SBAddInt64, arg1, arg1))
+      testTransform(original, expected)
+    }
+  }
+
+  // expression builders
+  private def lam(n: Int, body: SExpr): SExpr = SEMakeClo(Array(), n, body)
+  private def clo1(fv: SELoc, n: Int, body: SExpr): SExpr = SEMakeClo(Array(fv), n, body)
+
+  private def app(func: SExpr, arg: SExpr): SExpr = SEAppGeneral(func, Array(arg))
+
+  private def app2(func: SExpr, arg1: SExpr, arg2: SExpr): SExpr =
+    SEAppGeneral(func, Array(arg1, arg2))
+
+  private def app2n(func: SExprAtomic, arg1: SExpr, arg2: SExpr): SExpr =
+    SEAppAtomicFun(func, Array(arg1, arg2))
+
+  private def binop(op: SBuiltinPure, x: SExpr, y: SExpr): SExpr = SEApp(SEBuiltin(op), Array(x, y))
+
+  private def ite(i: SExpr, t: SExpr, e: SExpr): SExpr =
+    SECase(i, Array(SCaseAlt(patTrue, t), SCaseAlt(patFalse, e)))
+
+  // anf builders
+  private def let1(rhs: SExpr, body: SExpr): SExpr =
+    SELet1General(rhs, body)
+
+  private def let1b2(op: SBuiltinPure, arg1: SExprAtomic, arg2: SExprAtomic, body: SExpr): SExpr =
+    SELet1Builtin(op, Array(arg1, arg2), body)
+
+  private def appa(func: SExprAtomic, arg: SExprAtomic): SExpr =
+    SEAppAtomicGeneral(func, Array(arg))
+
+  private def binopa(op: SBuiltinPure, x: SExprAtomic, y: SExprAtomic): SExpr =
+    SEAppAtomicSaturatedBuiltin(op, Array(x, y))
+
+  private def itea(i: SExprAtomic, t: SExpr, e: SExpr): SExpr =
+    SECaseAtomic(i, Array(SCaseAlt(patTrue, t), SCaseAlt(patFalse, e)))
+
+  // true/false case-patterns
+  private def patTrue: SCasePat =
+    SCPVariant(Identifier.assertFromString("P:M:bool"), IdString.Name.assertFromString("True"), 1)
+
+  private def patFalse: SCasePat =
+    SCPVariant(Identifier.assertFromString("P:M:bool"), IdString.Name.assertFromString("False"), 2)
+
+  // atoms
+
+  private def arg0 = SELocA(0)
+  private def arg1 = SELocA(1)
+  private def arg2 = SELocA(2)
+  private def arg3 = SELocA(3)
+  private def free0 = SELocF(0)
+  private def stack1 = SELocS(1)
+  private def stack2 = SELocS(2)
+  private def stack3 = SELocS(3)
+  private def num0 = num(0)
+  private def num1 = num(1)
+  private def num2 = num(2)
+  private def num(n: Long): SExprAtomic = SEValue(SInt64(n))
+
+  // run a test...
+  private def testTransform(original: SExpr, expected: SExpr, show: Boolean = false): Assertion = {
+    val transformed = flattenToAnf(original)
+    if (show || transformed != expected) {
+      println(s"**original:\n${pp(original)}\n")
+      println(s"**transformed:\n${pp(transformed)}\n")
+      println(s"**expected:\n${pp(expected)}\n")
+    }
+    transformed shouldBe (expected)
+  }
+
+  private def pp(e: SExpr): String = {
+    prettySExpr(0)(e).render(80)
+  }
+
+}

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -308,11 +308,12 @@ class SpeedyTest extends WordSpec with Matchers {
       val p_1_0 = recUpdPkgs.getDefinition(LfDefRef(qualify("M:p_1_0")))
       p_1_0 shouldEqual
         Some(
-          SEAppSaturatedBuiltinFun(
-            SBRecUpd(qualify("M:Point"), 0),
-            Array(SEVal(LfDefRef(qualify("M:origin"))), SEValue(SInt64(1))),
-          )
-        )
+          SELet1General(
+            SEVal(LfDefRef(qualify("M:origin"))),
+            SEAppAtomicSaturatedBuiltin(
+              SBRecUpd(qualify("M:Point"), 0),
+              Array(SELocS(1), SEValue(SInt64(1))))))
+
     }
 
     "produce expected output for single update" in {
@@ -330,13 +331,16 @@ class SpeedyTest extends WordSpec with Matchers {
       val p_1_2 = recUpdPkgs.getDefinition(LfDefRef(qualify("M:p_1_2")))
       p_1_2 shouldEqual
         Some(
-          SEAppSaturatedBuiltinFun(
-            SBRecUpdMulti(qualify("M:Point"), Array(0, 1)),
-            Array(
-              SEVal(LfDefRef(qualify("M:origin"))),
-              SEValue(SInt64(1)),
-              SEValue(SInt64(2)),
-            ),
+          SELet1General(
+            SEVal(LfDefRef(qualify("M:origin"))),
+            SEAppAtomicSaturatedBuiltin(
+              SBRecUpdMulti(qualify("M:Point"), Array(0, 1)),
+              Array(
+                SELocS(1),
+                SEValue(SInt64(1)),
+                SEValue(SInt64(2)),
+              ),
+            )
           )
         )
     }
@@ -364,16 +368,18 @@ class SpeedyTest extends WordSpec with Matchers {
       val p_3_4 = recUpdPkgs.getDefinition(LfDefRef(qualify("M:p_3_4_loc")))
       p_3_4 shouldEqual
         Some(
-          SELocation(
-            mkLocation(0),
-            SEAppSaturatedBuiltinFun(
-              SBRecUpdMulti(qualify("M:Point"), Array(0, 1)),
-              Array(
-                SELocation(mkLocation(2), SEVal(LfDefRef(qualify("M:origin")))),
-                SEValue(SInt64(3)),
-                SEValue(SInt64(4)),
-              ),
-            ),
+          SELet1General(
+            SELocation(mkLocation(2), SEVal(LfDefRef(qualify("M:origin")))),
+            SELocation(
+              mkLocation(0),
+              SEAppAtomicSaturatedBuiltin(
+                SBRecUpdMulti(qualify("M:Point"), Array(0, 1)),
+                Array(
+                  SELocS(1),
+                  SEValue(SInt64(3)),
+                  SEValue(SInt64(4)),
+                ),
+              )),
           )
         )
     }


### PR DESCRIPTION
Partial ANF transformation for Speedy

This PR adds support to speedy for the ANF transform. The reason to transform is speed of execution. This PR is the 3rd attempt.

- The first attempt (#6440) was merged & then reverted (#6645) when we discovered it had an accidental change to the evaluation order.

- The second attempt (#6724) aimed to modify the original ANF transform to make it _safe_, by translating multi-apps to a cascade of single apps. This technique was ultimately rejected because it can cause a quadratic blowup. Attempts to revert to earlier Speedy code to support non-ANF execution floundered.

- And so we decided it would be best to make a 3rd attempt to support partial ANF by working forwards from the current no-ANF situation, rather than backwards from the full-ANF. This is that PR.

What is here:
- ANF transform code is from attempt #1 (and made _safe_ in attempt #2)
- No use of types `SExpr` and `AExpr` to distinguish before/after ANF. There is one type `SExpr` with all the original non-ANF expression forms + some new forms for ANF. And the execution engine must know how to execute both non-ANF and ANF forms.
-  It is in fact possible to switch off the ANF transformation in the speedy Compiler, and everything will still work. This is different from the first two attempts where the ANF transformation was much more invasive.
- `SBuiltin` forms are stratified into pure and effectful versions (as in attempt #1). This is to allow the special form `SELet1Builtin` to be handled to very efficiently, which turns out to be a critical aspect of the speedup of ANF.
- `SEBuiltinRecursiveDefinition` expansion bodies are recoded to use ANF forms (as in attempt #1)
- `AnfTest.scala` is from attempt #2


Here are the perf numbers for `CollectAuthority`, run 6-way interleaved vs master:

    here    58.579 ±(99.9%) 0.574 ms/op [Average]
    master  68.433 ±(99.9%) 0.747 ms/op [Average]
    here    60.459 ±(99.9%) 0.720 ms/op [Average]
    master  68.451 ±(99.9%) 0.454 ms/op [Average]
    here    59.138 ±(99.9%) 0.489 ms/op [Average]
    master  67.114 ±(99.9%) 0.452 ms/op [Average]

About x1.13 -- x1.17

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
