### PR TITLE
let users stop listening to event streams

### DIFF
--- a/language-support/ts/daml-ledger/index.test.ts
+++ b/language-support/ts/daml-ledger/index.test.ts
@@ -224,6 +224,22 @@ describe("streamQuery", () => {
     expect(mockChange).toHaveBeenCalledTimes(1);
     expect(mockChange).toHaveBeenCalledWith([fooCreateEvent(2)]);
   });
+
+  test("stop lisetning to a stream", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamQuery(Foo);
+    const count1 = jest.fn();
+    const count2 = jest.fn();
+    stream.on("change", count1);
+    stream.on("change", count2);
+    mockInstance.serverSend({ events: [1, 2, 3].map(fooEvent) });
+    expect(count1).toHaveBeenCalledTimes(1);
+    expect(count2).toHaveBeenCalledTimes(1);
+    stream.off("change", count1)
+    mockInstance.serverSend({ events: [1, 2, 3].map(fooEvent) });
+    expect(count1).toHaveBeenCalledTimes(1);
+    expect(count2).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("streamFetchByKey", () => {

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -561,7 +561,7 @@ class Ledger {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const on = (type: string, listener: any): void => void emitter.on(type, listener);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const off = (type: string, listener: any): void => void emitter.on(type, listener);
+    const off = (type: string, listener: any): void => void emitter.off(type, listener);
     const close = (): void => {
       emitter.removeAllListeners();
       ws.close();


### PR DESCRIPTION
I have to imagine this is a typo: there currently is no way to unsubscribe from a stream without closing it, as the `off` method we expose actually redirects to an `on` method internally, which means that instead of the method no longer being called, it now gets called twice (or rather, one more time) on each event.

That seems a bit rude.

CHANGELOG_BEGIN

- [JavaScript Client Libraries] Bugfix: calling the `off` method of event streams returned by `streamQuery` and `streamFetchByKey` now correctly removes the given listener, rather than adding it again.

CHANGELOG_END