### PR TITLE
Sandbox: More rigorous parsing for metrics reporters.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/MetricsReporter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/MetricsReporter.scala
@@ -46,13 +46,6 @@ object MetricsReporter {
   }
 
   implicit val metricsReporterRead: Read[MetricsReporter] = {
-    def parseUri(value: String): URI =
-      try {
-        new URI(value)
-      } catch {
-        case NonFatal(_) => throw invalidRead
-      }
-
     Read.reads {
       case "console" =>
         Console
@@ -76,7 +69,17 @@ object MetricsReporter {
     }
   }
 
+  def parseUri(value: String): URI =
+    try {
+      new URI(value)
+    } catch {
+      case NonFatal(exception) =>
+        throw new InvalidConfigException(invalidReadError + " " + exception.getMessage)
+    }
+
+  private val invalidReadError: String =
+    """Must be one of "console", "csv:///PATH", or "graphite://HOST[:PORT][/METRIC_PREFIX]"."""
+
   private def invalidRead: InvalidConfigException =
-    new InvalidConfigException(
-      """Must be one of "console", "csv:///PATH", or "graphite://HOST[:PORT][/METRIC_PREFIX]".""")
+    new InvalidConfigException(invalidReadError)
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/MetricsReporter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/MetricsReporter.scala
@@ -3,12 +3,11 @@
 
 package com.daml.platform.configuration
 
-import java.net.{InetAddress, InetSocketAddress}
+import java.net.InetSocketAddress
 import java.nio.file.{Path, Paths}
 
 import com.codahale.metrics
 import com.codahale.metrics.{MetricRegistry, ScheduledReporter}
-
 import scopt.Read
 
 sealed abstract class MetricsReporter {
@@ -41,14 +40,7 @@ object MetricsReporter {
   }
 
   object Graphite {
-    val defaultHost: InetAddress = InetAddress.getLoopbackAddress
     val defaultPort: Int = 2003
-
-    def apply(): Graphite =
-      Graphite(new InetSocketAddress(defaultHost, defaultPort))
-
-    def apply(port: Int): Graphite =
-      Graphite(new InetSocketAddress(defaultHost, port))
   }
 
   implicit val metricsReporterRead: Read[MetricsReporter] = Read.reads { value =>

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
@@ -121,11 +121,41 @@ abstract class CommonCliSpecBase(
       )
     }
 
+    "reject a console metrics reporter when it has extra information" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "console://foo"))
+      config shouldEqual None
+    }
+
+    "reject a console metrics reporter when it's got trailing information without '//'" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "console:foo"))
+      config shouldEqual None
+    }
+
     "parse a CSV metrics reporter when given" in {
       checkOption(
         Array("--metrics-reporter", "csv:///path/to/file.csv"),
         _.copy(metricsReporter = Some(MetricsReporter.Csv(Paths.get("/path/to/file.csv")))),
       )
+    }
+
+    "reject a CSV metrics reporter when it has no information" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "csv"))
+      config shouldEqual None
+    }
+
+    "reject a CSV metrics reporter when it has no path" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "csv://"))
+      config shouldEqual None
+    }
+
+    "reject a CSV metrics reporter when it has a host" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "csv://hostname/path"))
+      config shouldEqual None
+    }
+
+    "reject a CSV metrics reporter when it's missing '//'" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "csv:/path"))
+      config shouldEqual None
     }
 
     "parse a Graphite metrics reporter when given" in {
@@ -158,6 +188,26 @@ abstract class CommonCliSpecBase(
         Array("--metrics-reporter", "graphite://server:9876/prefix"),
         _.copy(metricsReporter = Some(MetricsReporter.Graphite(expectedAddress, Some("prefix")))),
       )
+    }
+
+    "reject a Graphite metrics reporter when it has no information" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "graphite"))
+      config shouldEqual None
+    }
+
+    "reject a Graphite metrics reporter without a host" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "graphite://"))
+      config shouldEqual None
+    }
+
+    "reject a Graphite metrics reporter without a host but with a prefix" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "graphite:///prefix"))
+      config shouldEqual None
+    }
+
+    "reject a Graphite metrics reporter when it's missing '//'" in {
+      val config = cli.parse(requiredArgs ++ Array("--metrics-reporter", "graphite:server:1234"))
+      config shouldEqual None
     }
 
     "parse the metrics reporting interval when given" in {

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/cli/CommonCliSpecBase.scala
@@ -4,11 +4,15 @@
 package com.daml.platform.sandbox.cli
 
 import java.io.File
-import java.nio.file.Files
+import java.net.InetSocketAddress
+import java.nio.file.{Files, Paths}
+import java.time.Duration
 
 import com.daml.bazeltools.BazelRunfiles.rlocation
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.participant.state.v1
+import com.daml.platform.configuration.MetricsReporter
+import com.daml.platform.configuration.MetricsReporter.Graphite
 import com.daml.platform.sandbox.cli.CommonCliSpecBase._
 import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.platform.services.time.TimeProviderType
@@ -27,7 +31,6 @@ abstract class CommonCliSpecBase(
   private val defaultConfig = expectedDefaultConfig.getOrElse(cli.defaultConfig)
 
   "Cli" should {
-
     "return the input config when no arguments are specified (except any required arguments)" in {
       val config = cli.parse(requiredArgs)
       config shouldEqual Some(defaultConfig)
@@ -109,6 +112,59 @@ abstract class CommonCliSpecBase(
 
     "parse the eager package loading flag when given" in {
       checkOption(Array("--eager-package-loading"), _.copy(eagerPackageLoading = true))
+    }
+
+    "parse a console metrics reporter when given" in {
+      checkOption(
+        Array("--metrics-reporter", "console"),
+        _.copy(metricsReporter = Some(MetricsReporter.Console)),
+      )
+    }
+
+    "parse a CSV metrics reporter when given" in {
+      checkOption(
+        Array("--metrics-reporter", "csv:///path/to/file.csv"),
+        _.copy(metricsReporter = Some(MetricsReporter.Csv(Paths.get("/path/to/file.csv")))),
+      )
+    }
+
+    "parse a Graphite metrics reporter when given" in {
+      val expectedAddress = new InetSocketAddress("server", Graphite.defaultPort)
+      checkOption(
+        Array("--metrics-reporter", "graphite://server"),
+        _.copy(metricsReporter = Some(MetricsReporter.Graphite(expectedAddress, None))),
+      )
+    }
+
+    "parse a Graphite metrics reporter with a port when given" in {
+      val expectedAddress = new InetSocketAddress("server", 9876)
+      checkOption(
+        Array("--metrics-reporter", "graphite://server:9876"),
+        _.copy(metricsReporter = Some(MetricsReporter.Graphite(expectedAddress, None))),
+      )
+    }
+
+    "parse a Graphite metrics reporter with a prefix when given" in {
+      val expectedAddress = new InetSocketAddress("server", Graphite.defaultPort)
+      checkOption(
+        Array("--metrics-reporter", "graphite://server/prefix"),
+        _.copy(metricsReporter = Some(MetricsReporter.Graphite(expectedAddress, Some("prefix")))),
+      )
+    }
+
+    "parse a Graphite metrics reporter with a port and prefix when given" in {
+      val expectedAddress = new InetSocketAddress("server", 9876)
+      checkOption(
+        Array("--metrics-reporter", "graphite://server:9876/prefix"),
+        _.copy(metricsReporter = Some(MetricsReporter.Graphite(expectedAddress, Some("prefix")))),
+      )
+    }
+
+    "parse the metrics reporting interval when given" in {
+      checkOption(
+        Array("--metrics-reporting-interval", "PT1M30S"),
+        _.copy(metricsReportingInterval = Duration.ofSeconds(90)),
+      )
     }
   }
 


### PR DESCRIPTION
This avoids the issue where a previously-valid value such as "graphite:server:1234" fails with a cryptic error message: "hostname can't be null".

Fixes #6994.

### Changelog

- **[Sandbox]** Improved the error message when providing an invalid metric reporter as a command line argument. Now the error message always shows the correct syntax.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
