### PR TITLE
Fix release cron job

### DIFF
--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -42,7 +42,7 @@ jobs:
           branch=$1
           title="$2"
           body="$3"
-          out=$4
+          out="${4:-}"
           git branch -D $branch || true
           git checkout -b $branch
           git add .


### PR DESCRIPTION
CI failed because $4 was unset. We explicitly check later if it is set
so this is intentional, we just need to actually get to that check and
not fail due to set -u.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
