### PR TITLE
Scenario service: simplify getScenarioLedger method.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -46,7 +46,7 @@ import java.nio.file.{Files, Path, Paths}
   *
   * This class is thread safe as long `nextRandomInt` is.
   */
-class Engine(config: EngineConfig = EngineConfig.Stable) {
+class Engine(private[lf] val config: EngineConfig = EngineConfig.Stable) {
   private[this] val compiledPackages = ConcurrentCompiledPackages()
   private[this] val preprocessor = new preprocessing.Preprocessor(compiledPackages)
   private[this] var profileDir: Option[Path] = None

--- a/daml-lf/scenario-interpreter/BUILD.bazel
+++ b/daml-lf/scenario-interpreter/BUILD.bazel
@@ -24,6 +24,7 @@ da_scala_library(
     ],
     deps = [
         "//daml-lf/data",
+        "//daml-lf/engine",
         "//daml-lf/interpreter",
         "//daml-lf/language",
         "//daml-lf/transaction",

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -3,17 +3,13 @@
 
 package com.daml.lf.speedy
 
-import com.daml.lf.{CompiledPackages, VersionRange, crypto}
+import com.daml.lf.crypto
 import com.daml.lf.scenario.ScenarioLedger
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{Ref, Time}
+import com.daml.lf.engine.Engine
 import com.daml.lf.language.Ast
-import com.daml.lf.transaction.{
-  GlobalKey,
-  SubmittedTransaction,
-  TransactionVersion,
-  Transaction => Tx
-}
+import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction, Transaction => Tx}
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
@@ -271,18 +267,17 @@ object ScenarioRunner {
 
   @deprecated("can be used only by sandbox classic.", since = "1.4.0")
   def getScenarioLedger(
+      engine: Engine,
       scenarioRef: Ref.DefinitionRef,
       scenarioDef: Ast.Definition,
-      compiledPackages: CompiledPackages,
       transactionSeed: crypto.Hash,
-      outputTransactionVersions: VersionRange[TransactionVersion],
   ): ScenarioLedger = {
     val scenarioExpr = getScenarioExpr(scenarioRef, scenarioDef)
     val speedyMachine = Speedy.Machine.fromScenarioExpr(
-      compiledPackages,
+      engine.compiledPackages(),
       transactionSeed,
       scenarioExpr,
-      outputTransactionVersions,
+      engine.config.outputTransactionVersions,
     )
     ScenarioRunner(speedyMachine).run() match {
       case Left(e) =>

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -212,7 +212,7 @@ final class SandboxServer(
         val (acs, records, ledgerTime) =
           ScenarioLoader.fromScenario(
             packageStore,
-            engine.compiledPackages(),
+            engine,
             scenario,
             seedingService.nextSeed(),
           )
@@ -310,7 +310,7 @@ final class SandboxServer(
         optWriteService = Some(new TimedWriteService(indexAndWriteService.writeService, metrics)),
         indexService = new TimedIndexService(indexAndWriteService.indexService, metrics),
         authorizer = authorizer,
-        engine = SandboxServer.engine,
+        engine = engine,
         timeProvider = timeProvider,
         timeProviderType = timeProviderType,
         ledgerConfiguration = ledgerConfiguration,


### PR DESCRIPTION
This PR simplifies the deprecated `getScenarioLedger` to take the
whole engine instead of `compiledPackages` (from the engine) and the
rest of the `outputTransactionVersions` (form the engine config).

This prepares for some changes for #5164, where more options for the
engine config will have to be used by the method. Also we will need to
be sure the `compiledPackages` follows the options from the engine
config.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
