### PR TITLE
Make frontend.jar reproducible

### DIFF
--- a/navigator/frontend/BUILD.bazel
+++ b/navigator/frontend/BUILD.bazel
@@ -120,7 +120,8 @@ genrule(
 
     # Package result (.JAR)
     echo "Packaging result from $$OUT to $(@D)/frontend.jar"
-    $(JAVABASE)/bin/jar c0Mf "$(@D)/frontend.jar" -C $$OUT .
+    $(rootpath @bazel_tools//tools/zip:zipper) c "$(@D)/frontend.jar" \\
+      $$($(POSIX_FIND) $$OUT -type f -printf "%P=%p\\n" | $(POSIX_SORT))
     """.format(
         PATHS_CASE_CHECK = "false" if is_windows else "true",
         WP_IN = "$$(cygpath -w $$IN)" if is_windows else "$$IN",
@@ -128,10 +129,11 @@ genrule(
         WP_OUT = "$$(cygpath -w $$OUT/frontend)" if is_windows else "$$OUT/frontend",
         WP_OUT_ESCAPED = "'$$WP_OUT'" if is_windows else "$$WP_OUT",
     ),
-    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    toolchains = ["@rules_sh//sh/posix:make_variables"],
     tools = [
         ":webpack",
         "//bazel_tools/sh:mktgz",
+        "@bazel_tools//tools/zip:zipper",
     ],
     visibility = [
         "//navigator:__subpackages__",


### PR DESCRIPTION
Before it was generated using `jar c0Mf` which is not reproducible as it includes current time-stamps and the order of entries in the archive is non-deterministic. The generated JAR is just a ZIP file and in this case `jar` is explicitly instructed to not generated a `MANIFEST` file (`M` flag). So, it is easy to replace the `jar` invocation by `zipper` which is designed to generate reproducible ZIP archives.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
