### PR TITLE
Add evaluation order tests for foldl and foldr

### DIFF
--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -30,6 +30,12 @@
 -- @ERROR Aborted: EvExpRecUpdErr2_1 OK
 -- @ERROR Aborted: EvExpRecUpdErr2_2 OK
 -- @ERROR Aborted: EvExpRecUpdErr2_3 OK
+-- @ERROR Aborted: EvExpFoldrErr1 OK
+-- @ERROR Aborted: EvExpFoldrErr2 OK
+-- @ERROR Aborted: EvExpFoldrErr3 OK
+-- @ERROR Aborted: EvExpFoldlErr1 OK
+-- @ERROR Aborted: EvExpFoldlErr2 OK
+-- @ERROR Aborted: EvExpFoldlErr3 OK
 -- @ERROR Aborted: EvExpUpPureErr OK
 -- @ERROR Aborted: EvExpUpBindErr OK
 -- @ERROR Aborted: EvExpUpCreateErr OK
@@ -170,6 +176,42 @@ evExpRecUpdErr2_3 = scenario do
 -- Can't test LF struct evaluation order from DAML, since we purposely avoid
 -- evaluation of struct fields during typeclass desugaring, and we don't have
 -- a way to construct LF structs directly.
+
+evExpFoldrErr1 = scenario do
+  pure (foldr f 0 [1, 2])
+  where
+    f 2 0 = error "EvExpFoldrErr1 OK"
+    f _ _ = error "EvExpFoldrErr1 failed"
+
+evExpFoldrErr2 = scenario do
+  pure (foldr f 0 [1, 2])
+  where
+    f 1 = error "EvExpFoldrErr2 OK"
+    f _ = error "EvExpFoldrErr2 failed"
+
+evExpFoldrErr3 = scenario do
+  pure (foldr f identity [1] (error "EvExpFoldrErr3 failed"))
+  where
+    f: Int -> (Int -> Int) -> (Int -> Int)
+    f _ = error "EvExpFoldrErr3 OK"
+
+evExpFoldlErr1 = scenario do
+  pure (foldl f 0 [1, 2])
+  where
+    f 0 1 = error "EvExpFoldlErr1 OK"
+    f _ _ = error "EvExpFoldlErr1 failed"
+
+evExpFoldlErr2 = scenario do
+  pure (foldl f 0 [1, 2])
+  where
+    f 0 = error "EvExpFoldlErr2 OK"
+    f _ = error "EvExpFoldlErr2 failed"
+
+evExpFoldlErr3 = scenario do
+  pure (foldr f identity [1] (error "EvExpFoldlErr3 failed"))
+  where
+    f: Int -> (Int -> Int) -> (Int -> Int)
+    f _ = error "EvExpFoldlErr3 OK"
 
 evExpUpPureErr = scenario do
   let _ : Update () = pure (error "EvExpUpPureErr OK")

--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -193,7 +193,7 @@ evExpFoldrErr3 = scenario do
   pure (foldr f identity [1] (error "EvExpFoldrErr3 failed"))
   where
     f: Int -> (Int -> Int) -> (Int -> Int)
-    f _ = error "EvExpFoldrErr3 OK"
+    f _ _ = error "EvExpFoldrErr3 OK"
 
 evExpFoldlErr1 = scenario do
   pure (foldl f 0 [1, 2])
@@ -210,8 +210,8 @@ evExpFoldlErr2 = scenario do
 evExpFoldlErr3 = scenario do
   pure (foldl f identity [1] (error "EvExpFoldlErr3 failed"))
   where
-    f: Int -> (Int -> Int) -> (Int -> Int)
-    f _ = error "EvExpFoldlErr3 OK"
+    f: (Int -> Int) -> Int -> (Int -> Int)
+    f _ _ = error "EvExpFoldlErr3 OK"
 
 evExpUpPureErr = scenario do
   let _ : Update () = pure (error "EvExpUpPureErr OK")

--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -208,7 +208,7 @@ evExpFoldlErr2 = scenario do
     f _ = error "EvExpFoldlErr2 failed"
 
 evExpFoldlErr3 = scenario do
-  pure (foldr f identity [1] (error "EvExpFoldlErr3 failed"))
+  pure (foldl f identity [1] (error "EvExpFoldlErr3 failed"))
   where
     f: Int -> (Int -> Int) -> (Int -> Int)
     f _ = error "EvExpFoldlErr3 OK"


### PR DESCRIPTION
I'd like to have a play with the implementation of `foldl` and `foldr`
in Speedy in order to improve their performance. Doing so without any
tests for the evaluation order of those builtins, is too scary for me.
Thus, let's kick off the effort by adding some tests.

Except for the usual case where we need to test that we're running over
the list in the right order, we also need to test for the case where
the step function only consumes one argument and the case where the
accumulator is a function. In the latter case we need to make sure we
don't evaluate the argument applied to the final accumulator too early.

We're also very short on the semantics of `foldl` and `foldr` in the
DAML-LF spec but I leave that for another PR.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6958)
<!-- Reviewable:end -->
