### PR TITLE
remove more unused definitions, params, args from triggers Scala code

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/AuthServiceClient.scala
@@ -141,9 +141,7 @@ class AuthServiceClient(authServiceBaseUri: Uri)(
     runRequest(req)(_ => Future(()))
   }
 
-  def getNewCredentialId(
-      authServiceToken: AuthServiceToken,
-      serviceAccountId: String): Future[CredentialId] =
+  def getNewCredentialId(authServiceToken: AuthServiceToken): Future[CredentialId] =
     for {
       sa <- getServiceAccount(authServiceToken)
       initialNumCreds = sa.creds.length

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -122,7 +122,7 @@ object ServiceConfig {
         s"Maximum time interval between restarting a failed trigger. Defaults to ${DefaultMaxRestartInterval.toSeconds} seconds.")
 
     opt[Unit]('w', "wall-clock-time")
-      .action { (t, c) =>
+      .action { (_, c) =>
         c.copy(timeProviderType = TimeProviderType.WallClock)
       }
       .text("Use wall clock time (UTC). When not provided, static time is used.")

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TokenManagement.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TokenManagement.scala
@@ -78,8 +78,8 @@ object TokenManagement {
       case None => Left("missing Authorization header with Basic Token")
       case Some((username, password)) =>
         Ref.Party.fromString(username) match {
-          case Left(err) => Left("invalid party identifier '" + username + "'")
-          case Right(p) => Right((username, password))
+          case Left(_) => Left("invalid party identifier '" + username + "'")
+          case Right(_) => Right((username, password))
         }
     }
   }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -40,21 +40,20 @@ class TriggerRunner(
   // Spawn a trigger runner impl. Supervise it. Stop immediately on
   // initialization halted exceptions, retry any initialization or
   // execution failure exceptions.
-  private val child =
-    ctx.spawn(
-      Behaviors
-        .supervise(
-          Behaviors
-            .supervise(TriggerRunnerImpl(config))
-            .onFailure[InitializationHalted](stop)
-        )
-        .onFailure(
-          restartWithBackoff(
-            config.restartConfig.minRestartInterval,
-            config.restartConfig.maxRestartInterval,
-            config.restartConfig.restartIntervalRandomFactor)),
-      name
-    )
+  ctx.spawn(
+    Behaviors
+      .supervise(
+        Behaviors
+          .supervise(TriggerRunnerImpl(config))
+          .onFailure[InitializationHalted](stop)
+      )
+      .onFailure(
+        restartWithBackoff(
+          config.restartConfig.minRestartInterval,
+          config.restartConfig.maxRestartInterval,
+          config.restartConfig.restartIntervalRandomFactor)),
+    name
+  )
 
   override def onMessage(msg: Message): Behavior[Message] =
     Behaviors.receiveMessagePartial[Message] {

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -7,7 +7,6 @@ import java.io.File
 import java.net.InetAddress
 import java.time.Duration
 
-import akka.actor.ActorSystem
 import akka.actor.typed.{ActorSystem => TypedActorSystem}
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.Uri
@@ -50,8 +49,7 @@ object TriggerServiceFixture {
       encodedDar: Option[Dar[(PackageId, DamlLf.ArchivePayload)]],
       jdbcConfig: Option[JdbcConfig],
   )(testFn: (Uri, LedgerClient, Proxy) => Future[A])(
-      implicit asys: ActorSystem,
-      mat: Materializer,
+      implicit mat: Materializer,
       aesf: ExecutionSequencerFactory,
       ec: ExecutionContext): Future[A] = {
     val host = InetAddress.getLoopbackAddress

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -208,12 +208,12 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "start up and shut down server" in
-    withTriggerService(Some(dar)) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    withTriggerService(Some(dar)) { (_, _, _) =>
       Future(succeed)
     }
 
   it should "allow repeated uploads of the same packages" in
-    withTriggerService(Some(dar)) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    withTriggerService(Some(dar)) { (uri: Uri, _, _) =>
       for {
         resp <- uploadDar(uri, darPath) // same dar as in initialization
         _ <- parseResult(resp)
@@ -223,7 +223,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
     }
 
   it should "fail to start non-existent trigger" in withTriggerService(Some(dar)) {
-    (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    (uri: Uri, _, _) =>
       val expectedError = StatusCodes.UnprocessableEntity
       for {
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:foobar", alice)
@@ -237,24 +237,23 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
       } yield succeed
   }
 
-  it should "start a trigger after uploading it" in withTriggerService(None) {
-    (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
-      for {
-        resp <- uploadDar(uri, darPath)
-        JsObject(fields) <- parseResult(resp)
-        Some(JsString(mainPackageId)) = fields.get("mainPackageId")
-        _ <- mainPackageId should not be empty
-        resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
-        triggerId <- parseTriggerId(resp)
-        _ <- assertTriggerIds(uri, alice, Vector(triggerId))
-        resp <- stopTrigger(uri, triggerId, alice)
-        stoppedTriggerId <- parseTriggerId(resp)
-        _ <- stoppedTriggerId should equal(triggerId)
-      } yield succeed
+  it should "start a trigger after uploading it" in withTriggerService(None) { (uri: Uri, _, _) =>
+    for {
+      resp <- uploadDar(uri, darPath)
+      JsObject(fields) <- parseResult(resp)
+      Some(JsString(mainPackageId)) = fields.get("mainPackageId")
+      _ <- mainPackageId should not be empty
+      resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
+      triggerId <- parseTriggerId(resp)
+      _ <- assertTriggerIds(uri, alice, Vector(triggerId))
+      resp <- stopTrigger(uri, triggerId, alice)
+      stoppedTriggerId <- parseTriggerId(resp)
+      _ <- stoppedTriggerId should equal(triggerId)
+    } yield succeed
   }
 
   it should "start multiple triggers and list them by party" in withTriggerService(Some(dar)) {
-    (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    (uri: Uri, _, _) =>
       for {
         resp <- listTriggers(uri, alice)
         result <- parseTriggerIds(resp)
@@ -286,7 +285,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "should enable a trigger on http request" in withTriggerService(Some(dar)) {
-    (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    (uri: Uri, client: LedgerClient, _) =>
       for {
         // Start the trigger
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
@@ -326,7 +325,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "restart trigger on initialization failure due to failed connection" in withTriggerService(
-    Some(dar)) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    Some(dar)) { (uri: Uri, _, ledgerProxy: Proxy) =>
     for {
       // Simulate a failed ledger connection which will prevent triggers from initializing.
       _ <- Future(ledgerProxy.disable())
@@ -344,7 +343,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "restart trigger on run-time failure due to dropped connection" in withTriggerService(
-    Some(dar)) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    Some(dar)) { (uri: Uri, _, ledgerProxy: Proxy) =>
     // Simulate the ledger being briefly unavailable due to network connectivity loss.
     // We continually restart the trigger until the connection returns.
     for {
@@ -364,7 +363,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "restart triggers with initialization errors" in withTriggerService(Some(dar)) {
-    (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    (uri: Uri, _, _) =>
       for {
         resp <- startTrigger(uri, s"$testPkgId:ErrorTrigger:trigger", alice)
         aliceTrigger <- parseTriggerId(resp)
@@ -382,7 +381,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "restart triggers with update errors" in withTriggerService(Some(dar)) {
-    (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    (uri: Uri, _, _) =>
       for {
         resp <- startTrigger(uri, s"$testPkgId:LowLevelErrorTrigger:trigger", alice)
         aliceTrigger <- parseTriggerId(resp)
@@ -400,7 +399,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "give an 'unauthorized' response for a stop request without an authorization header" in withTriggerService(
-    None) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    None) { (uri: Uri, _, _) =>
     val uuid: String = "ffffffff-ffff-ffff-ffff-ffffffffffff"
     val req = HttpRequest(
       method = HttpMethods.DELETE,
@@ -418,7 +417,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "give an 'unauthorized' response for a start request with an invalid party identifier" in withTriggerService(
-    Some(dar)) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    Some(dar)) { (uri: Uri, _, _) =>
     for {
       resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", User("Alice-!", "&alC2l3SDS*V"))
       _ <- resp.status should equal(StatusCodes.Unauthorized)
@@ -431,7 +430,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "give a 'not found' response for a stop request with an unparseable UUID" in withTriggerService(
-    None) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    None) { (uri: Uri, _, _) =>
     val uuid: String = "No More Mr Nice Guy"
     val req = HttpRequest(
       method = HttpMethods.DELETE,
@@ -444,7 +443,7 @@ abstract class AbstractTriggerServiceTest extends AsyncFlatSpec with Eventually 
   }
 
   it should "give a 'not found' response for a stop request on an unknown UUID" in withTriggerService(
-    None) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    None) { (uri: Uri, _, _) =>
     val uuid = UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff")
     for {
       resp <- stopTrigger(uri, uuid, alice)
@@ -513,14 +512,14 @@ class TriggerServiceTestWithDb
   behavior of "persistent backend"
 
   it should "recover packages after shutdown" in (for {
-    _ <- withTriggerService(None) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    _ <- withTriggerService(None) { (uri: Uri, _, _) =>
       for {
         resp <- uploadDar(uri, darPath)
         _ <- parseResult(resp)
       } yield succeed
     }
     // Once service is shutdown, start a new one and try to use the previously uploaded dar
-    _ <- withTriggerService(None) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    _ <- withTriggerService(None) { (uri: Uri, _, _) =>
       for {
         // start trigger defined in previously uploaded dar
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
@@ -531,7 +530,7 @@ class TriggerServiceTestWithDb
   } yield succeed)
 
   it should "restart triggers after shutdown" in (for {
-    _ <- withTriggerService(Some(dar)) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    _ <- withTriggerService(Some(dar)) { (uri: Uri, _, _) =>
       for {
         // Start a trigger in the first run of the service.
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
@@ -542,7 +541,7 @@ class TriggerServiceTestWithDb
       } yield succeed
     }
     // Once service is shutdown, start a new one and check the previously running trigger is restarted.
-    _ <- withTriggerService(None) { (uri: Uri, client: LedgerClient, ledgerProxy: Proxy) =>
+    _ <- withTriggerService(None) { (uri: Uri, _, _) =>
       for {
         // Get the previous trigger instance using a list request
         resp <- listTriggers(uri, alice)
@@ -554,7 +553,7 @@ class TriggerServiceTestWithDb
         _ <- assertTriggerStatus(uri, aliceTrigger, _.last should ===("running"), 60)
 
         // Finally go ahead and stop the trigger.
-        resp <- stopTrigger(uri, aliceTrigger, alice)
+        _ <- stopTrigger(uri, aliceTrigger, alice)
         _ <- assertTriggerIds(uri, alice, Vector())
         _ <- assertTriggerStatus(uri, aliceTrigger, _.last should ===("stopped: by user request"))
       } yield succeed

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceClientTest.scala
@@ -28,7 +28,7 @@ class AuthServiceClientTest extends AsyncFlatSpec with Eventually with Matchers 
         sa <- authServiceClient.getServiceAccount(authServiceToken)
         _ <- sa.serviceAccount should not be empty
         _ <- sa.creds should equal(List())
-        credId <- authServiceClient.getNewCredentialId(authServiceToken, sa.serviceAccount)
+        credId <- authServiceClient.getNewCredentialId(authServiceToken)
         _ <- credId.credId should not be empty
         cred <- authServiceClient.getCredential(authServiceToken, credId)
         _ <- cred.cred should not be empty

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/auth/client/AuthServiceFixture.scala
@@ -27,7 +27,7 @@ object AuthServiceFixture {
       implicit system: ActorSystem,
       mat: Materializer,
       ec: ExecutionContext): Future[A] = {
-    val adminLedgerId = LedgerId("admin-ledger")
+    val adminLedgerId = LedgerId(s"admin-ledger-$testName")
     val adminLedgerF = for {
       ledger <- Future(
         new SandboxServer(

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
@@ -173,7 +173,7 @@ abstract class AbstractFuncTests
           // 1 for corresponding completion
           finalStateF = runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(2))._2
           _ <- create(client, party, original(party, "original0"))
-          finalState <- finalStateF
+          _ <- finalStateF
           acs <- queryACS(client, party)
         } yield {
           assert(acs(originalId).length == 1)
@@ -195,7 +195,7 @@ abstract class AbstractFuncTests
           finalStateF = runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(6))._2
           _ <- create(client, party, original(party, "original0"))
           _ <- create(client, party, subscriber(party, party))
-          finalState <- finalStateF
+          _ <- finalStateF
           acs <- queryACS(client, party)
         } yield {
           assert(acs(originalId).length == 1)
@@ -217,7 +217,7 @@ abstract class AbstractFuncTests
           _ <- create(client, party, original(party, "original0"))
           _ <- create(client, party, original(party, "original1"))
           _ <- create(client, party, subscriber(party, party))
-          finalState <- finalStateF
+          _ <- finalStateF
           acs <- queryACS(client, party)
         } yield {
           assert(acs(originalId).length == 2)
@@ -340,7 +340,6 @@ abstract class AbstractFuncTests
 
     "CommandIdTests" should {
       val triggerId = QualifiedName.assertFromString("CommandId:test")
-      val tId = LedgerApi.Identifier(packageId, "CommandId", "T")
       "command-id" in {
         for {
           client <- ledgerClient()

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -121,7 +121,7 @@ trait AbstractTriggerTest extends SandboxFixture with TestCommands {
           commandId = UUID.randomUUID.toString
         )))
     for {
-      response <- client.commandServiceClient.submitAndWaitForTransaction(request)
+      _ <- client.commandServiceClient.submitAndWaitForTransaction(request)
     } yield ()
   }
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala
@@ -46,7 +46,7 @@ class Jwt
         // Start the future here
         finalStateF = runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(6))._2
         // Execute commands
-        contractId <- create(client, party, asset(party))
+        _ <- create(client, party, asset(party))
         // Wait for the trigger to terminate
         _ <- finalStateF
         acs <- queryACS(client, party)

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Tls.scala
@@ -56,7 +56,7 @@ class Tls
         // Start the future here
         finalStateF = runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(6))._2
         // Execute commands
-        contractId <- create(client, party, asset(party))
+        _ <- create(client, party, asset(party))
         // Wait for the trigger to terminate
         _ <- finalStateF
         acs <- queryACS(client, party)


### PR DESCRIPTION
As found by `-Ywarn-unused` in #6907. These were missed by #6983 because these parts of #6907's build plan weren't reachable when that PR was made.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
