### PR TITLE
Fix failed contract lookups in scenario runner

### DIFF
--- a/compiler/damlc/tests/daml-test-files/FailedFetch.daml
+++ b/compiler/damlc/tests/daml-test-files/FailedFetch.daml
@@ -1,0 +1,26 @@
+-- @ERROR range= 21:0-21:19; Attempt to fetch or exercise a contract not visible to the committer.
+module FailedFetch where
+
+template T
+  with
+    p: Party
+  where
+    signatory p
+
+template Helper
+  with
+    p: Party
+  where
+    signatory p
+    choice Fetch : T
+      with
+        id : ContractId T
+      controller p
+      do fetch @T id
+
+fetchNonStakeholder = scenario do
+  alice <- getParty "Alice"
+  bob <- getParty "Bob"
+  secret <- submit alice (create (T alice))
+  submit bob (createAndExercise (Helper bob) (Fetch secret))
+  return ()

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -66,7 +66,7 @@ final case class ScenarioRunner(
           crash(s"package $pkgId not found")
 
         case SResultNeedContract(coid, tid @ _, committers, cbMissing, cbPresent) =>
-          lookupContract(coid, committers, cbMissing, cbPresent)
+          lookupContractUnsafe(coid, committers, cbMissing, cbPresent)
 
         case SResultNeedTime(callback) =>
           callback(ledger.currentTime)


### PR DESCRIPTION
lookupContract catches the exception which results in us continuing
and eventually running into a null-pointer exception.

This is another reason why we should enable the NonUnitStatements wart
but I’ll leave that for a separate PR (last I tried the scenario
service resulted in a ton of false positives).

fixes #7185

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
