### PR TITLE
fix release pr notif

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -782,8 +782,10 @@ jobs:
           PR_NUM: $(pr.num)
           PR_BRANCH: $(pr.branch)
 
-  - job: notify_user
-    condition: and(eq(variables['Build.Reason'], 'PullRequest'), not(canceled()))
+  - job: notify_release_pr
+    condition: and(not(canceled()),
+                   startsWith(variables['Build.SourceBranchName'], 'auto-release-pr-'),
+                   eq(dependencies.check_for_release.outputs['out.is_release'], 'true'))
     dependsOn:
       - git_sha
       - collect_build_data
@@ -800,16 +802,6 @@ jobs:
       - bash: |
           set -euo pipefail
 
-          tell_slack() {
-              local MESSAGE=$1
-              local USER_ID=$2
-              curl -XPOST \
-                   -i \
-                   -H 'Content-Type: application/json' \
-                   --data "{\"text\":\"<@${USER_ID}> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for <https://github.com/digital-asset/daml/pull/$(pr.num)|PR $(pr.num)> has completed with status ${MESSAGE}.\"}" \
-                   $(Slack.team-daml-ci)
-          }
-
           tell_daml() {
               local message pr_handler
               message=$1
@@ -821,11 +813,34 @@ jobs:
                    $(Slack.team-daml)
           }
 
-          if [ "$(is_release)" == "true" ]; then
-              # releases matter to everyone
-              tell_daml "$(status)"
-              exit 0
-          fi
+          tell_daml "$(status)"
+
+  - job: notify_user
+    condition: and(eq(variables['Build.Reason'], 'PullRequest'), not(canceled()))
+    dependsOn:
+      - git_sha
+      - collect_build_data
+      - check_for_release
+    pool:
+      name: 'linux-pool'
+      demands: assignment -equals default
+    variables:
+      pr.num: $[ variables['System.PullRequest.PullRequestNumber'] ]
+      branch_sha: $[ dependencies.git_sha.outputs['out.branch'] ]
+      status: $[ dependencies.collect_build_data.result ]
+    steps:
+      - bash: |
+          set -euo pipefail
+
+          tell_slack() {
+              local MESSAGE=$1
+              local USER_ID=$2
+              curl -XPOST \
+                   -i \
+                   -H 'Content-Type: application/json' \
+                   --data "{\"text\":\"<@${USER_ID}> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for <https://github.com/digital-asset/daml/pull/$(pr.num)|PR $(pr.num)> has completed with status ${MESSAGE}.\"}" \
+                   $(Slack.team-daml-ci)
+          }
 
           EMAIL=$(git log -n 1 --format=%ae $(branch_sha))
           user_registered() {


### PR DESCRIPTION
At the moment, the release PR notification piggybacks on the existing PR notifications. Unfortunately, that does not work, because those explicitly only trigger for "pr" builds, whereas the release PR gets a "manual" build, as it is opened by Azure and thus does not run automatically.

CHANGELOG_BEGIN
CHANGELOG_END