### PR TITLE
run build on automated release PRs

### DIFF
--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -26,6 +26,11 @@ jobs:
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
 
+      setvar() {
+          echo "Setting '$1' to '$2'"
+          echo "##vso[task.setvariable variable=$1;isOutput=true]$2"
+      }
+
       AUTH="$(git config remote.origin.url | grep -o "://.*:.*@" | cut -c4- | rev | cut -c2- | rev)"
 
       BRANCH=auto-release-pr-$(date -I)
@@ -46,3 +51,19 @@ jobs:
            --location \
            -d "{\"title\": \"release $RELEASE\", \"head\": \"$BRANCH\", \"base\": \"master\", \"body\": \"This PR has been created by a script, which is not very smart and does not have all the context. Please do double-check that the version prefix is correct before merging.\"}" \
            https://api.github.com/repos/digital-asset/daml/pulls
+
+      setvar "branch" "$BRANCH"
+    name: out
+- job: trigger_ci
+  dependsOn: open_release_pr
+  pool:
+    vmImage: "ubuntu-latest"
+  variables:
+    branch: $[ dependencies.open_release_pr.outputs['out.branch'] ]
+  steps:
+  - checkout: none
+  - bash: |
+      set -euo pipefail
+      az extension add --name azure-devops
+      echo "$(System.AccessToken)" | az devops login --org "https://dev.azure.com/digitalasset"
+      az pipelines build queue --branch $(branch) --definition-name "digital-asset.daml" --org "https://dev.azure.com/digitalasset" --project daml


### PR DESCRIPTION
Even though the Azure Pipelines bot account _clearly_ has write access to our repo, as it can create the PR, it does not count as having write access for the purposes of Azure deciding to run the build on the PRs it opens. Not having the build run on the release PR would defeat the whole point of having it, so this adds a little nudge to Azure so it does start the build after opening the PR.

CHANGELOG_BEGIN
CHANGELOG_END