### PR TITLE
fix release cron

### DIFF
--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -42,7 +42,7 @@ jobs:
           branch=$1
           title="$2"
           body="$3"
-          out="${4:-}"
+          out="$4"
           git branch -D $branch || true
           git checkout -b $branch
           git add .
@@ -68,9 +68,7 @@ jobs:
               --definition-name "digital-asset.daml" \
               --org "https://dev.azure.com/digitalasset" \
               --project daml
-          if [ -n "$out" ]; then
-              echo $pr_number > $out
-          fi
+          echo $pr_number > $out
       }
       assign_and_label() {
           local pr_number assignee
@@ -115,4 +113,5 @@ jobs:
       rotate
       open_pr "rotate-after-$RELEASE" \
               "rotate release duty after $RELEASE" \
-              "@$NEXT_GH is taking care of $RELEASE (#$PR), so they get pushed back to the end of the line.\n\nPlease do not merge this before #$PR."
+              "@$NEXT_GH is taking care of $RELEASE (#$PR), so they get pushed back to the end of the line.\n\nPlease do not merge this before #$PR." \
+              /dev/null


### PR DESCRIPTION
It looks like Bash does not like my attempt at making a function with an optional argument. Not sure exactly why, but I'm not too attached to the idea anyway.

CHANGELOG_BEGIN
CHANGELOG_END