### PR TITLE
DAML Engine: Speed up updates of multiple fields in a record

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -417,11 +417,20 @@ private[lf] final case class Compiler(
           translate(record),
         )
 
-      case ERecUpd(tapp, field, record, update) =>
-        SBRecUpd(tapp.tycon, lookupRecordIndex(tapp, field))(
-          translate(record),
-          translate(update),
-        )
+      case erecupd: ERecUpd => {
+        val tapp = erecupd.tycon
+        val (record, fields, updates) = collectRecUpds(erecupd)
+        if (fields.length == 1) {
+          SBRecUpd(tapp.tycon, lookupRecordIndex(tapp, fields.head))(
+            translate(record),
+            translate(updates.head),
+          )
+        } else {
+          SBRecUpdMulti(tapp.tycon, fields.map(lookupRecordIndex(tapp, _)).toArray)(
+            (record :: updates).map(translate): _*,
+          )
+        }
+      }
 
       case EStructCon(fields) =>
         SEApp(SEBuiltin(SBStructCon(Name.Array(fields.map(_._1).toSeq: _*))), fields.iterator.map {
@@ -927,6 +936,26 @@ private[lf] final case class Compiler(
         (binding :: bindings, body2)
       case e => (List.empty, e)
     }
+
+  @tailrec
+  private def stripLocs(expr: Expr): Expr =
+    expr match {
+      case ELocation(_, expr1) => stripLocs(expr1)
+      case _ => expr
+    }
+
+  // ERecUpd(_, f2, ERecUpd(_, f1, e0, e1), e2) => (e0, [f1, f2], [e1, e2])
+  private def collectRecUpds(expr: Expr): (Expr, List[Name], List[Expr]) = {
+    @tailrec
+    def go(expr: Expr, fields: List[Name], updates: List[Expr]): (Expr, List[Name], List[Expr]) =
+      stripLocs(expr) match {
+        case ERecUpd(_, field, record, update) =>
+          go(record, field :: fields, update :: updates)
+        case _ =>
+          (expr, fields, updates)
+      }
+    go(expr, List.empty, List.empty)
+  }
 
   private def lookupPackage(pkgId: PackageId): Package =
     if (packages.isDefinedAt(pkgId)) packages(pkgId)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -506,6 +506,8 @@ private[lf] object Pretty {
               ) + char(']')
             case _: SBRecUpd =>
               text("$update")
+            case _: SBRecUpdMulti =>
+              text("$updateMulti")
             case SBRecProj(id, field) =>
               text("$project") + char('[') + text(id.qualifiedName.toString) + char(':') + str(
                 field,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -756,7 +756,8 @@ private[lf] object SBuiltin {
       with SomeArrayEquals {
     override private[speedy] final def execute(
         args: util.ArrayList[SValue],
-        machine: Machine): Unit = {
+        machine: Machine,
+    ): Unit = {
       machine.returnValue = args.get(0) match {
         case SRecord(id2, fields, values) =>
           if (id != id2) {


### PR DESCRIPTION
Currently, updating multiple fields of a single record is not very
efficient. If you update, say, `n` fields, as in
```haskell
  r with f_1 = ...; ...; f_n = ...
```
`n-1` intermediate records are created and almost immediately
discarded. Each creation of an intermediate record involves shallowly
cloning an array of size `m`, where `m` is the number of fields of the
record type. This does not only cost computation time but also a lot of
avoidable memory allocations. Overall, the cost of such an update is
`O(m*n)` in terms of time and memory.

This PR changes the DAML-LF interpreter such that multiple updates of
the same record are batched together. This avoids the creating of any
intermediate records but only creates the final record resulting from
the updates. This reduces the time complexity to `O(m+n)` and the
memory complexity to `O(m)`.

The code path for updating a single record field remains unchanged
(for now) and hence won't suffer from the additional complexity that
is required for the batching described above.

I've benchmarked this change by creating a single record with `m`
fields and updating all `m` fields in one single update expression,
for `m = 10` and `m = 20`. In both cases, the benchmarks showed a
speedup of ca. 2.5x.

This is part of #5766.

CHANGELOG_BEGIN
- [DAML Engine] Record update expressions of the form
  `R with f_1 = E_1; ...; f_n = E_n` are now run as batch updates
  in order to improve runtime performance and avoid unneccesary
  memory allocations.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6937)
<!-- Reviewable:end -->
