### PR TITLE
Bump Windows cache

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -49,6 +49,9 @@ function bazel() {
 # which is a workaround for this problem.
 bazel shutdown
 
+# Temporary, remove once cache reset is complete
+bazel clean --expunge
+
 # Prefetch nodejs_dev_env to avoid permission denied errors on external/nodejs_dev_env/nodejs_dev_env/node.exe
 # It isn’t clear where exactly those errors are coming from.
 bazel fetch @nodejs_dev_env//...

--- a/ci/configure-bazel.sh
+++ b/ci/configure-bazel.sh
@@ -74,7 +74,7 @@ if is_windows; then
   SUFFIX="${SUFFIX:0:3}"
   echo "Platform suffix: $SUFFIX"
   # We include an extra version at the end that we can bump manually.
-  CACHE_SUFFIX="$SUFFIX-v7"
+  CACHE_SUFFIX="$SUFFIX-v8"
   CACHE_URL="$CACHE_URL/$CACHE_SUFFIX"
   echo "build:windows-ci --remote_http_cache=https://bazel-cache.da-ext.net/$CACHE_SUFFIX" >> .bazelrc.local
 fi

--- a/compatibility/build-release-artifacts-windows.ps1
+++ b/compatibility/build-release-artifacts-windows.ps1
@@ -37,6 +37,8 @@ function bazel() {
 
 
 bazel shutdown
+# Temporary, remove once cache reset is complete
+bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build `
   `-`-experimental_execution_log_file ${ARTIFACT_DIRS}/build_execution_windows.log `

--- a/compatibility/test-windows.ps1
+++ b/compatibility/test-windows.ps1
@@ -45,6 +45,8 @@ cd compatibility
 cp ../.bazelrc .bazelrc
 
 bazel shutdown
+# Temporary, remove once cache reset is complete
+bazel clean --expunge
 bazel fetch @nodejs_dev_env//...
 bazel build //...
 bazel shutdown


### PR DESCRIPTION
The "output was not created" errors seem to have become very
frequent. While taking out nodes seems to work as a bandaid, I’d like
to see if resetting the cache buys us a few days of not having to deal
with this. Admittedly, I don’t really have an explanation for why
resetting the cache should help if taking out the machines seems to do
something (suggesting that it hasn’t propagated fully).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
