### PR TITLE
Push value conversion into ScriptLedgerClient implementations

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -139,7 +139,7 @@ object Converter {
         } yield
           ScriptLedgerClient.CreateCommand(
             templateId = anyTemplate.ty,
-            argument = anyTemplate.arg.toValue,
+            argument = anyTemplate.arg
           )
       }
       case _ => Left(s"Expected Create but got $v")
@@ -164,7 +164,7 @@ object Converter {
             templateId = tplId,
             contractId = cid,
             choice = anyChoice.name,
-            argument = (anyChoice.arg.toValue, anyChoice.arg),
+            argument = anyChoice.arg,
           )
       }
       case _ => Left(s"Expected Exercise but got $v")
@@ -181,9 +181,9 @@ object Converter {
         } yield
           ScriptLedgerClient.ExerciseByKeyCommand(
             templateId = tplId,
-            key = anyKey.key.toValue,
+            key = anyKey.key,
             choice = anyChoice.name,
-            argument = anyChoice.arg.toValue,
+            argument = anyChoice.arg,
           )
       }
       case _ => Left(s"Expected ExerciseByKey but got $v")
@@ -198,9 +198,9 @@ object Converter {
         } yield
           ScriptLedgerClient.CreateAndExerciseCommand(
             templateId = anyTemplate.ty,
-            template = anyTemplate.arg.toValue,
+            template = anyTemplate.arg,
             choice = anyChoice.name,
-            argument = anyChoice.arg.toValue,
+            argument = anyChoice.arg,
           )
       }
       case _ => Left(s"Expected CreateAndExercise but got $v")


### PR DESCRIPTION
For the script service, we don’t need any conversion so storing SValue
is faster (and easier since converting back needs type info). For
other client, calling `toValue` is easy enough.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
