### PR TITLE
announce release rotation on Tuesday

### DIFF
--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -22,5 +22,12 @@ steps:
             echo "Authorization: basic $(git config remote.origin.url | grep -o '://.*:.*@' | cut -c4- | rev | cut -c2- | rev | tr -d '\n' | base64 -w0)"
         fi
     }
+    tell_slack() {
+        local message channel
+        message="$1"
+        channel=${2:-$(Slack.team-daml)}
+        jq -n --arg message "$message" '{"text": $message}' \
+         | curl -XPOST -i -H 'Content-Type: application/json' -d @- $channel
+    }
     END
     echo "##vso[task.setvariable variable=${{parameters.var_name}}]$TMP"

--- a/ci/cron/tuesday.yml
+++ b/ci/cron/tuesday.yml
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+pr: none
+trigger: none
+
+schedules:
+- cron: "0 6 * * Tue"
+  displayName: Tuesday
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+- job: announce_rotation
+  timeoutInMinutes: 60
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+  - checkout: self
+    persistCredentials: true
+  - template: ../bash-lib.yml
+    parameters:
+      var_name: bash_lib
+  - bash: |
+      set -euo pipefail
+
+      source "$(bash_lib)"
+
+      RELEASE_MANAGER=$(head -1 release/rotation | awk '{print $1}')
+
+      tell_slack "Hi <@$RELEASE_MANAGER>! According to the <https://github.com/digital-asset/daml/blob/master/release/rotation|rotation>, you are in charge of the release tomorrow. Please make sure you plan accordingly, or find a replacement."


### PR DESCRIPTION
It's been pointed out to me that some people actually plan their work, and for them, it would be useful to know at least a day in advance that they will be doing a release. This PR attempts to accommodate that.

Note: this will run as a new, separate cron. I'll do the Azure setup after this gets approved.

CHANGELOG_BEGIN
CHANGELOG_END