### PR TITLE
rotate responsibility for release process

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -475,10 +475,11 @@ jobs:
         condition: not(eq(variables['skip-github'], 'TRUE'))
       - bash: |
           set -euo pipefail
+          pr_handler=$(head -1 release/rotation | awk "${print $1}")
           curl -XPOST \
                -i \
                -H 'Content-Type: application/json' \
-               --data "{\"text\":\"Release \`$(release_tag)\` is ready for testing. (<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|build>, <https://github.com/digital-asset/daml/commit/$(trigger_sha)|trigger commit>, <https://github.com/digital-asset/daml/commit/$(release_sha)|target commit>)\"}" \
+               --data "{\"text\":\"<@${pr_handler}> Release \`$(release_tag)\` is ready for testing. (<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|build>, <https://github.com/digital-asset/daml/commit/$(trigger_sha)|trigger commit>, <https://github.com/digital-asset/daml/commit/$(release_sha)|target commit>)\"}" \
                $(Slack.team-daml)
       - template: ci/tell-slack-failed.yml
         parameters:
@@ -523,7 +524,14 @@ jobs:
         # using basic auth format:
         # https://username:password@github.com/:user/:repo.git
         # This series of pipes extracts the `username:password` part.
-        AUTH="$(git config remote.origin.url | grep -o "://.*:.*@" | cut -c4- | rev | cut -c2- | rev)"
+        #
+        # It looks like in some cases the credentials get stored separately as
+        # a header instead.
+        if header=$(git config 'http.https://github.com/digital-asset/daml.extraheader'); then
+            AUTH="$header"
+        else
+            AUTH="Authorization: basic $(git config remote.origin.url | grep -o '://.*:.*@' | cut -c4- | rev | cut -c2- | rev)"
+        fi
 
         git checkout origin/master
         BRANCH=update-compat-versions-for-$(release_tag)
@@ -541,7 +549,7 @@ jobs:
             -m "$(printf "update compat versions for $(release_tag)\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n")"
         git push origin $BRANCH:$BRANCH
         curl -H "Content-Type: application/json" \
-             -u $AUTH \
+             -H "$AUTH" \
              --silent \
              --include \
              --location \
@@ -803,12 +811,13 @@ jobs:
           }
 
           tell_daml() {
-              local message
+              local message, pr_handler
               message=$1
+              pr_handler=$(head -1 release/rotation | awk "${print $1}")
               curl -XPOST \
                    -i \
                    -H 'Content-Type: application/json' \
-                   --data "{\"text\":\"<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for release PR <https://github.com/digital-asset/daml/pull/$(pr.num)|#$(pr.num)> has completed with status ${message}.\"}" \
+                   --data "{\"text\":\"<@${pr_handler}> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for release PR <https://github.com/digital-asset/daml/pull/$(pr.num)|#$(pr.num)> has completed with status ${message}.\"}" \
                    $(Slack.team-daml)
           }
 

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -16,54 +16,103 @@ jobs:
 - job: open_release_pr
   timeoutInMinutes: 60
   pool:
-    name: linux-pool
-    demands: assignment -equals default
+    vmImage: ubuntu-latest
   steps:
   - checkout: self
     persistCredentials: true
-  - bash: ci/dev-env-install.sh
   - bash: |
       set -euo pipefail
-      eval "$(./dev-env/bin/dade-assist)"
 
-      setvar() {
-          echo "Setting '$1' to '$2'"
-          echo "##vso[task.setvariable variable=$1;isOutput=true]$2"
-      }
+      if header=$(git config 'http.https://github.com/digital-asset/daml.extraheader'); then
+          AUTH="$header"
+      else
+          AUTH="Authorization: basic $(git config remote.origin.url | grep -o '://.*:.*@' | cut -c4- | rev | cut -c2- | rev)"
+      fi
 
-      AUTH="$(git config remote.origin.url | grep -o "://.*:.*@" | cut -c4- | rev | cut -c2- | rev)"
-
-      BRANCH=auto-release-pr-$(date -I)
-      git branch -D $BRANCH || true
-      git checkout -b $BRANCH
-      ./release.sh new snapshot
-      git add LATEST
-      RELEASE=$(head -1 LATEST | awk '{print $2}')
-      git -c user.name="Azure Pipelines DAML Build" \
-          -c user.email="support@digitalasset.com" \
-          commit \
-          -m "$(printf "release $RELEASE\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n")"
-      git push origin $BRANCH:$BRANCH
-      curl -H "Content-Type: application/json" \
-           -u $AUTH \
-           --silent \
-           --include \
-           --location \
-           -d "{\"title\": \"release $RELEASE\", \"head\": \"$BRANCH\", \"base\": \"master\", \"body\": \"This PR has been created by a script, which is not very smart and does not have all the context. Please do double-check that the version prefix is correct before merging.\"}" \
-           https://api.github.com/repos/digital-asset/daml/pulls
-
-      setvar "branch" "$BRANCH"
-    name: out
-- job: trigger_ci
-  dependsOn: open_release_pr
-  pool:
-    vmImage: "ubuntu-latest"
-  variables:
-    branch: $[ dependencies.open_release_pr.outputs['out.branch'] ]
-  steps:
-  - checkout: none
-  - bash: |
-      set -euo pipefail
+      BASE_SHA=$(git rev-parse HEAD)
       az extension add --name azure-devops
       echo "$(System.AccessToken)" | az devops login --org "https://dev.azure.com/digitalasset"
-      az pipelines build queue --branch $(branch) --definition-name "digital-asset.daml" --org "https://dev.azure.com/digitalasset" --project daml
+
+      reset() {
+          git checkout -f $BASE_SHA
+          git reset --hard
+      }
+      open_pr() {
+          local branch title body out pr_number
+          branch=$1
+          title="$2"
+          body="$3"
+          out=$4
+          git branch -D $branch || true
+          git checkout -b $branch
+          git add .
+          git -c user.name="Azure Pipelines DAML Build" \
+              -c user.email="support@digitalasset.com" \
+              commit \
+              -m "$(printf "$title\n\n$body\n\nCHANGELOG_BEGIN\nCHANGELOG_END\n")"
+          git push origin $branch:$branch
+          pr_number=$(jq -n \
+                         --arg branch "$branch" \
+                         --arg title "$title" \
+                         --arg body "$(printf "$body")" \
+                         '{"title": $title, "head": $branch, "base": "master", "body": $body}' \
+                    | curl -H "Content-Type: application/json" \
+                           -H "$AUTH" \
+                           --silent \
+                           --location \
+                           -d @- \
+                           https://api.github.com/repos/digital-asset/daml/pulls \
+                    | jq '.number')
+          az pipelines build queue \
+              --branch $branch \
+              --definition-name "digital-asset.daml" \
+              --org "https://dev.azure.com/digitalasset" \
+              --project daml
+          if [ -n "$out" ]; then
+              echo $pr_number > $out
+          fi
+      }
+      assign_and_label() {
+          local pr_number assignee
+          pr_number=$1
+          assignee=$2
+          curl -H "Content-Type: application/json" \
+               -X PATCH \
+               -H "$AUTH" \
+               --silent \
+               --location \
+               -d "{\"assignees\": [\"$assignee\"], \"labels\": [\"Standard-Change\"]}" \
+               https://api.github.com/repos/digital-asset/daml/issues/$pr_number
+          # For the purposes of "common" features, such as assignees and
+          # labels, PRs are issues as far as the GH API is concerned.
+      }
+      rotate() {
+          local tmp
+          tmp=$(mktemp)
+          cp release/rotation $tmp
+          (tail -n +2 $tmp; head -1 $tmp) > release/rotation
+      }
+
+      reset
+
+      NEXT_SLACK=$(head -1 release/rotation | awk '{print $1}')
+      NEXT_GH=$(head -1 release/rotation | awk '{print $2}')
+
+      ./release.sh new snapshot
+      RELEASE=$(head -1 LATEST | awk '{print $2}')
+      PR_FILE=$(mktemp)
+      open_pr "auto-release-pr-$(date -I)" \
+              "release $RELEASE" \
+              "This PR has been created by a script, which is not very smart and does not have all the context. Please do double-check that the version prefix is correct before merging.\n\n@$NEXT_GH is in charge of this release." \
+              $PR_FILE
+
+      PR=$(cat $PR_FILE)
+
+      assign_and_label $PR $NEXT_GH
+
+      reset
+
+      rotate
+      open_pr "rotate-after-$RELEASE" \
+              "rotate release duty after $RELEASE" \
+              "@$NEXT_GH is taking care of $RELEASE (#$PR), so they get pushed back to the end of the line.\n\nPlease do not merge this before #$PR."

--- a/release/rotation
+++ b/release/rotation
@@ -1,0 +1,12 @@
+UEHSF89AQ garyverhaegen-da
+U4ZB3PALQ leo-da
+U6MV7CUSX rohanjr
+U0PNNPY05 robin-da
+UEHLS0JUB cocreature
+UD3MUK6TA stefanobaghino-da
+U7BSDJUJX S11001001
+U011H6KFYPN sofiafaro-da
+U6XMLDZEX hurryabit
+UHHMLCNGM nickchapman-da
+UTUPD35SR aherrmann-da
+UPBBGF5MZ SamirTalwar-DA


### PR DESCRIPTION
This PR attempts to add some automation around assigning release management. The PR adds a file `release/rotation`; each week, the updated CI cron job will:

- Open a PR for the new release [as current].
- Assign the first user in the file to that PR.
- Add the Standard-Change label to the PR.
- Start the build for that PR [as current].
- Open a new PR that rotates the `release/rotate` file, i.e. pushes back the first line to the end of the file.

This PR also adds mentions of the "release handler" (the first line of `release/rotation`) to the various messages we send to Slack along the release process.

The initial state of the `release/rotation` file has been created by listing all the volunteers (Language team, Application Runtime team, as well as @SamirTalwar-DA and @stefanobaghino-da) and piping the file through `shuf`. (Then I put myself at the top so I can hopefully iron out the issues with the first attempt.)

CHANGELOG_BEGIN
CHANGELOG_END