### PR TITLE
allocateParty and listKnownParties in script service

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -447,15 +447,14 @@ main =
                       "  alice1 <- allocateParty \"alice\"",
                       "  t1 <- submit alice $ createCmd T { owner = alice, observer = alice1 }",
                       "  t2 <- submit alice $ exerciseCmd t1 (InventObserver \"bob\")",
+                      "  bob1 <- allocateParty \"bob\"",
                       "  details <- listKnownParties",
-                      "  assertEq (length details) 2",
-                      "  let [aliceDetails, alice1Details] = details",
-                      "  assertEq aliceDetails.party alice",
-                      "  assertEq aliceDetails.displayName (Some \"alice\")",
-                      "  assertEq aliceDetails.isLocal True",
-                      "  assertEq alice1Details.party (fromSome $ partyFromText \"alice1\")",
-                      "  assertEq alice1Details.displayName (Some \"alice\")",
-                      "  assertEq alice1Details.isLocal True"
+                      "  assertEq (length details) 4",
+                      "  let [aliceDetails, alice1Details, bobDetails, bob1Details] = details",
+                      "  assertEq aliceDetails (PartyDetails alice (Some \"alice\") True)",
+                      "  assertEq alice1Details (PartyDetails alice1 (Some \"alice\") True)",
+                      "  assertEq bobDetails (PartyDetails (fromSome $ partyFromText \"bob\") None True)",
+                      "  assertEq bob1Details (PartyDetails bob1 (Some \"bob\") True)"
                     ]
                 expectScriptSuccess rs (vr "partyManagement") $ \r ->
                   matchRegex r "Active contracts:  #1:1\n\nReturn value: {}\n\n$"

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -270,6 +270,8 @@ prettyScenarioErrorError (Just err) =  do
       pure "A must-fail commit succeeded."
     ScenarioErrorErrorScenarioInvalidPartyName name ->
       pure $ "Invalid party name: " <-> ltext name
+    ScenarioErrorErrorScenarioPartyAlreadyExists name ->
+      pure $ "Tried to allocate a party that already exists: " <-> ltext name
     ScenarioErrorErrorScenarioContractNotVisible ScenarioError_ContractNotVisible{..} ->
       pure $ vcat
         [ "Attempt to fetch or exercise a contract not visible to the committer."

--- a/compiler/scenario-service/protos/scenario_service.proto
+++ b/compiler/scenario-service/protos/scenario_service.proto
@@ -239,6 +239,7 @@ message ScenarioError {
     Empty scenario_mustfail_succeeded = 20;
     string scenario_invalid_party_name = 21;
     ContractKeyNotVisible scenario_contract_key_not_visible = 22;
+    string scenario_party_already_exists = 23;
   }
 }
 

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -151,6 +151,9 @@ final class Conversions(
       case SError.ScenarioErrorInvalidPartyName(party, _) =>
         builder.setScenarioInvalidPartyName(party)
 
+      case SError.ScenarioErrorPartyAlreadyExists(party) =>
+        builder.setScenarioPartyAlreadyExists(party)
+
       case wtc: SError.DamlEWronglyTypedContract =>
         sys.error(
           s"Got unexpected DamlEWronglyTypedContract error in scenario service: $wtc. Note that in the scenario service this error should never surface since contract fetches are all type checked.",

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -145,6 +145,8 @@ private[lf] object Pretty {
         text("due to a mustfailAt that succeeded.")
 
       case ScenarioErrorInvalidPartyName(_, msg) => text(s"Invalid party: $msg")
+
+      case ScenarioErrorPartyAlreadyExists(party) => text(s"Tried to allocate a party that already exists: $party")
     })
 
   def prettyFailedAuthorizations(fas: FailedAuthorizations): Doc =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -146,7 +146,8 @@ private[lf] object Pretty {
 
       case ScenarioErrorInvalidPartyName(_, msg) => text(s"Invalid party: $msg")
 
-      case ScenarioErrorPartyAlreadyExists(party) => text(s"Tried to allocate a party that already exists: $party")
+      case ScenarioErrorPartyAlreadyExists(party) =>
+        text(s"Tried to allocate a party that already exists: $party")
     })
 
   def prettyFailedAuthorizations(fas: FailedAuthorizations): Doc =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -125,4 +125,7 @@ object SError {
 
   /** Invalid party name supplied to 'getParty'. */
   final case class ScenarioErrorInvalidPartyName(name: String, msg: String) extends SErrorScenario
+
+  /** Tried to allocate a party that already exists. */
+  final case class ScenarioErrorPartyAlreadyExists(name: String) extends SErrorScenario
 }

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -503,7 +503,9 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
   }
 
   override def listKnownParties()(implicit ec: ExecutionContext, mat: Materializer) = {
-    val ledgerParties = getLedgerParties.map(p => (p -> PartyDetails(party = p, displayName = None, isLocal = true))).toMap
+    val ledgerParties = getLedgerParties
+      .map(p => (p -> PartyDetails(party = p, displayName = None, isLocal = true)))
+      .toMap
     Future.successful((ledgerParties ++ allocatedParties).values.toList)
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -484,7 +484,7 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       name <- if (partyIdHint != "") {
         // Try to allocate the given hint as party name. Will fail if the name is already taken.
         if (usedNames contains partyIdHint) {
-          Failure(new RuntimeException(s"Party $partyIdHint already exists"))
+          Failure(new ScenarioErrorPartyAlreadyExists(partyIdHint))
         } else {
           Success(partyIdHint)
         }


### PR DESCRIPTION
Closes #7000 

- Keeps track of allocated parties in the `IdeClient`
- `allocatePartyWithHint` behaves as on sandbox in that it uses the hint as party name and fails if the party already exists.
- `allocateParty` allocates a fresh party name based on the display name. (E.g. `alice1` if `alice` existed already)
- `listKnownParties` lists all allocated parties as well as parties that are otherwise known to the ledger, e.g. parties generated by `partyFromText`. These parties are also taken into account when generating fresh party names or checking for uniqueness on `allocatePartyWithHint`.
- Extends `SErrorScenario` with `ScenarioErrorPartyAlreadyExists`.
- Adds a test-case to the scenario service tests.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
