### PR TITLE
fix typo in date docstring

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Date.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Date.daml
@@ -64,7 +64,7 @@ dayOfWeek d = toEnum ((3 + dateToDaysSinceEpoch d) % 7)
 fromGregorian : (Int, Month, Int) -> Date
 fromGregorian (year, month, day) = date year month day
 
--- | Turn `Date` value into a `(year, month, day)` triple, according 
+-- | Turn `Date` value into a `(year, month, day)` triple, according
 -- to the Gregorian calendar.
 toGregorian : Date -> (Int, Month, Int)
 toGregorian date =
@@ -80,7 +80,7 @@ toGregorian date =
    in (year, toEnum $ mth - 1, day)
 
 -- | Given the three values (year, month, day), constructs a `Date` value.
--- `date (y, m, d)` turns the year `y`, month `m`, and day `d` into a `Date` value.
+-- `date y m d` turns the year `y`, month `m`, and day `d` into a `Date` value.
 date : Int -> Month -> Int -> Date
 date year month day =
   let a = (14 - (fromMonth month)) / 12
@@ -123,7 +123,7 @@ datetime : Int -> Month -> Int -> Int -> Int -> Int -> Time
 datetime year month day h m s = time (date year month day) h m s
 
 -- | Extracts UTC date from UTC time.
--- 
+--
 -- This function will truncate Time to Date, but in many cases it will not return the date you really want.
 -- The reason for this is that usually the source of Time would be getTime, and getTime returns UTC, and most likely
 -- the date you want is something local to a location or an exchange. Consequently the date retrieved this way would be


### PR DESCRIPTION
As reported by Gyorgy Balazsi on [the forum].

[the forum]: https://discuss.daml.com/t/day-parameter-overflow-for-the-date-function-simple-leap-year-handling/1068/7?u=gary_verhaegen

CHANGELOG_BEGIN
CHANGELOG_END