### PR TITLE
Run json-parser example using explore-dar.

### DIFF
--- a/daml-lf/interpreter/perf/BUILD.bazel
+++ b/daml-lf/interpreter/perf/BUILD.bazel
@@ -32,6 +32,8 @@ da_scala_binary(
     data = [
         ":Examples.dar",
         ":Examples.dar.pp",
+        ":JsonParser.dar",
+        ":JsonParser.dar.pp",
     ],
     main_class = "com.daml.lf.speedy.explore.ExploreDar",
     runtime_deps = [

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -30,6 +30,7 @@ object PlaySpeedy {
   }
 
   def parseArgs(args0: List[String]): Config = {
+    var moduleName: String = "Examples"
     var funcName: String = "triangle"
     var argValue: Long = 10
     var stacktracing: Compiler.StackTraceMode = Compiler.NoStackTrace
@@ -43,15 +44,19 @@ object PlaySpeedy {
       case "--stacktracing" :: args =>
         stacktracing = Compiler.FullStackTrace
         loop(args)
+      case "--base" :: x :: args =>
+        moduleName = x
+        loop(args)
       case x :: args =>
         funcName = x
         loop(args)
     }
     loop(args0)
-    Config(funcName, argValue, stacktracing)
+    Config(moduleName, funcName, argValue, stacktracing)
   }
 
   final case class Config(
+      moduleName: String,
       funcName: String,
       argValue: Long,
       stacktracing: Compiler.StackTraceMode,
@@ -60,8 +65,8 @@ object PlaySpeedy {
   def main(args0: List[String]) = {
 
     println("Start...")
-    val base = "Examples"
     val config = parseArgs(args0)
+    val base = config.moduleName
     val dar = s"daml-lf/interpreter/perf/${base}.dar"
     val darFile = new File(rlocation(dar))
 
@@ -76,7 +81,11 @@ object PlaySpeedy {
     val compiledPackages: CompiledPackages = PureCompiledPackages(
       packagesMap,
       config.stacktracing
-    ).right.get
+    ) match {
+      case Right(x) => x
+      case Left(x) =>
+        throw new MachineProblem(s"Unexpecteded result when compiling $x")
+    }
 
     val machine: Machine = {
       println(s"Setup machine for: ${config.funcName}(${config.argValue})")


### PR DESCRIPTION
This is another small PR split out from the ANF work.

Improve explore-dar to allow dar file to be selected on the command line, and so allows the json-parser example to be run like this:

    bazel run daml-lf/interpreter/perf:explore-dar -- --base JsonParser pipeline --arg 10

As well as a speed test:

    bazel run daml-lf/interpreter/perf:speed-json-parser

This example is a nice quick smoke test to check speedy execution is not broken.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
