### PR TITLE
Engine: fix computation of global contract IDs for validation.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -170,7 +170,7 @@ private[engine] final class Preprocessor(compiledPackages: MutableCompiledPackag
       node: Node.GenNode.WithTxValue[NodeId, Cid],
   ): Result[(speedy.Command, Set[Value.ContractId])] =
     safelyRun(getDependencies(List.empty, List(getTemplateId(node)))) {
-      val (cmd, (globalCids, _)) = unsafeTranslateNode((Set.empty, Set.empty), node)
+      val (cmd, (_, globalCids)) = unsafeTranslateNode((Set.empty, Set.empty), node)
       cmd -> globalCids
     }
 


### PR DESCRIPTION
This PR fixes the computation of global contract IDS during
translation of transaction node to command for validation.

This follows the scheme described in `daml-lf/spec/contract-id.rst`

Extensive testing will be part of #6665.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
