### PR TITLE
daml-lf/parser: Add the ability to parse location annotations

### DIFF
--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -42,7 +42,6 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       scenario ^^ EScenario |
       update ^^ EUpdate |
       id ^^ EVar |
-      eLoc |
       `(` ~> expr <~ `)`
 
   lazy val exprs: Parser[List[Expr]] = rep(expr0)
@@ -74,7 +73,8 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
           case (acc, EAppExprArg(e)) => EApp(acc, e)
           case (acc, EAppTypArg(t)) => ETyApp(acc, t)
         }
-    }
+    } |
+      eLoc
   }
 
   private lazy val fieldInit: Parser[(Name, Expr)] = id ~ (`=` ~> expr) ^^ {

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -42,7 +42,8 @@ private[parser] object Lexer extends RegexParsers {
     "to" -> `to`,
     "to_any" -> `to_any`,
     "from_any" -> `from_any`,
-    "type_rep" -> `type_rep`
+    "type_rep" -> `type_rep`,
+    "loc" -> `loc`
   )
 
   val token: Parser[Token] =

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -54,6 +54,7 @@ private[parser] object Token {
   case object `to_any` extends Token
   case object `from_any` extends Token
   case object `type_rep` extends Token
+  case object `loc` extends Token
 
   final case class Id(s: String) extends Token
   final case class ContractId(s: String) extends Token

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -560,7 +560,7 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
   }
 
   "parses location annotations" in {
-    e"loc(Mod, def, 0, 1, 2, 3) 4" shouldEqual
+    e"loc(Mod, def, 0, 1, 2, 3) f" shouldEqual
       ELocation(
         Location(
           defaultPackageId,
@@ -569,8 +569,12 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
           (0, 1),
           (2, 3)
         ),
-        EPrimLit(PLInt64(4)),
+        EVar(n"f"),
       )
+  }
+
+  "rejects bad location annotations" in {
+    a[ParsingError] should be thrownBy e"loc(Mod, def, 0, 1, 2, 3) f g"
   }
 
   private val keywords = Table(

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -559,6 +559,20 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
     }
   }
 
+  "parses location annotations" in {
+    e"loc(Mod, def, 0, 1, 2, 3) 4" shouldEqual
+      ELocation(
+        Location(
+          defaultPackageId,
+          ModuleName.assertFromString("Mod"),
+          "def",
+          (0, 1),
+          (2, 3)
+        ),
+        EPrimLit(PLInt64(4)),
+      )
+  }
+
   private val keywords = Table(
     "forall",
     "let",


### PR DESCRIPTION
Currently, the DAML-LF parser we use for testing in Scala land does not
understand location information and has in particular no way to produce
`ELocation` AST nodes. Having these nodes will be important in a test
for a feature I'm currently working on in order to demonstrate that my
Speedy AST transformation can actually look through location
information properly.

This PR adds a rule to the parser to allow for parsing location
information and producing `ELocation` nodes.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6932)
<!-- Reviewable:end -->
