### PR TITLE
Use `Future.unit` instead of `Future.successful(())`.

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -70,7 +70,7 @@ object TestMain extends StrictLogging {
             }
             val jsVal = fileContent.parseJson
             import ParticipantsJsonProtocol._
-            (jsVal.convertTo[Participants[ApiParameters]], () => Future.successful(()))
+            (jsVal.convertTo[Participants[ApiParameters]], () => Future.unit)
           case None =>
             val (apiParameters, cleanup) = if (config.ledgerHost.isEmpty) {
               val timeProviderType = config.timeMode match {
@@ -88,7 +88,7 @@ object TestMain extends StrictLogging {
             } else {
               (
                 ApiParameters(config.ledgerHost.get, config.ledgerPort.get, None, None),
-                () => Future.successful(()),
+                () => Future.unit,
               )
             }
             (

--- a/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/Extractor.scala
@@ -246,7 +246,7 @@ class Extractor[T](config: ExtractorConfig, target: T)(
 
   private def transactionHandled(t: TransactionTree): Future[Unit] = {
     startOffSet = LedgerOffset.Value.Absolute(t.offset)
-    Future.successful(())
+    Future.unit
   }
 
   private def createClient: Future[LedgerClient] =

--- a/extractor/src/main/scala/com/digitalasset/extractor/writers/PrinterFunctionWriter.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/writers/PrinterFunctionWriter.scala
@@ -25,7 +25,7 @@ trait PrinterFunctionWriter { self: Writer =>
     printer("DAML Extractor")
     printer("==============")
 
-    Future.successful(())
+    Future.unit
   }
 
   def handlePackages(packageStore: PackageStore): Future[Unit] = {
@@ -34,7 +34,7 @@ trait PrinterFunctionWriter { self: Writer =>
     printer("====================")
     packageStore.foreach((handlePackage _).tupled)
 
-    Future.successful(())
+    Future.unit
   }
 
   def handleTransaction(transaction: TransactionTree): Future[RefreshPackages \/ Unit] = {

--- a/extractor/src/test/suite/scala/com/digitalasset/extractor/AuthSpec.scala
+++ b/extractor/src/test/suite/scala/com/digitalasset/extractor/AuthSpec.scala
@@ -115,11 +115,15 @@ final class AuthSpec
         (_, _, _) =>
           new Writer {
             private val lastOffset = new AtomicReference[String]
-            override def init(): Future[Unit] = Future.successful(())
+
+            override def init(): Future[Unit] = Future.unit
+
             override def handlePackages(packageStore: PackageStore): Future[Unit] =
-              Future.successful(())
+              Future.unit
+
             override def handleTransaction(
-                transaction: TransactionTree): Future[Writer.RefreshPackages \/ Unit] = {
+                transaction: TransactionTree
+            ): Future[Writer.RefreshPackages \/ Unit] = {
               Future.successful {
                 \/.right {
                   lastOffset.set {

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/InterfaceTree.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/InterfaceTree.scala
@@ -26,7 +26,7 @@ private[codegen] final case class InterfaceTree(
     interface: Interface) {
 
   def process(f: NodeWithContext => Future[Unit])(implicit ec: ExecutionContext): Future[Unit] = {
-    bfs(Future.successful(())) {
+    bfs(Future.unit) {
       case (a, nodeWithContext) => a.zipWith(f(nodeWithContext))((_, _) => ())(ec)
     }
   }

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/JavaBackend.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/JavaBackend.scala
@@ -70,7 +70,7 @@ private[codegen] object JavaBackend extends Backend with StrictLogging {
           }
         }
       case _ =>
-        Future.successful(())
+        Future.unit
     }
   }
 

--- a/language-support/scala/examples/iou-no-codegen/application/src/main/scala/com/digitalasset/quickstart/iou/IouMain.scala
+++ b/language-support/scala/examples/iou-no-codegen/application/src/main/scala/com/digitalasset/quickstart/iou/IouMain.scala
@@ -73,7 +73,7 @@ object IouMain extends App with StrictLogging {
   private val issuerWorkflowId: WorkflowId = workflowIdFromParty(issuer)
 
   def validatePackageId(allPackageIds: Set[String], packageId: String): Future[Unit] =
-    if (allPackageIds(packageId)) Future.successful(())
+    if (allPackageIds(packageId)) Future.unit
     else
       Future.failed(
         new IllegalArgumentException(

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceTestFixture.scala
@@ -118,7 +118,7 @@ object HttpServiceTestFixture {
           Seq(
             ledgerF.map(_._1.close()),
             httpServiceF.flatMap(_.unbind()),
-          ) map (_ fallbackTo Future.successful(())))
+          ) map (_ fallbackTo Future.unit))
         .transform(_ => ta)
     }
   }

--- a/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
+++ b/ledger/ledger-api-client/src/test/suite/scala/com/digitalasset/ledger/client/services/commands/CommandTrackerFlowTest.scala
@@ -369,7 +369,7 @@ class CommandTrackerFlowTest
             _ <- completionStreamMock.breakCompletionsStream()
             offset3 <- completionStreamMock.getLastOffset
             _ <- if (offset3 != checkPointOffset) breakUntilOffsetArrives()
-            else Future.successful(())
+            else Future.unit
           } yield ()
 
         def sendCommand(commandId: String) = {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -226,7 +226,7 @@ private[testtool] final class ParticipantTestContext private[participant] (
           .map(_ => ())
       }
     } else {
-      Future.successful(())
+      Future.unit
     }
 
   def activeContracts(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -145,7 +145,7 @@ final class CommandDeduplicationIT extends LedgerTestSuite {
         // a resubmission of exactly the same command should succeed.
         _ <- submissionResults
           .collectFirst { case (request, Failure(_)) => request }
-          .fold(Future.successful(()))(request => ledger.submitAndWait(request))
+          .fold(Future.unit)(request => ledger.submitAndWait(request))
       } yield {
         ()
       }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
@@ -49,7 +49,7 @@ private[daml] final class LedgerApiServer(
       ).acquire()
       // Notify the caller that the services have been closed, so a reset request can complete
       // without blocking on the server terminating.
-      _ <- Resource(Future.successful(()))(_ =>
+      _ <- Resource(Future.unit)(_ =>
         apiServicesResource.release().map(_ => servicesClosedPromise.success(())))
     } yield {
       val host = address.getOrElse("localhost")

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/RecoveringIndexer.scala
@@ -92,7 +92,7 @@ private[indexer] final class RecoveringIndexer(
               }
             }
           } else {
-            Future.successful(())
+            Future.unit
           }
         }
       } yield ()

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -34,7 +34,7 @@ final class StandaloneIndexerServer(
     val indexer = new RecoveringIndexer(materializer.system.scheduler, config.restartDelay)
     config.startupMode match {
       case IndexerStartupMode.MigrateOnly =>
-        Resource.successful(())
+        Resource.unit
       case IndexerStartupMode.MigrateAndStart =>
         Resource
           .fromFuture(indexerFactory.migrateSchema(config.allowExistingSchema))

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -82,7 +82,7 @@ class RecoveringIndexerSpec
       val resource = recoveringIndexer.start(() => testIndexer.subscribe())
 
       for {
-        _ <- akka.pattern.after(100.millis, actorSystem.scheduler)(Future.successful(()))
+        _ <- akka.pattern.after(100.millis, actorSystem.scheduler)(Future.unit)
         _ <- resource.release()
         complete <- resource.asFuture
         _ <- complete

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueueSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueueSpec.scala
@@ -162,7 +162,7 @@ class BatchingQueueSpec
         ).run { batch =>
           {
             batches += batch
-            Future.successful(())
+            Future.unit
           }
         }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -153,7 +153,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with Inside {
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val writtenKeyValuesCaptor = captor[RawKeyValuePairs]
       when(mockStateOperations.writeState(writtenKeyValuesCaptor.capture()))
-        .thenReturn(Future.successful(()))
+        .thenReturn(Future.unit)
       val logEntryCaptor = captor[Bytes]
       when(mockStateOperations.appendToLog(any[Bytes](), logEntryCaptor.capture()))
         .thenReturn(Future.successful(expectedLogResult))
@@ -188,7 +188,7 @@ class SubmissionValidatorSpec extends AsyncWordSpec with Matchers with Inside {
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val writtenKeyValuesCaptor = captor[RawKeyValuePairs]
       when(mockStateOperations.writeState(writtenKeyValuesCaptor.capture()))
-        .thenReturn(Future.successful(()))
+        .thenReturn(Future.unit)
       val logEntryCaptor = captor[Bytes]
       when(mockStateOperations.appendToLog(any[Bytes](), logEntryCaptor.capture()))
         .thenReturn(Future.successful(expectedLogResult))

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -400,5 +400,5 @@ final class SandboxServer(
   private def writePortFile(port: Port)(implicit executionContext: ExecutionContext): Future[Unit] =
     config.portFile
       .map(path => Future(Files.write(path, Seq(port.toString).asJava)).map(_ => ()))
-      .getOrElse(Future.successful(()))
+      .getOrElse(Future.unit)
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -208,7 +208,7 @@ object SqlLedger {
           .transform(_ => (), e => sys.error("Failed to copy initial packages: " + e.getMessage))(
             DEC)
       } else {
-        Future.successful(())
+        Future.unit
       }
     }
 

--- a/libs-scala/resources/src/test/lib/scala/com/digitalasset/resources/TestResourceOwner.scala
+++ b/libs-scala/resources/src/test/lib/scala/com/digitalasset/resources/TestResourceOwner.scala
@@ -31,7 +31,7 @@ final class TestResourceOwner[T](acquire: Future[T], release: T => Future[Unit])
 
 object TestResourceOwner {
   def apply[T](value: T): TestResourceOwner[T] =
-    new TestResourceOwner(Future.successful(value), _ => Future.successful(()))
+    new TestResourceOwner(Future.successful(value), _ => Future.unit)
 
   final class TriedToAcquireTwice extends Exception("Tried to acquire twice.")
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformSubscriber.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformSubscriber.scala
@@ -217,7 +217,7 @@ class PlatformSubscriber(
       .runWith(Sink.ignore)
 
     // This stream starts immediately
-    Future.successful(())
+    Future.unit
   }
 
   private def startTrackingCommands()
@@ -289,7 +289,7 @@ class PlatformSubscriber(
         log.info(
           "Successfully loaded packages {}",
           interfaces.map(_.packageId).mkString("[", ", ", "]"))
-        Future.successful(())
+        Future.unit
       })
       .recoverWith(apiFailureF)
   }


### PR DESCRIPTION
And in one instance, `Resource.unit`.

I just think it's easier to read. Too many parentheses make Samir a dull boy.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
