### PR TITLE
Support exerciseByKeyCmd in DAML Script Service

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -116,6 +116,31 @@ main =
                         "    _1 = 23; _2 = 42",
                         ""
                       ],
+              testCase "exerciseByKeyCmd" $ do
+                rs <-
+                  runScripts
+                    scriptService
+                    [ "module Test where",
+                      "import DA.Assert",
+                      "import Daml.Script",
+                      "template WithKey",
+                      "  with",
+                      "    p : Party",
+                      "    v : Int",
+                      "  where",
+                      "    signatory p",
+                      "    key p : Party",
+                      "    maintainer key",
+                      "    choice C : Int",
+                      "      controller p",
+                      "      do pure v",
+                      "testExerciseByKey = do",
+                      "  p <- allocateParty \"p\"",
+                      "  submit p $ createCmd (WithKey p 42)",
+                      "  submit p $ exerciseByKeyCmd @WithKey p C"
+                    ]
+                expectScriptSuccess rs (vr "testExerciseByKey") $ \r ->
+                  matchRegex r "Active contracts: \n\nReturn value: 42\n\n$",
               testCase "failing transactions" $ do
                 rs <-
                   runScripts

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -356,9 +356,8 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       case ScriptLedgerClient.CreateAndExerciseCommand(_, _, _, _) =>
         // TODO Implement
         throw new RuntimeException(s"Support for CreateAndExercise has not yet been implemented")
-      case ScriptLedgerClient.ExerciseByKeyCommand(_, _, _, _) =>
-        // TODO Implement
-        throw new RuntimeException(s"Support for ExerciseByKey has not yet been implemented")
+      case ScriptLedgerClient.ExerciseByKeyCommand(tplId, key, choice, arg) =>
+        speedy.Command.ExerciseByKey(tplId, key, choice, arg)
     }
   }
 


### PR DESCRIPTION
Closes #6999

Implements `exerciseByKeyCmd` in the DAML script service.
Adds a test-case to test `exerciseByKeyCmd`.
I've tested the feature in DAML studio as well.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
