### PR TITLE
Fixed serialization of record time in ledger exports

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/Serialization.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/Serialization.scala
@@ -34,7 +34,8 @@ object Serialization {
     out.writeUTF(submissionInfo.correlationId)
     out.writeInt(submissionInfo.submissionEnvelope.size())
     submissionInfo.submissionEnvelope.writeTo(out)
-    out.writeLong(submissionInfo.recordTimeInstant.toEpochMilli)
+    out.writeLong(submissionInfo.recordTimeInstant.getEpochSecond)
+    out.writeInt(submissionInfo.recordTimeInstant.getNano)
     out.writeUTF(submissionInfo.participantId)
   }
 
@@ -43,12 +44,13 @@ object Serialization {
     val submissionEnvelopeSize = input.readInt()
     val submissionEnvelope = new Array[Byte](submissionEnvelopeSize)
     input.readFully(submissionEnvelope)
-    val recordTimeEpochMillis = input.readLong()
+    val recordTimeEpochSeconds = input.readLong()
+    val recordTimeEpochNanos = input.readInt()
     val participantId = input.readUTF()
     SubmissionInfo(
       ByteString.copyFrom(submissionEnvelope),
       correlationId,
-      Instant.ofEpochMilli(recordTimeEpochMillis),
+      Instant.ofEpochSecond(recordTimeEpochSeconds, recordTimeEpochNanos.toLong),
       state.v1.ParticipantId.assertFromString(participantId)
     )
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExportSpec.scala
@@ -66,7 +66,7 @@ class FileBasedLedgerDataExportSpec extends WordSpec with Matchers with MockitoS
       val baos = new ByteArrayOutputStream()
       val dataOutputStream = new DataOutputStream(baos)
       val instance = new FileBasedLedgerDataExporter(dataOutputStream)
-      val expectedRecordTimeInstant = Instant.now()
+      val expectedRecordTimeInstant = Instant.ofEpochSecond(123456, 123456789)
       val expectedParticipantId = v1.ParticipantId.assertFromString("id")
       instance.addSubmission(
         ByteString.copyFromUtf8("an envelope"),


### PR DESCRIPTION
Summary of changes:
* Serialize record time associated with a submission at nanoseconds precision instead of milliseconds only.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
