### PR TITLE
ledger-on-sql: Provide a dedicated committer execution context.

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
@@ -11,13 +11,13 @@ import com.daml.ledger.validator.BatchingLedgerStateOperations
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 private[memory] final class InMemoryLedgerStateOperations(
     log: InMemoryState.MutableLog,
     state: InMemoryState.MutableState,
-)(implicit executionContext: ExecutionContext)
-    extends BatchingLedgerStateOperations[Index] {
+) extends BatchingLedgerStateOperations[Index] {
+
   import InMemoryLedgerStateOperations.appendEntry
 
   override def readState(keys: Seq[Key]): Future[Seq[Option[Value]]] =
@@ -33,7 +33,7 @@ private[memory] final class InMemoryLedgerStateOperations(
 }
 
 object InMemoryLedgerStateOperations {
-  def apply()(implicit executionContext: ExecutionContext): InMemoryLedgerStateOperations = {
+  def apply(): InMemoryLedgerStateOperations = {
     val inMemoryState = mutable.Map.empty[Key, Value]
     val inMemoryLog = mutable.ArrayBuffer[LedgerRecord]()
     new InMemoryLedgerStateOperations(inMemoryLog, inMemoryState)

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
@@ -3,9 +3,10 @@
 
 package com.daml.ledger.on.sql
 
-import java.sql.Connection
+import java.sql.{Connection, SQLException}
 import java.util.concurrent.Executors
 
+import com.daml.ledger.on.sql.Database._
 import com.daml.ledger.on.sql.queries._
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
@@ -27,24 +28,25 @@ final class Database(
     writerExecutionContext: ExecutionContext,
     metrics: Metrics,
 ) {
-  def inReadTransaction[T](name: String)(
-      body: ReadQueries => Future[T],
-  ): Future[T] =
+  def inReadTransaction[T](name: String)(body: ReadQueries => Future[T]): Future[T] =
     inTransaction(name, readerConnectionPool)(connection =>
       Future(body(new TimedQueries(queries(connection), metrics)))(readerExecutionContext).flatten)
 
-  def inWriteTransaction[T](name: String)(
-      body: Queries => Future[T],
-  ): Future[T] =
+  def inWriteTransaction[T](name: String)(body: Queries => Future[T]): Future[T] =
     inTransaction(name, writerConnectionPool)(connection =>
       Future(body(new TimedQueries(queries(connection), metrics)))(writerExecutionContext).flatten)
 
   private def inTransaction[T](name: String, connectionPool: DataSource)(
       body: Connection => Future[T],
   ): Future[T] = {
-    val connection = Timed.value(
-      metrics.daml.ledger.database.transactions.acquireConnection(name),
-      connectionPool.getConnection())
+    val connection = try {
+      Timed.value(
+        metrics.daml.ledger.database.transactions.acquireConnection(name),
+        connectionPool.getConnection())
+    } catch {
+      case exception: SQLException =>
+        throw new ConnectionAcquisitionException(name, exception)
+    }
     Timed.future(
       metrics.daml.ledger.database.transactions.run(name), {
         body(connection)
@@ -243,4 +245,8 @@ object Database {
   class InvalidDatabaseException(message: String)
       extends RuntimeException(message)
       with StartupException
+
+  class ConnectionAcquisitionException(name: String, cause: Throwable)
+      extends RuntimeException(s"""Failed to acquire the connection during "$name".""", cause)
+
 }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -134,7 +134,7 @@ object SqlLedgerReaderWriter {
 
   private def updateOrRetrieveLedgerId(
       providedLedgerId: LedgerId,
-      database: Database
+      database: Database,
   ): Future[LedgerId] =
     database.inWriteTransaction("retrieve_ledger_id") { queries =>
       Future.fromTry(

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -47,6 +47,7 @@ da_scala_library(
         "//ledger/participant-state",
         "//ledger/participant-state/protobuf:ledger_configuration_java_proto",
         "//libs-scala/contextualized-logging",
+        "//libs-scala/direct-execution-context",
         "//libs-scala/timer-utils",
         "@maven//:com_github_ghik_silencer_lib_2_12_11",
         "@maven//:com_google_guava_guava",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.validator
 
+import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.validator.LedgerStateOperations._
 import com.daml.metrics.{Metrics, Timed}
@@ -66,10 +67,9 @@ trait LedgerStateOperations[LogResult] {
 /**
   * Convenience class for implementing read and write operations on a backing store that supports batched operations.
   */
-abstract class BatchingLedgerStateOperations[LogResult](implicit executionContext: ExecutionContext)
-    extends LedgerStateOperations[LogResult] {
+abstract class BatchingLedgerStateOperations[LogResult] extends LedgerStateOperations[LogResult] {
   override final def readState(key: Key): Future[Option[Value]] =
-    readState(Seq(key)).map(_.head)
+    readState(Seq(key)).map(_.head)(DirectExecutionContext)
 
   override final def writeState(key: Key, value: Value): Future[Unit] =
     writeState(Seq(key -> value))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -75,15 +75,18 @@ class SubmissionValidator[LogResult] private[validator] (
       participantId: ParticipantId,
   ): Future[Either[ValidationFailed, LogResult]] =
     newLoggingContext { implicit loggingContext =>
-      validateAndCommitWithLoggingContext(envelope, correlationId, recordTime, participantId)
+      validateAndCommitWithContext(envelope, correlationId, recordTime, participantId)
     }
 
-  private[validator] def validateAndCommitWithLoggingContext(
+  private[validator] def validateAndCommitWithContext(
       envelope: Bytes,
       correlationId: String,
       recordTime: Timestamp,
       participantId: ParticipantId,
-  )(implicit loggingContext: LoggingContext): Future[Either[ValidationFailed, LogResult]] =
+  )(
+      implicit executionContext: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[Either[ValidationFailed, LogResult]] =
     runValidation(
       envelope,
       correlationId,
@@ -147,7 +150,10 @@ class SubmissionValidator[LogResult] private[validator] (
           LedgerStateOperations[LogResult],
       ) => Future[T],
       postProcessResultTimer: Option[Timer],
-  )(implicit loggingContext: LoggingContext): Future[Either[ValidationFailed, T]] =
+  )(
+      implicit executionContext: ExecutionContext,
+      loggingContext: LoggingContext,
+  ): Future[Either[ValidationFailed, T]] =
     metrics.daml.kvutils.submission.validator.openEnvelope
       .time(() => Envelope.open(envelope)) match {
       case Right(Envelope.SubmissionBatchMessage(batch)) =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
@@ -52,7 +52,7 @@ class ValidatingCommitter[LogResult](
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
     newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
       validator
-        .validateAndCommitWithLoggingContext(
+        .validateAndCommitWithContext(
           envelope,
           correlationId,
           Timestamp.assertFromInstant(now()),


### PR DESCRIPTION
The committer was using the resource acquisition execution context. This isn't a problem in production (though it's bad and I'd like to make it crash), but it's an issue in some tests when the test only provides a single-threaded execution context (the ScalaTest default for asynchronous tests).

Detected while making other changes to resource acquisition that resulted in using a different execution context in tests.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
