### PR TITLE
Properly use LoggingContext in Participant Server

### DIFF
--- a/ledger-api/testing-utils/BUILD.bazel
+++ b/ledger-api/testing-utils/BUILD.bazel
@@ -21,6 +21,7 @@ da_scala_library(
         "//ledger-api/grpc-definitions:ledger-api-scalapb",
         "//ledger-api/rs-grpc-akka",
         "//ledger-api/rs-grpc-bridge",
+        "//libs-scala/contextualized-logging",
         "//libs-scala/direct-execution-context",
         "//libs-scala/grpc-utils",
         "//libs-scala/resources",

--- a/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/MultiFixtureBase.scala
+++ b/ledger-api/testing-utils/src/main/scala/com/digitalasset/ledger/api/testing/utils/MultiFixtureBase.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.api.testing.utils
 import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 
 import com.daml.dec.DirectExecutionContext
+import com.daml.logging.LoggingContext
 import org.scalatest._
 import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScaledTimeSpans}
 import org.scalatest.exceptions.TestCanceledException
@@ -22,6 +23,8 @@ trait MultiFixtureBase[FixtureId, TestContext]
     with ScaledTimeSpans
     with AsyncTimeLimitedTests {
   self: AsyncTestSuite =>
+
+  protected implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
   private var es: ScheduledExecutorService = _
 

--- a/ledger/daml-on-sql/README.rst
+++ b/ledger/daml-on-sql/README.rst
@@ -241,6 +241,26 @@ To see all the available options, run ``java -jar dam-on-sql-<version>.jar --hel
 Monitoring
 **********
 
+Configure logging
+=================
+
+*DAML on SQL* uses the industry-standard Logback for logging. You can
+read more on how to set it up on the *DAML on SQL* CLI reference and
+the `Logback documentation <http://logback.qos.ch/>`__.
+
+Structured logging
+^^^^^^^^^^^^^^^^^^
+
+The *DAML on SQL* logging infrastructure leverages structured logging
+as implemented by the `Logstash Logback Encoder <https://github.com/logstash/logstash-logback-encoder/blob/logstash-logback-encoder-6.3/README.md>`__.
+
+Each logged event carries information about the request being served by
+the Ledger API server (e.g. the command identifier). When using a
+traditional logging target (e.g. standard output or rotating files) this
+information will be part of the log description. Using a logging target
+compatible with the Logstash Logback Encoder allows to have rich logs
+with structured information about the event being logged.
+
 Enable and configure reporting
 ==============================
 

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -47,7 +47,7 @@ object Main {
         engine: Engine,
     )(
         implicit materializer: Materializer,
-        logCtx: LoggingContext,
+        loggingContext: LoggingContext,
     ): ResourceOwner[KeyValueParticipantState] =
       for {
         readerWriter <- owner(config, participantConfig, engine)
@@ -60,7 +60,7 @@ object Main {
 
     def owner(config: Config[ExtraConfig], participantConfig: ParticipantConfig, engine: Engine)(
         implicit materializer: Materializer,
-        logCtx: LoggingContext,
+        loggingContext: LoggingContext,
     ): ResourceOwner[KeyValueLedger] = {
       val metrics = createMetrics(participantConfig, config)
       new InMemoryLedgerReaderWriter.Owner(

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -140,7 +140,7 @@ object InMemoryLedgerReaderWriter {
       // We need to generate batched submissions for the validator in order to improve throughput.
       // Hence, we have a BatchingLedgerWriter collect and forward batched submissions to the
       // in-memory committer.
-      val batchingLedgerWriter = newLoggingContext { implicit logCtx =>
+      val batchingLedgerWriter = newLoggingContext { implicit loggingContext =>
         BatchingLedgerWriter(batchingLedgerWriterConfig, readerWriter)
       }
       Resource.successful(createKeyValueLedger(readerWriter, batchingLedgerWriter))

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
@@ -43,7 +43,7 @@ abstract class InMemoryLedgerReaderWriterIntegrationSpecBase(enableBatching: Boo
       participantId: ParticipantId,
       testId: String,
       metrics: Metrics,
-  )(implicit logCtx: LoggingContext): ResourceOwner[ParticipantState] =
+  )(implicit loggingContext: LoggingContext): ResourceOwner[ParticipantState] =
     new InMemoryLedgerReaderWriter.SingleParticipantOwner(
       ledgerId,
       batchingLedgerWriterConfig,

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -48,14 +48,16 @@ object SqlLedgerFactory extends LedgerFactory[ReadWriteService, ExtraConfig] {
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
       engine: Engine,
-  )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[ReadWriteService] =
+  )(
+      implicit materializer: Materializer,
+      loggingContext: LoggingContext): ResourceOwner[ReadWriteService] =
     new Owner(config, participantConfig, engine)
 
   class Owner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
       engine: Engine,
-  )(implicit materializer: Materializer, logCtx: LoggingContext)
+  )(implicit materializer: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[KeyValueParticipantState] {
     override def acquire()(
         implicit executionContext: ExecutionContext

--- a/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
+++ b/ledger/ledger-on-sql/src/app/scala/com/daml/ledger/on/sql/SqlLedgerFactory.scala
@@ -50,7 +50,8 @@ object SqlLedgerFactory extends LedgerFactory[ReadWriteService, ExtraConfig] {
       engine: Engine,
   )(
       implicit materializer: Materializer,
-      loggingContext: LoggingContext): ResourceOwner[ReadWriteService] =
+      loggingContext: LoggingContext,
+  ): ResourceOwner[ReadWriteService] =
     new Owner(config, participantConfig, engine)
 
   class Owner(

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
@@ -29,19 +29,19 @@ final class Database(
 ) {
   def inReadTransaction[T](name: String)(
       body: ReadQueries => Future[T],
-  )(implicit logCtx: LoggingContext): Future[T] =
+  )(implicit loggingContext: LoggingContext): Future[T] =
     inTransaction(name, readerConnectionPool)(connection =>
       Future(body(new TimedQueries(queries(connection), metrics)))(readerExecutionContext).flatten)
 
   def inWriteTransaction[T](name: String)(
       body: Queries => Future[T],
-  )(implicit logCtx: LoggingContext): Future[T] =
+  )(implicit loggingContext: LoggingContext): Future[T] =
     inTransaction(name, writerConnectionPool)(connection =>
       Future(body(new TimedQueries(queries(connection), metrics)))(writerExecutionContext).flatten)
 
   private def inTransaction[T](name: String, connectionPool: DataSource)(
       body: Connection => Future[T],
-  )(implicit logCtx: LoggingContext): Future[T] = {
+  )(implicit loggingContext: LoggingContext): Future[T] = {
     val connection = Timed.value(
       metrics.daml.ledger.database.transactions.acquireConnection(name),
       connectionPool.getConnection())
@@ -75,7 +75,7 @@ object Database {
   private val MaximumWriterConnectionPoolSize: Int = 1
 
   def owner(jdbcUrl: String, metrics: Metrics)(
-      implicit logCtx: LoggingContext,
+      implicit loggingContext: LoggingContext,
   ): ResourceOwner[UninitializedDatabase] =
     (jdbcUrl match {
       case "jdbc:h2:mem:" =>

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -51,7 +51,7 @@ final class SqlLedgerReaderWriter(
 )(
     implicit executionContext: ExecutionContext,
     materializer: Materializer,
-    logCtx: LoggingContext,
+    loggingContext: LoggingContext,
 ) extends LedgerWriter
     with LedgerReader {
 
@@ -137,7 +137,7 @@ object SqlLedgerReaderWriter {
       stateValueCache: Cache[Bytes, DamlStateValue] = Cache.none,
       timeProvider: TimeProvider = DefaultTimeProvider,
       seedService: SeedService,
-  )(implicit materializer: Materializer, logCtx: LoggingContext)
+  )(implicit materializer: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[SqlLedgerReaderWriter] {
     override def acquire()(
         implicit executionContext: ExecutionContext
@@ -165,7 +165,7 @@ object SqlLedgerReaderWriter {
 
   private def updateOrRetrieveLedgerId(providedLedgerId: LedgerId, database: Database)(
       implicit executionContext: ExecutionContext,
-      logCtx: LoggingContext,
+      loggingContext: LoggingContext,
   ): Future[LedgerId] =
     database.inWriteTransaction("retrieve_ledger_id") { queries =>
       Future.fromTry(
@@ -184,7 +184,7 @@ object SqlLedgerReaderWriter {
           })
     }
 
-  private final class DispatcherOwner(database: Database)(implicit logCtx: LoggingContext)
+  private final class DispatcherOwner(database: Database)(implicit loggingContext: LoggingContext)
       extends ResourceOwner[Dispatcher[Index]] {
     override def acquire()(
         implicit executionContext: ExecutionContext

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralDirectory.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralDirectory.scala
@@ -42,7 +42,7 @@ object MainWithEphemeralDirectory {
         engine: Engine,
     )(
         implicit materializer: Materializer,
-        logCtx: LoggingContext
+        loggingContext: LoggingContext
     ): ResourceOwner[ReadWriteService] =
       new Owner(config, participantConfig, engine)
 
@@ -50,7 +50,7 @@ object MainWithEphemeralDirectory {
         config: Config[ExtraConfig],
         participantConfig: ParticipantConfig,
         engine: Engine,
-    )(implicit materializer: Materializer, logCtx: LoggingContext)
+    )(implicit materializer: Materializer, loggingContext: LoggingContext)
         extends ResourceOwner[ReadWriteService] {
       override def acquire()(
           implicit executionContext: ExecutionContext

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralDirectory.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/MainWithEphemeralDirectory.scala
@@ -42,7 +42,7 @@ object MainWithEphemeralDirectory {
         engine: Engine,
     )(
         implicit materializer: Materializer,
-        loggingContext: LoggingContext
+        loggingContext: LoggingContext,
     ): ResourceOwner[ReadWriteService] =
       new Owner(config, participantConfig, engine)
 

--- a/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-sql/src/test/lib/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriterIntegrationSpecBase.scala
@@ -24,7 +24,7 @@ abstract class SqlLedgerReaderWriterIntegrationSpecBase(implementationName: Stri
       participantId: ParticipantId,
       testId: String,
       metrics: Metrics,
-  )(implicit logCtx: LoggingContext): ResourceOwner[ParticipantState] =
+  )(implicit loggingContext: LoggingContext): ResourceOwner[ParticipantState] =
     new SqlLedgerReaderWriter.Owner(
       ledgerId,
       participantId,

--- a/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/DatabaseSpec.scala
+++ b/ledger/ledger-on-sql/src/test/suite/scala/com/daml/ledger/on/sql/DatabaseSpec.scala
@@ -12,14 +12,14 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 class DatabaseSpec extends AsyncWordSpec with Matchers {
   "Database" should {
     "not accept unnamed H2 database URLs" in {
-      newLoggingContext { implicit logCtx =>
+      newLoggingContext { implicit loggingContext =>
         an[InvalidDatabaseException] should be thrownBy
           Database.owner("jdbc:h2:mem:", new Metrics(new MetricRegistry))
       }
     }
 
     "not accept unnamed SQLite database URLs" in {
-      newLoggingContext { implicit logCtx =>
+      newLoggingContext { implicit loggingContext =>
         an[InvalidDatabaseException] should be thrownBy
           Database.owner("jdbc:sqlite::memory:", new Metrics(new MetricRegistry))
       }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -185,7 +185,8 @@ private[daml] object ApiServices {
         apiTransactionService: GrpcTransactionService)(
         implicit mat: Materializer,
         ec: ExecutionContext,
-        loggingContext: LoggingContext): List[BindableService] = {
+        loggingContext: LoggingContext,
+    ): List[BindableService] = {
       optWriteService.toList.flatMap { writeService =>
         val commandExecutor = new TimedCommandExecutor(
           new LedgerTimeAwareCommandExecutor(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -84,7 +84,7 @@ private[daml] object ApiServices {
   )(
       implicit mat: Materializer,
       esf: ExecutionSequencerFactory,
-      logCtx: LoggingContext,
+      loggingContext: LoggingContext,
   ) extends ResourceOwner[ApiServices] {
     private val configurationService: IndexConfigurationService = indexService
     private val identityService: IdentityProvider = indexService
@@ -185,7 +185,7 @@ private[daml] object ApiServices {
         apiTransactionService: GrpcTransactionService)(
         implicit mat: Materializer,
         ec: ExecutionContext,
-        logCtx: LoggingContext): List[BindableService] = {
+        loggingContext: LoggingContext): List[BindableService] = {
       optWriteService.toList.flatMap { writeService =>
         val commandExecutor = new TimedCommandExecutor(
           new LedgerTimeAwareCommandExecutor(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
@@ -22,7 +22,7 @@ private[daml] final class LedgerApiServer(
     sslContext: Option[SslContext] = None,
     interceptors: List[ServerInterceptor] = List.empty,
     metrics: Metrics,
-)(implicit actorSystem: ActorSystem, materializer: Materializer, logCtx: LoggingContext)
+)(implicit actorSystem: ActorSystem, materializer: Materializer, loggingContext: LoggingContext)
     extends ResourceOwner[ApiServer] {
 
   private val logger = ContextualizedLogger.get(this.getClass)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -53,7 +53,7 @@ final class StandaloneApiServer(
     otherInterceptors: List[ServerInterceptor] = List.empty,
     engine: Engine,
     lfValueTranslationCache: LfValueTranslation.Cache,
-)(implicit actorSystem: ActorSystem, materializer: Materializer, logCtx: LoggingContext)
+)(implicit actorSystem: ActorSystem, materializer: Materializer, loggingContext: LoggingContext)
     extends ResourceOwner[ApiServer] {
 
   private val logger = ContextualizedLogger.get(this.getClass)
@@ -101,7 +101,7 @@ final class StandaloneApiServer(
         metrics = metrics,
         healthChecks = healthChecks,
         seedService = SeedService(config.seeding),
-      )(materializer, executionSequencerFactory, logCtx)
+      )(materializer, executionSequencerFactory, loggingContext)
         .map(_.withServices(otherServices))
       apiServer <- new LedgerApiServer(
         apiServicesOwner,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -33,6 +33,7 @@ import com.daml.lf.data.Ref
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
+import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 
 import scala.concurrent.Future
@@ -40,35 +41,45 @@ import scala.concurrent.Future
 private[daml] final class TimedIndexService(delegate: IndexService, metrics: Metrics)
     extends IndexService {
 
-  override def listLfPackages(): Future[Map[PackageId, v2.PackageDetails]] =
+  override def listLfPackages()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Map[PackageId, v2.PackageDetails]] =
     Timed.future(metrics.daml.services.index.listLfPackages, delegate.listLfPackages())
 
-  override def getLfArchive(packageId: PackageId): Future[Option[DamlLf.Archive]] =
+  override def getLfArchive(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[DamlLf.Archive]] =
     Timed.future(metrics.daml.services.index.getLfArchive, delegate.getLfArchive(packageId))
 
-  override def getLfPackage(packageId: PackageId): Future[Option[Ast.Package]] =
+  override def getLfPackage(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Ast.Package]] =
     Timed.future(metrics.daml.services.index.getLfPackage, delegate.getLfPackage(packageId))
 
   override def packageEntries(
       startExclusive: LedgerOffset.Absolute
-  ): Source[domain.PackageEntry, NotUsed] =
+  )(implicit loggingContext: LoggingContext): Source[domain.PackageEntry, NotUsed] =
     Timed.source(
       metrics.daml.services.index.packageEntries,
       delegate.packageEntries(startExclusive))
 
-  override def getLedgerConfiguration(): Source[v2.LedgerConfiguration, NotUsed] =
+  override def getLedgerConfiguration()(
+      implicit loggingContext: LoggingContext,
+  ): Source[v2.LedgerConfiguration, NotUsed] =
     Timed.source(
       metrics.daml.services.index.getLedgerConfiguration,
       delegate.getLedgerConfiguration())
 
-  override def currentLedgerEnd(): Future[LedgerOffset.Absolute] =
+  override def currentLedgerEnd()(
+      implicit loggingContext: LoggingContext,
+  ): Future[LedgerOffset.Absolute] =
     Timed.future(metrics.daml.services.index.currentLedgerEnd, delegate.currentLedgerEnd())
 
   override def getCompletions(
       begin: domain.LedgerOffset,
       applicationId: ApplicationId,
       parties: Set[Party]
-  ): Source[CompletionStreamResponse, NotUsed] =
+  )(implicit loggingContext: LoggingContext): Source[CompletionStreamResponse, NotUsed] =
     Timed.source(
       metrics.daml.services.index.getCompletions,
       delegate.getCompletions(begin, applicationId, parties))
@@ -77,8 +88,8 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
       begin: domain.LedgerOffset,
       endAt: Option[domain.LedgerOffset],
       filter: domain.TransactionFilter,
-      verbose: Boolean
-  ): Source[GetTransactionsResponse, NotUsed] =
+      verbose: Boolean,
+  )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed] =
     Timed.source(
       metrics.daml.services.index.transactions,
       delegate.transactions(begin, endAt, filter, verbose))
@@ -87,24 +98,24 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
       begin: domain.LedgerOffset,
       endAt: Option[domain.LedgerOffset],
       filter: domain.TransactionFilter,
-      verbose: Boolean
-  ): Source[GetTransactionTreesResponse, NotUsed] =
+      verbose: Boolean,
+  )(implicit loggingContext: LoggingContext): Source[GetTransactionTreesResponse, NotUsed] =
     Timed.source(
       metrics.daml.services.index.transactionTrees,
       delegate.transactionTrees(begin, endAt, filter, verbose))
 
   override def getTransactionById(
       transactionId: TransactionId,
-      requestingParties: Set[Party]
-  ): Future[Option[GetFlatTransactionResponse]] =
+      requestingParties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]] =
     Timed.future(
       metrics.daml.services.index.getTransactionById,
       delegate.getTransactionById(transactionId, requestingParties))
 
   override def getTransactionTreeById(
       transactionId: TransactionId,
-      requestingParties: Set[Party]
-  ): Future[Option[GetTransactionResponse]] =
+      requestingParties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]] =
     Timed.future(
       metrics.daml.services.index.getTransactionTreeById,
       delegate.getTransactionTreeById(transactionId, requestingParties))
@@ -112,57 +123,64 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
   override def getActiveContracts(
       filter: domain.TransactionFilter,
       verbose: Boolean,
-  ): Source[GetActiveContractsResponse, NotUsed] =
+  )(implicit loggingContext: LoggingContext): Source[GetActiveContractsResponse, NotUsed] =
     Timed.source(
       metrics.daml.services.index.getActiveContracts,
       delegate.getActiveContracts(filter, verbose))
 
   override def lookupActiveContract(
       submitter: Party,
-      contractId: Value.ContractId
-  ): Future[Option[Value.ContractInst[Value.VersionedValue[Value.ContractId]]]] =
+      contractId: Value.ContractId,
+  )(implicit loggingContext: LoggingContext)
+    : Future[Option[Value.ContractInst[Value.VersionedValue[Value.ContractId]]]] =
     Timed.future(
       metrics.daml.services.index.lookupActiveContract,
       delegate.lookupActiveContract(submitter, contractId))
 
   override def lookupContractKey(
       submitter: Party,
-      key: GlobalKey
-  ): Future[Option[Value.ContractId]] =
+      key: GlobalKey,
+  )(implicit loggingContext: LoggingContext): Future[Option[Value.ContractId]] =
     Timed.future(
       metrics.daml.services.index.lookupContractKey,
       delegate.lookupContractKey(submitter, key))
 
   override def lookupMaximumLedgerTime(
       ids: Set[Value.ContractId],
-  ): Future[Option[Instant]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[Instant]] =
     Timed.future(
       metrics.daml.services.index.lookupMaximumLedgerTime,
       delegate.lookupMaximumLedgerTime(ids))
 
-  override def getLedgerId(): Future[LedgerId] =
+  override def getLedgerId()(implicit loggingContext: LoggingContext): Future[LedgerId] =
     Timed.future(metrics.daml.services.index.getLedgerId, delegate.getLedgerId())
 
-  override def getParticipantId(): Future[ParticipantId] =
+  override def getParticipantId()(implicit loggingContext: LoggingContext): Future[ParticipantId] =
     Timed.future(metrics.daml.services.index.getParticipantId, delegate.getParticipantId())
 
-  override def getParties(parties: Seq[Party]): Future[List[domain.PartyDetails]] =
+  override def getParties(parties: Seq[Party])(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[domain.PartyDetails]] =
     Timed.future(metrics.daml.services.index.getParties, delegate.getParties(parties))
 
-  override def listKnownParties(): Future[List[domain.PartyDetails]] =
+  override def listKnownParties()(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[domain.PartyDetails]] =
     Timed.future(metrics.daml.services.index.listKnownParties, delegate.listKnownParties())
 
   override def partyEntries(
       startExclusive: LedgerOffset.Absolute
-  ): Source[domain.PartyEntry, NotUsed] =
+  )(implicit loggingContext: LoggingContext): Source[domain.PartyEntry, NotUsed] =
     Timed.source(metrics.daml.services.index.partyEntries, delegate.partyEntries(startExclusive))
 
-  override def lookupConfiguration(): Future[Option[(LedgerOffset.Absolute, Configuration)]] =
+  override def lookupConfiguration()(implicit loggingContext: LoggingContext)
+    : Future[Option[(LedgerOffset.Absolute, Configuration)]] =
     Timed.future(metrics.daml.services.index.lookupConfiguration, delegate.lookupConfiguration())
 
   override def configurationEntries(
-      startExclusive: Option[LedgerOffset.Absolute]
-  ): Source[(LedgerOffset.Absolute, ConfigurationEntry), NotUsed] =
+      startExclusive: Option[LedgerOffset.Absolute],
+  )(implicit loggingContext: LoggingContext)
+    : Source[(LedgerOffset.Absolute, ConfigurationEntry), NotUsed] =
     Timed.source(
       metrics.daml.services.index.configurationEntries,
       delegate.configurationEntries(startExclusive))
@@ -171,8 +189,8 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
       commandId: CommandId,
       submitter: Ref.Party,
       submittedAt: Instant,
-      deduplicateUntil: Instant
-  ): Future[v2.CommandDeduplicationResult] =
+      deduplicateUntil: Instant,
+  )(implicit loggingContext: LoggingContext): Future[v2.CommandDeduplicationResult] =
     Timed.future(
       metrics.daml.services.index.deduplicateCommand,
       delegate.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil))
@@ -180,7 +198,7 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
   override def stopDeduplicatingCommand(
       commandId: CommandId,
       submitter: Ref.Party,
-  ): Future[Unit] =
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
     Timed.future(
       metrics.daml.services.index.stopDeduplicateCommand,
       delegate.stopDeduplicatingCommand(commandId, submitter))

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/CommandExecutor.scala
@@ -16,6 +16,6 @@ private[apiserver] trait CommandExecutor {
       submissionSeed: crypto.Hash,
   )(
       implicit ec: ExecutionContext,
-      logCtx: LoggingContext,
+      loggingContext: LoggingContext,
   ): Future[Either[ErrorCause, CommandExecutionResult]]
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
@@ -44,7 +44,7 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
       retriesLeft: Int,
   )(
       implicit ec: ExecutionContext,
-      loggingContext: LoggingContext
+      loggingContext: LoggingContext,
   ): Future[Either[ErrorCause, CommandExecutionResult]] = {
     delegate
       .execute(commands, submissionSeed)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/LedgerTimeAwareCommandExecutor.scala
@@ -34,7 +34,7 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
       submissionSeed: crypto.Hash,
   )(
       implicit ec: ExecutionContext,
-      logCtx: LoggingContext,
+      loggingContext: LoggingContext,
   ): Future[Either[ErrorCause, CommandExecutionResult]] =
     loop(commands, submissionSeed, maxRetries)
 
@@ -44,7 +44,7 @@ private[apiserver] final class LedgerTimeAwareCommandExecutor(
       retriesLeft: Int,
   )(
       implicit ec: ExecutionContext,
-      logCtx: LoggingContext
+      loggingContext: LoggingContext
   ): Future[Either[ErrorCause, CommandExecutionResult]] = {
     delegate
       .execute(commands, submissionSeed)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -44,7 +44,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
       submissionSeed: crypto.Hash,
   )(
       implicit ec: ExecutionContext,
-      logCtx: LoggingContext,
+      loggingContext: LoggingContext,
   ): Future[Either[ErrorCause, CommandExecutionResult]] = {
     val start = System.nanoTime()
     val submissionResult = engine.submit(commands.commands, participant, submissionSeed)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -86,7 +86,8 @@ private[apiserver] final class StoreBackedCommandExecutor(
     new ConcurrentHashMap()
 
   private def consume[A](submitter: Ref.Party, result: Result[A])(
-      implicit ec: ExecutionContext
+      implicit ec: ExecutionContext,
+      loggingContext: LoggingContext,
   ): Future[Either[DamlLfError, A]] = {
 
     val lookupActiveContractTime = new AtomicLong(0L)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/TimedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/TimedCommandExecutor.scala
@@ -21,7 +21,7 @@ private[apiserver] class TimedCommandExecutor(
       submissionSeed: crypto.Hash,
   )(
       implicit ec: ExecutionContext,
-      logCtx: LoggingContext,
+      loggingContext: LoggingContext,
   ): Future[Either[ErrorCause, CommandExecutionResult]] =
     Timed.future(metrics.daml.execution.total, delegate.execute(commands, submissionSeed))
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
@@ -12,8 +12,10 @@ import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.v1.active_contracts_service.ActiveContractsServiceGrpc.ActiveContractsService
 import com.daml.ledger.api.v1.active_contracts_service._
+import com.daml.ledger.api.v1.transaction_filter.Filters
 import com.daml.ledger.api.validation.TransactionFilterValidator
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.validation.ActiveContractsServiceValidation
 import io.grpc.{BindableService, ServerServiceDefinition}
@@ -26,21 +28,24 @@ private[apiserver] final class ApiActiveContractsService private (
     implicit executionContext: ExecutionContext,
     protected val mat: Materializer,
     protected val esf: ExecutionSequencerFactory,
-    logCtx: LoggingContext,
+    loggingContext: LoggingContext,
 ) extends ActiveContractsServiceAkkaGrpc
     with GrpcApiService {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 
+  import ApiActiveContractsService.filters
   override protected def getActiveContractsSource(
-      request: GetActiveContractsRequest): Source[GetActiveContractsResponse, NotUsed] = {
-    logger.trace("Serving an Active Contracts request...")
-
-    TransactionFilterValidator
-      .validate(request.getFilter, "filter")
-      .fold(Source.failed, backend.getActiveContracts(_, request.verbose))
-      .via(logger.logErrorsOnStream)
-  }
+      request: GetActiveContractsRequest,
+  ): Source[GetActiveContractsResponse, NotUsed] =
+    withEnrichedLoggingContext(filters(request.getFilter.filtersByParty)) {
+      implicit loggingContext: LoggingContext =>
+        logger.trace("Serving an Active Contracts request...")
+        TransactionFilterValidator
+          .validate(request.getFilter, "filter")
+          .fold(Source.failed, backend.getActiveContracts(_, request.verbose))
+          .via(logger.logErrorsOnStream)
+    }
 
   override def bindService(): ServerServiceDefinition =
     ActiveContractsServiceGrpc.bindService(this, DirectExecutionContext)
@@ -48,11 +53,21 @@ private[apiserver] final class ApiActiveContractsService private (
 
 private[apiserver] object ApiActiveContractsService {
 
+  private val AllTemplates = Iterator.single("all-templates")
+  private def filters(filtersByParty: Map[String, Filters]): Map[String, String] =
+    filtersByParty.iterator.flatMap {
+      case (party, filters) =>
+        Iterator
+          .continually(s"party-$party")
+          .zip(filters.inclusive.fold(AllTemplates)(_.templateIds.iterator.map(_.toString)))
+    }.toMap
+
   def create(ledgerId: LedgerId, backend: ACSBackend)(
       implicit ec: ExecutionContext,
       mat: Materializer,
       esf: ExecutionSequencerFactory,
-      logCtx: LoggingContext): ActiveContractsService with GrpcApiService =
+      loggingContext: LoggingContext,
+  ): ActiveContractsService with GrpcApiService =
     new ActiveContractsServiceValidation(new ApiActiveContractsService(backend), ledgerId)
     with BindableService {
       override def bindService(): ServerServiceDefinition =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
@@ -54,6 +54,7 @@ private[apiserver] final class ApiActiveContractsService private (
 private[apiserver] object ApiActiveContractsService {
 
   private val AllTemplates = Iterator.single("all-templates")
+
   private def filters(filtersByParty: Map[String, Filters]): Map[String, String] =
     filtersByParty.iterator.flatMap {
       case (party, filters) =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -67,7 +67,8 @@ private[apiserver] object ApiCommandCompletionService {
       implicit ec: ExecutionContext,
       mat: Materializer,
       esf: ExecutionSequencerFactory,
-      loggingContext: LoggingContext): GrpcCommandCompletionService with GrpcApiService = {
+      loggingContext: LoggingContext,
+  ): GrpcCommandCompletionService with GrpcApiService = {
     val impl: CommandCompletionService =
       new ApiCommandCompletionService(completionsService)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandCompletionService.scala
@@ -26,21 +26,23 @@ import io.grpc.ServerServiceDefinition
 import scala.concurrent.{ExecutionContext, Future}
 
 private[apiserver] final class ApiCommandCompletionService private (
-    completionsService: IndexCompletionsService)(
+    completionsService: IndexCompletionsService,
+)(
     implicit ec: ExecutionContext,
     protected val mat: Materializer,
     protected val esf: ExecutionSequencerFactory,
-    logCtx: LoggingContext)
-    extends CommandCompletionService {
+    loggingContext: LoggingContext,
+) extends CommandCompletionService {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 
   private val subscriptionIdCounter = new AtomicLong()
 
   override def completionStreamSource(
-      request: CompletionStreamRequest): Source[CompletionStreamResponse, NotUsed] =
+      request: CompletionStreamRequest,
+  ): Source[CompletionStreamResponse, NotUsed] =
     withEnrichedLoggingContext(logging.parties(request.parties), logging.offset(request.offset)) {
-      implicit logCtx =>
+      implicit loggingContext =>
         val subscriptionId = subscriptionIdCounter.getAndIncrement().toString
         logger.debug(s"Received request for completion subscription $subscriptionId: $request")
 
@@ -65,7 +67,7 @@ private[apiserver] object ApiCommandCompletionService {
       implicit ec: ExecutionContext,
       mat: Materializer,
       esf: ExecutionSequencerFactory,
-      logCtx: LoggingContext): GrpcCommandCompletionService with GrpcApiService = {
+      loggingContext: LoggingContext): GrpcCommandCompletionService with GrpcApiService = {
     val impl: CommandCompletionService =
       new ApiCommandCompletionService(completionsService)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -53,7 +53,7 @@ private[apiserver] final class ApiCommandService private (
     implicit grpcExecutionContext: ExecutionContext,
     actorMaterializer: Materializer,
     esf: ExecutionSequencerFactory,
-    loggingContext: LoggingContext
+    loggingContext: LoggingContext,
 ) extends CommandServiceGrpc.CommandService
     with AutoCloseable {
 
@@ -173,7 +173,7 @@ private[apiserver] object ApiCommandService {
       implicit grpcExecutionContext: ExecutionContext,
       actorMaterializer: Materializer,
       esf: ExecutionSequencerFactory,
-      loggingContext: LoggingContext
+      loggingContext: LoggingContext,
   ): CommandServiceGrpc.CommandService with GrpcApiService =
     new GrpcCommandService(
       new ApiCommandService(services, configuration, ledgerConfigProvider),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -53,7 +53,7 @@ private[apiserver] final class ApiCommandService private (
     implicit grpcExecutionContext: ExecutionContext,
     actorMaterializer: Materializer,
     esf: ExecutionSequencerFactory,
-    logCtx: LoggingContext
+    loggingContext: LoggingContext
 ) extends CommandServiceGrpc.CommandService
     with AutoCloseable {
 
@@ -74,23 +74,28 @@ private[apiserver] final class ApiCommandService private (
     submissionTracker.close()
   }
 
-  private def submitAndWaitInternal(request: SubmitAndWaitRequest): Future[Completion] =
+  private def submitAndWaitInternal(request: SubmitAndWaitRequest)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Completion] =
     withEnrichedLoggingContext(
       logging.commandId(request.getCommands.commandId),
-      logging.party(request.getCommands.party)) { implicit logCtx =>
+      logging.party(request.getCommands.party),
+    ) { implicit loggingContext =>
       if (running) {
         ledgerConfigProvider.latestConfiguration.fold[Future[Completion]](
           Future.failed(ErrorFactories.missingLedgerConfig()))(ledgerConfig =>
           track(request, ledgerConfig))
       } else {
         Future.failed(
-          new ApiException(Status.UNAVAILABLE.withDescription("Service has been shut down.")))
+          new ApiException(Status.UNAVAILABLE.withDescription("Service has been shut down."))
+        )
       }.andThen(logger.logErrorsOnCall[Completion])
     }
 
   private def track(
       request: SubmitAndWaitRequest,
-      ledgerConfig: LedgerConfiguration): Future[Completion] = {
+      ledgerConfig: LedgerConfiguration,
+  )(implicit loggingContext: LoggingContext): Future[Completion] = {
     val appId = request.getCommands.applicationId
     val submitter = TrackerMap.Key(application = appId, party = request.getCommands.party)
     submissionTracker.track(submitter, request) {
@@ -168,7 +173,7 @@ private[apiserver] object ApiCommandService {
       implicit grpcExecutionContext: ExecutionContext,
       actorMaterializer: Materializer,
       esf: ExecutionSequencerFactory,
-      logCtx: LoggingContext
+      loggingContext: LoggingContext
   ): CommandServiceGrpc.CommandService with GrpcApiService =
     new GrpcCommandService(
       new ApiCommandService(services, configuration, ledgerConfigProvider),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
@@ -13,7 +13,6 @@ import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.v1.ledger_configuration_service._
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
-import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.validation.LedgerConfigurationServiceValidation
 import io.grpc.{BindableService, ServerServiceDefinition}
@@ -34,17 +33,15 @@ private[apiserver] final class ApiLedgerConfigurationService private (
   override protected def getLedgerConfigurationSource(
       request: GetLedgerConfigurationRequest,
   ): Source[GetLedgerConfigurationResponse, NotUsed] =
-    withEnrichedLoggingContext(Map.empty[String, String]) { implicit loggingContext =>
-      configurationService
-        .getLedgerConfiguration()
-        .map(
-          configuration =>
-            GetLedgerConfigurationResponse(
-              Some(LedgerConfiguration(
-                Some(toProto(configuration.maxDeduplicationTime)),
-              ))))
-        .via(logger.logErrorsOnStream)
-    }
+    configurationService
+      .getLedgerConfiguration()
+      .map(
+        configuration =>
+          GetLedgerConfigurationResponse(
+            Some(LedgerConfiguration(
+              Some(toProto(configuration.maxDeduplicationTime)),
+            ))))
+      .via(logger.logErrorsOnStream)
 
   override def bindService(): ServerServiceDefinition =
     LedgerConfigurationServiceGrpc.bindService(this, DirectExecutionContext)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerConfigurationService.scala
@@ -25,8 +25,8 @@ private[apiserver] final class ApiLedgerConfigurationService private (
 )(
     implicit protected val esf: ExecutionSequencerFactory,
     protected val mat: Materializer,
-    loggingContext: LoggingContext)
-    extends LedgerConfigurationServiceAkkaGrpc
+    loggingContext: LoggingContext,
+) extends LedgerConfigurationServiceAkkaGrpc
     with GrpcApiService {
 
   private val logger = ContextualizedLogger.get(this.getClass)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerIdentityService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiLedgerIdentityService.scala
@@ -14,7 +14,6 @@ import com.daml.ledger.api.v1.ledger_identity_service.{
   LedgerIdentityServiceGrpc
 }
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
-import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.ApiException
 import io.grpc.{BindableService, ServerServiceDefinition, Status}
@@ -40,11 +39,9 @@ private[apiserver] final class ApiLedgerIdentityService private (
           Status.UNAVAILABLE
             .withDescription("Ledger Identity Service closed.")))
     else
-      withEnrichedLoggingContext(Map.empty[String, String]) { implicit loggingContext =>
-        getLedgerId()
-          .map(ledgerId => GetLedgerIdentityResponse(ledgerId.unwrap))(DirectExecutionContext)
-          .andThen(logger.logErrorsOnCall[GetLedgerIdentityResponse])(DirectExecutionContext)
-      }
+      getLedgerId()
+        .map(ledgerId => GetLedgerIdentityResponse(ledgerId.unwrap))(DirectExecutionContext)
+        .andThen(logger.logErrorsOnCall[GetLedgerIdentityResponse])(DirectExecutionContext)
 
   override def close(): Unit = closed = true
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiPackageService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiPackageService.scala
@@ -15,6 +15,7 @@ import com.daml.ledger.api.v1.package_service.HashFunction.{
 import com.daml.ledger.api.v1.package_service.PackageServiceGrpc.PackageService
 import com.daml.ledger.api.v1.package_service.{HashFunction => APIHashFunction, _}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.validation.PackageServiceValidation
 import io.grpc.{BindableService, ServerServiceDefinition, Status}
@@ -22,8 +23,8 @@ import io.grpc.{BindableService, ServerServiceDefinition, Status}
 import scala.concurrent.Future
 
 private[apiserver] final class ApiPackageService private (backend: IndexPackagesService)(
-    implicit logCtx: LoggingContext)
-    extends PackageService
+    implicit loggingContext: LoggingContext,
+) extends PackageService
     with GrpcApiService {
 
   private val logger = ContextualizedLogger.get(this.getClass)
@@ -34,31 +35,33 @@ private[apiserver] final class ApiPackageService private (backend: IndexPackages
   override def close(): Unit = ()
 
   override def listPackages(request: ListPackagesRequest): Future[ListPackagesResponse] =
-    backend
-      .listLfPackages()
-      .map(p => ListPackagesResponse(p.keys.toSeq))(DEC)
-      .andThen(logger.logErrorsOnCall[ListPackagesResponse])(DEC)
+    withEnrichedLoggingContext(Map.empty[String, String]) { implicit loggingContext =>
+      backend
+        .listLfPackages()
+        .map(p => ListPackagesResponse(p.keys.toSeq))(DEC)
+        .andThen(logger.logErrorsOnCall[ListPackagesResponse])(DEC)
+    }
 
   override def getPackage(request: GetPackageRequest): Future[GetPackageResponse] =
-    withValidatedPackageId(
-      request.packageId,
-      pId =>
+    withEnrichedLoggingContext("packageId" -> request.packageId) { implicit loggingContext =>
+      withValidatedPackageId(request.packageId) { packageId =>
         backend
-          .getLfArchive(pId)
+          .getLfArchive(packageId)
           .flatMap(_.fold(Future.failed[GetPackageResponse](Status.NOT_FOUND.asRuntimeException()))(
             archive => Future.successful(toGetPackageResponse(archive))))(DEC)
           .andThen(logger.logErrorsOnCall[GetPackageResponse])(DEC)
-    )
+      }
+    }
 
   override def getPackageStatus(
-      request: GetPackageStatusRequest): Future[GetPackageStatusResponse] =
-    withValidatedPackageId(
-      request.packageId,
-      pId =>
+      request: GetPackageStatusRequest,
+  ): Future[GetPackageStatusResponse] =
+    withEnrichedLoggingContext("packageId" -> request.packageId) { implicit loggingContext =>
+      withValidatedPackageId(request.packageId) { packageId =>
         backend
           .listLfPackages()
           .map { packages =>
-            val result = if (packages.contains(pId)) {
+            val result = if (packages.contains(packageId)) {
               PackageStatus.REGISTERED
             } else {
               PackageStatus.UNKNOWN
@@ -66,9 +69,10 @@ private[apiserver] final class ApiPackageService private (backend: IndexPackages
             GetPackageStatusResponse(result)
           }(DEC)
           .andThen(logger.logErrorsOnCall[GetPackageStatusResponse])(DEC)
-    )
+      }
+    }
 
-  private def withValidatedPackageId[T](packageId: String, block: Ref.PackageId => Future[T]) =
+  private def withValidatedPackageId[T](packageId: String)(block: Ref.PackageId => Future[T]) =
     Ref.PackageId
       .fromString(packageId)
       .fold(
@@ -92,7 +96,8 @@ private[apiserver] final class ApiPackageService private (backend: IndexPackages
 
 private[platform] object ApiPackageService {
   def create(ledgerId: LedgerId, backend: IndexPackagesService)(
-      implicit logCtx: LoggingContext): PackageService with GrpcApiService =
+      implicit loggingContext: LoggingContext,
+  ): PackageService with GrpcApiService =
     new PackageServiceValidation(new ApiPackageService(backend), ledgerId) with BindableService {
       override def bindService(): ServerServiceDefinition =
         PackageServiceGrpc.bindService(this, DEC)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiPackageService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiPackageService.scala
@@ -35,12 +35,10 @@ private[apiserver] final class ApiPackageService private (backend: IndexPackages
   override def close(): Unit = ()
 
   override def listPackages(request: ListPackagesRequest): Future[ListPackagesResponse] =
-    withEnrichedLoggingContext(Map.empty[String, String]) { implicit loggingContext =>
-      backend
-        .listLfPackages()
-        .map(p => ListPackagesResponse(p.keys.toSeq))(DEC)
-        .andThen(logger.logErrorsOnCall[ListPackagesResponse])(DEC)
-    }
+    backend
+      .listLfPackages()
+      .map(p => ListPackagesResponse(p.keys.toSeq))(DEC)
+      .andThen(logger.logErrorsOnCall[ListPackagesResponse])(DEC)
 
   override def getPackage(request: GetPackageRequest): Future[GetPackageResponse] =
     withEnrichedLoggingContext("packageId" -> request.packageId) { implicit loggingContext =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -115,7 +115,7 @@ private[apiserver] final class ApiSubmissionService private (
 
   override def submit(request: SubmitRequest): Future[Unit] =
     withEnrichedLoggingContext(logging.commands(request.commands)) { implicit loggingContext =>
-      logger.trace(s"Received composite commands: ${request.commands}")
+      logger.trace(s"Commands: ${request.commands.commands.commands}")
       ledgerConfigProvider.latestConfiguration
         .map(deduplicateAndRecordOnLedger(seedService.nextSeed(), request.commands, _))
         .getOrElse(Future.failed(ErrorFactories.missingLedgerConfig()))

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -212,7 +212,7 @@ private[apiserver] final class ApiSubmissionService private (
                   logging.party(name),
                   logging.submissionId(submissionId),
                 ) { implicit loggingContext =>
-                  logger.info(s"Implicit party allocation")
+                  logger.info("Implicit party allocation")
                   writeService
                     .allocateParty(
                       hint = Some(name),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -8,7 +8,6 @@ import java.util.UUID
 
 import akka.stream.Materializer
 import com.daml.api.util.TimeProvider
-import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.domain.{LedgerId, Commands => ApiCommands}
 import com.daml.ledger.api.messages.command.submission.SubmitRequest
 import com.daml.ledger.participant.state.index.v2._
@@ -26,7 +25,6 @@ import com.daml.ledger.participant.state.v1.{
   WriteService
 }
 import com.daml.lf.crypto
-import com.daml.lf.data.Ref.Party
 import com.daml.lf.transaction.SubmittedTransaction
 import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
@@ -43,6 +41,7 @@ import io.grpc.Status
 
 import scala.compat.java8.FutureConverters.CompletionStageOps
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 private[apiserver] object ApiSubmissionService {
@@ -63,7 +62,7 @@ private[apiserver] object ApiSubmissionService {
   )(
       implicit ec: ExecutionContext,
       mat: Materializer,
-      logCtx: LoggingContext
+      loggingContext: LoggingContext,
   ): GrpcCommandSubmissionService with GrpcApiService =
     new GrpcCommandSubmissionService(
       service = new ApiSubmissionService(
@@ -105,59 +104,55 @@ private[apiserver] final class ApiSubmissionService private (
     commandExecutor: CommandExecutor,
     configuration: ApiSubmissionService.Configuration,
     metrics: Metrics,
-)(implicit ec: ExecutionContext, mat: Materializer, logCtx: LoggingContext)
+)(implicit ec: ExecutionContext, mat: Materializer, loggingContext: LoggingContext)
     extends CommandSubmissionService
     with ErrorFactories
     with AutoCloseable {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 
+  private val DuplicateCommand = Status.ALREADY_EXISTS.augmentDescription("Duplicate command")
+
+  override def submit(request: SubmitRequest): Future[Unit] =
+    withEnrichedLoggingContext(logging.commands(request.commands)) { implicit loggingContext =>
+      logger.trace(s"Received composite commands: ${request.commands}")
+      ledgerConfigProvider.latestConfiguration
+        .map(deduplicateAndRecordOnLedger(seedService.nextSeed(), request.commands, _))
+        .getOrElse(Future.failed(ErrorFactories.missingLedgerConfig()))
+        .andThen(logger.logErrorsOnCall[Unit])
+    }
+
   private def deduplicateAndRecordOnLedger(
       seed: crypto.Hash,
       commands: ApiCommands,
-      ledgerConfig: Configuration)(implicit logCtx: LoggingContext): Future[Unit] = {
-    val submittedAt = commands.submittedAt
-    val deduplicateUntil = commands.deduplicateUntil
-
+      ledgerConfig: Configuration,
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
     submissionService
-      .deduplicateCommand(commands.commandId, commands.submitter, submittedAt, deduplicateUntil)
+      .deduplicateCommand(
+        commands.commandId,
+        commands.submitter,
+        commands.submittedAt,
+        commands.deduplicateUntil,
+      )
       .flatMap {
         case CommandDeduplicationNew =>
-          recordOnLedger(seed, commands, ledgerConfig)
-            .transform(mapSubmissionResult)
+          evaluateAndSubmit(seed, commands, ledgerConfig)
+            .transform(handleSubmissionResult)
             .recoverWith {
-              case error =>
+              case NonFatal(originalCause) =>
                 submissionService
                   .stopDeduplicatingCommand(commands.commandId, commands.submitter)
-                  .transform(_ => Failure(error))
+                  .transform(_ => Failure(originalCause))
             }
-        case CommandDeduplicationDuplicate(until) =>
+        case _: CommandDeduplicationDuplicate =>
           metrics.daml.commands.deduplicatedCommands.mark()
-          val reason =
-            s"A command with the same command ID ${commands.commandId} and submitter ${commands.submitter} was submitted before. Deduplication window until $until"
-          logger.debug(reason)
-          Future.failed(Status.ALREADY_EXISTS.augmentDescription(reason).asRuntimeException)
+          logger.debug(DuplicateCommand.getDescription)
+          Future.failed(DuplicateCommand.asRuntimeException)
       }
-  }
 
-  override def submit(request: SubmitRequest): Future[Unit] =
-    withEnrichedLoggingContext(
-      logging.commandId(request.commands.commandId),
-      logging.party(request.commands.submitter)) { implicit logCtx =>
-      val commands = request.commands
-
-      logger.trace(s"Received composite commands: $commands")
-      logger.debug(s"Received composite command let ${commands.commands.ledgerEffectiveTime}.")
-      ledgerConfigProvider.latestConfiguration.fold[Future[Unit]](
-        Future.failed(ErrorFactories.missingLedgerConfig())
-      )(
-        ledgerConfig =>
-          deduplicateAndRecordOnLedger(seedService.nextSeed(), commands, ledgerConfig)
-            .andThen(logger.logErrorsOnCall[Unit])(DirectExecutionContext))
-    }
-
-  private def mapSubmissionResult(result: Try[SubmissionResult])(
-      implicit logCtx: LoggingContext): Try[Unit] = result match {
+  private def handleSubmissionResult(result: Try[SubmissionResult])(
+      implicit loggingContext: LoggingContext,
+  ): Try[Unit] = result match {
     case Success(Acknowledged) =>
       logger.debug("Submission of command succeeded")
       Success(())
@@ -179,40 +174,55 @@ private[apiserver] final class ApiSubmissionService private (
       Failure(error)
   }
 
-  private def recordOnLedger(
+  private def handleCommandExecutionResult(
+      result: Either[ErrorCause, CommandExecutionResult],
+  ): Future[CommandExecutionResult] =
+    result.fold(error => {
+      metrics.daml.commands.failedCommandInterpretations.mark()
+      Future.failed(grpcError(toStatus(error)))
+    }, Future.successful)
+
+  private def evaluateAndSubmit(
       submissionSeed: crypto.Hash,
       commands: ApiCommands,
       ledgerConfig: Configuration,
-  )(implicit logCtx: LoggingContext): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     for {
-      res <- commandExecutor.execute(commands, submissionSeed)
-      transactionInfo <- res.fold(error => {
-        metrics.daml.commands.failedCommandInterpretations.mark()
-        Future.failed(grpcError(toStatus(error)))
-      }, Future.successful)
+      result <- commandExecutor.execute(commands, submissionSeed)
+      transactionInfo <- handleCommandExecutionResult(result)
       partyAllocationResults <- allocateMissingInformees(transactionInfo.transaction)
       submissionResult <- submitTransaction(transactionInfo, partyAllocationResults, ledgerConfig)
     } yield submissionResult
 
+  // Takes the whole transaction to ensure to traverse it only if necessary
   private def allocateMissingInformees(
       transaction: SubmittedTransaction,
-  ): Future[Seq[SubmissionResult]] =
+  )(implicit loggingContext: LoggingContext): Future[Seq[SubmissionResult]] =
     if (configuration.implicitPartyAllocation) {
-      val parties: Set[Party] = transaction.nodes.values.flatMap(_.informeesOfNode).toSet
-      partyManagementService.getParties(parties.toSeq).flatMap { partyDetails =>
-        val missingParties = parties -- partyDetails.map(_.party)
+      val partiesInTransaction = transaction.nodes.valuesIterator.flatMap(_.informeesOfNode).toSeq
+      partyManagementService.getParties(partiesInTransaction).flatMap { partyDetails =>
+        val knownParties = partyDetails.iterator.map(_.party).toSet
+        val missingParties = partiesInTransaction.filterNot(knownParties)
         if (missingParties.nonEmpty) {
-          logger.info(s"Implicitly allocating the parties: ${missingParties.mkString(", ")}")
           Future.sequence(
-            missingParties.toSeq
-              .map(name =>
-                writeService.allocateParty(
-                  hint = Some(name),
-                  displayName = Some(name),
-                  // TODO: Just like the ApiPartyManagementService, this should do proper validation.
-                  submissionId = v1.SubmissionId.assertFromString(UUID.randomUUID().toString),
-              ))
-              .map(_.toScala))
+            missingParties
+              .map(name => {
+                val submissionId = v1.SubmissionId.assertFromString(UUID.randomUUID().toString)
+                withEnrichedLoggingContext(
+                  logging.party(name),
+                  logging.submissionId(submissionId),
+                ) { implicit loggingContext =>
+                  logger.info(s"Implicit party allocation")
+                  writeService
+                    .allocateParty(
+                      hint = Some(name),
+                      displayName = Some(name),
+                      submissionId = submissionId,
+                    )
+                    .toScala
+                }
+              })
+          )
         } else {
           Future.successful(Seq.empty)
         }
@@ -225,7 +235,7 @@ private[apiserver] final class ApiSubmissionService private (
       transactionInfo: CommandExecutionResult,
       partyAllocationResults: Seq[SubmissionResult],
       ledgerConfig: Configuration,
-  ): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     partyAllocationResults.find(_ != SubmissionResult.Acknowledged) match {
       case Some(result) =>
         Future.successful(result)
@@ -253,7 +263,7 @@ private[apiserver] final class ApiSubmissionService private (
 
   private def submitTransaction(
       result: CommandExecutionResult,
-  ): Future[SubmissionResult] = {
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] = {
     metrics.daml.commands.validSubmissions.mark()
     writeService
       .submitTransaction(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -154,23 +154,23 @@ private[apiserver] final class ApiSubmissionService private (
       implicit loggingContext: LoggingContext,
   ): Try[Unit] = result match {
     case Success(Acknowledged) =>
-      logger.debug("Submission of command succeeded")
+      logger.debug("Success")
       Success(())
 
     case Success(Overloaded) =>
-      logger.info("Submission has failed due to backpressure")
+      logger.info("Back-pressure")
       Failure(Status.RESOURCE_EXHAUSTED.asRuntimeException)
 
     case Success(NotSupported) =>
-      logger.warn("Submission of command was not supported")
+      logger.warn("Not supported")
       Failure(Status.INVALID_ARGUMENT.asRuntimeException)
 
     case Success(InternalError(reason)) =>
-      logger.error(s"Submission of command failed due to an internal error, reason=$reason")
+      logger.error(s"Internal error: $reason")
       Failure(Status.INTERNAL.augmentDescription(reason).asRuntimeException)
 
     case Failure(error) =>
-      logger.info(s"Submission of command rejected: ${error.getMessage}")
+      logger.info(s"Rejected: ${error.getMessage}")
       Failure(error)
   }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
@@ -33,8 +33,8 @@ private[apiserver] final class ApiTimeService private (
     implicit grpcExecutionContext: ExecutionContext,
     protected val mat: Materializer,
     protected val esf: ExecutionSequencerFactory,
-    loggingContext: LoggingContext)
-    extends TimeServiceAkkaGrpc
+    loggingContext: LoggingContext,
+) extends TimeServiceAkkaGrpc
     with FieldValidations
     with GrpcApiService {
 
@@ -126,6 +126,7 @@ private[apiserver] object ApiTimeService {
       implicit grpcExecutionContext: ExecutionContext,
       mat: Materializer,
       esf: ExecutionSequencerFactory,
-      loggingContext: LoggingContext): TimeService with GrpcApiService =
+      loggingContext: LoggingContext,
+  ): TimeService with GrpcApiService =
     new ApiTimeService(ledgerId, backend)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiTimeService.scala
@@ -33,7 +33,7 @@ private[apiserver] final class ApiTimeService private (
     implicit grpcExecutionContext: ExecutionContext,
     protected val mat: Materializer,
     protected val esf: ExecutionSequencerFactory,
-    logCtx: LoggingContext)
+    loggingContext: LoggingContext)
     extends TimeServiceAkkaGrpc
     with FieldValidations
     with GrpcApiService {
@@ -126,6 +126,6 @@ private[apiserver] object ApiTimeService {
       implicit grpcExecutionContext: ExecutionContext,
       mat: Materializer,
       esf: ExecutionSequencerFactory,
-      logCtx: LoggingContext): TimeService with GrpcApiService =
+      loggingContext: LoggingContext): TimeService with GrpcApiService =
     new ApiTimeService(ledgerId, backend)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/LedgerConfigProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/LedgerConfigProvider.scala
@@ -41,7 +41,7 @@ private[apiserver] final class LedgerConfigProvider private (
     timeProvider: TimeProvider,
     config: LedgerConfiguration,
     materializer: Materializer,
-)(implicit logCtx: LoggingContext)
+)(implicit loggingContext: LoggingContext)
     extends AutoCloseable {
 
   private[this] val logger = ContextualizedLogger.get(this.getClass)
@@ -174,6 +174,6 @@ private[apiserver] object LedgerConfigProvider {
       timeProvider: TimeProvider,
       config: LedgerConfiguration)(
       implicit materializer: Materializer,
-      logCtx: LoggingContext): LedgerConfigProvider =
+      loggingContext: LoggingContext): LedgerConfigProvider =
     new LedgerConfigProvider(index, optWriteService, timeProvider, config, materializer)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/LedgerConfigProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/LedgerConfigProvider.scala
@@ -174,6 +174,7 @@ private[apiserver] object LedgerConfigProvider {
       timeProvider: TimeProvider,
       config: LedgerConfiguration)(
       implicit materializer: Materializer,
-      loggingContext: LoggingContext): LedgerConfigProvider =
+      loggingContext: LoggingContext,
+  ): LedgerConfigProvider =
     new LedgerConfigProvider(index, optWriteService, timeProvider, config, materializer)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -38,7 +38,7 @@ private[apiserver] final class ApiConfigManagementService private (
     timeProvider: TimeProvider,
     ledgerConfiguration: LedgerConfiguration,
     materializer: Materializer
-)(implicit logCtx: LoggingContext)
+)(implicit loggingContext: LoggingContext)
     extends ConfigManagementService
     with GrpcApiService {
 
@@ -196,7 +196,9 @@ private[apiserver] object ApiConfigManagementService {
       readBackend: IndexConfigManagementService,
       writeBackend: WriteConfigService,
       timeProvider: TimeProvider,
-      ledgerConfiguration: LedgerConfiguration)(implicit mat: Materializer, logCtx: LoggingContext)
+      ledgerConfiguration: LedgerConfiguration)(
+      implicit mat: Materializer,
+      loggingContext: LoggingContext)
     : ConfigManagementServiceGrpc.ConfigManagementService with GrpcApiService =
     new ApiConfigManagementService(
       readBackend,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -198,8 +198,8 @@ private[apiserver] object ApiConfigManagementService {
       timeProvider: TimeProvider,
       ledgerConfiguration: LedgerConfiguration)(
       implicit mat: Materializer,
-      loggingContext: LoggingContext)
-    : ConfigManagementServiceGrpc.ConfigManagementService with GrpcApiService =
+      loggingContext: LoggingContext,
+  ): ConfigManagementServiceGrpc.ConfigManagementService with GrpcApiService =
     new ApiConfigManagementService(
       readBackend,
       writeBackend,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -36,7 +36,7 @@ private[apiserver] final class ApiPackageManagementService private (
     packagesWrite: WritePackagesService,
     timeProvider: TimeProvider,
     materializer: Materializer,
-    scheduler: Scheduler)(implicit logCtx: LoggingContext)
+    scheduler: Scheduler)(implicit loggingContext: LoggingContext)
     extends PackageManagementService
     with GrpcApiService {
 
@@ -134,7 +134,7 @@ private[apiserver] object ApiPackageManagementService {
       readBackend: IndexPackagesService,
       transactionsService: IndexTransactionsService,
       writeBackend: WritePackagesService,
-      timeProvider: TimeProvider)(implicit mat: Materializer, logCtx: LoggingContext)
+      timeProvider: TimeProvider)(implicit mat: Materializer, loggingContext: LoggingContext)
     : PackageManagementServiceGrpc.PackageManagementService with GrpcApiService =
     new ApiPackageManagementService(
       readBackend,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -37,7 +37,7 @@ private[apiserver] final class ApiPartyManagementService private (
     writeService: WritePartyService,
     materializer: Materializer,
     scheduler: Scheduler,
-)(implicit logCtx: LoggingContext)
+)(implicit loggingContext: LoggingContext)
     extends PartyManagementService
     with GrpcApiService {
 
@@ -141,7 +141,7 @@ private[apiserver] object ApiPartyManagementService {
       implicit ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,
-      logCtx: LoggingContext)
+      loggingContext: LoggingContext)
     : PartyManagementServiceGrpc.PartyManagementService with GrpcApiService =
     new ApiPartyManagementService(
       partyManagementServiceBackend,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -141,8 +141,8 @@ private[apiserver] object ApiPartyManagementService {
       implicit ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
       mat: Materializer,
-      loggingContext: LoggingContext)
-    : PartyManagementServiceGrpc.PartyManagementService with GrpcApiService =
+      loggingContext: LoggingContext,
+  ): PartyManagementServiceGrpc.PartyManagementService with GrpcApiService =
     new ApiPartyManagementService(
       partyManagementServiceBackend,
       transactionsService,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -3,7 +3,17 @@
 
 package com.daml.platform.apiserver.services
 
-import com.daml.ledger.api.domain.{CommandId, EventId, LedgerOffset, TransactionId}
+import java.time.Instant
+
+import com.daml.ledger.api.domain.{
+  ApplicationId,
+  CommandId,
+  Commands,
+  EventId,
+  LedgerOffset,
+  TransactionId,
+  WorkflowId
+}
 import net.logstash.logback.argument.StructuredArguments
 import scalaz.syntax.tag.ToTagOps
 
@@ -27,13 +37,37 @@ package object logging {
       case LedgerOffset.LedgerBegin => "%begin%"
       case LedgerOffset.LedgerEnd => "%end%"
     }
+  private[services] def applicationId(id: ApplicationId): (String, String) =
+    "applicationId" -> id.unwrap
   private[services] def commandId(id: String): (String, String) =
     "commandId" -> id
   private[services] def commandId(id: CommandId): (String, String) =
     "commandId" -> id.unwrap
+  private[services] def deduplicateUntil(t: Instant): (String, String) =
+    "deduplicateUntil" -> t.toString
   private[services] def eventId(id: EventId): (String, String) =
     "eventId" -> id.unwrap
+  private[services] def submissionId(id: String): (String, String) =
+    "submissionId" -> id
+  private[services] def submittedAt(t: Instant): (String, String) =
+    "submittedAt" -> t.toString
+  private[services] def submitter(party: String): (String, String) =
+    "submitter" -> party
   private[services] def transactionId(id: TransactionId): (String, String) =
     "transactionId" -> id.unwrap
+  private[services] def workflowId(id: WorkflowId): (String, String) =
+    "workflowId" -> id.unwrap
+  private[services] def commands(cmds: Commands): Map[String, String] = {
+    val context =
+      Map(
+        commandId(cmds.commandId),
+        party(cmds.submitter),
+        deduplicateUntil(cmds.deduplicateUntil),
+        applicationId(cmds.applicationId),
+        submittedAt(cmds.submittedAt),
+        submitter(cmds.submitter),
+      )
+    cmds.workflowId.fold(context)(context + workflowId(_))
+  }
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.api.domain.{
   TransactionId,
   WorkflowId
 }
+import com.daml.ledger.api.v1.transaction_filter.Filters
 import net.logstash.logback.argument.StructuredArguments
 import scalaz.syntax.tag.ToTagOps
 
@@ -47,6 +48,14 @@ package object logging {
     "deduplicateUntil" -> t.toString
   private[services] def eventId(id: EventId): (String, String) =
     "eventId" -> id.unwrap
+  private[services] def filters(filtersByParty: Map[String, Filters]): Map[String, String] =
+    filtersByParty.iterator.flatMap {
+      case (party, filters) =>
+        Iterator
+          .continually(s"party-$party")
+          .zip(filters.inclusive.fold(Iterator.single("all-templates"))(
+            _.templateIds.iterator.map(_.toString)))
+    }.toMap
   private[services] def submissionId(id: String): (String, String) =
     "submissionId" -> id
   private[services] def submittedAt(t: Instant): (String, String) =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/Tracker.scala
@@ -5,12 +5,17 @@ package com.daml.platform.apiserver.services.tracking
 
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.completion.Completion
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.{ExecutionContext, Future}
 
 private[tracking] trait Tracker extends AutoCloseable {
 
-  def track(request: SubmitAndWaitRequest)(implicit ec: ExecutionContext): Future[Completion]
+  def track(request: SubmitAndWaitRequest)(
+      implicit ec: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[Completion]
+
 }
 
 private[tracking] object Tracker {
@@ -24,7 +29,9 @@ private[tracking] object Tracker {
     def getLastSubmission: Long = lastSubmission
 
     override def track(request: SubmitAndWaitRequest)(
-        implicit ec: ExecutionContext): Future[Completion] = {
+        implicit ec: ExecutionContext,
+        loggingContext: LoggingContext,
+    ): Future[Completion] = {
       lastSubmission = System.nanoTime()
       delegate.track(request)
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerImpl.scala
@@ -11,12 +11,12 @@ import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
 import com.daml.ledger.api.v1.completion.Completion
 import com.daml.ledger.client.services.commands.CommandTrackerFlow.Materialized
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.platform.server.api.ApiException
 import com.daml.util.Ctx
 import com.google.rpc.code.Code
 import com.google.rpc.status.Status
 import io.grpc.{Status => GrpcStatus}
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
@@ -26,23 +26,25 @@ import scala.util.{Failure, Success}
   * Tracks SubmitAndWaitRequests.
   * @param queue The input queue to the tracking flow.
   */
-private[services] final class TrackerImpl(queue: SourceQueueWithComplete[TrackerImpl.QueueInput])
-    extends Tracker {
+private[services] final class TrackerImpl(queue: SourceQueueWithComplete[TrackerImpl.QueueInput])(
+    implicit loggingContext: LoggingContext,
+) extends Tracker {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  import TrackerImpl.logger
 
   override def track(request: SubmitAndWaitRequest)(
-      implicit ec: ExecutionContext): Future[Completion] = {
-    logger.trace(
-      s"tracking command for party: ${request.getCommands.party}, commandId: ${request.getCommands.commandId}")
+      implicit ec: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[Completion] = {
+    logger.trace("Tracking command")
     val promise = Promise[Completion]
-
     submitNewRequest(request, promise)
   }
 
   private def submitNewRequest(request: SubmitAndWaitRequest, promise: Promise[Completion])(
-      implicit ec: ExecutionContext): Future[Completion] = {
-
+      implicit ec: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[Completion] = {
     queue
       .offer(
         Ctx(
@@ -67,7 +69,7 @@ private[services] final class TrackerImpl(queue: SourceQueueWithComplete[Tracker
 
 private[services] object TrackerImpl {
 
-  private val logger = LoggerFactory.getLogger(this.getClass.getName)
+  private val logger = ContextualizedLogger.get(this.getClass)
 
   def apply(
       tracker: Flow[
@@ -75,7 +77,7 @@ private[services] object TrackerImpl {
         Ctx[Promise[Completion], Completion],
         Materialized[NotUsed, Promise[Completion]]],
       inputBufferSize: Int,
-  )(implicit materializer: Materializer): TrackerImpl = {
+  )(implicit materializer: Materializer, loggingContext: LoggingContext): TrackerImpl = {
     val ((queue, mat), foreachMat) = Source
       .queue[QueueInput](inputBufferSize, OverflowStrategy.dropNew)
       .viaMat(tracker)(Keep.both)
@@ -95,7 +97,7 @@ private[services] object TrackerImpl {
                 .getOrElse(GrpcStatus.INTERNAL
                   .withDescription("Missing status in completion response."))
 
-              logger.trace("Completing promise with failure: {}", status)
+              logger.trace(s"Completing promise with failure: $status")
               promise.tryFailure(status.asException())
           }
           ()

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/tracking/TrackerMap.scala
@@ -21,8 +21,8 @@ import scala.util.{Failure, Success}
   * @param retentionPeriod The minimum finite duration for which to retain idle trackers.
   */
 private[services] final class TrackerMap(retentionPeriod: FiniteDuration)(
-    implicit logCtx: LoggingContext)
-    extends AutoCloseable {
+    implicit loggingContext: LoggingContext,
+) extends AutoCloseable {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 
@@ -149,6 +149,6 @@ private[services] object TrackerMap {
     }
   }
 
-  def apply(retentionPeriod: FiniteDuration)(implicit logCtx: LoggingContext): TrackerMap =
+  def apply(retentionPeriod: FiniteDuration)(implicit loggingContext: LoggingContext): TrackerMap =
     new TrackerMap(retentionPeriod)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -150,10 +150,12 @@ private[apiserver] final class ApiTransactionService private (
     }
 
   override def getFlatTransactionById(
-      request: GetTransactionByIdRequest): Future[GetFlatTransactionResponse] =
+      request: GetTransactionByIdRequest,
+  ): Future[GetFlatTransactionResponse] =
     withEnrichedLoggingContext(
       logging.transactionId(request.transactionId),
-      logging.parties(request.requestingParties)) { implicit loggingContext =>
+      logging.parties(request.requestingParties),
+    ) { implicit loggingContext =>
       lookUpFlatByTransactionId(request.transactionId, request.requestingParties)
         .andThen(logger.logErrorsOnCall[GetFlatTransactionResponse])
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -41,7 +41,7 @@ private[apiserver] object ApiTransactionService {
       implicit ec: ExecutionContext,
       mat: Materializer,
       esf: ExecutionSequencerFactory,
-      logCtx: LoggingContext): GrpcTransactionService with BindableService =
+      loggingContext: LoggingContext): GrpcTransactionService with BindableService =
     new GrpcTransactionService(
       new ApiTransactionService(transactionsService),
       ledgerId,
@@ -55,7 +55,7 @@ private[apiserver] final class ApiTransactionService private (
     implicit executionContext: ExecutionContext,
     materializer: Materializer,
     esf: ExecutionSequencerFactory,
-    logCtx: LoggingContext)
+    loggingContext: LoggingContext)
     extends TransactionService
     with ErrorFactories {
 
@@ -69,7 +69,7 @@ private[apiserver] final class ApiTransactionService private (
       logging.startExclusive(request.startExclusive),
       logging.endInclusive(request.endInclusive),
       logging.parties(request.filter.filtersByParty.keys),
-    ) { implicit logCtx =>
+    ) { implicit loggingContext =>
       val subscriptionId = subscriptionIdCounter.incrementAndGet().toString
       logger.debug(s"Received request for transaction subscription $subscriptionId: $request")
       transactionsService
@@ -83,7 +83,7 @@ private[apiserver] final class ApiTransactionService private (
       logging.startExclusive(request.startExclusive),
       logging.endInclusive(request.endInclusive),
       logging.parties(request.parties),
-    ) { implicit logCtx =>
+    ) { implicit loggingContext =>
       logger.debug(s"Received $request")
       transactionsService
         .transactionTrees(
@@ -100,7 +100,7 @@ private[apiserver] final class ApiTransactionService private (
     withEnrichedLoggingContext(
       logging.eventId(request.eventId),
       logging.parties(request.requestingParties),
-    ) { implicit logCtx =>
+    ) { implicit loggingContext =>
       logger.debug(s"Received $request")
       ledger.EventId
         .fromString(request.eventId.unwrap)
@@ -121,7 +121,7 @@ private[apiserver] final class ApiTransactionService private (
     withEnrichedLoggingContext(
       logging.transactionId(request.transactionId),
       logging.parties(request.requestingParties),
-    ) { implicit logCtx =>
+    ) { implicit loggingContext =>
       logger.debug(s"Received $request")
       lookUpTreeByTransactionId(request.transactionId, request.requestingParties)
         .andThen(logger.logErrorsOnCall[GetTransactionResponse])
@@ -132,7 +132,7 @@ private[apiserver] final class ApiTransactionService private (
     withEnrichedLoggingContext(
       logging.eventId(request.eventId),
       logging.parties(request.requestingParties),
-    ) { implicit logCtx =>
+    ) { implicit loggingContext =>
       ledger.EventId
         .fromString(request.eventId.unwrap)
         .fold(
@@ -151,7 +151,7 @@ private[apiserver] final class ApiTransactionService private (
       request: GetTransactionByIdRequest): Future[GetFlatTransactionResponse] =
     withEnrichedLoggingContext(
       logging.transactionId(request.transactionId),
-      logging.parties(request.requestingParties)) { implicit logCtx =>
+      logging.parties(request.requestingParties)) { implicit loggingContext =>
       lookUpFlatByTransactionId(request.transactionId, request.requestingParties)
         .andThen(logger.logErrorsOnCall[GetFlatTransactionResponse])
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -41,7 +41,8 @@ private[apiserver] object ApiTransactionService {
       implicit ec: ExecutionContext,
       mat: Materializer,
       esf: ExecutionSequencerFactory,
-      loggingContext: LoggingContext): GrpcTransactionService with BindableService =
+      loggingContext: LoggingContext,
+  ): GrpcTransactionService with BindableService =
     new GrpcTransactionService(
       new ApiTransactionService(transactionsService),
       ledgerId,
@@ -51,12 +52,13 @@ private[apiserver] object ApiTransactionService {
 
 private[apiserver] final class ApiTransactionService private (
     transactionsService: IndexTransactionsService,
-    parallelism: Int = 4)(
+    parallelism: Int = 4,
+)(
     implicit executionContext: ExecutionContext,
     materializer: Materializer,
     esf: ExecutionSequencerFactory,
-    loggingContext: LoggingContext)
-    extends TransactionService
+    loggingContext: LoggingContext,
+) extends TransactionService
     with ErrorFactories {
 
   private val logger = ContextualizedLogger.get(this.getClass)

--- a/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
@@ -22,7 +22,7 @@ private[platform] object JdbcIndex {
       eventsPageSize: Int,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
-  )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[IndexService] =
+  )(implicit mat: Materializer, loggingContext: LoggingContext): ResourceOwner[IndexService] =
     new ReadOnlySqlLedger.Owner(
       serverRole,
       jdbcUrl,

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -135,7 +135,8 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
     Timed.future(metrics.daml.index.getLfArchive, ledger.getLfArchive(packageId))
 
   override def getLfPackage(packageId: PackageId)(
-      implicit loggingContext: LoggingContext): Future[Option[Ast.Package]] =
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Ast.Package]] =
     Timed.future(metrics.daml.index.getLfPackage, ledger.getLfPackage(packageId))
 
   override def packageEntries(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -27,6 +27,7 @@ import com.daml.lf.language.Ast
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
+import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.ReadOnlyLedger
 import com.daml.platform.store.entries.{ConfigurationEntry, PackageLedgerEntry, PartyLedgerEntry}
@@ -45,7 +46,7 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
       endInclusive: Option[Offset],
       filter: Map[Party, Set[Identifier]],
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionsResponse), NotUsed] =
+  )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] =
     ledger.flatTransactions(startExclusive, endInclusive, filter, verbose)
 
   override def transactionTrees(
@@ -53,37 +54,43 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
       endInclusive: Option[Offset],
       requestingParties: Set[Party],
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionTreesResponse), NotUsed] =
+  )(implicit loggingContext: LoggingContext)
+    : Source[(Offset, GetTransactionTreesResponse), NotUsed] =
     ledger.transactionTrees(startExclusive, endInclusive, requestingParties, verbose)
 
-  override def ledgerEnd: Offset = ledger.ledgerEnd
+  override def ledgerEnd()(implicit loggingContext: LoggingContext): Offset = ledger.ledgerEnd
 
   override def completions(
       startExclusive: Option[Offset],
       endInclusive: Option[Offset],
       applicationId: ApplicationId,
-      parties: Set[Party]): Source[(Offset, CompletionStreamResponse), NotUsed] =
+      parties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Source[(Offset, CompletionStreamResponse), NotUsed] =
     ledger.completions(startExclusive, endInclusive, applicationId, parties)
 
   override def activeContracts(
       filter: Map[Party, Set[Identifier]],
       verbose: Boolean,
-  ): (Source[GetActiveContractsResponse, NotUsed], Offset) =
+  )(implicit loggingContext: LoggingContext)
+    : (Source[GetActiveContractsResponse, NotUsed], Offset) =
     ledger.activeContracts(filter, verbose)
 
   override def lookupContract(
       contractId: Value.ContractId,
-      forParty: Party
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
+      forParty: Party,
+  )(implicit loggingContext: LoggingContext)
+    : Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
     Timed.future(metrics.daml.index.lookupContract, ledger.lookupContract(contractId, forParty))
 
-  override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[ContractId]] =
+  override def lookupKey(key: GlobalKey, forParty: Party)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[ContractId]] =
     Timed.future(metrics.daml.index.lookupKey, ledger.lookupKey(key, forParty))
 
   override def lookupFlatTransactionById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetFlatTransactionResponse]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]] =
     Timed.future(
       metrics.daml.index.lookupFlatTransactionById,
       ledger.lookupFlatTransactionById(transactionId, requestingParties),
@@ -92,7 +99,7 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
   override def lookupTransactionTreeById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetTransactionResponse]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]] =
     Timed.future(
       metrics.daml.index.lookupTransactionTreeById,
       ledger.lookupTransactionTreeById(transactionId, requestingParties),
@@ -100,54 +107,68 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
 
   override def lookupMaximumLedgerTime(
       contractIds: Set[ContractId],
-  ): Future[Option[Instant]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[Instant]] =
     Timed.future(
       metrics.daml.index.lookupMaximumLedgerTime,
       ledger.lookupMaximumLedgerTime(contractIds))
 
-  override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
+  override def getParties(parties: Seq[Party])(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[PartyDetails]] =
     Timed.future(metrics.daml.index.getParties, ledger.getParties(parties))
 
-  override def listKnownParties(): Future[List[PartyDetails]] =
+  override def listKnownParties()(
+      implicit loggingContext: LoggingContext): Future[List[PartyDetails]] =
     Timed.future(metrics.daml.index.listKnownParties, ledger.listKnownParties())
 
-  override def partyEntries(startExclusive: Offset): Source[(Offset, PartyLedgerEntry), NotUsed] =
+  override def partyEntries(startExclusive: Offset)(
+      implicit loggingContext: LoggingContext): Source[(Offset, PartyLedgerEntry), NotUsed] =
     ledger.partyEntries(startExclusive)
 
-  override def listLfPackages(): Future[Map[PackageId, PackageDetails]] =
+  override def listLfPackages()(
+      implicit loggingContext: LoggingContext): Future[Map[PackageId, PackageDetails]] =
     Timed.future(metrics.daml.index.listLfPackages, ledger.listLfPackages())
 
-  override def getLfArchive(packageId: PackageId): Future[Option[Archive]] =
+  override def getLfArchive(packageId: PackageId)(
+      implicit loggingContext: LoggingContext): Future[Option[Archive]] =
     Timed.future(metrics.daml.index.getLfArchive, ledger.getLfArchive(packageId))
 
-  override def getLfPackage(packageId: PackageId): Future[Option[Ast.Package]] =
+  override def getLfPackage(packageId: PackageId)(
+      implicit loggingContext: LoggingContext): Future[Option[Ast.Package]] =
     Timed.future(metrics.daml.index.getLfPackage, ledger.getLfPackage(packageId))
 
   override def packageEntries(
-      startExclusive: Offset): Source[(Offset, PackageLedgerEntry), NotUsed] =
+      startExclusive: Offset,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, PackageLedgerEntry), NotUsed] =
     ledger.packageEntries(startExclusive)
 
   override def close(): Unit = {
     ledger.close()
   }
 
-  override def lookupLedgerConfiguration(): Future[Option[(Offset, Configuration)]] =
+  override def lookupLedgerConfiguration()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[(Offset, Configuration)]] =
     Timed.future(metrics.daml.index.lookupLedgerConfiguration, ledger.lookupLedgerConfiguration())
 
   override def configurationEntries(
-      startExclusive: Option[Offset]): Source[(Offset, ConfigurationEntry), NotUsed] =
+      startExclusive: Option[Offset],
+  )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed] =
     ledger.configurationEntries(startExclusive)
 
   override def deduplicateCommand(
       commandId: CommandId,
       submitter: Ref.Party,
       submittedAt: Instant,
-      deduplicateUntil: Instant): Future[CommandDeduplicationResult] =
+      deduplicateUntil: Instant,
+  )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult] =
     Timed.future(
       metrics.daml.index.deduplicateCommand,
       ledger.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil))
 
-  override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
+  override def removeExpiredDeduplicationData(currentTime: Instant)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Unit] =
     Timed.future(
       metrics.daml.index.removeExpiredDeduplicationData,
       ledger.removeExpiredDeduplicationData(currentTime))
@@ -155,7 +176,7 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
   override def stopDeduplicatingCommand(
       commandId: CommandId,
       submitter: Ref.Party,
-  ): Future[Unit] =
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
     Timed.future(
       metrics.daml.index.stopDeduplicatingCommand,
       ledger.stopDeduplicatingCommand(commandId, submitter))

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -130,7 +130,8 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
     Timed.future(metrics.daml.index.listLfPackages, ledger.listLfPackages())
 
   override def getLfArchive(packageId: PackageId)(
-      implicit loggingContext: LoggingContext): Future[Option[Archive]] =
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Archive]] =
     Timed.future(metrics.daml.index.getLfArchive, ledger.getLfArchive(packageId))
 
   override def getLfPackage(packageId: PackageId)(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -39,7 +39,7 @@ private[platform] object ReadOnlySqlLedger {
       eventsPageSize: Int,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
-  )(implicit mat: Materializer, logCtx: LoggingContext)
+  )(implicit mat: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[ReadOnlyLedger] {
     override def acquire()(
         implicit executionContext: ExecutionContext
@@ -57,7 +57,9 @@ private[platform] object ReadOnlySqlLedger {
     private def verifyLedgerId(
         ledgerDao: LedgerReadDao,
         initialLedgerId: LedgerId,
-    )(implicit executionContext: ExecutionContext, logCtx: LoggingContext): Future[LedgerId] = {
+    )(
+        implicit executionContext: ExecutionContext,
+        loggingContext: LoggingContext): Future[LedgerId] = {
       val predicate: PartialFunction[Throwable, Boolean] = {
         case _: LedgerIdNotFoundException => true
         case _: LedgerIdMismatchException => false

--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -59,7 +59,8 @@ private[platform] object ReadOnlySqlLedger {
         initialLedgerId: LedgerId,
     )(
         implicit executionContext: ExecutionContext,
-        loggingContext: LoggingContext): Future[LedgerId] = {
+        loggingContext: LoggingContext,
+    ): Future[LedgerId] = {
       val predicate: PartialFunction[Throwable, Boolean] = {
         case _: LedgerIdNotFoundException => true
         case _: LedgerIdMismatchException => false
@@ -111,7 +112,7 @@ private final class ReadOnlySqlLedger(
     ledgerId: LedgerId,
     ledgerDao: LedgerReadDao,
     dispatcher: Dispatcher[Offset],
-)(implicit mat: Materializer)
+)(implicit mat: Materializer, loggingContext: LoggingContext)
     extends BaseLedger(ledgerId, ledgerDao, dispatcher) {
 
   private val (ledgerEndUpdateKillSwitch, ledgerEndUpdateDone) =

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -34,7 +34,7 @@ private[indexer] final class JdbcIndexerFactory(
     readService: ReadService,
     metrics: Metrics,
     lfValueTranslationCache: LfValueTranslation.Cache,
-)(implicit materializer: Materializer, logCtx: LoggingContext) {
+)(implicit materializer: Materializer, loggingContext: LoggingContext) {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
@@ -26,7 +26,7 @@ import scala.util.{Failure, Success}
 private[indexer] final class RecoveringIndexer(
     scheduler: Scheduler,
     restartDelay: FiniteDuration,
-)(implicit logCtx: LoggingContext) {
+)(implicit loggingContext: LoggingContext) {
   private implicit val executionContext: ExecutionContext = DirectExecutionContext
   private val logger = ContextualizedLogger.get(this.getClass)
   private val clock = Clock.systemUTC()

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -24,7 +24,7 @@ final class StandaloneIndexerServer(
   private val logger = ContextualizedLogger.get(this.getClass)
 
   override def acquire()(implicit executionContext: ExecutionContext): Resource[Unit] = {
-    val indexerFactory = new JdbcIndexerFactory(
+    val indexerFactory = new JdbcIndexer.Factory(
       ServerRole.Indexer,
       config,
       readService,

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -18,7 +18,7 @@ final class StandaloneIndexerServer(
     config: IndexerConfig,
     metrics: Metrics,
     lfValueTranslationCache: LfValueTranslation.Cache,
-)(implicit materializer: Materializer, logCtx: LoggingContext)
+)(implicit materializer: Materializer, loggingContext: LoggingContext)
     extends ResourceOwner[Unit] {
 
   private val logger = ContextualizedLogger.get(this.getClass)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -31,6 +31,7 @@ import com.daml.lf.language.Ast
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
+import com.daml.logging.LoggingContext
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
 import com.daml.platform.akkastreams.dispatcher.SubSource.RangeSource
 import com.daml.platform.store.dao.LedgerReadDao
@@ -50,7 +51,9 @@ private[platform] abstract class BaseLedger(
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
 
-  override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[ContractId]] =
+  override def lookupKey(key: GlobalKey, forParty: Party)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[ContractId]] =
     ledgerDao.lookupKey(key, forParty)
 
   override def flatTransactions(
@@ -58,7 +61,7 @@ private[platform] abstract class BaseLedger(
       endInclusive: Option[Offset],
       filter: Map[Party, Set[Identifier]],
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionsResponse), NotUsed] =
+  )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] =
     dispatcher.startingAt(
       startExclusive.getOrElse(Offset.beforeBegin),
       RangeSource(ledgerDao.transactionsReader.getFlatTransactions(_, _, filter, verbose)),
@@ -69,7 +72,9 @@ private[platform] abstract class BaseLedger(
       startExclusive: Option[Offset],
       endInclusive: Option[Offset],
       requestingParties: Set[Party],
-      verbose: Boolean): Source[(Offset, GetTransactionTreesResponse), NotUsed] =
+      verbose: Boolean,
+  )(implicit loggingContext: LoggingContext)
+    : Source[(Offset, GetTransactionTreesResponse), NotUsed] =
     dispatcher.startingAt(
       startExclusive.getOrElse(Offset.beforeBegin),
       RangeSource(
@@ -77,13 +82,14 @@ private[platform] abstract class BaseLedger(
       endInclusive
     )
 
-  override def ledgerEnd: Offset = dispatcher.getHead()
+  override def ledgerEnd()(implicit loggingContext: LoggingContext): Offset = dispatcher.getHead()
 
   override def completions(
       startExclusive: Option[Offset],
       endInclusive: Option[Offset],
       applicationId: ApplicationId,
-      parties: Set[Party]): Source[(Offset, CompletionStreamResponse), NotUsed] =
+      parties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Source[(Offset, CompletionStreamResponse), NotUsed] =
     dispatcher.startingAt(
       startExclusive.getOrElse(Offset.beforeBegin),
       RangeSource(ledgerDao.completions.getCommandCompletions(_, _, applicationId.unwrap, parties)),
@@ -93,64 +99,82 @@ private[platform] abstract class BaseLedger(
   override def activeContracts(
       filter: Map[Party, Set[Identifier]],
       verbose: Boolean,
-  ): (Source[GetActiveContractsResponse, NotUsed], Offset) = {
-    val activeAt = ledgerEnd
+  )(implicit loggingContext: LoggingContext)
+    : (Source[GetActiveContractsResponse, NotUsed], Offset) = {
+    val activeAt = ledgerEnd()
     (ledgerDao.transactionsReader.getActiveContracts(activeAt, filter, verbose), activeAt)
   }
 
   override def lookupContract(
       contractId: ContractId,
       forParty: Party
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
+  )(implicit loggingContext: LoggingContext)
+    : Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
     ledgerDao.lookupActiveOrDivulgedContract(contractId, forParty)
 
   override def lookupFlatTransactionById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetFlatTransactionResponse]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]] =
     ledgerDao.transactionsReader.lookupFlatTransactionById(transactionId, requestingParties)
 
   override def lookupTransactionTreeById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetTransactionResponse]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]] =
     ledgerDao.transactionsReader.lookupTransactionTreeById(transactionId, requestingParties)
 
   override def lookupMaximumLedgerTime(
       contractIds: Set[ContractId],
-  ): Future[Option[Instant]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[Instant]] =
     ledgerDao.lookupMaximumLedgerTime(contractIds)
 
-  override def getParties(parties: Seq[Party]): Future[List[domain.PartyDetails]] =
+  override def getParties(parties: Seq[Party])(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[domain.PartyDetails]] =
     ledgerDao.getParties(parties)
 
-  override def listKnownParties(): Future[List[domain.PartyDetails]] =
+  override def listKnownParties()(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[domain.PartyDetails]] =
     ledgerDao.listKnownParties()
 
-  override def partyEntries(startExclusive: Offset): Source[(Offset, PartyLedgerEntry), NotUsed] =
+  override def partyEntries(startExclusive: Offset)(
+      implicit loggingContext: LoggingContext,
+  ): Source[(Offset, PartyLedgerEntry), NotUsed] =
     dispatcher.startingAt(startExclusive, RangeSource(ledgerDao.getPartyEntries))
 
-  override def listLfPackages(): Future[Map[PackageId, v2.PackageDetails]] =
+  override def listLfPackages()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Map[PackageId, v2.PackageDetails]] =
     ledgerDao.listLfPackages
 
-  override def getLfArchive(packageId: PackageId): Future[Option[DamlLf.Archive]] =
+  override def getLfArchive(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[DamlLf.Archive]] =
     ledgerDao.getLfArchive(packageId)
 
-  override def getLfPackage(packageId: PackageId): Future[Option[Ast.Package]] =
+  override def getLfPackage(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Ast.Package]] =
     ledgerDao
       .getLfArchive(packageId)
       .flatMap(archiveO =>
         Future.fromTry(Try(archiveO.map(archive => Decode.decodeArchive(archive)._2))))(DEC)
 
-  override def packageEntries(
-      startExclusive: Offset): Source[(Offset, PackageLedgerEntry), NotUsed] =
+  override def packageEntries(startExclusive: Offset)(
+      implicit loggingContext: LoggingContext,
+  ): Source[(Offset, PackageLedgerEntry), NotUsed] =
     dispatcher.startingAt(startExclusive, RangeSource(ledgerDao.getPackageEntries))
 
-  override def lookupLedgerConfiguration(): Future[Option[(Offset, Configuration)]] =
+  override def lookupLedgerConfiguration()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[(Offset, Configuration)]] =
     ledgerDao.lookupLedgerConfiguration()
 
-  override def configurationEntries(
-      startExclusive: Option[Offset]): Source[(Offset, ConfigurationEntry), NotUsed] =
+  override def configurationEntries(startExclusive: Option[Offset])(
+      implicit loggingContext: LoggingContext,
+  ): Source[(Offset, ConfigurationEntry), NotUsed] =
     dispatcher.startingAt(
       startExclusive.getOrElse(Offset.beforeBegin),
       RangeSource(ledgerDao.getConfigurationEntries))
@@ -159,13 +183,18 @@ private[platform] abstract class BaseLedger(
       commandId: CommandId,
       submitter: Ref.Party,
       submittedAt: Instant,
-      deduplicateUntil: Instant): Future[CommandDeduplicationResult] =
+      deduplicateUntil: Instant,
+  )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult] =
     ledgerDao.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil)
 
-  override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
+  override def removeExpiredDeduplicationData(currentTime: Instant)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Unit] =
     ledgerDao.removeExpiredDeduplicationData(currentTime)
 
-  override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party): Future[Unit] =
+  override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Unit] =
     ledgerDao.stopDeduplicatingCommand(commandId, submitter)
 
   override def close(): Unit = ()

--- a/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
@@ -16,7 +16,7 @@ import org.flywaydb.core.api.configuration.FluentConfiguration
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
-private[platform] class FlywayMigrations(jdbcUrl: String)(implicit logCtx: LoggingContext) {
+private[platform] class FlywayMigrations(jdbcUrl: String)(implicit loggingContext: LoggingContext) {
   private val logger = ContextualizedLogger.get(this.getClass)
 
   private val dbType = DbType.jdbcType(jdbcUrl)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
@@ -25,8 +25,9 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetFlatTransactionResponse,
   GetTransactionResponse,
   GetTransactionTreesResponse,
-  GetTransactionsResponse,
+  GetTransactionsResponse
 }
+import com.daml.logging.LoggingContext
 import com.daml.platform.store.entries.{ConfigurationEntry, PackageLedgerEntry, PartyLedgerEntry}
 
 import scala.concurrent.Future
@@ -41,69 +42,89 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
       endInclusive: Option[Offset],
       filter: Map[Party, Set[Identifier]],
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionsResponse), NotUsed]
+  )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed]
 
   def transactionTrees(
       startExclusive: Option[Offset],
       endInclusive: Option[Offset],
       requestingParties: Set[Party],
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionTreesResponse), NotUsed]
+  )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionTreesResponse), NotUsed]
 
-  def ledgerEnd: Offset
+  def ledgerEnd()(implicit loggingContext: LoggingContext): Offset
 
   def completions(
       startExclusive: Option[Offset],
       endInclusive: Option[Offset],
       applicationId: ApplicationId,
-      parties: Set[Ref.Party]): Source[(Offset, CompletionStreamResponse), NotUsed]
+      parties: Set[Ref.Party],
+  )(implicit loggingContext: LoggingContext): Source[(Offset, CompletionStreamResponse), NotUsed]
 
   def activeContracts(
       filter: Map[Party, Set[Identifier]],
       verbose: Boolean,
-  ): (Source[GetActiveContractsResponse, NotUsed], Offset)
+  )(implicit loggingContext: LoggingContext): (Source[GetActiveContractsResponse, NotUsed], Offset)
 
   def lookupContract(
       contractId: Value.ContractId,
       forParty: Party
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]]
+  )(implicit loggingContext: LoggingContext)
+    : Future[Option[ContractInst[Value.VersionedValue[ContractId]]]]
 
   def lookupMaximumLedgerTime(
       contractIds: Set[ContractId],
-  ): Future[Option[Instant]]
+  )(implicit loggingContext: LoggingContext): Future[Option[Instant]]
 
-  def lookupKey(key: GlobalKey, forParty: Party): Future[Option[ContractId]]
+  def lookupKey(key: GlobalKey, forParty: Party)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[ContractId]]
 
   def lookupFlatTransactionById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetFlatTransactionResponse]]
+  )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]]
 
   def lookupTransactionTreeById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetTransactionResponse]]
+  )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]]
 
   // Party management
-  def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
+  def getParties(parties: Seq[Party])(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[PartyDetails]]
 
-  def listKnownParties(): Future[List[PartyDetails]]
+  def listKnownParties()(implicit loggingContext: LoggingContext): Future[List[PartyDetails]]
 
-  def partyEntries(startExclusive: Offset): Source[(Offset, PartyLedgerEntry), NotUsed]
+  def partyEntries(startExclusive: Offset)(
+      implicit loggingContext: LoggingContext,
+  ): Source[(Offset, PartyLedgerEntry), NotUsed]
 
   // Package management
-  def listLfPackages(): Future[Map[PackageId, PackageDetails]]
+  def listLfPackages()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Map[PackageId, PackageDetails]]
 
-  def getLfArchive(packageId: PackageId): Future[Option[Archive]]
+  def getLfArchive(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Archive]]
 
-  def getLfPackage(packageId: PackageId): Future[Option[Ast.Package]]
+  def getLfPackage(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Ast.Package]]
 
-  def packageEntries(startExclusive: Offset): Source[(Offset, PackageLedgerEntry), NotUsed]
+  def packageEntries(startExclusive: Offset)(
+      implicit loggingContext: LoggingContext,
+  ): Source[(Offset, PackageLedgerEntry), NotUsed]
 
   // Configuration management
-  def lookupLedgerConfiguration(): Future[Option[(Offset, Configuration)]]
+  def lookupLedgerConfiguration()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[(Offset, Configuration)]]
+
   def configurationEntries(
-      startExclusive: Option[Offset]): Source[(Offset, ConfigurationEntry), NotUsed]
+      startExclusive: Option[Offset],
+  )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed]
 
   /** Deduplicates commands.
     * Returns CommandDeduplicationNew if this is the first time the command is submitted
@@ -116,7 +137,8 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
       commandId: CommandId,
       submitter: Ref.Party,
       submittedAt: Instant,
-      deduplicateUntil: Instant): Future[CommandDeduplicationResult]
+      deduplicateUntil: Instant,
+  )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult]
 
   /**
     * Stops deduplicating the given command.
@@ -127,7 +149,7 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
   def stopDeduplicatingCommand(
       commandId: CommandId,
       submitter: Ref.Party,
-  ): Future[Unit]
+  )(implicit loggingContext: LoggingContext): Future[Unit]
 
   /**
     * Remove all expired deduplication entries. This method has to be called
@@ -144,5 +166,5 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
     */
   def removeExpiredDeduplicationData(
       currentTime: Instant,
-  ): Future[Unit]
+  )(implicit loggingContext: LoggingContext): Future[Unit]
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsReader.scala
@@ -9,6 +9,7 @@ import com.daml.ledger.participant.state.v1.Offset
 import com.daml.lf.data.Ref
 import com.daml.ledger.ApplicationId
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
+import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.ApiOffset
 
@@ -21,7 +22,9 @@ private[dao] final class CommandCompletionsReader(dispatcher: DbDispatcher, metr
       startExclusive: Offset,
       endInclusive: Offset,
       applicationId: ApplicationId,
-      parties: Set[Ref.Party]): Source[(Offset, CompletionStreamResponse), NotUsed] = {
+      parties: Set[Ref.Party],
+  )(implicit loggingContext: LoggingContext)
+    : Source[(Offset, CompletionStreamResponse), NotUsed] = {
     val query = CommandCompletionsTable.prepareGet(
       startExclusive = startExclusive,
       endInclusive = endInclusive,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
@@ -23,7 +23,7 @@ private[platform] final class DbDispatcher private (
     executor: Executor,
     overallWaitTimer: Timer,
     overallExecutionTimer: Timer,
-)(implicit logCtx: LoggingContext)
+)(implicit loggingContext: LoggingContext)
     extends ReportsHealth {
 
   private val logger = ContextualizedLogger.get(this.getClass)
@@ -91,7 +91,7 @@ private[platform] object DbDispatcher {
       jdbcUrl: String,
       maxConnections: Int,
       metrics: Metrics,
-  )(implicit logCtx: LoggingContext): ResourceOwner[DbDispatcher] =
+  )(implicit loggingContext: LoggingContext): ResourceOwner[DbDispatcher] =
     for {
       connectionProvider <- HikariJdbcConnectionProvider.owner(
         serverRole,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
@@ -31,7 +31,7 @@ private[platform] final class HikariConnection(
     metrics: Option[MetricRegistry],
     connectionPoolPrefix: String,
     maxInitialConnectRetryAttempts: Int,
-)(implicit logCtx: LoggingContext)
+)(implicit loggingContext: LoggingContext)
     extends ResourceOwner[HikariDataSource] {
 
   private val logger = ContextualizedLogger.get(this.getClass)
@@ -82,7 +82,7 @@ private[platform] object HikariConnection {
       connectionTimeout: FiniteDuration,
       metrics: Option[MetricRegistry],
   )(
-      implicit logCtx: LoggingContext
+      implicit loggingContext: LoggingContext
   ): HikariConnection =
     new HikariConnection(
       serverRole,
@@ -100,7 +100,7 @@ private[platform] class HikariJdbcConnectionProvider(
     dataSource: HikariDataSource,
     healthPoller: Timer,
 )(
-    implicit logCtx: LoggingContext
+    implicit loggingContext: LoggingContext
 ) extends JdbcConnectionProvider {
   private val transientFailureCount = new AtomicInteger(0)
 
@@ -160,7 +160,7 @@ private[platform] object HikariJdbcConnectionProvider {
       jdbcUrl: String,
       maxConnections: Int,
       metrics: MetricRegistry,
-  )(implicit logCtx: LoggingContext): ResourceOwner[HikariJdbcConnectionProvider] =
+  )(implicit loggingContext: LoggingContext): ResourceOwner[HikariJdbcConnectionProvider] =
     for {
       // these connections should never time out as we have the same number of threads as connections
       dataSource <- HikariConnection.owner(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -27,6 +27,7 @@ import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.ledger.WorkflowId
 import com.daml.ledger.api.domain.{CommandId, LedgerId, PartyDetails}
 import com.daml.ledger.api.health.ReportsHealth
+import com.daml.logging.LoggingContext
 import com.daml.platform.store.dao.events.TransactionsReader
 import com.daml.platform.store.entries.{
   ConfigurationEntry,
@@ -42,31 +43,34 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
   def maxConcurrentConnections: Int
 
   /** Looks up the ledger id */
-  def lookupLedgerId(): Future[Option[LedgerId]]
+  def lookupLedgerId()(implicit loggingContext: LoggingContext): Future[Option[LedgerId]]
 
   /** Looks up the current ledger end */
-  def lookupLedgerEnd(): Future[Offset]
+  def lookupLedgerEnd()(implicit loggingContext: LoggingContext): Future[Offset]
 
   /** Looks up the current external ledger end offset */
-  def lookupInitialLedgerEnd(): Future[Option[Offset]]
+  def lookupInitialLedgerEnd()(implicit loggingContext: LoggingContext): Future[Option[Offset]]
 
   /** Looks up an active or divulged contract if it is visible for the given party. Archived contracts must not be returned by this method */
-  def lookupActiveOrDivulgedContract(
-      contractId: ContractId,
-      forParty: Party): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]]
+  def lookupActiveOrDivulgedContract(contractId: ContractId, forParty: Party)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]]
 
   /** Returns the largest ledger time of any of the given contracts */
   def lookupMaximumLedgerTime(
       contractIds: Set[ContractId],
-  ): Future[Option[Instant]]
+  )(implicit loggingContext: LoggingContext): Future[Option[Instant]]
 
   /** Looks up the current ledger configuration, if it has been set. */
-  def lookupLedgerConfiguration(): Future[Option[(Offset, Configuration)]]
+  def lookupLedgerConfiguration()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[(Offset, Configuration)]]
 
   /** Returns a stream of configuration entries. */
   def getConfigurationEntries(
       startExclusive: Offset,
-      endInclusive: Offset): Source[(Offset, ConfigurationEntry), NotUsed]
+      endInclusive: Offset,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed]
 
   def transactionsReader: TransactionsReader
 
@@ -77,31 +81,40 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
     * @param forParty the party for which the contract must be visible
     * @return the optional ContractId
     */
-  def lookupKey(key: GlobalKey, forParty: Party): Future[Option[ContractId]]
+  def lookupKey(key: GlobalKey, forParty: Party)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[ContractId]]
 
   /** Returns a list of party details for the parties specified. */
-  def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
+  def getParties(parties: Seq[Party])(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[PartyDetails]]
 
   /** Returns a list of all known parties. */
-  def listKnownParties(): Future[List[PartyDetails]]
+  def listKnownParties()(implicit loggingContext: LoggingContext): Future[List[PartyDetails]]
 
   def getPartyEntries(
       startExclusive: Offset,
       endInclusive: Offset
-  ): Source[(Offset, PartyLedgerEntry), NotUsed]
+  )(implicit loggingContext: LoggingContext): Source[(Offset, PartyLedgerEntry), NotUsed]
 
   /** Returns a list of all known DAML-LF packages */
-  def listLfPackages: Future[Map[PackageId, PackageDetails]]
+  def listLfPackages()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Map[PackageId, PackageDetails]]
 
   /** Returns the given DAML-LF archive */
-  def getLfArchive(packageId: PackageId): Future[Option[Archive]]
+  def getLfArchive(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Archive]]
 
   /** Returns a stream of package upload entries.
     * @return a stream of package entries tupled with their offset
     */
   def getPackageEntries(
       startExclusive: Offset,
-      endInclusive: Offset): Source[(Offset, PackageLedgerEntry), NotUsed]
+      endInclusive: Offset,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, PackageLedgerEntry), NotUsed]
 
   def completions: CommandCompletionsReader
 
@@ -117,7 +130,8 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
       commandId: CommandId,
       submitter: Ref.Party,
       submittedAt: Instant,
-      deduplicateUntil: Instant): Future[CommandDeduplicationResult]
+      deduplicateUntil: Instant,
+  )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult]
 
   /**
     * Remove all expired deduplication entries. This method has to be called
@@ -132,7 +146,7 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
     */
   def removeExpiredDeduplicationData(
       currentTime: Instant,
-  ): Future[Unit]
+  )(implicit loggingContext: LoggingContext): Future[Unit]
 
   /**
     * Stops deduplicating the given command. This method should be called after
@@ -148,7 +162,7 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
   def stopDeduplicatingCommand(
       commandId: CommandId,
       submitter: Ref.Party,
-  ): Future[Unit]
+  )(implicit loggingContext: LoggingContext): Future[Unit]
 }
 
 private[platform] trait LedgerWriteDao extends ReportsHealth {
@@ -160,7 +174,7 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
     *
     * @param ledgerId the ledger id to be stored
     */
-  def initializeLedger(ledgerId: LedgerId): Future[Unit]
+  def initializeLedger(ledgerId: LedgerId)(implicit loggingContext: LoggingContext): Future[Unit]
 
   def storeTransaction(
       submitterInfo: Option[SubmitterInfo],
@@ -171,14 +185,14 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
       offset: Offset,
       transaction: CommittedTransaction,
       divulged: Iterable[DivulgedContract],
-  ): Future[PersistenceResponse]
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
   def storeRejection(
       submitterInfo: Option[SubmitterInfo],
       recordTime: Instant,
       offset: Offset,
       reason: RejectionReason,
-  ): Future[PersistenceResponse]
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
   /**
     * Stores the initial ledger state, e.g., computed by the scenario loader.
@@ -190,7 +204,7 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
   def storeInitialState(
       ledgerEntries: Vector[(Offset, LedgerEntry)],
       newLedgerEnd: Offset
-  ): Future[Unit]
+  )(implicit loggingContext: LoggingContext): Future[Unit]
 
   /**
     * Stores a party allocation or rejection thereof.
@@ -199,7 +213,9 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
     * @param partyEntry  the PartyEntry to be stored
     * @return Ok when the operation was successful otherwise a Duplicate
     */
-  def storePartyEntry(offset: Offset, partyEntry: PartyLedgerEntry): Future[PersistenceResponse]
+  def storePartyEntry(offset: Offset, partyEntry: PartyLedgerEntry)(
+      implicit loggingContext: LoggingContext,
+  ): Future[PersistenceResponse]
 
   /**
     * Store a configuration change or rejection.
@@ -211,7 +227,7 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
       participantId: ParticipantId,
       configuration: Configuration,
       rejectionReason: Option[String]
-  ): Future[PersistenceResponse]
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
   /**
     * Store a DAML-LF package upload result.
@@ -220,10 +236,10 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
       offset: Offset,
       packages: List[(Archive, PackageDetails)],
       optEntry: Option[PackageLedgerEntry]
-  ): Future[PersistenceResponse]
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
   /** Resets the platform into a state as it was never used before. Meant to be used solely for testing. */
-  def reset(): Future[Unit]
+  def reset()(implicit loggingContext: LoggingContext): Future[Unit]
 
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -18,6 +18,7 @@ import com.daml.lf.data.Ref.{PackageId, Party}
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
+import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.dao.events.TransactionsReader
 import com.daml.platform.store.entries.{
@@ -36,59 +37,69 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
 
-  override def lookupLedgerId(): Future[Option[LedgerId]] =
+  override def lookupLedgerId()(implicit loggingContext: LoggingContext): Future[Option[LedgerId]] =
     Timed.future(metrics.daml.index.db.lookupLedgerId, ledgerDao.lookupLedgerId())
 
-  override def lookupLedgerEnd(): Future[Offset] =
+  override def lookupLedgerEnd()(implicit loggingContext: LoggingContext): Future[Offset] =
     Timed.future(metrics.daml.index.db.lookupLedgerEnd, ledgerDao.lookupLedgerEnd())
 
-  override def lookupInitialLedgerEnd(): Future[Option[Offset]] =
+  override def lookupInitialLedgerEnd()(
+      implicit loggingContext: LoggingContext): Future[Option[Offset]] =
     Timed.future(metrics.daml.index.db.lookupLedgerEnd, ledgerDao.lookupInitialLedgerEnd())
 
   override def lookupActiveOrDivulgedContract(
       contractId: Value.ContractId,
-      forParty: Party): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
+      forParty: Party,
+  )(implicit loggingContext: LoggingContext)
+    : Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
     Timed.future(
       metrics.daml.index.db.lookupActiveContract,
       ledgerDao.lookupActiveOrDivulgedContract(contractId, forParty))
 
   override def lookupMaximumLedgerTime(
       contractIds: Set[ContractId],
-  ): Future[Option[Instant]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[Instant]] =
     Timed.future(
       metrics.daml.index.db.lookupMaximumLedgerTime,
       ledgerDao.lookupMaximumLedgerTime(contractIds))
 
   override def transactionsReader: TransactionsReader = ledgerDao.transactionsReader
 
-  override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[Value.ContractId]] =
+  override def lookupKey(key: GlobalKey, forParty: Party)(
+      implicit loggingContext: LoggingContext): Future[Option[Value.ContractId]] =
     Timed.future(metrics.daml.index.db.lookupKey, ledgerDao.lookupKey(key, forParty))
 
-  override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
+  override def getParties(parties: Seq[Party])(
+      implicit loggingContext: LoggingContext): Future[List[PartyDetails]] =
     Timed.future(metrics.daml.index.db.getParties, ledgerDao.getParties(parties))
 
-  override def listKnownParties(): Future[List[PartyDetails]] =
+  override def listKnownParties()(
+      implicit loggingContext: LoggingContext): Future[List[PartyDetails]] =
     Timed.future(metrics.daml.index.db.listKnownParties, ledgerDao.listKnownParties())
 
   override def getPartyEntries(
       startExclusive: Offset,
       endInclusive: Offset
-  ): Source[(Offset, PartyLedgerEntry), NotUsed] =
+  )(implicit loggingContext: LoggingContext): Source[(Offset, PartyLedgerEntry), NotUsed] =
     ledgerDao.getPartyEntries(startExclusive, endInclusive)
 
-  override def listLfPackages: Future[Map[PackageId, PackageDetails]] =
+  override def listLfPackages()(
+      implicit loggingContext: LoggingContext): Future[Map[PackageId, PackageDetails]] =
     Timed.future(metrics.daml.index.db.listLfPackages, ledgerDao.listLfPackages)
 
-  override def getLfArchive(packageId: PackageId): Future[Option[Archive]] =
+  override def getLfArchive(packageId: PackageId)(
+      implicit loggingContext: LoggingContext): Future[Option[Archive]] =
     Timed.future(metrics.daml.index.db.getLfArchive, ledgerDao.getLfArchive(packageId))
 
   override def getPackageEntries(
       startExclusive: Offset,
-      endInclusive: Offset): Source[(Offset, PackageLedgerEntry), NotUsed] =
+      endInclusive: Offset,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, PackageLedgerEntry), NotUsed] =
     ledgerDao.getPackageEntries(startExclusive, endInclusive)
 
   /** Looks up the current ledger configuration, if it has been set. */
-  override def lookupLedgerConfiguration(): Future[Option[(Offset, Configuration)]] =
+  override def lookupLedgerConfiguration()(
+      implicit loggingContext: LoggingContext): Future[Option[(Offset, Configuration)]] =
     Timed.future(
       metrics.daml.index.db.lookupLedgerConfiguration,
       ledgerDao.lookupLedgerConfiguration())
@@ -96,7 +107,8 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
   /** Get a stream of configuration entries. */
   override def getConfigurationEntries(
       startExclusive: Offset,
-      endInclusive: Offset): Source[(Offset, ConfigurationEntry), NotUsed] =
+      endInclusive: Offset,
+  )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed] =
     ledgerDao.getConfigurationEntries(startExclusive, endInclusive)
 
   override val completions: CommandCompletionsReader = ledgerDao.completions
@@ -105,17 +117,20 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
       commandId: CommandId,
       submitter: Ref.Party,
       submittedAt: Instant,
-      deduplicateUntil: Instant): Future[CommandDeduplicationResult] =
+      deduplicateUntil: Instant,
+  )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult] =
     Timed.future(
       metrics.daml.index.db.deduplicateCommand,
       ledgerDao.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil))
 
-  override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
+  override def removeExpiredDeduplicationData(currentTime: Instant)(
+      implicit loggingContext: LoggingContext): Future[Unit] =
     Timed.future(
       metrics.daml.index.db.removeExpiredDeduplicationData,
       ledgerDao.removeExpiredDeduplicationData(currentTime))
 
-  override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party): Future[Unit] =
+  override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party)(
+      implicit loggingContext: LoggingContext): Future[Unit] =
     Timed.future(
       metrics.daml.index.db.stopDeduplicatingCommand,
       ledgerDao.stopDeduplicatingCommand(commandId, submitter))
@@ -135,7 +150,8 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
       ledgerEffectiveTime: Instant,
       offset: Offset,
       transaction: CommittedTransaction,
-      divulged: Iterable[DivulgedContract]): Future[PersistenceResponse] =
+      divulged: Iterable[DivulgedContract],
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storeTransaction,
       ledgerDao.storeTransaction(
@@ -155,7 +171,7 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
       recordTime: Instant,
       offset: Offset,
       reason: RejectionReason,
-  ): Future[PersistenceResponse] =
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storeRejection,
       ledgerDao.storeRejection(submitterInfo, recordTime, offset, reason),
@@ -164,23 +180,26 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
   override def storeInitialState(
       ledgerEntries: Vector[(Offset, LedgerEntry)],
       newLedgerEnd: Offset,
-  ): Future[Unit] =
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
     Timed.future(
       metrics.daml.index.db.storeInitialState,
       ledgerDao.storeInitialState(ledgerEntries, newLedgerEnd))
 
-  override def initializeLedger(ledgerId: LedgerId): Future[Unit] =
+  override def initializeLedger(ledgerId: LedgerId)(
+      implicit loggingContext: LoggingContext): Future[Unit] =
     ledgerDao.initializeLedger(ledgerId)
 
-  override def reset(): Future[Unit] =
+  override def reset()(implicit loggingContext: LoggingContext): Future[Unit] =
     ledgerDao.reset()
 
   override def storePartyEntry(
       offset: Offset,
-      partyEntry: PartyLedgerEntry): Future[PersistenceResponse] =
+      partyEntry: PartyLedgerEntry,
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storePartyEntry,
-      ledgerDao.storePartyEntry(offset, partyEntry))
+      ledgerDao.storePartyEntry(offset, partyEntry)
+    )
 
   override def storeConfigurationEntry(
       offset: Offset,
@@ -188,8 +207,8 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
       submissionId: String,
       participantId: ParticipantId,
       configuration: Configuration,
-      rejectionReason: Option[String]
-  ): Future[PersistenceResponse] =
+      rejectionReason: Option[String],
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storeConfigurationEntry,
       ledgerDao.storeConfigurationEntry(
@@ -198,14 +217,15 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
         submissionId,
         participantId,
         configuration,
-        rejectionReason)
+        rejectionReason,
+      )
     )
 
   override def storePackageEntry(
       offset: Offset,
       packages: List[(Archive, PackageDetails)],
-      entry: Option[PackageLedgerEntry]
-  ): Future[PersistenceResponse] =
+      entry: Option[PackageLedgerEntry],
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storePackageEntry,
       ledgerDao.storePackageEntry(offset, packages, entry))

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -88,7 +88,8 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
     Timed.future(metrics.daml.index.db.listLfPackages, ledgerDao.listLfPackages)
 
   override def getLfArchive(packageId: PackageId)(
-      implicit loggingContext: LoggingContext): Future[Option[Archive]] =
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Archive]] =
     Timed.future(metrics.daml.index.db.getLfArchive, ledgerDao.getLfArchive(packageId))
 
   override def getPackageEntries(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -100,7 +100,8 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
 
   /** Looks up the current ledger configuration, if it has been set. */
   override def lookupLedgerConfiguration()(
-      implicit loggingContext: LoggingContext): Future[Option[(Offset, Configuration)]] =
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[(Offset, Configuration)]] =
     Timed.future(
       metrics.daml.index.db.lookupLedgerConfiguration,
       ledgerDao.lookupLedgerConfiguration())

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -126,7 +126,8 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
       ledgerDao.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil))
 
   override def removeExpiredDeduplicationData(currentTime: Instant)(
-      implicit loggingContext: LoggingContext): Future[Unit] =
+      implicit loggingContext: LoggingContext,
+  ): Future[Unit] =
     Timed.future(
       metrics.daml.index.db.removeExpiredDeduplicationData,
       ledgerDao.removeExpiredDeduplicationData(currentTime))

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -133,7 +133,8 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
       ledgerDao.removeExpiredDeduplicationData(currentTime))
 
   override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party)(
-      implicit loggingContext: LoggingContext): Future[Unit] =
+      implicit loggingContext: LoggingContext,
+  ): Future[Unit] =
     Timed.future(
       metrics.daml.index.db.stopDeduplicatingCommand,
       ledgerDao.stopDeduplicatingCommand(commandId, submitter))

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -10,6 +10,7 @@ import anorm.SqlParser.{binaryStream, str}
 import anorm.{Row, RowParser, SimpleSql, SqlParser, SqlStringInterpolation}
 import com.codahale.metrics.Timer
 import com.daml.ledger.participant.state.index.v2.ContractStore
+import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.Conversions._
 import com.daml.platform.store.DbType
@@ -46,7 +47,7 @@ private[dao] sealed abstract class ContractsReader(
   private def lookupActiveContractAndLoadArgument(
       submitter: Party,
       contractId: ContractId,
-  ): Future[Option[Contract]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
     dispatcher
       .executeSql(metrics.daml.index.db.lookupActiveContractDbMetrics) { implicit connection =>
         SQL"select participant_contracts.contract_id, template_id, create_argument from #$contractsTable where contract_witness = $submitter and participant_contracts.contract_id = $contractId"
@@ -68,7 +69,7 @@ private[dao] sealed abstract class ContractsReader(
       submitter: Party,
       contractId: ContractId,
       createArgument: Value,
-  ): Future[Option[Contract]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
     dispatcher
       .executeSql(metrics.daml.index.db.lookupActiveContractWithCachedArgumentDbMetrics) {
         implicit connection =>
@@ -86,7 +87,7 @@ private[dao] sealed abstract class ContractsReader(
   override def lookupActiveContract(
       submitter: Party,
       contractId: ContractId,
-  ): Future[Option[Contract]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[Contract]] =
     // Depending on whether the contract argument is cached or not, submit a different query to the database
     translation.cache.contracts
       .getIfPresent(LfValueTranslation.ContractCache.Key(contractId)) match {
@@ -100,12 +101,14 @@ private[dao] sealed abstract class ContractsReader(
   override def lookupContractKey(
       submitter: Party,
       key: Key,
-  ): Future[Option[ContractId]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[ContractId]] =
     dispatcher.executeSql(metrics.daml.index.db.lookupContractByKey) { implicit connection =>
       lookupContractKeyQuery(submitter, key).as(contractId("contract_id").singleOpt)
     }
 
-  override def lookupMaximumLedgerTime(ids: Set[ContractId]): Future[Option[Instant]] =
+  override def lookupMaximumLedgerTime(ids: Set[ContractId])(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Instant]] =
     dispatcher
       .executeSql(metrics.daml.index.db.lookupMaximumLedgerTimeDbMetrics) { implicit connection =>
         committedContracts.lookupMaximumLedgerTime(ids)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
@@ -39,7 +39,7 @@ private[dao] final class TransactionsReader(
     pageSize: Int,
     metrics: Metrics,
     lfValueTranslation: LfValueTranslation,
-)(implicit executionContext: ExecutionContext, loggingContext: LoggingContext) {
+)(implicit executionContext: ExecutionContext) {
 
   private val dbMetrics = metrics.daml.index.db
 
@@ -66,7 +66,7 @@ private[dao] final class TransactionsReader(
       endInclusive: Offset,
       filter: FilterRelation,
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionsResponse), NotUsed] = {
+  )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] = {
 
     logger.debug(s"getFlatTransactions($startExclusive, $endInclusive, $filter, $verbose)")
 
@@ -129,7 +129,8 @@ private[dao] final class TransactionsReader(
       endInclusive: Offset,
       requestingParties: Set[Party],
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionTreesResponse), NotUsed] = {
+  )(implicit loggingContext: LoggingContext)
+    : Source[(Offset, GetTransactionTreesResponse), NotUsed] = {
 
     logger.debug(
       s"getTransactionTrees($startExclusive, $endInclusive, $requestingParties, $verbose)")
@@ -192,7 +193,7 @@ private[dao] final class TransactionsReader(
       activeAt: Offset,
       filter: FilterRelation,
       verbose: Boolean,
-  ): Source[GetActiveContractsResponse, NotUsed] = {
+  )(implicit loggingContext: LoggingContext): Source[GetActiveContractsResponse, NotUsed] = {
 
     logger.debug(s"getActiveContracts($activeAt, $filter, $verbose)")
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -24,7 +24,7 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll { this: Su
   protected def jdbcUrl: String
 
   protected def daoOwner(eventsPageSize: Int)(
-      implicit logCtx: LoggingContext
+      implicit loggingContext: LoggingContext
   ): ResourceOwner[LedgerDao] =
     JdbcLedgerDao
       .writeOwner(
@@ -43,7 +43,7 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll { this: Su
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     implicit val executionContext: ExecutionContext = system.dispatcher
-    resource = newLoggingContext { implicit logCtx =>
+    resource = newLoggingContext { implicit loggingContext =>
       for {
         _ <- Resource.fromFuture(new FlywayMigrations(jdbcUrl).migrate())
         dao <- daoOwner(100).acquire()

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPostCommitValidationSpec.scala
@@ -18,7 +18,7 @@ private[dao] trait JdbcLedgerDaoPostCommitValidationSpec extends LoneElement {
   this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
 
   override protected def daoOwner(eventsPageSize: Int)(
-      implicit logCtx: LoggingContext
+      implicit loggingContext: LoggingContext
   ): ResourceOwner[LedgerDao] =
     JdbcLedgerDao
       .validatingWriteOwner(

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPostCommitValidationSpec.scala
@@ -18,7 +18,7 @@ private[dao] trait JdbcLedgerDaoPostCommitValidationSpec extends LoneElement {
   this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
 
   override protected def daoOwner(eventsPageSize: Int)(
-      implicit loggingContext: LoggingContext
+      implicit loggingContext: LoggingContext,
   ): ResourceOwner[LedgerDao] =
     JdbcLedgerDao
       .validatingWriteOwner(

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -23,6 +23,7 @@ import com.daml.lf.value.Value
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.logging.LoggingContext
 import com.daml.platform.store.entries.LedgerEntry
 import org.scalatest.Suite
 
@@ -32,6 +33,8 @@ import scala.util.{Success, Try}
 
 private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLedgerDaoBackend {
   this: Suite =>
+
+  protected implicit final val loggingContext: LoggingContext = LoggingContext.ForTesting
 
   protected final val nextOffset: () => Offset = {
     val base = BigInt(1) << 32

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -574,7 +574,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
     responses.foldLeft(Vector.empty[Transaction])((b, a) => b ++ a._2.transactions.toVector)
 
   private def createLedgerDao(pageSize: Int) =
-    LoggingContext.newLoggingContext { implicit logCtx =>
+    LoggingContext.newLoggingContext { implicit loggingContext =>
       daoOwner(eventsPageSize = 2).acquire()
     }.asFuture
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
@@ -17,6 +17,7 @@ import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands.Commands
 import com.daml.ledger.api.v1.completion.Completion
 import com.daml.dec.DirectExecutionContext
+import com.daml.logging.LoggingContext
 import com.google.rpc.status.{Status => RpcStatus}
 import io.grpc.Status
 import org.scalatest.concurrent.ScalaFutures
@@ -34,6 +35,7 @@ class TrackerImplTest
   private var sut: Tracker = _
   private var consumer: TestSubscriber.Probe[NotUsed] = _
   private var queue: SourceQueueWithComplete[TrackerImpl.QueueInput] = _
+  private implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
   private def input(cid: Int) = SubmitAndWaitRequest(Some(Commands(commandId = cid.toString)))
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -104,7 +104,7 @@ class RecoveringIndexerSpec
       }
     }
 
-    "wait until the subscription completes" in newLoggingContext { implicit loggingContext =>
+    "wait until the subscription completes" in {
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       val testIndexer = new TestIndexer(
         SubscribeResult("A", SuccessfullyCompletes, 100.millis, 10.millis),

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -73,7 +73,7 @@ class RecoveringIndexerSpec
         }
     }
 
-    "work when the stream is stopped" in newLoggingContext { implicit loggingContext =>
+    "work when the stream is stopped" in {
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       // Stream completes after 10s, but is released before that happens
       val testIndexer = new TestIndexer(

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem
 import akka.pattern.after
 import ch.qos.logback.classic.Level
 import com.daml.dec.DirectExecutionContext
+import com.daml.logging.LoggingContext
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.platform.indexer.RecoveringIndexerSpec._
 import com.daml.platform.testing.LogCollector
@@ -28,6 +29,7 @@ class RecoveringIndexerSpec
     with BeforeAndAfterEach {
 
   private[this] implicit val executionContext: ExecutionContext = DirectExecutionContext
+  private[this] implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
   private[this] var actorSystem: ActorSystem = _
 
   override def beforeEach(): Unit = {
@@ -44,7 +46,7 @@ class RecoveringIndexerSpec
   private def readLog(): Seq[(Level, String)] = LogCollector.read[this.type, RecoveringIndexer]
 
   "RecoveringIndexer" should {
-    "work when the stream completes" in newLoggingContext { implicit loggingContext =>
+    "work when the stream completes" in {
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       val testIndexer = new TestIndexer(
         SubscribeResult("A", SuccessfullyCompletes, 10.millis, 10.millis),

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -10,7 +10,6 @@ import akka.pattern.after
 import ch.qos.logback.classic.Level
 import com.daml.dec.DirectExecutionContext
 import com.daml.logging.LoggingContext
-import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.platform.indexer.RecoveringIndexerSpec._
 import com.daml.platform.testing.LogCollector
 import com.daml.resources.{Resource, ResourceOwner}
@@ -175,7 +174,7 @@ class RecoveringIndexerSpec
         }
     }
 
-    "respect restart delay" in newLoggingContext { implicit loggingContext =>
+    "respect restart delay" in {
       val restartDelay = 500.millis
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, restartDelay)
       // Subscribe fails, then the stream completes without errors. Note the restart delay of 500ms.

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -133,7 +133,7 @@ class RecoveringIndexerSpec
         }
     }
 
-    "recover from failure" in newLoggingContext { implicit loggingContext =>
+    "recover from failure" in {
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       // Subscribe fails, then the stream fails, then the stream completes without errors.
       val testIndexer = new TestIndexer(

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -44,7 +44,7 @@ class RecoveringIndexerSpec
   private def readLog(): Seq[(Level, String)] = LogCollector.read[this.type, RecoveringIndexer]
 
   "RecoveringIndexer" should {
-    "work when the stream completes" in newLoggingContext { implicit logCtx =>
+    "work when the stream completes" in newLoggingContext { implicit loggingContext =>
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       val testIndexer = new TestIndexer(
         SubscribeResult("A", SuccessfullyCompletes, 10.millis, 10.millis),
@@ -71,7 +71,7 @@ class RecoveringIndexerSpec
         }
     }
 
-    "work when the stream is stopped" in newLoggingContext { implicit logCtx =>
+    "work when the stream is stopped" in newLoggingContext { implicit loggingContext =>
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       // Stream completes after 10s, but is released before that happens
       val testIndexer = new TestIndexer(
@@ -102,7 +102,7 @@ class RecoveringIndexerSpec
       }
     }
 
-    "wait until the subscription completes" in newLoggingContext { implicit logCtx =>
+    "wait until the subscription completes" in newLoggingContext { implicit loggingContext =>
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       val testIndexer = new TestIndexer(
         SubscribeResult("A", SuccessfullyCompletes, 100.millis, 10.millis),
@@ -131,7 +131,7 @@ class RecoveringIndexerSpec
         }
     }
 
-    "recover from failure" in newLoggingContext { implicit logCtx =>
+    "recover from failure" in newLoggingContext { implicit loggingContext =>
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, 10.millis)
       // Subscribe fails, then the stream fails, then the stream completes without errors.
       val testIndexer = new TestIndexer(
@@ -173,7 +173,7 @@ class RecoveringIndexerSpec
         }
     }
 
-    "respect restart delay" in newLoggingContext { implicit logCtx =>
+    "respect restart delay" in newLoggingContext { implicit loggingContext =>
       val restartDelay = 500.millis
       val recoveringIndexer = new RecoveringIndexer(actorSystem.scheduler, restartDelay)
       // Subscribe fails, then the stream completes without errors. Note the restart delay of 500ms.

--- a/ledger/participant-state-index/BUILD.bazel
+++ b/ledger/participant-state-index/BUILD.bazel
@@ -24,6 +24,7 @@ da_scala_library(
         "//ledger/ledger-api-domain",
         "//ledger/ledger-api-health",
         "//ledger/participant-state",
+        "//libs-scala/contextualized-logging",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/ContractStore.scala
@@ -10,6 +10,7 @@ import com.daml.lf.data.Ref.Party
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
 
@@ -20,14 +21,19 @@ trait ContractStore {
   def lookupActiveContract(
       submitter: Ref.Party,
       contractId: ContractId
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]]
+  )(implicit loggingContext: LoggingContext)
+    : Future[Option[ContractInst[Value.VersionedValue[ContractId]]]]
 
-  def lookupContractKey(submitter: Party, key: GlobalKey): Future[Option[ContractId]]
+  def lookupContractKey(submitter: Party, key: GlobalKey)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[ContractId]]
 
   /**
     * @return The maximum ledger effective time of all contracts in ids, fails as follows:
     *         - if ids is empty or not all the non-divulged ids can be found, a failed [[Future]]
     *         - if all ids are found but each refer to a divulged contract, a successful [[None]]
     */
-  def lookupMaximumLedgerTime(ids: Set[ContractId]): Future[Option[Instant]]
+  def lookupMaximumLedgerTime(ids: Set[ContractId])(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Instant]]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IdentityProvider.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IdentityProvider.scala
@@ -4,6 +4,8 @@
 package com.daml.ledger.participant.state.index.v2
 
 import com.daml.ledger.api.domain.LedgerId
+import com.daml.logging.LoggingContext
+
 import scala.concurrent.Future
 
 /**
@@ -11,5 +13,5 @@ import scala.concurrent.Future
   * [[com.daml.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc.LedgerIdentityService]]
   **/
 trait IdentityProvider {
-  def getLedgerId(): Future[LedgerId]
+  def getLedgerId()(implicit loggingContext: LoggingContext): Future[LedgerId]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexActiveContractsService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexActiveContractsService.scala
@@ -7,6 +7,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.api.domain.TransactionFilter
 import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
+import com.daml.logging.LoggingContext
 
 /**
   * Serves as a backend to implement
@@ -17,5 +18,5 @@ trait IndexActiveContractsService {
   def getActiveContracts(
       filter: TransactionFilter,
       verbose: Boolean,
-  ): Source[GetActiveContractsResponse, NotUsed]
+  )(implicit loggingContext: LoggingContext): Source[GetActiveContractsResponse, NotUsed]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexCompletionsService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexCompletionsService.scala
@@ -8,6 +8,7 @@ import akka.stream.scaladsl.Source
 import com.daml.lf.data.Ref
 import com.daml.ledger.api.domain.{ApplicationId, LedgerOffset}
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
+import com.daml.logging.LoggingContext
 
 /**
   * Serves as a backend to implement
@@ -17,6 +18,6 @@ trait IndexCompletionsService extends LedgerEndService {
   def getCompletions(
       begin: LedgerOffset,
       applicationId: ApplicationId,
-      parties: Set[Ref.Party]
-  ): Source[CompletionStreamResponse, NotUsed]
+      parties: Set[Ref.Party],
+  )(implicit loggingContext: LoggingContext): Source[CompletionStreamResponse, NotUsed]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexConfigManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexConfigManagementService.scala
@@ -7,6 +7,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.v1.Configuration
 import com.daml.ledger.api.domain.{ConfigurationEntry, LedgerOffset}
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
 
@@ -20,10 +21,13 @@ trait IndexConfigManagementService {
   /** Looks up the current configuration, if set, and the offset from which
     * to subscribe to new configuration entries using [[configurationEntries]].
     */
-  def lookupConfiguration(): Future[Option[(LedgerOffset.Absolute, Configuration)]]
+  def lookupConfiguration()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[(LedgerOffset.Absolute, Configuration)]]
 
   /** Retrieve configuration entries. */
-  def configurationEntries(startExclusive: Option[LedgerOffset.Absolute])
-    : Source[(LedgerOffset.Absolute, ConfigurationEntry), NotUsed]
+  def configurationEntries(startExclusive: Option[LedgerOffset.Absolute])(
+      implicit loggingContext: LoggingContext,
+  ): Source[(LedgerOffset.Absolute, ConfigurationEntry), NotUsed]
 
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexConfigurationService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexConfigurationService.scala
@@ -5,11 +5,14 @@ package com.daml.ledger.participant.state.index.v2
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
+import com.daml.logging.LoggingContext
 
 /**
   * Serves as a backend to implement
   * [[com.daml.ledger.api.v1.ledger_configuration_service.LedgerConfigurationServiceGrpc.LedgerConfigurationService]]
   **/
 trait IndexConfigurationService {
-  def getLedgerConfiguration(): Source[LedgerConfiguration, NotUsed]
+  def getLedgerConfiguration()(
+      implicit loggingContext: LoggingContext,
+  ): Source[LedgerConfiguration, NotUsed]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPackagesService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPackagesService.scala
@@ -9,6 +9,7 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.lf.language.Ast.Package
 import com.daml.ledger.api.domain.{LedgerOffset, PackageEntry}
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
 
@@ -17,12 +18,20 @@ import scala.concurrent.Future
   * PackageService and PackageManagementService.
   */
 trait IndexPackagesService {
-  def listLfPackages(): Future[Map[PackageId, PackageDetails]]
+  def listLfPackages()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Map[PackageId, PackageDetails]]
 
-  def getLfArchive(packageId: PackageId): Future[Option[Archive]]
+  def getLfArchive(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Archive]]
 
   /** Like [[getLfArchive]], but already parsed. */
-  def getLfPackage(packageId: PackageId): Future[Option[Package]]
+  def getLfPackage(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Package]]
 
-  def packageEntries(startExclusive: LedgerOffset.Absolute): Source[PackageEntry, NotUsed]
+  def packageEntries(startExclusive: LedgerOffset.Absolute)(
+      implicit loggingContext: LoggingContext,
+  ): Source[PackageEntry, NotUsed]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
@@ -7,6 +7,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.v1.{ParticipantId, Party}
 import com.daml.ledger.api.domain.{LedgerOffset, PartyDetails, PartyEntry}
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
 
@@ -15,11 +16,15 @@ import scala.concurrent.Future
   * [[com.daml.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc]]
   */
 trait IndexPartyManagementService {
-  def getParticipantId(): Future[ParticipantId]
+  def getParticipantId()(implicit loggingContext: LoggingContext): Future[ParticipantId]
 
-  def getParties(parties: Seq[Party]): Future[List[PartyDetails]]
+  def getParties(parties: Seq[Party])(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[PartyDetails]]
 
-  def listKnownParties(): Future[List[PartyDetails]]
+  def listKnownParties()(implicit loggingContext: LoggingContext): Future[List[PartyDetails]]
 
-  def partyEntries(startExclusive: LedgerOffset.Absolute): Source[PartyEntry, NotUsed]
+  def partyEntries(startExclusive: LedgerOffset.Absolute)(
+      implicit loggingContext: LoggingContext,
+  ): Source[PartyEntry, NotUsed]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexSubmissionService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexSubmissionService.scala
@@ -7,6 +7,7 @@ import java.time.Instant
 
 import com.daml.lf.data.Ref
 import com.daml.ledger.api.domain.CommandId
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
 
@@ -19,10 +20,11 @@ trait IndexSubmissionService {
       commandId: CommandId,
       submitter: Ref.Party,
       submittedAt: Instant,
-      deduplicateUntil: Instant): Future[CommandDeduplicationResult]
+      deduplicateUntil: Instant,
+  )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult]
 
   def stopDeduplicatingCommand(
       commandId: CommandId,
       submitter: Ref.Party,
-  ): Future[Unit]
+  )(implicit loggingContext: LoggingContext): Future[Unit]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexTimeService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexTimeService.scala
@@ -6,10 +6,13 @@ package com.daml.ledger.participant.state.index.v2
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.lf.data.Time
+import com.daml.logging.LoggingContext
 
 /** Serves as a backend to implement
   * [[com.daml.ledger.api.v1.testing.time_service.TimeServiceGrpc.TimeService]]
   */
 trait IndexTimeService {
-  def getLedgerRecordTimeStream(): Source[Time.Timestamp, NotUsed]
+  def getLedgerRecordTimeStream()(
+      implicit loggingContext: LoggingContext,
+  ): Source[Time.Timestamp, NotUsed]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexTransactionsService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexTransactionsService.scala
@@ -13,6 +13,7 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse
 }
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
 
@@ -26,22 +27,22 @@ trait IndexTransactionsService extends LedgerEndService {
       endAt: Option[LedgerOffset],
       filter: TransactionFilter,
       verbose: Boolean,
-  ): Source[GetTransactionsResponse, NotUsed]
+  )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed]
 
   def transactionTrees(
       begin: LedgerOffset,
       endAt: Option[LedgerOffset],
       filter: TransactionFilter,
       verbose: Boolean,
-  ): Source[GetTransactionTreesResponse, NotUsed]
+  )(implicit loggingContext: LoggingContext): Source[GetTransactionTreesResponse, NotUsed]
 
   def getTransactionById(
       transactionId: TransactionId,
       requestingParties: Set[Ref.Party],
-  ): Future[Option[GetFlatTransactionResponse]]
+  )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]]
 
   def getTransactionTreeById(
       transactionId: TransactionId,
       requestingParties: Set[Ref.Party],
-  ): Future[Option[GetTransactionResponse]]
+  )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/LedgerEndService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/LedgerEndService.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.participant.state.index.v2
 
 import com.daml.ledger.api.domain.LedgerOffset
+import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
 
@@ -11,5 +12,5 @@ import scala.concurrent.Future
   * Serves as a backend to implement ledger end related API calls.
   **/
 trait LedgerEndService {
-  def currentLedgerEnd(): Future[LedgerOffset.Absolute]
+  def currentLedgerEnd()(implicit loggingContext: LoggingContext): Future[LedgerOffset.Absolute]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/package.scala
@@ -104,7 +104,8 @@ package v2 {
   final case class PackageDetails(
       size: Long,
       knownSince: Instant,
-      sourceDescription: Option[String])
+      sourceDescription: Option[String],
+  )
 
   sealed abstract class CommandDeduplicationResult extends Product with Serializable
 

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -94,7 +94,7 @@ trait ReadServiceOwner[+RS <: ReadService, ExtraConfig] extends ConfigProvider[E
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
       engine: Engine,
-  )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[RS]
+  )(implicit materializer: Materializer, loggingContext: LoggingContext): ResourceOwner[RS]
 }
 
 trait WriteServiceOwner[+WS <: WriteService, ExtraConfig] extends ConfigProvider[ExtraConfig] {
@@ -102,7 +102,7 @@ trait WriteServiceOwner[+WS <: WriteService, ExtraConfig] extends ConfigProvider
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
       engine: Engine,
-  )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[WS]
+  )(implicit materializer: Materializer, loggingContext: LoggingContext): ResourceOwner[WS]
 }
 
 trait LedgerFactory[+RWS <: ReadWriteService, ExtraConfig]
@@ -113,21 +113,21 @@ trait LedgerFactory[+RWS <: ReadWriteService, ExtraConfig]
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
       engine: Engine,
-  )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[RWS] =
+  )(implicit materializer: Materializer, loggingContext: LoggingContext): ResourceOwner[RWS] =
     readWriteServiceOwner(config, participantConfig, engine)
 
   override final def writeServiceOwner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
       engine: Engine,
-  )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[RWS] =
+  )(implicit materializer: Materializer, loggingContext: LoggingContext): ResourceOwner[RWS] =
     readWriteServiceOwner(config, participantConfig, engine)
 
   def readWriteServiceOwner(
       config: Config[ExtraConfig],
       participantConfig: ParticipantConfig,
       engine: Engine,
-  )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[RWS]
+  )(implicit materializer: Materializer, loggingContext: LoggingContext): ResourceOwner[RWS]
 }
 
 object LedgerFactory {
@@ -142,7 +142,7 @@ object LedgerFactory {
         engine: Engine,
     )(
         implicit materializer: Materializer,
-        logCtx: LoggingContext,
+        loggingContext: LoggingContext,
     ): ResourceOwner[KeyValueParticipantState] =
       for {
         readerWriter <- owner(config, participantConfig, engine)
@@ -157,7 +157,7 @@ object LedgerFactory {
         value: Config[Unit],
         config: ParticipantConfig,
         engine: Engine,
-    )(implicit materializer: Materializer, logCtx: LoggingContext): ResourceOwner[KVL]
+    )(implicit materializer: Materializer, loggingContext: LoggingContext): ResourceOwner[KVL]
 
     override final def extraConfigParser(parser: OptionParser[Config[Unit]]): Unit =
       ()

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -49,7 +49,7 @@ final class Runner[T <: ReadWriteService, Extra](
       // This should be made configurable
       val sharedEngine = Engine.DevEngine()
 
-      newLoggingContext { implicit logCtx =>
+      newLoggingContext { implicit loggingContext =>
         for {
           // Take ownership of the actor system and materializer so they're cleaned up properly.
           // This is necessary because we can't declare them as implicits in a `for` comprehension.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
@@ -29,7 +29,7 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class BatchingLedgerWriter(val queue: BatchingQueue, val writer: LedgerWriter)(
     implicit val materializer: Materializer,
-    implicit val logCtx: LoggingContext)
+    implicit val loggingContext: LoggingContext)
     extends LedgerWriter
     with Closeable {
 
@@ -63,7 +63,7 @@ class BatchingLedgerWriter(val queue: BatchingQueue, val writer: LedgerWriter)(
     // Pick a correlation id for the batch.
     val correlationId = UUID.randomUUID().toString
 
-    newLoggingContext("correlationId" -> correlationId) { implicit logCtx =>
+    newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
       // Log the correlation ids of the submissions so we can correlate the batch to the submissions.
       val childCorrelationIds = submissions.map(_.getCorrelationId).mkString(", ")
       logger.trace(s"Committing batch $correlationId with submissions: $childCorrelationIds")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
@@ -87,7 +87,8 @@ class BatchingLedgerWriter(val queue: BatchingQueue, val writer: LedgerWriter)(
 object BatchingLedgerWriter {
   def apply(batchingLedgerWriterConfig: BatchingLedgerWriterConfig, delegate: LedgerWriter)(
       implicit materializer: Materializer,
-      loggingContext: LoggingContext): BatchingLedgerWriter = {
+      loggingContext: LoggingContext,
+  ): BatchingLedgerWriter = {
     val batchingQueue = batchingQueueFrom(batchingLedgerWriterConfig)
     new BatchingLedgerWriter(batchingQueue, delegate)
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -63,7 +63,7 @@ class SubmissionValidator[LogResult] private[validator] (
       recordTime: Timestamp,
       participantId: ParticipantId,
   ): Future[Either[ValidationFailed, Unit]] =
-    newLoggingContext { implicit logCtx =>
+    newLoggingContext { implicit loggingContext =>
       runValidation(
         envelope,
         correlationId,
@@ -80,7 +80,7 @@ class SubmissionValidator[LogResult] private[validator] (
       recordTime: Timestamp,
       participantId: ParticipantId,
   ): Future[Either[ValidationFailed, LogResult]] =
-    newLoggingContext { implicit logCtx =>
+    newLoggingContext { implicit loggingContext =>
       validateAndCommitWithLoggingContext(envelope, correlationId, recordTime, participantId)
     }
 
@@ -89,7 +89,7 @@ class SubmissionValidator[LogResult] private[validator] (
       correlationId: String,
       recordTime: Timestamp,
       participantId: ParticipantId,
-  )(implicit logCtx: LoggingContext): Future[Either[ValidationFailed, LogResult]] =
+  )(implicit loggingContext: LoggingContext): Future[Either[ValidationFailed, LogResult]] =
     runValidation(
       envelope,
       correlationId,
@@ -110,7 +110,7 @@ class SubmissionValidator[LogResult] private[validator] (
           LogEntryAndState,
           LedgerStateOperations[LogResult]) => Future[U]
   ): Future[Either[ValidationFailed, U]] =
-    newLoggingContext { implicit logCtx =>
+    newLoggingContext { implicit loggingContext =>
       runValidation(
         envelope,
         correlationId,
@@ -153,7 +153,7 @@ class SubmissionValidator[LogResult] private[validator] (
           LedgerStateOperations[LogResult],
       ) => Future[T],
       postProcessResultTimer: Option[Timer],
-  )(implicit logCtx: LoggingContext): Future[Either[ValidationFailed, T]] =
+  )(implicit loggingContext: LoggingContext): Future[Either[ValidationFailed, T]] =
     metrics.daml.kvutils.submission.validator.openEnvelope
       .time(() => Envelope.open(envelope)) match {
       case Right(Envelope.SubmissionBatchMessage(batch)) =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
@@ -50,7 +50,7 @@ class ValidatingCommitter[LogResult](
       envelope: Bytes,
       submittingParticipantId: ParticipantId,
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
-    newLoggingContext("correlationId" -> correlationId) { implicit logCtx =>
+    newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
       validator
         .validateAndCommitWithLoggingContext(
           envelope,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -261,7 +261,8 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
       commitStrategy: CommitStrategy[CommitResult])(
       implicit materializer: Materializer,
       executionContext: ExecutionContext,
-      loggingContext: LoggingContext): Future[Unit] =
+      loggingContext: LoggingContext,
+  ): Future[Unit] =
     indexedSubmissions
     // Fetch the submission inputs in parallel.
       .mapAsyncUnordered[Outputs1](params.readParallelism) {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/ConflictDetection.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/ConflictDetection.scala
@@ -24,7 +24,7 @@ class ConflictDetection(val damlMetrics: Metrics) {
     * @param inputState input state used for the submission
     * @param logEntry log entry generated from processing the submission
     * @param outputState  output state generated from processing the submission
-    * @param logCtx logging context to use
+    * @param loggingContext logging context to use
     * @return pair of invalidated keys and output log entry and state; in case a conflict cannot be
     *         recovered None is output
     */
@@ -32,7 +32,7 @@ class ConflictDetection(val damlMetrics: Metrics) {
       invalidatedKeys: collection.Set[DamlStateKey],
       inputState: Map[DamlStateKey, Option[DamlStateValue]],
       logEntry: DamlLogEntry,
-      outputState: Map[DamlStateKey, DamlStateValue])(implicit logCtx: LoggingContext)
+      outputState: Map[DamlStateKey, DamlStateValue])(implicit loggingContext: LoggingContext)
     : Option[(collection.Set[DamlStateKey], (DamlLogEntry, Map[DamlStateKey, DamlStateValue]))] = {
     val newInvalidatedKeys = outputState.collect {
       case (key, outputValue)
@@ -54,7 +54,7 @@ class ConflictDetection(val damlMetrics: Metrics) {
   private def changedStateValueOf(
       key: DamlStateKey,
       inputValueMaybe: Option[DamlStateValue],
-      outputValue: DamlStateValue)(implicit logCtx: LoggingContext): Boolean =
+      outputValue: DamlStateValue)(implicit loggingContext: LoggingContext): Boolean =
     inputValueMaybe.forall { inputValue =>
       val contentsDiffer = inputValue.hashCode() != outputValue
         .hashCode() || inputValue != outputValue

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -39,7 +39,7 @@ class PreExecutingSubmissionValidator[WriteSet](
       submittingParticipantId: ParticipantId,
       ledgerStateReader: DamlLedgerStateReaderWithFingerprints,
   )(implicit executionContext: ExecutionContext): Future[PreExecutionOutput[WriteSet]] =
-    newLoggingContext("correlationId" -> correlationId) { implicit logCtx =>
+    newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
       Timed.timedAndTrackedFuture(
         metrics.daml.kvutils.submission.validator.validatePreExecute,
         metrics.daml.kvutils.submission.validator.validatePreExecuteRunning,
@@ -75,7 +75,7 @@ class PreExecutingSubmissionValidator[WriteSet](
 
   private def decodeSubmission(submissionEnvelope: Bytes)(
       implicit executionContext: ExecutionContext,
-      logCtx: LoggingContext): Future[DamlSubmission] =
+      loggingContext: LoggingContext): Future[DamlSubmission] =
     Timed.timedAndTrackedFuture(
       metrics.daml.kvutils.submission.validator.decode,
       metrics.daml.kvutils.submission.validator.decodeRunning,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -75,7 +75,8 @@ class PreExecutingSubmissionValidator[WriteSet](
 
   private def decodeSubmission(submissionEnvelope: Bytes)(
       implicit executionContext: ExecutionContext,
-      loggingContext: LoggingContext): Future[DamlSubmission] =
+      loggingContext: LoggingContext,
+  ): Future[DamlSubmission] =
     Timed.timedAndTrackedFuture(
       metrics.daml.kvutils.submission.validator.decode,
       metrics.daml.kvutils.submission.validator.decodeRunning,

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/ParticipantStateIntegrationSpecBase.scala
@@ -59,7 +59,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)(
       participantId: ParticipantId,
       testId: String,
       metrics: Metrics,
-  )(implicit logCtx: LoggingContext): ResourceOwner[ParticipantState]
+  )(implicit loggingContext: LoggingContext): ResourceOwner[ParticipantState]
 
   private def participantState: ResourceOwner[ParticipantState] =
     newParticipantState(Ref.LedgerString.assertFromString(UUID.randomUUID.toString))
@@ -67,7 +67,7 @@ abstract class ParticipantStateIntegrationSpecBase(implementationName: String)(
   private def newParticipantState(
       ledgerId: LedgerId,
   ): ResourceOwner[ParticipantState] =
-    newLoggingContext { implicit logCtx =>
+    newLoggingContext { implicit loggingContext =>
       participantStateFactory(ledgerId, participantId, testId, new Metrics(new MetricRegistry))
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriterSpec.scala
@@ -51,7 +51,7 @@ class BatchingLedgerWriterSpec
       val batchCaptor = MockitoHelpers.captor[kvutils.Bytes]
       val mockWriter = createMockWriter(captor = Some(batchCaptor))
       val batchingWriter =
-        LoggingContext.newLoggingContext { implicit logCtx =>
+        LoggingContext.newLoggingContext { implicit loggingContext =>
           new BatchingLedgerWriter(immediateBatchingQueue, mockWriter)
         }
       val expectedBatch = createExpectedBatch(aCorrelationId -> aSubmission)
@@ -71,7 +71,7 @@ class BatchingLedgerWriterSpec
       val mockWriter =
         createMockWriter(captor = None, submissionResult = SubmissionResult.Overloaded)
       val batchingWriter =
-        LoggingContext.newLoggingContext { implicit logCtx =>
+        LoggingContext.newLoggingContext { implicit loggingContext =>
           new BatchingLedgerWriter(immediateBatchingQueue, mockWriter)
         }
       for {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/ConflictDetectionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/ConflictDetectionSpec.scala
@@ -23,7 +23,7 @@ class ConflictDetectionSpec extends AsyncWordSpec with Matchers with Inside with
       val conflictDetection = new ConflictDetection(damlMetrics)
 
       val Some((actualInvalidatedKeys, result)) = LoggingContext.newLoggingContext {
-        implicit logCtx =>
+        implicit loggingContext =>
           conflictDetection.detectConflictsAndRecover(
             invalidatedKeys = Set.empty,
             inputState = Map(aliceKey -> None),
@@ -42,13 +42,14 @@ class ConflictDetectionSpec extends AsyncWordSpec with Matchers with Inside with
       val outputState = Map(aliceKey -> DamlStateValue.getDefaultInstance)
       val conflictDetection = new ConflictDetection(metrics())
 
-      val Some((actualInvalidatedKeys, _)) = LoggingContext.newLoggingContext { implicit logCtx =>
-        conflictDetection.detectConflictsAndRecover(
-          invalidatedKeys = Set.empty,
-          inputState = Map.empty,
-          logEntry = aPartyLogEntry("Alice"),
-          outputState = outputState
-        )
+      val Some((actualInvalidatedKeys, _)) = LoggingContext.newLoggingContext {
+        implicit loggingContext =>
+          conflictDetection.detectConflictsAndRecover(
+            invalidatedKeys = Set.empty,
+            inputState = Map.empty,
+            logEntry = aPartyLogEntry("Alice"),
+            outputState = outputState
+          )
       }
 
       actualInvalidatedKeys should be(Set(aliceKey))
@@ -59,7 +60,7 @@ class ConflictDetectionSpec extends AsyncWordSpec with Matchers with Inside with
       val outputState = Map(aliceKey -> DamlStateValue.getDefaultInstance)
       val conflictDetection = new ConflictDetection(metrics())
 
-      val result = LoggingContext.newLoggingContext { implicit logCtx =>
+      val result = LoggingContext.newLoggingContext { implicit loggingContext =>
         conflictDetection.detectConflictsAndRecover(
           invalidatedKeys = Set(aliceKey),
           inputState = Map.empty,
@@ -80,7 +81,7 @@ class ConflictDetectionSpec extends AsyncWordSpec with Matchers with Inside with
       val conflictDetectionMetrics = damlMetrics.daml.kvutils.conflictdetection
       val conflictDetection = new ConflictDetection(damlMetrics)
 
-      val result = LoggingContext.newLoggingContext { implicit logCtx =>
+      val result = LoggingContext.newLoggingContext { implicit loggingContext =>
         conflictDetection.detectConflictsAndRecover(
           invalidatedKeys = invalidatedKeys,
           inputState = Map(aliceKey -> None),
@@ -106,7 +107,7 @@ class ConflictDetectionSpec extends AsyncWordSpec with Matchers with Inside with
       val conflictDetectionMetrics = damlMetrics.daml.kvutils.conflictdetection
       val conflictDetection = new ConflictDetection(damlMetrics)
 
-      val result = LoggingContext.newLoggingContext { implicit logCtx =>
+      val result = LoggingContext.newLoggingContext { implicit loggingContext =>
         conflictDetection.detectConflictsAndRecover(
           invalidatedKeys = invalidatedKeys,
           inputState = invalidatedKeys.map(_ -> None).toMap,
@@ -161,7 +162,7 @@ class ConflictDetectionSpec extends AsyncWordSpec with Matchers with Inside with
       val conflictDetection = new ConflictDetection(damlMetrics)
 
       val Some((actualInvalidatedKeys, result)) = LoggingContext.newLoggingContext {
-        implicit logCtx =>
+        implicit loggingContext =>
           conflictDetection.detectConflictsAndRecover(
             invalidatedKeys = Set.empty,
             inputState = Map(aliceKey -> Some(aStateValue)),
@@ -192,7 +193,7 @@ class ConflictDetectionSpec extends AsyncWordSpec with Matchers with Inside with
       val conflictDetection = new ConflictDetection(damlMetrics)
 
       val Some((actualInvalidatedKeys, result)) = LoggingContext.newLoggingContext {
-        implicit logCtx =>
+        implicit loggingContext =>
           conflictDetection.detectConflictsAndRecover(
             invalidatedKeys = Set.empty,
             inputState = Map(aliceKey -> Some(inputStateValue)),
@@ -214,7 +215,7 @@ class ConflictDetectionSpec extends AsyncWordSpec with Matchers with Inside with
     val outputState = Map(key -> DamlStateValue.getDefaultInstance)
     val invalidatedKeys = Set(key)
     val Some((_, (newLogEntry, newOutputState))) = LoggingContext.newLoggingContext {
-      implicit logCtx =>
+      implicit loggingContext =>
         conflictDetection.detectConflictsAndRecover(
           invalidatedKeys = invalidatedKeys,
           inputState = Map(key -> None),

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -236,7 +236,7 @@ object RecoveringIndexerIntegrationSpec {
   private object SimpleParticipantState extends ParticipantStateFactory {
     override def apply(ledgerId: LedgerId, participantId: ParticipantId)(
         implicit materializer: Materializer,
-        loggingContext: LoggingContext
+        loggingContext: LoggingContext,
     ): ResourceOwner[ParticipantState] = {
       val metrics = new Metrics(new MetricRegistry)
       new InMemoryLedgerReaderWriter.SingleParticipantOwner(
@@ -252,7 +252,7 @@ object RecoveringIndexerIntegrationSpec {
   private object ParticipantStateThatFailsOften extends ParticipantStateFactory {
     override def apply(ledgerId: LedgerId, participantId: ParticipantId)(
         implicit materializer: Materializer,
-        loggingContext: LoggingContext
+        loggingContext: LoggingContext,
     ): ResourceOwner[ParticipantState] =
       SimpleParticipantState(ledgerId, participantId)
         .map { delegate =>

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -167,7 +167,7 @@ final class SandboxServer(
 
   def resetAndRestartServer()(
       implicit executionContext: ExecutionContext,
-      logCtx: LoggingContext,
+      loggingContext: LoggingContext,
   ): Future[Unit] = {
     val apiServicesClosed = apiServer.flatMap(_.servicesClosed())
 
@@ -228,7 +228,7 @@ final class SandboxServer(
       packageStore: InMemoryPackageStore,
       startMode: SqlStartMode,
       currentPort: Option[Port],
-  )(implicit logCtx: LoggingContext): Resource[ApiServer] = {
+  )(implicit loggingContext: LoggingContext): Resource[ApiServer] = {
     implicit val _materializer: Materializer = materializer
     implicit val actorSystem: ActorSystem = materializer.system
     implicit val executionContext: ExecutionContext = materializer.executionContext
@@ -330,7 +330,7 @@ final class SandboxServer(
         metrics = metrics,
         healthChecks = healthChecks,
         seedService = seedingService,
-      )(materializer, executionSequencerFactory, logCtx)
+      )(materializer, executionSequencerFactory, loggingContext)
         .map(_.withServices(List(resetService)))
       apiServer <- new LedgerApiServer(
         apiServicesOwner,
@@ -375,7 +375,7 @@ final class SandboxServer(
   }
 
   private def start(): Future[SandboxState] = {
-    newLoggingContext(logging.participantId(config.participantId)) { implicit logCtx =>
+    newLoggingContext(logging.participantId(config.participantId)) { implicit loggingContext =>
       val packageStore = loadDamlPackages()
       val apiServerResource = buildAndStartApiServer(
         materializer,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -23,6 +23,7 @@ import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.{ImmArray, Time}
 import com.daml.lf.transaction.TransactionCommitter
 import com.daml.logging.LoggingContext
+import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.common.LedgerIdMode
 import com.daml.platform.configuration.ServerRole
@@ -70,7 +71,8 @@ object SandboxIndexAndWriteService {
       lfValueTranslationCache: LfValueTranslation.Cache,
   )(
       implicit mat: Materializer,
-      loggingContext: LoggingContext): ResourceOwner[IndexAndWriteService] =
+      loggingContext: LoggingContext,
+  ): ResourceOwner[IndexAndWriteService] =
     new SqlLedger.Owner(
       name = name,
       serverRole = ServerRole.Sandbox,
@@ -101,7 +103,10 @@ object SandboxIndexAndWriteService {
       transactionCommitter: TransactionCommitter,
       templateStore: InMemoryPackageStore,
       metrics: Metrics,
-  )(implicit mat: Materializer): ResourceOwner[IndexAndWriteService] = {
+  )(
+      implicit mat: Materializer,
+      loggingContext: LoggingContext,
+  ): ResourceOwner[IndexAndWriteService] = {
     val ledger =
       new InMemoryLedger(
         initialLedgerId.or(new LedgerIdGenerator(name).generateRandomId()),
@@ -120,7 +125,10 @@ object SandboxIndexAndWriteService {
       participantId: ParticipantId,
       initialConfig: Configuration,
       timeProvider: TimeProvider,
-  )(implicit mat: Materializer): ResourceOwner[IndexAndWriteService] = {
+  )(
+      implicit mat: Materializer,
+      loggingContext: LoggingContext,
+  ): ResourceOwner[IndexAndWriteService] = {
     val indexSvc = new LedgerBackedIndexService(ledger, participantId)
     val writeSvc = new LedgerBackedWriteService(ledger, timeProvider)
 
@@ -129,7 +137,8 @@ object SandboxIndexAndWriteService {
         TimeProvider.UTC,
         10.minutes,
         "deduplication cache maintenance",
-        ledger.removeExpiredDeduplicationData)
+        ledger.removeExpiredDeduplicationData,
+      )
     } yield
       new IndexAndWriteService {
         override val indexService: IndexService = indexSvc
@@ -170,37 +179,53 @@ object SandboxIndexAndWriteService {
   }
 }
 
-class LedgerBackedWriteService(ledger: Ledger, timeProvider: TimeProvider) extends WriteService {
+final class LedgerBackedWriteService(ledger: Ledger, timeProvider: TimeProvider)(
+    implicit loggingContext: LoggingContext,
+) extends WriteService {
 
   override def currentHealth(): HealthStatus = ledger.currentHealth()
 
+  // TODO DO NOT PASS THE REVIEW IF THE LOGGING CONTEXT INFO IS NOT ADDED HERE
   override def submitTransaction(
       submitterInfo: ParticipantState.SubmitterInfo,
       transactionMeta: ParticipantState.TransactionMeta,
-      transaction: SubmittedTransaction): CompletionStage[ParticipantState.SubmissionResult] =
-    FutureConverters.toJava(ledger.publishTransaction(submitterInfo, transactionMeta, transaction))
+      transaction: SubmittedTransaction,
+  ): CompletionStage[ParticipantState.SubmissionResult] =
+    withEnrichedLoggingContext(Map.empty[String, String]) { implicit loggingContext =>
+      FutureConverters.toJava(
+        ledger.publishTransaction(submitterInfo, transactionMeta, transaction))
+    }
 
+  // TODO DO NOT PASS THE REVIEW IF THE LOGGING CONTEXT INFO IS NOT ADDED HERE
   override def allocateParty(
       hint: Option[Party],
       displayName: Option[String],
-      submissionId: SubmissionId): CompletionStage[SubmissionResult] = {
-    val party = hint.getOrElse(PartyIdGenerator.generateRandomId())
-    FutureConverters.toJava(ledger.publishPartyAllocation(submissionId, party, displayName))
-  }
+      submissionId: SubmissionId): CompletionStage[SubmissionResult] =
+    withEnrichedLoggingContext(Map.empty[String, String]) { implicit loggingContext =>
+      val party = hint.getOrElse(PartyIdGenerator.generateRandomId())
+      FutureConverters.toJava(ledger.publishPartyAllocation(submissionId, party, displayName))
+    }
 
   // WritePackagesService
+  // TODO DO NOT PASS THE REVIEW IF THE LOGGING CONTEXT INFO IS NOT ADDED HERE
   override def uploadPackages(
       submissionId: SubmissionId,
       payload: List[Archive],
       sourceDescription: Option[String]
   ): CompletionStage[SubmissionResult] =
-    FutureConverters.toJava(
-      ledger.uploadPackages(submissionId, timeProvider.getCurrentTime, sourceDescription, payload))
+    withEnrichedLoggingContext(Map.empty[String, String]) { implicit loggingContext =>
+      FutureConverters.toJava(
+        ledger
+          .uploadPackages(submissionId, timeProvider.getCurrentTime, sourceDescription, payload))
+    }
 
   // WriteConfigService
+  // TODO DO NOT PASS THE REVIEW IF THE LOGGING CONTEXT INFO IS NOT ADDED HERE
   override def submitConfiguration(
       maxRecordTime: Time.Timestamp,
       submissionId: SubmissionId,
       config: Configuration): CompletionStage[SubmissionResult] =
-    FutureConverters.toJava(ledger.publishConfiguration(maxRecordTime, submissionId, config))
+    withEnrichedLoggingContext("" -> "") { implicit loggingContext =>
+      FutureConverters.toJava(ledger.publishConfiguration(maxRecordTime, submissionId, config))
+    }
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -68,7 +68,9 @@ object SandboxIndexAndWriteService {
       eventsPageSize: Int,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
-  )(implicit mat: Materializer, logCtx: LoggingContext): ResourceOwner[IndexAndWriteService] =
+  )(
+      implicit mat: Materializer,
+      loggingContext: LoggingContext): ResourceOwner[IndexAndWriteService] =
     new SqlLedger.Owner(
       name = name,
       serverRole = ServerRole.Sandbox,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Ledger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/Ledger.scala
@@ -13,6 +13,7 @@ import com.daml.lf.engine.Blinding
 import com.daml.lf.transaction.{NodeId, TransactionCommitter}
 import com.daml.lf.value.Value.ContractId
 import com.daml.daml_lf_dev.DamlLf.Archive
+import com.daml.logging.LoggingContext
 import com.daml.platform.store.ReadOnlyLedger
 
 import scala.concurrent.Future
@@ -22,30 +23,30 @@ trait Ledger extends ReadOnlyLedger {
   def publishTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
-      transaction: SubmittedTransaction
-  ): Future[SubmissionResult]
+      transaction: SubmittedTransaction,
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult]
 
   // Party management
   def publishPartyAllocation(
       submissionId: SubmissionId,
       party: Party,
-      displayName: Option[String]
-  ): Future[SubmissionResult]
+      displayName: Option[String],
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult]
 
   // Package management
   def uploadPackages(
       submissionId: SubmissionId,
       knownSince: Instant,
       sourceDescription: Option[String],
-      payload: List[Archive]
-  ): Future[SubmissionResult]
+      payload: List[Archive],
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult]
 
   // Configuration management
   def publishConfiguration(
       maxRecordTime: Timestamp,
       submissionId: String,
-      config: Configuration
-  ): Future[SubmissionResult]
+      config: Configuration,
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult]
 
 }
 

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/MeteredLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/MeteredLedger.scala
@@ -9,6 +9,7 @@ import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.ledger.participant.state.v1._
 import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Time
+import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.index.MeteredReadOnlyLedger
 
@@ -21,7 +22,8 @@ private class MeteredLedger(ledger: Ledger, metrics: Metrics)
   override def publishTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
-      transaction: SubmittedTransaction): Future[SubmissionResult] =
+      transaction: SubmittedTransaction,
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     Timed.future(
       metrics.daml.index.publishTransaction,
       ledger.publishTransaction(submitterInfo, transactionMeta, transaction))
@@ -29,7 +31,8 @@ private class MeteredLedger(ledger: Ledger, metrics: Metrics)
   def publishPartyAllocation(
       submissionId: SubmissionId,
       party: Party,
-      displayName: Option[String]): Future[SubmissionResult] =
+      displayName: Option[String],
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     Timed.future(
       metrics.daml.index.publishPartyAllocation,
       ledger.publishPartyAllocation(submissionId, party, displayName))
@@ -38,7 +41,8 @@ private class MeteredLedger(ledger: Ledger, metrics: Metrics)
       submissionId: SubmissionId,
       knownSince: Instant,
       sourceDescription: Option[String],
-      payload: List[Archive]): Future[SubmissionResult] =
+      payload: List[Archive],
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     Timed.future(
       metrics.daml.index.uploadPackages,
       ledger.uploadPackages(submissionId, knownSince, sourceDescription, payload))
@@ -46,7 +50,8 @@ private class MeteredLedger(ledger: Ledger, metrics: Metrics)
   override def publishConfiguration(
       maxRecordTime: Time.Timestamp,
       submissionId: String,
-      config: Configuration): Future[SubmissionResult] =
+      config: Configuration,
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     Timed.future(
       metrics.daml.index.publishConfiguration,
       ledger.publishConfiguration(maxRecordTime, submissionId, config))

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -50,6 +50,7 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse
 }
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.platform.index.TransactionConversion
 import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.participant.util.LfEngineToApi
@@ -65,7 +66,6 @@ import com.daml.platform.store.entries.{
 }
 import com.daml.platform.store.CompletionFromTransaction
 import com.daml.platform.{ApiOffset, index}
-import org.slf4j.LoggerFactory
 import scalaz.syntax.tag.ToTagOps
 
 import scala.concurrent.Future
@@ -95,7 +95,7 @@ class InMemoryLedger(
     ledgerEntries: ImmArray[LedgerEntryOrBump],
 ) extends Ledger {
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  private val logger = ContextualizedLogger.get(this.getClass)
 
   private val entries = {
     val l = new LedgerEntries[InMemoryEntry](_.toString)
@@ -128,7 +128,7 @@ class InMemoryLedger(
       endInclusive: Option[Offset],
       filter: Map[Party, Set[Ref.Identifier]],
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionsResponse), NotUsed] =
+  )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] =
     entries
       .getSource(startExclusive, endInclusive)
       .flatMapConcat {
@@ -157,7 +157,8 @@ class InMemoryLedger(
       endInclusive: Option[Offset],
       requestingParties: Set[Party],
       verbose: Boolean,
-  ): Source[(Offset, GetTransactionTreesResponse), NotUsed] =
+  )(implicit loggingContext: LoggingContext)
+    : Source[(Offset, GetTransactionTreesResponse), NotUsed] =
     entries
       .getSource(startExclusive, endInclusive)
       .flatMapConcat {
@@ -185,7 +186,8 @@ class InMemoryLedger(
       startExclusive: Option[Offset],
       endInclusive: Option[Offset],
       applicationId: ApplicationId,
-      parties: Set[Party]): Source[(Offset, CompletionStreamResponse), NotUsed] =
+      parties: Set[Party],
+  )(implicit loggingContext: LoggingContext): Source[(Offset, CompletionStreamResponse), NotUsed] =
     entries
       .getSource(startExclusive, endInclusive)
       .collect {
@@ -193,12 +195,13 @@ class InMemoryLedger(
       }
       .collect(CompletionFromTransaction(applicationId.unwrap, parties))
 
-  override def ledgerEnd: Offset = entries.ledgerEnd
+  override def ledgerEnd()(implicit loggingContext: LoggingContext): Offset = entries.ledgerEnd
 
   override def activeContracts(
       filter: Map[Party, Set[Ref.Identifier]],
       verbose: Boolean,
-  ): (Source[GetActiveContractsResponse, NotUsed], Offset) = {
+  )(implicit loggingContext: LoggingContext)
+    : (Source[GetActiveContractsResponse, NotUsed], Offset) = {
     val (acsNow, ledgerEndNow) = this.synchronized { (acs, ledgerEnd) }
     (
       Source
@@ -245,7 +248,8 @@ class InMemoryLedger(
   override def lookupContract(
       contractId: ContractId,
       forParty: Party
-  ): Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
+  )(implicit loggingContext: LoggingContext)
+    : Future[Option[ContractInst[Value.VersionedValue[ContractId]]]] =
     Future.successful(this.synchronized {
       acs.activeContracts
         .get(contractId)
@@ -253,12 +257,16 @@ class InMemoryLedger(
         .map(_.contract)
     })
 
-  override def lookupKey(key: GlobalKey, forParty: Party): Future[Option[ContractId]] =
+  override def lookupKey(key: GlobalKey, forParty: Party)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[ContractId]] =
     Future.successful(this.synchronized {
       acs.keys.get(key).filter(acs.isVisibleForStakeholders(_, forParty))
     })
 
-  override def lookupMaximumLedgerTime(contractIds: Set[ContractId]): Future[Option[Instant]] =
+  override def lookupMaximumLedgerTime(contractIds: Set[ContractId])(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Instant]] =
     if (contractIds.isEmpty) {
       Future.failed(
         new IllegalArgumentException(
@@ -281,7 +289,8 @@ class InMemoryLedger(
   override def publishTransaction(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
-      transaction: SubmittedTransaction): Future[SubmissionResult] =
+      transaction: SubmittedTransaction,
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     Future.successful(
       this.synchronized[SubmissionResult] {
         handleSuccessfulTx(entries.nextTransactionId, submitterInfo, transactionMeta, transaction)
@@ -290,7 +299,9 @@ class InMemoryLedger(
     )
 
   // Validates the given ledger time according to the ledger time model
-  private def checkTimeModel(ledgerTime: Instant, recordTime: Instant): Either[String, Unit] = {
+  private def checkTimeModel(ledgerTime: Instant, recordTime: Instant)(
+      implicit loggingContext: LoggingContext,
+  ): Either[String, Unit] = {
     ledgerConfiguration
       .fold[Either[String, Unit]](
         Left("No ledger configuration available, cannot validate ledger time")
@@ -303,7 +314,8 @@ class InMemoryLedger(
       transactionId: LedgerString,
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
-      transaction: SubmittedTransaction): Unit = {
+      transaction: SubmittedTransaction,
+  )(implicit loggingContext: LoggingContext): Unit = {
     val ledgerTime = transactionMeta.ledgerEffectiveTime.toInstant
     val recordTime = timeProvider.getCurrentTime
     checkTimeModel(ledgerTime, recordTime)
@@ -354,7 +366,9 @@ class InMemoryLedger(
 
   }
 
-  private def handleError(submitterInfo: SubmitterInfo, reason: RejectionReason): Unit = {
+  private def handleError(submitterInfo: SubmitterInfo, reason: RejectionReason)(
+      implicit loggingContext: LoggingContext,
+  ): Unit = {
     logger.warn(s"Publishing error to ledger: ${reason.description}")
     stopDeduplicatingCommand(CommandId(submitterInfo.commandId), submitterInfo.submitter)
     entries.publish(
@@ -387,7 +401,7 @@ class InMemoryLedger(
   override def lookupFlatTransactionById(
       transactionId: ledger.TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetFlatTransactionResponse]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]] =
     Future.successful {
       lookupTransactionEntry(transactionId).flatMap {
         case (offset, entry) =>
@@ -405,7 +419,7 @@ class InMemoryLedger(
   override def lookupTransactionTreeById(
       transactionId: ledger.TransactionId,
       requestingParties: Set[Party],
-  ): Future[Option[GetTransactionResponse]] =
+  )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]] =
     Future.successful {
       lookupTransactionEntry(transactionId).flatMap {
         case (offset, entry) =>
@@ -420,12 +434,16 @@ class InMemoryLedger(
       }
     }
 
-  override def getParties(parties: Seq[Party]): Future[List[PartyDetails]] =
+  override def getParties(parties: Seq[Party])(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[PartyDetails]] =
     Future.successful(this.synchronized {
       parties.flatMap(party => acs.parties.get(party).toList).toList
     })
 
-  override def listKnownParties(): Future[List[PartyDetails]] =
+  override def listKnownParties()(
+      implicit loggingContext: LoggingContext,
+  ): Future[List[PartyDetails]] =
     Future.successful(this.synchronized {
       acs.parties.values.toList
     })
@@ -434,7 +452,7 @@ class InMemoryLedger(
       submissionId: SubmissionId,
       party: Party,
       displayName: Option[String]
-  ): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     Future.successful(this.synchronized[SubmissionResult] {
       val ids = acs.parties.keySet
       if (ids.contains(party)) {
@@ -444,7 +462,10 @@ class InMemoryLedger(
               submissionId,
               participantId,
               timeProvider.getCurrentTime,
-              "Party already exists")))
+              "Party already exists",
+            )
+          )
+        )
       } else {
         acs = acs.addParty(PartyDetails(party, displayName, isLocal = true))
         entries.publish(
@@ -458,23 +479,32 @@ class InMemoryLedger(
       SubmissionResult.Acknowledged
     })
 
-  override def partyEntries(startExclusive: Offset): Source[(Offset, PartyLedgerEntry), NotUsed] = {
+  override def partyEntries(startExclusive: Offset)(
+      implicit loggingContext: LoggingContext,
+  ): Source[(Offset, PartyLedgerEntry), NotUsed] = {
     entries.getSource(Some(startExclusive), None).collect {
       case (offset, InMemoryPartyEntry(partyEntry)) => (offset, partyEntry)
     }
   }
 
-  override def listLfPackages(): Future[Map[PackageId, PackageDetails]] =
+  override def listLfPackages()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Map[PackageId, PackageDetails]] =
     packageStoreRef.get.listLfPackages()
 
-  override def getLfArchive(packageId: PackageId): Future[Option[Archive]] =
+  override def getLfArchive(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Archive]] =
     packageStoreRef.get.getLfArchive(packageId)
 
-  override def getLfPackage(packageId: PackageId): Future[Option[Ast.Package]] =
+  override def getLfPackage(packageId: PackageId)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[Ast.Package]] =
     packageStoreRef.get.getLfPackage(packageId)
 
-  override def packageEntries(
-      startExclusive: Offset): Source[(Offset, PackageLedgerEntry), NotUsed] =
+  override def packageEntries(startExclusive: Offset)(
+      implicit loggingContext: LoggingContext,
+  ): Source[(Offset, PackageLedgerEntry), NotUsed] =
     entries.getSource(Some(startExclusive), None).collect {
       case (offset, InMemoryPackageEntry(entry)) => (offset, entry)
     }
@@ -483,7 +513,8 @@ class InMemoryLedger(
       submissionId: SubmissionId,
       knownSince: Instant,
       sourceDescription: Option[String],
-      payload: List[Archive]): Future[SubmissionResult] = {
+      payload: List[Archive],
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] = {
 
     val oldStore = packageStoreRef.get
     oldStore
@@ -510,7 +541,8 @@ class InMemoryLedger(
   override def publishConfiguration(
       maxRecordTime: Time.Timestamp,
       submissionId: String,
-      config: Configuration): Future[SubmissionResult] =
+      config: Configuration,
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     Future.successful {
       this.synchronized {
         val recordTime = timeProvider.getCurrentTime
@@ -544,13 +576,17 @@ class InMemoryLedger(
       }
     }
 
-  override def lookupLedgerConfiguration(): Future[Option[(Offset, Configuration)]] =
+  override def lookupLedgerConfiguration()(
+      implicit loggingContext: LoggingContext,
+  ): Future[Option[(Offset, Configuration)]] =
     Future.successful(this.synchronized {
-      ledgerConfiguration.map(config => ledgerEnd -> config)
+      val end = ledgerEnd()
+      ledgerConfiguration.map(config => end -> config)
     })
 
-  override def configurationEntries(
-      startExclusive: Option[Offset]): Source[(Offset, ConfigurationEntry), NotUsed] =
+  override def configurationEntries(startExclusive: Option[Offset])(
+      implicit loggingContext: LoggingContext,
+  ): Source[(Offset, ConfigurationEntry), NotUsed] =
     entries
       .getSource(startExclusive, None)
       .collect {
@@ -566,7 +602,8 @@ class InMemoryLedger(
       commandId: CommandId,
       submitter: Ref.Party,
       submittedAt: Instant,
-      deduplicateUntil: Instant): Future[CommandDeduplicationResult] =
+      deduplicateUntil: Instant,
+  )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult] =
     Future.successful {
       this.synchronized {
         val key = deduplicationKey(commandId, submitter)
@@ -589,7 +626,9 @@ class InMemoryLedger(
       }
     }
 
-  override def removeExpiredDeduplicationData(currentTime: Instant): Future[Unit] =
+  override def removeExpiredDeduplicationData(currentTime: Instant)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Unit] =
     Future.successful {
       this.synchronized {
         commands.retain((_, v) => v.deduplicateUntil.isAfter(currentTime))
@@ -597,7 +636,9 @@ class InMemoryLedger(
       }
     }
 
-  override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party): Future[Unit] =
+  override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party)(
+      implicit loggingContext: LoggingContext,
+  ): Future[Unit] =
     Future.successful {
       val key = deduplicationKey(commandId, submitter)
       this.synchronized {

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -338,7 +338,8 @@ private final class SqlLedger(
   // Validates the given ledger time according to the ledger time model
   private def checkTimeModel(
       ledgerTime: Instant,
-      recordTime: Instant): Either[RejectionReason, Unit] = {
+      recordTime: Instant,
+  ): Either[RejectionReason, Unit] = {
     currentConfiguration
       .get()
       .fold[Either[RejectionReason, Unit]](
@@ -354,7 +355,7 @@ private final class SqlLedger(
       submitterInfo: SubmitterInfo,
       transactionMeta: TransactionMeta,
       transaction: SubmittedTransaction,
-  ): Future[SubmissionResult] =
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     enqueue { offset =>
       val transactionId = offset.toApiString
 
@@ -408,7 +409,8 @@ private final class SqlLedger(
   override def publishPartyAllocation(
       submissionId: SubmissionId,
       party: Party,
-      displayName: Option[String]): Future[SubmissionResult] = {
+      displayName: Option[String],
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] = {
     enqueue { offset =>
       ledgerDao
         .storePartyEntry(
@@ -433,7 +435,8 @@ private final class SqlLedger(
       submissionId: SubmissionId,
       knownSince: Instant,
       sourceDescription: Option[String],
-      payload: List[Archive]): Future[SubmissionResult] = {
+      payload: List[Archive],
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] = {
     val packages = payload.map(archive =>
       (archive, PackageDetails(archive.getPayload.size().toLong, knownSince, sourceDescription)))
     enqueue { offset =>
@@ -456,7 +459,8 @@ private final class SqlLedger(
   override def publishConfiguration(
       maxRecordTime: Time.Timestamp,
       submissionId: String,
-      config: Configuration): Future[SubmissionResult] =
+      config: Configuration,
+  )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     enqueue { offset =>
       val recordTime = timeProvider.getCurrentTime
       val mrt = maxRecordTime.toInstant

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -66,7 +66,7 @@ object SqlLedger {
       eventsPageSize: Int,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
-  )(implicit mat: Materializer, logCtx: LoggingContext)
+  )(implicit mat: Materializer, loggingContext: LoggingContext)
       extends ResourceOwner[Ledger] {
 
     private val logger = ContextualizedLogger.get(this.getClass)
@@ -318,7 +318,7 @@ private final class SqlLedger(
     packages: InMemoryPackageStore,
     persistenceQueue: PersistenceQueue,
     transactionCommitter: TransactionCommitter,
-)(implicit mat: Materializer, logCtx: LoggingContext)
+)(implicit mat: Materializer, loggingContext: LoggingContext)
     extends BaseLedger(ledgerId, ledgerDao, dispatcher)
     with Ledger {
 

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
@@ -60,7 +60,7 @@ object LedgerResource {
   )(
       implicit executionContext: ExecutionContext,
       materializer: Materializer,
-      logCtx: LoggingContext,
+      loggingContext: LoggingContext,
   ): Resource[Ledger] =
     new OwnedResource(
       for {

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/persistence/PostgresIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/persistence/PostgresIT.scala
@@ -25,7 +25,7 @@ class PostgresIT extends AsyncWordSpec with Matchers with PostgresAroundAll with
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    newLoggingContext { implicit logCtx =>
+    newLoggingContext { implicit loggingContext =>
       connectionProviderResource = HikariJdbcConnectionProvider
         .owner(
           ServerRole.Testing(getClass),
@@ -58,7 +58,7 @@ class PostgresIT extends AsyncWordSpec with Matchers with PostgresAroundAll with
 
   "Flyway" should {
     "execute initialisation script" in {
-      newLoggingContext { implicit logCtx =>
+      newLoggingContext { implicit loggingContext =>
         new FlywayMigrations(postgresDatabase.url).migrate()(DirectExecutionContext)
       }.map { _ =>
         connectionProvider.runSQL(metrics.test.db) { conn =>

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -62,7 +62,7 @@ class TransactionTimeModelComplianceIT
       case BackendType.InMemory =>
         LedgerResource.inMemory(ledgerId, participantId, timeProvider)
       case BackendType.Postgres =>
-        newLoggingContext { implicit logCtx =>
+        newLoggingContext { implicit loggingContext =>
           LedgerResource.postgres(
             getClass,
             ledgerId,

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/TransactionTimeModelComplianceIT.scala
@@ -24,11 +24,9 @@ import com.daml.ledger.api.testing.utils.{
   SuiteResourceManagementAroundEach
 }
 import com.daml.ledger.api.v1.completion.Completion
-import com.daml.ledger.participant.state.v1._
 import com.daml.lf.crypto
 import com.daml.lf.data.{Ref, Time}
 import com.daml.lf.transaction.test.TransactionBuilder
-import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.platform.sandbox.stores.ledger.TransactionTimeModelComplianceIT._
 import com.daml.platform.sandbox.{LedgerResource, MetricsAround}
 import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
@@ -62,15 +60,13 @@ class TransactionTimeModelComplianceIT
       case BackendType.InMemory =>
         LedgerResource.inMemory(ledgerId, participantId, timeProvider)
       case BackendType.Postgres =>
-        newLoggingContext { implicit loggingContext =>
-          LedgerResource.postgres(
-            getClass,
-            ledgerId,
-            participantId,
-            timeProvider,
-            metrics,
-          )
-        }
+        LedgerResource.postgres(
+          getClass,
+          ledgerId,
+          participantId,
+          timeProvider,
+          metrics,
+        )
     }
   }
 

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -17,7 +17,6 @@ import com.daml.lf.archive.DarReader
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.transaction.LegacyTransactionCommitter
 import com.daml.logging.LoggingContext
-import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.common.LedgerIdMode
 import com.daml.platform.configuration.ServerRole
@@ -178,7 +177,7 @@ class SqlLedgerSpec
       packages: List[DamlLf.Archive],
   ): Future[Ledger] = {
     metrics.getNames.forEach(name => { val _ = metrics.remove(name) })
-    val ledger = newLoggingContext { implicit loggingContext =>
+    val ledger =
       new SqlLedger.Owner(
         name = LedgerName(getClass.getSimpleName),
         serverRole = ServerRole.Testing(getClass),
@@ -198,7 +197,6 @@ class SqlLedgerSpec
         metrics = new Metrics(metrics),
         lfValueTranslationCache = LfValueTranslation.Cache.none,
       ).acquire()(system.dispatcher)
-    }
     createdLedgers += ledger
     ledger.asFuture
   }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -16,6 +16,7 @@ import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.archive.DarReader
 import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.transaction.LegacyTransactionCommitter
+import com.daml.logging.LoggingContext
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.common.LedgerIdMode
@@ -47,6 +48,8 @@ class SqlLedgerSpec
     with AkkaBeforeAndAfterAll
     with PostgresAroundEach
     with MetricsAround {
+
+  protected implicit val loggingContext: LoggingContext = LoggingContext.ForTesting
 
   override val timeLimit: Span = scaled(Span(1, Minute))
   implicit override val patienceConfig: PatienceConfig =

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -175,7 +175,7 @@ class SqlLedgerSpec
       packages: List[DamlLf.Archive],
   ): Future[Ledger] = {
     metrics.getNames.forEach(name => { val _ = metrics.remove(name) })
-    val ledger = newLoggingContext { implicit logCtx =>
+    val ledger = newLoggingContext { implicit loggingContext =>
       new SqlLedger.Owner(
         name = LedgerName(getClass.getSimpleName),
         serverRole = ServerRole.Testing(getClass),

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/services/SandboxResetService.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/services/SandboxResetService.scala
@@ -21,7 +21,7 @@ class SandboxResetService(
     ledgerId: LedgerId,
     resetAndRestartServer: () => Future[Unit],
     authorizer: Authorizer,
-)(implicit logCtx: LoggingContext)
+)(implicit loggingContext: LoggingContext)
     extends ResetServiceGrpc.ResetService
     with BindableService
     with ServerInterceptor {

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -94,7 +94,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
     config.timeProviderType.getOrElse(SandboxConfig.DefaultTimeProviderType)
 
   override def acquire()(implicit executionContext: ExecutionContext): Resource[Port] =
-    newLoggingContext { implicit logCtx =>
+    newLoggingContext { implicit loggingContext =>
       implicit val actorSystem: ActorSystem = ActorSystem("sandbox")
       implicit val materializer: Materializer = Materializer(actorSystem)
 

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/ContextualizedLogger.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/ContextualizedLogger.scala
@@ -49,10 +49,12 @@ final class ContextualizedLogger private (val withoutContext: Logger) {
   private def internalOrUnknown(code: Status.Code): Boolean =
     code == Status.Code.INTERNAL || code == Status.Code.UNKNOWN
 
-  private def logError(t: Throwable)(implicit logCtx: LoggingContext): Unit =
+  private def logError(t: Throwable)(implicit loggingContext: LoggingContext): Unit =
     error("Unhandled internal error", t)
 
-  def logErrorsOnCall[Out](implicit logCtx: LoggingContext): PartialFunction[Try[Out], Unit] = {
+  def logErrorsOnCall[Out](
+      implicit loggingContext: LoggingContext,
+  ): PartialFunction[Try[Out], Unit] = {
     case Failure(e @ GrpcException(s, _)) =>
       if (internalOrUnknown(s.getCode)) {
         logError(e)
@@ -61,7 +63,7 @@ final class ContextualizedLogger private (val withoutContext: Logger) {
       logError(e)
   }
 
-  def logErrorsOnStream[Out](implicit logCtx: LoggingContext): Flow[Out, Out, NotUsed] =
+  def logErrorsOnStream[Out](implicit loggingContext: LoggingContext): Flow[Out, Out, NotUsed] =
     Flow[Out].mapError {
       case e @ GrpcException(s, _) =>
         if (internalOrUnknown(s.getCode)) {

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LeveledLogger.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LeveledLogger.scala
@@ -83,12 +83,12 @@ private[logging] sealed abstract class LeveledLogger {
   protected def log(m: Marker, msg: String, t: Throwable): Unit
   protected def log(fmt: String, arg: AnyRef): Unit
 
-  final def apply(msg: => String)(implicit logCtx: LoggingContext): Unit =
+  final def apply(msg: => String)(implicit loggingContext: LoggingContext): Unit =
     if (isEnabled)
-      logCtx.ifEmpty(log(msg))(log(s"$msg (context: {})", _))
+      loggingContext.ifEmpty(log(msg))(log(s"$msg (context: {})", _))
 
-  final def apply(msg: => String, t: Throwable)(implicit logCtx: LoggingContext): Unit =
+  final def apply(msg: => String, t: Throwable)(implicit loggingContext: LoggingContext): Unit =
     if (isEnabled)
-      logCtx.ifEmpty(log(msg, t))(c => log(c, s"$msg (context: $c)", t))
+      loggingContext.ifEmpty(log(msg, t))(c => log(c, s"$msg (context: $c)", t))
 
 }

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
@@ -32,6 +32,8 @@ object LoggingContext {
   )(implicit loggingContext: LoggingContext): A =
     f(loggingContext ++ (kv +: kvs))
 
+  val ForTesting: LoggingContext = new LoggingContext(Map.empty)
+
 }
 
 final class LoggingContext private (ctxMap: Map[String, String]) {

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
@@ -70,7 +70,7 @@ object LoggingContext {
     * Scala case class instance, means embedding some form of string
     * formatting in another (likely to be JSON). This can be difficult
     * to manage and parse, so stick to simple values (strings, numbers,
-    * dates, etc.) and be deliberate in adding
+    * dates, etc.).
     *
     */
   def withEnrichedLoggingContext[A](kv: (String, String), kvs: (String, String)*)(

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
@@ -22,11 +22,57 @@ object LoggingContext {
   ): A =
     newLoggingContext(withEnrichedLoggingContext(kv, kvs: _*)(f)(_))
 
+  /**
+    * ## Principles to follow when enriching the logging context
+    *
+    * ### Don't add values coming from a scope outside of the current method
+    *
+    * If a method receives a value as a parameter, it should trust that,
+    * if it was relevant, the caller already added this value to the context.
+    * Add values to the context as upstream as possible in the call chain.
+    * This ensures to not add duplicates, possibly using slightly different
+    * names to track the same value. The context was implemented to ensure
+    * that values did not have to be passed down the entire call stack to
+    * be logged at relevant points.
+    *
+    * ### Don't dump string representations of complex objects
+    *
+    * The purpose of the context is to be consumed by structured logging
+    * frameworks. Dumping the string representation of an object, like a
+    * Scala case class instance, means embedding some form of string
+    * formatting in another (likely to be JSON). This can be difficult
+    * to manage and parse, so stick to simple values (strings, numbers,
+    * dates, etc.) and be deliberate in adding
+    *
+    */
   def withEnrichedLoggingContext[A](kvs: Map[String, String])(f: LoggingContext => A)(
       implicit loggingContext: LoggingContext,
   ): A =
     f(loggingContext ++ kvs)
 
+  /**
+    * ## Principles to follow when enriching the logging context
+    *
+    * ### Don't add values coming from a scope outside of the current method
+    *
+    * If a method receives a value as a parameter, it should trust that,
+    * if it was relevant, the caller already added this value to the context.
+    * Add values to the context as upstream as possible in the call chain.
+    * This ensures to not add duplicates, possibly using slightly different
+    * names to track the same value. The context was implemented to ensure
+    * that values did not have to be passed down the entire call stack to
+    * be logged at relevant points.
+    *
+    * ### Don't dump string representations of complex objects
+    *
+    * The purpose of the context is to be consumed by structured logging
+    * frameworks. Dumping the string representation of an object, like a
+    * Scala case class instance, means embedding some form of string
+    * formatting in another (likely to be JSON). This can be difficult
+    * to manage and parse, so stick to simple values (strings, numbers,
+    * dates, etc.) and be deliberate in adding
+    *
+    */
   def withEnrichedLoggingContext[A](kv: (String, String), kvs: (String, String)*)(
       f: LoggingContext => A,
   )(implicit loggingContext: LoggingContext): A =

--- a/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
+++ b/libs-scala/contextualized-logging/src/main/scala/com/digitalasset/logging/LoggingContext.scala
@@ -42,7 +42,7 @@ object LoggingContext {
     * Scala case class instance, means embedding some form of string
     * formatting in another (likely to be JSON). This can be difficult
     * to manage and parse, so stick to simple values (strings, numbers,
-    * dates, etc.) and be deliberate in adding
+    * dates, etc.).
     *
     */
   def withEnrichedLoggingContext[A](kvs: Map[String, String])(f: LoggingContext => A)(

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/ContextualizedLoggerIT.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/ContextualizedLoggerIT.scala
@@ -31,13 +31,13 @@ final class ContextualizedLoggerIT extends FlatSpec with Matchers {
   behavior of "ContextualizedLogger"
 
   def testCase(logger: ContextualizedLogger): Unit = {
-    newLoggingContext { implicit logCtx =>
+    newLoggingContext { implicit loggingContext =>
       logger.error("1")
-      withEnrichedLoggingContext("a" -> "1") { implicit logCtx =>
+      withEnrichedLoggingContext("a" -> "1") { implicit loggingContext =>
         logger.error("2")
-        withEnrichedLoggingContext("b" -> "2") { implicit logCtx =>
+        withEnrichedLoggingContext("b" -> "2") { implicit loggingContext =>
           logger.error("3")
-          Await.result(withEnrichedLoggingContext("c" -> "3") { implicit logCtx =>
+          Await.result(withEnrichedLoggingContext("c" -> "3") { implicit loggingContext =>
             Future(logger.error("4"))(concurrent.ExecutionContext.global)
           }, 10.seconds)
           logger.info("3")

--- a/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/ContextualizedLoggerSpec.scala
+++ b/libs-scala/contextualized-logging/src/test/suite/scala/com/digitalasset/logging/ContextualizedLoggerSpec.scala
@@ -19,20 +19,20 @@ final class ContextualizedLoggerSpec
   behavior of "ContextualizedLogger"
 
   it should "leave the logs unchanged if the logging context is empty" in
-    withEmptyContext { logger => implicit logCtx =>
+    withEmptyContext { logger => implicit loggingContext =>
       logger.info("foobar")
       verify(logger.withoutContext).info("foobar")
     }
 
   it should "decorate the logs with the provided context" in
-    withContext("id" -> "foobar") { logger => implicit logCtx =>
+    withContext("id" -> "foobar") { logger => implicit loggingContext =>
       logger.info("a")
       val m = logger.withoutContext
       verify(m).info(eqTo("a (context: {})"), toStringEqTo[AnyRef]("{id=foobar}"))
     }
 
   it should "pass the context via the markers if a throwable is provided" in
-    withContext("id" -> "foo") { logger => implicit logCtx =>
+    withContext("id" -> "foo") { logger => implicit loggingContext =>
       logger.error("a", new IllegalArgumentException("quux"))
       verify(logger.withoutContext).error(
         toStringEqTo[Marker]("{id=foo}"),
@@ -43,15 +43,15 @@ final class ContextualizedLoggerSpec
   def thisThrows(): String = throw new RuntimeException("failed on purpose")
 
   it should "construct log entries lazily based on the required level" in
-    withEmptyContext { logger => implicit logCtx =>
+    withEmptyContext { logger => implicit loggingContext =>
       noException should be thrownBy { logger.debug(s"${thisThrows()}") }
       verify(logger.withoutContext, times(0)).debug(any[String])
     }
 
   it should "always pick the context in the most specific scope" in
-    withContext("i1" -> "x") { logger => implicit logCtx =>
+    withContext("i1" -> "x") { logger => implicit loggingContext =>
       logger.info("a")
-      LoggingContext.withEnrichedLoggingContext("i2" -> "y") { implicit logCtx =>
+      LoggingContext.withEnrichedLoggingContext("i2" -> "y") { implicit loggingContext =>
         logger.info("b")
       }
       logger.info("c")
@@ -62,9 +62,9 @@ final class ContextualizedLoggerSpec
     }
 
   it should "override with values provided in a more specific scope" in
-    withContext("id" -> "foobar") { logger => implicit logCtx =>
+    withContext("id" -> "foobar") { logger => implicit loggingContext =>
       logger.info("a")
-      LoggingContext.withEnrichedLoggingContext("id" -> "quux") { implicit logCtx =>
+      LoggingContext.withEnrichedLoggingContext("id" -> "quux") { implicit loggingContext =>
         logger.info("b")
       }
       logger.info("c")
@@ -75,13 +75,13 @@ final class ContextualizedLoggerSpec
     }
 
   it should "pick the expected context also when executing in a future" in
-    withContext("id" -> "future") { logger => implicit logCtx =>
+    withContext("id" -> "future") { logger => implicit loggingContext =>
       import scala.concurrent.ExecutionContext.Implicits.global
       import scala.concurrent.duration.DurationInt
       import scala.concurrent.{Await, Future}
 
       val f1 = Future { logger.info("a") }
-      LoggingContext.withEnrichedLoggingContext("id" -> "next") { implicit logCtx =>
+      LoggingContext.withEnrichedLoggingContext("id" -> "next") { implicit loggingContext =>
         val f2 = Future { logger.info("b") }
         Await.result(Future.sequence(Seq(f1, f2)), 10.seconds)
       }
@@ -91,9 +91,9 @@ final class ContextualizedLoggerSpec
     }
 
   it should "drop the context if new context is provided at a more specific scope" in
-    withContext("id" -> "foobar") { logger => implicit logCtx =>
+    withContext("id" -> "foobar") { logger => implicit loggingContext =>
       logger.info("a")
-      LoggingContext.newLoggingContext { implicit logCtx =>
+      LoggingContext.newLoggingContext { implicit loggingContext =>
         logger.info("b")
       }
       logger.info("d")
@@ -110,7 +110,7 @@ final class ContextualizedLoggerSpec
     }
 
   it should "allows users to pick and choose between the contextualized logger and the underlying one" in
-    withContext("id" -> "foobar") { logger => implicit logCtx =>
+    withContext("id" -> "foobar") { logger => implicit loggingContext =>
       logger.withoutContext.info("a")
       logger.info("b")
       val m = logger.withoutContext

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ProgramResource.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ProgramResource.scala
@@ -23,7 +23,7 @@ class ProgramResource[T](
   private val executorService = Executors.newCachedThreadPool()
 
   def run(): Unit = {
-    newLoggingContext { implicit logCtx =>
+    newLoggingContext { implicit loggingContext =>
       val resource = {
         implicit val executionContext: ExecutionContext =
           ExecutionContext.fromExecutor(executorService)


### PR DESCRIPTION
Fixes #6837

Spreads usage of LoggingContext and ContextualizedLogger throughout the participant server.

changelog_begin
[Sandbox/Integration Kit] We have enriched the contextual information
exposed by the Ledger API server. You should note richer logging information,
which can be read either via unstructured or structured logging frameworks.
A paragraph on how to configure structured logging has been added to the docs.
For more on the issue, see #6837.
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
