### PR TITLE
LF: shortcup failure in TypeOrdering

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/TypeOrdering.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/TypeOrdering.scala
@@ -30,7 +30,7 @@ object TypeOrdering extends Ordering[Type] {
     }
 
     @inline
-    def compareNames(xs: Iterator[Ref.Name], ys: Iterator[Ref.Name]): Unit = {
+    def compareNamesLexicographically(xs: Iterator[Ref.Name], ys: Iterator[Ref.Name]): Unit = {
       while (diff == 0 && xs.hasNext && ys.hasNext) diff = xs.next() compare ys.next()
       if (diff == 0) diff = xs.hasNext compare ys.hasNext
     }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/TypeOrdering.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/TypeOrdering.scala
@@ -45,7 +45,7 @@ object TypeOrdering extends Ordering[Type] {
         case (Ast.TNat(n1), Ast.TNat(n2)) =>
           diff = n1 compareTo n2
         case (Ast.TStruct(xs), Ast.TStruct(ys)) =>
-          compareNames(xs.names, ys.names)
+          compareNamesLexicographically(xs.names, ys.names)
           push(xs.values, ys.values)
         case (Ast.TApp(x1, x2), Ast.TApp(y1, y2)) =>
           push(Iterator(x1, x2), Iterator(y1, y2))


### PR DESCRIPTION
In this PR, we shortcut failure, before comparison of structural record has always a linear complexity (even in case of failure of the first component).


### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
