### PR TITLE
LF Engine: move profileDir and stackTraceMode to Engine Config.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -17,31 +17,20 @@ import scala.collection.concurrent.{Map => ConcurrentMap}
 /** Thread-safe class that can be used when you need to maintain a shared, mutable collection of
   * packages.
   */
-final class ConcurrentCompiledPackages extends MutableCompiledPackages {
+private[lf] final class ConcurrentCompiledPackages(
+    stackTraceMode: speedy.Compiler.StackTraceMode,
+    profilingMode: Compiler.ProfilingMode,
+) extends MutableCompiledPackages(stackTraceMode, profilingMode) {
   private[this] val _packages: ConcurrentMap[PackageId, Package] =
     new ConcurrentHashMap().asScala
   private[this] val _defns: ConcurrentHashMap[speedy.SExpr.SDefinitionRef, speedy.SExpr] =
     new ConcurrentHashMap()
   private[this] val _packageDeps: ConcurrentHashMap[PackageId, Set[PackageId]] =
     new ConcurrentHashMap()
-  private[this] var _profilingMode: speedy.Compiler.ProfilingMode = speedy.Compiler.NoProfile
-  private[this] var _stackTraceMode: speedy.Compiler.StackTraceMode = speedy.Compiler.FullStackTrace
 
   override def getPackage(pId: PackageId): Option[Package] = _packages.get(pId)
   override def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
     Option(_defns.get(dref))
-
-  override def profilingMode: Compiler.ProfilingMode = _profilingMode
-
-  def profilingMode_=(profilingMode: speedy.Compiler.ProfilingMode) = {
-    _profilingMode = profilingMode
-  }
-
-  override def stackTraceMode = _stackTraceMode
-
-  def stackTraceMode_=(stackTraceMode: speedy.Compiler.StackTraceMode) = {
-    _stackTraceMode = stackTraceMode
-  }
 
   /** Might ask for a package if the package you're trying to add references it.
     *
@@ -135,7 +124,11 @@ final class ConcurrentCompiledPackages extends MutableCompiledPackages {
 }
 
 object ConcurrentCompiledPackages {
-  def apply(): ConcurrentCompiledPackages = new ConcurrentCompiledPackages()
+  def apply(
+      stackTraceMode: speedy.Compiler.StackTraceMode = Compiler.NoStackTrace,
+      profilingMode: Compiler.ProfilingMode = Compiler.NoProfile,
+  ): ConcurrentCompiledPackages =
+    new ConcurrentCompiledPackages(stackTraceMode, profilingMode)
 
   private case class AddPackageState(
       packages: Map[PackageId, Package], // the packages we're currently compiling

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -48,6 +48,9 @@ import java.nio.file.{Files, Path, Paths}
   */
 class Engine(val config: EngineConfig = EngineConfig.Stable) {
   private[this] val compiledPackages = ConcurrentCompiledPackages()
+  setProfileDir(config.profileDir)
+  enableStackTraces(config.stackTraceMode)
+
   private[this] val preprocessor = new preprocessing.Preprocessor(compiledPackages)
   private[this] var profileDir: Option[Path] = None
   def info = new EngineInfo(config)
@@ -412,7 +415,7 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
   def preloadPackage(pkgId: PackageId, pkg: Package): Result[Unit] =
     addPackage(pkgId, pkg)
 
-  def setProfileDir(optProfileDir: Option[Path]): Unit = {
+  private[this] def setProfileDir(optProfileDir: Option[Path]): Unit = {
     optProfileDir match {
       case None =>
         compiledPackages.profilingMode = speedy.Compiler.NoProfile
@@ -423,7 +426,7 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
     }
   }
 
-  def enableStackTraces(enable: Boolean) = {
+  private[this] def enableStackTraces(enable: Boolean) = {
     compiledPackages.stackTraceMode =
       if (enable) speedy.Compiler.FullStackTrace else speedy.Compiler.NoStackTrace
   }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -14,7 +14,7 @@ import com.daml.lf.speedy.SResult._
 import com.daml.lf.transaction.{NodeId, SubmittedTransaction, Transaction => Tx}
 import com.daml.lf.transaction.Node._
 import com.daml.lf.value.Value
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.Files
 
 /**
   * Allows for evaluating [[Commands]] and validating [[Transaction]]s.
@@ -47,12 +47,19 @@ import java.nio.file.{Files, Path, Paths}
   * This class is thread safe as long `nextRandomInt` is.
   */
 class Engine(val config: EngineConfig = EngineConfig.Stable) {
-  private[this] val compiledPackages = ConcurrentCompiledPackages()
-  setProfileDir(config.profileDir)
-  enableStackTraces(config.stackTraceMode)
+
+  config.profileDir.foreach(Files.createDirectories(_))
+
+  private[this] val compiledPackages = {
+    val stacktraceMode =
+      if (config.stackTraceMode) speedy.Compiler.FullStackTrace else speedy.Compiler.NoStackTrace
+    val profileMode =
+      if (config.profileDir.isDefined) speedy.Compiler.FullProfile else speedy.Compiler.NoProfile
+    ConcurrentCompiledPackages(stacktraceMode, profileMode)
+  }
 
   private[this] val preprocessor = new preprocessing.Preprocessor(compiledPackages)
-  private[this] var profileDir: Option[Path] = None
+
   def info = new EngineInfo(config)
 
   /**
@@ -383,15 +390,12 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
           nodeSeeds = machine.ptx.nodeSeeds.toImmArray,
           byKeyNodes = machine.ptx.byKeyNodes.toImmArray,
         )
-        profileDir match {
-          case None => ()
-          case Some(profileDir) =>
-            val hash = meta.nodeSeeds(0)._2.toHexString
-            val desc = Engine.profileDesc(tx)
-            machine.profile.name = s"$desc-${hash.substring(0, 6)}"
-            val profileFile =
-              profileDir.resolve(Paths.get(s"${meta.submissionTime}-$desc-$hash.json"))
-            machine.profile.writeSpeedscopeJson(profileFile)
+        config.profileDir.foreach { dir =>
+          val hash = meta.nodeSeeds(0)._2.toHexString
+          val desc = Engine.profileDesc(tx)
+          machine.profile.name = s"$desc-${hash.substring(0, 6)}"
+          val profileFile = dir.resolve(s"${meta.submissionTime}-$desc-$hash.json")
+          machine.profile.writeSpeedscopeJson(profileFile)
         }
         ResultDone((tx, meta))
     }
@@ -414,22 +418,6 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
     */
   def preloadPackage(pkgId: PackageId, pkg: Package): Result[Unit] =
     addPackage(pkgId, pkg)
-
-  private[this] def setProfileDir(optProfileDir: Option[Path]): Unit = {
-    optProfileDir match {
-      case None =>
-        compiledPackages.profilingMode = speedy.Compiler.NoProfile
-      case Some(profileDir) =>
-        Files.createDirectories(profileDir)
-        this.profileDir = Some(profileDir)
-        compiledPackages.profilingMode = speedy.Compiler.FullProfile
-    }
-  }
-
-  private[this] def enableStackTraces(enable: Boolean) = {
-    compiledPackages.stackTraceMode =
-      if (enable) speedy.Compiler.FullStackTrace else speedy.Compiler.NoStackTrace
-  }
 
   private[engine] def addPackage(pkgId: PackageId, pkg: Package): Result[Unit] =
     if (config.allowedLanguageVersions.contains(pkg.languageVersion))

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf.engine
+package com.daml.lf
+package engine
 
 import java.nio.file.Path
 
-import com.daml.lf.VersionRange
 import com.daml.lf.language.{LanguageVersion => LV}
 import com.daml.lf.transaction.{TransactionVersions, TransactionVersion => TV}
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -9,18 +9,12 @@ import com.daml.lf.VersionRange
 import com.daml.lf.language.{LanguageVersion => LV}
 import com.daml.lf.transaction.{TransactionVersions, TransactionVersion => TV}
 
-// FIXME: https://github.com/digital-asset/daml/issues/5164
-// Currently only outputTransactionVersions is used.
-// languageVersions and outputTransactionVersions should be plug
 final case class EngineConfig(
-    // constrains the versions of language accepted by the engine
     allowedLanguageVersions: VersionRange[LV],
-    // constrains the versions of input transactions
     allowedInputTransactionVersions: VersionRange[TV],
-    // constrains the versions of output transactions
     allowedOutputTransactionVersions: VersionRange[TV],
-    profileDir: Option[Path] = None,
     stackTraceMode: Boolean = false,
+    profileDir: Option[Path] = None,
 ) {
 
   private[lf] val allowedInputValueVersions =

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -3,6 +3,8 @@
 
 package com.daml.lf.engine
 
+import java.nio.file.Path
+
 import com.daml.lf.VersionRange
 import com.daml.lf.language.{LanguageVersion => LV}
 import com.daml.lf.transaction.{TransactionVersions, TransactionVersion => TV}
@@ -17,6 +19,8 @@ final case class EngineConfig(
     allowedInputTransactionVersions: VersionRange[TV],
     // constrains the versions of output transactions
     allowedOutputTransactionVersions: VersionRange[TV],
+    profileDir: Option[Path] = None,
+    stackTraceMode: Boolean = false,
 ) {
 
   private[lf] val allowedInputValueVersions =

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/MutableCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/MutableCompiledPackages.scala
@@ -3,14 +3,18 @@
 
 package com.daml.lf.engine
 
-import com.daml.lf.CompiledPackages
+import com.daml.lf.{CompiledPackages, speedy}
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.language.Ast.Package
+import com.daml.lf.speedy.Compiler
 
 /** Trait that extends [[CompiledPackages]] with the ability to
   * add new packages.
   */
-abstract class MutableCompiledPackages extends CompiledPackages {
+abstract class MutableCompiledPackages(
+    stackTraceMode: speedy.Compiler.StackTraceMode,
+    profilingMode: Compiler.ProfilingMode,
+) extends CompiledPackages(stackTraceMode, profilingMode) {
 
   /** Add a new package and compile it to internal form. If package
     * depends on another package the call may return with [[ResultNeedPackage]].

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/MutableCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/MutableCompiledPackages.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf.engine
+package com.daml.lf
+package engine
 
-import com.daml.lf.{CompiledPackages, speedy}
 import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.language.Ast.Package
 import com.daml.lf.speedy.Compiler

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -316,7 +316,7 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
       case LfDefRef(id) if id == script.scriptIds.damlScript("fromLedgerValue") =>
         SEMakeClo(Array(), 1, SELocA(0))
     }
-    new CompiledPackages {
+    new CompiledPackages(Compiler.FullStackTrace, Compiler.NoProfile) {
       override def getPackage(pkgId: PackageId): Option[Package] =
         compiledPackages.getPackage(pkgId)
       override def getDefinition(dref: SDefinitionRef): Option[SExpr] =
@@ -327,11 +327,8 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
       // FIXME: avoid override of non abstract method
       override def definitions: PartialFunction[SDefinitionRef, SExpr] =
         fromLedgerValue.orElse(compiledPackages.definitions)
-      override def stackTraceMode: Compiler.FullStackTrace.type = Compiler.FullStackTrace
-      override def profilingMode: Compiler.NoProfile.type = Compiler.NoProfile
       override def packageLanguageVersion: PartialFunction[PackageId, LanguageVersion] =
         compiledPackages.packageLanguageVersion
-
     }
   }
   private val valueTranslator = new preprocessing.ValueTranslator(extendedCompiledPackages)

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -146,16 +146,16 @@ final class SandboxServer(
   @silent("Sandbox_Classic_Stable in object EngineConfig is deprecated")
   private[this] val engineConfig =
     (if (config.devMode) EngineConfig.Sandbox_Classic_Stable else EngineConfig.Sandbox_Classic_Dev)
+      .copy(
+        profileDir = config.profileDir,
+        stackTraceMode = config.stackTraces,
+      )
 
   private[this] val engine = getEngine(engineConfig)
 
   // Only used for testing.
   def this(config: SandboxConfig, materializer: Materializer) =
     this(DefaultName, config, materializer, new Metrics(new MetricRegistry))
-
-  // NOTE(MH): We must do this _before_ we load the first package.
-  engine.setProfileDir(config.profileDir)
-  engine.enableStackTraces(config.stackTraces)
 
   private val authService: AuthService = config.authService.getOrElse(AuthServiceWildcard)
   private val seedingService = SeedService(config.seeding.getOrElse(SeedService.Seeding.Weak))

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -142,16 +142,17 @@ final class SandboxServer(
     metrics: Metrics,
 ) extends AutoCloseable {
 
-  @silent("Sandbox_Classic_Dev in object EngineConfig is deprecated")
-  @silent("Sandbox_Classic_Stable in object EngineConfig is deprecated")
-  private[this] val engineConfig =
-    (if (config.devMode) EngineConfig.Sandbox_Classic_Stable else EngineConfig.Sandbox_Classic_Dev)
-      .copy(
-        profileDir = config.profileDir,
-        stackTraceMode = config.stackTraces,
-      )
-
-  private[this] val engine = getEngine(engineConfig)
+  private[this] val engine = {
+    @silent("Sandbox_Classic_Dev in object EngineConfig is deprecated")
+    @silent("Sandbox_Classic_Stable in object EngineConfig is deprecated")
+    val engineConfig = (
+      if (config.devMode) EngineConfig.Sandbox_Classic_Stable else EngineConfig.Sandbox_Classic_Dev
+    ).copy(
+      profileDir = config.profileDir,
+      stackTraceMode = config.stackTraces,
+    )
+    getEngine(engineConfig)
+  }
 
   // Only used for testing.
   def this(config: SandboxConfig, materializer: Materializer) =

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -33,6 +33,7 @@ da_scala_library(
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
         "//daml-lf/engine",
+        "//daml-lf/transaction",
         "//language-support/scala/bindings",
         "//ledger/caching",
         "//ledger/ledger-api-auth",

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -33,7 +33,6 @@ da_scala_library(
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
         "//daml-lf/engine",
-        "//daml-lf/transaction",
         "//language-support/scala/bindings",
         "//ledger/caching",
         "//ledger/ledger-api-auth",

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -63,13 +63,15 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
       None
   }
 
-  private[this] val engineConfig =
-    (if (config.devMode) EngineConfig.Dev else EngineConfig.Stable).copy(
+  private[this] val engine = {
+    val engineConfig = (
+      if (config.devMode) EngineConfig.Dev else EngineConfig.Stable
+    ).copy(
       profileDir = config.profileDir,
       stackTraceMode = config.stackTraces,
     )
-
-  private[this] val engine = new Engine(engineConfig)
+    new Engine(engineConfig)
+  }
 
   private val (ledgerType, ledgerJdbcUrl, indexJdbcUrl, startupMode): (
       String,

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -64,7 +64,10 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
   }
 
   private[this] val engineConfig =
-    if (config.devMode) EngineConfig.Dev else EngineConfig.Stable
+    (if (config.devMode) EngineConfig.Dev else EngineConfig.Stable).copy(
+      profileDir = config.profileDir,
+      stackTraceMode = config.stackTraces,
+    )
 
   private[this] val engine = new Engine(engineConfig)
 

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -67,8 +67,6 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
     if (config.devMode) EngineConfig.Dev else EngineConfig.Stable
 
   private[this] val engine = new Engine(engineConfig)
-  engine.setProfileDir(config.profileDir)
-  engine.enableStackTraces(config.stackTraces)
 
   private val (ledgerType, ledgerJdbcUrl, indexJdbcUrl, startupMode): (
       String,


### PR DESCRIPTION
Originally those two options were set up by calling state mutating
method on a build engine.

In this PR, we move this two options to the new `EngineConfig` (used for #5164) that is passed to the `Engine` constructor.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
