### PR TITLE
Make ApplicationId in DAML Triggers configurable

### DIFF
--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerConfig.scala
@@ -6,6 +6,7 @@ package com.daml.lf.engine.trigger
 import java.nio.file.{Path, Paths}
 import java.time.Duration
 
+import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.api.tls.TlsConfigurationCli
 import com.daml.platform.services.time.TimeProviderType
@@ -23,12 +24,15 @@ case class RunnerConfig(
     timeProviderType: Option[TimeProviderType],
     commandTtl: Duration,
     accessTokenFile: Option[Path],
+    applicationId: ApplicationId,
     tlsConfig: TlsConfiguration,
 )
 
 object RunnerConfig {
-  val DefaultMaxInboundMessageSize: Int = 4194304
-  val DefaultTimeProviderType: TimeProviderType = TimeProviderType.WallClock
+  private[trigger] val DefaultMaxInboundMessageSize: Int = 4194304
+  private[trigger] val DefaultTimeProviderType: TimeProviderType = TimeProviderType.WallClock
+  private[trigger] val DefaultApplicationId: ApplicationId =
+    ApplicationId("daml-trigger")
 
   private val parser = new scopt.OptionParser[RunnerConfig]("trigger-runner") {
     head("trigger-runner")
@@ -83,6 +87,12 @@ object RunnerConfig {
         c.copy(accessTokenFile = Some(Paths.get(f)))
       }
       .text("File from which the access token will be read, required to interact with an authenticated ledger")
+
+    opt[String]("application-id")
+      .action { (appId, c) =>
+        c.copy(applicationId = ApplicationId(appId))
+      }
+      .text(s"Application ID used to submit commands. Defaults to ${DefaultApplicationId}")
 
     TlsConfigurationCli.parse(this, colSpacer = "        ")((f, c) =>
       c.copy(tlsConfig = f(c.tlsConfig)))
@@ -140,6 +150,7 @@ object RunnerConfig {
         commandTtl = Duration.ofSeconds(30L),
         accessTokenFile = None,
         tlsConfig = TlsConfiguration(false, None, None, None),
+        applicationId = DefaultApplicationId,
       )
     )
 }

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/RunnerMain.scala
@@ -76,9 +76,8 @@ object RunnerMain {
         // any time it would in principle also be fine to just have the auth failure due
         // to an expired token tear the trigger down and have some external monitoring process (e.g. systemd)
         // restart it.
-        val applicationId = ApplicationId("Trigger Runner")
         val clientConfig = LedgerClientConfiguration(
-          applicationId = ApplicationId.unwrap(applicationId),
+          applicationId = ApplicationId.unwrap(config.applicationId),
           ledgerIdRequirement = LedgerIdRequirement.none,
           commandClient =
             CommandClientConfiguration.default.copy(defaultDeduplicationTime = config.commandTtl),
@@ -100,7 +99,7 @@ object RunnerMain {
             triggerId,
             client,
             config.timeProviderType.getOrElse(RunnerConfig.DefaultTimeProviderType),
-            applicationId,
+            config.applicationId,
             config.ledgerParty)
         } yield ()
 

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractTriggerTest.scala
@@ -11,7 +11,6 @@ import com.daml.bazeltools.BazelRunfiles._
 import com.daml.lf.PureCompiledPackages
 import com.daml.lf.archive.{DarReader, Decode}
 import com.daml.lf.data.Ref._
-import com.daml.ledger.api.testing.utils.MockMessages
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands._
 import com.daml.ledger.api.v1.commands.{Command, CreateCommand, ExerciseCommand}
@@ -33,14 +32,16 @@ import scala.concurrent.{ExecutionContext, Future}
 import scalaz.syntax.tag._
 import scalaz.syntax.traverse._
 
-import com.daml.lf.engine.trigger.{Runner, Trigger}
+import com.daml.lf.engine.trigger.{Runner, RunnerConfig, Trigger}
 
 trait AbstractTriggerTest extends SandboxFixture with TestCommands {
   self: Suite =>
 
+  protected val applicationId = RunnerConfig.DefaultApplicationId
+
   protected def ledgerClientConfiguration =
     LedgerClientConfiguration(
-      applicationId = MockMessages.applicationId,
+      applicationId = ApplicationId.unwrap(applicationId),
       ledgerIdRequirement = LedgerIdRequirement.none,
       commandClient = CommandClientConfiguration.default,
       sslContext = None,
@@ -70,13 +71,7 @@ trait AbstractTriggerTest extends SandboxFixture with TestCommands {
   protected def getRunner(client: LedgerClient, name: QualifiedName, party: String): Runner = {
     val triggerId = Identifier(packageId, name)
     val trigger = Trigger.fromIdentifier(compiledPackages, triggerId).right.get
-    new Runner(
-      compiledPackages,
-      trigger,
-      client,
-      config.timeProviderType.get,
-      ApplicationId(MockMessages.applicationId),
-      party)
+    new Runner(compiledPackages, trigger, client, config.timeProviderType.get, applicationId, party)
   }
 
   protected def allocateParty(client: LedgerClient)(implicit ec: ExecutionContext): Future[String] =
@@ -91,7 +86,7 @@ trait AbstractTriggerTest extends SandboxFixture with TestCommands {
           party = party,
           commands = commands,
           ledgerId = client.ledgerId.unwrap,
-          applicationId = MockMessages.applicationId,
+          applicationId = ApplicationId.unwrap(applicationId),
           commandId = UUID.randomUUID.toString
         )))
     for {
@@ -117,7 +112,7 @@ trait AbstractTriggerTest extends SandboxFixture with TestCommands {
           party = party,
           commands = commands,
           ledgerId = client.ledgerId.unwrap,
-          applicationId = MockMessages.applicationId,
+          applicationId = ApplicationId.unwrap(applicationId),
           commandId = UUID.randomUUID.toString
         )))
     for {

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/Jwt.scala
@@ -6,6 +6,7 @@ package com.daml.lf.engine.trigger.test
 import akka.stream.scaladsl.{Flow}
 import com.daml.lf.data.Ref._
 import com.daml.platform.sandbox.services.SandboxFixtureWithAuth
+import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.testing.utils.{SuiteResourceManagementAroundAll}
 import com.daml.ledger.api.v1.commands._
 import com.daml.ledger.api.v1.commands.CreateCommand
@@ -23,8 +24,11 @@ class Jwt
     with TryValues {
   self: Suite =>
 
+  // Override to make sure we set it correctly.
+  override protected val applicationId: ApplicationId = ApplicationId("custom app id")
+
   override protected def ledgerClientConfiguration = super.ledgerClientConfiguration.copy(
-    token = Some(toHeader(readWriteToken(party)))
+    token = Some(toHeader(forApplicationId("custom app id", readWriteToken(party))))
   )
 
   private val party = "AliceAuth"


### PR DESCRIPTION
fixes #7030

This deliberately ignores the trigger service. The main reason for
setting the ApplicationId at the moment is authentication and this is
still very WIP in the trigger service, so I don’t think it makes sense
to add this in some form to the API until that has settled.

changelog_begin

- [DAML Trigger] You can now configure the application id via
  `--application-id` in `daml trigger`. This is primarily useful if
  you run with authentication.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
