### PR TITLE
Move ApplicationId in daml-script to ledger client

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -224,11 +224,8 @@ class ReplService(
         compiledDefinitions ++ defs,
         Compiler.FullStackTrace,
         Compiler.NoProfile)
-    val runner = new Runner(
-      compiledPackages,
-      Script.Action(scriptExpr, ScriptIds(scriptPackageId)),
-      ApplicationId("daml repl"),
-      timeMode)
+    val runner =
+      new Runner(compiledPackages, Script.Action(scriptExpr, ScriptIds(scriptPackageId)), timeMode)
     runner.runWithClients(clients).onComplete {
       case Failure(e: SError.SError) =>
         // The error here is already printed by the logger in stepToValue.

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -23,7 +23,6 @@ import com.daml.lf.speedy.SExpr.{LfDefRef, SDefinitionRef}
 import com.daml.lf.transaction.TransactionVersions
 import com.daml.lf.validation.Validation
 import com.google.protobuf.ByteString
-import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 
 import com.daml.lf.engine.script.{
   Runner,
@@ -202,8 +201,6 @@ class Context(val contextId: Context.ContextId, languageVersion: LanguageVersion
     val runner = new Runner(
       compiledPackages,
       Script.Action(scriptExpr, ScriptIds(scriptPackageId)),
-      // TODO The application id should be part of the client.
-      ApplicationId("Script Service"),
       ScriptTimeMode.Static
     )
     val client = new IdeClient(compiledPackages)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -120,10 +120,9 @@ trait ScriptLedgerClient {
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Seq[ScriptLedgerClient.ActiveContract]]
 
-  def submit(
-      applicationId: ApplicationId,
-      party: SParty,
-      commands: List[ScriptLedgerClient.Command])(implicit ec: ExecutionContext, mat: Materializer)
+  def submit(party: SParty, commands: List[ScriptLedgerClient.Command])(
+      implicit ec: ExecutionContext,
+      mat: Materializer)
     : Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]]
 
   def allocateParty(partyIdHint: String, displayName: String)(
@@ -145,7 +144,8 @@ trait ScriptLedgerClient {
       mat: Materializer): Future[Unit]
 }
 
-class GrpcLedgerClient(val grpcClient: LedgerClient) extends ScriptLedgerClient {
+class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: ApplicationId)
+    extends ScriptLedgerClient {
   override def query(party: SParty, templateId: Identifier)(
       implicit ec: ExecutionContext,
       mat: Materializer) = {
@@ -173,10 +173,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient) extends ScriptLedgerClient 
         })))
   }
 
-  override def submit(
-      applicationId: ApplicationId,
-      party: SParty,
-      commands: List[ScriptLedgerClient.Command])(
+  override def submit(party: SParty, commands: List[ScriptLedgerClient.Command])(
       implicit ec: ExecutionContext,
       mat: Materializer) = {
     val ledgerCommands = commands.traverse(toCommand(_)) match {
@@ -358,10 +355,9 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
     compiledPackages.compiler.unsafeCompile(cmds)
   }
 
-  override def submit(
-      applicationId: ApplicationId,
-      party: SParty,
-      commands: List[ScriptLedgerClient.Command])(implicit ec: ExecutionContext, mat: Materializer)
+  override def submit(party: SParty, commands: List[ScriptLedgerClient.Command])(
+      implicit ec: ExecutionContext,
+      mat: Materializer)
     : Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = {
     machine.returnValue = null
     val translated = translateCommands(commands)
@@ -562,10 +558,9 @@ class JsonLedgerClient(
       parsedResults
     }
   }
-  override def submit(
-      applicationId: ApplicationId,
-      party: SParty,
-      commands: List[ScriptLedgerClient.Command])(implicit ec: ExecutionContext, mat: Materializer)
+  override def submit(party: SParty, commands: List[ScriptLedgerClient.Command])(
+      implicit ec: ExecutionContext,
+      mat: Materializer)
     : Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = {
     for {
       () <- validateTokenParty(party, "submit a command")

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -10,7 +10,6 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
-import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.lf.PureCompiledPackages
 import com.daml.lf.archive.{Dar, DarReader, Decode}
@@ -55,7 +54,7 @@ object TestMain extends StrictLogging {
           case (pkgId, pkgArchive) => Decode.readArchivePayload(pkgId, pkgArchive)
         }
 
-        val applicationId = ApplicationId("Script Test")
+        val applicationId = Runner.DEFAULT_APPLICATION_ID
         val system: ActorSystem = ActorSystem("ScriptTest")
         implicit val sequencer: ExecutionSequencerFactory =
           new AkkaExecutionSequencerPool("ScriptTestPool")(system)
@@ -135,7 +134,7 @@ object TestMain extends StrictLogging {
           _ <- sequentialTraverse(testScripts.toList) {
             case (id, script) =>
               val runner =
-                new Runner(compiledPackages, script, applicationId, config.timeMode)
+                new Runner(compiledPackages, script, config.timeMode)
               val testRun: Future[Unit] = runner.runWithClients(clients).map(_ => ())
               // Print test result and remember failure.
               testRun.onComplete {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -40,9 +40,7 @@ import com.daml.http.HttpService
 import com.daml.jwt.JwtSigner
 import com.daml.jwt.domain.DecodedJwt
 import com.daml.ledger.api.domain.LedgerId
-import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.testing.utils.{
-  MockMessages,
   OwnedResource,
   SuiteResource,
   SuiteResourceManagementAroundAll,
@@ -103,7 +101,7 @@ trait JsonApiFixture
               val config = new HttpService.DefaultStartSettings {
                 override val ledgerHost = "localhost"
                 override val ledgerPort = server.port.value
-                override val applicationId = ApplicationId(MockMessages.applicationId)
+                override val applicationId = Runner.DEFAULT_APPLICATION_ID
                 override val address = "localhost"
                 override val httpPort = 0
                 override val portFile = None
@@ -197,13 +195,7 @@ final class JsonApiIt
       inputValue: Option[JsValue] = Some(JsString(party)),
       dar: Dar[(PackageId, Package)] = dar): Future[SValue] = {
     val scriptId = Identifier(dar.main._1, name)
-    Runner.run(
-      dar,
-      scriptId,
-      inputValue,
-      clients,
-      ApplicationId(MockMessages.applicationId),
-      ScriptTimeMode.WallClock)
+    Runner.run(dar, scriptId, inputValue, clients, ScriptTimeMode.WallClock)
   }
 
   "DAML Script over JSON API" can {

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/TestRunner.scala
@@ -19,7 +19,6 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SValue
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
-import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId}
 import com.daml.ledger.api.tls.TlsConfiguration
 
 import com.daml.lf.engine.script._
@@ -63,8 +62,6 @@ class TestRunner(
     val wallclockTime: Boolean,
     val rootCa: Option[File],
 ) {
-  val applicationId = ApplicationId("DAML Script Test Runner")
-
   val tlsConfig = rootCa.fold(TlsConfiguration(false, None, None, None))(file =>
     TlsConfiguration.Empty.copy(trustCertCollectionFile = Some(file)))
 
@@ -94,11 +91,15 @@ class TestRunner(
     implicit val ec: ExecutionContext = system.dispatcher
 
     val clientsF =
-      Runner.connect(participantParams, applicationId, tlsConfig, maxInboundMessageSize)
+      Runner.connect(
+        participantParams,
+        Runner.DEFAULT_APPLICATION_ID,
+        tlsConfig,
+        maxInboundMessageSize)
 
     val testFlow: Future[Unit] = for {
       clients <- clientsF
-      result <- Runner.run(dar, scriptId, inputValue, clients, applicationId, timeMode)
+      result <- Runner.run(dar, scriptId, inputValue, clients, timeMode)
       _ <- expectedLog match {
         case None => Future.unit
         case Some(expectedLogs) =>


### PR DESCRIPTION
This makes much more sense since for things like the JSON API and the
script service, we don’t actually have the application id as a
separate parameter.

I’ve also cleaned up all the arbitrary hardcoded application id in
various tests in favor of a DEFAULT_APPLICATION_ID value.

Next step is #7029

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
