### PR TITLE
Trigger service tests: Make sure toxiproxy server is running before connecting the client

### DIFF
--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -56,19 +56,19 @@ object TriggerServiceFixture {
     val host = InetAddress.getLoopbackAddress
     val isWindows: Boolean = sys.props("os.name").toLowerCase.contains("windows")
 
-    // Launch a toxiproxy instance. Wait on it to be ready to accept
-    // connections.
+    // Launch a Toxiproxy server. Wait on it to be ready to accept connections and
+    // then create a client.
     val toxiProxyExe =
-      if (!isWindows)
-        BazelRunfiles.rlocation("external/toxiproxy_dev_env/bin/toxiproxy-cmd")
-      else
-        BazelRunfiles.rlocation("external/toxiproxy_dev_env/toxiproxy-server-windows-amd64.exe")
-    val toxiProxyPort = LockedFreePort.find()
-    val toxiProxyProc =
-      Process(Seq(toxiProxyExe, "--port", toxiProxyPort.port.value.toString)).run()
-    RetryStrategy.constant(attempts = 3, waitTime = 2.seconds)((_, _) =>
-      Future(toxiProxyPort.testAndUnlock(host)))
-    val toxiProxyClient = new ToxiproxyClient(host.getHostName, toxiProxyPort.port.value)
+      if (!isWindows) BazelRunfiles.rlocation("external/toxiproxy_dev_env/bin/toxiproxy-cmd")
+      else BazelRunfiles.rlocation("external/toxiproxy_dev_env/toxiproxy-server-windows-amd64.exe")
+    val toxiproxyF: Future[(Process, ToxiproxyClient)] = for {
+      toxiproxyPort <- Future(LockedFreePort.find())
+      toxiproxyServer <- Future(
+        Process(Seq(toxiProxyExe, "--port", toxiproxyPort.port.value.toString)).run())
+      _ <- RetryStrategy.constant(attempts = 3, waitTime = 2.seconds)((_, _) =>
+        Future(toxiproxyPort.testAndUnlock(host)))
+      toxiproxyClient = new ToxiproxyClient(host.getHostName, toxiproxyPort.port.value)
+    } yield (toxiproxyServer, toxiproxyClient)
 
     val ledgerId = LedgerId(testName)
     val applicationId = ApplicationId(testName)
@@ -76,7 +76,8 @@ object TriggerServiceFixture {
       ledger <- Future(new SandboxServer(ledgerConfig(Port.Dynamic, dars, ledgerId), mat))
       ledgerPort <- ledger.portF
       ledgerProxyPort = LockedFreePort.find()
-      ledgerProxy = toxiProxyClient.createProxy(
+      (_, toxiproxyClient) <- toxiproxyF
+      ledgerProxy = toxiproxyClient.createProxy(
         "sandbox",
         s"${host.getHostName}:${ledgerProxyPort.port}",
         s"${host.getHostName}:$ledgerPort")
@@ -166,7 +167,7 @@ object TriggerServiceFixture {
       serviceF.foreach({ case (_, system) => system ! Stop })
       refLedgerAuthProcF.foreach({ case (_, proc) => proc.destroy })
       ledgerF.foreach(_._1.close())
-      toxiProxyProc.destroy
+      toxiproxyF.foreach(_._1.destroy)
     }
 
     fa

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -58,13 +58,13 @@ object TriggerServiceFixture {
 
     // Launch a Toxiproxy server. Wait on it to be ready to accept connections and
     // then create a client.
-    val toxiProxyExe =
+    val toxiproxyExe =
       if (!isWindows) BazelRunfiles.rlocation("external/toxiproxy_dev_env/bin/toxiproxy-cmd")
       else BazelRunfiles.rlocation("external/toxiproxy_dev_env/toxiproxy-server-windows-amd64.exe")
     val toxiproxyF: Future[(Process, ToxiproxyClient)] = for {
       toxiproxyPort <- Future(LockedFreePort.find())
       toxiproxyServer <- Future(
-        Process(Seq(toxiProxyExe, "--port", toxiproxyPort.port.value.toString)).run())
+        Process(Seq(toxiproxyExe, "--port", toxiproxyPort.port.value.toString)).run())
       _ <- RetryStrategy.constant(attempts = 3, waitTime = 2.seconds)((_, _) =>
         Future(toxiproxyPort.testAndUnlock(host)))
       toxiproxyClient = new ToxiproxyClient(host.getHostName, toxiproxyPort.port.value)


### PR DESCRIPTION
This fixes an issue where running the trigger service tests locally on a mac would often result in `Connection refused` errors. I believe the problem was attempting to make a request to the Toxiproxy server before finished starting up. There was a `RetryStrategy` to wait for the Toxiproxy server process but it was not executing as it was never sequenced in a Future. I'm not sure why Scalac/Intellij didn't warn about the unassigned value. This may also mean that the Toxiproxy server port was never unlocked, leaking ports across tests.

After this change, I ran `bazel test --runs_per_test=10 //triggers/service:tests` locally and saw a few failed tests but due to the server binding timing out (which is a separate issue).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
