### PR TITLE
Reset the machine on every submit in IdeClient

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -294,10 +294,13 @@ main =
                         "testAssertFail = do",
                         "  p <- allocateParty \"p\"",
                         "  cid <- submit p (createCmd (T p))",
-                        "  submitMustFail p (exerciseCmd cid AssertFail)"
+                        "  submitMustFail p (exerciseCmd cid AssertFail)",
+                        -- Make sure that the script service still works afterwards.
+                        "  cid <- submit p (createCmd (T p))",
+                        "  pure ()"
                       ]
                   expectScriptSuccess rs (vr "testAssertFail") $ \r ->
-                    matchRegex r "Active contracts:  #0:0\n\nReturn value: {}\n\n$"
+                    matchRegex r "Active contracts:  #0:0, #1:0\n\nReturn value: {}\n\n$"
                   pure (),
               testCase "contract keys" $ do
                 rs <-

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -430,12 +430,6 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
                   result = Failure(ScenarioErrorCommitError(fas))
                 case Right(commitResult) =>
                   scenarioRunner.ledger = commitResult.newLedger
-                  // Clear the ledger
-                  machine.returnValue = null
-                  machine.clearCommit
-                  // Taken from SBSBeginCommit which is used for scenarios.
-                  machine.localContracts = Map.empty
-                  machine.globalDiscriminators = Set.empty
                   // Capture the result and exit.
                   result = Success(Right(results.toSeq))
               }
@@ -471,6 +465,11 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
             new RuntimeException("FATAL: Encountered scenario instruction getParty in DAML Script"))
       }
     }
+    // Reset the machine
+    machine.returnValue = null
+    machine.clearCommit
+    machine.localContracts = Map.empty
+    machine.globalDiscriminators = Set.empty
     Future.fromTry(result)
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -381,96 +381,101 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       implicit ec: ExecutionContext,
       mat: Materializer)
     : Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = {
-    machine.returnValue = null
-    val translated = translateCommands(commands)
-    machine.setExpressionToEvaluate(SEApp(translated, Array(SEValue.Token)))
-    machine.committers = Set(party.value)
-    var result: Try[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = null
-    while (result == null) {
-      machine.run() match {
-        case SResultNeedContract(coid, tid @ _, committers, cbMissing, cbPresent) =>
-          scenarioRunner.lookupContract(coid, committers, cbMissing, cbPresent).left.foreach {
-            err =>
-              result = Failure(err)
-          }
-        case SResultNeedKey(keyWithMaintainers, committers, cb) =>
-          scenarioRunner.lookupKey(keyWithMaintainers.globalKey, committers, cb).left.foreach {
-            err =>
-              result = Failure(err)
-          }
-        case SResultFinalValue(SUnit) =>
-          machine.ptx.finish(
-            machine.outputTransactionVersions,
-            machine.compiledPackages.packageLanguageVersion) match {
-            case Left(x) => result = Failure(new RuntimeException(s"Unexpected abort: $x"))
-            case Right(tx) =>
-              val results: ImmArray[ScriptLedgerClient.CommandResult] = tx.roots.map { n =>
-                tx.nodes(n) match {
-                  case create: NodeCreate.WithTxValue[ContractId] =>
-                    ScriptLedgerClient.CreateResult(create.coid)
-                  case exercise: NodeExercises.WithTxValue[_, ContractId] =>
-                    ScriptLedgerClient.ExerciseResult(
-                      exercise.templateId,
-                      exercise.choiceId,
-                      exercise.exerciseResult.get.value)
-                  case n =>
-                    // Root nodes can only be creates and exercises.
-                    throw new RuntimeException(s"Unexpected node: $n")
+    try {
+      machine.returnValue = null
+      val translated = translateCommands(commands)
+      machine.setExpressionToEvaluate(SEApp(translated, Array(SEValue.Token)))
+      machine.committers = Set(party.value)
+      var result: Try[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = null
+      while (result == null) {
+        machine.run() match {
+          case SResultNeedContract(coid, tid @ _, committers, cbMissing, cbPresent) =>
+            scenarioRunner.lookupContract(coid, committers, cbMissing, cbPresent).left.foreach {
+              err =>
+                result = Failure(err)
+            }
+          case SResultNeedKey(keyWithMaintainers, committers, cb) =>
+            scenarioRunner.lookupKey(keyWithMaintainers.globalKey, committers, cb).left.foreach {
+              err =>
+                result = Failure(err)
+            }
+          case SResultFinalValue(SUnit) =>
+            machine.ptx.finish(
+              machine.outputTransactionVersions,
+              machine.compiledPackages.packageLanguageVersion) match {
+              case Left(x) => result = Failure(new RuntimeException(s"Unexpected abort: $x"))
+              case Right(tx) =>
+                val results: ImmArray[ScriptLedgerClient.CommandResult] = tx.roots.map { n =>
+                  tx.nodes(n) match {
+                    case create: NodeCreate.WithTxValue[ContractId] =>
+                      ScriptLedgerClient.CreateResult(create.coid)
+                    case exercise: NodeExercises.WithTxValue[_, ContractId] =>
+                      ScriptLedgerClient.ExerciseResult(
+                        exercise.templateId,
+                        exercise.choiceId,
+                        exercise.exerciseResult.get.value)
+                    case n =>
+                      // Root nodes can only be creates and exercises.
+                      throw new RuntimeException(s"Unexpected node: $n")
+                  }
                 }
-              }
-              ScenarioLedger.commitTransaction(
-                committer = party.value,
-                effectiveAt = scenarioRunner.ledger.currentTime,
-                optLocation = machine.commitLocation,
-                tx = tx,
-                l = scenarioRunner.ledger
-              ) match {
-                case Left(fas) =>
-                  // Capture the error and exit.
-                  result = Failure(ScenarioErrorCommitError(fas))
-                case Right(commitResult) =>
-                  scenarioRunner.ledger = commitResult.newLedger
-                  // Capture the result and exit.
-                  result = Success(Right(results.toSeq))
-              }
-          }
-        case SResultFinalValue(v) =>
-          // The final result should always be unit.
-          result = Failure(new RuntimeException(s"FATAL: Unexpected non-unit final result: $v"))
-        case SResultScenarioCommit(_, _, _, _) =>
-          result = Failure(
-            new RuntimeException("FATAL: Encountered scenario commit in DAML Script"))
-        case SResultError(err) =>
-          // Capture the error and exit.
-          result = Failure(err)
-        case SResultNeedTime(callback) =>
-          callback(scenarioRunner.ledger.currentTime)
-        case SResultNeedPackage(pkg, callback @ _) =>
-          result = Failure(
-            new RuntimeException(
-              s"FATAL: Missing package $pkg should have been reported at Script compilation"))
-        case SResultScenarioInsertMustFail(committers @ _, optLocation @ _) =>
-          result = Failure(
-            new RuntimeException(
-              "FATAL: Encountered scenario instruction for submitMustFail in DAML script"))
-        case SResultScenarioMustFail(ptx @ _, committers @ _, callback @ _) =>
-          result = Failure(
-            new RuntimeException(
-              "FATAL: Encountered scenario instruction for submitMustFail in DAML Script"))
-        case SResultScenarioPassTime(relTime @ _, callback @ _) =>
-          result = Failure(
-            new RuntimeException("FATAL: Encountered scenario instruction setTime in DAML Script"))
-        case SResultScenarioGetParty(partyText @ _, callback @ _) =>
-          result = Failure(
-            new RuntimeException("FATAL: Encountered scenario instruction getParty in DAML Script"))
+                ScenarioLedger.commitTransaction(
+                  committer = party.value,
+                  effectiveAt = scenarioRunner.ledger.currentTime,
+                  optLocation = machine.commitLocation,
+                  tx = tx,
+                  l = scenarioRunner.ledger
+                ) match {
+                  case Left(fas) =>
+                    // Capture the error and exit.
+                    result = Failure(ScenarioErrorCommitError(fas))
+                  case Right(commitResult) =>
+                    scenarioRunner.ledger = commitResult.newLedger
+                    // Capture the result and exit.
+                    result = Success(Right(results.toSeq))
+                }
+            }
+          case SResultFinalValue(v) =>
+            // The final result should always be unit.
+            result = Failure(new RuntimeException(s"FATAL: Unexpected non-unit final result: $v"))
+          case SResultScenarioCommit(_, _, _, _) =>
+            result = Failure(
+              new RuntimeException("FATAL: Encountered scenario commit in DAML Script"))
+          case SResultError(err) =>
+            // Capture the error and exit.
+            result = Failure(err)
+          case SResultNeedTime(callback) =>
+            callback(scenarioRunner.ledger.currentTime)
+          case SResultNeedPackage(pkg, callback @ _) =>
+            result = Failure(
+              new RuntimeException(
+                s"FATAL: Missing package $pkg should have been reported at Script compilation"))
+          case SResultScenarioInsertMustFail(committers @ _, optLocation @ _) =>
+            result = Failure(
+              new RuntimeException(
+                "FATAL: Encountered scenario instruction for submitMustFail in DAML script"))
+          case SResultScenarioMustFail(ptx @ _, committers @ _, callback @ _) =>
+            result = Failure(
+              new RuntimeException(
+                "FATAL: Encountered scenario instruction for submitMustFail in DAML Script"))
+          case SResultScenarioPassTime(relTime @ _, callback @ _) =>
+            result = Failure(
+              new RuntimeException(
+                "FATAL: Encountered scenario instruction setTime in DAML Script"))
+          case SResultScenarioGetParty(partyText @ _, callback @ _) =>
+            result = Failure(
+              new RuntimeException(
+                "FATAL: Encountered scenario instruction getParty in DAML Script"))
+        }
       }
+      Future.fromTry(result)
+    } finally {
+      // Reset the machine
+      machine.returnValue = null
+      machine.clearCommit
+      machine.localContracts = Map.empty
+      machine.globalDiscriminators = Set.empty
     }
-    // Reset the machine
-    machine.returnValue = null
-    machine.clearCommit
-    machine.localContracts = Map.empty
-    machine.globalDiscriminators = Set.empty
-    Future.fromTry(result)
   }
 
   override def submitMustFail(party: SParty, commands: List[ScriptLedgerClient.Command])(


### PR DESCRIPTION
This ensures that the machine is not stuck in a broken state after a `submitMustFail` completed.
Otherwise, the script service fails with the following error if another submission follows after `submitMustFail`.
```
BErrorClient (ClientIOError (GRPCIOBadStatusCode StatusUnknown (StatusDetails {unStatusDetails = ""})))
```


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
