### PR TITLE
Add a useFetch.

### DIFF
--- a/language-support/ts/daml-react/defaultLedgerContext.ts
+++ b/language-support/ts/daml-react/defaultLedgerContext.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createLedgerContext, FetchResult, QueryResult, LedgerProps } from "./createLedgerContext";
-import { Party, Template } from '@daml/types';
+import { ContractId, Party, Template } from '@daml/types';
 import Ledger, { Query } from '@daml/ledger';
 
 /**
@@ -46,6 +46,22 @@ export function useQuery<T extends object, K, I extends string>(template: Templa
 export function useQuery<T extends object, K, I extends string>(template: Template<T, K, I>): QueryResult<T, K, I>
 export function useQuery<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory?: () => Query<T>, queryDeps?: readonly unknown[]): QueryResult<T, K, I> {
   return ledgerContext.useQuery(template, queryFactory, queryDeps);
+}
+
+/**
+ * React Hook for a lookup by contractId against the `/v1/fetch` endpoint of the JSON API.
+ *
+ * @typeparam T The contract template type of the query.
+ * @typeparam K The contract key type of the query.
+ * @typeparam I The template id type.
+ *
+ * @param template The template of the contracts to fetch.
+ * @param contractId The contractId to fetch.
+ *
+ * @return The fetched contract.
+ */
+export function useFetch<T extends object, K, I extends string>(template: Template<T, K, I>, contractId: ContractId<T>): FetchResult<T, K, I> {
+  return ledgerContext.useFetch(template, contractId);
 }
 
 /**

--- a/language-support/ts/daml-react/defaultLedgerContext.ts
+++ b/language-support/ts/daml-react/defaultLedgerContext.ts
@@ -55,7 +55,7 @@ export function useQuery<T extends object, K, I extends string>(template: Templa
  * @typeparam K The contract key type of the query.
  * @typeparam I The template id type.
  *
- * @param template The template of the contracts to fetch.
+ * @param template The template of the contract to fetch.
  * @param contractId The contractId to fetch.
  *
  * @return The fetched contract.

--- a/language-support/ts/daml-react/index.ts
+++ b/language-support/ts/daml-react/index.ts
@@ -3,6 +3,6 @@
 
 export { createLedgerContext, FetchResult, LedgerContext, QueryResult } from './createLedgerContext';
 
-import { DamlLedger, useParty, useLedger, useQuery, useFetchByKey, useStreamQuery, useStreamFetchByKey, useReload } from "./defaultLedgerContext";
-export { useParty, useLedger, useQuery, useFetchByKey, useStreamQuery, useStreamFetchByKey, useReload };
+import { DamlLedger, useParty, useLedger, useQuery, useFetch, useFetchByKey, useStreamQuery, useStreamFetchByKey, useReload } from "./defaultLedgerContext";
+export { useParty, useLedger, useQuery, useFetch, useFetchByKey, useStreamQuery, useStreamFetchByKey, useReload };
 export default DamlLedger;


### PR DESCRIPTION
CHANGELOG_BEGIN
Add a useFetch hook to the @daml/react bindings for when the user knows
a contractId.
CHANGELOG_END

Fixes https://github.com/digital-asset/daml/issues/6990

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
