### PR TITLE
fix release job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -480,8 +480,6 @@ jobs:
                -H 'Content-Type: application/json' \
                --data "{\"text\":\"Release \`$(release_tag)\` is ready for testing. (<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|build>, <https://github.com/digital-asset/daml/commit/$(trigger_sha)|trigger commit>, <https://github.com/digital-asset/daml/commit/$(release_sha)|target commit>)\"}" \
                $(Slack.team-daml)
-          }
-
       - template: ci/tell-slack-failed.yml
         parameters:
           trigger_sha: '$(trigger_sha)'


### PR DESCRIPTION
This failed on [the master build for the latest release][0] (trigger commit 08d4bb0a21f9a22c97e6ff92161dc5445f49c8f3), fortunately after everything was done so the only consequence is a red tick in the commit list.

[0]: https://dev.azure.com/digitalasset/daml/_build/results?buildId=50840&view=logs&jobId=8d802004-fbbb-5f17-b73e-f23de0c1dec8&j=8d802004-fbbb-5f17-b73e-f23de0c1dec8&t=3f4756f8-86d7-526f-1a17-d1c7745ae68d

CHANGELOG_BEGIN
CHANGELOG_END