### PR TITLE
Remove duplicated tls config parsing from DAML Script/Triggers

### DIFF
--- a/compiler/repl-service/server/BUILD.bazel
+++ b/compiler/repl-service/server/BUILD.bazel
@@ -31,6 +31,7 @@ da_scala_binary(
         "//daml-script/runner:script-runner-lib",
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
+        "//ledger-service/cli-opts",
         "//ledger/ledger-api-common",
         "//libs-scala/auth-utils",
         "@maven//:com_github_scopt_scopt_2_12",

--- a/daml-script/runner/BUILD.bazel
+++ b/daml-script/runner/BUILD.bazel
@@ -23,6 +23,7 @@ da_scala_library(
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
+        "//ledger-service/cli-opts",
         "//ledger-service/jwt",
         "//ledger-service/lf-value-json",
         "//ledger/caching",

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -171,7 +171,7 @@ object Runner {
   private def connectApiParameters(
       params: ApiParameters,
       applicationId: ApplicationId,
-      tlsConfig: Option[TlsConfiguration],
+      tlsConfig: TlsConfiguration,
       maxInboundMessageSize: Int)(
       implicit ec: ExecutionContext,
       seq: ExecutionSequencerFactory): Future[GrpcLedgerClient] = {
@@ -179,7 +179,7 @@ object Runner {
       applicationId = ApplicationId.unwrap(applicationId),
       ledgerIdRequirement = LedgerIdRequirement.none,
       commandClient = CommandClientConfiguration.default,
-      sslContext = tlsConfig.flatMap(_.client),
+      sslContext = tlsConfig.client,
       token = params.access_token,
     )
     LedgerClient
@@ -195,7 +195,7 @@ object Runner {
   def connect(
       participantParams: Participants[ApiParameters],
       applicationId: ApplicationId,
-      tlsConfig: Option[TlsConfiguration],
+      tlsConfig: TlsConfiguration,
       maxInboundMessageSize: Int)(
       implicit ec: ExecutionContext,
       seq: ExecutionSequencerFactory): Future[Participants[GrpcLedgerClient]] = {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerConfig.scala
@@ -8,7 +8,7 @@ import java.io.File
 import java.time.Duration
 import scala.util.Try
 
-import com.daml.ledger.api.tls.TlsConfiguration
+import com.daml.ledger.api.tls.{TlsConfiguration, TlsConfigurationCli}
 
 case class RunnerConfig(
     darPath: File,
@@ -22,7 +22,7 @@ case class RunnerConfig(
     inputFile: Option[File],
     outputFile: Option[File],
     accessTokenFile: Option[Path],
-    tlsConfig: Option[TlsConfiguration],
+    tlsConfig: TlsConfiguration,
     jsonApi: Boolean,
     maxInboundMessageSize: Int,
 )
@@ -101,39 +101,8 @@ object RunnerConfig {
       }
       .text("File from which the access token will be read, required to interact with an authenticated ledger")
 
-    opt[String]("pem")
-      .optional()
-      .text("TLS: The pem file to be used as the private key.")
-      .validate(path => validatePath(path, "The file specified via --pem does not exist"))
-      .action((path, arguments) =>
-        arguments.copy(tlsConfig = arguments.tlsConfig.fold(
-          Some(TlsConfiguration(true, None, Some(new File(path)), None)))(c =>
-          Some(c.copy(keyFile = Some(new File(path)))))))
-
-    opt[String]("crt")
-      .optional()
-      .text("TLS: The crt file to be used as the cert chain. Required for client authentication.")
-      .validate(path => validatePath(path, "The file specified via --crt does not exist"))
-      .action((path, arguments) =>
-        arguments.copy(tlsConfig = arguments.tlsConfig.fold(
-          Some(TlsConfiguration(true, None, Some(new File(path)), None)))(c =>
-          Some(c.copy(keyFile = Some(new File(path)))))))
-
-    opt[String]("cacrt")
-      .optional()
-      .text("TLS: The crt file to be used as the trusted root CA.")
-      .validate(path => validatePath(path, "The file specified via --cacrt does not exist"))
-      .action((path, arguments) =>
-        arguments.copy(tlsConfig = arguments.tlsConfig.fold(
-          Some(TlsConfiguration(true, None, None, Some(new File(path)))))(c =>
-          Some(c.copy(trustCertCollectionFile = Some(new File(path)))))))
-
-    opt[Unit]("tls")
-      .optional()
-      .text("TLS: Enable tls. This is redundant if --pem, --crt or --cacrt are set")
-      .action((path, arguments) =>
-        arguments.copy(tlsConfig =
-          arguments.tlsConfig.fold(Some(TlsConfiguration(true, None, None, None)))(Some(_))))
+    TlsConfigurationCli.parse(this, colSpacer = "        ")((f, c) =>
+      c.copy(tlsConfig = f(c.tlsConfig)))
 
     opt[Unit]("json-api")
       .action { (t, c) =>
@@ -188,7 +157,7 @@ object RunnerConfig {
         inputFile = None,
         outputFile = None,
         accessTokenFile = None,
-        tlsConfig = None,
+        tlsConfig = TlsConfiguration(false, None, None, None),
         jsonApi = false,
         maxInboundMessageSize = DefaultMaxInboundMessageSize,
       )

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -111,7 +111,7 @@ object RunnerMain {
               applicationId = ApplicationId.unwrap(applicationId),
               ledgerIdRequirement = LedgerIdRequirement.none,
               commandClient = CommandClientConfiguration.default,
-              sslContext = config.tlsConfig.flatMap(_.client),
+              sslContext = config.tlsConfig.client,
               token = tokenHolder.flatMap(_.token),
             )
             Runner.connect(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -11,6 +11,7 @@ import akka.stream.Materializer
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
+import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.lf.PureCompiledPackages
 import com.daml.lf.archive.{Dar, DarReader, Decode}
 import com.daml.lf.data.Ref.{Identifier, PackageId, QualifiedName}
@@ -121,7 +122,7 @@ object TestMain extends StrictLogging {
           clients <- Runner.connect(
             participantParams,
             applicationId,
-            None,
+            TlsConfiguration(false, None, None, None),
             config.maxInboundMessageSize,
           )
           _ <- clients.getParticipant(None) match {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -65,8 +65,8 @@ class TestRunner(
 ) {
   val applicationId = ApplicationId("DAML Script Test Runner")
 
-  val tlsConfig =
-    rootCa.map(file => TlsConfiguration.Empty.copy(trustCertCollectionFile = Some(file)))
+  val tlsConfig = rootCa.fold(TlsConfiguration(false, None, None, None))(file =>
+    TlsConfiguration.Empty.copy(trustCertCollectionFile = Some(file)))
 
   val ttl = java.time.Duration.ofSeconds(30)
   val timeMode: ScriptTimeMode =

--- a/triggers/runner/BUILD.bazel
+++ b/triggers/runner/BUILD.bazel
@@ -23,6 +23,7 @@ da_scala_library(
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
+        "//ledger-service/cli-opts",
         "//ledger/ledger-api-common",
         "//libs-scala/auth-utils",
         "@maven//:com_github_scopt_scopt_2_12",

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -3,12 +3,12 @@
 
 package com.daml.lf.engine.trigger
 
-import java.io.File
 import java.nio.file.{Path, Paths}
 import java.time.Duration
 import scala.util.Try
 
 import com.daml.ledger.api.tls.TlsConfiguration
+import com.daml.ledger.api.tls.TlsConfigurationCli
 import com.daml.platform.services.time.TimeProviderType
 
 case class RunnerConfig(
@@ -24,7 +24,7 @@ case class RunnerConfig(
     timeProviderType: Option[TimeProviderType],
     commandTtl: Duration,
     accessTokenFile: Option[Path],
-    tlsConfig: Option[TlsConfiguration],
+    tlsConfig: TlsConfiguration,
 )
 
 object RunnerConfig {
@@ -90,39 +90,8 @@ object RunnerConfig {
       }
       .text("File from which the access token will be read, required to interact with an authenticated ledger")
 
-    opt[String]("pem")
-      .optional()
-      .text("TLS: The pem file to be used as the private key.")
-      .validate(path => validatePath(path, "The file specified via --pem does not exist"))
-      .action((path, arguments) =>
-        arguments.copy(tlsConfig = arguments.tlsConfig.fold(
-          Some(TlsConfiguration(true, None, Some(new File(path)), None)))(c =>
-          Some(c.copy(keyFile = Some(new File(path)))))))
-
-    opt[String]("crt")
-      .optional()
-      .text("TLS: The crt file to be used as the cert chain. Required for client authentication.")
-      .validate(path => validatePath(path, "The file specified via --crt does not exist"))
-      .action((path, arguments) =>
-        arguments.copy(tlsConfig = arguments.tlsConfig.fold(
-          Some(TlsConfiguration(true, None, Some(new File(path)), None)))(c =>
-          Some(c.copy(keyFile = Some(new File(path)))))))
-
-    opt[String]("cacrt")
-      .optional()
-      .text("TLS: The crt file to be used as the trusted root CA.")
-      .validate(path => validatePath(path, "The file specified via --cacrt does not exist"))
-      .action((path, arguments) =>
-        arguments.copy(tlsConfig = arguments.tlsConfig.fold(
-          Some(TlsConfiguration(true, None, None, Some(new File(path)))))(c =>
-          Some(c.copy(trustCertCollectionFile = Some(new File(path)))))))
-
-    opt[Unit]("tls")
-      .optional()
-      .text("TLS: Enable tls. This is redundant if --pem, --crt or --cacrt are set")
-      .action((path, arguments) =>
-        arguments.copy(tlsConfig =
-          arguments.tlsConfig.fold(Some(TlsConfiguration(true, None, None, None)))(Some(_))))
+    TlsConfigurationCli.parse(this, colSpacer = "        ")((f, c) =>
+      c.copy(tlsConfig = f(c.tlsConfig)))
 
     help("help").text("Print this usage text")
 
@@ -176,7 +145,7 @@ object RunnerConfig {
         timeProviderType = None,
         commandTtl = Duration.ofSeconds(30L),
         accessTokenFile = None,
-        tlsConfig = None,
+        tlsConfig = TlsConfiguration(false, None, None, None),
       )
     )
 }

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -82,7 +82,7 @@ object RunnerMain {
           ledgerIdRequirement = LedgerIdRequirement.none,
           commandClient =
             CommandClientConfiguration.default.copy(defaultDeduplicationTime = config.commandTtl),
-          sslContext = config.tlsConfig.flatMap(_.client),
+          sslContext = config.tlsConfig.client,
           token = tokenHolder.flatMap(_.token)
         )
 


### PR DESCRIPTION
This was not only unnecessarily duplicated, it also had a bug where
`--crt` behaved like `--pem` instead of setting the cert chain.

I didn’t add new tests since it seems like the wrong place to test
config parsing of a library. We do have tests for TLS in general for
both DAML Script and DAML Triggers.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
