### PR TITLE
remove unused definitions, params, args from ledger API Scala code

### DIFF
--- a/ledger-api/rs-grpc-akka/src/test/scala/com/digitalasset/grpc/adapter/operation/AkkaClientCompatibilityCheck.scala
+++ b/ledger-api/rs-grpc-akka/src/test/scala/com/digitalasset/grpc/adapter/operation/AkkaClientCompatibilityCheck.scala
@@ -11,7 +11,6 @@ import com.daml.grpc.adapter.client.ResultAssertions
 import com.daml.grpc.adapter.client.akka.ClientAdapter
 import com.daml.platform.hello.HelloRequest
 import com.daml.platform.hello.HelloServiceGrpc.HelloServiceStub
-import io.grpc.{ClientCall, MethodDescriptor}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 
@@ -28,9 +27,6 @@ trait AkkaClientCompatibilityCheck {
   implicit protected def esf: ExecutionSequencerFactory
 
   def akkaClientCompatible(helloStub: => HelloServiceStub): Unit = {
-
-    def getCall[Req, Resp](call: MethodDescriptor[Req, Resp]): ClientCall[Req, Resp] =
-      helloStub.getChannel.newCall(call, helloStub.getCallOptions)
 
     "respond with the correct number of elements and correct content in 1-* setup" in {
       val elemsF = ClientAdapter

--- a/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/PublisherCreation.scala
+++ b/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/client/rs/PublisherCreation.scala
@@ -108,7 +108,7 @@ trait PublisherCreation {
 
   def createFailedPublisher(): Publisher[Long] = {
 
-    val stub: BiConsumer[Long, StreamObserver[Long]] = { (req, responseObserver) =>
+    val stub: BiConsumer[Long, StreamObserver[Long]] = { (_, responseObserver) =>
       responseObserver.onError(
         new RuntimeException("Exception created to test failed Publisher") with NoStackTrace)
     }

--- a/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/server/rs/ServerSubscriberWhiteboxTest.scala
+++ b/ledger-api/rs-grpc-bridge/src/test/suite/scala/com/digitalasset/grpc/adapter/server/rs/ServerSubscriberWhiteboxTest.scala
@@ -26,7 +26,7 @@ class ServerSubscriberWhiteboxTest
         super.onSubscribe(subscription)
         probe.registerOnSubscribe(new SubscriberPuppet {
           override def triggerRequest(elements: Long): Unit = {
-            for (i <- 1l to elements) so.demandResponse()
+            for (_ <- 1l to elements) so.demandResponse()
           }
 
           override def signalCancel(): Unit = {

--- a/ledger-api/rs-grpc-testing-utils/src/main/scala/com/digitalasset/grpc/adapter/server/rs/MockClientCallStreamObserver.scala
+++ b/ledger-api/rs-grpc-testing-utils/src/main/scala/com/digitalasset/grpc/adapter/server/rs/MockClientCallStreamObserver.scala
@@ -12,8 +12,6 @@ class MockClientCallStreamObserver[Request](onRequest: Int => Unit)
 
   private val cancellationPromise = Promise[(String, Throwable)]
 
-  private val cancellationFuture = cancellationPromise.future
-
   override def cancel(s: String, throwable: Throwable): Unit = {
     cancellationPromise.trySuccess(s -> throwable)
     ()

--- a/ledger-api/sample-service/src/test/scala/com/digitalasset/grpc/adapter/client/ReferenceClientCompatibilityCheck.scala
+++ b/ledger-api/sample-service/src/test/scala/com/digitalasset/grpc/adapter/client/ReferenceClientCompatibilityCheck.scala
@@ -6,7 +6,6 @@ package com.daml.grpc.adapter.client
 import com.daml.grpc.adapter.utils.BufferingObserver
 import com.daml.platform.hello.HelloServiceGrpc.HelloServiceStub
 import com.daml.platform.hello.{HelloRequest, HelloResponse}
-import io.grpc.stub.StreamObserver
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 
@@ -30,27 +29,5 @@ trait ReferenceClientCompatibilityCheck extends ResultAssertions with ScalaFutur
 
       whenReady(observer.resultsF)(assertElementsAreInOrder(halfCount.toLong))
     }
-  }
-
-  private def checkClientStreamingSetup(
-      observer: BufferingObserver[HelloResponse],
-      reqObserver: StreamObserver[HelloRequest]) = {
-    for (i <- elemRange) {
-      reqObserver.onNext(HelloRequest(i))
-    }
-    reqObserver.onCompleted()
-
-    whenReady(observer.resultsF)(elementsAreSummed)
-  }
-
-  private def checkBidiSetup(
-      observer: BufferingObserver[HelloResponse],
-      reqObserver: StreamObserver[HelloRequest]) = {
-    for (i <- elemRange) {
-      reqObserver.onNext(HelloRequest(i))
-    }
-    reqObserver.onCompleted()
-
-    whenReady(observer.resultsF)(everyElementIsDoubled)
   }
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Main.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Main.scala
@@ -56,7 +56,7 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     parseConfig(args) match {
-      case Some(Config(Some(config @ GenerateJwks(Some(outputFile), publicKeys)))) =>
+      case Some(Config(Some(GenerateJwks(Some(outputFile), publicKeys)))) =>
         // Load RSA keys. They ID of each key is its file name.
         val keys: Map[String, RSAPublicKey] = publicKeys
           .map(
@@ -87,7 +87,7 @@ object Main {
                 exp,
                 kid,
                 parties,
-                readOnly,
+                readOnly @ _,
                 admin)))) =>
         import JwtSigner.Error.showInstance
 
@@ -119,13 +119,6 @@ object Main {
 
         def changeExtension(file: File, extension: String): File = {
           val filename = file.getName
-
-          val baseName =
-            if (filename.contains("."))
-              filename.substring(0, filename.lastIndexOf('.'))
-            else
-              filename
-
           new File(file.getParentFile, filename + extension)
         }
 

--- a/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
+++ b/ledger/ledger-api-client/src/it/scala/com/digitalasset/ledger/client/CommandClientIT.scala
@@ -76,7 +76,6 @@ final class CommandClientIT
       ledgerId,
       applicationId,
       configuration,
-      None
     )
 
   private def timeProvider(ledgerId: domain.LedgerId = testLedgerId): Future[TimeProvider] = {
@@ -92,9 +91,8 @@ final class CommandClientIT
     : Future[CommandClient] =
     timeProvider(ledgerId)
       .map(
-        tp =>
-          commandClientWithoutTime(ledgerId, applicationId, configuration)
-            .withTimeProvider(Some(tp)))(DirectExecutionContext)
+        tp => commandClientWithoutTime(ledgerId, applicationId, configuration)
+      )(DirectExecutionContext)
 
   override protected def config: SandboxConfig =
     super.config.copy(ledgerIdMode = LedgerIdMode.Static(testLedgerId))

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/CommandClient.scala
@@ -6,7 +6,6 @@ package com.daml.ledger.client.services.commands
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import com.daml.api.util.TimeProvider
 import com.daml.grpc.adapter.ExecutionSequencerFactory
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.v1.command_completion_service.CommandCompletionServiceGrpc.CommandCompletionServiceStub
@@ -40,8 +39,6 @@ import scalaz.syntax.tag._
   * @param ledgerId                 Will be applied to submitted commands.
   * @param applicationId            Will be applied to submitted commands.
   * @param config                   Options for changing behavior.
-  * @param timeProviderO            If defined, it will be used to override LET and MRT values on incoming commands.
-  *                                 Let will be set based on current time, and TTL will stay the same or be adjusted based on [[config]]
   */
 final class CommandClient(
     commandSubmissionService: CommandSubmissionServiceStub,
@@ -49,7 +46,6 @@ final class CommandClient(
     ledgerId: LedgerId,
     applicationId: String,
     config: CommandClientConfiguration,
-    timeProviderO: Option[TimeProvider] = None,
     logger: Logger = LoggerFactory.getLogger(getClass))(implicit esf: ExecutionSequencerFactory) {
 
   /**
@@ -171,16 +167,4 @@ final class CommandClient(
     LedgerClient
       .stub(commandCompletionService, token)
       .completionEnd(CompletionEndRequest(ledgerId.unwrap))
-
-  /**
-    * Returns a new CommandClient which will update ledger effective times and maximum record times based on the new time provider.
-    */
-  def withTimeProvider(newProvider: Option[TimeProvider]) =
-    new CommandClient(
-      commandSubmissionService,
-      commandCompletionService,
-      ledgerId,
-      applicationId,
-      config,
-      newProvider)
 }

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/transactions/TransactionClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/transactions/TransactionClient.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.api.v1.transaction_service._
 import com.daml.ledger.client.LedgerClient
 import scalaz.syntax.tag._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 final class TransactionClient(ledgerId: LedgerId, service: TransactionServiceStub)(
     implicit esf: ExecutionSequencerFactory) {
@@ -42,14 +42,18 @@ final class TransactionClient(ledgerId: LedgerId, service: TransactionServiceStu
       LedgerClient.stub(service, token).getTransactions,
       GetTransactionsRequest(ledgerId.unwrap, Some(start), end, Some(transactionFilter), verbose))
 
-  def getTransactionById(transactionId: String, parties: Seq[String], token: Option[String] = None)(
-      implicit ec: ExecutionContext): Future[GetTransactionResponse] =
+  def getTransactionById(
+      transactionId: String,
+      parties: Seq[String],
+      token: Option[String] = None): Future[GetTransactionResponse] =
     LedgerClient
       .stub(service, token)
       .getTransactionById(GetTransactionByIdRequest(ledgerId.unwrap, transactionId, parties))
 
-  def getTransactionByEventId(eventId: String, parties: Seq[String], token: Option[String] = None)(
-      implicit ec: ExecutionContext): Future[GetTransactionResponse] =
+  def getTransactionByEventId(
+      eventId: String,
+      parties: Seq[String],
+      token: Option[String] = None): Future[GetTransactionResponse] =
     LedgerClient
       .stub(service, token)
       .getTransactionByEventId(GetTransactionByEventIdRequest(ledgerId.unwrap, eventId, parties))
@@ -57,8 +61,7 @@ final class TransactionClient(ledgerId: LedgerId, service: TransactionServiceStu
   def getFlatTransactionById(
       transactionId: String,
       parties: Seq[String],
-      token: Option[String] = None)(
-      implicit ec: ExecutionContext): Future[GetFlatTransactionResponse] =
+      token: Option[String] = None): Future[GetFlatTransactionResponse] =
     LedgerClient
       .stub(service, token)
       .getFlatTransactionById(GetTransactionByIdRequest(ledgerId.unwrap, transactionId, parties))
@@ -66,8 +69,7 @@ final class TransactionClient(ledgerId: LedgerId, service: TransactionServiceStu
   def getFlatTransactionByEventId(
       eventId: String,
       parties: Seq[String],
-      token: Option[String] = None)(
-      implicit ec: ExecutionContext): Future[GetFlatTransactionResponse] =
+      token: Option[String] = None): Future[GetFlatTransactionResponse] =
     LedgerClient
       .stub(service, token)
       .getFlatTransactionByEventId(

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/CommandsValidator.scala
@@ -46,7 +46,7 @@ final class CommandsValidator(ledgerId: LedgerId) {
       commandId <- requireLedgerString(commands.commandId, "command_id").map(domain.CommandId(_))
       submitter <- requireParty(commands.party, "party")
       commandz <- requireNonEmpty(commands.commands, "commands")
-      validatedCommands <- validateInnerCommands(commandz, submitter)
+      validatedCommands <- validateInnerCommands(commandz)
       ledgerEffectiveTime <- validateLedgerTime(currentLedgerTime, commands)
       ledgerEffectiveTimestamp <- Time.Timestamp
         .fromInstant(ledgerEffectiveTime)
@@ -96,7 +96,6 @@ final class CommandsValidator(ledgerId: LedgerId) {
 
   private def validateInnerCommands(
       commands: Seq[ProtoCommand],
-      submitter: Ref.Party
   ): Either[StatusRuntimeException, immutable.Seq[Command]] =
     commands.foldLeft[Either[StatusRuntimeException, Vector[Command]]](
       Right(Vector.empty[Command]))((commandz, command) => {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionFilterValidator.scala
@@ -16,8 +16,7 @@ import scalaz.syntax.traverse._
 object TransactionFilterValidator {
 
   def validate(
-      txFilter: TransactionFilter,
-      fieldName: String): Either[StatusRuntimeException, domain.TransactionFilter] = {
+      txFilter: TransactionFilter): Either[StatusRuntimeException, domain.TransactionFilter] = {
     if (txFilter.filtersByParty.isEmpty) {
       Left(ErrorFactories.invalidArgument("filtersByParty cannot be empty"))
     } else {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
@@ -81,9 +81,7 @@ class TransactionServiceRequestValidator(
         partial.end,
         ledgerEnd,
         offsetOrdering)
-      convertedFilter <- TransactionFilterValidator.validate(
-        partial.transactionFilter,
-        "filter.filters_by_party")
+      convertedFilter <- TransactionFilterValidator.validate(partial.transactionFilter)
     } yield {
       transaction.GetTransactionsRequest(
         ledgerId,
@@ -112,9 +110,7 @@ class TransactionServiceRequestValidator(
         partial.end,
         ledgerEnd,
         offsetOrdering)
-      convertedFilter <- transactionFilterToPartySet(
-        partial.transactionFilter,
-        "filter.filters_by_party")
+      convertedFilter <- transactionFilterToPartySet(partial.transactionFilter)
     } yield {
       transaction.GetTransactionTreesRequest(
         partial.ledgerId,
@@ -169,7 +165,6 @@ class TransactionServiceRequestValidator(
 
   private def transactionFilterToPartySet(
       transactionFilter: TransactionFilter,
-      fieldName: String
   ) =
     transactionFilter.filtersByParty
       .collectFirst {

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherImpl.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherImpl.scala
@@ -73,7 +73,7 @@ final class DispatcherImpl[Index: Ordering](
       } match {
       case Running(prev, disp) =>
         if (Ordering[Index].gt(head, prev)) disp.signal()
-      case c: Closed =>
+      case _: Closed =>
         logger.debug(s"$name: Failed to update Dispatcher HEAD: instance already closed.")
     }
 
@@ -141,10 +141,10 @@ final class DispatcherImpl[Index: Ordering](
       case Running(idx, _) => Closed(idx)
       case c: Closed => c
     } match {
-      case Running(idx, disp) =>
+      case Running(_, disp) =>
         disp.signal()
         disp.close()
-      case c: Closed => ()
+      case _: Closed => ()
     }
 
   private def closedError: IllegalStateException =

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcHealthService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcHealthService.scala
@@ -21,7 +21,7 @@ import io.grpc.health.v1.health.{
 import io.grpc.{ServerServiceDefinition, Status, StatusException}
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 class GrpcHealthService(
@@ -30,7 +30,6 @@ class GrpcHealthService(
 )(
     implicit protected val esf: ExecutionSequencerFactory,
     protected val mat: Materializer,
-    executionContext: ExecutionContext,
 ) extends HealthAkkaGrpc
     with GrpcApiService {
   override def bindService(): ServerServiceDefinition =

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcTransactionService.scala
@@ -37,8 +37,6 @@ class GrpcTransactionService(
 
   protected val logger: Logger = LoggerFactory.getLogger(ApiTransactionService.getClass)
 
-  private type MapStringSet[T] = Map[String, Set[T]]
-
   private val validator =
     new TransactionServiceRequestValidator(ledgerId, partyNameChecker)
 
@@ -126,7 +124,7 @@ class GrpcTransactionService(
 
     validation.fold(
       Future.failed,
-      v =>
+      _ =>
         service
           .getLedgerEnd(request.ledgerId)
           .map(abs =>

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/ValueConversionRoundTripTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/ValueConversionRoundTripTest.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.api
 
 import com.daml.lf.data.Time
-import com.daml.lf.testing.parser.Implicits._
 import com.daml.ledger.api.v1.value.Value.Sum
 import com.daml.ledger.api.v1.{value => api}
 import com.daml.ledger.api.validation.{ValidatorTestUtils, ValueValidator}
@@ -20,30 +19,8 @@ class ValueConversionRoundTripTest
 
   private val recordId =
     api.Identifier(packageId, moduleName = "Mod", entityName = "Record")
-  private val emptyRecordId =
-    api.Identifier(packageId, moduleName = "Mod", entityName = "EmptyRecord")
-  private val variantId =
-    api.Identifier(packageId, moduleName = "Mod", entityName = "Variant")
-
-  private val label: String = "label"
-
-  private def record(values: api.Value*): api.Value =
-    api.Value(Sum.Record(api.Record(Some(recordId), values.zipWithIndex.map {
-      case (v, i) => api.RecordField(label + "1")
-    })))
 
   private val constructor: String = "constructor"
-
-  private def variant(value: api.Value): api.Value =
-    api.Value(Sum.Variant(api.Variant(Some(recordId), constructor, Some(value))))
-
-  private val pkg = p"""
-         module Mod {
-           record EmptyRecord = {};
-           record Record = { label1: Int64, label2: Int64, label0: Int64 };
-           variant Variant = constructor: Unit;
-         }
-         """
 
   private def roundTrip(v: api.Value): Either[String, api.Value] =
     for {

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/ledger/api/validation/SubmitRequestValidatorTest.scala
@@ -326,7 +326,7 @@ class SubmitRequestValidatorTest
           )
 
         forEvery(signs) { sign =>
-          forEvery(absoluteValues) { (absoluteValue, scale) =>
+          forEvery(absoluteValues) { (absoluteValue, _) =>
             val s = sign + absoluteValue
             val input = Value(Sum.Numeric(s))
             requestMustFailWith(

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherSpec.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/DispatcherSpec.scala
@@ -167,7 +167,7 @@ class DispatcherSpec
   "A Dispatcher" should {
 
     "fail to initialize if end index < begin index" in {
-      forAllSteppingModes() { subSrc =>
+      forAllSteppingModes() { _ =>
         recoverToSucceededIf[IllegalArgumentException](Future(newDispatcher(Index(0), Index(-1))))
       }
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiActiveContractsService.scala
@@ -40,7 +40,7 @@ private[apiserver] final class ApiActiveContractsService private (
       implicit loggingContext: LoggingContext =>
         logger.trace("Serving an Active Contracts request...")
         TransactionFilterValidator
-          .validate(request.getFilter, "filter")
+          .validate(request.getFilter)
           .fold(Source.failed, backend.getActiveContracts(_, request.verbose))
           .via(logger.logErrorsOnStream)
     }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandStaticTimeIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/command/CommandStaticTimeIT.scala
@@ -60,8 +60,7 @@ final class CommandStaticTimeIT
             maxCommandsInFlight = 1,
             maxParallelSubmissions = 1,
             defaultDeduplicationTime = java.time.Duration.ofSeconds(30)),
-          None
-        ).withTimeProvider(Some(tp)))(DirectExecutionContext)
+      ))(DirectExecutionContext)
 
   private lazy val submitRequest: SubmitRequest =
     MockMessages.submitRequest.update(
@@ -87,7 +86,6 @@ final class CommandStaticTimeIT
         for {
           commandClient <- createCommandClient()
           completion <- commandClient
-            .withTimeProvider(None)
             .trackSingleCommand(
               SubmitRequest(
                 Some(submitRequest.getCommands

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/TransactionStreamTerminationIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/TransactionStreamTerminationIT.scala
@@ -65,7 +65,6 @@ class TransactionStreamTerminationIT
       ledgerId,
       applicationId,
       commandClientConfig,
-      None
     )
 
   "TransactionService" when {

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -454,7 +454,6 @@ class Runner(
       msgSource(client, offset, trigger.heartbeat, party, transactionFilter)
     def submit(req: SubmitRequest): Unit = {
       val f: Future[Empty] = client.commandClient
-        .withTimeProvider(Some(Runner.getTimeProvider(timeProviderType)))
         .submitSingleCommand(req)
       f.failed.foreach({
         case s: StatusRuntimeException =>


### PR DESCRIPTION
As found by `-Ywarn-unused` in #6907. We also follow up #5100 by removing `CommandClient#withTimeProvider`.

```rst
CHANGELOG_BEGIN
- [Ledger API] withTimeProvider removed from CommandClient; this method
  has done nothing since the new ledger time model was introduced in
  1.0.0.
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
