### PR TITLE
fix auth header for compat pr

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -499,15 +499,19 @@ jobs:
     - checkout: self
       persistCredentials: true
     - bash: ci/dev-env-install.sh
+    - template: ci/bash-lib.yml
+      parameters:
+        var_name: bash_lib
     - bash: |
         set -euo pipefail
         eval "$(./dev-env/bin/dade-assist)"
+
+        source $(bash_lib)
 
         setvar() {
             echo "Setting '$1' to '$2'"
             echo "##vso[task.setvariable variable=$1;isOutput=true]$2"
         }
-
 
         DELAY=1
         while ! curl --fail -I https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/$(release_tag)/ledger-api-test-tool-$(release_tag).jar; do
@@ -519,19 +523,7 @@ jobs:
             fi
         done
 
-        # With `persistCredentials: true`, Azure Pipelines will store the
-        # credentials to interact with GitHub in the url for the origin remote,
-        # using basic auth format:
-        # https://username:password@github.com/:user/:repo.git
-        # This series of pipes extracts the `username:password` part.
-        #
-        # It looks like in some cases the credentials get stored separately as
-        # a header instead.
-        if header=$(git config 'http.https://github.com/digital-asset/daml.extraheader'); then
-            AUTH="$header"
-        else
-            AUTH="Authorization: basic $(git config remote.origin.url | grep -o '://.*:.*@' | cut -c4- | rev | cut -c2- | rev)"
-        fi
+        AUTH="$(get_gh_auth_header)"
 
         git checkout origin/master
         BRANCH=update-compat-versions-for-$(release_tag)
@@ -551,6 +543,7 @@ jobs:
         curl -H "Content-Type: application/json" \
              -H "$AUTH" \
              --silent \
+             --fail \
              --include \
              --location \
              -d "{\"title\": \"update compat versions for $(release_tag)\", \"head\": \"$BRANCH\", \"base\": \"master\"}" \

--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  var_name: ''
+
+steps:
+- bash: |
+    set -euo pipefail
+    TMP=$(mktemp)
+    cat > $TMP <<'END'
+    get_gh_auth_header() {
+        # Credentials are persisted in a different way on GCP and Azure nodes.
+        if header=$(git config 'http.https://github.com/digital-asset/daml.extraheader'); then
+            # On Azure nodes, the auth header is stored directly in the git
+            # config.
+            echo $header
+        else
+            # On GCP nodes, the credentials are stored as part of the remote
+            # url instead of as a separate header. The format is
+            # https://username:password@github.com/:user/:repo.git
+            echo "Authorization: basic $(git config remote.origin.url | grep -o '://.*:.*@' | cut -c4- | rev | cut -c2- | rev | tr -d '\n' | base64 -w0)"
+        fi
+    }
+    END
+    echo "##vso[task.setvariable variable=${{parameters.var_name}}]$TMP"

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -20,14 +20,15 @@ jobs:
   steps:
   - checkout: self
     persistCredentials: true
+  - template: ../bash-lib.yml
+    parameters:
+      var_name: bash_lib
   - bash: |
       set -euo pipefail
 
-      if header=$(git config 'http.https://github.com/digital-asset/daml.extraheader'); then
-          AUTH="$header"
-      else
-          AUTH="Authorization: basic $(git config remote.origin.url | grep -o '://.*:.*@' | cut -c4- | rev | cut -c2- | rev)"
-      fi
+      source "$(bash_lib)"
+
+      AUTH="$(get_gh_auth_header)"
 
       BASE_SHA=$(git rev-parse HEAD)
       az extension add --name azure-devops


### PR DESCRIPTION
On the last release, the job succeeded despite no being able to create the compat PR. This fixes:

- The curl call to actually return non-0 on non-2xx HTTP response.
- The way in which we encode the credentials.

This also attempts to create a Bash library, hopefully this time in a way that doesn't get destroyed by our release process. IIUC pipeline instructions (YAML files) are all parsed and read before any execution, so by embedding the Bash library in a template we should get the correct version (i.e. the one that is running the pipeline) even when checking out other commits.

CHANGELOG_BEGIN
CHANGELOG_END