### PR TITLE
Mark pureconfig-macros as neverlink

### DIFF
--- a/bazel-java-deps.bzl
+++ b/bazel-java-deps.bzl
@@ -6,6 +6,7 @@
 # See https://github.com/bazelbuild/rules_jvm_external#updating-maven_installjson
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@rules_jvm_external//:specs.bzl", "maven")
 
 def install_java_deps():
     maven_install(
@@ -20,6 +21,7 @@ def install_java_deps():
             "com.github.ghik:silencer-lib_2.12.11:1.6.0",
             "com.github.ghik:silencer-plugin_2.12.11:1.6.0",
             "com.github.pureconfig:pureconfig_2.12:0.8.0",
+            maven.artifact("com.github.pureconfig", "pureconfig-macros_2.12", "0.8.0", neverlink = True),
             "com.github.scopt:scopt_2.12:3.7.1",
             "com.google.code.findbugs:jsr305:3.0.2",
             "com.google.code.gson:gson:2.8.2",


### PR DESCRIPTION
pureconfig-macros pulls in the scala-compiler library which in turn
pulls in jansi-native which is somewhat problematic as it’s not
well supported outside of x86. It also just adds roughly 10% unused
junk to the http-json fat JAR. Afaict, pureconfig-macros is only used
at compile time so we can remove it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
