### PR TITLE
sandbox: Use a different H2 database for every test.

### DIFF
--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/SandboxBackend.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/SandboxBackend.scala
@@ -6,33 +6,39 @@ import java.util.UUID
 
 import com.daml.platform.sandbox.services.DbInfo
 import com.daml.platform.store.DbType
-import com.daml.resources.{Resource, ResourceOwner}
+import com.daml.resources.ResourceOwner
 import com.daml.testing.postgresql.PostgresResource
-
-import scala.concurrent.ExecutionContext
 
 object SandboxBackend {
 
   trait Postgresql {
     this: AbstractSandboxFixture =>
+
     override protected final def database: Option[ResourceOwner[DbInfo]] =
-      Some(PostgresResource.owner().map(database => DbInfo(database.url, DbType.Postgres)))
+      Some(Postgresql.owner)
+  }
+
+  object Postgresql {
+
+    def owner: ResourceOwner[DbInfo] =
+      PostgresResource.owner().map(database => DbInfo(database.url, DbType.Postgres))
+
   }
 
   trait H2Database {
     this: AbstractSandboxFixture =>
+
     override protected final def database: Option[ResourceOwner[DbInfo]] =
-      Some(H2Database.Owner)
+      Some(H2Database.owner)
   }
 
   object H2Database {
 
-    object Owner extends ResourceOwner[DbInfo] {
-      override def acquire()(implicit executionContext: ExecutionContext): Resource[DbInfo] = {
+    def owner: ResourceOwner[DbInfo] =
+      ResourceOwner.forValue { () =>
         val jdbcUrl = s"jdbc:h2:mem:${UUID.randomUUID().toString};db_close_delay=-1"
-        Resource.successful(DbInfo(jdbcUrl, DbType.H2Database))
+        DbInfo(jdbcUrl, DbType.H2Database)
       }
-    }
 
   }
 

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/SandboxBackend.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/SandboxBackend.scala
@@ -6,23 +6,34 @@ import java.util.UUID
 
 import com.daml.platform.sandbox.services.DbInfo
 import com.daml.platform.store.DbType
-import com.daml.resources.ResourceOwner
+import com.daml.resources.{Resource, ResourceOwner}
 import com.daml.testing.postgresql.PostgresResource
 
-import scala.util.Success
+import scala.concurrent.ExecutionContext
 
 object SandboxBackend {
 
-  trait Postgresql { this: AbstractSandboxFixture =>
+  trait Postgresql {
+    this: AbstractSandboxFixture =>
     override protected final def database: Option[ResourceOwner[DbInfo]] =
       Some(PostgresResource.owner().map(database => DbInfo(database.url, DbType.Postgres)))
   }
 
-  trait H2Database { this: AbstractSandboxFixture =>
-    private def randomDatabaseName = UUID.randomUUID().toString
-    private[this] def jdbcUrl = s"jdbc:h2:mem:$randomDatabaseName;db_close_delay=-1"
+  trait H2Database {
+    this: AbstractSandboxFixture =>
     override protected final def database: Option[ResourceOwner[DbInfo]] =
-      Some(ResourceOwner.forTry(() => Success(DbInfo(jdbcUrl, DbType.H2Database))))
+      Some(H2Database.Owner)
+  }
+
+  object H2Database {
+
+    object Owner extends ResourceOwner[DbInfo] {
+      override def acquire()(implicit executionContext: ExecutionContext): Resource[DbInfo] = {
+        val jdbcUrl = s"jdbc:h2:mem:${UUID.randomUUID().toString};db_close_delay=-1"
+        Resource.successful(DbInfo(jdbcUrl, DbType.H2Database))
+      }
+    }
+
   }
 
 }

--- a/ledger/sandbox/src/test/lib/scala/platform/sandboxnext/SandboxNextFixture.scala
+++ b/ledger/sandbox/src/test/lib/scala/platform/sandboxnext/SandboxNextFixture.scala
@@ -29,7 +29,7 @@ trait SandboxNextFixture extends AbstractSandboxFixture with SuiteResource[(Port
         // share an index. As you can imagine, this causes all manner of issues, the most important
         // of which is that the ledger and index databases will be out of sync.
         jdbcUrl <- database
-          .getOrElse(SandboxBackend.H2Database.Owner)
+          .getOrElse(SandboxBackend.H2Database.owner)
           .map(info => Some(info.jdbcUrl))
         port <- new Runner(config.copy(jdbcUrl = jdbcUrl))
         channel <- GrpcClientResource.owner(port)

--- a/ledger/sandbox/src/test/lib/scala/platform/sandboxnext/SandboxNextFixture.scala
+++ b/ledger/sandbox/src/test/lib/scala/platform/sandboxnext/SandboxNextFixture.scala
@@ -5,9 +5,8 @@ package com.daml.platform.sandboxnext
 
 import com.daml.ledger.api.testing.utils.{OwnedResource, Resource, SuiteResource}
 import com.daml.platform.apiserver.services.GrpcClientResource
-import com.daml.platform.sandbox.AbstractSandboxFixture
+import com.daml.platform.sandbox.{AbstractSandboxFixture, SandboxBackend}
 import com.daml.ports.Port
-import com.daml.resources.ResourceOwner
 import io.grpc.Channel
 import org.scalatest.Suite
 
@@ -25,9 +24,13 @@ trait SandboxNextFixture extends AbstractSandboxFixture with SuiteResource[(Port
     implicit val ec: ExecutionContext = system.dispatcher
     new OwnedResource[(Port, Channel)](
       for {
+        // We must provide a random database if none is provided.
+        // The default is to always use the same index database URL, which means that tests can
+        // share an index. As you can imagine, this causes all manner of issues, the most important
+        // of which is that the ledger and index databases will be out of sync.
         jdbcUrl <- database
-          .fold[ResourceOwner[Option[String]]](ResourceOwner.successful(None))(_.map(info =>
-            Some(info.jdbcUrl)))
+          .getOrElse(SandboxBackend.H2Database.Owner)
+          .map(info => Some(info.jdbcUrl))
         port <- new Runner(config.copy(jdbcUrl = jdbcUrl))
         channel <- GrpcClientResource.owner(port)
       } yield (port, channel),


### PR DESCRIPTION
Previously tests would share an index database, but not a ledger database, if not explicitly overridden. This is _very bad_.

Fortunately all tests did specify a backend explicitly, but it shouldn't be necessary.

I caught this while writing a new test using `SandboxNextFixture`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
