### PR TITLE
Require 2 CPUs for repl integration tests

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -484,6 +484,8 @@ da_haskell_test(
     ],
     main_function = "DA.Test.Repl.main",
     src_strip_prefix = "src",
+    # Spinning up Sandbox is expensive, so require 2 CPUs.
+    tags = ["cpu:2"],
     visibility = ["//visibility:public"],
     deps = [
         "//libs-haskell/bazel-runfiles",


### PR DESCRIPTION
We have seen timeouts on port file waits occasionally.

Those timeouts are already very high so reducing load is a more
sensible option than bumping the timeout.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
