### PR TITLE
Sync query perf scenario, new ACS every query

### DIFF
--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/AsyncQueryConstantAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/AsyncQueryConstantAcs.scala
@@ -45,7 +45,7 @@ class AsyncQueryConstantAcs
   }
 
   private val asyncQueryScenario = scenario(s"AsyncQueryConstantAcs, numberOfRuns: $numberOfRuns")
-    .doWhile(_ => acsQueue.size() < wantedAcsSize) {
+    .doWhile(_ => acsSize() < wantedAcsSize) {
       pause(1.second)
     }
     .exec(
@@ -53,7 +53,7 @@ class AsyncQueryConstantAcs
     )
 
   setUp(
-    fillAcsScenario(wantedAcsSize).inject(atOnceUsers(1)),
+    fillAcsScenario(wantedAcsSize, silent = true).inject(atOnceUsers(1)),
     asyncQueryScenario.inject(atOnceUsers(1)),
   ).protocols(httpProtocol)
 

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasArchiveRequest.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasArchiveRequest.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http.perf.scenario
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+private[scenario] trait HasArchiveRequest {
+
+  lazy val archiveRequest =
+    http("ExerciseCommand")
+      .post("/v1/exercise")
+      .body(StringBody("""{
+    "templateId": "Iou:Iou",
+    "contractId": "${archiveContractId}",
+    "choice": "Archive",
+    "argument": {}
+}"""))
+
+}

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasCreateRequest.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasCreateRequest.scala
@@ -6,16 +6,24 @@ package com.daml.http.perf.scenario
 import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue}
 
 import io.gatling.core.Predef._
-import io.gatling.core.structure.ScenarioBuilder
+import io.gatling.core.action.{Action, ChainableAction}
+import io.gatling.core.action.builder.ActionBuilder
+import io.gatling.core.structure.{ScenarioBuilder, ScenarioContext}
 import io.gatling.http.Predef._
+import io.gatling.http.check.HttpCheck
 import io.gatling.http.request.builder.HttpRequestBuilder
 
 private[scenario] trait HasCreateRequest {
   this: HasRandomAmount =>
 
-  lazy val acsQueue: BlockingQueue[String] = new LinkedBlockingQueue[String]()
+  private lazy val acsQueue: BlockingQueue[String] = new LinkedBlockingQueue[String]()
 
-  lazy val createRequestAndCollectContractId: HttpRequestBuilder =
+  def acsSize(): Int = acsQueue.size
+
+  // would block until at least one element gets available in the queue
+  def takeNextContractIdFromAcs(): String = acsQueue.take
+
+  lazy val randomAmountCreateRequest: HttpRequestBuilder =
     http("CreateCommand")
       .post("/v1/create")
       .body(StringBody("""{
@@ -28,15 +36,18 @@ private[scenario] trait HasCreateRequest {
     "observers": []
   }
 }"""))
-      .check(
-        status.is(200),
-        jsonPath("$.result.contractId").transform(x => acsQueue.put(x))
-      )
 
-  def fillAcsScenario(size: Int): ScenarioBuilder =
+  lazy val captureContractId: HttpCheck =
+    jsonPath("$.result.contractId").transform(x => acsQueue.put(x))
+
+  def fillAcsScenario(size: Int, silent: Boolean): ScenarioBuilder =
     scenario(s"FillAcsScenario, size: $size")
-      .doWhile(_ => acsQueue.size() < size) {
+      .doWhile(_ => this.acsSize() < size) {
         feed(Iterator.continually(Map("amount" -> randomAmount())))
-          .exec(createRequestAndCollectContractId.silent)
+          .group("FillAcsGroup") {
+            val create =
+              if (silent) randomAmountCreateRequest.silent else randomAmountCreateRequest.notSilent
+            exec(create.check(status.is(200)).check(captureContractId)).exitHereIfFailed
+          }
       }
 }

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasCreateRequest.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasCreateRequest.scala
@@ -6,9 +6,7 @@ package com.daml.http.perf.scenario
 import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue}
 
 import io.gatling.core.Predef._
-import io.gatling.core.action.{Action, ChainableAction}
-import io.gatling.core.action.builder.ActionBuilder
-import io.gatling.core.structure.{ScenarioBuilder, ScenarioContext}
+import io.gatling.core.structure.ScenarioBuilder
 import io.gatling.http.Predef._
 import io.gatling.http.check.HttpCheck
 import io.gatling.http.request.builder.HttpRequestBuilder

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasCreateRequest.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasCreateRequest.scala
@@ -18,8 +18,8 @@ private[scenario] trait HasCreateRequest {
 
   def acsSize(): Int = acsQueue.size
 
-  // would block until at least one element gets available in the queue
-  def takeNextContractIdFromAcs(): String = acsQueue.take
+  // does not block throws an exception if queue is empty
+  def removeNextContractIdFromAcs(): String = acsQueue.remove
 
   lazy val randomAmountCreateRequest: HttpRequestBuilder =
     http("CreateCommand")

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasQueryRequest.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/HasQueryRequest.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http.perf.scenario
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+private[scenario] trait HasQueryRequest {
+
+  lazy val randomAmountQueryRequest =
+    http("SyncQueryRequest")
+      .post("/v1/query")
+      .body(StringBody("""{
+    "templateIds": ["Iou:Iou"],
+    "query": {"amount": ${amount}}
+}"""))
+
+}

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
@@ -17,9 +17,9 @@ class SyncQueryNewAcs
     with HasArchiveRequest
     with HasQueryRequest {
 
-  private val wantedAcsSize = 100
+  private val wantedAcsSize = 1000
 
-  private val numberOfRuns = 5
+  private val numberOfRuns = 100
 
   private val syncQueryNewAcs =
     scenario(s"SyncQueryNewAcs, numberOfRuns: $numberOfRuns, ACS size: $wantedAcsSize")

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
@@ -15,7 +15,7 @@ class SyncQueryNewAcs
     with HasArchiveRequest
     with HasQueryRequest {
 
-  private val wantedAcsSize = 5000
+  private val wantedAcsSize = 1000
 
   private val numberOfRuns = 25
 

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
@@ -25,7 +25,7 @@ class SyncQueryNewAcs
         group("Populate ACS") {
           doWhile(_ => acsSize() < wantedAcsSize) {
             feed(Iterator.continually(Map("amount" -> String.valueOf(randomAmount()))))
-              .exec(randomAmountCreateRequest.check(status.is(200), captureContractId).notSilent)
+              .exec(randomAmountCreateRequest.check(status.is(200), captureContractId).silent)
           }
         }.group("Run Query") {
             feed(Iterator.continually(Map("amount" -> String.valueOf(randomAmount()))))
@@ -34,7 +34,7 @@ class SyncQueryNewAcs
           .group("Archive ACS") {
             doWhile(_ => acsSize() > 0) {
               feed(Iterator.continually(Map("archiveContractId" -> removeNextContractIdFromAcs())))
-                .exec(archiveRequest.notSilent)
+                .exec(archiveRequest.silent)
             }
           }
       }

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http.perf.scenario
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+import scala.concurrent.duration._
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+class SyncQueryNewAcs
+    extends Simulation
+    with SimulationConfig
+    with HasRandomAmount
+    with HasCreateRequest
+    with HasArchiveRequest
+    with HasQueryRequest {
+
+  private val wantedAcsSize = 1000
+
+  private val numberOfRuns = 100
+
+  private val syncQueryNewAcs =
+    scenario(s"SyncQueryNewAcs, numberOfRuns: $numberOfRuns")
+      .doWhile(_ => acsSize() < wantedAcsSize) {
+        pause(1.second)
+      }
+      .repeat(numberOfRuns) {
+        // run a query
+        feed(Iterator.continually(Map("amount" -> String.valueOf(randomAmount()))))
+          .exec(randomAmountQueryRequest.notSilent)
+          // archive and re-fill the ACS
+          .repeat(wantedAcsSize)(
+            feed(
+              Iterator.continually(
+                Map[String, String](
+                  "archiveContractId" -> takeNextContractIdFromAcs(),
+                  "amount" -> String.valueOf(randomAmount())
+                )
+              )
+            ).exec(archiveRequest.silent)
+              .exec(
+                randomAmountCreateRequest
+                  .check(status.is(200))
+                  .check(captureContractId)
+                  .silent)
+          )
+      }
+
+  setUp(
+    fillAcsScenario(wantedAcsSize, silent = true).inject(atOnceUsers(1)),
+    syncQueryNewAcs.inject(atOnceUsers(1)),
+  ).protocols(httpProtocol)
+}

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryNewAcs.scala
@@ -22,24 +22,20 @@ class SyncQueryNewAcs
   private val syncQueryNewAcs =
     scenario(s"SyncQueryNewAcs, numberOfRuns: $numberOfRuns, ACS size: $wantedAcsSize")
       .repeat(numberOfRuns) {
-        group("Archive ACS") {
-          doWhile(_ => this.acsSize() > 0) {
-            feed(Iterator.continually(Map("archiveContractId" -> takeNextContractIdFromAcs())))
-              .exec(archiveRequest.silent)
+        group("Populate ACS") {
+          doWhile(_ => acsSize() < wantedAcsSize) {
+            feed(Iterator.continually(Map("amount" -> String.valueOf(randomAmount()))))
+              .exec(randomAmountCreateRequest.check(status.is(200), captureContractId).notSilent)
           }
-        }.group("Populate ACS") {
-            doWhile(_ => this.acsSize() < wantedAcsSize) {
-              feed(Iterator.continually(Map("amount" -> String.valueOf(randomAmount()))))
-                .exec(
-                  randomAmountCreateRequest
-                    .check(status.is(200))
-                    .check(captureContractId)
-                    .silent)
-            }
-          }
-          .group("Run Query") {
+        }.group("Run Query") {
             feed(Iterator.continually(Map("amount" -> String.valueOf(randomAmount()))))
               .exec(randomAmountQueryRequest.notSilent)
+          }
+          .group("Archive ACS") {
+            doWhile(_ => acsSize() > 0) {
+              feed(Iterator.continually(Map("archiveContractId" -> removeNextContractIdFromAcs())))
+                .exec(archiveRequest.notSilent)
+            }
           }
       }
 

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryVariableAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryVariableAcs.scala
@@ -4,7 +4,6 @@
 package com.daml.http.perf.scenario
 
 import io.gatling.core.Predef._
-import io.gatling.http.Predef._
 
 import scala.concurrent.duration._
 

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryVariableAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryVariableAcs.scala
@@ -30,7 +30,7 @@ class SyncQueryVariableAcs
           Iterator.continually(
             Map[String, String](
               "amount" -> String.valueOf(randomAmount()),
-              "archiveContractId" -> takeNextContractIdFromAcs(),
+              "archiveContractId" -> removeNextContractIdFromAcs(),
             )
           )
         ).exec {

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryVariableAcs.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/scenario/SyncQueryVariableAcs.scala
@@ -13,33 +13,17 @@ class SyncQueryVariableAcs
     extends Simulation
     with SimulationConfig
     with HasRandomAmount
-    with HasCreateRequest {
-
-  private val queryRequest =
-    http("SyncQueryRequest")
-      .post("/v1/query")
-      .body(StringBody("""{
-    "templateIds": ["Iou:Iou"],
-    "query": {"amount": ${amount}}
-}"""))
-
-  private val archiveRequest =
-    http("ExerciseCommand")
-      .post("/v1/exercise")
-      .body(StringBody("""{
-    "templateId": "Iou:Iou",
-    "contractId": "${archiveContractId}",
-    "choice": "Archive",
-    "argument": {}
-  }"""))
+    with HasCreateRequest
+    with HasQueryRequest
+    with HasArchiveRequest {
 
   private val wantedAcsSize = 5000
 
   private val numberOfRuns = 500
 
-  private val syncQueryScn =
+  private val syncQueryScenario =
     scenario(s"SyncQueryWithVariableAcsScenario, numberOfRuns: $numberOfRuns")
-      .doWhile(_ => acsQueue.size() < wantedAcsSize) {
+      .doWhile(_ => acsSize() < wantedAcsSize) {
         pause(1.second)
       }
       .repeat(numberOfRuns) {
@@ -47,20 +31,20 @@ class SyncQueryVariableAcs
           Iterator.continually(
             Map[String, String](
               "amount" -> String.valueOf(randomAmount()),
-              "archiveContractId" -> acsQueue.take(),
+              "archiveContractId" -> takeNextContractIdFromAcs(),
             )
           )
         ).exec {
           // run query in parallel with archive and create
-          queryRequest.notSilent.resources(
+          randomAmountQueryRequest.notSilent.resources(
             archiveRequest.silent,
-            createRequestAndCollectContractId.silent
+            randomAmountCreateRequest.silent
           )
         }
       }
 
   setUp(
-    fillAcsScenario(wantedAcsSize).inject(atOnceUsers(1)),
-    syncQueryScn.inject(atOnceUsers(1)),
+    fillAcsScenario(wantedAcsSize, silent = true).inject(atOnceUsers(1)),
+    syncQueryScenario.inject(atOnceUsers(1)),
   ).protocols(httpProtocol)
 }


### PR DESCRIPTION
Every query, the scenario archives 1,000 existing IOUs and creates 1,000 new ones.

It takes some time to run this scenario. Technically, it can be optimized with DAML choice that archives and creates 1,000 IOUs but in this case it will be one large transaction isntead of 1,000 small ones.

Related to:
- #6674
- #6675
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
