### PR TITLE
FrontStack: Ensure that claimed invariant is maintained

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
@@ -76,10 +76,9 @@ final class FrontStack[+A] private (fq: FQ[A], val length: Int) {
         case FQPrepend(head, tail) =>
           if (head.length > 1) {
             Some((head.head, new FrontStack(FQPrepend(head.tail, tail), length - 1)))
-          } else if (head.length > 0) {
-            Some((head.head, new FrontStack(tail, length - 1)))
           } else {
-            throw new RuntimeException(s"FrontStack had FQPrepend with non-empty head: $head")
+            // NOTE(MH): We maintain the invariant that `head` is never empty.
+            Some((head.head, new FrontStack(tail, length - 1)))
           }
       }
     } else {
@@ -151,7 +150,11 @@ object FrontStack extends FrontStackInstances {
   def empty[A]: FrontStack[A] = emptySingleton
 
   def apply[A](xs: ImmArray[A]): FrontStack[A] =
-    new FrontStack(FQPrepend(xs, FQEmpty), length = xs.length)
+    if (xs.length > 0) {
+      new FrontStack(FQPrepend(xs, FQEmpty), length = xs.length)
+    } else {
+      empty
+    }
 
   def apply[T](element: T): FrontStack[T] =
     new FrontStack(FQCons(element, FQEmpty), length = 1)

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/FrontStack.scala
@@ -77,7 +77,7 @@ final class FrontStack[+A] private (fq: FQ[A], val length: Int) {
           if (head.length > 1) {
             Some((head.head, new FrontStack(FQPrepend(head.tail, tail), length - 1)))
           } else {
-            // NOTE(MH): We maintain the invariant that `head` is never empty.
+            // NOTE: We maintain the invariant that `head` is never empty.
             Some((head.head, new FrontStack(tail, length - 1)))
           }
       }


### PR DESCRIPTION
The documentation of `FrontStack` claims that the head of the
`FQPrepend` is never empty but there's a way to violate this claimed
invariant.

This PR makes sure the invariant is maintained and then uses the
invariant to remove a redundant `else`-branch.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6960)
<!-- Reviewable:end -->
