### PR TITLE
Fix user notify job (again)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -813,7 +813,7 @@ jobs:
           tell_daml() {
               local message pr_handler
               message=$1
-              pr_handler=$(head -1 release/rotation | awk "${print $1}")
+              pr_handler=$(head -1 release/rotation | awk '${print $1}')
               curl -XPOST \
                    -i \
                    -H 'Content-Type: application/json' \


### PR DESCRIPTION
Double quotes cause $1 to be expanded instead of being passed to AWK.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
