### PR TITLE
Add TO_TEXT_CONTRACT_ID primitive

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -244,6 +244,7 @@ data BuiltinExpr
   | BEGreater    !BuiltinType    -- :: t -> t -> Bool, where t is the builtin type
   | BEToText     !BuiltinType    -- :: t -> Text, where t is one of the builtin types
                                  -- {Int64, Decimal, Text, Timestamp, Date, Party}
+  | BEToTextContractId           -- :: forall t. ContractId t -> Option Text
 
   -- Decimal arithmetic
   | BEAddDecimal                 -- :: Decimal -> Decimal -> Decimal, crashes on overflow

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -218,6 +218,7 @@ instance Pretty BuiltinExpr where
     BEGreater t   -> pPrintAppKeyword lvl prec "GREATER"    [TyArg (TBuiltin t)]
     BEGreaterEq t -> pPrintAppKeyword lvl prec "GREATER_EQ" [TyArg (TBuiltin t)]
     BEToText t    -> pPrintAppKeyword lvl prec "TO_TEXT"    [TyArg (TBuiltin t)]
+    BEToTextContractId -> "TO_TEXT_CONTRACT_ID"
     BEAddDecimal -> "ADD_DECIMAL"
     BESubDecimal -> "SUB_DECIMAL"
     BEMulDecimal -> "MUL_DECIMAL"

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -381,6 +381,7 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionTO_TEXT_TIMESTAMP -> BEToText BTTimestamp
   LF1.BuiltinFunctionTO_TEXT_PARTY -> BEToText BTParty
   LF1.BuiltinFunctionTO_TEXT_DATE -> BEToText BTDate
+  LF1.BuiltinFunctionTO_TEXT_CONTRACT_ID -> BEToTextContractId
   LF1.BuiltinFunctionTEXT_FROM_CODE_POINTS -> BETextFromCodePoints
   LF1.BuiltinFunctionFROM_TEXT_PARTY -> BEPartyFromText
   LF1.BuiltinFunctionFROM_TEXT_INT64 -> BEInt64FromText

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -427,6 +427,7 @@ encodeBuiltinExpr = \case
       BTDate -> builtin P.BuiltinFunctionTO_TEXT_DATE
       BTParty -> builtin P.BuiltinFunctionTO_TEXT_PARTY
       other -> error $ "BEToText unexpected type " <> show other
+    BEToTextContractId -> builtin P.BuiltinFunctionTO_TEXT_CONTRACT_ID
     BEToTextNumeric -> builtin P.BuiltinFunctionTO_TEXT_NUMERIC
     BETextFromCodePoints -> builtin P.BuiltinFunctionTEXT_FROM_CODE_POINTS
     BEPartyFromText -> builtin P.BuiltinFunctionFROM_TEXT_PARTY

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -94,6 +94,7 @@ safetyStep = \case
       BEGreaterEq _       -> Safe 2
       BEGreater _         -> Safe 2
       BEToText _          -> Safe 1
+      BEToTextContractId  -> Safe 1
       BETextFromCodePoints  -> Safe 1
       BEAddDecimal        -> Safe 1
       BESubDecimal        -> Safe 1

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -205,6 +205,7 @@ typeOfBuiltin = \case
   BEGreater   btype  -> pure $ tComparison btype
   BEGreaterEq btype  -> pure $ tComparison btype
   BEToText    btype  -> pure $ TBuiltin btype :-> TText
+  BEToTextContractId -> pure $ TForall (alpha, KStar) $ TContractId tAlpha :-> TOptional TText
   BETextFromCodePoints -> pure $ TList TInt64 :-> TText
   BEPartyToQuotedText -> pure $ TParty :-> TText
   BEPartyFromText    -> pure $ TText :-> TOptional TParty

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -508,6 +508,7 @@ enum BuiltinFunction {
   FROM_TEXT_INT64 = 103; // *Available in versions >= 1.5*
   FROM_TEXT_DECIMAL = 104; // *Available in versions 1.5 and 1.6
   FROM_TEXT_NUMERIC = 117;  // *Available in versions >= 1.7*
+  TO_TEXT_CONTRACT_ID = 136; // *Available in versions >= 1.dev*
   SHA256_TEXT = 93; // *Available in versions >= 1.2*
 
   DATE_TO_UNIX_DAYS = 72; // Date -> Int64
@@ -549,7 +550,7 @@ enum BuiltinFunction {
   TEXT_FROM_CODE_POINTS = 105;  // *Available in versions >= 1.6*
   TEXT_TO_CODE_POINTS = 106; // *Available in versions >= 1.6*
 
-  // Next id is 136. 135 is GREATER.
+  // Next id is 137. 136 is TO_TEXT_CONTRACT_ID.
 
   // EXPERIMENTAL TEXT PRIMITIVES -- these do not yet have stable numbers.
   TEXT_TO_UPPER = 9901; // *Available in versions >= 1.dev*

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1556,6 +1556,10 @@ private[lf] object DecodeV1 {
       BuiltinFunctionInfo(TO_TEXT_TIMESTAMP, BToTextTimestamp),
       BuiltinFunctionInfo(TO_TEXT_PARTY, BToTextParty, minVersion = partyTextConversions),
       BuiltinFunctionInfo(TO_TEXT_TEXT, BToTextText),
+      BuiltinFunctionInfo(
+        TO_TEXT_CONTRACT_ID,
+        BToTextContractId,
+        minVersion = contractIdTextConversions),
       BuiltinFunctionInfo(TO_QUOTED_TEXT_PARTY, BToQuotedTextParty),
       BuiltinFunctionInfo(TEXT_FROM_CODE_POINTS, BToTextCodePoints, minVersion = textPacking),
       BuiltinFunctionInfo(FROM_TEXT_PARTY, BFromTextParty, minVersion = partyTextConversions),

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1559,7 +1559,8 @@ private[lf] object DecodeV1 {
       BuiltinFunctionInfo(
         TO_TEXT_CONTRACT_ID,
         BToTextContractId,
-        minVersion = contractIdTextConversions),
+        minVersion = contractIdTextConversions,
+      ),
       BuiltinFunctionInfo(TO_QUOTED_TEXT_PARTY, BToQuotedTextParty),
       BuiltinFunctionInfo(TEXT_FROM_CODE_POINTS, BToTextCodePoints, minVersion = textPacking),
       BuiltinFunctionInfo(FROM_TEXT_PARTY, BFromTextParty, minVersion = partyTextConversions),

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -116,12 +116,15 @@ class DecodeV1Spec
 
   private val preContractIdTextConversionVersions = Table(
     "minVersion",
-    List(1, 4, 6, 7).map(i => LV.Minor.Stable(i.toString)): _*
+    List(1, 4, 6, 8).map(i => LV.Minor.Stable(i.toString)): _*
   )
 
   private val postContractIdTextConversionVersions = Table(
     "minVersion",
-    LV.Minor.Dev
+    // FIXME: https://github.com/digital-asset/daml/issues/7139
+    // uncomment the following line once LF 1.9 is released
+    // LV.Minor.Stable("9"),
+    LV.Minor.Dev,
   )
 
   "decodeKind" should {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -330,6 +330,7 @@ private[lf] final case class Compiler(
               case BToTextTimestamp => SBToText
               case BToTextParty => SBToText
               case BToTextDate => SBToText
+              case BToTextContractId => SBToTextContractId
               case BToQuotedTextParty => SBToQuotedTextParty
               case BToTextCodePoints => SBToTextCodePoints
               case BFromTextParty => SBFromTextParty

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -312,7 +312,7 @@ private[lf] object SBuiltin {
       args.get(0) match {
         case SContractId(cid) =>
           if (machine.onLedger) {
-            machine.returnValue = SOptional(None)
+            machine.returnValue = SValue.SValue.None
           } else {
             machine.returnValue = SOptional(Some(SText(cid.coid)))
           }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -305,6 +305,22 @@ private[lf] object SBuiltin {
     }
   }
 
+  final case object SBToTextContractId extends SBuiltin(1) {
+    override private[speedy] final def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine): Unit = {
+      args.get(0) match {
+        case SContractId(cid) =>
+          if (machine.onLedger) {
+            machine.returnValue = SOptional(None)
+          } else {
+            machine.returnValue = SOptional(Some(SText(cid.coid)))
+          }
+        case _ => crash(s"type mismatch toTextContractId: $args")
+      }
+    }
+  }
+
   final case object SBToTextNumeric extends SBuiltinPure(2) {
     override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
       val x = args.get(1).asInstanceOf[SNumeric].value

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -148,6 +148,12 @@ private[lf] object Speedy {
       var track: Instrumentation,
       /* Profile of the run when the packages haven been compiled with profiling enabled. */
       var profile: Profile,
+      /* True if we are running on ledger building transactions, false if we
+         are running off-ledger code, e.g., DAML Script or
+         Triggers. It is safe to use on ledger for off ledger code but
+         not the other way around.
+       */
+      val onLedger: Boolean,
   ) {
 
     /* kont manipulation... */
@@ -662,6 +668,7 @@ private[lf] object Speedy {
         inputValueVersions: VersionRange[ValueVersion],
         outputTransactionVersions: VersionRange[TransactionVersion],
         validating: Boolean = false,
+        onLedger: Boolean = true,
     ): Machine =
       new Machine(
         inputValueVersions = inputValueVersions,
@@ -687,6 +694,7 @@ private[lf] object Speedy {
         steps = 0,
         track = Instrumentation(),
         profile = new Profile(),
+        onLedger = onLedger,
       )
 
     @throws[PackageNotFound]
@@ -733,6 +741,7 @@ private[lf] object Speedy {
     def fromPureSExpr(
         compiledPackages: CompiledPackages,
         expr: SExpr,
+        onLedger: Boolean = true,
     ): Machine =
       Machine(
         compiledPackages = compiledPackages,
@@ -743,6 +752,7 @@ private[lf] object Speedy {
         committers = Set.empty,
         inputValueVersions = ValueVersions.Empty,
         outputTransactionVersions = TransactionVersions.Empty,
+        onLedger = onLedger,
       )
 
     @throws[PackageNotFound]
@@ -751,8 +761,9 @@ private[lf] object Speedy {
     def fromPureExpr(
         compiledPackages: CompiledPackages,
         expr: Expr,
+        onLedger: Boolean = true,
     ): Machine =
-      fromPureSExpr(compiledPackages, compiledPackages.compiler.unsafeCompile(expr))
+      fromPureSExpr(compiledPackages, compiledPackages.compiler.unsafeCompile(expr), onLedger)
 
   }
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -11,8 +11,10 @@ import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SError.{DamlEArithmeticError, SError, SErrorCrash}
 import com.daml.lf.speedy.SResult.{SResultFinalValue, SResultError}
+import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.testing.parser.Implicits._
+import com.daml.lf.value.Value
 import org.scalactic.Equality
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FreeSpec, Matchers}
@@ -1280,6 +1282,23 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
         }
       }
 
+      "TO_TEXT_CONTRACT_ID" - {
+        "returns None on-ledger" in {
+          val f = """(\(c:(ContractId Mod:T)) -> TO_TEXT_CONTRACT_ID @Mod:T c)"""
+          evalApp(
+            e"$f",
+            Array(SContractId(Value.ContractId.assertFromString("#abc"))),
+            onLedger = true) shouldEqual Right(SOptional(None))
+        }
+        "returns Some(abc) off-ledger" in {
+          val f = """(\(c:(ContractId Mod:T)) -> TO_TEXT_CONTRACT_ID @Mod:T c)"""
+          evalApp(
+            e"$f",
+            Array(SContractId(Value.ContractId.assertFromString("#abc"))),
+            onLedger = false) shouldEqual Right(SOptional(Some(SText("#abc"))))
+        }
+      }
+
       "handle ridiculously huge strings" in {
 
         val testCases = Table(
@@ -1451,8 +1470,16 @@ object SBuiltinTest {
   val compiledPackages =
     PureCompiledPackages(Map(defaultParserParameters.defaultPackageId -> pkg)).right.get
 
-  private def eval(e: Expr): Either[SError, SValue] = {
-    val machine = Speedy.Machine.fromPureExpr(compiledPackages, e)
+  private def eval(e: Expr, onLedger: Boolean = true): Either[SError, SValue] = {
+    evalSExpr(compiledPackages.compiler.unsafeCompile(e), onLedger)
+  }
+
+  private def evalApp(e: Expr, args: Array[SValue], onLedger: Boolean): Either[SError, SValue] = {
+    evalSExpr(SEApp(compiledPackages.compiler.unsafeCompile(e), args.map(SEValue(_))), onLedger)
+  }
+
+  private def evalSExpr(e: SExpr, onLedger: Boolean): Either[SError, SValue] = {
+    val machine = Speedy.Machine.fromPureSExpr(compiledPackages, e, onLedger)
     final case class Goodbye(e: SError) extends RuntimeException("", null, false, false)
     try {
       val value = machine.run() match {

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -384,6 +384,7 @@ object Ast {
   final case object BToTextTimestamp extends BuiltinFunction(1) // : Timestamp → Text
   final case object BToTextParty extends BuiltinFunction(1) // : Party → Text
   final case object BToTextDate extends BuiltinFunction(1) // : Date -> Text
+  final case object BToTextContractId extends BuiltinFunction(1) // : forall t. ContractId t -> Optional Text
   final case object BToQuotedTextParty extends BuiltinFunction(1) // : Party -> Text
   final case object BToTextCodePoints extends BuiltinFunction(1) // : [Int64] -> Text
   final case object BFromTextParty extends BuiltinFunction(1) // : Text -> Optional Party

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -63,6 +63,7 @@ object LanguageVersion {
     val genComparison = v1_dev
     val genMap = v1_dev
     val scenarioMustFailAtMsg = v1_dev
+    val contractIdTextConversions = v1_dev
 
     /** Unstable, experimental features. This should stay in 1.dev forever.
       * Features implemented with this flag should be moved to a separate

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -255,6 +255,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     "TO_TEXT_TIMESTAMP" -> BToTextTimestamp,
     "TO_TEXT_PARTY" -> BToTextParty,
     "TO_TEXT_DATE" -> BToTextDate,
+    "TO_TEXT_CONTRACT_ID" -> BToTextContractId,
     "TO_QUOTED_TEXT_PARTY" -> BToQuotedTextParty,
     "TEXT_FROM_CODE_POINTS" -> BToTextCodePoints,
     "FROM_TEXT_PARTY" -> BFromTextParty,

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -298,6 +298,8 @@ Version: 1.dev
 
   + **Add** generic map type ``GenMap``.
 
+  + **Add** ``TO_TEXT_CONTRACT_ID`` builtin.
+
 Abstract syntax
 ^^^^^^^^^^^^^^^
 
@@ -3600,6 +3602,13 @@ ContractId functions
   Returns the given contract ID unchanged at a different type.
 
   [*Available in versions >= 1.5*]
+
+* ``TO_TEXT_CONTRACT_ID : ∀ (α : ⋆) . 'ContractId' α -> 'Optional' 'Text'``
+
+  Always returns ``None`` in ledger code. This function is only useful
+  for off-ledger code which is not covered by this specification.
+
+  [*Available in versions >= 1.dev*]
 
 List functions
 ~~~~~~~~~~~~~~

--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/Typing.scala
@@ -180,6 +180,7 @@ private[validation] object Typing {
       BToTextTimestamp -> (TTimestamp ->: TText),
       BToTextParty -> (TParty ->: TText),
       BToTextDate -> (TDate ->: TText),
+      BToTextContractId -> TForall(alpha.name -> KStar, TContractId(alpha) ->: TOptional(TText)),
       BSHA256Text -> (TText ->: TText),
       BToQuotedTextParty -> (TParty ->: TText),
       BToTextCodePoints -> (TList(TInt64) ->: TText),

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -196,6 +196,9 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           T"TypeRep",
         E"""(( type_rep @((ContractId Mod:T) → Mod:Color) ))""" ->
           T"TypeRep",
+        // TO_TEXT_CONTRACT_ID
+        E"""Λ (σ : ⋆). λ (c : (ContractId σ)) → TO_TEXT_CONTRACT_ID @σ c""" ->
+          T"∀ (σ : ⋆). ContractId σ → Option Text"
       )
 
       forEvery(testCases) { (exp: Expr, expectedType: Type) =>


### PR DESCRIPTION
This is the first part of #7114.

This PR

* Adds the primitive to the protobuf.
* Handles decoding and encoding in Haskell and Scala.
* Handles typechecking in Haskell and Scala.
* Handles speedy compilation and interpretation in Scala.
* Updates the specification.

This PR does not yet change the standard library to make use of this
primitive.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
