### PR TITLE
Fix example in the trigger docs.

### DIFF
--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -211,7 +211,11 @@ To send the corresponding archve commands to the ledger, we iterate
 over ``archiveCopies`` using ``forA`` and call the ``emitCommands``
 function. Each call to ``emitCommands`` takes a list of commands which
 will be submitted as a single transaction. The actual commands can be
-created using ``exerciseCmd`` and ``createCmd``.
+created using ``exerciseCmd`` and ``createCmd``. In addition to that,
+we also pass in a list of contract ids. Those contracts will be marked
+pending and not be included in the result of ``getContracts`` until
+the commands have either been comitted to the ledger or the command
+submission failed.
 
 .. literalinclude:: ./template-root/src/CopyTrigger.daml
    :language: daml

--- a/docs/source/triggers/template-root/src/CopyTrigger.daml
+++ b/docs/source/triggers/template-root/src/CopyTrigger.daml
@@ -93,7 +93,7 @@ copyRule party acs _time commandsInFlight () = do
 -- ARCHIVE_COPIES_END
 
 -- ARCHIVE_COMMAND_BEGIN
-  forA archiveCopies $ \cid -> dedupExercise cid Archive
+  forA archiveCopies $ \cid -> emitCommands [exerciseCmd cid Archive] [toAnyContractId cid]
 -- ARCHIVE_COMMAND_END
 
 -- CREATE_COPIES_BEGIN


### PR DESCRIPTION
The docs talked about `emitCommands` while the code talked about
`dedupExercise`. I’m increasingly leaning towards recommending
`emitCommands` for everything so I’ve switched the code instead of the
docs.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
