### PR TITLE
Publish ledger-on-memory

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -15,7 +15,7 @@ da_scala_library(
     name = "ledger-on-memory",
     srcs = glob(["src/main/scala/**/*.scala"]),
     resources = glob(["src/main/resources/**/*"]),
-    tags = ["maven_coordinates=com.daml:daml-on-memory:__VERSION__"],
+    tags = ["maven_coordinates=com.daml:ledger-on-memory:__VERSION__"],
     visibility = [
         "//visibility:public",
     ],

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -87,6 +87,8 @@
   type: jar-scala
 - target: //ledger/ledger-api-test-tool:ledger-api-test-tool
   type: jar-deploy
+- target: //ledger/ledger-on-memory:ledger-on-memory
+  type: jar-scala
 - target: //ledger/ledger-on-sql:ledger-on-sql
   type: jar-scala
 - target: //ledger/metrics:metrics


### PR DESCRIPTION
`ledger-on-memory` declares Maven coordinates, but is not being published at the moment.

https://github.com/digital-asset/daml/blob/15395b31a2a640143da8b8bfc43d43388061fa32/ledger/ledger-on-memory/BUILD.bazel#L18

This PR adds `ledger-on-memory` to `artifacts.yaml` for publishing.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description
