### PR TITLE
Fix off-by-one error in logging

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
@@ -62,7 +62,7 @@ private[platform] final class HikariConnection(
       ) { (i, _) =>
         Future {
           logger.info(
-            s"Attempting to connect to Postgres (attempt ${i + 1}/${maxInitialConnectRetryAttempts})")
+            s"Attempting to connect to $jdbcUrl (attempt $i/$maxInitialConnectRetryAttempts)")
           new HikariDataSource(config)
         }
       }


### PR DESCRIPTION
Furthermore, does not mention PostgreSQL in the message, as
the HikariJdbcConnectionProvider is shared across all our
usages of RDBMSs (including H2 and Sqlite).

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
