### PR TITLE
Refactor IdeClient.submit - avoid Future.fromTry

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -18,7 +18,7 @@ import io.grpc.{Status, StatusRuntimeException}
 import java.time.Instant
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 import scalaz.{-\/, \/-}
 import scalaz.std.either._
 import scalaz.std.list._
@@ -380,25 +380,19 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
   override def submit(party: SParty, commands: List[ScriptLedgerClient.Command])(
       implicit ec: ExecutionContext,
       mat: Materializer)
-    : Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = {
+    : Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = Future {
     try {
       machine.returnValue = null
       val translated = translateCommands(commands)
       machine.setExpressionToEvaluate(SEApp(translated, Array(SEValue.Token)))
       machine.committers = Set(party.value)
-      var result: Try[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = null
+      var result: Seq[ScriptLedgerClient.CommandResult] = null
       while (result == null) {
         machine.run() match {
           case SResultNeedContract(coid, tid @ _, committers, cbMissing, cbPresent) =>
-            scenarioRunner.lookupContract(coid, committers, cbMissing, cbPresent).left.foreach {
-              err =>
-                result = Failure(err)
-            }
+            scenarioRunner.lookupContract(coid, committers, cbMissing, cbPresent).toTry.get
           case SResultNeedKey(keyWithMaintainers, committers, cb) =>
-            scenarioRunner.lookupKey(keyWithMaintainers.globalKey, committers, cb).left.foreach {
-              err =>
-                result = Failure(err)
-            }
+            scenarioRunner.lookupKey(keyWithMaintainers.globalKey, committers, cb).toTry.get
           case SResultFinalValue(SUnit) =>
             machine.ptx.finish(
               machine.outputTransactionVersions,
@@ -427,51 +421,45 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
                 ) match {
                   case Left(fas) =>
                     // Capture the error and exit.
-                    result = Failure(ScenarioErrorCommitError(fas))
+                    throw ScenarioErrorCommitError(fas)
                   case Right(commitResult) =>
                     scenarioRunner.ledger = commitResult.newLedger
                     // Capture the result and exit.
-                    result = Success(Right(results.toSeq))
+                    result = results.toSeq
                 }
               case Right(Left(x)) =>
-                result = Failure(new RuntimeException(s"Unexpected abort: $x"))
+                throw new RuntimeException(s"Unexpected abort: $x")
               case Left(msg) =>
-                result = Failure(new RuntimeException(msg))
+                throw new RuntimeException(msg)
             }
           case SResultFinalValue(v) =>
             // The final result should always be unit.
-            result = Failure(new RuntimeException(s"FATAL: Unexpected non-unit final result: $v"))
+            throw new RuntimeException(s"FATAL: Unexpected non-unit final result: $v")
           case SResultScenarioCommit(_, _, _, _) =>
-            result = Failure(
-              new RuntimeException("FATAL: Encountered scenario commit in DAML Script"))
+            throw new RuntimeException("FATAL: Encountered scenario commit in DAML Script")
           case SResultError(err) =>
             // Capture the error and exit.
-            result = Failure(err)
+            throw err
           case SResultNeedTime(callback) =>
             callback(scenarioRunner.ledger.currentTime)
           case SResultNeedPackage(pkg, callback @ _) =>
-            result = Failure(
-              new RuntimeException(
-                s"FATAL: Missing package $pkg should have been reported at Script compilation"))
+            throw new RuntimeException(
+              s"FATAL: Missing package $pkg should have been reported at Script compilation")
           case SResultScenarioInsertMustFail(committers @ _, optLocation @ _) =>
-            result = Failure(
-              new RuntimeException(
-                "FATAL: Encountered scenario instruction for submitMustFail in DAML script"))
+            throw new RuntimeException(
+              "FATAL: Encountered scenario instruction for submitMustFail in DAML script")
           case SResultScenarioMustFail(ptx @ _, committers @ _, callback @ _) =>
-            result = Failure(
-              new RuntimeException(
-                "FATAL: Encountered scenario instruction for submitMustFail in DAML Script"))
+            throw new RuntimeException(
+              "FATAL: Encountered scenario instruction for submitMustFail in DAML Script")
           case SResultScenarioPassTime(relTime @ _, callback @ _) =>
-            result = Failure(
-              new RuntimeException(
-                "FATAL: Encountered scenario instruction setTime in DAML Script"))
+            throw new RuntimeException(
+              "FATAL: Encountered scenario instruction setTime in DAML Script")
           case SResultScenarioGetParty(partyText @ _, callback @ _) =>
-            result = Failure(
-              new RuntimeException(
-                "FATAL: Encountered scenario instruction getParty in DAML Script"))
+            throw new RuntimeException(
+              "FATAL: Encountered scenario instruction getParty in DAML Script")
         }
       }
-      Future.fromTry(result)
+      Right(result)
     } finally {
       // Reset the machine
       machine.returnValue = null


### PR DESCRIPTION
The code was using `result: Try` combined with `Future.fromTry` to signal success or failure. However, the code also used a `try { } finally { }` block to ensure cleanup. Wrapping the whole block in a `Future { }` and simply throwing exceptions instead of setting `result = Failure( )` has the same effect, but avoids the nesting of `try { }` and `Future.fromTry`.

Addresses https://github.com/digital-asset/daml/pull/7172#discussion_r472324400

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
