### PR TITLE
avoid generating unused warnings in Scala codegen

### DIFF
--- a/language-support/scala/bindings/BUILD.bazel
+++ b/language-support/scala/bindings/BUILD.bazel
@@ -11,10 +11,8 @@ da_scala_library(
     name = "bindings",
     srcs = glob(["src/main/**/*.scala"]),
     plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_11",
         "@maven//:org_spire_math_kind_projector_2_12",
     ],
-    scalacopts = ["-P:silencer:checkUnused"],
     tags = ["maven_coordinates=com.daml:bindings-scala:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -28,7 +26,6 @@ da_scala_library(
     deps = [
         "//daml-lf/data",
         "//ledger-api/grpc-definitions:ledger-api-scalapb",
-        "@maven//:com_github_ghik_silencer_lib_2_12_11",
         "@maven//:io_grpc_grpc_core",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/language-support/scala/bindings/BUILD.bazel
+++ b/language-support/scala/bindings/BUILD.bazel
@@ -11,8 +11,10 @@ da_scala_library(
     name = "bindings",
     srcs = glob(["src/main/**/*.scala"]),
     plugins = [
+        "@maven//:com_github_ghik_silencer_plugin_2_12_11",
         "@maven//:org_spire_math_kind_projector_2_12",
     ],
+    scalacopts = ["-P:silencer:checkUnused"],
     tags = ["maven_coordinates=com.daml:bindings-scala:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -26,6 +28,7 @@ da_scala_library(
     deps = [
         "//daml-lf/data",
         "//ledger-api/grpc-definitions:ledger-api-scalapb",
+        "@maven//:com_github_ghik_silencer_lib_2_12_11",
         "@maven//:io_grpc_grpc_core",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
@@ -80,7 +80,9 @@ abstract class TemplateCompanion[T](implicit isTemplate: T <~< Template[T])
       (id, _.createArguments flatMap fromNamedArguments))
   }
 
+  @com.github.ghik.silencer.silent(" actor .* is never used") // part of generated code API
   protected final def ` exercise`[ExOn, Out](
+      actor: Primitive.Party,
       receiver: ExOn,
       choiceId: String,
       arguments: Option[rpcvalue.Value])(

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/TemplateCompanion.scala
@@ -80,7 +80,6 @@ abstract class TemplateCompanion[T](implicit isTemplate: T <~< Template[T])
       (id, _.createArguments flatMap fromNamedArguments))
   }
 
-  @com.github.ghik.silencer.silent(" actor .* is never used") // part of generated code API
   protected final def ` exercise`[ExOn, Out](
       actor: Primitive.Party,
       receiver: ExOn,

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/Util.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/Util.scala
@@ -15,6 +15,7 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.TraversableLike
 import scalaz.{Tree => _, _}
 import scalaz.std.list._
+import scalaz.syntax.std.option._
 
 /**
   *  In order to avoid endlessly passing around "packageName" and "iface" to
@@ -186,6 +187,12 @@ object Util {
       case TypeConName(nm) => List(nm)
       case _: PrimType => Nil
     }
+
+  private[codegen] def packageNameTailToRefTree(packageName: String) =
+    packageName
+      .split('.')
+      .lastOption
+      .cata(TermName(_), sys error s"invalid package name $packageName")
 
   def packageNameToRefTree(packageName: String): RefTree = {
     val ss = packageName.split('.')

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlDataTypeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlDataTypeGen.scala
@@ -495,7 +495,7 @@ object DamlDataTypeGen {
           override def encoding(lte: $domainApiAlias.encoding.LfTypeEncoding
                               )(...${if (isTemplate) Seq(q"$view: view[lte.Field]") else Seq.empty}
                               ): lte.Out[$appliedValueType] = {
-            ..${if (isTemplate) Seq.empty else Seq(viewDef)}
+            ..${if (isTemplate || fieldDefs.isEmpty) Seq.empty else Seq(viewDef)}
             $generateEncodingBody
           }
          """

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlDataTypeGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlDataTypeGen.scala
@@ -373,7 +373,7 @@ object DamlDataTypeGen {
 
         lazy val typeObjectCase = if (fields.isEmpty) {
           q"""
-            {_ => _root_.scala.Some(${TermName(damlScalaName.name)}())}
+            {_root_.scala.Function const _root_.scala.Some(${TermName(damlScalaName.name)}())}
           """
         } else {
           val decodeFields =

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
@@ -245,7 +245,7 @@ final case class LFUtil(
     val actorParam = q"${TermName(actorParamName)}: $domainApiAlias.Primitive.Party"
     val exerciseOnParam = q"` exOn`: $domainApiAlias.encoding.ExerciseOn[$idType, $templateType]"
     val resultType = genTypeToScalaType(choiceInterface.returnType)
-    val body = q"` exercise`(id, $choiceId, $namedArguments)"
+    val body = q"` exercise`(${TermName(actorParamName)}, id, $choiceId, $namedArguments)"
 
     Seq(q"""def $choiceMethod($actorParam, ..${typedParam.toList})(implicit $exerciseOnParam)
                 : $domainApiAlias.Primitive.Update[$resultType] = $body""") ++

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/PackageIDsGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/PackageIDsGen.scala
@@ -30,7 +30,7 @@ object PackageIDsGen {
     val packageIdsSrc: Tree =
       q"""
         package ${Util.packageNameToRefTree(util.packageName)} {
-          private object `Package IDs` {
+          private[${Util.packageNameTailToRefTree(util.packageName)}] object `Package IDs` {
             ..$packageIdBindings
           }
         }


### PR DESCRIPTION
From #6907, these remove all `-Ywarn-unused` warnings in Scala codegen's output, with one exception, explained in 839fff38dfff5c4404f28205644b198d7421b145 .

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
