### PR TITLE
focus SDK install page

### DIFF
--- a/docs/configs/html/conf.py
+++ b/docs/configs/html/conf.py
@@ -169,13 +169,11 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-extlinks = {
-    'github-asset': ('https://github.com/digital-asset/daml/releases/download/v{}/%s-{}.zip'.format(version, version), None),
-    # For some reason extlinks insists that you can use %s only once.
-    # We need it twice in the URL so we need one URL per Maven artifact.
-    # Using it zero times also doesn’t work so you still have to supply an argument.
-    'ledger-api-test-tool-maven': ('https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/{}/%s-{}.jar'.format(version, version), None)
-}
+rst_prolog = """
+.. _installer: https://github.com/digital-asset/daml/releases/download/v{release}/daml-sdk-{release}-windows.exe
+.. _protobufs: https://github.com/digital-asset/daml/releases/download/v{release}/protobufs-{release}.zip
+.. _api-test-tool: https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/{release}/ledger-api-test-tool-{release}.jar
+""".format(release = release)
 
 # Import the DAML lexer
 def setup(sphinx):

--- a/docs/configs/pdf/conf.py
+++ b/docs/configs/pdf/conf.py
@@ -330,13 +330,11 @@ texinfo_documents = [
 ]
 
 
-extlinks = {
-    'github-asset': ('https://github.com/https://github.com/digital-asset/daml/releases/download/v{}/%s-{}.zip'.format(version, version), None),
-    # For some reason extlinks insists that you can use %s only once.
-    # We need it twice in the URL so we need one URL per Maven artifact.
-    # Using it zero times also doesn’t work so you still have to supply an argument.
-    'ledger-api-test-tool-maven': ('https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/{}/%s-{}.jar'.format(version, version), None)
-}
+rst_prolog = """
+.. _installer: https://github.com/digital-asset/daml/releases/download/v{release}/daml-sdk-{release}-windows.exe
+.. _protobufs: https://github.com/digital-asset/daml/releases/download/v{release}/protobufs-{release}.zip
+.. _api-test-tool: https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/{release}/ledger-api-test-tool-{release}.jar
+""".format(release = release)
 
 # Import the DAML lexer
 def setup(sphinx):

--- a/docs/source/app-dev/grpc/index.rst
+++ b/docs/source/app-dev/grpc/index.rst
@@ -13,7 +13,7 @@ If you're not familiar with gRPC and protobuf, we strongly recommend following t
 Getting started
 ***************
 
-You can get the protobufs from a :github-asset:`GitHub release<protobufs>`, or from the ``daml`` repository `here <https://github.com/digital-asset/daml/tree/master/ledger-api/grpc-definitions>`__.
+You can get the protobufs from a `GitHub release <protobufs_>`_, or from the ``daml`` repository `here <https://github.com/digital-asset/daml/tree/master/ledger-api/grpc-definitions>`__.
 
 Protobuf reference documentation
 ********************************
@@ -26,7 +26,7 @@ Example project
 We have an example project demonstrating the use of the Ledger API with gRPC. To get the example project, ``PingPongGrpc``:
 
 #. Configure your machine to use the example by following the instructions at :ref:`bindings-java-setup-maven`.
-#. Clone the `repository from GitHub <https://github.com/digital-asset/ex-java-bindings>`__. 
+#. Clone the `repository from GitHub <https://github.com/digital-asset/ex-java-bindings>`__.
 #. Follow the `setup instructions in the README <https://github.com/digital-asset/ex-java-bindings/blob/master/README.rst#setting-up-the-example-projects>`__. Use ``examples.pingpong.grpc.PingPongGrpcMain`` as the main class.
 
 About the example project

--- a/docs/source/daml-integration-kit/index.rst
+++ b/docs/source/daml-integration-kit/index.rst
@@ -372,7 +372,7 @@ there are consistency or conformance problem with your implementation.
 
 Assuming that your Ledger API endpoint is accessible at ``localhost:6865``, you can use the tool in the following manner:
 
-#. Download the Ledger API Test Tool from :ledger-api-test-tool-maven:`Maven <ledger-api-test-tool>`
+#. Download the Ledger API Test Tool from `Maven <api-test-tool_>`_
    and save it as ``ledger-api-test-tool.jar`` in your current directory.
 
 #. Obtain the DAML archives required to run the tests:

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -7,47 +7,35 @@ Installing the SDK
 1. Install the dependencies
 ***************************
 
-The SDK currently runs on Windows, MacOS or Linux.
+The SDK currently runs on Windows, macOS and Linux.
 
 You need to install:
 
 1. `Visual Studio Code <https://code.visualstudio.com/download>`_.
-2. JDK 8 or greater.
+2. JDK 8 or greater. If you don't already have a JDK installed, try `AdoptOpenJDK <https://adoptopenjdk.net>`_.
 
-   You can get the JDK from `Zulu 8 JDK <https://www.azul.com/downloads/zulu/>`_ or `Oracle 8 JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ (requires you to accept Oracle's license).
-   As part of the installation process you might need to set up the ``JAVA_HOME`` variable. You can find here the instructions on how to do it on :doc:`Windows, Mac OS, and Linux <path-variables>`.
-
-.. toctree::
-   :hidden:
-
-   path-variables
+   As part of the installation process you might need to set up the ``JAVA_HOME`` variable. You can find here the instructions on how to do it on :doc:`Windows,macOS, and Linux <path-variables>`.
 
 2. Install the SDK
 *******************
 
-In order to install the DAML SDK you will first need to
+Windows 10
+==========
 
-1. download and install it and
-2. **add** ``~/.daml/bin`` **to your** ``PATH`` **variable settings**.
-   You need to do this in order to be able to call :doc:`daml assistant's commands </tools/assistant>` with ease.
-   This will allow you easier workflow when developing your DAML application.
+Download and run the installer_, which will install DAML and set up your PATH.
 
 Mac and Linux
 =============
 
 To install the SDK on Mac or Linux:
 
-1. Run::
+1. In a terminal, run:
 
-     curl -sSL https://get.daml.com/ | sh
+   .. code-block:: shell
+
+      curl -sSL https://get.daml.com/ | sh
 
 2. Add ``~/.daml/bin`` to your PATH. You can find the Mac OS and Linux instructions :doc:`here <path-variables>`.
-
-Windows
-=======
-
-1. We support running the SDK on Windows 10. To install the SDK on Windows, download and run the installer from https://github.com/digital-asset/daml/releases/latest.
-2. Your ``PATH`` variable is already set up correctly by the installer.
 
 Next steps
 **********
@@ -59,39 +47,11 @@ Next steps
 Alternative: manual download
 ****************************
 
-The cURL command above will automatically download and run the DAML installation script from GitHub (using TLS). If you require a higher level of security, you can instead install the SDK by manually downloading the compressed tarball, verifying its signature, extracting it and manually running the install script.
+If you want to verify the SDK download for security purposes before installing, you can look at :doc:`our detailed instructions for manual download and installation <manual-download>`.
 
-Note that the Windows installer is already signed (within the binary itself), and that signature is checked by Windows before starting it. Nevertheless, you can still follow the steps below to check its external signature file.
+.. toctree::
+   :hidden:
 
-To do that:
+   path-variables
+   manual-download
 
-1. Go to https://github.com/digital-asset/daml/releases. Confirm your browser sees a valid certificate for the github.com domain.
-2. Download the artifact (*Assets* section, after the release notes) for your platform as well as the corresponding signature file. For example, if you are on macOS and want to install release 0.13.27, you would download the files ``daml-sdk-0.13.27-macos.tar.gz`` and ``daml-sdk-0.13.27-macos.tar.gz.asc``. Note that for Windows you can choose between the tarball, which follows the same instructions as the Linux and macOS ones (but assumes you have a number of typical Unix tools installed), or the installer, which ends with ``.exe``. Regardless, the steps to verify the signature are the same.
-3. To verify the signature, you need to have ``gpg`` installed (see https://gnupg.org for more information on that) and the Digital Asset Security Public Key imported into your keychain. Once you have ``gpg`` installed, you can import the key by running::
-
-     gpg --keyserver pool.sks-keyservers.net --search 4911A8DFE976ACDFA07130DBE8372C0C1C734C51
-
-   This should come back with a key belonging to ``Digital Asset Holdings, LLC <security@digitalasset.com>``, created on 2019-05-16 and expiring on 2021-05-15. If any of those details are different, something is wrong. In that case please contact Digital Asset immediately.
-4. Once the key is imported, you can ask ``gpg`` to verify that the file you have downloaded has indeed been signed by that key. Continuing with our example of v0.13.27 on macOS, you should have both files in the current directory and run::
-
-     gpg --verify daml-sdk-0.13.27-macos.tar.gz.asc
-
-   and that should give you a result that looks like::
-
-     gpg: assuming signed data in 'daml-sdk-0.13.27-macos.tar.gz'
-     gpg: Signature made Wed Sep 25 11:57:28 2019 BST
-     gpg:                using RSA key E8372C0C1C734C51
-     gpg: Good signature from "Digital Asset Holdings, LLC <security@digitalasset.com>" [unknown]
-     gpg: WARNING: This key is not certified with a trusted signature!
-     gpg:          There is no indication that the signature belongs to the owner.
-     Primary key fingerprint: 4911 A8DF E976 ACDF A071  30DB E837 2C0C 1C73 4C51
-
-   Note: This warning means you have not told gnupg that you trust this key actually belongs to Digital Asset. The ``[unknown]`` tag next to the key has the same meaning: ``gpg`` relies on a web of trust, and you have not told it how far you trust this key. Nevertheless, at this point you have verified that this is indeed the key that has been used to sign the archive.
-
-5. The next step is to extract the tarball and run the install script (unless you chose the Windows installer, in which case the next step is to double-click it)::
-
-     tar xzf daml-sdl-0.13.27-macos.tar.gz
-     cd sdk-0.13.27
-     ./install.sh
-
-6. Just like for the more automated install procedure, you may want to add ``~/.daml/bin`` to your ``$PATH``.

--- a/docs/source/getting-started/manual-download.rst
+++ b/docs/source/getting-started/manual-download.rst
@@ -1,0 +1,42 @@
+.. Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Manually installing the SDK
+***************************
+
+If you require a higher level of security, you can instead install the SDK by manually downloading the compressed tarball, verifying its signature, extracting it and manually running the install script.
+
+Note that the Windows installer is already signed (within the binary itself), and that signature is checked by Windows before starting it. Nevertheless, you can still follow the steps below to check its external signature file.
+
+To do that:
+
+1. Go to https://github.com/digital-asset/daml/releases. Confirm your browser sees a valid certificate for the github.com domain.
+2. Download the artifact (*Assets* section, after the release notes) for your platform as well as the corresponding signature file. For example, if you are on macOS and want to install release 1.4.0, you would download the files ``daml-sdk-1.4.0-macos.tar.gz`` and ``daml-sdk-1.4.0-macos.tar.gz.asc``. Note that for Windows you can choose between the tarball (ends in ``.tar.gz``), which follows the same instructions as the Linux and macOS ones (but assumes you have a number of typical Unix tools installed), or the installer, which ends with ``.exe``. Regardless, the steps to verify the signature are the same.
+3. To verify the signature, you need to have ``gpg`` installed (see https://gnupg.org for more information on that) and the Digital Asset Security Public Key imported into your keychain. Once you have ``gpg`` installed, you can import the key by running::
+
+     gpg --keyserver pool.sks-keyservers.net --search 4911A8DFE976ACDFA07130DBE8372C0C1C734C51
+
+   This should come back with a key belonging to ``Digital Asset Holdings, LLC <security@digitalasset.com>``, created on 2019-05-16 and expiring on 2021-05-15. If any of those details are different, something is wrong. In that case please contact Digital Asset immediately.
+4. Once the key is imported, you can ask ``gpg`` to verify that the file you have downloaded has indeed been signed by that key. Continuing with our example of 1.4.0 on macOS, you should have both files in the current directory and run::
+
+     gpg --verify daml-sdk-1.4.0-macos.tar.gz.asc
+
+   and that should give you a result that looks like::
+
+     gpg: assuming signed data in 'daml-sdk-1.4.0-macos.tar.gz'
+     gpg: Signature made Wed Aug 12 13:30:49 2020 CEST
+     gpg:                using RSA key E8372C0C1C734C51
+     gpg: Good signature from "Digital Asset Holdings, LLC <security@digitalasset.com>" [unknown]
+     gpg: WARNING: This key is not certified with a trusted signature!
+     gpg:          There is no indication that the signature belongs to the owner.
+     Primary key fingerprint: 4911 A8DF E976 ACDF A071  30DB E837 2C0C 1C73 4C51
+
+   Note: This warning means you have not told gnupg that you trust this key actually belongs to Digital Asset. The ``[unknown]`` tag next to the key has the same meaning: ``gpg`` relies on a web of trust, and you have not told it how far you trust this key. Nevertheless, at this point you have verified that this is indeed the key that has been used to sign the archive.
+
+5. The next step is to extract the tarball and run the install script (unless you chose the Windows installer, in which case the next step is to double-click it)::
+
+     tar xzf daml-sdl-1.4.0-macos.tar.gz
+     cd sdk-1.4.0
+     ./install.sh
+
+6. Just like for the more automated install procedure, you may want to add ``~/.daml/bin`` to your ``$PATH``.

--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -20,7 +20,7 @@ Ledger Model </concepts/ledger-model/index>`.
 Downloading the tool
 ====================
 
-Download the Ledger API Test Tool from :ledger-api-test-tool-maven:`Maven <ledger-api-test-tool>`
+Download the Ledger API Test Tool from `Maven <api-test-tool_>`_
 and save it as ``ledger-api-test-tool.jar`` in your current directory.
 
 Extracting ``.dar`` files required to run the tests


### PR DESCRIPTION
- Put Windows first, and add a direct link to the installer.
- Move the manual step to a separate page.
- Link to AdoptOpenJDK as they have by far the simplest download page.

CHANGELOG_BEGIN
CHANGELOG_END