### PR TITLE
ledger-on-memory: Split the tests into a test suite.

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -5,7 +5,7 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
     "da_scala_library",
-    "da_scala_test",
+    "da_scala_test_suite",
 )
 load("//ledger/ledger-api-test-tool:conformance.bzl", "conformance_test")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
@@ -38,7 +38,33 @@ da_scala_library(
     ],
 )
 
-da_scala_test(
+da_scala_library(
+    name = "ledger-on-memory-test-lib",
+    srcs = glob(["src/test/lib/scala/**/*.scala"]),
+    deps = [
+        ":ledger-on-memory",
+        "//daml-lf/data",
+        "//daml-lf/engine",
+        "//language-support/scala/bindings",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger/caching",
+        "//ledger/ledger-api-common",
+        "//ledger/ledger-api-health",
+        "//ledger/metrics",
+        "//ledger/participant-state",
+        "//ledger/participant-state/kvutils",
+        "//ledger/participant-state/kvutils:kvutils-tests-lib",
+        "//libs-scala/contextualized-logging",
+        "//libs-scala/resources",
+        "@maven//:com_typesafe_akka_akka_actor_2_12",
+        "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:org_scalactic_scalactic_2_12",
+        "@maven//:org_scalatest_scalatest_2_12",
+    ],
+)
+
+da_scala_test_suite(
     name = "ledger-on-memory-tests",
     size = "small",
     srcs = glob(["src/test/suite/**/*.scala"]),
@@ -48,12 +74,11 @@ da_scala_test(
     resources = glob(["src/test/resources/*"]),
     deps = [
         ":ledger-on-memory",
+        ":ledger-on-memory-test-lib",
         "//daml-lf/data",
-        "//daml-lf/engine",
         "//language-support/scala/bindings",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",
-        "//ledger/caching",
         "//ledger/ledger-api-common",
         "//ledger/ledger-api-health",
         "//ledger/metrics",

--- a/ledger/ledger-on-memory/src/test/lib/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-memory/src/test/lib/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpecBase.scala
@@ -30,7 +30,7 @@ abstract class InMemoryLedgerReaderWriterIntegrationSpecBase(enableBatching: Boo
       // (otherwise some of those would be rejected).
       // See [[ParticipantStateIntegrationSpecBase]].
       maxBatchQueueSize = if (enableBatching) 100 else 1000,
-      maxBatchSizeBytes = 4 * 1024 * 1024 /* 4MB */,
+      maxBatchSizeBytes = 4L * 1024L * 1024L /* 4MB */,
       maxBatchWaitDuration = 100.millis,
       // In-memory ledger doesn't support concurrent commits.
       maxBatchConcurrentCommits = 1

--- a/ledger/ledger-on-memory/src/test/lib/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpecBase.scala
+++ b/ledger/ledger-on-memory/src/test/lib/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpecBase.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.on.memory
+
+import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase
+import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase.ParticipantState
+import com.daml.ledger.participant.state.kvutils.api.{
+  BatchingLedgerWriterConfig,
+  KeyValueParticipantState
+}
+import com.daml.ledger.participant.state.v1.{LedgerId, ParticipantId}
+import com.daml.lf.engine.Engine
+import com.daml.logging.LoggingContext
+import com.daml.metrics.Metrics
+import com.daml.resources.ResourceOwner
+
+import scala.concurrent.duration.DurationInt
+
+abstract class InMemoryLedgerReaderWriterIntegrationSpecBase(enableBatching: Boolean)
+    extends ParticipantStateIntegrationSpecBase(
+      s"In-memory ledger/participant with parallel validation ${if (enableBatching) "enabled"
+      else "disabled"}") {
+
+  private val batchingLedgerWriterConfig =
+    BatchingLedgerWriterConfig(
+      enableBatching = enableBatching,
+      // In case of serial validation, we need a queue length of 1000 because the
+      // "process many party allocations" test case will be sending in that many requests at once
+      // (otherwise some of those would be rejected).
+      // See [[ParticipantStateIntegrationSpecBase]].
+      maxBatchQueueSize = if (enableBatching) 100 else 1000,
+      maxBatchSizeBytes = 4 * 1024 * 1024 /* 4MB */,
+      maxBatchWaitDuration = 100.millis,
+      // In-memory ledger doesn't support concurrent commits.
+      maxBatchConcurrentCommits = 1
+    )
+
+  override val isPersistent: Boolean = false
+
+  override def participantStateFactory(
+      ledgerId: LedgerId,
+      participantId: ParticipantId,
+      testId: String,
+      metrics: Metrics,
+  )(implicit loggingContext: LoggingContext): ResourceOwner[ParticipantState] =
+    new InMemoryLedgerReaderWriter.SingleParticipantBatchingOwner(
+      ledgerId,
+      batchingLedgerWriterConfig,
+      participantId,
+      metrics = metrics,
+      engine = Engine.DevEngine()
+    ).map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter, metrics))
+
+}

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterIntegrationSpec.scala
@@ -3,56 +3,5 @@
 
 package com.daml.ledger.on.memory
 
-import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase
-import com.daml.ledger.participant.state.kvutils.ParticipantStateIntegrationSpecBase.ParticipantState
-import com.daml.ledger.participant.state.kvutils.api.{
-  BatchingLedgerWriterConfig,
-  KeyValueParticipantState
-}
-import com.daml.ledger.participant.state.v1.{LedgerId, ParticipantId}
-import com.daml.lf.engine.Engine
-import com.daml.logging.LoggingContext
-import com.daml.metrics.Metrics
-import com.daml.resources.ResourceOwner
-
-import scala.concurrent.duration._
-
-abstract class InMemoryLedgerReaderWriterIntegrationSpecBase(enableBatching: Boolean)
-    extends ParticipantStateIntegrationSpecBase(
-      s"In-memory ledger/participant with parallel validation ${if (enableBatching) "enabled"
-      else "disabled"}") {
-
-  private val batchingLedgerWriterConfig =
-    BatchingLedgerWriterConfig(
-      enableBatching = enableBatching,
-      // In case of serial validation, we need a queue length of 1000 because the
-      // "process many party allocations" test case will be sending in that many requests at once
-      // (otherwise some of those would be rejected).
-      // See [[ParticipantStateIntegrationSpecBase]].
-      maxBatchQueueSize = if (enableBatching) 100 else 1000,
-      maxBatchSizeBytes = 4 * 1024 * 1024 /* 4MB */,
-      maxBatchWaitDuration = 100.millis,
-      // In-memory ledger doesn't support concurrent commits.
-      maxBatchConcurrentCommits = 1
-    )
-
-  override val isPersistent: Boolean = false
-
-  override def participantStateFactory(
-      ledgerId: LedgerId,
-      participantId: ParticipantId,
-      testId: String,
-      metrics: Metrics,
-  )(implicit loggingContext: LoggingContext): ResourceOwner[ParticipantState] =
-    new InMemoryLedgerReaderWriter.SingleParticipantBatchingOwner(
-      ledgerId,
-      batchingLedgerWriterConfig,
-      participantId,
-      metrics = metrics,
-      engine = Engine.DevEngine()
-    ).map(readerWriter => new KeyValueParticipantState(readerWriter, readerWriter, metrics))
-
-}
-
 class InMemoryLedgerReaderWriterIntegrationSpec
     extends InMemoryLedgerReaderWriterIntegrationSpecBase(enableBatching = true)


### PR DESCRIPTION
The ledger-on-memory tests are sporadically failing on CI because they hit the timeout of 60s, which is the default for a "small" test target. This is not outside the realm of possibility, as tests can take a while on CI when lots of other things are running.

To mitigate this, rather than increasing the timeout, I am splitting the tests up into a suite, which means they'll run as 3 targets, not 1, each with a 60s timeout. This means they're far more likely to complete in the allocated time.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
