### PR TITLE
language: daml-ledger: deal with null offsets

### DIFF
--- a/language-support/ts/daml-ledger/index.test.ts
+++ b/language-support/ts/daml-ledger/index.test.ts
@@ -19,7 +19,7 @@ type Foo = {key: string};
 const fooKey = 'fooKey';
 
 type Message =
-  | { events: Event<Foo>[]; offset?: string }
+  | { events: Event<Foo>[]; offset?: string | null }
   | { warnings: string[] }
   | { errors: string[] }
   | string //for unexpected messages
@@ -161,6 +161,17 @@ describe("streamQuery", () => {
     expect(mockLive).toHaveBeenLastCalledWith([fooCreateEvent(1)]);
     expect(mockChange).toHaveBeenCalledTimes(1);
     expect(mockChange).toHaveBeenLastCalledWith([fooCreateEvent(1)])
+  });
+
+  test("receive null offset", () => {
+    const ledger = new Ledger(mockOptions);
+    const stream = ledger.streamQuery(Foo);
+    stream.on("live", mockLive);
+    stream.on("change", state => mockChange(state));
+    mockInstance.serverSend({ events: [], offset: null });
+    expect(mockLive).toHaveBeenCalledTimes(1);
+    expect(mockLive).toHaveBeenLastCalledWith([]);
+    expect(mockChange).not.toHaveBeenCalled();
   });
 
   test("reconnect on close", async () => {


### PR DESCRIPTION
    We allow the `offset` field of a websocket message send in response to a
    `streamQuery` request to be `null`. Previously this would cause an
    exception to be thrown.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
