### PR TITLE
Speedy refactor Kmatch.execute

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -793,6 +793,82 @@ private[lf] object Speedy {
   }
 
   /** The scrutinee of a match has been evaluated, now match the alternatives against it. */
+  private[speedy] def executeMatchAlts(machine: Machine, alts: Array[SCaseAlt], v: SValue): Unit = {
+    val altOpt = v match {
+      case SBool(b) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPPrimCon(PCTrue) => b
+            case SCPPrimCon(PCFalse) => !b
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SVariant(_, _, rank1, arg) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPVariant(_, _, rank2) if rank1 == rank2 =>
+              machine.pushEnv(arg)
+              true
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SEnum(_, _, rank1) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPEnum(_, _, rank2) => rank1 == rank2
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SList(lst) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPNil if lst.isEmpty => true
+            case SCPCons if !lst.isEmpty =>
+              val Some((head, tail)) = lst.pop
+              machine.pushEnv(head)
+              machine.pushEnv(SList(tail))
+              true
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SUnit =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPPrimCon(PCUnit) => true
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SOptional(mbVal) =>
+        alts.find { alt =>
+          alt.pattern match {
+            case SCPNone if mbVal.isEmpty => true
+            case SCPSome =>
+              mbVal match {
+                case None => false
+                case Some(x) =>
+                  machine.pushEnv(x)
+                  true
+              }
+            case SCPDefault => true
+            case _ => false
+          }
+        }
+      case SContractId(_) | SDate(_) | SNumeric(_) | SInt64(_) | SParty(_) | SText(_) | STimestamp(
+            _) | SStruct(_, _) | STextMap(_) | SGenMap(_) | SRecord(_, _, _) | SAny(_, _) |
+          STypeRep(_) | STNat(_) | _: SPAP | SToken =>
+        crash("Match on non-matchable value")
+    }
+
+    machine.ctrl = altOpt
+      .getOrElse(throw DamlEMatchError(s"No match for $v in ${alts.toList}"))
+      .body
+  }
+
   private[speedy] final case class KMatch(
       alts: Array[SCaseAlt],
       frame: Frame,
@@ -802,79 +878,7 @@ private[lf] object Speedy {
       with SomeArrayEquals {
     def execute(v: SValue, machine: Machine) = {
       machine.restoreEnv(frame, actuals, envSize)
-      val altOpt = v match {
-        case SBool(b) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPPrimCon(PCTrue) => b
-              case SCPPrimCon(PCFalse) => !b
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SVariant(_, _, rank1, arg) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPVariant(_, _, rank2) if rank1 == rank2 =>
-                machine.pushEnv(arg)
-                true
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SEnum(_, _, rank1) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPEnum(_, _, rank2) => rank1 == rank2
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SList(lst) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPNil if lst.isEmpty => true
-              case SCPCons if !lst.isEmpty =>
-                val Some((head, tail)) = lst.pop
-                machine.pushEnv(head)
-                machine.pushEnv(SList(tail))
-                true
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SUnit =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPPrimCon(PCUnit) => true
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SOptional(mbVal) =>
-          alts.find { alt =>
-            alt.pattern match {
-              case SCPNone if mbVal.isEmpty => true
-              case SCPSome =>
-                mbVal match {
-                  case None => false
-                  case Some(x) =>
-                    machine.pushEnv(x)
-                    true
-                }
-              case SCPDefault => true
-              case _ => false
-            }
-          }
-        case SContractId(_) | SDate(_) | SNumeric(_) | SInt64(_) | SParty(_) | SText(_) |
-            STimestamp(_) | SStruct(_, _) | STextMap(_) | SGenMap(_) | SRecord(_, _, _) |
-            SAny(_, _) | STypeRep(_) | STNat(_) | _: SPAP | SToken =>
-          crash("Match on non-matchable value")
-      }
-
-      machine.ctrl = altOpt
-        .getOrElse(throw DamlEMatchError(s"No match for $v in ${alts.toList}"))
-        .body
+      executeMatchAlts(machine, alts, v);
     }
   }
 


### PR DESCRIPTION
Factor out `executeMatchAlts` from `KMatch.execute`.

This is a pre-step for ANF, which will allow ANF expression forms to call `executeMatchAlts` directly, rather than always from the `KMatch` continuation.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
