### PR TITLE
DAML Engine: Use reflection for state classification

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Classify.scala
@@ -4,76 +4,23 @@
 package com.daml.lf
 package speedy
 
-import com.daml.lf.speedy.Speedy._
-import com.daml.lf.speedy.SExpr._
+import com.daml.lf.speedy.Speedy.Machine
+import scala.collection.mutable.Map
 
 private[speedy] object Classify { // classify the machine state w.r.t what step occurs next
 
   final class Counts(
       var ctrlExpr: Int = 0,
       var ctrlValue: Int = 0,
-      // expression classification (ctrlExpr)
-      var evalue: Int = 0,
-      var evarS: Int = 0,
-      var evarA: Int = 0,
-      var evarF: Int = 0,
-      var eappE: Int = 0,
-      var eappA: Int = 0,
-      var eappB: Int = 0,
-      var eclose: Int = 0,
-      var ebuiltin: Int = 0,
-      var eval: Int = 0,
-      var elocation: Int = 0,
-      var elet: Int = 0,
-      var ecase: Int = 0,
-      var erecdef: Int = 0,
-      var ecatch: Int = 0,
-      var eimportvalue: Int = 0,
-      var ewrongcid: Int = 0,
-      // kont classification (ctrlValue)
-      var kfinished: Int = 0,
-      var karg: Int = 0,
-      var kfun: Int = 0,
-      var kbuiltin: Int = 0,
-      var kpap: Int = 0,
-      var kpushto: Int = 0,
-      var kcacheval: Int = 0,
-      var klocation: Int = 0,
-      var kmatch: Int = 0,
-      var kcatch: Int = 0,
+      var exprs: Map[String, Int] = Map.empty,
+      var konts: Map[String, Int] = Map.empty,
   ) {
     def steps = ctrlExpr + ctrlValue
     def pp: String = {
-      List(
-        ("CtrlExpr:", ctrlExpr),
-        ("- evalue", evalue),
-        ("- evarS", evarS),
-        ("- evarA", evarA),
-        ("- evarF", evarF),
-        ("- eappE", eappE),
-        ("- eappA", eappA),
-        ("- eappB", eappB),
-        ("- eclose", eclose),
-        ("- ebuiltin", ebuiltin),
-        ("- eval", eval),
-        ("- elocation", elocation),
-        ("- elet", elet),
-        ("- ecase", ecase),
-        ("- erecdef", erecdef),
-        ("- ecatch", ecatch),
-        ("- eimportvalue", eimportvalue),
-        ("CtrlValue:", ctrlValue),
-        ("- kfinished", kfinished),
-        ("- karg", karg),
-        ("- kfun", kfun),
-        ("- kbuiltin", kbuiltin),
-        ("- kpap", kpap),
-        ("- kpushto", kpushto),
-        ("- kcacheval", kcacheval),
-        ("- klocation", klocation),
-        ("- kmatch", kmatch),
-        ("- kcatch", kcatch),
-      ).map { case (tag, n) => s"$tag : $n" }.mkString("\n")
+      val lines =
+        (("CtrlExpr:", ctrlExpr) :: exprs.toList.map { case (expr, n) => ("- " + expr, n) }) ++
+          (("CtrlValue:", ctrlValue) :: konts.toList.map { case (kont, n) => (" -" + kont, n) })
+      lines.map { case (tag, n) => s"$tag : $n" }.mkString("\n")
     }
   }
 
@@ -81,54 +28,12 @@ private[speedy] object Classify { // classify the machine state w.r.t what step 
     if (machine.returnValue != null) {
       // classify a value by the continution it is about to return to
       counts.ctrlValue += 1
-      val kont = machine.kontStack.get(machine.kontStack.size - 1)
-      classifyKont(kont, counts)
+      val kont = machine.kontStack.get(machine.kontStack.size - 1).getClass.getSimpleName
+      val _ = counts.konts += kont -> (counts.konts.get(kont).getOrElse(0) + 1)
     } else {
       counts.ctrlExpr += 1
-      classifyExpr(machine.ctrl, counts)
+      val expr = machine.ctrl.getClass.getSimpleName
+      val _ = counts.exprs += expr -> (counts.exprs.get(expr).getOrElse(0) + 1)
     }
   }
-
-  def classifyExpr(exp: SExpr, counts: Counts): Unit = {
-    exp match {
-      case _: SEVar => //not expected at runtime
-      case _: SEAbs => //not expected at runtime
-      case _: SEValue => counts.evalue += 1
-      case _: SELocS => counts.evarS += 1
-      case _: SELocA => counts.evarA += 1
-      case _: SELocF => counts.evarF += 1
-      case _: SEAppGeneral => counts.eappE += 1
-      case _: SEAppAtomicFun => counts.eappA += 1
-      case _: SEAppSaturatedBuiltinFun => counts.eappB += 1
-      case _: SEMakeClo => counts.eclose += 1
-      case _: SEBuiltin => counts.ebuiltin += 1
-      case _: SEVal => counts.eval += 1
-      case _: SELocation => counts.elocation += 1
-      case _: SELet => counts.elet += 1
-      case _: SECase => counts.ecase += 1
-      case _: SEBuiltinRecursiveDefinition => counts.erecdef += 1
-      case _: SECatch => counts.ecatch += 1
-      case _: SELabelClosure => ()
-      case _: SEImportValue => counts.eimportvalue += 1
-      case _: SEWronglyTypeContractId => counts.ewrongcid += 1
-    }
-  }
-
-  def classifyKont(kont: Kont, counts: Counts): Unit = {
-    kont match {
-      case KFinished => counts.kfinished += 1
-      case _: KArg => counts.karg += 1
-      case _: KFun => counts.kfun += 1
-      case _: KBuiltin => counts.kbuiltin += 1
-      case _: KPap => counts.kpap += 1
-      case _: KPushTo => counts.kpushto += 1
-      case _: KCacheVal => counts.kcacheval += 1
-      case _: KLocation => counts.klocation += 1
-      case _: KMatch => counts.kmatch += 1
-      case _: KCatch => counts.kcatch += 1
-      case _: KLabelClosure => ()
-      case _: KLeaveClosure => ()
-    }
-  }
-
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/PrettyLightweight.scala
@@ -32,20 +32,7 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     s"[${ppKont(ks.get(ks.size - 1))}... #${ks.size()}]" // head kont & size
   }
 
-  def ppKont(k: Kont): String = k match {
-    case KFinished => "KFinished"
-    case _: KArg => "KArg"
-    case _: KFun => "KFun"
-    case _: KBuiltin => "KBuiltin"
-    case _: KPap => "KPap"
-    case _: KPushTo => "KPushTo"
-    case _: KCacheVal => "KCacheVal"
-    case _: KLocation => "KLocation"
-    case _: KMatch => "KMatch"
-    case _: KCatch => "KCatch"
-    case _: KLabelClosure => "KLabelClosure"
-    case _: KLeaveClosure => "KLeaveClosure"
-  }
+  def ppKont(k: Kont): String = k.getClass.getSimpleName
 
   def pp(v: SELoc) = v match {
     case SELocS(n) => s"S#$n"
@@ -70,25 +57,15 @@ private[speedy] object PrettyLightweight { // lightweight pretty printer for CEK
     case SELocation(_, exp) => s"LOC(${pp(exp)})"
     case SELet(rhss, body) => s"let (${commas(rhss.map(pp))}) in ${pp(body)}"
     case SECase(scrut, _) => s"case ${pp(scrut)} of..."
-    case SEBuiltinRecursiveDefinition(_) => "<SEBuiltinRecursiveDefinition...>"
-    case SECatch(_, _, _) => "<SECatch...>" //not seen one yet
-    case SEAbs(_, _) => "<SEAbs...>" // will never get these on a running machine
-    case SELabelClosure(_, _) => "<SELabelClosure...>"
-    case SEImportValue(_) => "<SEImportValue...>"
-    case SEWronglyTypeContractId(_, _, _) => "<SEWronglyTypeContractId...>"
+    case _ => "<" + e.getClass.getSimpleName + "...>"
   }
 
   def pp(v: SValue): String = v match {
     case SInt64(n) => s"$n"
     case SBool(b) => s"$b"
     case SPAP(_, args, arity) => s"PAP(${args.size}/$arity)"
-    case SToken => "SToken"
     case SText(s) => s"'$s'"
-    case SParty(_) => "<SParty>"
-    case SStruct(_, _) => "<SStruct...>"
-    case SUnit => "SUnit"
-    case SList(_) => "SList"
-    case _ => "<Unknown-value>" // TODO: complete cases
+    case _ => "<" + v.getClass.getSimpleName + "...>"
   }
 
   def pp(prim: Prim): String = prim match {


### PR DESCRIPTION
I've already grown very tired of almost always having to touch the
`Classify` class whenever I change anything about Speedy. Let's put an
end to this by using reflection instead of explicitly listing all
different AST nodes and continuation types.

The `PrettyLightweight` class has similar problems that can be fixed
using the same idea.

This change might slightly change this output but since this is an
experimentation tool, I deem this acceptable.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6974)
<!-- Reviewable:end -->
