### PR TITLE
Updating template ID references in the JSON API query spec

### DIFF
--- a/docs/source/json-api/search-query-language.rst
+++ b/docs/source/json-api/search-query-language.rst
@@ -4,10 +4,14 @@
 Query language
 ##############
 
-The body of ``POST /v1/query`` looks like so::
+The body of ``POST /v1/query`` looks like so:
 
-  {"templateIds": [...template IDs...],
-   "query": {...query elements...}}
+.. code-block:: text
+
+    {
+        "templateIds": [...template IDs...],
+        "query": {...query elements...}
+    }
 
 The elements of that query are defined here.
 
@@ -105,12 +109,14 @@ is no way that the above query could be written to match ``A`` but never
 
 For these reasons, as with LF value input via JSON, queries written in
 JSON are also always interpreted with respect to some specified LF types
-(e.g. template IDs). For example::
+(e.g. template IDs). For example:
 
-  {"templateIds": [{"moduleName": "Foo", "entityName": "A"},
-                   {"moduleName": "Foo", "entityName": "B"},
-                   {"moduleName": "Foo", "entityName": "C"}],
-   "query": {"foo": "bar"}}
+.. code-block:: json
+
+    {
+        "templateIds": ["Foo:A", "Foo:B", "Foo:C"],
+        "query": {"foo": "bar"}
+    }
 
 will treat ``"foo"`` as a field equality query for A and B, and
 (supposing templates' associated data types were permitted to be


### PR DESCRIPTION
the format changed a while ago, we just never updated this doc.

Also using `.. code-block:: text` and `.. code-block:: json` as I was told it is a preferred way to format code blocks, it would do syntax checks in case of non-text.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
