### PR TITLE
ledger-api-test-tool: When in verbose mode, print exception causes.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
-import java.io.PrintStream
+import java.io.{PrintStream, PrintWriter, StringWriter}
 
 import scala.util.Try
 
@@ -16,16 +16,21 @@ object Reporter {
     private val reset = "\u001b[0m"
 
     private def red(s: String): String = s"\u001b[31m$s$reset"
+
     private def green(s: String): String = s"\u001b[32m$s$reset"
+
     private def yellow(s: String): String = s"\u001b[33m$s$reset"
+
     private def blue(s: String): String = s"\u001b[34m$s$reset"
+
     private def cyan(s: String): String = s"\u001b[36m$s$reset"
 
-    private def render(t: Throwable): Seq[String] =
-      s"${t.getClass.getName}: ${t.getMessage}" +: t.getStackTrace.map(render)
-
-    private def render(e: StackTraceElement): String =
-      s"\tat ${e.getClassName}.${e.getMethodName}(${e.getFileName}:${e.getLineNumber})"
+    private def render(t: Throwable): Iterator[String] = {
+      val stringWriter = new StringWriter
+      val writer = new PrintWriter(stringWriter)
+      t.printStackTrace(writer)
+      stringWriter.toString.linesIterator
+    }
 
     private def extractRelevantLineNumber(t: Throwable): Option[Int] =
       t.getStackTrace


### PR DESCRIPTION
The current implementation of generating stack traces ignores the `cause` of any exception, which means the actual error tends to be masked. This changes the logic to rely on `Throwable::printStackTrace`, which correctly prints the chain of causes too.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
