### PR TITLE
IDE distinguish scripts and scenarios

### DIFF
--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
@@ -41,7 +41,7 @@ handle ide (CodeLensParams (TextDocumentIdentifier uri) _) = Right <$> do
               Just (mod, mapping) ->
                   pure
                       [ virtualResourceToCodeLens (range, kind, name, vr)
-                      | (kind, (valRef, Just loc)) <- map ("Scenario",) (scenariosInModule mod) ++ map ("Script",) (scriptsInModule envEnableScripts mod)
+                      | (kind, (valRef, Just loc)) <- map (Scenario,) (scenariosInModule mod) ++ map (Script,) (scriptsInModule envEnableScripts mod)
                       , let name = LF.unExprValName (LF.qualObject valRef)
                       , let vr = VRScenario filePath name
                       , Just range <- [toCurrentRange mapping $ sourceLocToRange loc]
@@ -50,18 +50,21 @@ handle ide (CodeLensParams (TextDocumentIdentifier uri) _) = Right <$> do
 
     pure $ List $ toList mbResult
 
+data Kind = Scenario | Script
+  deriving Show
+
 -- | Convert a compiler virtual resource into a code lens.
 virtualResourceToCodeLens
-    :: (Range, T.Text, T.Text, VirtualResource)
+    :: (Range, Kind, T.Text, VirtualResource)
     -> CodeLens
 virtualResourceToCodeLens (range, kind, title, vr) =
  CodeLens
     { _range = range
     , _command = Just $ Command
-        (kind <> " results")
+        (T.pack (show kind) <> " results")
         "daml.showResource"
         (Just $ List
-              [ Aeson.String $ kind <> ": " <> title
+              [ Aeson.String $ T.pack (show kind) <> ": " <> title
               , Aeson.String $ virtualResourceToUri vr])
     , _xdata = Nothing
     }

--- a/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
+++ b/compiler/damlc/daml-ide/src/DA/Daml/LanguageServer/CodeLens.hs
@@ -40,8 +40,8 @@ handle ide (CodeLensParams (TextDocumentIdentifier uri) _) = Right <$> do
               Nothing -> pure []
               Just (mod, mapping) ->
                   pure
-                      [ virtualResourceToCodeLens (range, prefix <> name, vr)
-                      | (prefix, (valRef, Just loc)) <- map ("Scenario: ",) (scenariosInModule mod) ++ map ("Script: ",) (scriptsInModule envEnableScripts mod)
+                      [ virtualResourceToCodeLens (range, kind, name, vr)
+                      | (kind, (valRef, Just loc)) <- map ("Scenario",) (scenariosInModule mod) ++ map ("Script",) (scriptsInModule envEnableScripts mod)
                       , let name = LF.unExprValName (LF.qualObject valRef)
                       , let vr = VRScenario filePath name
                       , Just range <- [toCurrentRange mapping $ sourceLocToRange loc]
@@ -52,16 +52,16 @@ handle ide (CodeLensParams (TextDocumentIdentifier uri) _) = Right <$> do
 
 -- | Convert a compiler virtual resource into a code lens.
 virtualResourceToCodeLens
-    :: (Range, T.Text, VirtualResource)
+    :: (Range, T.Text, T.Text, VirtualResource)
     -> CodeLens
-virtualResourceToCodeLens (range, title, vr) =
+virtualResourceToCodeLens (range, kind, title, vr) =
  CodeLens
     { _range = range
     , _command = Just $ Command
-        "Scenario results"
+        (kind <> " results")
         "daml.showResource"
         (Just $ List
-              [ Aeson.String title
+              [ Aeson.String $ kind <> ": " <> title
               , Aeson.String $ virtualResourceToUri vr])
     , _xdata = Nothing
     }

--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -10,6 +10,7 @@ da_haskell_test(
     srcs = glob(["src/**/*.hs"]),
     data = [
         "//compiler/damlc",
+        "//daml-script/daml:daml-script.dar",
     ],
     # See https://github.com/digital-asset/daml/issues/4904.
     flaky = is_windows,

--- a/compiler/lsp-tests/src/DA/Daml/Lsp/Test/Util.hs
+++ b/compiler/lsp-tests/src/DA/Daml/Lsp/Test/Util.hs
@@ -10,6 +10,10 @@ module DA.Daml.Lsp.Test.Util
     , openDocs
     , openDoc'
     , replaceDoc
+    , waitForScriptDidChange
+    , scriptUri
+    , openScript
+    , expectScriptContent
     , waitForScenarioDidChange
     , scenarioUri
     , openScenario
@@ -65,6 +69,18 @@ openDoc' file languageId contents = do
     let item = TextDocumentItem uri (T.pack languageId) 0 contents
     sendNotification TextDocumentDidOpen (DidOpenTextDocumentParams item)
     pure $ TextDocumentIdentifier uri
+
+waitForScriptDidChange :: Session VirtualResourceChangedParams
+waitForScriptDidChange = waitForScenarioDidChange
+
+scriptUri :: FilePath -> String -> Session Uri
+scriptUri = scenarioUri
+
+openScript :: FilePath -> String -> Session TextDocumentIdentifier
+openScript = openScenario
+
+expectScriptContent :: T.Text -> Session ()
+expectScriptContent = expectScenarioContent
 
 waitForScenarioDidChange :: Session VirtualResourceChangedParams
 waitForScenarioDidChange = do

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -41,6 +41,8 @@ main = do
     setEnv "TASTY_NUM_THREADS" "1" True
     damlcPath <- locateRunfiles $
         mainWorkspace </> "compiler" </> "damlc" </> exe "damlc"
+    scriptDarPath <- locateRunfiles $
+        mainWorkspace </> "daml-script" </> "daml" </> "daml-script.dar"
     let run s = withTempDir $ \dir -> runSessionWithConfig conf (damlcPath <> " ide --scenarios=no") fullCaps' dir s
         runScenarios s
             -- We are currently seeing issues with GRPC FFI calls which make everything
@@ -53,6 +55,7 @@ main = do
         [ diagnosticTests run runScenarios
         , requestTests run runScenarios
         , scenarioTests runScenarios
+        , scriptTests damlcPath scriptDarPath
         , stressTests run runScenarios
         , executeCommandTests run runScenarios
         , regressionTests run runScenarios
@@ -470,6 +473,76 @@ scenarioTests run = testGroup "scenarios"
           closeDoc scenario
           closeDoc main'
     ]
+
+scriptTests :: FilePath -> FilePath -> TestTree
+scriptTests damlcPath scriptDarPath = testGroup "scripts"
+    [ testCase "opening codelens produces a notification" $ run $ do
+          main' <- openDoc' "Main.daml" damlId $ T.unlines
+              [ "{-# LANGUAGE ApplicativeDo #-}"
+              , "module Main where"
+              , "import Daml.Script"
+              , "main : Script ()"
+              , "main = assert (True == True)"
+              ]
+          lenses <- getCodeLenses main'
+          uri <- scriptUri "Main.daml" "main"
+          liftIO $ lenses @?=
+              [ CodeLens
+                    { _range = Range (Position 4 0) (Position 4 4)
+                    , _command = Just $ Command
+                          { _title = "Script results"
+                          , _command = "daml.showResource"
+                          , _arguments = Just $ List
+                              [ "Script: main"
+                              ,  toJSON uri
+                              ]
+                          }
+                    , _xdata = Nothing
+                    }
+              ]
+          mainScript <- openScript "Main.daml" "main"
+          _ <- waitForScriptDidChange
+          closeDoc mainScript
+    , testCase "script ok" $ run $ do
+          main' <- openDoc' "Main.daml" damlId $ T.unlines
+              [ "{-# LANGUAGE ApplicativeDo #-}"
+              , "module Main where"
+              , "import Daml.Script"
+              , "main : Script String"
+              , "main = pure \"ok\""
+              ]
+          script <- openScript "Main.daml" "main"
+          expectScriptContent "Return value: &quot;ok&quot"
+          closeDoc script
+          closeDoc main'
+    , testCase "spaces in path" $ run $ do
+          main' <- openDoc' "spaces in path/Main.daml" damlId $ T.unlines
+              [ "{-# LANGUAGE ApplicativeDo #-}"
+              , "module Main where"
+              , "import Daml.Script"
+              , "main : Script String"
+              , "main = pure \"ok\""
+              ]
+          script <- openScript "spaces in path/Main.daml" "main"
+          expectScriptContent "Return value: &quot;ok&quot"
+          closeDoc script
+          closeDoc main'
+    ]
+  where
+    run s = withTempDir $ \dir -> do
+        copyFile scriptDarPath (dir </> "daml-script.dar")
+        writeFileUTF8 (dir </> "daml.yaml") $ unlines
+            [ "sdk-version: " <> sdkVersion
+            , "name: script-test"
+            , "version: 0.0.1"
+            , "source: ."
+            , "dependencies:"
+            , "- daml-prim"
+            , "- daml-stdlib"
+            , "- daml-script.dar"
+            ]
+        withCurrentDirectory dir $
+            runSessionWithConfig conf (damlcPath <> " ide --daml-script=yes") fullCaps' dir s
 
 executeCommandTests :: (forall a. Session a -> IO a) -> (Session () -> IO ()) -> TestTree
 executeCommandTests run _ = testGroup "execute command"


### PR DESCRIPTION
The code lens above DAML script definitions now reads `Script results` instead of `Scenario results`.

This also adds DAML Script test cases to the lsp-tests.

The functionality for testing scenario and script code-lenses in the `Utils` module is identical. However, this adds dedicated definitions for scripts to clearly distinguish the scenario and script test-cases.


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
