### PR TITLE
DAML Engine: Don't restore environment in KFoldl

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -422,7 +422,7 @@ private[lf] object SBuiltin {
       val func = SEValue(args.get(0))
       val init = args.get(1)
       val list = args.get(2).asInstanceOf[SList].list
-      machine.pushKont(KFoldl(func, list, machine.frame, machine.actuals, machine.env.size))
+      machine.pushKont(KFoldl(func, list))
       machine.returnValue = init
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -902,9 +902,6 @@ private[lf] object Speedy {
   private[speedy] final case class KFoldl(
       func: SEValue,
       var list: FrontStack[SValue],
-      frame: Frame,
-      actuals: Actuals,
-      envSize: Int,
   ) extends Kont
       with SomeArrayEquals {
     def execute(acc: SValue, machine: Machine) = {
@@ -912,7 +909,6 @@ private[lf] object Speedy {
         case None =>
           machine.returnValue = acc
         case Some((item, rest)) =>
-          machine.restoreEnv(frame, actuals, envSize)
           // NOTE: We are "recycling" the current continuation with the
           // remainder of the list to avoid allocating a new continuation.
           list = rest


### PR DESCRIPTION
The `KFoldl` continuation sets the control of the machine to a PAP
applied to two values. Neither of those contain references into the
environment. Hence, restoring the environment is unnecessary.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6976)
<!-- Reviewable:end -->
