### PR TITLE
participant-integration-api: Never use a delay of zero.

### DIFF
--- a/libs-scala/timer-utils/BUILD.bazel
+++ b/libs-scala/timer-utils/BUILD.bazel
@@ -4,6 +4,7 @@
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
+    "da_scala_test_suite",
 )
 
 da_scala_library(
@@ -14,4 +15,12 @@ da_scala_library(
         "//visibility:public",
     ],
     deps = [],
+)
+
+da_scala_test_suite(
+    name = "timer-utils-test",
+    srcs = glob(["src/test/suite/scala/**/*.scala"]),
+    deps = [
+        ":timer-utils",
+    ],
 )

--- a/libs-scala/timer-utils/src/main/scala/com/digitalasset/timer/RetryStrategy.scala
+++ b/libs-scala/timer-utils/src/main/scala/com/digitalasset/timer/RetryStrategy.scala
@@ -40,7 +40,7 @@ object RetryStrategy {
     new RetryStrategy(attempts, waitTime, waitTime, identity, predicate)
 
   final class ZeroAttemptsException
-      extends RuntimeException("Cannot retry an operation with zero attempts.")
+      extends RuntimeException("Cannot retry an operation with zero or negative attempts.")
 
 }
 
@@ -55,7 +55,7 @@ final class RetryStrategy private (
   private def clip(t: Duration): Duration = t.min(waitTimeCap).max(0.millis)
 
   def apply[A](run: (Int, Duration) => Future[A])(implicit ec: ExecutionContext): Future[A] =
-    if (attempts.contains(0)) {
+    if (attempts.exists(_ <= 0)) {
       Future.failed(new ZeroAttemptsException)
     } else {
       def go(attempt: Int, wait: Duration): Future[A] = {

--- a/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/DelayedSpec.scala
+++ b/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/DelayedSpec.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timer
+
+import java.time
+
+import org.scalatest.{AsyncWordSpec, Matchers}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.{Duration, DurationInt}
+
+class DelayedSpec extends AsyncWordSpec with Matchers {
+
+  "Delayed.Future" should {
+    "delay by zero" in {
+      for {
+        result <- Delayed.Future.by(Duration.Zero)(Future {
+          7
+        })
+      } yield {
+        result should be(7)
+      }
+    }
+
+    "delay by a little while" in {
+      val start = time.Instant.now()
+      for {
+        result <- Delayed.Future.by(1.second)(Future {
+          10
+        })
+        end = time.Instant.now()
+      } yield {
+        result should be(10)
+        time.Duration.between(start, end).toMillis should (be >= 1000L and be <= 1500L)
+      }
+    }
+
+    "delay by zero if a negative duration is provided" in {
+      val start = time.Instant.now()
+      for {
+        result <- Delayed.Future.by(-1.second)(Future {
+          12
+        })
+        end = time.Instant.now()
+      } yield {
+        result should be(12)
+        time.Duration.between(start, end).toMillis should (be < 500L)
+      }
+    }
+
+    "rethrow a failed future" in {
+      for {
+        exception <- Delayed.Future
+          .by(10.milliseconds)(Future {
+            throw new IllegalStateException("Whoops.")
+          })
+          .failed
+      } yield {
+        exception should be(an[IllegalStateException])
+        exception.getMessage should be("Whoops.")
+      }
+    }
+
+    "throw an error if the duration is not finite" in {
+      for {
+        exception <- Delayed.Future
+          .by(Duration.Inf)(Future {
+            14
+          })
+          .failed
+      } yield {
+        exception should be(an[IllegalArgumentException])
+      }
+    }
+  }
+
+}

--- a/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
+++ b/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
@@ -31,13 +31,25 @@ class RetryStrategySpec extends AsyncWordSpec with Matchers with CustomMatchers 
     "fail if the number of attempts is exceeded" in {
       val retry = RetryStrategy.constant(attempts = 10, waitTime = 10.milliseconds)
       for {
-        (retryCount, result, duration) <- succeedAfter(tries = 12, retry)
+        (retryCount, result, duration) <- succeedAfter(tries = 11, retry)
       } yield {
         inside(result) {
           case Failure(_: FailureDuringRetry) =>
         }
-        retryCount should be(11)
+        retryCount should be(10)
         duration should beAround(100.milliseconds)
+      }
+    }
+
+    "fail immediately if zero attempts should be made" in {
+      val retry = RetryStrategy.constant(attempts = 0, waitTime = 10.milliseconds)
+      for {
+        (retryCount, result, _) <- succeedAfter(tries = 1, retry)
+      } yield {
+        inside(result) {
+          case Failure(_: RetryStrategy.ZeroAttemptsException) =>
+        }
+        retryCount should be(0)
       }
     }
   }
@@ -57,13 +69,13 @@ class RetryStrategySpec extends AsyncWordSpec with Matchers with CustomMatchers 
     "fail if the number of attempts is exceeded" in {
       val retry = RetryStrategy.exponentialBackoff(attempts = 5, firstWaitTime = 10.milliseconds)
       for {
-        (retryCount, result, duration) <- succeedAfter(tries = 7, retry)
+        (retryCount, result, duration) <- succeedAfter(tries = 6, retry)
       } yield {
         inside(result) {
           case Failure(_: FailureDuringRetry) =>
         }
-        retryCount should be(6)
-        duration should beAround(310.milliseconds)
+        retryCount should be(5)
+        duration should beAround(150.milliseconds)
       }
     }
   }

--- a/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
+++ b/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
@@ -64,6 +64,18 @@ class RetryStrategySpec extends AsyncWordSpec with Matchers with CustomMatchers 
         retryCount should be(0)
       }
     }
+
+    "fail immediately if a negative number of attempts should be made" in {
+      val retry = RetryStrategy.constant(attempts = -7, waitTime = 10.milliseconds)
+      for {
+        (retryCount, result, _) <- succeedAfter(tries = 1, retry)
+      } yield {
+        inside(result) {
+          case Failure(_: RetryStrategy.ZeroAttemptsException) =>
+        }
+        retryCount should be(0)
+      }
+    }
   }
 
   "RetryStrategy.exponentialBackoff" should {

--- a/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
+++ b/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
@@ -1,0 +1,110 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.timer
+
+import java.time
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.{AsyncWordSpec, Matchers}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+class RetryStrategySpec extends AsyncWordSpec with Matchers {
+
+  "RetryStrategy.constant" should {
+    "try a number of times, with a constant delay" in {
+      val retry = RetryStrategy.constant(attempts = 10, waitTime = 10.milliseconds)
+      val retryCount = new AtomicInteger()
+      val start = time.Instant.now()
+      for {
+        result <- retry { (_, _) =>
+          Future {
+            if (retryCount.incrementAndGet() >= 5) {
+              "Success!"
+            } else {
+              throw new IllegalStateException("Failure!")
+            }
+          }
+        }
+        end = time.Instant.now()
+      } yield {
+        result should be("Success!")
+        retryCount.get() should be(5)
+        time.Duration.between(start, end).toMillis should (be >= 50L and be <= 250L)
+      }
+    }
+
+    "fail if the number of attempts is exceeded" in {
+      val retry = RetryStrategy.constant(attempts = 10, waitTime = 10.milliseconds)
+      val retryCount = new AtomicInteger()
+      val start = time.Instant.now()
+      for {
+        result <- retry { (_, _) =>
+          Future {
+            if (retryCount.incrementAndGet() > 11) {
+              "Success!"
+            } else {
+              throw new IllegalStateException("Failure!")
+            }
+          }
+        }.failed
+        end = time.Instant.now()
+      } yield {
+        result should be(an[IllegalStateException])
+        result.getMessage should be("Failure!")
+        retryCount.get() should be(11)
+        time.Duration.between(start, end).toMillis should (be >= 100L and be <= 500L)
+      }
+    }
+  }
+
+  "RetryStrategy.exponentialBackoff" should {
+    "try a number of times, with an exponentially-increasing delay" in {
+      val retry = RetryStrategy.exponentialBackoff(attempts = 10, firstWaitTime = 10.milliseconds)
+      val retryCount = new AtomicInteger()
+      val start = time.Instant.now()
+      for {
+        result <- retry { (_, _) =>
+          Future {
+            if (retryCount.incrementAndGet() >= 5) {
+              "Success!"
+            } else {
+              throw new IllegalStateException("Failure!")
+            }
+          }
+        }
+        end = time.Instant.now()
+      } yield {
+        result should be("Success!")
+        retryCount.get() should be(5)
+        time.Duration.between(start, end).toMillis should (be >= 150L and be <= 250L)
+      }
+    }
+
+    "fail if the number of attempts is exceeded" in {
+      val retry = RetryStrategy.exponentialBackoff(attempts = 5, firstWaitTime = 10.milliseconds)
+      val retryCount = new AtomicInteger()
+      val start = time.Instant.now()
+      for {
+        result <- retry { (_, _) =>
+          Future {
+            if (retryCount.incrementAndGet() > 6) {
+              "Success!"
+            } else {
+              throw new IllegalStateException("Failure!")
+            }
+          }
+        }.failed
+        end = time.Instant.now()
+      } yield {
+        result should be(an[IllegalStateException])
+        result.getMessage should be("Failure!")
+        retryCount.get() should be(6)
+        time.Duration.between(start, end).toMillis should (be >= 310L and be <= 500L)
+      }
+    }
+  }
+
+}

--- a/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
+++ b/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
@@ -6,56 +6,37 @@ package com.daml.timer
 import java.time
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.scalatest.{AsyncWordSpec, Matchers}
+import com.daml.timer.RetryStrategySpec._
+import org.scalatest.{AsyncWordSpec, Inside, Matchers}
 
-import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
-class RetryStrategySpec extends AsyncWordSpec with Matchers {
+class RetryStrategySpec extends AsyncWordSpec with Matchers with Inside {
 
   "RetryStrategy.constant" should {
     "try a number of times, with a constant delay" in {
       val retry = RetryStrategy.constant(attempts = 10, waitTime = 10.milliseconds)
-      val retryCount = new AtomicInteger()
-      val start = time.Instant.now()
       for {
-        result <- retry { (_, _) =>
-          Future {
-            if (retryCount.incrementAndGet() >= 5) {
-              "Success!"
-            } else {
-              throw new IllegalStateException("Failure!")
-            }
-          }
-        }
-        end = time.Instant.now()
+        (retryCount, result, duration) <- succeedAfter(tries = 5, retry)
       } yield {
-        result should be("Success!")
-        retryCount.get() should be(5)
-        time.Duration.between(start, end).toMillis should (be >= 50L and be <= 250L)
+        result should be(Success("Success!"))
+        retryCount should be(5)
+        duration.toMillis should (be >= 50L and be <= 250L)
       }
     }
 
     "fail if the number of attempts is exceeded" in {
       val retry = RetryStrategy.constant(attempts = 10, waitTime = 10.milliseconds)
-      val retryCount = new AtomicInteger()
-      val start = time.Instant.now()
       for {
-        result <- retry { (_, _) =>
-          Future {
-            if (retryCount.incrementAndGet() > 11) {
-              "Success!"
-            } else {
-              throw new IllegalStateException("Failure!")
-            }
-          }
-        }.failed
-        end = time.Instant.now()
+        (retryCount, result, duration) <- succeedAfter(tries = 12, retry)
       } yield {
-        result should be(an[IllegalStateException])
-        result.getMessage should be("Failure!")
-        retryCount.get() should be(11)
-        time.Duration.between(start, end).toMillis should (be >= 100L and be <= 500L)
+        inside(result) {
+          case Failure(_: FailureDuringRetry) =>
+        }
+        retryCount should be(11)
+        duration.toMillis should (be >= 100L and be <= 500L)
       }
     }
   }
@@ -63,48 +44,51 @@ class RetryStrategySpec extends AsyncWordSpec with Matchers {
   "RetryStrategy.exponentialBackoff" should {
     "try a number of times, with an exponentially-increasing delay" in {
       val retry = RetryStrategy.exponentialBackoff(attempts = 10, firstWaitTime = 10.milliseconds)
-      val retryCount = new AtomicInteger()
-      val start = time.Instant.now()
       for {
-        result <- retry { (_, _) =>
-          Future {
-            if (retryCount.incrementAndGet() >= 5) {
-              "Success!"
-            } else {
-              throw new IllegalStateException("Failure!")
-            }
-          }
-        }
-        end = time.Instant.now()
+        (retryCount, result, duration) <- succeedAfter(tries = 5, retry)
       } yield {
-        result should be("Success!")
-        retryCount.get() should be(5)
-        time.Duration.between(start, end).toMillis should (be >= 150L and be <= 250L)
+        result should be(Success("Success!"))
+        retryCount should be(5)
+        duration.toMillis should (be >= 150L and be <= 250L)
       }
     }
 
     "fail if the number of attempts is exceeded" in {
       val retry = RetryStrategy.exponentialBackoff(attempts = 5, firstWaitTime = 10.milliseconds)
-      val retryCount = new AtomicInteger()
-      val start = time.Instant.now()
       for {
-        result <- retry { (_, _) =>
-          Future {
-            if (retryCount.incrementAndGet() > 6) {
-              "Success!"
-            } else {
-              throw new IllegalStateException("Failure!")
-            }
-          }
-        }.failed
-        end = time.Instant.now()
+        (retryCount, result, duration) <- succeedAfter(tries = 7, retry)
       } yield {
-        result should be(an[IllegalStateException])
-        result.getMessage should be("Failure!")
-        retryCount.get() should be(6)
-        time.Duration.between(start, end).toMillis should (be >= 310L and be <= 500L)
+        inside(result) {
+          case Failure(_: FailureDuringRetry) =>
+        }
+        retryCount should be(6)
+        duration.toMillis should (be >= 310L and be <= 500L)
       }
     }
   }
+
+}
+
+object RetryStrategySpec {
+
+  private def succeedAfter(
+      tries: Int,
+      retry: RetryStrategy,
+  )(implicit executionContext: ExecutionContext): Future[(Int, Try[String], time.Duration)] = {
+    val retryCount = new AtomicInteger()
+    val start = time.Instant.now()
+    retry { (_, _) =>
+      Future {
+        if (retryCount.incrementAndGet() >= tries) {
+          "Success!"
+        } else {
+          throw new FailureDuringRetry
+        }
+      }
+    }.transform(Success(_))
+      .map((retryCount.get(), _, time.Duration.between(start, time.Instant.now())))
+  }
+
+  private final class FailureDuringRetry extends RuntimeException
 
 }


### PR DESCRIPTION
If `akka.pattern.after` is passed a delay of zero, it will execute the body synchronously, potentially leading to a stack overflow error.

This error was observed in tests.

Fixes a bug in `RetryStrategy` too, where it would always make one more attempt than asked for.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
