### PR TITLE
DAML Engine: Speed up foldl

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -264,9 +264,6 @@ private[lf] final case class Compiler(
       case EVal(ref) => SEVal(LfDefRef(ref))
       case EBuiltin(bf) =>
         bf match {
-          case BFoldl =>
-            val ref = SEBuiltinRecursiveDefinition.FoldL
-            withLabel(ref.ref, ref)
           case BFoldr =>
             val ref = SEBuiltinRecursiveDefinition.FoldR
             withLabel(ref.ref, ref)
@@ -331,6 +328,9 @@ private[lf] final case class Compiler(
               case BFromTextCodePoints => SBFromTextCodePoints
 
               case BSHA256Text => SBSHA256Text
+
+              // List functions
+              case BFoldl => SBFoldl
 
               // Errors
               case BError => SBError

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -13,7 +13,7 @@ import com.daml.lf.data.Numeric.Scale
 import com.daml.lf.language.Ast
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.Speedy.{Machine, SpeedyHungry}
+import com.daml.lf.speedy.Speedy.{KFoldl, Machine, SpeedyHungry}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SValue.{SValue => SV}
@@ -412,6 +412,18 @@ private[lf] object SBuiltin {
         case _ =>
           throw SErrorCrash(s"type mismatch textSHA256: $args")
       }
+    }
+  }
+
+  final case object SBFoldl extends SBuiltin(3) {
+    override private[speedy] final def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine): Unit = {
+      val func = SEValue(args.get(0))
+      val init = args.get(1)
+      val list = args.get(2).asInstanceOf[SList].list
+      machine.pushKont(KFoldl(func, list, machine.frame, machine.actuals, machine.env.size))
+      machine.returnValue = init
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -430,7 +430,6 @@ object SExpr {
 
     def execute(machine: Machine): Unit = {
       val body = ref match {
-        case Reference.FoldL => foldLBody
         case Reference.FoldR => foldRBody
         case Reference.EqualList => equalListBody
       }
@@ -443,45 +442,12 @@ object SExpr {
     sealed abstract class Reference
 
     final object Reference {
-      final case object FoldL extends Reference
       final case object FoldR extends Reference
       final case object EqualList extends Reference
     }
 
-    val FoldL: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.FoldL)
     val FoldR: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.FoldR)
     val EqualList: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.EqualList)
-
-    private val foldLBody: SExpr =
-      // foldl f z xs =
-      SEMakeClo(
-        Array(),
-        3,
-        // case xs of
-        SECase(SELocA(2)) of (
-          // nil -> z
-          SCaseAlt(SCPNil, SELocA(1)),
-          // cons y ys ->
-          SCaseAlt(
-            SCPCons,
-            // foldl f (f z y) ys
-            SEApp(
-              FoldL,
-              Array(
-                SELocA(0), /* f */
-                SEApp(
-                  SELocA(0),
-                  Array(
-                    SELocA(1), /* z */
-                    SELocS(2) /* y */
-                  )
-                ),
-                SELocS(1) /* ys */
-              )
-            )
-          )
-        )
-      )
 
     private val foldRBody: SExpr =
       // foldr f z xs =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -7,7 +7,7 @@ package speedy
 import java.util
 
 import com.daml.lf.data.Ref._
-import com.daml.lf.data.{ImmArray, Ref, Time}
+import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.Compiler.{CompilationError, PackageNotFound}
 import com.daml.lf.speedy.SError._
@@ -896,6 +896,31 @@ private[lf] object Speedy {
       machine.restoreEnv(frame, actuals, envSize)
       to.add(v)
       machine.ctrl = next
+    }
+  }
+
+  private[speedy] final case class KFoldl(
+      func: SEValue,
+      var list: FrontStack[SValue],
+      frame: Frame,
+      actuals: Actuals,
+      envSize: Int,
+  ) extends Kont
+      with SomeArrayEquals {
+    def execute(acc: SValue, machine: Machine) = {
+      list.pop match {
+        case None =>
+          machine.returnValue = acc
+        case Some((item, rest)) =>
+          machine.restoreEnv(frame, actuals, envSize)
+          // NOTE: We are "recycling" the current continuation with the
+          // remainder of the list to avoid allocating a new continuation.
+          list = rest
+          machine.pushKont(this)
+          // TODO(MH): This looks like it has some potential for further
+          // performance gains once the AST nodes related to ANF have landed.
+          machine.ctrl = SEAppAtomicFun(func, Array(SEValue(acc), SEValue(item)))
+      }
     }
   }
 


### PR DESCRIPTION
This PR replaces Speedy's current implementation of `foldl`, which
basically does nothing more than replace the builtine`foldl` with an
expression for its standard implementation in a functional language,
with a more loop-like implementation that takes advantage of the
structure of Speedy.

I've benchmarked the application of `foldl (+) 0` to the pre-computed
list `[1..100_000]`. With the old implementation of `foldl` this took
ca. 31ms, with the new implementation ca. 11ms. Further experiments
indicate that out of these times ca. 5ms are spent applying the
arguments to `(+)` and performing the addition. Thus, the time actually
spent in `foldl` amounts to 6ms and 26ms, respectively. This means
the new implementation of `foldl` is ca. 4.3x faster than the old
implementation.

CHANGELOG_BEGIN
- [DAML Engine] The performance of `foldl` has been improved by more
  than 4x.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6973)
<!-- Reviewable:end -->
