### PR TITLE
DAML Engine: Use ANF to make foldl/foldr faster

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -13,7 +13,7 @@ import com.daml.lf.data.Numeric.Scale
 import com.daml.lf.language.Ast
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.Speedy.{KFoldl, KFoldr, KFoldr1Map, Machine, SpeedyHungry}
+import com.daml.lf.speedy.Speedy._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SValue.{SValue => SV}
@@ -408,7 +408,7 @@ private[lf] object SBuiltin {
         args: util.ArrayList[SValue],
         machine: Machine,
     ): Unit = {
-      val func = SEValue(args.get(0))
+      val func = args.get(0)
       val init = args.get(1)
       val list = args.get(2).asInstanceOf[SList].list
       machine.pushKont(KFoldl(func, list, machine.frame, machine.actuals, machine.env.size))
@@ -448,11 +448,10 @@ private[lf] object SBuiltin {
     override private[speedy] final def execute(
         args: util.ArrayList[SValue],
         machine: Machine): Unit = {
-      val pap = args.get(0).asInstanceOf[SPAP]
-      val func = SEValue(pap)
+      val func = args.get(0).asInstanceOf[SPAP]
       val init = args.get(1)
       val list = args.get(2)
-      if (pap.arity - pap.actuals.size >= 2) {
+      if (func.arity - func.actuals.size >= 2) {
         val array = list.asInstanceOf[SList].list.toImmArray
         machine.pushKont(
           KFoldr(func, array, array.length, machine.frame, machine.actuals, machine.env.size))
@@ -471,7 +470,7 @@ private[lf] object SBuiltin {
                 machine.frame,
                 machine.actuals,
                 machine.env.size))
-            machine.ctrl = SEAppAtomicFun(func, Array(SEValue(head)))
+            enterApplication(machine, func, Array(SEValue(head)))
         }
       }
     }


### PR DESCRIPTION
This PR addresses a TODO in the implementations of `foldl` and `foldr`.
The continuations for both primitives have to apply the step function to
the accumulcation and the current list item. So far, we've used the
`SEAppAtomicFun` AST node for this purpose.  However, since the step
function and both arguments have already been evaluated to values, we
can also use the `enterApplication` function that has recently been
introduced together with our use of ANF.

Benchmarks: Applying `foldr (+) 0` (or `foldl (+) 0`) to the
pre-computed (and pre-allocated) list `[1..1_000_000]` has taken ca.
117s before this change and now takes only ca. 83ms. This is a speedup
of ca. 1.4x.

This fixes https://github.com/digital-asset/daml/issues/7055.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7102)
<!-- Reviewable:end -->
