### PR TITLE
ledger-api-test-tool: Upload DARs, rather than expecting them.

### DIFF
--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -23,22 +23,6 @@ Downloading the tool
 Download the Ledger API Test Tool from :ledger-api-test-tool-maven:`Maven <ledger-api-test-tool>`
 and save it as ``ledger-api-test-tool.jar`` in your current directory.
 
-Extracting ``.dar`` files required to run the tests
-======================================================
-
-Before you can run the Ledger API test tool on your ledger, you need to load a
-specific set of DAML templates onto your ledger.
-
-#. To obtain the corresponding ``.dar`` files, run:
-
-   .. code-block:: console
-
-     $ java -jar ledger-api-test-tool.jar --extract
-
-   This writes all ``.dar`` files required for the tests into the current directory.
-
-#. Load all ``.dar`` files into your Ledger.
-
 Running the tool against a custom Ledger API endpoint
 =====================================================
 
@@ -49,11 +33,13 @@ at a port ``<port>``:
 
    $ java -jar ledger-api-test-tool.jar <host>:<port>
 
-For example
+For example:
 
 .. code-block:: console
 
    $ java -jar ledger-api-test-tool.jar localhost:6865
+
+The tool will upload the required DARs to the ledger, and then run all tests.
 
 If any test embedded in the tool fails, it will print out details of the failure
 for further debugging.

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -106,19 +106,6 @@ trap stop EXIT INT TERM
 
 wait_until curl -fsS "http://${PARTICIPANT_1_HOST}:${PARTICIPANT_1_MONITORING_PORT}/health"
 
-for participant in "${PARTICIPANTS[@]}"; do
-  for dar in "${dars[@]}"; do
-    base64 "$dar" |
-      jq -R --slurp '{"darFile": .}' |
-      grpcurl \
-        -plaintext \
-        -d @ \
-        "$participant" \
-        com.daml.ledger.api.v1.admin.PackageManagementService.UploadDarFile \
-        >/dev/null
-  done
-done
-
 # This should write two ports, but the runner doesn't support that.
 echo "$PARTICIPANT_1_LEDGER_API_PORT" >"$port_file"
 

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -16,18 +16,6 @@ CANTON_COMMAND=(
 PARTICIPANT_1_HOST=localhost
 PARTICIPANT_1_LEDGER_API_PORT=5011
 PARTICIPANT_1_MONITORING_PORT=7000
-PARTICIPANT_2_HOST=localhost
-PARTICIPANT_2_LEDGER_API_PORT=5021
-PARTICIPANT_3_HOST=localhost
-PARTICIPANT_3_LEDGER_API_PORT=5031
-PARTICIPANT_4_HOST=localhost
-PARTICIPANT_4_LEDGER_API_PORT=5041
-PARTICIPANTS=(
-  "${PARTICIPANT_1_HOST}:${PARTICIPANT_1_LEDGER_API_PORT}"
-  "${PARTICIPANT_2_HOST}:${PARTICIPANT_2_LEDGER_API_PORT}"
-  "${PARTICIPANT_3_HOST}:${PARTICIPANT_3_LEDGER_API_PORT}"
-  "${PARTICIPANT_4_HOST}:${PARTICIPANT_4_LEDGER_API_PORT}"
-)
 
 TIMEOUT=60
 
@@ -50,17 +38,12 @@ function wait_until() {
 }
 
 command=("${CANTON_COMMAND[@]}")
-dars=()
 port_file=''
 while (($#)); do
-  # extract the port file
+  # Extract the port file.
   if [[ "$1" == '--port-file' ]]; then
     port_file="$2"
     shift
-    shift
-  # upload DARs with the DAML assistant
-  elif [[ "$1" =~ \.dar$ ]]; then
-    dars+=("$1")
     shift
   else
     command+=("$1")
@@ -74,15 +57,13 @@ if [[ -z "$port_file" ]]; then
   exit 2
 fi
 
-# Change HOME since Canton uses ammonite in the default configuration
-# which tries to write to ~/.ammonite/cache which is read-only
-# when sandboxing is enabled.
-export HOME=$(mktemp -d)
-# ammonite calls System.getProperty('user.home') which does not
-# read $HOME.
+# Change HOME since Canton uses ammonite in the default configuration, which tries to write to
+# ~/.ammonite/cache, which is read-only when sandboxing is enabled.
+HOME="$(mktemp -d)"
+export HOME
+# ammonite calls `System.getProperty('user.home')` which does not read $HOME.
 command+=("--wrapper_script_flag=--jvm_flag=-Duser.home=$HOME")
 
-# Redirect the Canton logs to a file for now, because they're really, really noisy.
 echo >&2 'Starting Canton...'
 "${command[@]}" &
 pid="$!"

--- a/ledger/ledger-api-test-tool/conformance.bzl
+++ b/ledger/ledger-api-test-tool/conformance.bzl
@@ -29,9 +29,6 @@ def conformance_test(
         ],
         server = server,
         server_args = server_args,
-        server_files = [
-            "$(rootpaths //ledger/test-common:dar-files)",
-        ],
         tags = [
             "dont-run-on-darwin",
             "exclusive",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -8,6 +8,7 @@ import java.nio.file.{Files, Paths, StandardCopyOption}
 
 import com.daml.ledger.api.testtool.infrastructure.Reporter.ColorizedPrintStreamReporter
 import com.daml.ledger.api.testtool.infrastructure.{
+  Dars,
   LedgerSessionConfiguration,
   LedgerTestCase,
   LedgerTestCasesRunner,
@@ -60,7 +61,7 @@ object LedgerApiTestTool {
     printListOfTests(Tests.all.flatMap(_.tests))(_.name)
   }
 
-  private def extractResources(resources: String*): Unit = {
+  private def extractResources(resources: Seq[String]): Unit = {
     val pwd = Paths.get(".").toAbsolutePath
     println(s"Extracting all DAML resources necessary to run the tests into $pwd.")
     for (resource <- resources) {
@@ -93,12 +94,7 @@ object LedgerApiTestTool {
     }
 
     if (config.extract) {
-      // This must be kept aligned manually with artifacts declared in /ledger/test-common/BUILD.bazel.
-      extractResources(
-        "/ledger/test-common/model-tests.dar",
-        "/ledger/test-common/performance-tests.dar",
-        "/ledger/test-common/semantic-tests.dar",
-      )
+      extractResources(Dars.resources)
       sys.exit(0)
     }
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Dars.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Dars.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.infrastructure
+
+import com.google.protobuf.ByteString
+
+import scala.collection.immutable
+
+object Dars {
+
+  // This must be kept aligned manually with artifacts declared in /ledger/test-common/BUILD.bazel.
+  val resources: immutable.Seq[String] = immutable.Seq(
+    "/ledger/test-common/model-tests.dar",
+    "/ledger/test-common/performance-tests.dar",
+    "/ledger/test-common/semantic-tests.dar",
+  )
+
+  def read(name: String): ByteString =
+    ByteString.readFrom(getClass.getResourceAsStream(name))
+
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -3,10 +3,7 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
-import com.daml.ledger.api.testtool.infrastructure.participant.{
-  ParticipantSessionConfiguration,
-  ParticipantSessionManager
-}
+import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessionManager
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -20,17 +17,8 @@ private[testtool] final class LedgerSession(
 
   private[this] val participantSessions =
     Future
-      .sequence(config.participants.map {
-        case (host, port) =>
-          participantSessionManager.getOrCreate(
-            ParticipantSessionConfiguration(
-              host,
-              port,
-              config.ssl,
-              config.partyAllocation,
-            ),
-          )
-      })
+      .sequence(config.participants.map(hostAndPort =>
+        participantSessionManager.getOrCreate(config.forParticipant(hostAndPort))))
       .map(_.map(endpointIdProvider() -> _))
 
   private[testtool] def createTestContext(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
+import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessionConfiguration
 import com.daml.ledger.api.tls.TlsConfiguration
 
 private[testtool] final case class LedgerSessionConfiguration(
@@ -10,4 +11,9 @@ private[testtool] final case class LedgerSessionConfiguration(
     shuffleParticipants: Boolean,
     ssl: Option[TlsConfiguration],
     partyAllocation: PartyAllocationConfiguration,
-)
+) {
+  def forParticipant(hostAndPort: (String, Int)): ParticipantSessionConfiguration = {
+    val (host, port) = hostAndPort
+    ParticipantSessionConfiguration(host, port, ssl, partyAllocation)
+  }
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -11,10 +11,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestCasesRunner._
 import com.daml.ledger.api.testtool.infrastructure.Result.Retired
-import com.daml.ledger.api.testtool.infrastructure.participant.{
-  ParticipantSessionConfiguration,
-  ParticipantSessionManager
-}
+import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessionManager
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.{Duration, DurationInt}
@@ -125,13 +122,7 @@ final class LedgerTestCasesRunner(
     val ledgerSession = new LedgerSession(config, participantSessionManager)
 
     def uploadDars(): Future[Unit] = {
-      val (host, port) = config.participants.head
-      val firstParticipant = ParticipantSessionConfiguration(
-        host,
-        port,
-        config.ssl,
-        config.partyAllocation,
-      )
+      val firstParticipant = config.forParticipant(config.participants.head)
       for {
         session <- participantSessionManager.getOrCreate(firstParticipant)
         context <- session.createInitContext("upload-dars", identifierSuffix)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
@@ -34,6 +34,12 @@ private[participant] final class ParticipantSession(
       services.identity.getLedgerIdentity(new GetLedgerIdentityRequest).map(_.ledgerId)
     }
 
+  private[testtool] def createInitContext(
+      applicationId: String,
+      identifierSuffix: String,
+  ): Future[ParticipantTestContext] =
+    createTestContext("init", applicationId, identifierSuffix)
+
   private[testtool] def createTestContext(
       endpointId: String,
       applicationId: String,


### PR DESCRIPTION
This allows us to avoid knowing the DARs.

Closes #2536.

Facilitates #6866, if we decide to go for it.

### Changelog

- **[Integration Kit]** When running the Ledger API Test Tool, the required DAR files are now uploaded to the ledger automatically before running the tests. You no longer need to upload these DARs before running the test tool.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
