### PR TITLE
Sandbox: add a development mode

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -46,7 +46,7 @@ import java.nio.file.{Files, Path, Paths}
   *
   * This class is thread safe as long `nextRandomInt` is.
   */
-class Engine(private[lf] val config: EngineConfig = EngineConfig.Stable) {
+class Engine(val config: EngineConfig = EngineConfig.Stable) {
   private[this] val compiledPackages = ConcurrentCompiledPackages()
   private[this] val preprocessor = new preprocessing.Preprocessor(compiledPackages)
   private[this] var profileDir: Option[Path] = None

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -64,7 +64,7 @@ object EngineConfig {
   val Sandbox_Classic_Stable: EngineConfig =
     Stable.copy(
       allowedLanguageVersions =
-        Stable.allowedLanguageVersions.copy(min = LV(LV.Major.V0, LV.Minor.Stable(""))),
+        Stable.allowedLanguageVersions.copy(min = LV(LV.Major.V1, LV.Minor.Stable("0"))),
       allowedInputTransactionVersions = Stable.allowedInputTransactionVersions.copy(
         min = TransactionVersions.acceptedVersions.head),
       allowedOutputTransactionVersions = Stable.allowedOutputTransactionVersions.copy(

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -35,35 +35,15 @@ final case class EngineConfig(
 
 object EngineConfig {
 
-  // Development configuration, should not be used in PROD.
-  val Dev: EngineConfig = new EngineConfig(
-    allowedLanguageVersions = VersionRange(
-      LV(LV.Major.V1, LV.Minor.Stable("6")),
-      LV(LV.Major.V1, LV.Minor.Dev),
-    ),
-    allowedInputTransactionVersions = VersionRange(
-      TV("10"),
-      TransactionVersions.acceptedVersions.last
-    ),
-    allowedOutputTransactionVersions = TransactionVersions.DevOutputVersions
-  )
-
-  // Legacy configuration, to be used by sandbox classic only
-  @deprecated("Sandbox_Classic is to be used by sandbox classic only", since = "1.4.0")
-  val Sandbox_Classic: EngineConfig = new EngineConfig(
-    allowedLanguageVersions = VersionRange(
-      LV(LV.Major.V1, LV.Minor.Stable("0")),
-      LV(LV.Major.V1, LV.Minor.Dev),
-    ),
-    allowedInputTransactionVersions = VersionRange(
-      TransactionVersions.acceptedVersions.head,
-      TransactionVersions.acceptedVersions.last
-    ),
-    allowedOutputTransactionVersions = VersionRange(
-      TV("10"),
-      TransactionVersions.acceptedVersions.last
+  private[this] def toDev(config: EngineConfig): EngineConfig =
+    config.copy(
+      allowedLanguageVersions =
+        config.allowedLanguageVersions.copy(max = LV(LV.Major.V1, LV.Minor.Dev)),
+      allowedInputTransactionVersions = config.allowedInputTransactionVersions.copy(
+        max = TransactionVersions.acceptedVersions.last),
+      allowedOutputTransactionVersions = config.allowedOutputTransactionVersions.copy(
+        max = TransactionVersions.acceptedVersions.last),
     )
-  )
 
   // recommended configuration
   val Stable: EngineConfig = new EngineConfig(
@@ -74,5 +54,25 @@ object EngineConfig {
     allowedInputTransactionVersions = VersionRange(TV("10"), TV("10")),
     allowedOutputTransactionVersions = VersionRange(TV("10"), TV("10"))
   )
+
+  // development configuration, should not be used in PROD.
+  // accept all language and transaction versions supported by SDK_1_x plus development versions.
+  val Dev: EngineConfig = toDev(Stable)
+
+  // Legacy configuration, to be used by sandbox classic only
+  @deprecated("Sandbox_Classic_Stable is to be used by sandbox classic only", since = "1.5.0")
+  val Sandbox_Classic_Stable: EngineConfig =
+    Stable.copy(
+      allowedLanguageVersions =
+        Stable.allowedLanguageVersions.copy(min = LV(LV.Major.V0, LV.Minor.Stable(""))),
+      allowedInputTransactionVersions = Stable.allowedInputTransactionVersions.copy(
+        min = TransactionVersions.acceptedVersions.head),
+      allowedOutputTransactionVersions = Stable.allowedOutputTransactionVersions.copy(
+        min = TransactionVersions.acceptedVersions.head),
+    )
+
+  // Legacy configuration, to be used by sandbox classic only
+  @deprecated("Sandbox_Classic_Dev is to be used by sandbox classic only", since = "1.5.0")
+  val Sandbox_Classic_Dev = toDev(Sandbox_Classic_Stable)
 
 }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -67,8 +67,6 @@ object EngineConfig {
         Stable.allowedLanguageVersions.copy(min = LV(LV.Major.V1, LV.Minor.Stable("0"))),
       allowedInputTransactionVersions = Stable.allowedInputTransactionVersions.copy(
         min = TransactionVersions.acceptedVersions.head),
-      allowedOutputTransactionVersions = Stable.allowedOutputTransactionVersions.copy(
-        min = TransactionVersions.acceptedVersions.head),
     )
 
   // Legacy configuration, to be used by sandbox classic only

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package com.daml.lf.engine
+
 import com.github.ghik.silencer.silent
 import org.scalatest.{Matchers, WordSpec}
 
@@ -9,9 +10,9 @@ class EngineInfoTest extends WordSpec with Matchers {
 
   "EngineInfo" should {
 
-    @silent("Sandbox_Classic in object EngineConfig is deprecated")
+    @silent("Sandbox_Classic_Dev in object EngineConfig is deprecated")
     def infos =
-      Seq(EngineConfig.Stable, EngineConfig.Dev, EngineConfig.Sandbox_Classic)
+      Seq(EngineConfig.Stable, EngineConfig.Dev, EngineConfig.Sandbox_Classic_Dev)
         .map(new EngineInfo(_))
 
     val Seq(engineInfoStable, engineInfoDev, engineInfoLegacy) = infos

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -63,14 +63,17 @@ object SandboxServer {
 
   private val logger = ContextualizedLogger.get(this.getClass)
 
-  // FIXME: https://github.com/digital-asset/daml/issues/5164
-  // This should be made configurable
-  @silent("Sandbox_Classic in object EngineConfig is deprecated")
-  private[sandbox] val engineConfig: EngineConfig = EngineConfig.Sandbox_Classic
-
   // We memoize the engine between resets so we avoid the expensive
   // repeated validation of the sames packages after each reset
-  private val engine = new Engine(engineConfig)
+  private[this] var engine: Option[Engine] = None
+
+  private def getEngine(config: EngineConfig): Engine = synchronized {
+    engine.getOrElse {
+      val engine = new Engine(config)
+      this.engine = Some(engine)
+      engine
+    }
+  }
 
   // Only used for testing.
   def owner(config: SandboxConfig): ResourceOwner[SandboxServer] =
@@ -136,6 +139,13 @@ final class SandboxServer(
     materializer: Materializer,
     metrics: Metrics,
 ) extends AutoCloseable {
+
+  @silent("Sandbox_Classic_Dev in object EngineConfig is deprecated")
+  @silent("Sandbox_Classic_Stable in object EngineConfig is deprecated")
+  private[this] val engineConfig =
+    (if (config.devMode) EngineConfig.Sandbox_Classic_Stable else EngineConfig.Sandbox_Classic_Dev)
+
+  private[this] val engine = getEngine(engineConfig)
 
   // Only used for testing.
   def this(config: SandboxConfig, materializer: Materializer) =

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -68,10 +68,12 @@ object SandboxServer {
   private[this] var engine: Option[Engine] = None
 
   private def getEngine(config: EngineConfig): Engine = synchronized {
-    engine.getOrElse {
-      val engine = new Engine(config)
-      this.engine = Some(engine)
-      engine
+    engine match {
+      case Some(eng) if eng.config == config => eng
+      case _ =>
+        val eng = new Engine(config)
+        engine = Some(eng)
+        eng
     }
   }
 

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCli.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCli.scala
@@ -296,6 +296,11 @@ class CommonCli(name: LedgerName) {
         .text(
           s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${v1.TimeModel.reasonableDefault.minSkew.getSeconds}.")
 
+      opt[Unit]("dev-mode")
+        .optional()
+        .action((_, config) => config.copy(devMode = true))
+        .text("Allows development versions of DAML-LF language and transaction format.")
+
       help("help").text("Print the usage text")
 
       checkConfig(c => {

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -47,6 +47,7 @@ final case class SandboxConfig(
     lfValueTranslationContractCacheConfiguration: SizedCache.Configuration,
     profileDir: Option[Path],
     stackTraces: Boolean,
+    devMode: Boolean,
 )
 
 object SandboxConfig {
@@ -91,6 +92,7 @@ object SandboxConfig {
       lfValueTranslationContractCacheConfiguration = DefaultLfValueTranslationCacheConfiguration,
       profileDir = None,
       stackTraces = true,
+      devMode = false,
     )
 
 }

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -25,7 +25,7 @@ import com.daml.ledger.participant.state.v1.metrics.{TimedReadService, TimedWrit
 import com.daml.ledger.participant.state.v1.{SeedService, WritePackagesService}
 import com.daml.lf.archive.DarReader
 import com.daml.lf.data.Ref
-import com.daml.lf.engine.Engine
+import com.daml.lf.engine.{Engine, EngineConfig}
 import com.daml.logging.ContextualizedLogger
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.platform.apiserver._
@@ -63,9 +63,10 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
       None
   }
 
-  // FIXME: https://github.com/digital-asset/daml/issues/5164
-  // should not use DevEngine
-  private val engine = Engine.DevEngine()
+  private[this] val engineConfig =
+    if (config.devMode) EngineConfig.Dev else EngineConfig.Stable
+
+  private[this] val engine = Engine.DevEngine()
   engine.setProfileDir(config.profileDir)
   engine.enableStackTraces(config.stackTraces)
 

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -66,7 +66,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
   private[this] val engineConfig =
     if (config.devMode) EngineConfig.Dev else EngineConfig.Stable
 
-  private[this] val engine = Engine.DevEngine()
+  private[this] val engine = new Engine(engineConfig)
   engine.setProfileDir(config.profileDir)
   engine.enableStackTraces(config.stackTraces)
 


### PR DESCRIPTION
With this PR, sandbox reject non development version of LF and transaction.
Previous behaviour can be set using the  command line option `--dev-mode`.

This is part of #5164.

CHANGELOG_BEGIN
 * [Sandbox] By default Sandbox rejects the development versions of
   DAML-LF and transaction format. One has to explicitly use the
   command line option `--dev-mode` to allows those versions.
CHANGELOG_END


### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
