### PR TITLE
participant-integration-api: Factor out similar behavior in the admin service implementations.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -57,7 +57,7 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
     Timed.future(metrics.daml.services.index.getLfPackage, delegate.getLfPackage(packageId))
 
   override def packageEntries(
-      startExclusive: LedgerOffset.Absolute
+      startExclusive: Option[LedgerOffset.Absolute],
   )(implicit loggingContext: LoggingContext): Source[domain.PackageEntry, NotUsed] =
     Timed.source(
       metrics.daml.services.index.packageEntries,
@@ -169,7 +169,7 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
     Timed.future(metrics.daml.services.index.listKnownParties, delegate.listKnownParties())
 
   override def partyEntries(
-      startExclusive: LedgerOffset.Absolute
+      startExclusive: Option[LedgerOffset.Absolute],
   )(implicit loggingContext: LoggingContext): Source[domain.PartyEntry, NotUsed] =
     Timed.source(metrics.daml.services.index.partyEntries, delegate.partyEntries(startExclusive))
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -26,7 +26,7 @@ import com.daml.platform.server.api.validation
 import com.daml.platform.server.api.validation.ErrorFactories
 import io.grpc.{ServerServiceDefinition, StatusRuntimeException}
 
-import scala.compat.java8.FutureConverters
+import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -102,9 +102,9 @@ private[apiserver] final class ApiConfigManagementService private (
 
       // Submit configuration to the ledger, and start polling for the result.
       submissionId = SubmissionId.assertFromString(request.submissionId)
-      submissionResult <- FutureConverters.toScala(
-        writeService.submitConfiguration(params.maximumRecordTime, submissionId, newConfig))
-
+      submissionResult <- writeService
+        .submitConfiguration(params.maximumRecordTime, submissionId, newConfig)
+        .toScala
       entry <- submissionResult match {
         // Ledger acknowledged. Start polling to wait for the result to land in the index.
         case SubmissionResult.Acknowledged =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -145,7 +145,7 @@ private[apiserver] final class ApiConfigManagementService private (
   )
 
   private def validateParameters(
-      request: SetTimeModelRequest
+      request: SetTimeModelRequest,
   ): Either[StatusRuntimeException, SetTimeModelParameters] = {
     import validation.FieldValidations._
     for {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -118,7 +118,7 @@ private[apiserver] final class ApiConfigManagementService private (
                   entry
               },
             params.timeToLive,
-          )(materializer)
+          )(executionContext, materializer)
         case SubmissionResult.Overloaded =>
           Future.failed(ErrorFactories.resourceExhausted("Resource exhausted"))
         case SubmissionResult.InternalError(reason) =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -8,19 +8,21 @@ import java.util.UUID
 import java.util.zip.ZipInputStream
 
 import akka.stream.Materializer
+import akka.stream.scaladsl.Source
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.dec.{DirectExecutionContext => DE}
-import com.daml.ledger.api.domain.PackageEntry
+import com.daml.ledger.api.domain.{LedgerOffset, PackageEntry}
 import com.daml.ledger.api.v1.admin.package_management_service.PackageManagementServiceGrpc.PackageManagementService
 import com.daml.ledger.api.v1.admin.package_management_service._
 import com.daml.ledger.participant.state.index.v2.{IndexPackagesService, IndexTransactionsService}
 import com.daml.ledger.participant.state.v1.{SubmissionId, SubmissionResult, WritePackagesService}
-import com.daml.lf.archive.DarReader
+import com.daml.lf.archive.{Dar, DarReader}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.platform.api.grpc.GrpcApiService
+import com.daml.platform.apiserver.services.admin.ApiPackageManagementService._
 import com.daml.platform.server.api.validation.ErrorFactories
 import com.google.protobuf.timestamp.Timestamp
-import io.grpc.ServerServiceDefinition
+import io.grpc.{ServerServiceDefinition, StatusRuntimeException}
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.DurationInt
@@ -31,7 +33,8 @@ private[apiserver] final class ApiPackageManagementService private (
     packagesIndex: IndexPackagesService,
     transactionsService: IndexTransactionsService,
     packagesWrite: WritePackagesService,
-    materializer: Materializer)(implicit loggingContext: LoggingContext)
+    materializer: Materializer,
+)(implicit loggingContext: LoggingContext)
     extends PackageManagementService
     with GrpcApiService {
 
@@ -75,6 +78,7 @@ private[apiserver] final class ApiPackageManagementService private (
 
     // Execute subsequent transforms in the thread of the previous operation.
     implicit val executionContext: ExecutionContext = DE
+    implicit val mat: Materializer = materializer
 
     val response = for {
       dar <- DarReader { case (_, x) => Try(Archive.parseFrom(x)) }
@@ -85,36 +89,18 @@ private[apiserver] final class ApiPackageManagementService private (
           err => Future.failed(ErrorFactories.invalidArgument(err.getMessage)),
           Future.successful
         )
-      ledgerEndBeforeRequest <- transactionsService.currentLedgerEnd()
-      submissionResult <- packagesWrite.uploadPackages(submissionId, dar.all, None).toScala
-      entry <- submissionResult match {
-        case SubmissionResult.Acknowledged =>
-          SynchronousResponse.pollUntilPersisted(
-            packagesIndex
-              .packageEntries(ledgerEndBeforeRequest)
-              .collect {
-                case entry @ PackageEntry.PackageUploadAccepted(`submissionId`, _) => entry
-                case entry @ PackageEntry.PackageUploadRejected(`submissionId`, _, _) => entry
-              },
-            timeToLive,
-          )(executionContext, materializer)
-        case r @ SubmissionResult.Overloaded =>
-          Future.failed(ErrorFactories.resourceExhausted(r.description))
-        case r @ SubmissionResult.InternalError(_) =>
-          Future.failed(ErrorFactories.internal(r.reason))
-        case r @ SubmissionResult.NotSupported =>
-          Future.failed(ErrorFactories.unimplemented(r.description))
+      synchronousResponse = new SynchronousResponse(
+        transactionsService,
+        timeToLive,
+        new SynchronousResponseStrategy(packagesIndex, packagesWrite, dar),
+      )
+      _ <- synchronousResponse.submitAndWait(submissionId)
+    } yield {
+      for (archive <- dar.all) {
+        logger.info(s"Package ${archive.getHash} successfully uploaded")
       }
-      response <- entry match {
-        case _: PackageEntry.PackageUploadAccepted =>
-          for (archive <- dar.all) {
-            logger.info(s"Package ${archive.getHash} successfully uploaded")
-          }
-          Future.successful(UploadDarFileResponse())
-        case PackageEntry.PackageUploadRejected(_, _, reason) =>
-          Future.failed(ErrorFactories.invalidArgument(reason))
-      }
-    } yield response
+      UploadDarFileResponse()
+    }
 
     response.andThen(logger.logErrorsOnCall[UploadDarFileResponse])
   }
@@ -130,5 +116,33 @@ private[apiserver] object ApiPackageManagementService {
   )(implicit mat: Materializer, loggingContext: LoggingContext)
     : PackageManagementServiceGrpc.PackageManagementService with GrpcApiService =
     new ApiPackageManagementService(readBackend, transactionsService, writeBackend, mat)
+
+  private final class SynchronousResponseStrategy(
+      packagesIndex: IndexPackagesService,
+      packagesWrite: WritePackagesService,
+      dar: Dar[Archive],
+  )(implicit loggingContext: LoggingContext)
+      extends SynchronousResponse.Strategy[PackageEntry, PackageEntry.PackageUploadAccepted] {
+
+    override def submit(submissionId: SubmissionId): Future[SubmissionResult] =
+      packagesWrite.uploadPackages(submissionId, dar.all, None).toScala
+
+    override def entries(offset: LedgerOffset.Absolute): Source[PackageEntry, _] =
+      packagesIndex.packageEntries(offset)
+
+    override def accept(
+        submissionId: SubmissionId,
+    ): PartialFunction[PackageEntry, PackageEntry.PackageUploadAccepted] = {
+      case entry @ PackageEntry.PackageUploadAccepted(`submissionId`, _) => entry
+    }
+
+    override def reject(
+        submissionId: SubmissionId,
+    ): PartialFunction[PackageEntry, StatusRuntimeException] = {
+      case PackageEntry.PackageUploadRejected(`submissionId`, _, reason) =>
+        ErrorFactories.invalidArgument(reason)
+    }
+
+  }
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -97,7 +97,7 @@ private[apiserver] final class ApiPackageManagementService private (
                 case entry @ PackageEntry.PackageUploadRejected(`submissionId`, _, _) => entry
               },
             timeToLive,
-          )(materializer)
+          )(executionContext, materializer)
         case r @ SubmissionResult.Overloaded =>
           Future.failed(ErrorFactories.resourceExhausted(r.description))
         case r @ SubmissionResult.InternalError(_) =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -128,7 +128,7 @@ private[apiserver] object ApiPackageManagementService {
       packagesWrite.uploadPackages(submissionId, dar.all, None).toScala
 
     override def entries(offset: LedgerOffset.Absolute): Source[PackageEntry, _] =
-      packagesIndex.packageEntries(offset)
+      packagesIndex.packageEntries(Some(offset))
 
     override def accept(
         submissionId: SubmissionId,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -22,7 +22,7 @@ import com.daml.platform.server.api.validation.ErrorFactories
 import com.google.protobuf.timestamp.Timestamp
 import io.grpc.ServerServiceDefinition
 
-import scala.compat.java8.FutureConverters
+import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -86,9 +86,7 @@ private[apiserver] final class ApiPackageManagementService private (
           Future.successful
         )
       ledgerEndBeforeRequest <- transactionsService.currentLedgerEnd()
-      submissionResult <- FutureConverters.toScala(
-        packagesWrite.uploadPackages(submissionId, dar.all, None)
-      )
+      submissionResult <- packagesWrite.uploadPackages(submissionId, dar.all, None).toScala
       entry <- submissionResult match {
         case SubmissionResult.Acknowledged =>
           waitForEntry(submissionId, ledgerEndBeforeRequest, timeToLive)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -88,7 +88,7 @@ private[apiserver] final class ApiPartyManagementService private (
         case SubmissionResult.Acknowledged =>
           SynchronousResponse.pollUntilPersisted(
             partyManagementService
-              .partyEntries(ledgerEndBeforeRequest)
+              .partyEntries(Some(ledgerEndBeforeRequest))
               .collect {
                 case entry @ AllocationAccepted(Some(`submissionId`), _) => entry
                 case entry @ AllocationRejected(`submissionId`, _) => entry

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -6,28 +6,26 @@ package com.daml.platform.apiserver.services.admin
 import java.util.UUID
 
 import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
+import com.daml.dec.{DirectExecutionContext => DE}
+import com.daml.ledger.api.domain
+import com.daml.ledger.api.domain.PartyEntry.{AllocationAccepted, AllocationRejected}
+import com.daml.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc.PartyManagementService
+import com.daml.ledger.api.v1.admin.party_management_service._
 import com.daml.ledger.participant.state.index.v2.{
   IndexPartyManagementService,
   IndexTransactionsService
 }
 import com.daml.ledger.participant.state.v1
-import com.daml.ledger.participant.state.v1.{SubmissionId, SubmissionResult, WritePartyService}
+import com.daml.ledger.participant.state.v1.{SubmissionResult, WritePartyService}
 import com.daml.lf.data.Ref
-import com.daml.dec.{DirectExecutionContext => DE}
-import com.daml.ledger.api.domain
-import com.daml.ledger.api.domain.PartyEntry.{AllocationAccepted, AllocationRejected}
-import com.daml.ledger.api.domain.{LedgerOffset, PartyEntry}
-import com.daml.ledger.api.v1.admin.party_management_service.PartyManagementServiceGrpc.PartyManagementService
-import com.daml.ledger.api.v1.admin.party_management_service._
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.validation.ErrorFactories
 import io.grpc.ServerServiceDefinition
 
 import scala.compat.java8.FutureConverters
-import scala.concurrent.duration.DurationInt
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
 private[apiserver] final class ApiPartyManagementService private (
     partyManagementService: IndexPartyManagementService,
@@ -72,24 +70,6 @@ private[apiserver] final class ApiPartyManagementService private (
       .map(ps => ListKnownPartiesResponse(ps.map(mapPartyDetails)))(DE)
       .andThen(logger.logErrorsOnCall[ListKnownPartiesResponse])(DE)
 
-  /**
-    * Checks invariants and forwards the original result after the party is found to be persisted.
-    *
-    * @return The result of the party allocation received originally, wrapped in a [[Future]]
-    */
-  private def pollUntilPersisted(
-      submissionId: SubmissionId,
-      offset: LedgerOffset.Absolute): Future[PartyEntry] = {
-    partyManagementService
-      .partyEntries(offset)
-      .collect {
-        case entry @ AllocationAccepted(Some(`submissionId`), _) => entry
-        case entry @ AllocationRejected(`submissionId`, _) => entry
-      }
-      .completionTimeout(30.seconds)
-      .runWith(Sink.head)(materializer)
-  }
-
   override def allocateParty(request: AllocatePartyRequest): Future[AllocatePartyResponse] = {
     // TODO: This should do proper validation.
     val submissionId = v1.SubmissionId.assertFromString(UUID.randomUUID().toString)
@@ -106,19 +86,28 @@ private[apiserver] final class ApiPartyManagementService private (
             .allocateParty(party, displayName, submissionId))
           .flatMap {
             case SubmissionResult.Acknowledged =>
-              pollUntilPersisted(submissionId, ledgerEndBeforeRequest).flatMap {
-                case domain.PartyEntry.AllocationAccepted(_, partyDetails) =>
-                  Future.successful(
-                    AllocatePartyResponse(
-                      Some(
-                        PartyDetails(
+              SynchronousResponse
+                .pollUntilPersisted(
+                  partyManagementService
+                    .partyEntries(ledgerEndBeforeRequest)
+                    .collect {
+                      case entry @ AllocationAccepted(Some(`submissionId`), _) => entry
+                      case entry @ AllocationRejected(`submissionId`, _) => entry
+                    },
+                  timeToLive = 30.seconds,
+                )(materializer)
+                .flatMap {
+                  case domain.PartyEntry.AllocationAccepted(_, partyDetails) =>
+                    Future.successful(
+                      AllocatePartyResponse(
+                        Some(PartyDetails(
                           partyDetails.party,
                           partyDetails.displayName.getOrElse(""),
                           partyDetails.isLocal,
                         ))))
-                case domain.PartyEntry.AllocationRejected(_, reason) =>
-                  Future.failed(ErrorFactories.invalidArgument(reason))
-              }(DE)
+                  case domain.PartyEntry.AllocationRejected(_, reason) =>
+                    Future.failed(ErrorFactories.invalidArgument(reason))
+                }(DE)
             case r @ SubmissionResult.Overloaded =>
               Future.failed(ErrorFactories.resourceExhausted(r.description))
             case r @ SubmissionResult.InternalError(_) =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -24,7 +24,7 @@ import com.daml.platform.api.grpc.GrpcApiService
 import com.daml.platform.server.api.validation.ErrorFactories
 import io.grpc.ServerServiceDefinition
 
-import scala.compat.java8.FutureConverters
+import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -84,8 +84,7 @@ private[apiserver] final class ApiPartyManagementService private (
 
     val response = for {
       ledgerEndBeforeRequest <- transactionService.currentLedgerEnd()
-      submissionResult <- FutureConverters.toScala(
-        writeService.allocateParty(party, displayName, submissionId))
+      submissionResult <- writeService.allocateParty(party, displayName, submissionId).toScala
       entry <- submissionResult match {
         case SubmissionResult.Acknowledged =>
           waitForEntry(submissionId, ledgerEndBeforeRequest, timeToLive = 30.seconds)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -94,7 +94,7 @@ private[apiserver] final class ApiPartyManagementService private (
                 case entry @ AllocationRejected(`submissionId`, _) => entry
               },
             30.seconds,
-          )(materializer)
+          )(executionContext, materializer)
         case r @ SubmissionResult.Overloaded =>
           Future.failed(ErrorFactories.resourceExhausted(r.description))
         case r @ SubmissionResult.InternalError(_) =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
@@ -5,10 +5,59 @@ package com.daml.platform.apiserver.services.admin
 
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
+import com.daml.ledger.api.domain.LedgerOffset
+import com.daml.ledger.participant.state.index.v2.LedgerEndService
+import com.daml.ledger.participant.state.v1.{SubmissionId, SubmissionResult}
+import com.daml.logging.LoggingContext
+import com.daml.platform.apiserver.services.admin.SynchronousResponse.{Accepted, Rejected}
 import com.daml.platform.server.api.validation.ErrorFactories
+import io.grpc.StatusRuntimeException
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+
+class SynchronousResponse[Entry, AcceptedEntry](
+    ledgerEndService: LedgerEndService,
+    timeToLive: FiniteDuration,
+    strategy: SynchronousResponse.Strategy[Entry, AcceptedEntry],
+) {
+
+  def submitAndWait(submissionId: SubmissionId)(
+      implicit executionContext: ExecutionContext,
+      materializer: Materializer,
+      loggingContext: LoggingContext,
+  ): Future[AcceptedEntry] = {
+    for {
+      ledgerEndBeforeRequest <- ledgerEndService.currentLedgerEnd()
+      submissionResult <- strategy.submit(submissionId)
+      entry <- submissionResult match {
+        case SubmissionResult.Acknowledged =>
+          val isAccepted = new Accepted(strategy.accept(submissionId))
+          val isRejected = new Rejected(strategy.reject(submissionId))
+          strategy
+            .entries(ledgerEndBeforeRequest)
+            .collect {
+              case isAccepted(entry) => Future.successful(entry)
+              case isRejected(exception) => Future.failed(exception)
+            }
+            .completionTimeout(timeToLive)
+            .runWith(Sink.head)
+            .recoverWith {
+              case _: TimeoutException =>
+                Future.failed(ErrorFactories.aborted("Request timed out"))
+            }
+            .flatten
+        case r @ SubmissionResult.Overloaded =>
+          Future.failed(ErrorFactories.resourceExhausted(r.description))
+        case r @ SubmissionResult.InternalError(_) =>
+          Future.failed(ErrorFactories.internal(r.reason))
+        case r @ SubmissionResult.NotSupported =>
+          Future.failed(ErrorFactories.unimplemented(r.description))
+      }
+    } yield entry
+  }
+
+}
 
 object SynchronousResponse {
 
@@ -23,5 +72,33 @@ object SynchronousResponse {
         case _: TimeoutException =>
           Future.failed(ErrorFactories.aborted("Request timed out"))
       }
+
+  trait Strategy[Entry, AcceptedEntry] {
+
+    def submit(submissionId: SubmissionId): Future[SubmissionResult]
+
+    def entries(offset: LedgerOffset.Absolute): Source[Entry, _]
+
+    def accept(submissionId: SubmissionId): PartialFunction[Entry, AcceptedEntry]
+
+    def reject(submissionId: SubmissionId): PartialFunction[Entry, StatusRuntimeException]
+
+  }
+
+  private final class Accepted[Entry, AcceptedEntry](
+      accept: PartialFunction[Entry, AcceptedEntry],
+  ) {
+    private val liftedAccept = accept.lift
+
+    def unapply(entry: Entry): Option[AcceptedEntry] =
+      liftedAccept(entry)
+  }
+
+  private final class Rejected[Entry](reject: PartialFunction[Entry, StatusRuntimeException]) {
+    private val liftedReject = reject.lift
+
+    def unapply(entry: Entry): Option[StatusRuntimeException] =
+      liftedReject(entry)
+  }
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
@@ -5,24 +5,23 @@ package com.daml.platform.apiserver.services.admin
 
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
-import com.daml.dec.DirectExecutionContext
 import com.daml.platform.server.api.validation.ErrorFactories
 
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{Future, TimeoutException}
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 
 object SynchronousResponse {
 
   def pollUntilPersisted[T](
       source: Source[T, _],
       timeToLive: FiniteDuration,
-  )(implicit materializer: Materializer): Future[T] =
+  )(implicit executionContext: ExecutionContext, materializer: Materializer): Future[T] =
     source
       .completionTimeout(timeToLive)
       .runWith(Sink.head)
       .recoverWith {
         case _: TimeoutException =>
           Future.failed(ErrorFactories.aborted("Request timed out"))
-      }(DirectExecutionContext)
+      }
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.apiserver.services.admin
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
+import com.daml.dec.DirectExecutionContext
+import com.daml.platform.server.api.validation.ErrorFactories
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{Future, TimeoutException}
+
+object SynchronousResponse {
+
+  def pollUntilPersisted[T](
+      source: Source[T, _],
+      timeToLive: FiniteDuration,
+  )(implicit materializer: Materializer): Future[T] =
+    source
+      .completionTimeout(timeToLive)
+      .runWith(Sink.head)
+      .recoverWith {
+        case _: TimeoutException =>
+          Future.failed(ErrorFactories.aborted("Request timed out"))
+      }(DirectExecutionContext)
+
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/SynchronousResponse.scala
@@ -15,8 +15,8 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 
 class SynchronousResponse[Entry, AcceptedEntry](
-    timeToLive: FiniteDuration,
     strategy: SynchronousResponse.Strategy[Entry, AcceptedEntry],
+    timeToLive: FiniteDuration,
 ) {
 
   def submitAndWait(submissionId: SubmissionId)(
@@ -56,18 +56,6 @@ class SynchronousResponse[Entry, AcceptedEntry](
 }
 
 object SynchronousResponse {
-
-  def pollUntilPersisted[T](
-      source: Source[T, _],
-      timeToLive: FiniteDuration,
-  )(implicit executionContext: ExecutionContext, materializer: Materializer): Future[T] =
-    source
-      .completionTimeout(timeToLive)
-      .runWith(Sink.head)
-      .recoverWith {
-        case _: TimeoutException =>
-          Future.failed(ErrorFactories.aborted("Request timed out"))
-      }
 
   trait Strategy[Entry, AcceptedEntry] {
 

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -154,7 +154,7 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
     Timed.future(metrics.daml.index.lookupLedgerConfiguration, ledger.lookupLedgerConfiguration())
 
   override def configurationEntries(
-      startExclusive: Option[Offset],
+      startExclusive: Offset,
   )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed] =
     ledger.configurationEntries(startExclusive)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -172,12 +172,10 @@ private[platform] abstract class BaseLedger(
   ): Future[Option[(Offset, Configuration)]] =
     ledgerDao.lookupLedgerConfiguration()
 
-  override def configurationEntries(startExclusive: Option[Offset])(
+  override def configurationEntries(startExclusive: Offset)(
       implicit loggingContext: LoggingContext,
   ): Source[(Offset, ConfigurationEntry), NotUsed] =
-    dispatcher.startingAt(
-      startExclusive.getOrElse(Offset.beforeBegin),
-      RangeSource(ledgerDao.getConfigurationEntries))
+    dispatcher.startingAt(startExclusive, RangeSource(ledgerDao.getConfigurationEntries))
 
   override def deduplicateCommand(
       commandId: CommandId,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
@@ -7,14 +7,6 @@ import java.time.Instant
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.index.v2.{CommandDeduplicationResult, PackageDetails}
-import com.daml.ledger.participant.state.v1.{Configuration, Offset}
-import com.daml.lf.data.Ref
-import com.daml.lf.data.Ref.{Identifier, PackageId, Party}
-import com.daml.lf.language.Ast
-import com.daml.lf.transaction.GlobalKey
-import com.daml.lf.value.Value
-import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.daml_lf_dev.DamlLf.Archive
 import com.daml.ledger.TransactionId
 import com.daml.ledger.api.domain.{ApplicationId, CommandId, LedgerId, PartyDetails}
@@ -27,6 +19,14 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse
 }
+import com.daml.ledger.participant.state.index.v2.{CommandDeduplicationResult, PackageDetails}
+import com.daml.ledger.participant.state.v1.{Configuration, Offset}
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.{Identifier, PackageId, Party}
+import com.daml.lf.language.Ast
+import com.daml.lf.transaction.GlobalKey
+import com.daml.lf.value.Value
+import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.LoggingContext
 import com.daml.platform.store.entries.{ConfigurationEntry, PackageLedgerEntry, PartyLedgerEntry}
 
@@ -123,7 +123,7 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
   ): Future[Option[(Offset, Configuration)]]
 
   def configurationEntries(
-      startExclusive: Option[Offset],
+      startExclusive: Offset,
   )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed]
 
   /** Deduplicates commands.

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPackagesService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPackagesService.scala
@@ -5,10 +5,10 @@ package com.daml.ledger.participant.state.index.v2
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.lf.data.Ref.PackageId
 import com.daml.daml_lf_dev.DamlLf.Archive
-import com.daml.lf.language.Ast.Package
 import com.daml.ledger.api.domain.{LedgerOffset, PackageEntry}
+import com.daml.lf.data.Ref.PackageId
+import com.daml.lf.language.Ast.Package
 import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
@@ -22,16 +22,16 @@ trait IndexPackagesService {
       implicit loggingContext: LoggingContext,
   ): Future[Map[PackageId, PackageDetails]]
 
-  def getLfArchive(packageId: PackageId)(
-      implicit loggingContext: LoggingContext,
-  ): Future[Option[Archive]]
+  def getLfArchive(
+      packageId: PackageId,
+  )(implicit loggingContext: LoggingContext): Future[Option[Archive]]
 
   /** Like [[getLfArchive]], but already parsed. */
-  def getLfPackage(packageId: PackageId)(
-      implicit loggingContext: LoggingContext,
-  ): Future[Option[Package]]
+  def getLfPackage(
+      packageId: PackageId,
+  )(implicit loggingContext: LoggingContext): Future[Option[Package]]
 
-  def packageEntries(startExclusive: LedgerOffset.Absolute)(
-      implicit loggingContext: LoggingContext,
-  ): Source[PackageEntry, NotUsed]
+  def packageEntries(
+      startExclusive: Option[LedgerOffset.Absolute],
+  )(implicit loggingContext: LoggingContext): Source[PackageEntry, NotUsed]
 }

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexPartyManagementService.scala
@@ -5,8 +5,8 @@ package com.daml.ledger.participant.state.index.v2
 
 import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.v1.{ParticipantId, Party}
 import com.daml.ledger.api.domain.{LedgerOffset, PartyDetails, PartyEntry}
+import com.daml.ledger.participant.state.v1.{ParticipantId, Party}
 import com.daml.logging.LoggingContext
 
 import scala.concurrent.Future
@@ -18,13 +18,13 @@ import scala.concurrent.Future
 trait IndexPartyManagementService {
   def getParticipantId()(implicit loggingContext: LoggingContext): Future[ParticipantId]
 
-  def getParties(parties: Seq[Party])(
-      implicit loggingContext: LoggingContext,
-  ): Future[List[PartyDetails]]
+  def getParties(
+      parties: Seq[Party],
+  )(implicit loggingContext: LoggingContext): Future[List[PartyDetails]]
 
   def listKnownParties()(implicit loggingContext: LoggingContext): Future[List[PartyDetails]]
 
-  def partyEntries(startExclusive: LedgerOffset.Absolute)(
-      implicit loggingContext: LoggingContext,
-  ): Source[PartyEntry, NotUsed]
+  def partyEntries(
+      startExclusive: Option[LedgerOffset.Absolute],
+  )(implicit loggingContext: LoggingContext): Source[PartyEntry, NotUsed]
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -103,15 +103,6 @@ private[sandbox] final class InMemoryLedger(
 
   override def currentHealth(): HealthStatus = Healthy
 
-  def ledgerEntries(
-      startExclusive: Option[Offset],
-      endInclusive: Option[Offset]): Source[(Offset, LedgerEntry), NotUsed] =
-    entries
-      .getSource(startExclusive, endInclusive)
-      .collect {
-        case (offset, InMemoryLedgerEntry(entry)) => offset -> entry
-      }
-
   override def flatTransactions(
       startExclusive: Option[Offset],
       endInclusive: Option[Offset],
@@ -568,11 +559,11 @@ private[sandbox] final class InMemoryLedger(
       ledgerConfiguration.map(config => end -> config)
     })
 
-  override def configurationEntries(startExclusive: Option[Offset])(
+  override def configurationEntries(startExclusive: Offset)(
       implicit loggingContext: LoggingContext,
   ): Source[(Offset, ConfigurationEntry), NotUsed] =
     entries
-      .getSource(startExclusive, None)
+      .getSource(Some(startExclusive), None)
       .collect {
         case (offset, InMemoryConfigEntry(entry)) => offset -> entry
       }


### PR DESCRIPTION
Preliminary work to make #6880 a little easier.

This changes the API of the indexing traits and `ReadOnlyLedger` a little to make methods that stream entries more consistent with each other. All three of configuration, package, and party entries now accept an `Option[LedgerOffset.Absolute]` in the indexing APIs, and a `LedgerOffset.Absolute` in the `ReadOnlyLedger` API.

It also changes a couple of error messages coming from the `ConfigurationManagementService`. Error messages in the case of `SubmissionResult.Overloaded` or `SubmissionResult.NotSupported` are now more generic.

### Changelog

- **[Ledger API]** The ConfigurationManagementService will now use the same description as other services in case of certain errors. The error status codes have not changed.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
