### PR TITLE
add multi-{key,query} stream to daml-ledger

### DIFF
--- a/language-support/ts/codegen/tests/daml/Main.daml
+++ b/language-support/ts/codegen/tests/daml/Main.daml
@@ -153,3 +153,17 @@ data VoidRecord = VoidRecord with
 
 data VoidEnum = VoidEnum VoidEnum
   deriving (Eq, Show)
+
+template Counter with
+    p: Party
+    t: Text
+    c: Int
+  where
+    signatory p
+    key (p, t): (Party, Text)
+    maintainer key._1
+    controller p can
+      preconsuming Change: ContractId Counter
+        with n: Int
+        do
+          create Counter {c = n, ..}

--- a/language-support/ts/daml-ledger/BUILD.bazel
+++ b/language-support/ts/daml-ledger/BUILD.bazel
@@ -24,6 +24,7 @@ da_ts_library(
         "//language-support/ts/daml-types",
         "@language_support_ts_deps//@mojotech/json-type-validation",
         "@language_support_ts_deps//@types/jest",
+        "@language_support_ts_deps//@types/lodash",
         "@language_support_ts_deps//@types/ws",
         "@language_support_ts_deps//cross-fetch",
         "@language_support_ts_deps//events",

--- a/language-support/ts/daml-ledger/README.md
+++ b/language-support/ts/daml-ledger/README.md
@@ -54,10 +54,21 @@ of that template visible for the submitting party are returned.
 
 `streamQuery`
 -------------
-Retrieve a consolidated stream of events for a given template and query. The accumulated state is
-the current set of active contracts matching the query. An event can be a `CreateEvent` or an
-`ArchiveEvent`. When no `query` argument is given, all events visible to the submitting party are
-returned.
+
+> Deprecated: prefer `streamQueries`.
+
+Retrieve a consolidated stream of events for a given template and optional
+query. The accumulated state is the current set of active contracts matching
+the query if one was given; if the function was called without a query
+argument, or the query argument was `undefined`, the accumulated state will
+instead contain all of the active contracts for the given template.
+
+`streamQueries`
+---------------
+Retrieve a consolidated stream of events for a given template and queries. The
+accumulated state is the current set of active contracts matching at least one
+of the given queries, or all contracts for the given template if no query is
+given.
 
 `fetch`
 -------
@@ -69,11 +80,32 @@ Fetch a contract identified by its contract key.
 
 `streamFetchByKey`
 ------------------
-Retrieve a consolidated stream of `CreateEvent`'s for a given template and contract key.
 
+> Deprecated: prefer `streamFetchByKeys`.
+
+Retrieve a consolidated stream of `CreateEvent`'s for a given template and
+contract key. The accumulated state is either the `CreateEvent` for the active
+contract matching the given key, or null if there is no currently-active
+contract for the given key.
+
+`streamFetchByKeys`
+-------------------
+Retrieve a consolidated stream of `CreateEvent`'s for a given template and
+contract keys. The accumulated state is a vector of the same length as the
+given vector of keys, where each element is the CreateEvent for the current
+active contract of the corresponding key (element-wise), or null if there is no
+current active contract for that key.
+
+Note: the given `key` objects will be compared for (deep) equality with the
+values returned by the API. As such, they have to be given in the "output"
+format of the JSON API. See the [JSON API docs] for details.
+
+[JSON API docs]: https://docs.daml.com/json-api/lf-value-specification.html
 
 ## Source
+
 https://github.com/digital-asset/daml/tree/master/language-support/ts/daml-ledger
 
 ## License
+
 [Apache-2.0](https://github.com/digital-asset/daml/blob/master/LICENSE)

--- a/language-support/ts/daml-ledger/index.test.ts
+++ b/language-support/ts/daml-ledger/index.test.ts
@@ -3,6 +3,7 @@
 
 import { Template, Choice, ContractId } from "@daml/types";
 import Ledger, {CreateEvent} from "./index";
+import {assert} from "./index";
 import { Event } from "./index";
 import * as jtv from "@mojotech/json-type-validation";
 import type { EventEmitter } from 'events';
@@ -74,7 +75,8 @@ const Foo: Template<Foo, string, "foo-id"> = {
 };
 
 const fooCreateEvent = (
-  coid: number
+  coid: number,
+  key?: string,
 ): CreateEvent<Foo, string, "foo-id"> => {
   return {
     templateId: "foo-id",
@@ -82,7 +84,7 @@ const fooCreateEvent = (
     signatories: [],
     observers: [],
     agreementText: "fooAgreement",
-    key: fooKey,
+    key: key || fooKey,
     payload: {key: fooKey},
   };
 };
@@ -111,7 +113,14 @@ beforeEach(() => {
   mockFunctions.forEach(f => f.mockClear());
 });
 
-describe("streamQuery", () => {
+describe("internals", () => {
+  test("assert throws as expected", () => {
+    assert(true, "not thrown");
+    expect(() => assert(false, "throws")).toThrow();
+  });
+});
+
+describe("streamSubmit", () => {
   test("receive unknown message", () => {
     const ledger = new Ledger(mockOptions);
     const stream = ledger.streamQuery(Foo);
@@ -124,7 +133,7 @@ describe("streamQuery", () => {
 
     mockInstance.serverOpen();
     expect(mockSend).toHaveBeenCalledTimes(1);
-    expect(mockSend).toHaveBeenLastCalledWith({templateIds: [Foo.templateId]});
+    expect(mockSend).toHaveBeenLastCalledWith([{templateIds: [Foo.templateId]}]);
     const restoreConsole = mockConsole();
     mockInstance.serverSend('mickey mouse');
     expect(console.error).toHaveBeenCalledWith("Ledger.streamQuery unknown message", "mickey mouse");
@@ -133,34 +142,22 @@ describe("streamQuery", () => {
 
   test("receive warnings", () => {
     const ledger = new Ledger(mockOptions);
-    const stream = ledger.streamQuery(Foo);
+    const stream = ledger.streamQueries(Foo, []);
     stream.on("change", mockChange);
     const restoreConsole = mockConsole();
     mockInstance.serverSend({ warnings: ["oh oh"] });
-    expect(console.warn).toHaveBeenCalledWith("Ledger.streamQuery warnings", {"warnings": ["oh oh"]});
+    expect(console.warn).toHaveBeenCalledWith("Ledger.streamQueries warnings", {"warnings": ["oh oh"]});
     restoreConsole();
   });
 
   test("receive errors", () => {
     const ledger = new Ledger(mockOptions);
-    const stream = ledger.streamQuery(Foo);
+    const stream = ledger.streamFetchByKey(Foo, fooKey);
     stream.on("change", mockChange);
     const restoreConsole = mockConsole();
     mockInstance.serverSend({ errors: ["not good!"] });
-    expect(console.error).toHaveBeenCalledWith("Ledger.streamQuery errors", { errors: ["not good!"] });
+    expect(console.error).toHaveBeenCalledWith("Ledger.streamFetchByKey errors", { errors: ["not good!"] });
     restoreConsole();
-  });
-
-  test("receive live event", () => {
-    const ledger = new Ledger(mockOptions);
-    const stream = ledger.streamQuery(Foo);
-    stream.on("live", mockLive);
-    stream.on("change", state => mockChange(state));
-    mockInstance.serverSend({ events: [fooEvent(1)], offset: '3' });
-    expect(mockLive).toHaveBeenCalledTimes(1);
-    expect(mockLive).toHaveBeenLastCalledWith([fooCreateEvent(1)]);
-    expect(mockChange).toHaveBeenCalledTimes(1);
-    expect(mockChange).toHaveBeenLastCalledWith([fooCreateEvent(1)])
   });
 
   test("receive null offset", () => {
@@ -205,6 +202,36 @@ describe("streamQuery", () => {
     expect(mockChange).toHaveBeenCalledTimes(0);
   });
 
+  test("stop listening to a stream", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamQuery(Foo);
+    const count1 = jest.fn();
+    const count2 = jest.fn();
+    stream.on("change", count1);
+    stream.on("change", count2);
+    mockInstance.serverSend({ events: [1, 2, 3].map(fooEvent) });
+    expect(count1).toHaveBeenCalledTimes(1);
+    expect(count2).toHaveBeenCalledTimes(1);
+    stream.off("change", count1)
+    mockInstance.serverSend({ events: [1, 2, 3].map(fooEvent) });
+    expect(count1).toHaveBeenCalledTimes(1);
+    expect(count2).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("streamQuery", () => {
+  test("receive live event", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamQuery(Foo);
+    stream.on("live", mockLive);
+    stream.on("change", state => mockChange(state));
+    mockInstance.serverSend({ events: [fooEvent(1)], offset: '3' });
+    expect(mockLive).toHaveBeenCalledTimes(1);
+    expect(mockLive).toHaveBeenLastCalledWith([fooCreateEvent(1)]);
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenLastCalledWith([fooCreateEvent(1)])
+  });
+
   test("receive one event", () => {
     const ledger = new Ledger(mockOptions);
     const stream = ledger.streamQuery(Foo);
@@ -220,7 +247,7 @@ describe("streamQuery", () => {
     stream.on("change", state => mockChange(state));
     mockInstance.serverSend({ events: [1, 2, 3].map(fooEvent) });
     expect(mockChange).toHaveBeenCalledTimes(1);
-    expect(mockChange).toHaveBeenCalledWith([1, 2, 3].map(fooCreateEvent));
+    expect(mockChange).toHaveBeenCalledWith([1, 2, 3].map(cid => fooCreateEvent(cid)));
   });
 
   test("drop matching created and archived events", () => {
@@ -235,21 +262,50 @@ describe("streamQuery", () => {
     expect(mockChange).toHaveBeenCalledTimes(1);
     expect(mockChange).toHaveBeenCalledWith([fooCreateEvent(2)]);
   });
+});
 
-  test("stop lisetning to a stream", () => {
+describe("streamQueries", () => {
+  test("receive live event", () => {
     const ledger = new Ledger(mockOptions);
-    const stream = ledger.streamQuery(Foo);
-    const count1 = jest.fn();
-    const count2 = jest.fn();
-    stream.on("change", count1);
-    stream.on("change", count2);
+    const stream = ledger.streamQueries(Foo, []);
+    stream.on("live", mockLive);
+    stream.on("change", state => mockChange(state));
+    mockInstance.serverSend({ events: [fooEvent(1)], offset: '3' });
+    expect(mockLive).toHaveBeenCalledTimes(1);
+    expect(mockLive).toHaveBeenLastCalledWith([fooCreateEvent(1)]);
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenLastCalledWith([fooCreateEvent(1)])
+  });
+
+  test("receive one event", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamQueries(Foo, []);
+    stream.on("change", state => mockChange(state));
+    mockInstance.serverSend({ events: [fooEvent(1)] });
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenLastCalledWith([fooCreateEvent(1)]);
+  });
+
+  test("receive several events", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamQueries(Foo, []);
+    stream.on("change", state => mockChange(state));
     mockInstance.serverSend({ events: [1, 2, 3].map(fooEvent) });
-    expect(count1).toHaveBeenCalledTimes(1);
-    expect(count2).toHaveBeenCalledTimes(1);
-    stream.off("change", count1)
-    mockInstance.serverSend({ events: [1, 2, 3].map(fooEvent) });
-    expect(count1).toHaveBeenCalledTimes(1);
-    expect(count2).toHaveBeenCalledTimes(2);
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith([1, 2, 3].map(cid => fooCreateEvent(cid)));
+  });
+
+  test("drop matching created and archived events", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamQueries(Foo, []);
+    stream.on("change", state => mockChange(state));
+    mockInstance.serverSend({ events: [fooEvent(1), fooEvent(2)] });
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith([fooCreateEvent(1), fooCreateEvent(2)]);
+    mockChange.mockClear();
+    mockInstance.serverSend({ events: [fooArchiveEvent(1)]});
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith([fooCreateEvent(2)]);
   });
 });
 
@@ -293,40 +349,73 @@ describe("streamFetchByKey", () => {
     expect(mockChange).toHaveBeenCalledWith(null);
   });
 
-  test("reconnect on close", async () => {
-    const reconnectThreshold = 200;
-    const ledger = new Ledger({...mockOptions, reconnectThreshold: reconnectThreshold} );
-    const stream = ledger.streamFetchByKey(Foo, fooKey);
-    stream.on("live", mockLive);
-    stream.on("close", mockClose);
-    //send live event, but no contract yet.
-    mockInstance.serverSend({events: [], offset: '3'});
-    await new Promise(resolve => setTimeout(resolve, reconnectThreshold));
-    mockConstructor.mockClear();
-    mockInstance.serverClose({code: 1, reason: 'test close'});
-    expect(mockConstructor).toHaveBeenCalled();
-    mockInstance.serverOpen();
-    expect(mockSend).toHaveBeenCalledTimes(2)
-    expect(mockSend).toHaveBeenNthCalledWith(1, {'offset': '3'});
-    expect(mockSend).toHaveBeenNthCalledWith(2, [{'key': 'fooKey', 'templateId': 'foo-id', 'contractIdAtOffset': null}]);
+});
 
-    //send live event and set the last contract id.
-    mockInstance.serverSend({events: [fooEvent(1)], offset: '4'});
-    await new Promise(resolve => setTimeout(resolve, reconnectThreshold));
-    mockConstructor.mockClear();
-    mockInstance.serverClose({code: 1, reason: 'second test close'});
-    expect(mockConstructor).toHaveBeenCalled();
-    mockSend.mockClear();
-    mockInstance.serverOpen();
-    expect(mockSend).toHaveBeenCalledTimes(2);
-    expect(mockSend).toHaveBeenNthCalledWith(1, {'offset': '4'});
-    expect(mockSend).toHaveBeenNthCalledWith(2, [{'key': 'fooKey', 'templateId': 'foo-id', 'contractIdAtOffset': '1'}]);
-    mockSend.mockClear();
-    mockConstructor.mockClear();
+describe("streamFetchByKeys", () => {
+  test("receive one event", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamFetchByKeys(Foo, [fooKey]);
+    stream.on("change", state => mockChange(state));
+    mockInstance.serverSend({ events: [fooEvent(1)] });
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith([fooCreateEvent(1)]);
+  });
 
-    // check that the client doesn't try to reconnect again.  it should only reconnect if it
-    // received an event confirming the stream is live again, i.e. {events: [], offset: '3'}
-    mockInstance.serverClose({code: 1, reason: 'test close'});
-    expect(mockConstructor).not.toHaveBeenCalled();
+  test("receive several events", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamFetchByKeys(Foo, [fooKey]);
+    stream.on("change", state => mockChange(state));
+    mockInstance.serverSend({ events: [fooEvent(1), fooEvent(2), fooEvent(3)] });
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith([fooCreateEvent(3)]);
+  });
+
+  test("drop matching created and archived events", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamFetchByKeys(Foo, [fooKey]);
+    stream.on("change", state => mockChange(state));
+    mockInstance.serverSend({ events: [fooEvent(1)] });
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith([fooCreateEvent(1)]);
+    mockChange.mockClear();
+    mockInstance.serverSend({ events: [fooArchiveEvent(1)] });
+    expect(mockChange).toHaveBeenCalledTimes(1);
+    expect(mockChange).toHaveBeenCalledWith([null]);
+  });
+
+  test("watch multiple keys", () => {
+    const create = (cid: number, key: string): Event<Foo> => ({created: fooCreateEvent(cid, key)});
+    const archive = fooArchiveEvent;
+    const send = (events: Event<Foo>[]): void => mockInstance.serverSend({events});
+    const expectCids = (expected: (number | null)[]): void => expect(mockChange) .toHaveBeenCalledWith( expected.map((cid: number | null, idx) => cid ? fooCreateEvent(cid, 'key' + (idx + 1)) : null));
+
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamFetchByKeys(Foo, ['key1', 'key2']);
+    stream.on("change", state => mockChange(state));
+
+    send([create(1, 'key1')]);
+    expectCids([1, null]);
+
+    send([create(2, 'key2')]);
+    expectCids([1, 2]);
+
+    send([archive(1), create(3, 'key1')]);
+    expectCids([3, 2]);
+
+    send([archive(2), archive(3), create(4, 'key2')]);
+    expectCids([null, 4]);
+  });
+
+  test("watch zero keys", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamFetchByKeys(Foo, []);
+    stream.close();
+    const change = jest.fn();
+    stream.on("change", state => change(state));
+    expect(change).toHaveBeenCalledTimes(1);
+    expect(change).toHaveBeenCalledWith([]);
+    mockInstance.serverSend({ events: [1, 2, 3].map(fooEvent) });
+    expect(change).toHaveBeenCalledWith([]);
+    expect(change).toHaveBeenCalledTimes(1);
   });
 });

--- a/language-support/ts/daml-ledger/package.json
+++ b/language-support/ts/daml-ledger/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
+    "@types/lodash": "4.14.161",
     "@types/ws": "^7.2.1",
     "@typescript-eslint/eslint-plugin": "^2.16.0",
     "@typescript-eslint/parser": "^2.16.0",

--- a/language-support/ts/daml-react/createLedgerContext.ts
+++ b/language-support/ts/daml-react/createLedgerContext.ts
@@ -170,9 +170,9 @@ export function createLedgerContext(contextName="DamlLedgerContext"): LedgerCont
     const state = useDamlState();
     useEffect(() => {
       setResult({contracts: [], loading: true});
-      const query = queryFactory ? queryFactory() : undefined;
+      const query = queryFactory ? [queryFactory()] : [];
       console.debug(`mount useStreamQuery(${template.templateId}, ...)`, query);
-      const stream = state.ledger.streamQuery(template, query);
+      const stream = state.ledger.streamQueries(template, query);
       stream.on('live', () => setResult(result => ({...result, loading: false})));
       stream.on('change', contracts => setResult(result => ({...result, contracts})));
       stream.on('close', closeEvent => {
@@ -195,8 +195,8 @@ export function createLedgerContext(contextName="DamlLedgerContext"): LedgerCont
       setResult({contract: null, loading: true});
       const key = keyFactory();
       console.debug(`mount useStreamFetchByKey(${template.templateId}, ...)`, key);
-      const stream = state.ledger.streamFetchByKey(template, key);
-      stream.on('change', contract => setResult(result => ({...result, contract})));
+      const stream = state.ledger.streamFetchByKeys(template, [key]);
+      stream.on('change', contracts => setResult(result => ({...result, contract: contracts[0]})));
       stream.on('close', closeEvent => {
         console.error('useStreamFetchByKey: web socket closed', closeEvent);
         setResult(result => ({...result, loading: true}));

--- a/language-support/ts/daml-react/index.test.ts
+++ b/language-support/ts/daml-react/index.test.ts
@@ -15,9 +15,9 @@ const mockConstructor = jest.fn();
 const mockQuery = jest.fn();
 const mockFetch = jest.fn();
 const mockFetchByKey = jest.fn();
-const mockStreamQuery = jest.fn();
-const mockStreamFetchByKey = jest.fn();
-const mockFunctions = [mockConstructor, mockQuery, mockFetch, mockFetchByKey, mockStreamQuery, mockStreamFetchByKey];
+const mockStreamQueries = jest.fn();
+const mockStreamFetchByKeys = jest.fn();
+const mockFunctions = [mockConstructor, mockQuery, mockFetch, mockFetchByKey, mockStreamQueries, mockStreamFetchByKeys];
 
 jest.mock('@daml/ledger', () => class {
   constructor(...args: unknown[]) {
@@ -35,12 +35,12 @@ jest.mock('@daml/ledger', () => class {
     return mockFetchByKey(...args);
   }
 
-  streamQuery(...args: unknown[]): Stream<object, string, string, string[]>{
-    return mockStreamQuery(...args);
+  streamQueries(...args: unknown[]): Stream<object, string, string, string[]>{
+    return mockStreamQueries(...args);
   }
 
-  streamFetchByKey(...args: unknown[]): Stream<object, string, string, string | null>{
-    return mockStreamFetchByKey(...args);
+  streamFetchByKeys(...args: unknown[]): Stream<object, string, string, string | null>{
+    return mockStreamFetchByKeys(...args);
   }
 });
 
@@ -312,10 +312,10 @@ describe('useStreamQuery', () => {
     // setup
     const query = 'foo-query';
     const [stream, emitter] = mockStream();
-    mockStreamQuery.mockReturnValueOnce(stream);
+    mockStreamQueries.mockReturnValueOnce(stream);
     const hookResult = renderDamlHook(() => useStreamQuery(Foo, () => ({query}), [query]));
-    expect(mockStreamQuery).toHaveBeenCalledTimes(1);
-    expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query});
+    expect(mockStreamQueries).toHaveBeenCalledTimes(1);
+    expect(mockStreamQueries).toHaveBeenLastCalledWith(Foo, [{query}]);
 
     // no events have been emitted.
     expect(hookResult.result.current).toEqual({contracts: [], loading:true});
@@ -331,10 +331,10 @@ describe('useStreamQuery', () => {
     // setup
     const query = 'foo-query';
     const [stream, emitter] = mockStream();
-    mockStreamQuery.mockReturnValueOnce(stream);
+    mockStreamQueries.mockReturnValueOnce(stream);
     const hookResult = renderDamlHook(() => useStreamQuery(Foo, () => ({query}), [query]));
-    expect(mockStreamQuery).toHaveBeenCalledTimes(1);
-    expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query});
+    expect(mockStreamQueries).toHaveBeenCalledTimes(1);
+    expect(mockStreamQueries).toHaveBeenLastCalledWith(Foo, [{query}]);
 
     // no events have been emitted.
     expect(hookResult.result.current).toEqual({contracts: [], loading:true});
@@ -350,10 +350,10 @@ describe('useStreamQuery', () => {
     // setup
     const query = 'foo-query';
     const [stream, emitter] = mockStream();
-    mockStreamQuery.mockReturnValueOnce(stream);
+    mockStreamQueries.mockReturnValueOnce(stream);
     const hookResult = renderDamlHook(() => useStreamQuery(Foo, () => ({query}), [query]));
-    expect(mockStreamQuery).toHaveBeenCalledTimes(1);
-    expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query});
+    expect(mockStreamQueries).toHaveBeenCalledTimes(1);
+    expect(mockStreamQueries).toHaveBeenLastCalledWith(Foo, [{query}]);
 
     // live event
     act(() =>
@@ -375,10 +375,10 @@ describe('useStreamQuery', () => {
     // setup
     const query = 'foo-query';
     const [stream, emitter] = mockStream();
-    mockStreamQuery.mockReturnValueOnce(stream);
+    mockStreamQueries.mockReturnValueOnce(stream);
     const hookResult = renderDamlHook(() => useStreamQuery(Foo, () => ({query}), [query]));
-    expect(mockStreamQuery).toHaveBeenCalledTimes(1);
-    expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query: query});
+    expect(mockStreamQueries).toHaveBeenCalledTimes(1);
+    expect(mockStreamQueries).toHaveBeenLastCalledWith(Foo, [{query: query}]);
     expect(hookResult.result.current.contracts).toEqual([]);
 
     // live event
@@ -403,14 +403,14 @@ describe('useStreamQuery', () => {
     const query1 = 'foo-query';
     const query2 = 'bar-query';
     const [stream, emitter] = mockStream();
-    mockStreamQuery.mockReturnValueOnce(stream);
+    mockStreamQueries.mockReturnValueOnce(stream);
     const {result} = renderDamlHook(() => {
       const [query, setQuery] = useState(query1);
       const queryResult = useStreamQuery(Foo, () => ({query}), [query]);
       return {queryResult, query, setQuery};
     })
-    expect(mockStreamQuery).toHaveBeenCalledTimes(1);
-    expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query: query1});
+    expect(mockStreamQueries).toHaveBeenCalledTimes(1);
+    expect(mockStreamQueries).toHaveBeenLastCalledWith(Foo, [{query: query1}]);
 
     // live event
     act(() =>
@@ -424,15 +424,15 @@ describe('useStreamQuery', () => {
     expect(result.current.queryResult).toEqual({contracts: ['foo'], loading: false});
 
     // change query, expect stream to have been called with new query.
-    mockStreamQuery.mockClear();
-    mockStreamQuery.mockReturnValueOnce(stream);
+    mockStreamQueries.mockClear();
+    mockStreamQueries.mockReturnValueOnce(stream);
     act(() => result.current.setQuery(query2));
     // live event
     act(() => void emitter.emit('live', null));
     // change event
     act(() => void emitter.emit('change', ['bar']));
-    expect(mockStreamQuery).toHaveBeenCalledTimes(1);
-    expect(mockStreamQuery).toHaveBeenLastCalledWith(Foo, {query: query2});
+    expect(mockStreamQueries).toHaveBeenCalledTimes(1);
+    expect(mockStreamQueries).toHaveBeenLastCalledWith(Foo, [{query: query2}]);
     expect(result.current.queryResult).toEqual({contracts: ['bar'], loading: false});
   });
 });
@@ -442,13 +442,13 @@ describe('useStreamFetchByKey', () => {
     const contract = {owner: 'Alice'};
     const key = contract.owner;
     const [stream, emitter] = mockStream();
-    mockStreamFetchByKey.mockReturnValueOnce(stream);
+    mockStreamFetchByKeys.mockReturnValueOnce(stream);
     const {result} = renderDamlHook(() => useStreamFetchByKey(Foo, () => key, [key]));
-    expect(mockStreamFetchByKey).toHaveBeenCalledTimes(1);
-    expect(mockStreamFetchByKey).toHaveBeenLastCalledWith(Foo, key);
+    expect(mockStreamFetchByKeys).toHaveBeenCalledTimes(1);
+    expect(mockStreamFetchByKeys).toHaveBeenLastCalledWith(Foo, [key]);
     expect(result.current).toEqual({contract: null, loading: false});
 
-    act(() => void emitter.emit('change', null));
+    act(() => void emitter.emit('change', [null]));
     expect(result.current).toEqual({contract: null, loading: false});
   }),
 
@@ -456,13 +456,13 @@ describe('useStreamFetchByKey', () => {
     const contract = {owner: 'Alice'};
     const key = contract.owner;
     const [stream, emitter] = mockStream();
-    mockStreamFetchByKey.mockReturnValueOnce(stream);
+    mockStreamFetchByKeys.mockReturnValueOnce(stream);
     const {result} = renderDamlHook(() => useStreamFetchByKey(Foo, () => key, [key]));
-    expect(mockStreamFetchByKey).toHaveBeenCalledTimes(1);
-    expect(mockStreamFetchByKey).toHaveBeenLastCalledWith(Foo, key);
+    expect(mockStreamFetchByKeys).toHaveBeenCalledTimes(1);
+    expect(mockStreamFetchByKeys).toHaveBeenLastCalledWith(Foo, [key]);
     expect(result.current).toEqual({contract: null, loading: false});
 
-    act(() => void emitter.emit('change', contract));
+    act(() => void emitter.emit('change', [contract]));
     expect(result.current).toEqual({contract: contract, loading: false});
   }),
 
@@ -471,22 +471,22 @@ describe('useStreamFetchByKey', () => {
     const key1 = contract.k1;
     const key2 = contract.k2
     const [stream, emitter] = mockStream();
-    mockStreamFetchByKey.mockReturnValueOnce(stream);
+    mockStreamFetchByKeys.mockReturnValueOnce(stream);
     const {result} = renderDamlHook(() => {
       const [key, setKey] = useState(key1);
       const fetchResult = useStreamFetchByKey(Foo, () => key, [key]);
       return {fetchResult, key, setKey};
     })
-    act(() => void emitter.emit('change', contract));
-    expect(mockStreamFetchByKey).toHaveBeenCalledTimes(1);
-    expect(mockStreamFetchByKey).toHaveBeenLastCalledWith(Foo, key1);
+    act(() => void emitter.emit('change', [contract]));
+    expect(mockStreamFetchByKeys).toHaveBeenCalledTimes(1);
+    expect(mockStreamFetchByKeys).toHaveBeenLastCalledWith(Foo, [key1]);
     expect(result.current.fetchResult).toEqual({contract: contract, loading: false});
 
-    mockStreamFetchByKey.mockClear();
-    mockStreamFetchByKey.mockReturnValueOnce(stream);
+    mockStreamFetchByKeys.mockClear();
+    mockStreamFetchByKeys.mockReturnValueOnce(stream);
     act(() => result.current.setKey(key2));
-    expect(mockStreamFetchByKey).toHaveBeenCalledTimes(1);
-    expect(mockStreamFetchByKey).toHaveBeenLastCalledWith(Foo, key2);
+    expect(mockStreamFetchByKeys).toHaveBeenCalledTimes(1);
+    expect(mockStreamFetchByKeys).toHaveBeenLastCalledWith(Foo, [key2]);
   });
 
   describe('createLedgerContext', () => {

--- a/language-support/ts/packages/package.json
+++ b/language-support/ts/packages/package.json
@@ -15,6 +15,7 @@
     "@bazel/hide-bazel-files": "1.7.0",
     "@bazel/typescript": "2.0.0",
     "@types/jest": "^24.9.0",
+    "@types/lodash": "4.14.161",
     "@types/react": "^16.9.20",
     "@types/ws": "^7.2.1",
     "@typescript-eslint/eslint-plugin": "^2.16.0",

--- a/language-support/ts/packages/yarn.lock
+++ b/language-support/ts/packages/yarn.lock
@@ -510,6 +510,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/lodash@4.14.161":
+  version "4.14.161"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
+  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
+
 "@types/long@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"


### PR DESCRIPTION
This is an attempt to address #7034 & #7036. I'd like to gather feedback
before moving further, though, because while I believe (based on limited
problem domain knowledge) that this is the rigth way to address them,
strictly speaking this does not fulfill their stated acceptance
criteria.

In particular, I have chosen to keep limiting both scopes to a single
template ID. Ignoring the fact that I'm having trouble reasoning about
the type of the resulting stream if we accept arbitrary lists of
template IDs in these calls, I'm also questioning whether we want to
encourage our users to build their applications on top of such
dynamically heterogeneous lists.

CHANGELOG_BEGIN

deprecation warning & upgrade instructions to be fleshed out

CHANGELOG_END