### PR TITLE
Support createAndExerciseCmd in DAML Script Service

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -75,7 +75,7 @@ main =
         defaultMain $
           testGroup
             "Script Service"
-            [ testCase "createCmd + exerciseCmd" $ do
+            [ testCase "createCmd + exerciseCmd + createAndExerciseCmd" $ do
                 rs <-
                   runScripts
                     scriptService
@@ -97,6 +97,9 @@ main =
                       "  p <- allocateParty \"p\"",
                       "  cid <- submit p $ createCmd (T p 42)",
                       "  submit p $ exerciseCmd cid C",
+                      "testCreateAndExercise = do",
+                      "  p <- allocateParty \"p\"",
+                      "  submit p $ createAndExerciseCmd (T p 42) C",
                       "testMulti = do",
                       "  p <- allocateParty \"p\"",
                       "  (cid1, cid2) <- submit p $ (,) <$> createCmd (T p 23) <*> createCmd (T p 42)",
@@ -105,6 +108,8 @@ main =
                 expectScriptSuccess rs (vr "testCreate") $ \r ->
                   matchRegex r "Active contracts:  #0:0\n\nReturn value: #0:0\n\n$"
                 expectScriptSuccess rs (vr "testExercise") $ \r ->
+                  matchRegex r "Active contracts: \n\nReturn value: 42\n\n$"
+                expectScriptSuccess rs (vr "testCreateAndExercise") $ \r ->
                   matchRegex r "Active contracts: \n\nReturn value: 42\n\n$"
                 expectScriptSuccess rs (vr "testMulti") $ \r ->
                   matchRegex r $

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -353,9 +353,8 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
         speedy.Command.Create(tplId, arg)
       case ScriptLedgerClient.ExerciseCommand(tplId, cid, choice, arg) =>
         speedy.Command.Exercise(tplId, SContractId(cid), choice, arg)
-      case ScriptLedgerClient.CreateAndExerciseCommand(_, _, _, _) =>
-        // TODO Implement
-        throw new RuntimeException(s"Support for CreateAndExercise has not yet been implemented")
+      case ScriptLedgerClient.CreateAndExerciseCommand(tplId, tpl, choice, arg) =>
+        speedy.Command.CreateAndExercise(tplId, tpl, choice, arg)
       case ScriptLedgerClient.ExerciseByKeyCommand(tplId, key, choice, arg) =>
         speedy.Command.ExerciseByKey(tplId, key, choice, arg)
     }


### PR DESCRIPTION
Closes #6998

Implements `createAndExerciseCmd` in the DAML script service.
Extends the `createCmd + exerciseCmd` test-case to also test `createAndExerciseCmd`.
I've tested the feature in DAML studio as well.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
