### PR TITLE
DAML Engine: Speed up foldr

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -264,9 +264,6 @@ private[lf] final case class Compiler(
       case EVal(ref) => SEVal(LfDefRef(ref))
       case EBuiltin(bf) =>
         bf match {
-          case BFoldr =>
-            val ref = SEBuiltinRecursiveDefinition.FoldR
-            withLabel(ref.ref, ref)
           case BEqualList =>
             val ref = SEBuiltinRecursiveDefinition.EqualList
             withLabel(ref.ref, ref)
@@ -331,6 +328,7 @@ private[lf] final case class Compiler(
 
               // List functions
               case BFoldl => SBFoldl
+              case BFoldr => SBFoldr
 
               // Errors
               case BError => SBError

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -435,6 +435,15 @@ private[lf] object SBuiltin {
   //    is missing only one argument.
   // 3. `KFoldr1Reduce` is for the second reduce from right-to-left stage when
   //    `f` is missing only one argument.
+  //
+  // We could have omitted the special casse for `f` missing only one argument,
+  // if the semantics of `foldr` had been implemented as
+  // ```
+  // foldr f z [] = z
+  // foldr f z (x:xs) = let y = foldr f z xs in f x y
+  // ```
+  // However, this would be a breaking change compared to the aforementioned
+  // implementation of `foldr`.
   final case object SBFoldr extends SBuiltin(3) {
     override private[speedy] final def execute(
         args: util.ArrayList[SValue],

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -13,7 +13,7 @@ import com.daml.lf.data.Numeric.Scale
 import com.daml.lf.language.Ast
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.Speedy.{KFoldl, Machine, SpeedyHungry}
+import com.daml.lf.speedy.Speedy.{KFoldl, KFoldr, KFoldr1Map, Machine, SpeedyHungry}
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SValue.{SValue => SV}
@@ -413,6 +413,58 @@ private[lf] object SBuiltin {
       val list = args.get(2).asInstanceOf[SList].list
       machine.pushKont(KFoldl(func, list, machine.frame, machine.actuals, machine.env.size))
       machine.returnValue = init
+    }
+  }
+
+  // NOTE: Past implementations of `foldr` have used the semantics given by the
+  // recursive definition
+  // ```
+  // foldr f z [] = z
+  // foldr f z (x::xs) = f x (foldr f z xs)
+  // ```
+  // When the PAP for `f` expects at least two more arguments, this leads to the
+  // expected right-to-left evaluation order. However, if the PAP `f` is missing
+  // only one argument, the evaluation order suddenly changes. First, `f` is
+  // applied to all the elements of `xs` in left-to-right order, then the
+  // resulting list of PAPs is reduced from right-to-left by application, using
+  // `z` as the initial value argument.
+  //
+  // For this reason, we need three different continuations for `foldr`:
+  // 1. `KFoldr` is for the case where `f` expects at least two more arguments.
+  // 2. `KFoldr1Map` is for the first mapping from left-to-right stage when `f`
+  //    is missing only one argument.
+  // 3. `KFoldr1Reduce` is for the second reduce from right-to-left stage when
+  //    `f` is missing only one argument.
+  final case object SBFoldr extends SBuiltin(3) {
+    override private[speedy] final def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine): Unit = {
+      val pap = args.get(0).asInstanceOf[SPAP]
+      val func = SEValue(pap)
+      val init = args.get(1)
+      val list = args.get(2)
+      if (pap.arity - pap.actuals.size >= 2) {
+        val array = list.asInstanceOf[SList].list.toImmArray
+        machine.pushKont(
+          KFoldr(func, array, array.length, machine.frame, machine.actuals, machine.env.size))
+        machine.returnValue = init
+      } else {
+        val stack = list.asInstanceOf[SList].list
+        stack.pop match {
+          case None => machine.returnValue = init
+          case Some((head, tail)) =>
+            machine.pushKont(
+              KFoldr1Map(
+                func,
+                tail,
+                FrontStack.empty,
+                init,
+                machine.frame,
+                machine.actuals,
+                machine.env.size))
+            machine.ctrl = SEAppAtomicFun(func, Array(SEValue(head)))
+        }
+      }
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -400,7 +400,7 @@ object SExpr {
   final case class ChoiceDefRef(ref: DefinitionRef, choiceName: ChoiceName) extends SDefinitionRef
 
   //
-  // List builtins (foldl, foldr, equalList) are implemented as recursive
+  // List builtins (equalList) are implemented as recursive
   // definition to save java stack
   //
 
@@ -413,7 +413,6 @@ object SExpr {
     val arity = 3
 
     private def body: SExpr = ref match {
-      case Reference.FoldR => foldRBody
       case Reference.EqualList => equalListBody
     }
 
@@ -429,39 +428,10 @@ object SExpr {
     sealed abstract class Reference
 
     final object Reference {
-      final case object FoldR extends Reference
       final case object EqualList extends Reference
     }
 
-    val FoldR: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.FoldR)
     val EqualList: SEBuiltinRecursiveDefinition = SEBuiltinRecursiveDefinition(Reference.EqualList)
-
-    private val foldRBody: SExpr =
-      // foldr f z xs =
-      // case xs of
-      SECase(SELocA(2)) of (// nil -> z
-      SCaseAlt(SCPNil, SELocA(1)),
-      // cons y ys ->
-      SCaseAlt(
-        SCPCons,
-        // f y (foldr f z ys)
-        SEApp(
-          SELocA(0),
-          Array(
-            /* f */
-            SELocS(2), /* y */
-            SEApp(
-              FoldR,
-              Array(
-                /* foldr f z ys */
-                SELocA(0), /* f */
-                SELocA(1), /* z */
-                SELocS(1) /* ys */
-              )
-            )
-          )
-        )
-      ))
 
     private val equalListBody: SExpr =
       // equalList f xs ys =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -924,6 +924,81 @@ private[lf] object Speedy {
     }
   }
 
+  private[speedy] final case class KFoldr(
+      func: SEValue,
+      list: ImmArray[SValue],
+      var lastIndex: Int,
+      frame: Frame,
+      actuals: Actuals,
+      envSize: Int,
+  ) extends Kont
+      with SomeArrayEquals {
+    def execute(acc: SValue, machine: Machine) = {
+      if (lastIndex > 0) {
+        machine.restoreEnv(frame, actuals, envSize)
+        val currentIndex = lastIndex - 1
+        val item = list(currentIndex)
+        lastIndex = currentIndex
+        machine.pushKont(this) // NOTE: We've updated `lastIndex`.
+        // TODO(MH): This looks like it has some potential for further
+        // performance gains once the AST nodes related to ANF have landed.
+        // The same applies to `KFoldr1Map/Reduce` below.
+        machine.ctrl = SEAppAtomicFun(func, Array(SEValue(item), SEValue(acc)))
+      } else {
+        machine.returnValue = acc
+      }
+    }
+  }
+
+  // NOTE: See the explanation above the definition of `SBFoldr` on why we need
+  // this continuation and what it does.
+  private[speedy] final case class KFoldr1Map(
+      func: SEValue,
+      var list: FrontStack[SValue],
+      var revClosures: FrontStack[SValue],
+      init: SValue,
+      frame: Frame,
+      actuals: Actuals,
+      envSize: Int,
+  ) extends Kont
+      with SomeArrayEquals {
+    def execute(closure: SValue, machine: Machine) = {
+      revClosures = closure +: revClosures
+      list.pop match {
+        case None =>
+          machine.pushKont(KFoldr1Reduce(revClosures, frame, actuals, envSize))
+          machine.returnValue = init
+        case Some((item, rest)) =>
+          machine.restoreEnv(frame, actuals, envSize)
+          list = rest
+          machine.pushKont(this) // NOTE: We've updated `revClosures` and `list`.
+          machine.ctrl = SEAppAtomicFun(func, Array(SEValue(item)))
+      }
+    }
+  }
+
+  // NOTE: See the explanation above the definition of `SBFoldr` on why we need
+  // this continuation and what it does.
+  private[speedy] final case class KFoldr1Reduce(
+      var revClosures: FrontStack[SValue],
+      frame: Frame,
+      actuals: Actuals,
+      envSize: Int,
+  ) extends Kont
+      with SomeArrayEquals {
+    def execute(acc: SValue, machine: Machine) = {
+      revClosures.pop match {
+        case None =>
+          machine.returnValue = acc
+        case Some((closure, rest)) =>
+          machine.restoreEnv(frame, actuals, envSize)
+          revClosures = rest
+          machine.pushKont(this) // NOTE: We've updated `revClosures`.
+          machine.ctrl = SEAppAtomicFun(SEValue(closure), Array(SEValue(acc)))
+      }
+    }
+  }
+
   /** Store the evaluated value in the 'SEVal' from which the expression came from.
     * This in principle makes top-level values lazy. It is a useful optimization to
     * allow creation of large constants (for example records) that are repeatedly

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -752,6 +752,7 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
   "List operations" - {
 
     val f = """(\ (x:Int64) (y:Int64) ->  ADD_INT64 3 (MUL_INT64 x y))"""
+    val g = """(\ (x:Int64) -> let z:Int64 = 3 in \ (y:Int64) -> ADD_INT64 z (MUL_INT64 x y))"""
 
     "FOLDL" - {
       "works as expected" in {
@@ -764,6 +765,10 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
       "works as expected" in {
         eval(e"FOLDR @Int64 @Int64 $f 5 ${intList()}") shouldEqual Right(SInt64(5))
         eval(e"FOLDR @Int64 @Int64 $f 5 ${intList(7, 11, 13)}") shouldEqual Right(SInt64(5260))
+      }
+      "works as expected when step function takes one argument" in {
+        eval(e"FOLDR @Int64 @Int64 $g 5 ${intList()}") shouldEqual Right(SInt64(5))
+        eval(e"FOLDR @Int64 @Int64 $g 5 ${intList(7, 11, 13)}") shouldEqual Right(SInt64(5260))
       }
     }
 


### PR DESCRIPTION
This PR replaces Speedy's current implementation of `foldr`, which
basically does nothing more than replace the builtin `foldr` with an
expression for its standard implementation in a functional language,
with a more loop-like implementation that takes advantage of the
structure of Speedy. There's additional complexity for the case when
the step function expects only one more argument before it performs
some computation. The exact issue and the solution are explained in a
comment in the code.

I've benchmarked the application of `foldr (+) 0` to the pre-computed
list `[1..100_000]`. With the old implementation of `foldl` this took
ca. 35ms, with the new implementation ca. 11ms. Further experiments
indicate that out of these times ca. 5ms are spent applying the
arguments to `(+)` and performing the addition. Thus, the time actually
spent in `foldr` amounts to 30ms and 6ms, respectively. This means
the new implementation of `foldr` is ca. 5x faster than the old
implementation when the step function takes at least two arguments.

For the case of a step function which expects only one argument before
performing computation, I've benchmarked the application of
`foldr (\_ -> identity) 0` to the pre-computed list `[1..100_00]`. The
measured times have dropped from ca. 42ms to ca. 19ms. Further
experiments that the time spent in `foldr` itself has dropped from
ca. 32ms to 9ms.

CHANGELOG_BEGIN
- [DAML Engine] The performance of `foldr` has been improved by more
  than 4x.
CHANGELOG_END

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/6997)
<!-- Reviewable:end -->
