### PR TITLE
Expose lookupContract and lookupKey methods from ScenarioRunner

### DIFF
--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -37,14 +37,18 @@ final case class ScenarioRunner(
   import scala.util.{Try, Success, Failure}
 
   def run(): Either[(SError, ScenarioLedger), (Double, Int, ScenarioLedger, SValue)] =
-    Try(runUnsafe) match {
-      case Failure(SRunnerException(err)) =>
-        Left((err, ledger))
-      case Failure(other) =>
-        throw other
-      case Success(res) =>
-        Right(res)
+    handleUnsafe(runUnsafe) match {
+      case Left(err) => Left((err, ledger))
+      case Right(t) => Right(t)
     }
+
+  private def handleUnsafe[T](unsafe: => T): Either[SError, T] = {
+    Try(unsafe) match {
+      case Failure(SRunnerException(err)) => Left(err)
+      case Failure(other) => throw other
+      case Success(t) => Right(t)
+    }
+  }
 
   private def runUnsafe(): (Double, Int, ScenarioLedger, SValue) = {
     // NOTE(JM): Written with an imperative loop and exceptions for speed
@@ -92,7 +96,7 @@ final case class ScenarioRunner(
           getParty(partyText, callback)
 
         case SResultNeedKey(keyWithMaintainers, committers, cb) =>
-          lookupKey(keyWithMaintainers.globalKey, committers, cb)
+          lookupKeyUnsafe(keyWithMaintainers.globalKey, committers, cb)
       }
     }
     val endTime = System.nanoTime()
@@ -158,7 +162,14 @@ final case class ScenarioRunner(
     callback(ledger.currentTime)
   }
 
-  private def lookupContract(
+  def lookupContract(
+      acoid: ContractId,
+      committers: Set[Party],
+      cbMissing: Unit => Boolean,
+      cbPresent: ContractInst[Tx.Value[ContractId]] => Unit): Either[SError, Unit] =
+    handleUnsafe(lookupContractUnsafe(acoid, committers, cbMissing, cbPresent))
+
+  private def lookupContractUnsafe(
       acoid: ContractId,
       committers: Set[Party],
       cbMissing: Unit => Boolean,
@@ -195,7 +206,14 @@ final case class ScenarioRunner(
     }
   }
 
-  private def lookupKey(
+  def lookupKey(
+      gk: GlobalKey,
+      committers: Set[Party],
+      canContinue: SKeyLookupResult => Boolean,
+  ): Either[SError, Unit] =
+    handleUnsafe(lookupKeyUnsafe(gk, committers, canContinue))
+
+  private def lookupKeyUnsafe(
       gk: GlobalKey,
       committers: Set[Party],
       canContinue: SKeyLookupResult => Boolean,


### PR DESCRIPTION
This is a spinoff from IDE support for DAML Script #6929. There I need
cannot quite use `run` from ScenarioRunner since I need to handle
results differently but I don’t want to replicate all the visibility
and authorization logic from `lookupContract` and `lookupKey`.

This is best viewed together with https://github.com/digital-asset/daml/pull/6929/commits/144736e7cab5367ea0275076af4e13530f191a37 to see how this simplifies things. That commit not only removes the duplication, it also adds support for key lookups which is now trivial to do.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
