### PR TITLE
kvutils/tools: If there's an error in reading a submission, crash.

### DIFF
--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
@@ -73,8 +73,8 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
       if (input.available() == 0) {
         Future.successful(0)
       } else {
-        val (submissionInfo, expectedWriteSet) = readSubmissionAndOutputs(input)
         for {
+          (submissionInfo, expectedWriteSet) <- Future(readSubmissionAndOutputs(input))
           _ <- submissionValidator.validateAndCommit(
             submissionInfo.submissionEnvelope,
             submissionInfo.correlationId,


### PR DESCRIPTION
Right now the error is logged, but the program stalls, because the exception is outside any `Future`, and so the cleanup never happens.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
