### PR TITLE
Use TO_TEXT_CONTRACT_ID in Show instance of ContractId

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -119,6 +119,14 @@ featureUnstable = Feature
     , featureCppFlag = "DAML_UNSTABLE"
     }
 
+featureToTextContractId :: Feature
+featureToTextContractId = Feature
+    { featureName = "TO_TEXT_CONTRACT_ID primitive"
+    -- TODO Change as part of #7139
+    , featureMinVersion = versionDev
+    , featureCppFlag = "DAML_TO_TEXT_CONTRACT_ID"
+    }
+
 allFeatures :: [Feature]
 allFeatures =
     [ featureNumeric
@@ -130,6 +138,7 @@ allFeatures =
     , featureGenMap
     , featurePackageMetadata
     , featureUnstable
+    , featureToTextContractId
     ]
 
 allFeaturesForVersion :: Version -> [Feature]

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -269,6 +269,12 @@ convertPrim _ "BETextReplicate" (TInt64 :-> TText :-> TText) = EBuiltin BETextRe
 convertPrim _ "BETextSplitOn" (TText :-> TText :-> TList TText) = EBuiltin BETextSplitOn
 convertPrim _ "BETextIntercalate" (TText :-> TList TText :-> TText) = EBuiltin BETextIntercalate
 
+-- Conversion from ContractId to Text
+
+convertPrim _ "BEToTextContractId" (TContractId t :-> TOptional TText) =
+    ETyApp (EBuiltin BEToTextContractId) t
+
+
 -- Template Desugaring.
 
 convertPrim _ "UCreate" (TCon template :-> TUpdate (TContractId (TCon template')))

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -133,7 +133,14 @@ data Map a b =
 data ContractId a =
   ContractId Opaque
 instance Eq (ContractId a) where (==) = primitive @"BEEqualContractId"
-instance Show (ContractId a) where show _ = "<contract-id>"
+instance Show (ContractId a) where
+#ifdef DAML_TO_TEXT_CONTRACT_ID
+  show cid = case primitive @"BEToTextContractId" cid of
+    None -> "<contract-id>"
+    Some t -> t
+#else
+  show _ = "<contract-id>"
+#endif
 
 -- | HIDE This is currently used in the internals of DAML script and DAML triggers
 -- but not really something that we want to expose to users.

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -338,7 +338,8 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
       esf: ExecutionSequencerFactory,
       mat: Materializer): Future[SValue] = {
     var clients = initialClients
-    val machine = Speedy.Machine.fromPureSExpr(extendedCompiledPackages, script.expr)
+    val machine =
+      Speedy.Machine.fromPureSExpr(extendedCompiledPackages, script.expr, onLedger = false)
 
     def stepToValue(): Either[RuntimeException, SValue] =
       machine.run() match {

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -47,6 +47,37 @@ EOF
     visibility = ["//visibility:public"],
 )
 
+# Test DAR in 1.dev to test new features.
+genrule(
+    name = "script-test-1.dev",
+    srcs =
+        glob(["**/*.daml"]) + ["//daml-script/daml:daml-script-1.dev.dar"],
+    outs = ["script-test-1.dev.dar"],
+    cmd = """
+      set -eou pipefail
+      TMP_DIR=$$(mktemp -d)
+      mkdir -p $$TMP_DIR/daml
+      cp -L $(location :daml/TestContractId.daml) $$TMP_DIR/daml
+      cp -L $(location //daml-script/daml:daml-script-1.dev.dar) $$TMP_DIR/
+      cat << EOF > $$TMP_DIR/daml.yaml
+sdk-version: {sdk}
+name: script-test-1dev
+version: 0.0.1
+source: daml
+build-options:
+  - --target=1.dev
+dependencies:
+  - daml-stdlib
+  - daml-prim
+  - daml-script-1.dev.dar
+EOF
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR -o $$PWD/$(location script-test-1.dev.dar)
+      rm -rf $$TMP_DIR
+    """.format(sdk = sdk_version),
+    tools = ["//compiler/damlc"],
+    visibility = ["//visibility:public"],
+)
+
 # A variant of script-test that has not been uploaded to the ledger
 # to test missing template ids. We only care that this has a different package id.
 genrule(
@@ -93,6 +124,7 @@ da_scala_library(
         "//daml-lf/data",
         "//daml-lf/interpreter",
         "//daml-lf/language",
+        "//daml-lf/transaction",
         "//daml-script/runner:script-runner-lib",
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
@@ -175,28 +207,46 @@ da_scala_test_suite(
 client_server_test(
     name = "test_static_time",
     client = ":test_client_single_participant",
-    client_files = ["$(rootpath :script-test.dar)"],
-    data = [":script-test.dar"],
+    client_files = [
+        "$(rootpath :script-test.dar)",
+        "$(rootpath :script-test-1.dev.dar)",
+    ],
+    data = [
+        ":script-test.dar",
+        ":script-test-1.dev.dar",
+    ],
     server = "//ledger/sandbox-classic:sandbox-classic-binary",
     server_args = [
         "--static-time",
         "--port=0",
     ],
-    server_files = ["$(rootpath :script-test.dar)"],
+    server_files = [
+        "$(rootpath :script-test.dar)",
+        "$(rootpath :script-test-1.dev.dar)",
+    ],
 )
 
 client_server_test(
     name = "test_wallclock_time",
     client = ":test_client_single_participant",
     client_args = ["-w"],
-    client_files = ["$(rootpath :script-test.dar)"],
-    data = [":script-test.dar"],
+    client_files = [
+        "$(rootpath :script-test.dar)",
+        "$(rootpath :script-test-1.dev.dar)",
+    ],
+    data = [
+        ":script-test.dar",
+        ":script-test-1.dev.dar",
+    ],
     server = "//ledger/sandbox-classic:sandbox-classic-binary",
     server_args = [
         "--wall-clock-time",
         "--port=0",
     ],
-    server_files = ["$(rootpath :script-test.dar)"],
+    server_files = [
+        "$(rootpath :script-test.dar)",
+        "$(rootpath :script-test-1.dev.dar)",
+    ],
 )
 
 client_server_test(
@@ -208,9 +258,11 @@ client_server_test(
     ],
     client_files = [
         "$(rootpath :script-test.dar)",
+        "$(rootpath :script-test-1.dev.dar)",
     ],
     data = [
         ":script-test.dar",
+        ":script-test-1.dev.dar",
     ],
     server = "//ledger/sandbox-classic:sandbox-classic-binary",
     server_args = [
@@ -230,9 +282,11 @@ client_server_test(
     ],
     client_files = [
         "$(rootpath :script-test.dar)",
+        "$(rootpath :script-test-1.dev.dar)",
     ],
     data = [
         ":script-test.dar",
+        ":script-test-1.dev.dar",
         "//ledger/test-common/test-certificates:ca.crt",
         "//ledger/test-common/test-certificates:server.crt",
         "//ledger/test-common/test-certificates:server.pem",
@@ -245,7 +299,10 @@ client_server_test(
         "--pem $$(rlocation $$TEST_WORKSPACE/$(rootpath //ledger/test-common/test-certificates:server.pem))",
         "--client-auth=none",
     ],
-    server_files = ["$(rootpath :script-test.dar)"],
+    server_files = [
+        "$(rootpath :script-test.dar)",
+        "$(rootpath :script-test-1.dev.dar)",
+    ],
 )
 
 client_server_test(

--- a/daml-script/test/daml/TestContractId.daml
+++ b/daml-script/test/daml/TestContractId.daml
@@ -1,0 +1,18 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module TestContractId where
+
+import Daml.Script
+
+template T
+  with
+    t : Party
+  where
+    signatory t
+
+testContractId = do
+  p <- allocateParty "p"
+  cid <- submit p (createCmd (T p))
+  pure (cid, show cid)
+

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -346,7 +346,8 @@ class Runner(
         getInitialState,
         Array(SParty(Party.assertFromString(party)), STimestamp(clientTime), createdValue))
     // Prepare a speedy machine for evaluting expressions.
-    val machine: Speedy.Machine = Speedy.Machine.fromPureSExpr(compiledPackages, initialState)
+    val machine: Speedy.Machine =
+      Speedy.Machine.fromPureSExpr(compiledPackages, initialState, onLedger = false)
     // Evaluate it.
     machine.setExpressionToEvaluate(initialState)
     val value = Machine.stepToValue(machine)


### PR DESCRIPTION
fixes #7114

This PR changes the Show instance of ContractId and flips the switch
on triggers and DAML Script to run in off-ledger mode.

It also adds a test that for DAML Script we actually get back the
correct contract id.

There is a bit of a design decision here in how we want to print
contract ids, so let me list the options I considered. $cid will stand
for the actual cid and all options are wrapped in markdown inline
code.

1. `"$cid"`. Indistinguishable from string. Suggests that there might
be an IsString instance for ContractId.
2. `<$cid>`. Matches the dummy `<contract-id>` but it’s not a dummy so
I don’t think matching that is benefitial.
3. `$cid`. Easy to spot (contract ids start with # and have no
spaces), clearly not a string but might look slightly weird.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
