### PR TITLE
Move ChoiceName -> String conversion to the edges in DAML Script

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -58,7 +58,7 @@ object ScriptIds {
 class ConverterException(message: String) extends RuntimeException(message)
 
 case class AnyTemplate(ty: Identifier, arg: SValue)
-case class AnyChoice(name: String, arg: SValue)
+case class AnyChoice(name: ChoiceName, arg: SValue)
 case class AnyContractKey(key: SValue)
 
 object Converter {
@@ -98,7 +98,10 @@ object Converter {
       case SRecord(_, _, vals) if vals.size == 2 => {
         vals.get(0) match {
           case SAny(_, choiceVal @ SRecord(_, _, _)) =>
-            Right(AnyChoice(choiceVal.id.qualifiedName.name.toString, choiceVal))
+            for { // This exploits the fact that in DAML, choice argument type names
+              // and choice names match up.
+              name <- ChoiceName.fromString(choiceVal.id.qualifiedName.name.toString)
+            } yield AnyChoice(name, choiceVal)
           case _ => Left(s"Expected SAny but got $v")
         }
       }


### PR DESCRIPTION
Just gives us a bit more typesafety until we really need to drop it
and avoids a bunch of ugly ChoiceName.assertFromString

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
