### PR TITLE
Add 'unknown contract' cases in LF spec.

### DIFF
--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2672,6 +2672,12 @@ as described by the ledger model::
        ⇓ᵤ
      Ok (cid, tr) ‖ (st₁, keys₁)
 
+     cid ∉ dom(st₀)
+   —————————————————————————————————————————————————————————————————————— EvUpdExercMissing
+     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀; keys₀)
+       ⇓ᵤ
+     Err "Exercise on unknown contract"
+
      'tpl' (x : T)
          ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
@@ -2768,6 +2774,12 @@ as described by the ledger model::
        ⇓ᵤ
      Ok (vₐ, 'exercise' v₁ (cid, Mod:T, vₜ) 'non-consuming' trₐ) ‖ (st₁, keys₁)
 
+     cid ∉ dom(st₀)
+   —————————————————————————————————————————————————————————————————————— EvUpdExercWithoutActorsMissing
+     'exercise_without_actors' Mod:T.Ch cid v₁ ‖ (st₀, keys₀)  ⇓ᵤ  Err t
+       ⇓ᵤ
+     Err "Exercise on unknown contract"
+
      'tpl' (x : T)
          ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
@@ -2784,6 +2796,12 @@ as described by the ledger model::
      'exercise' Mod:T.Ch cid vₚ v₁ ‖ (st₀, keys₀)  ⇓ᵤ  ur
    —————————————————————————————————————————————————————————————————————— EvUpdExercWithoutActors
      'exercise_without_actors' Mod:T.Ch cid v₁ ‖ (st₀, keys₀)  ⇓ᵤ  ur
+
+     cid ∉ dom(st)
+   —————————————————————————————————————————————————————————————————————— EvUpdFetchMissing
+     'fetch' @Mod:T cid ‖ (st; keys)
+       ⇓ᵤ
+     Err "Exercise on unknown contract"
 
      'tpl' (x : T) ↦ …  ∈  〚Ξ〛Mod
      cid ∈ dom(st)

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2776,7 +2776,7 @@ as described by the ledger model::
 
      cid ∉ dom(st₀)
    —————————————————————————————————————————————————————————————————————— EvUpdExercWithoutActorsMissing
-     'exercise_without_actors' Mod:T.Ch cid v₁ ‖ (st₀, keys₀)  ⇓ᵤ  Err t
+     'exercise_without_actors' Mod:T.Ch cid v₁ ‖ (st₀, keys₀)
        ⇓ᵤ
      Err "Exercise on unknown contract"
 

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2672,9 +2672,9 @@ as described by the ledger model::
        ⇓ᵤ
      Ok (cid, tr) ‖ (st₁, keys₁)
 
-     cid ∉ dom(st₀)
+     cid ∉ dom(st)
    —————————————————————————————————————————————————————————————————————— EvUpdExercMissing
-     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀; keys₀)
+     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st; keys)
        ⇓ᵤ
      Err "Exercise on unknown contract"
 
@@ -2774,9 +2774,9 @@ as described by the ledger model::
        ⇓ᵤ
      Ok (vₐ, 'exercise' v₁ (cid, Mod:T, vₜ) 'non-consuming' trₐ) ‖ (st₁, keys₁)
 
-     cid ∉ dom(st₀)
+     cid ∉ dom(st)
    —————————————————————————————————————————————————————————————————————— EvUpdExercWithoutActorsMissing
-     'exercise_without_actors' Mod:T.Ch cid v₁ ‖ (st₀, keys₀)
+     'exercise_without_actors' Mod:T.Ch cid v ‖ (st, keys)
        ⇓ᵤ
      Err "Exercise on unknown contract"
 


### PR DESCRIPTION
As Rémy pointed out, I was missing error cases for when `cid` does not refer to a known contract. Although not possible to trigger this in DAML directly, these cases can be triggered via the ledger API. 

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
