### PR TITLE
Engine: submit fails nicely when transaction output cannot be serialized

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -379,9 +379,7 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
       machine.outputTransactionVersions,
       compiledPackages.packageLanguageVersion,
     ) match {
-      case Left(p) =>
-        ResultError(Error(s"Interpretation error: ended with partial result: $p"))
-      case Right(tx) =>
+      case Right(Right(tx)) =>
         val meta = Tx.Metadata(
           submissionSeed = None,
           submissionTime = machine.ptx.submissionTime,
@@ -398,6 +396,10 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
           machine.profile.writeSpeedscopeJson(profileFile)
         }
         ResultDone((tx, meta))
+      case Right(Left(p)) =>
+        ResultError(Error(s"Interpretation error: ended with partial result: $p"))
+      case Left(s) =>
+        ResultError(Error(s))
     }
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -153,7 +153,7 @@ private[lf] object TransactionVersions
     Either.cond(
       !(supportedTxVersions.max precedes transactionVersion),
       transactionVersion,
-      s"inferred version $transactionVersion is not supported"
+      s"inferred transaction version ${transactionVersion.protoValue} is not allowed"
     )
   }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -403,8 +403,7 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
             machine.ptx.finish(
               machine.outputTransactionVersions,
               machine.compiledPackages.packageLanguageVersion) match {
-              case Left(x) => result = Failure(new RuntimeException(s"Unexpected abort: $x"))
-              case Right(tx) =>
+              case Right(Right(tx)) =>
                 val results: ImmArray[ScriptLedgerClient.CommandResult] = tx.roots.map { n =>
                   tx.nodes(n) match {
                     case create: NodeCreate.WithTxValue[ContractId] =>
@@ -434,6 +433,10 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
                     // Capture the result and exit.
                     result = Success(Right(results.toSeq))
                 }
+              case Right(Left(x)) =>
+                result = Failure(new RuntimeException(s"Unexpected abort: $x"))
+              case Left(msg) =>
+                result = Failure(new RuntimeException(msg))
             }
           case SResultFinalValue(v) =>
             // The final result should always be unit.


### PR DESCRIPTION
Before this change the engine was throwing an exception when the output transaction  could not be serialized.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
