### PR TITLE
kvutils: Simplify exporting by pushing the mutations outwards.

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -11,6 +11,7 @@ import com.daml.caching.Cache
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.health.{HealthStatus, Healthy}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.`export`.LedgerDataExporter
 import com.daml.ledger.participant.state.kvutils.api._
 import com.daml.ledger.participant.state.kvutils.{
   Bytes,
@@ -93,6 +94,7 @@ object InMemoryLedgerReaderWriter {
         metrics,
         timeProvider,
         stateValueCache,
+        LedgerDataExporter.retrieve(),
       )
 
       val readerWriter = new InMemoryLedgerReaderWriter(
@@ -195,13 +197,15 @@ object InMemoryLedgerReaderWriter {
       metrics: Metrics,
       timeProvider: TimeProvider,
       stateValueCache: Cache[DamlStateKey, DamlStateValue],
+      ledgerDataExporter: LedgerDataExporter,
   )(implicit materializer: Materializer): ValidateAndCommit = {
     val validator = BatchedSubmissionValidator[Index](
       BatchedSubmissionValidatorFactory.defaultParametersFor(
         batchingLedgerWriterConfig.enableBatching),
       keyValueCommitting,
       new ConflictDetection(metrics),
-      metrics
+      metrics,
+      ledgerDataExporter,
     )
     val committer = BatchedValidatingCommitter[Index](
       () => timeProvider.getCurrentTime,

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -11,8 +11,8 @@ import com.daml.caching.Cache
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.health.{HealthStatus, Healthy}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
-import com.daml.ledger.participant.state.kvutils.`export`.LedgerDataExporter
 import com.daml.ledger.participant.state.kvutils.api._
+import com.daml.ledger.participant.state.kvutils.export.LedgerDataExporter
 import com.daml.ledger.participant.state.kvutils.{
   Bytes,
   Fingerprint,

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -194,6 +194,7 @@ da_java_proto_library(
         # Test for checking the integrity of the ledger export produced above.
         integrity_test(
             name = "%s-integrity-test" % name,
+            size = "small",
             checker = checker,
             dump = ":%s" % name,
         ) if not is_windows else None,

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -167,35 +167,39 @@ da_java_proto_library(
     deps = [":daml_kvutils_proto"],
 )
 
-# Builds a ledger dump from running the test tool against a kvutils-based
-# in-memory ledger.
-client_server_build(
-    name = "reference-ledger-dump",
-    testonly = True,  # only test targets can depend on this.
-    client = "//ledger/ledger-api-test-tool",
-    client_args = [
-        "--concurrent-test-runs=4",
-        "--timeout-scale-factor=20",
-        "localhost:6865",
-    ],
-    data = [
-        "//ledger/test-common:dar-files",
-    ],
-    output_env = "KVUTILS_LEDGER_DUMP",
-    runner = "@//bazel_tools/client_server/runner_with_port_check:runner",
-    runner_args = ["6865"],
-    server = "//ledger/ledger-on-memory:app",
-    server_args = [
-        "--contract-id-seeding=testing-weak",
-        "--participant participant-id=ledger-dump,port=6865",
-    ],
-    server_files = [
-        "//ledger/test-common:dar-files",
-    ],
-) if not is_windows else None
-
-# Test for checking the integrity of the ledger dump produced above.
-integrity_test(
-    name = "reference-ledger-dump-integrity-test",
-    dump = ":reference-ledger-dump",
-) if not is_windows else None
+[
+    (
+        # Generates a ledger export by running the test tool against a kvutils-based ledger.
+        client_server_build(
+            name = name,
+            testonly = True,  # only test targets can depend on this.
+            client = "//ledger/ledger-api-test-tool",
+            client_args = [
+                "--concurrent-test-runs=4",
+                "--timeout-scale-factor=20",
+                "localhost:%d" % port,
+            ],
+            data = [
+                "//ledger/test-common:dar-files",
+            ],
+            output_env = environment_variable,
+            runner = "@//bazel_tools/client_server/runner_with_port_check:runner",
+            runner_args = [str(port)],
+            server = "//ledger/ledger-on-memory:app",
+            server_args = [
+                "--contract-id-seeding=testing-weak",
+                "--participant participant-id=%s,port=%d" % (name, port),
+            ],
+        ) if not is_windows else None,
+        # Test for checking the integrity of the ledger export produced above.
+        integrity_test(
+            name = "%s-integrity-test" % name,
+            checker = checker,
+            dump = ":%s" % name,
+        ) if not is_windows else None,
+    )
+    for (name, port, environment_variable, checker) in [
+        ("reference-ledger-dump", 65101, "KVUTILS_LEDGER_DUMP", "//ledger/participant-state/kvutils/tools:integrity-check"),
+        ("reference-ledger-export", 65102, "KVUTILS_LEDGER_EXPORT", "//ledger/participant-state/kvutils/tools:integrity-check-v2"),
+    ]
+]

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -48,6 +48,7 @@ da_scala_library(
         "//ledger/participant-state/protobuf:ledger_configuration_java_proto",
         "//libs-scala/contextualized-logging",
         "//libs-scala/direct-execution-context",
+        "//libs-scala/resources",
         "//libs-scala/timer-utils",
         "@maven//:com_github_ghik_silencer_lib_2_12_11",
         "@maven//:com_google_guava_guava",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Debug.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Debug.scala
@@ -3,7 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils
 
-import java.io.{DataOutputStream, FileOutputStream}
+import java.io.DataOutputStream
+import java.nio.file.{Files, Paths}
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import org.slf4j.LoggerFactory
@@ -18,13 +19,14 @@ object Debug {
   /** The ledger dump stream is a gzip-compressed stream of `LedgerDumpEntry` messages prefixed
     * by their size.
     */
-  private lazy val optLedgerDumpStream: Option[DataOutputStream] = {
-    Option(System.getenv("KVUTILS_LEDGER_DUMP"))
-      .map { filename =>
-        logger.info(s"Enabled writing ledger entries to $filename")
-        new DataOutputStream(new FileOutputStream(filename))
+  private lazy val optLedgerDumpStream: Option[DataOutputStream] =
+    sys.env
+      .get("KVUTILS_LEDGER_DUMP")
+      .map { filePath =>
+        val path = Paths.get(filePath)
+        logger.info(s"Enabled writing ledger entries to $path.")
+        new DataOutputStream(Files.newOutputStream(path))
       }
-  }
 
   /** Dump ledger entry to disk if dumping is enabled.
     * Ledger dumps are mostly used to test for backwards compatibility of new releases.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/Deserialization.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/Deserialization.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.export
+
+import java.io.DataInputStream
+import java.time.Instant
+
+import com.daml.ledger.participant.state
+import com.google.protobuf.ByteString
+
+object Deserialization {
+  def deserializeEntry(input: DataInputStream): (SubmissionInfo, WriteSet) = {
+    val submissionInfo = deserializeSubmissionInfo(input)
+    val writeSet = deserializeWriteSet(input)
+    (submissionInfo, writeSet)
+  }
+
+  private def deserializeSubmissionInfo(input: DataInputStream): SubmissionInfo = {
+    val correlationId = input.readUTF()
+    val submissionEnvelopeSize = input.readInt()
+    val submissionEnvelope = new Array[Byte](submissionEnvelopeSize)
+    input.readFully(submissionEnvelope)
+    val recordTimeEpochSeconds = input.readLong()
+    val recordTimeEpochNanos = input.readInt()
+    val participantId = input.readUTF()
+    SubmissionInfo(
+      state.v1.ParticipantId.assertFromString(participantId),
+      correlationId,
+      ByteString.copyFrom(submissionEnvelope),
+      Instant.ofEpochSecond(recordTimeEpochSeconds, recordTimeEpochNanos.toLong),
+    )
+  }
+
+  private def deserializeWriteSet(input: DataInputStream): WriteSet = {
+    val numKeyValuePairs = input.readInt()
+    (1 to numKeyValuePairs).map { _ =>
+      val keySize = input.readInt()
+      val keyBytes = new Array[Byte](keySize)
+      input.readFully(keyBytes)
+      val valueSize = input.readInt()
+      val valueBytes = new Array[Byte](valueSize)
+      input.readFully(valueBytes)
+      (ByteString.copyFrom(keyBytes), ByteString.copyFrom(valueBytes))
+    }
+  }
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExporter.scala
@@ -10,9 +10,6 @@ import java.util.concurrent.locks.StampedLock
 import com.daml.ledger.participant.state.kvutils.CorrelationId
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
-import com.google.protobuf.ByteString
-
-import scala.collection.mutable
 
 /**
   * Enables exporting ledger data to an output stream.
@@ -20,72 +17,34 @@ import scala.collection.mutable
   */
 class FileBasedLedgerDataExporter(output: DataOutputStream) extends LedgerDataExporter {
 
-  import FileBasedLedgerDataExporter._
-
   private val outputLock = new StampedLock
 
-  private var submissionCorrelationId: Option[CorrelationId] = None
-  private[export] val inProgressSubmissions =
-    mutable.Map.empty[CorrelationId, (SubmissionInfo, SubmissionAggregator)]
-
   override def addSubmission(
-      submissionEnvelope: ByteString,
-      correlationId: CorrelationId,
-      recordTimeInstant: Instant,
       participantId: ParticipantId,
+      correlationId: CorrelationId,
+      submissionEnvelope: Key,
+      recordTimeInstant: Instant,
   ): SubmissionAggregator =
     this.synchronized {
-      if (submissionCorrelationId.isDefined) {
-        throw new RuntimeException("Cannot add a submission without finishing the previous one.")
-      }
-      submissionCorrelationId = Some(correlationId)
-      val aggregator = new InMemorySubmissionAggregator
-      inProgressSubmissions.put(
-        correlationId,
-        SubmissionInfo(submissionEnvelope, correlationId, recordTimeInstant, participantId) -> aggregator,
-      )
-      aggregator
+      val submissionInfo =
+        SubmissionInfo(participantId, correlationId, submissionEnvelope, recordTimeInstant)
+      new InMemorySubmissionAggregator(submissionInfo, FileBasedLedgerDataWriter)
     }
 
-  override def finishedProcessing(correlationId: CorrelationId): Unit = {
-    this.synchronized {
-      if (!submissionCorrelationId.contains(correlationId)) {
-        throw new RuntimeException(
-          s"Attempted to finish processing, but couldn't. Expected: $submissionCorrelationId, actual: $correlationId.")
+  object FileBasedLedgerDataWriter extends LedgerDataWriter {
+    override def write(submissionInfo: SubmissionInfo, writeSet: Seq[(Key, Value)]): Unit = {
+      val stamp = outputLock.writeLock()
+      try {
+        Serialization.serializeEntry(submissionInfo, writeSet, output)
+        output.flush()
+      } finally {
+        outputLock.unlock(stamp)
       }
-      val (submissionInfo, aggregator) = inProgressSubmissions.getOrElse(
-        correlationId,
-        throw new RuntimeException(
-          s"Missing correlation ID during ledger data export (submissionInfo): $correlationId"),
-      )
-      writeSubmissionData(submissionInfo, aggregator.finish())
-      submissionCorrelationId = None
-      inProgressSubmissions.remove(correlationId)
-      ()
     }
   }
 
-  private def writeSubmissionData(
-      submissionInfo: SubmissionInfo,
-      writeSet: Seq[(Key, Value)],
-  ): Unit = {
-    val stamp = outputLock.writeLock()
-    try {
-      Serialization.serializeEntry(submissionInfo, writeSet, output)
-      output.flush()
-    } finally {
-      outputLock.unlock(stamp)
-    }
-  }
 }
 
 object FileBasedLedgerDataExporter {
-  case class SubmissionInfo(
-      submissionEnvelope: ByteString,
-      correlationId: CorrelationId,
-      recordTimeInstant: Instant,
-      participantId: ParticipantId,
-  )
-
   type WriteSet = Seq[(Key, Value)]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExporter.scala
@@ -13,7 +13,6 @@ import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.google.protobuf.ByteString
 
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 
 /**
   * Enables exporting ledger data to an output stream.
@@ -25,58 +24,27 @@ class FileBasedLedgerDataExporter(output: DataOutputStream) extends LedgerDataEx
 
   private val outputLock = new StampedLock
 
-  private[export] val correlationIdMapping = mutable.Map.empty[CorrelationId, CorrelationId]
-  private[export] val inProgressSubmissions = mutable.Map.empty[CorrelationId, SubmissionInfo]
-  private[export] val bufferedKeyValueDataPerCorrelationId =
-    mutable.Map.empty[CorrelationId, mutable.ListBuffer[(Key, Value)]]
-
   private var submissionCorrelationId: Option[CorrelationId] = None
+  private[export] val inProgressSubmissions =
+    mutable.Map.empty[CorrelationId, (SubmissionInfo, SubmissionAggregator)]
 
   override def addSubmission(
       submissionEnvelope: ByteString,
       correlationId: CorrelationId,
       recordTimeInstant: Instant,
       participantId: ParticipantId,
-  ): Unit =
+  ): SubmissionAggregator =
     this.synchronized {
       if (submissionCorrelationId.isDefined) {
         throw new RuntimeException("Cannot add a submission without finishing the previous one.")
       }
       submissionCorrelationId = Some(correlationId)
+      val aggregator = new InMemorySubmissionAggregator
       inProgressSubmissions.put(
         correlationId,
-        SubmissionInfo(submissionEnvelope, correlationId, recordTimeInstant, participantId))
-      ()
-    }
-
-  override def addParentChild(
-      parentCorrelationId: CorrelationId,
-      childCorrelationId: CorrelationId,
-  ): Unit =
-    this.synchronized {
-      if (submissionCorrelationId.isEmpty) {
-        throw new RuntimeException(
-          s"Cannot add a parent/child when the submission correlation ID is empty.")
-      }
-      if (!submissionCorrelationId.contains(parentCorrelationId)) {
-        throw new RuntimeException(
-          s"Invalid parent correlation ID: $parentCorrelationId; expected $submissionCorrelationId")
-      }
-      correlationIdMapping.put(childCorrelationId, parentCorrelationId)
-      ()
-    }
-
-  override def addToWriteSet(correlationId: CorrelationId, data: Iterable[(Key, Value)]): Unit =
-    this.synchronized {
-      val parentCorrelationId = correlationIdMapping.getOrElse(
-        correlationId,
-        throw new RuntimeException(
-          s"Missing correlation ID during ledger data export (addToWriteSet): $correlationId"))
-      val keyValuePairs = bufferedKeyValueDataPerCorrelationId
-        .getOrElseUpdate(parentCorrelationId, ListBuffer.empty)
-      keyValuePairs.appendAll(data)
-      bufferedKeyValueDataPerCorrelationId.put(parentCorrelationId, keyValuePairs)
-      ()
+        SubmissionInfo(submissionEnvelope, correlationId, recordTimeInstant, participantId) -> aggregator,
+      )
+      aggregator
     }
 
   override def finishedProcessing(correlationId: CorrelationId): Unit = {
@@ -85,31 +53,22 @@ class FileBasedLedgerDataExporter(output: DataOutputStream) extends LedgerDataEx
         throw new RuntimeException(
           s"Attempted to finish processing, but couldn't. Expected: $submissionCorrelationId, actual: $correlationId.")
       }
-      val submissionInfo = inProgressSubmissions.getOrElse(
+      val (submissionInfo, aggregator) = inProgressSubmissions.getOrElse(
         correlationId,
         throw new RuntimeException(
           s"Missing correlation ID during ledger data export (submissionInfo): $correlationId"),
       )
-      val bufferedData = bufferedKeyValueDataPerCorrelationId.getOrElse(
-        correlationId,
-        throw new RuntimeException(
-          s"Missing correlation ID during ledger data export (bufferedData): $correlationId"),
-      )
-      writeSubmissionData(submissionInfo, bufferedData)
+      writeSubmissionData(submissionInfo, aggregator.finish())
       submissionCorrelationId = None
       inProgressSubmissions.remove(correlationId)
-      bufferedKeyValueDataPerCorrelationId.remove(correlationId)
-      correlationIdMapping
-        .collect {
-          case (key, value) if value == correlationId => key
-        }
-        .foreach(correlationIdMapping.remove)
+      ()
     }
   }
 
   private def writeSubmissionData(
       submissionInfo: SubmissionInfo,
-      writeSet: ListBuffer[(Key, Value)]): Unit = {
+      writeSet: Seq[(Key, Value)],
+  ): Unit = {
     val stamp = outputLock.writeLock()
     try {
       Serialization.serializeEntry(submissionInfo, writeSet, output)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExporter.scala
@@ -28,11 +28,12 @@ class FileBasedLedgerDataExporter(output: DataOutputStream) extends LedgerDataEx
   private[export] val bufferedKeyValueDataPerCorrelationId =
     mutable.Map.empty[String, mutable.ListBuffer[(Key, Value)]]
 
-  def addSubmission(
+  override def addSubmission(
       submissionEnvelope: ByteString,
       correlationId: String,
       recordTimeInstant: Instant,
-      participantId: ParticipantId): Unit =
+      participantId: ParticipantId,
+  ): Unit =
     this.synchronized {
       inProgressSubmissions.put(
         correlationId,
@@ -40,13 +41,13 @@ class FileBasedLedgerDataExporter(output: DataOutputStream) extends LedgerDataEx
       ()
     }
 
-  def addParentChild(parentCorrelationId: String, childCorrelationId: String): Unit =
+  override def addParentChild(parentCorrelationId: String, childCorrelationId: String): Unit =
     this.synchronized {
       correlationIdMapping.put(childCorrelationId, parentCorrelationId)
       ()
     }
 
-  def addToWriteSet(correlationId: String, data: Iterable[(Key, Value)]): Unit =
+  override def addToWriteSet(correlationId: String, data: Iterable[(Key, Value)]): Unit =
     this.synchronized {
       correlationIdMapping
         .get(correlationId)
@@ -58,7 +59,7 @@ class FileBasedLedgerDataExporter(output: DataOutputStream) extends LedgerDataEx
         }
     }
 
-  def finishedProcessing(correlationId: String): Unit = {
+  override def finishedProcessing(correlationId: String): Unit = {
     val (submissionInfo, bufferedData) = this.synchronized {
       (
         inProgressSubmissions.get(correlationId),

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExporter.scala
@@ -44,7 +44,3 @@ class FileBasedLedgerDataExporter(output: DataOutputStream) extends LedgerDataEx
   }
 
 }
-
-object FileBasedLedgerDataExporter {
-  type WriteSet = Seq[(Key, Value)]
-}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.export
+
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.{Data, WriteSet}
+
+import scala.collection.mutable
+
+final class InMemorySubmissionAggregator extends SubmissionAggregator {
+
+  import InMemorySubmissionAggregator._
+
+  private val buffer = mutable.ListBuffer.empty[Data]
+
+  override def addChild(): WriteSet = new InMemoryWriteSet(buffer)
+
+  override def finish(): Seq[Data] = buffer
+}
+
+object InMemorySubmissionAggregator {
+
+  final class InMemoryWriteSet(buffer: mutable.Buffer[Data]) extends WriteSet {
+    override def +=(data: Data): Unit = buffer.synchronized {
+      buffer += data
+      ()
+    }
+
+    override def ++=(data: Iterable[Data]): Unit = buffer.synchronized {
+      buffer ++= data
+      ()
+    }
+  }
+
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
@@ -7,7 +7,8 @@ import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.{Da
 
 import scala.collection.mutable
 
-final class InMemorySubmissionAggregator extends SubmissionAggregator {
+final class InMemorySubmissionAggregator(submissionInfo: SubmissionInfo, writer: LedgerDataWriter)
+    extends SubmissionAggregator {
 
   import InMemorySubmissionAggregator._
 
@@ -15,7 +16,7 @@ final class InMemorySubmissionAggregator extends SubmissionAggregator {
 
   override def addChild(): WriteSet = new InMemoryWriteSet(buffer)
 
-  override def finish(): Seq[Data] = buffer
+  override def finish(): Unit = writer.write(submissionInfo, buffer)
 }
 
 object InMemorySubmissionAggregator {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.{Data, WriteSet}
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.WriteSetBuilder
 
 import scala.collection.mutable
 
@@ -12,22 +12,22 @@ final class InMemorySubmissionAggregator(submissionInfo: SubmissionInfo, writer:
 
   import InMemorySubmissionAggregator._
 
-  private val buffer = mutable.ListBuffer.empty[Data]
+  private val buffer = mutable.ListBuffer.empty[WriteItem]
 
-  override def addChild(): WriteSet = new InMemoryWriteSet(buffer)
+  override def addChild(): WriteSetBuilder = new InMemoryWriteSetBuilder(buffer)
 
   override def finish(): Unit = writer.write(submissionInfo, buffer)
 }
 
 object InMemorySubmissionAggregator {
 
-  final class InMemoryWriteSet(buffer: mutable.Buffer[Data]) extends WriteSet {
-    override def +=(data: Data): Unit = buffer.synchronized {
+  final class InMemoryWriteSetBuilder(buffer: mutable.Buffer[WriteItem]) extends WriteSetBuilder {
+    override def +=(data: WriteItem): Unit = buffer.synchronized {
       buffer += data
       ()
     }
 
-    override def ++=(data: Iterable[Data]): Unit = buffer.synchronized {
+    override def ++=(data: Iterable[WriteItem]): Unit = buffer.synchronized {
       buffer ++= data
       ()
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
@@ -12,21 +12,12 @@ import com.google.protobuf.ByteString
 import org.slf4j.LoggerFactory
 
 trait LedgerDataExporter {
-
-  /**
-    * Adds given submission and its parameters to the list of in-progress submissions.
-    */
   def addSubmission(
-      submissionEnvelope: ByteString,
-      correlationId: CorrelationId,
-      recordTimeInstant: Instant,
       participantId: ParticipantId,
+      correlationId: CorrelationId,
+      submissionEnvelope: ByteString,
+      recordTimeInstant: Instant,
   ): SubmissionAggregator
-
-  /**
-    * Signals that entries for the given top-level (parent) correlation ID may be persisted.
-    */
-  def finishedProcessing(correlationId: CorrelationId): Unit
 }
 
 object LedgerDataExporter {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
@@ -20,7 +20,8 @@ trait LedgerDataExporter {
       submissionEnvelope: ByteString,
       correlationId: String,
       recordTimeInstant: Instant,
-      participantId: ParticipantId): Unit
+      participantId: ParticipantId,
+  ): Unit
 
   /**
     * Establishes parent-child relation between two correlation IDs.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.participant.state.kvutils.export
 import java.io.{DataOutputStream, FileOutputStream}
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.CorrelationId
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.google.protobuf.ByteString
@@ -18,7 +19,7 @@ trait LedgerDataExporter {
     */
   def addSubmission(
       submissionEnvelope: ByteString,
-      correlationId: String,
+      correlationId: CorrelationId,
       recordTimeInstant: Instant,
       participantId: ParticipantId,
   ): Unit
@@ -26,17 +27,17 @@ trait LedgerDataExporter {
   /**
     * Establishes parent-child relation between two correlation IDs.
     */
-  def addParentChild(parentCorrelationId: String, childCorrelationId: String): Unit
+  def addParentChild(parentCorrelationId: CorrelationId, childCorrelationId: CorrelationId): Unit
 
   /**
     * Adds given key-value pairs to the write-set belonging to the given correlation ID.
     */
-  def addToWriteSet(correlationId: String, data: Iterable[(Key, Value)]): Unit
+  def addToWriteSet(correlationId: CorrelationId, data: Iterable[(Key, Value)]): Unit
 
   /**
     * Signals that entries for the given top-level (parent) correlation ID may be persisted.
     */
-  def finishedProcessing(correlationId: String): Unit
+  def finishedProcessing(correlationId: CorrelationId): Unit
 }
 
 object LedgerDataExporter {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
@@ -8,7 +8,6 @@ import java.time.Instant
 
 import com.daml.ledger.participant.state.kvutils.CorrelationId
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.google.protobuf.ByteString
 import org.slf4j.LoggerFactory
 
@@ -22,17 +21,7 @@ trait LedgerDataExporter {
       correlationId: CorrelationId,
       recordTimeInstant: Instant,
       participantId: ParticipantId,
-  ): Unit
-
-  /**
-    * Establishes parent-child relation between two correlation IDs.
-    */
-  def addParentChild(parentCorrelationId: CorrelationId, childCorrelationId: CorrelationId): Unit
-
-  /**
-    * Adds given key-value pairs to the write-set belonging to the given correlation ID.
-    */
-  def addToWriteSet(correlationId: CorrelationId, data: Iterable[(Key, Value)]): Unit
+  ): SubmissionAggregator
 
   /**
     * Signals that entries for the given top-level (parent) correlation ID may be persisted.
@@ -55,7 +44,7 @@ object LedgerDataExporter {
 
   private lazy val instance = outputStreamMaybe
     .map(new FileBasedLedgerDataExporter(_))
-    .getOrElse(NoopLedgerDataExporter)
+    .getOrElse(NoOpLedgerDataExporter)
 
   def apply(): LedgerDataExporter = instance
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
@@ -25,17 +25,11 @@ object LedgerDataExporter {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private lazy val outputStreamMaybe: Option[DataOutputStream] = {
+  def retrieve(): LedgerDataExporter =
     Option(System.getenv(EnvironmentVariableName))
       .map { filename =>
-        logger.info(s"Enabled writing ledger entries to $filename")
-        new DataOutputStream(new FileOutputStream(filename))
+        logger.info(s"Enabled writing ledger entries to $filename.")
+        new FileBasedLedgerDataExporter(new DataOutputStream(new FileOutputStream(filename)))
       }
-  }
-
-  private lazy val instance = outputStreamMaybe
-    .map(new FileBasedLedgerDataExporter(_))
-    .getOrElse(NoOpLedgerDataExporter)
-
-  def apply(): LedgerDataExporter = instance
+      .getOrElse(NoOpLedgerDataExporter)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataWriter.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.`export`
+
+import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+
+trait LedgerDataWriter {
+  def write(submissionInfo: SubmissionInfo, writeSet: Seq[(Key, Value)]): Unit
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataWriter.scala
@@ -1,10 +1,8 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.participant.state.kvutils.`export`
-
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+package com.daml.ledger.participant.state.kvutils.export
 
 trait LedgerDataWriter {
-  def write(submissionInfo: SubmissionInfo, writeSet: Seq[(Key, Value)]): Unit
+  def write(submissionInfo: SubmissionInfo, writeSet: WriteSet): Unit
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoOpLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoOpLedgerDataExporter.scala
@@ -7,23 +7,15 @@ import java.time.Instant
 
 import com.daml.ledger.participant.state.kvutils.CorrelationId
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.google.protobuf.ByteString
 
-object NoopLedgerDataExporter extends LedgerDataExporter {
+object NoOpLedgerDataExporter extends LedgerDataExporter {
   override def addSubmission(
       submissionEnvelope: ByteString,
       correlationId: CorrelationId,
       recordTimeInstant: Instant,
       participantId: ParticipantId,
-  ): Unit = ()
-
-  override def addParentChild(
-      parentCorrelationId: CorrelationId,
-      childCorrelationId: CorrelationId,
-  ): Unit = ()
-
-  override def addToWriteSet(correlationId: CorrelationId, data: Iterable[(Key, Value)]): Unit = ()
+  ): SubmissionAggregator = NoOpSubmissionAggregator
 
   override def finishedProcessing(correlationId: CorrelationId): Unit = ()
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoOpSubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoOpSubmissionAggregator.scala
@@ -3,16 +3,17 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.{Data, WriteSet}
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.WriteSetBuilder
 
 object NoOpSubmissionAggregator extends SubmissionAggregator {
-  override def addChild(): WriteSet = NoOpWriteSet
+  override def addChild(): WriteSetBuilder = NoOpWriteSetBuilder
 
   override def finish(): Unit = ()
 
-  object NoOpWriteSet extends WriteSet {
-    override def +=(data: Data): Unit = ()
+  object NoOpWriteSetBuilder extends WriteSetBuilder {
+    override def +=(data: WriteItem): Unit = ()
 
-    override def ++=(data: Iterable[Data]): Unit = ()
+    override def ++=(data: Iterable[WriteItem]): Unit = ()
   }
+
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoOpSubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoOpSubmissionAggregator.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.export
+
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.{Data, WriteSet}
+
+object NoOpSubmissionAggregator extends SubmissionAggregator {
+  override def addChild(): WriteSet = NoOpWriteSet
+
+  override def finish(): Seq[Data] = Seq.empty
+
+  object NoOpWriteSet extends WriteSet {
+    override def +=(data: Data): Unit = ()
+
+    override def ++=(data: Iterable[Data]): Unit = ()
+  }
+
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoOpSubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoOpSubmissionAggregator.scala
@@ -8,12 +8,11 @@ import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.{Da
 object NoOpSubmissionAggregator extends SubmissionAggregator {
   override def addChild(): WriteSet = NoOpWriteSet
 
-  override def finish(): Seq[Data] = Seq.empty
+  override def finish(): Unit = ()
 
   object NoOpWriteSet extends WriteSet {
     override def +=(data: Data): Unit = ()
 
     override def ++=(data: Iterable[Data]): Unit = ()
   }
-
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoopLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoopLedgerDataExporter.scala
@@ -14,7 +14,8 @@ object NoopLedgerDataExporter extends LedgerDataExporter {
       submissionEnvelope: ByteString,
       correlationId: String,
       recordTimeInstant: Instant,
-      participantId: ParticipantId): Unit = ()
+      participantId: ParticipantId,
+  ): Unit = ()
 
   override def addParentChild(parentCorrelationId: String, childCorrelationId: String): Unit = ()
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoopLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/NoopLedgerDataExporter.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.participant.state.kvutils.export
 
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.CorrelationId
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.google.protobuf.ByteString
@@ -12,14 +13,17 @@ import com.google.protobuf.ByteString
 object NoopLedgerDataExporter extends LedgerDataExporter {
   override def addSubmission(
       submissionEnvelope: ByteString,
-      correlationId: String,
+      correlationId: CorrelationId,
       recordTimeInstant: Instant,
       participantId: ParticipantId,
   ): Unit = ()
 
-  override def addParentChild(parentCorrelationId: String, childCorrelationId: String): Unit = ()
+  override def addParentChild(
+      parentCorrelationId: CorrelationId,
+      childCorrelationId: CorrelationId,
+  ): Unit = ()
 
-  override def addToWriteSet(correlationId: String, data: Iterable[(Key, Value)]): Unit = ()
+  override def addToWriteSet(correlationId: CorrelationId, data: Iterable[(Key, Value)]): Unit = ()
 
-  override def finishedProcessing(correlationId: String): Unit = ()
+  override def finishedProcessing(correlationId: CorrelationId): Unit = ()
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/Serialization.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/Serialization.scala
@@ -7,17 +7,15 @@ import java.io.{DataInputStream, DataOutputStream}
 import java.time.Instant
 
 import com.daml.ledger.participant.state
-import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.{
-  SubmissionInfo,
-  WriteSet
-}
+import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.WriteSet
 import com.google.protobuf.ByteString
 
 object Serialization {
   def serializeEntry(
       submissionInfo: SubmissionInfo,
       writeSet: WriteSet,
-      out: DataOutputStream): Unit = {
+      out: DataOutputStream,
+  ): Unit = {
     serializeSubmissionInfo(submissionInfo, out)
     serializeWriteSet(writeSet, out)
   }
@@ -30,7 +28,8 @@ object Serialization {
 
   private def serializeSubmissionInfo(
       submissionInfo: SubmissionInfo,
-      out: DataOutputStream): Unit = {
+      out: DataOutputStream,
+  ): Unit = {
     out.writeUTF(submissionInfo.correlationId)
     out.writeInt(submissionInfo.submissionEnvelope.size())
     submissionInfo.submissionEnvelope.writeTo(out)
@@ -48,10 +47,10 @@ object Serialization {
     val recordTimeEpochNanos = input.readInt()
     val participantId = input.readUTF()
     SubmissionInfo(
-      ByteString.copyFrom(submissionEnvelope),
+      state.v1.ParticipantId.assertFromString(participantId),
       correlationId,
+      ByteString.copyFrom(submissionEnvelope),
       Instant.ofEpochSecond(recordTimeEpochSeconds, recordTimeEpochNanos.toLong),
-      state.v1.ParticipantId.assertFromString(participantId)
     )
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/Serialization.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/Serialization.scala
@@ -7,7 +7,6 @@ import java.io.{DataInputStream, DataOutputStream}
 import java.time.Instant
 
 import com.daml.ledger.participant.state
-import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.WriteSet
 import com.google.protobuf.ByteString
 
 object Serialization {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregator.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.export
+
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator._
+import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+
+trait SubmissionAggregator {
+  def addChild(): WriteSet
+
+  def finish(): Seq[Data]
+}
+
+object SubmissionAggregator {
+  type Data = (Key, Value)
+
+  trait WriteSet {
+    def +=(data: Data): Unit
+
+    def ++=(data: Iterable[Data]): Unit
+  }
+
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregator.scala
@@ -4,21 +4,19 @@
 package com.daml.ledger.participant.state.kvutils.export
 
 import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator._
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
 trait SubmissionAggregator {
-  def addChild(): WriteSet
+  def addChild(): WriteSetBuilder
 
   def finish(): Unit
 }
 
 object SubmissionAggregator {
-  type Data = (Key, Value)
 
-  trait WriteSet {
-    def +=(data: Data): Unit
+  trait WriteSetBuilder {
+    def +=(data: WriteItem): Unit
 
-    def ++=(data: Iterable[Data]): Unit
+    def ++=(data: Iterable[WriteItem]): Unit
   }
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregator.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 trait SubmissionAggregator {
   def addChild(): WriteSet
 
-  def finish(): Seq[Data]
+  def finish(): Unit
 }
 
 object SubmissionAggregator {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
@@ -9,11 +9,9 @@ import com.daml.ledger.participant.state.kvutils.CorrelationId
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.google.protobuf.ByteString
 
-object NoOpLedgerDataExporter extends LedgerDataExporter {
-  override def addSubmission(
-      participantId: ParticipantId,
-      correlationId: CorrelationId,
-      submissionEnvelope: ByteString,
-      recordTimeInstant: Instant,
-  ): SubmissionAggregator = NoOpSubmissionAggregator
-}
+case class SubmissionInfo(
+    participantId: ParticipantId,
+    correlationId: CorrelationId,
+    submissionEnvelope: ByteString,
+    recordTimeInstant: Instant,
+)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+
+package object export {
+
+  type WriteItem = (Key, Value)
+
+  type WriteSet = Seq[WriteItem]
+
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -32,6 +32,8 @@ package object kvutils {
   type Bytes = ByteString
   type DamlStateMap = Map[DamlStateKey, Option[DamlStateValue]]
 
+  type CorrelationId = String
+
   type Fingerprint = Bytes
   type DamlStateMapWithFingerprints = Map[DamlStateKey, (Option[DamlStateValue], Fingerprint)]
   val FingerprintPlaceholder: Fingerprint = ByteString.EMPTY

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CommitStrategy.scala
@@ -25,6 +25,6 @@ trait CommitStrategy[Result] {
       entry: DamlLogEntry,
       inputState: Map[DamlStateKey, Option[DamlStateValue]],
       outputState: Map[DamlStateKey, DamlStateValue],
-      exporterWriteSet: Option[SubmissionAggregator.WriteSet] = None,
+      exporterWriteSet: Option[SubmissionAggregator.WriteSetBuilder] = None,
   ): Future[Result]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CommitStrategy.scala
@@ -9,6 +9,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.ledger.participant.state.v1.ParticipantId
 
 import scala.concurrent.Future
@@ -23,5 +24,7 @@ trait CommitStrategy[Result] {
       entryId: DamlLogEntryId,
       entry: DamlLogEntry,
       inputState: Map[DamlStateKey, Option[DamlStateValue]],
-      outputState: Map[DamlStateKey, DamlStateValue]): Future[Result]
+      outputState: Map[DamlStateKey, DamlStateValue],
+      exporterWriteSet: Option[SubmissionAggregator.WriteSet] = None,
+  ): Future[Result]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
@@ -28,7 +28,7 @@ class LogAppendingCommitStrategy[Index](
       entry: DamlLogEntry,
       inputState: Map[DamlStateKey, Option[DamlStateValue]],
       outputState: Map[DamlStateKey, DamlStateValue],
-      exporterWriteSet: Option[SubmissionAggregator.WriteSet] = None,
+      exporterWriteSet: Option[SubmissionAggregator.WriteSetBuilder] = None,
   ): Future[Index] =
     for {
       serializedKeyValuePairs <- Future.successful(outputState.map {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateValue
 }
 import com.daml.ledger.participant.state.kvutils.Envelope
-import com.daml.ledger.participant.state.kvutils.export.LedgerDataExporter
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.ledger.participant.state.v1.ParticipantId
 
 import scala.collection.breakOut
@@ -19,8 +19,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class LogAppendingCommitStrategy[Index](
     ledgerStateOperations: LedgerStateOperations[Index],
     keySerializationStrategy: StateKeySerializationStrategy,
-    ledgerDataExporter: LedgerDataExporter = LedgerDataExporter())(
-    implicit executionContext: ExecutionContext)
+)(implicit executionContext: ExecutionContext)
     extends CommitStrategy[Index] {
   override def commit(
       participantId: ParticipantId,
@@ -28,21 +27,26 @@ class LogAppendingCommitStrategy[Index](
       entryId: DamlLogEntryId,
       entry: DamlLogEntry,
       inputState: Map[DamlStateKey, Option[DamlStateValue]],
-      outputState: Map[DamlStateKey, DamlStateValue]): Future[Index] =
+      outputState: Map[DamlStateKey, DamlStateValue],
+      exporterWriteSet: Option[SubmissionAggregator.WriteSet] = None,
+  ): Future[Index] =
     for {
       serializedKeyValuePairs <- Future.successful(outputState.map {
         case (key, value) =>
           (keySerializationStrategy.serializeStateKey(key), Envelope.enclose(value))
       }(breakOut))
-      _ = ledgerDataExporter.addToWriteSet(correlationId, serializedKeyValuePairs)
+      _ = exporterWriteSet.foreach {
+        _ ++= serializedKeyValuePairs
+      }
       _ <- if (serializedKeyValuePairs.nonEmpty) {
         ledgerStateOperations.writeState(serializedKeyValuePairs)
       } else {
         Future.unit
       }
       envelopedLogEntry <- Future.successful(Envelope.enclose(entry))
-      _ = ledgerDataExporter
-        .addToWriteSet(correlationId, List((entryId.toByteString, envelopedLogEntry)))
+      _ = exporterWriteSet.foreach {
+        _ += entryId.toByteString -> envelopedLogEntry
+      }
       index <- ledgerStateOperations
         .appendToLog(
           entryId.toByteString,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -11,7 +11,6 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
-import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.WriteSet
 import com.daml.ledger.participant.state.kvutils.export.{LedgerDataExporter, SubmissionAggregator}
 import com.daml.ledger.participant.state.kvutils.{CorrelationId, Envelope, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.ParticipantId
@@ -233,7 +232,7 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
       correlatedSubmission: CorrelatedSubmission,
       inputState: DamlInputState,
       logEntryAndState: LogEntryAndState,
-      exporterWriteSet: WriteSet,
+      exporterWriteSet: SubmissionAggregator.WriteSetBuilder,
   )
 
   private type Outputs2 = Indexed[ValidatedSubmission]
@@ -356,7 +355,7 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
       recordTime: Timestamp,
       correlatedSubmission: CorrelatedSubmission,
       inputState: DamlInputState,
-      exporterWriteSet: WriteSet,
+      exporterWriteSet: SubmissionAggregator.WriteSetBuilder,
   )(implicit executionContext: ExecutionContext): Future[ValidatedSubmission] =
     withSubmissionLoggingContext(correlatedSubmission) { _ =>
       Timed.timedAndTrackedFuture(
@@ -381,7 +380,7 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
       inputState: DamlInputState,
       logEntryAndState: LogEntryAndState,
       invalidatedKeys: mutable.Set[DamlStateKey],
-      exporterWriteSet: WriteSet,
+      exporterWriteSet: SubmissionAggregator.WriteSetBuilder,
   ): scala.collection.immutable.Iterable[ValidatedSubmission] = {
     val (logEntry, outputState) = logEntryAndState
     withSubmissionLoggingContext(correlatedSubmission) { implicit loggingContext =>
@@ -420,7 +419,7 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
       inputState: DamlInputState,
       logEntryAndState: LogEntryAndState,
       commitStrategy: CommitStrategy[CommitResult],
-      exporterWriteSet: WriteSet,
+      exporterWriteSet: SubmissionAggregator.WriteSetBuilder,
   )(implicit executionContext: ExecutionContext): Future[Unit] = {
     val (logEntry, outputState) = logEntryAndState
     withSubmissionLoggingContext(correlatedSubmission) { _ =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -12,7 +12,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
 import com.daml.ledger.participant.state.kvutils.export.LedgerDataExporter
-import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{CorrelationId, Envelope, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator
 import com.daml.ledger.validator.SubmissionValidator.LogEntryAndState
@@ -55,8 +55,6 @@ object BatchedSubmissionValidator {
       new KeyValueCommitting(engine, metrics),
       new ConflictDetection(metrics),
       metrics)
-
-  private type CorrelationId = String
 
   /** A [[DamlSubmission]] with an associated correlation id and a log entry id computed
     * from the envelope. */

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -19,7 +19,6 @@ import com.daml.ledger.validator.SubmissionValidator.LogEntryAndState
 import com.daml.ledger.validator._
 import com.daml.lf.data.Time
 import com.daml.lf.data.Time.Timestamp
-import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
@@ -42,20 +41,6 @@ object BatchedSubmissionValidator {
       params,
       committer,
       conflictDetection,
-      metrics,
-      ledgerDataExporter,
-    )
-
-  private[validator] def apply[CommitResult](
-      params: BatchedSubmissionValidatorParameters,
-      engine: Engine,
-      metrics: Metrics,
-      ledgerDataExporter: LedgerDataExporter,
-  ): BatchedSubmissionValidator[CommitResult] =
-    new BatchedSubmissionValidator[CommitResult](
-      params,
-      new KeyValueCommitting(engine, metrics),
-      new ConflictDetection(metrics),
       metrics,
       ledgerDataExporter,
     )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -36,25 +36,29 @@ object BatchedSubmissionValidator {
       committer: KeyValueCommitting,
       conflictDetection: ConflictDetection,
       metrics: Metrics,
-      ledgerDataExporter: LedgerDataExporter = LedgerDataExporter())
-    : BatchedSubmissionValidator[CommitResult] =
+      ledgerDataExporter: LedgerDataExporter,
+  ): BatchedSubmissionValidator[CommitResult] =
     new BatchedSubmissionValidator[CommitResult](
       params,
       committer,
       conflictDetection,
       metrics,
-      ledgerDataExporter
+      ledgerDataExporter,
     )
 
   private[validator] def apply[CommitResult](
       params: BatchedSubmissionValidatorParameters,
       engine: Engine,
-      metrics: Metrics): BatchedSubmissionValidator[CommitResult] =
+      metrics: Metrics,
+      ledgerDataExporter: LedgerDataExporter,
+  ): BatchedSubmissionValidator[CommitResult] =
     new BatchedSubmissionValidator[CommitResult](
       params,
       new KeyValueCommitting(engine, metrics),
       new ConflictDetection(metrics),
-      metrics)
+      metrics,
+      ledgerDataExporter,
+    )
 
   /** A [[DamlSubmission]] with an associated correlation id and a log entry id computed
     * from the envelope. */
@@ -102,7 +106,8 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
     committer: KeyValueCommitting,
     conflictDetection: ConflictDetection,
     damlMetrics: Metrics,
-    ledgerDataExporter: LedgerDataExporter = LedgerDataExporter()) {
+    ledgerDataExporter: LedgerDataExporter,
+) {
 
   import BatchedSubmissionValidator._
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -21,8 +21,6 @@ import com.daml.ledger.validator.{
   LogAppendingCommitStrategy,
   StateKeySerializationStrategy
 }
-import com.daml.lf.engine.Engine
-import com.daml.metrics.Metrics
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -87,28 +85,5 @@ object BatchedSubmissionValidatorFactory {
       )
     )
     (ledgerStateReader, commitStrategy)
-  }
-
-  case class CachingEnabledComponents[LogResult](
-      ledgerStateReader: DamlLedgerStateReader with QueryableReadSet,
-      commitStrategy: CommitStrategy[LogResult],
-      batchValidator: BatchedSubmissionValidator[LogResult])
-
-  def componentsEnabledForCaching[LogResult](
-      params: BatchedSubmissionValidatorParameters,
-      ledgerStateOperations: LedgerStateOperations[LogResult],
-      stateCache: Cache[DamlStateKey, DamlStateValue],
-      cacheUpdatePolicy: CacheUpdatePolicy,
-      metrics: Metrics,
-      engine: Engine
-  )(implicit executionContext: ExecutionContext): CachingEnabledComponents[LogResult] = {
-    val (ledgerStateReader, commitStrategy) =
-      cachingReaderAndCommitStrategyFrom(ledgerStateOperations, stateCache, cacheUpdatePolicy)
-    val batchValidator = BatchedSubmissionValidator[LogResult](
-      params,
-      engine,
-      metrics
-    )
-    CachingEnabledComponents(ledgerStateReader, commitStrategy, batchValidator)
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
@@ -24,7 +24,7 @@ class CachingCommitStrategy[Result](
       entry: DamlKvutils.DamlLogEntry,
       inputState: Map[DamlStateKey, Option[DamlStateValue]],
       outputState: Map[DamlStateKey, DamlStateValue],
-      exporterWriteSet: Option[SubmissionAggregator.WriteSet],
+      exporterWriteSet: Option[SubmissionAggregator.WriteSetBuilder],
   ): Future[Result] =
     for {
       _ <- Future {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingCommitStrategy.scala
@@ -6,6 +6,7 @@ package com.daml.ledger.validator.caching
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.CommitStrategy
 
@@ -22,7 +23,9 @@ class CachingCommitStrategy[Result](
       entryId: DamlKvutils.DamlLogEntryId,
       entry: DamlKvutils.DamlLogEntry,
       inputState: Map[DamlStateKey, Option[DamlStateValue]],
-      outputState: Map[DamlStateKey, DamlStateValue]): Future[Result] =
+      outputState: Map[DamlStateKey, DamlStateValue],
+      exporterWriteSet: Option[SubmissionAggregator.WriteSet],
+  ): Future[Result] =
     for {
       _ <- Future {
         outputState.view.filter { case (key, _) => shouldCache(key) }.foreach {
@@ -35,6 +38,8 @@ class CachingCommitStrategy[Result](
         entryId,
         entry,
         inputState,
-        outputState)
+        outputState,
+        exporterWriteSet,
+      )
     } yield result
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
@@ -3,13 +3,12 @@
 
 package com.daml.ledger
 
-import com.daml.ledger.participant.state.kvutils.Bytes
+import com.daml.ledger.participant.state.kvutils.{Bytes, CorrelationId}
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 
 import scala.concurrent.Future
 
 package object validator {
-  type CorrelationId = String
   type SubmissionEnvelope = Bytes
   type SubmittingParticipantId = ParticipantId
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExportSpec.scala
@@ -22,6 +22,12 @@ class FileBasedLedgerDataExportSpec extends WordSpec with Matchers with MockitoS
   "addParentChild" should {
     "add entry to correlation ID mapping" in {
       val instance = new FileBasedLedgerDataExporter(mock[DataOutputStream])
+      instance.addSubmission(
+        ByteString.copyFromUtf8("an envelope"),
+        "parent",
+        Instant.now(),
+        v1.ParticipantId.assertFromString("id"),
+      )
       instance.addParentChild("parent", "child")
 
       instance.correlationIdMapping should contain("child" -> "parent")
@@ -31,6 +37,12 @@ class FileBasedLedgerDataExportSpec extends WordSpec with Matchers with MockitoS
   "addToWriteSet" should {
     "append to existing data" in {
       val instance = new FileBasedLedgerDataExporter(mock[DataOutputStream])
+      instance.addSubmission(
+        ByteString.copyFromUtf8("an envelope"),
+        "parent",
+        Instant.now(),
+        v1.ParticipantId.assertFromString("id"),
+      )
       instance.addParentChild("parent", "child")
       instance.addToWriteSet("child", Seq(keyValuePairOf("a", "b")))
       instance.addToWriteSet("child", Seq(keyValuePairOf("c", "d")))
@@ -49,7 +61,8 @@ class FileBasedLedgerDataExportSpec extends WordSpec with Matchers with MockitoS
         ByteString.copyFromUtf8("an envelope"),
         "parent",
         Instant.now(),
-        v1.ParticipantId.assertFromString("id"))
+        v1.ParticipantId.assertFromString("id"),
+      )
       instance.addParentChild("parent", "parent")
       instance.addToWriteSet("parent", Seq(keyValuePairOf("a", "b")))
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/FileBasedLedgerDataExportSpec.scala
@@ -34,7 +34,7 @@ final class FileBasedLedgerDataExportSpec extends WordSpec with Matchers with Mo
       submission.finish()
 
       val dataInputStream = new DataInputStream(new ByteArrayInputStream(baos.toByteArray))
-      val (actualSubmissionInfo, actualWriteSet) = Serialization.readEntry(dataInputStream)
+      val (actualSubmissionInfo, actualWriteSet) = Deserialization.deserializeEntry(dataInputStream)
       actualSubmissionInfo.submissionEnvelope should be(ByteString.copyFromUtf8("an envelope"))
       actualSubmissionInfo.correlationId should be("parent")
       actualSubmissionInfo.recordTimeInstant should be(expectedRecordTimeInstant)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -3,14 +3,25 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
+import java.time.Instant
+
+import com.daml.ledger.participant.state.v1.ParticipantId
 import com.google.protobuf.ByteString
+import org.mockito.Mockito
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 
-class InMemorySubmissionAggregatorSpec extends WordSpec with Matchers with MockitoSugar {
+final class InMemorySubmissionAggregatorSpec extends WordSpec with Matchers with MockitoSugar {
   "InMemorySubmissionAggregatorSpec" should {
     "aggregate data" in {
-      val submission = new InMemorySubmissionAggregator()
+      val submissionInfo = SubmissionInfo(
+        ParticipantId.assertFromString("participant-id"),
+        "correlation ID",
+        ByteString.copyFromUtf8("the envelope"),
+        Instant.now(),
+      )
+      val writer = mock[LedgerDataWriter]
+      val submission = new InMemorySubmissionAggregator(submissionInfo, writer)
       val writeSetA = submission.addChild()
       writeSetA += keyValuePairOf("a", "b")
       writeSetA += keyValuePairOf("c", "d")
@@ -19,13 +30,15 @@ class InMemorySubmissionAggregatorSpec extends WordSpec with Matchers with Mocki
       writeSetB += keyValuePairOf("e", "f")
       writeSetB += keyValuePairOf("g", "h")
 
-      submission.finish() should be(
-        Seq(
-          keyValuePairOf("a", "b"),
-          keyValuePairOf("c", "d"),
-          keyValuePairOf("e", "f"),
-          keyValuePairOf("g", "h"),
-        ))
+      submission.finish()
+
+      val expected = Seq(
+        keyValuePairOf("a", "b"),
+        keyValuePairOf("c", "d"),
+        keyValuePairOf("e", "f"),
+        keyValuePairOf("g", "h"),
+      )
+      Mockito.verify(writer).write(submissionInfo, expected)
     }
   }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.export
+
+import com.google.protobuf.ByteString
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+
+class InMemorySubmissionAggregatorSpec extends WordSpec with Matchers with MockitoSugar {
+  "InMemorySubmissionAggregatorSpec" should {
+    "aggregate data" in {
+      val submission = new InMemorySubmissionAggregator()
+      val writeSetA = submission.addChild()
+      writeSetA += keyValuePairOf("a", "b")
+      writeSetA += keyValuePairOf("c", "d")
+
+      val writeSetB = submission.addChild()
+      writeSetB += keyValuePairOf("e", "f")
+      writeSetB += keyValuePairOf("g", "h")
+
+      submission.finish() should be(
+        Seq(
+          keyValuePairOf("a", "b"),
+          keyValuePairOf("c", "d"),
+          keyValuePairOf("e", "f"),
+          keyValuePairOf("g", "h"),
+        ))
+    }
+  }
+
+  private def keyValuePairOf(key: String, value: String): (ByteString, ByteString) =
+    ByteString.copyFromUtf8(key) -> ByteString.copyFromUtf8(value)
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 
 final class InMemorySubmissionAggregatorSpec extends WordSpec with Matchers with MockitoSugar {
-  "InMemorySubmissionAggregatorSpec" should {
+  "InMemorySubmissionAggregator" should {
     "aggregate data" in {
       val submissionInfo = SubmissionInfo(
         ParticipantId.assertFromString("participant-id"),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -10,8 +10,10 @@ import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch.CorrelatedSubmission
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.Envelope
-import com.daml.ledger.participant.state.kvutils.`export`.NoOpLedgerDataExporter
-import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
+import com.daml.ledger.participant.state.kvutils.export.{
+  NoOpLedgerDataExporter,
+  SubmissionAggregator
+}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.TestHelper.{aParticipantId, anInvalidEnvelope, makePartySubmission}
 import com.daml.ledger.validator.{CommitStrategy, DamlLedgerStateReader, ValidationFailed}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch.CorrelatedSubmission
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.Envelope
-import com.daml.ledger.participant.state.kvutils.`export`.SubmissionAggregator
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.TestHelper.{aParticipantId, anInvalidEnvelope, makePartySubmission}
 import com.daml.ledger.validator.{CommitStrategy, DamlLedgerStateReader, ValidationFailed}
@@ -21,8 +21,8 @@ import com.google.protobuf.ByteString
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, argThat}
 import org.mockito.Mockito._
-import org.scalatest.{Assertion, AsyncWordSpec, Inside, Matchers}
 import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Assertion, AsyncWordSpec, Inside, Matchers}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -126,7 +126,7 @@ class BatchedSubmissionValidatorSpec
           logEntryCaptor.capture(),
           any[Map[DamlStateKey, Option[DamlStateValue]]],
           outputStateCaptor.capture(),
-          any[Option[SubmissionAggregator.WriteSet]],
+          any[Option[SubmissionAggregator.WriteSetBuilder]],
         ))
         .thenReturn(Future.unit)
       val validator = BatchedSubmissionValidator[Unit](
@@ -183,7 +183,7 @@ class BatchedSubmissionValidatorSpec
           logEntryCaptor.capture(),
           any[Map[DamlStateKey, Option[DamlStateValue]]],
           any[Map[DamlStateKey, DamlStateValue]],
-          any[Option[SubmissionAggregator.WriteSet]],
+          any[Option[SubmissionAggregator.WriteSetBuilder]],
         ))
         .thenReturn(Future.unit)
       val validatorConfig =
@@ -207,7 +207,7 @@ class BatchedSubmissionValidatorSpec
             any[DamlLogEntry],
             any[DamlInputState],
             any[DamlOutputState],
-            any[Option[SubmissionAggregator.WriteSet]],
+            any[Option[SubmissionAggregator.WriteSetBuilder]],
           )
           // Verify that the log entries have been committed in the right order.
           val logEntries = logEntryCaptor.getAllValues.asScala.map(_.asInstanceOf[DamlLogEntry])
@@ -240,7 +240,7 @@ class BatchedSubmissionValidatorSpec
           any[DamlLogEntry],
           any[Map[DamlStateKey, Option[DamlStateValue]]],
           any[Map[DamlStateKey, DamlStateValue]],
-          any[Option[SubmissionAggregator.WriteSet]],
+          any[Option[SubmissionAggregator.WriteSetBuilder]],
         ))
         .thenReturn(Future.unit)
       val validator = BatchedSubmissionValidator[Unit](
@@ -266,7 +266,7 @@ class BatchedSubmissionValidatorSpec
             any[DamlLogEntry],
             any[DamlInputState],
             any[DamlOutputState],
-            any[Option[SubmissionAggregator.WriteSet]],
+            any[Option[SubmissionAggregator.WriteSetBuilder]],
           )
           succeed
         }
@@ -289,7 +289,7 @@ class BatchedSubmissionValidatorSpec
           any[DamlLogEntry],
           any[Map[DamlStateKey, Option[DamlStateValue]]],
           any[Map[DamlStateKey, DamlStateValue]],
-          any[Option[SubmissionAggregator.WriteSet]],
+          any[Option[SubmissionAggregator.WriteSetBuilder]],
         ))
         .thenReturn(Future.unit)
       val validator =
@@ -346,7 +346,7 @@ class BatchedSubmissionValidatorSpec
         logEntryCaptor.capture(),
         any[Map[DamlStateKey, Option[DamlStateValue]]],
         outputStateCaptor.capture(),
-        any[Option[SubmissionAggregator.WriteSet]],
+        any[Option[SubmissionAggregator.WriteSetBuilder]],
       ))
       .thenReturn(Future.unit)
     val validatorConfig =
@@ -373,7 +373,7 @@ class BatchedSubmissionValidatorSpec
           any[DamlLogEntry],
           any[DamlInputState],
           any[DamlOutputState],
-          any[Option[SubmissionAggregator.WriteSet]],
+          any[Option[SubmissionAggregator.WriteSetBuilder]],
         )
         // Verify we have all the expected log entries.
         val logEntries = logEntryCaptor.getAllValues.asScala.map(_.asInstanceOf[DamlLogEntry])

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -10,6 +10,7 @@ import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch.CorrelatedSubmission
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.`export`.SubmissionAggregator
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.TestHelper.{aParticipantId, anInvalidEnvelope, makePartySubmission}
 import com.daml.ledger.validator.{CommitStrategy, DamlLedgerStateReader, ValidationFailed}
@@ -124,7 +125,9 @@ class BatchedSubmissionValidatorSpec
           any[DamlLogEntryId],
           logEntryCaptor.capture(),
           any[Map[DamlStateKey, Option[DamlStateValue]]],
-          outputStateCaptor.capture()))
+          outputStateCaptor.capture(),
+          any[Option[SubmissionAggregator.WriteSet]],
+        ))
         .thenReturn(Future.unit)
       val validator = BatchedSubmissionValidator[Unit](
         BatchedSubmissionValidatorParameters.reasonableDefault,
@@ -179,7 +182,8 @@ class BatchedSubmissionValidatorSpec
           any[DamlLogEntryId],
           logEntryCaptor.capture(),
           any[Map[DamlStateKey, Option[DamlStateValue]]],
-          any[Map[DamlStateKey, DamlStateValue]]
+          any[Map[DamlStateKey, DamlStateValue]],
+          any[Option[SubmissionAggregator.WriteSet]],
         ))
         .thenReturn(Future.unit)
       val validatorConfig =
@@ -202,7 +206,9 @@ class BatchedSubmissionValidatorSpec
             any[DamlLogEntryId],
             any[DamlLogEntry],
             any[DamlInputState],
-            any[DamlOutputState])
+            any[DamlOutputState],
+            any[Option[SubmissionAggregator.WriteSet]],
+          )
           // Verify that the log entries have been committed in the right order.
           val logEntries = logEntryCaptor.getAllValues.asScala.map(_.asInstanceOf[DamlLogEntry])
           logEntries.map(_.getPartyAllocationEntry) should be(
@@ -233,7 +239,8 @@ class BatchedSubmissionValidatorSpec
           any[DamlLogEntryId],
           any[DamlLogEntry],
           any[Map[DamlStateKey, Option[DamlStateValue]]],
-          any[Map[DamlStateKey, DamlStateValue]]
+          any[Map[DamlStateKey, DamlStateValue]],
+          any[Option[SubmissionAggregator.WriteSet]],
         ))
         .thenReturn(Future.unit)
       val validator = BatchedSubmissionValidator[Unit](
@@ -258,7 +265,9 @@ class BatchedSubmissionValidatorSpec
             any[DamlLogEntryId],
             any[DamlLogEntry],
             any[DamlInputState],
-            any[DamlOutputState])
+            any[DamlOutputState],
+            any[Option[SubmissionAggregator.WriteSet]],
+          )
           succeed
         }
     }
@@ -279,7 +288,8 @@ class BatchedSubmissionValidatorSpec
           any[DamlLogEntryId],
           any[DamlLogEntry],
           any[Map[DamlStateKey, Option[DamlStateValue]]],
-          any[Map[DamlStateKey, DamlStateValue]]
+          any[Map[DamlStateKey, DamlStateValue]],
+          any[Option[SubmissionAggregator.WriteSet]],
         ))
         .thenReturn(Future.unit)
       val validator =
@@ -335,7 +345,9 @@ class BatchedSubmissionValidatorSpec
         any[DamlLogEntryId],
         logEntryCaptor.capture(),
         any[Map[DamlStateKey, Option[DamlStateValue]]],
-        outputStateCaptor.capture()))
+        outputStateCaptor.capture(),
+        any[Option[SubmissionAggregator.WriteSet]],
+      ))
       .thenReturn(Future.unit)
     val validatorConfig =
       BatchedSubmissionValidatorParameters.reasonableDefault.copy(
@@ -360,7 +372,9 @@ class BatchedSubmissionValidatorSpec
           any[DamlLogEntryId],
           any[DamlLogEntry],
           any[DamlInputState],
-          any[DamlOutputState])
+          any[DamlOutputState],
+          any[Option[SubmissionAggregator.WriteSet]],
+        )
         // Verify we have all the expected log entries.
         val logEntries = logEntryCaptor.getAllValues.asScala.map(_.asInstanceOf[DamlLogEntry])
         logEntries.map(_.getPartyAllocationEntry) should contain allElementsOf

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -10,6 +10,7 @@ import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch.CorrelatedSubmission
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.`export`.NoOpLedgerDataExporter
 import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.TestHelper.{aParticipantId, anInvalidEnvelope, makePartySubmission}
@@ -43,7 +44,9 @@ class BatchedSubmissionValidatorSpec
       val validator = BatchedSubmissionValidator[Unit](
         BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
-        metrics)
+        metrics,
+        NoOpLedgerDataExporter,
+      )
 
       validator
         .validateAndCommit(
@@ -64,7 +67,9 @@ class BatchedSubmissionValidatorSpec
       val validator = BatchedSubmissionValidator[Unit](
         BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
-        metrics)
+        metrics,
+        NoOpLedgerDataExporter,
+      )
       val notASubmission = Envelope.enclose(DamlStateValue.getDefaultInstance)
 
       validator
@@ -86,7 +91,9 @@ class BatchedSubmissionValidatorSpec
       val validator = BatchedSubmissionValidator[Unit](
         BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
-        metrics)
+        metrics,
+        NoOpLedgerDataExporter,
+      )
       val batchSubmission = DamlSubmissionBatch.newBuilder
         .addSubmissions(
           CorrelatedSubmission.newBuilder
@@ -132,7 +139,9 @@ class BatchedSubmissionValidatorSpec
       val validator = BatchedSubmissionValidator[Unit](
         BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
-        metrics)
+        metrics,
+        NoOpLedgerDataExporter,
+      )
 
       validator
         .validateAndCommit(
@@ -188,7 +197,8 @@ class BatchedSubmissionValidatorSpec
         .thenReturn(Future.unit)
       val validatorConfig =
         BatchedSubmissionValidatorParameters.reasonableDefault.copy(commitParallelism = 1)
-      val validator = BatchedSubmissionValidator[Unit](validatorConfig, engine, metrics)
+      val validator =
+        BatchedSubmissionValidator[Unit](validatorConfig, engine, metrics, NoOpLedgerDataExporter)
 
       validator
         .validateAndCommit(
@@ -246,7 +256,9 @@ class BatchedSubmissionValidatorSpec
       val validator = BatchedSubmissionValidator[Unit](
         BatchedSubmissionValidatorParameters.reasonableDefault,
         engine,
-        metrics)
+        metrics,
+        NoOpLedgerDataExporter,
+      )
 
       validator
         .validateAndCommit(
@@ -292,11 +304,12 @@ class BatchedSubmissionValidatorSpec
           any[Option[SubmissionAggregator.WriteSetBuilder]],
         ))
         .thenReturn(Future.unit)
-      val validator =
-        BatchedSubmissionValidator[Unit](
-          BatchedSubmissionValidatorParameters.reasonableDefault,
-          engine,
-          metrics)
+      val validator = BatchedSubmissionValidator[Unit](
+        BatchedSubmissionValidatorParameters.reasonableDefault,
+        engine,
+        metrics,
+        NoOpLedgerDataExporter,
+      )
 
       validator
         .validateAndCommit(
@@ -352,7 +365,8 @@ class BatchedSubmissionValidatorSpec
     val validatorConfig =
       BatchedSubmissionValidatorParameters.reasonableDefault.copy(
         commitParallelism = commitParallelism)
-    val validator = BatchedSubmissionValidator[Unit](validatorConfig, engine, metrics)
+    val validator =
+      BatchedSubmissionValidator[Unit](validatorConfig, engine, metrics, NoOpLedgerDataExporter)
 
     validator
       .validateAndCommit(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingCommitStrategySpec.scala
@@ -10,8 +10,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.`export`.SubmissionAggregator
 import com.daml.ledger.participant.state.kvutils.caching.`Message Weight`
+import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.CommitStrategy
 import com.daml.ledger.validator.TestHelper._
@@ -66,7 +66,7 @@ class CachingCommitStrategySpec extends AsyncWordSpec with Matchers with Mockito
         any[DamlLogEntry](),
         any[Map[DamlStateKey, Option[DamlStateValue]]](),
         any[Map[DamlStateKey, DamlStateValue]](),
-        any[Option[SubmissionAggregator.WriteSet]],
+        any[Option[SubmissionAggregator.WriteSetBuilder]],
       ))
       .thenReturn(Future.unit)
     new CachingCommitStrategy[Unit](cache, _ => shouldCache, mockCommitStrategy)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingCommitStrategySpec.scala
@@ -10,6 +10,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
+import com.daml.ledger.participant.state.kvutils.`export`.SubmissionAggregator
 import com.daml.ledger.participant.state.kvutils.caching.`Message Weight`
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.CommitStrategy
@@ -64,7 +65,8 @@ class CachingCommitStrategySpec extends AsyncWordSpec with Matchers with Mockito
         any[DamlLogEntryId](),
         any[DamlLogEntry](),
         any[Map[DamlStateKey, Option[DamlStateValue]]](),
-        any[Map[DamlStateKey, DamlStateValue]]()
+        any[Map[DamlStateKey, DamlStateValue]](),
+        any[Option[SubmissionAggregator.WriteSet]],
       ))
       .thenReturn(Future.unit)
     new CachingCommitStrategy[Unit](cache, _ => shouldCache, mockCommitStrategy)

--- a/ledger/participant-state/kvutils/tools/integrity_test.bzl
+++ b/ledger/participant-state/kvutils/tools/integrity_test.bzl
@@ -9,7 +9,7 @@ def _integrity_test_impl(ctx):
 set -eux
 {checker} $(rlocation "$TEST_WORKSPACE/{dump}")
 """.format(
-            checker = ctx.executable._checker.short_path,
+            checker = ctx.executable.checker.short_path,
             dump = ctx.file.dump.short_path,
         ),
         is_executable = True,
@@ -17,7 +17,7 @@ set -eux
     runfiles = ctx.runfiles(
         files = [wrapper, ctx.file.dump],
     )
-    runfiles = runfiles.merge(ctx.attr._checker[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge(ctx.attr.checker[DefaultInfo].default_runfiles)
     return DefaultInfo(
         executable = wrapper,
         files = depset([wrapper]),
@@ -29,11 +29,7 @@ integrity_test = rule(
     test = True,
     executable = True,
     attrs = {
-        "_checker": attr.label(
-            cfg = "host",
-            executable = True,
-            default = Label("@//ledger/participant-state/kvutils/tools:integrity-check"),
-        ),
+        "checker": attr.label(cfg = "host", executable = True),
         "dump": attr.label(allow_single_file = True),
     },
 )

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/CommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/CommitStrategySupport.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.export
 
-import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.WriteSet
+import com.daml.ledger.participant.state.kvutils.export.WriteSet
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.{
   CommitStrategy,

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
@@ -12,8 +12,8 @@ import com.codahale.metrics.{ConsoleReporter, MetricRegistry}
 import com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting
 import com.daml.ledger.participant.state.kvutils.export.{
+  Deserialization,
   NoOpLedgerDataExporter,
-  Serialization,
   SubmissionInfo,
   WriteSet
 }
@@ -166,7 +166,7 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
       .orElse(commitStrategySupport.explainMismatchingValue(key, expectedValue, actualValue))
 
   private def readSubmissionAndOutputs(input: DataInputStream): (SubmissionInfo, WriteSet) = {
-    val (submissionInfo, writeSet) = Serialization.readEntry(input)
+    val (submissionInfo, writeSet) = Deserialization.deserializeEntry(input)
     println(
       s"Read submission correlationId=${submissionInfo.correlationId} submissionEnvelopeSize=${submissionInfo.submissionEnvelope
         .size()} writeSetSize=${writeSet.size}")

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
@@ -11,11 +11,11 @@ import akka.stream.Materializer
 import com.codahale.metrics.{ConsoleReporter, MetricRegistry}
 import com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting
-import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.WriteSet
 import com.daml.ledger.participant.state.kvutils.export.{
   NoOpLedgerDataExporter,
   Serialization,
-  SubmissionInfo
+  SubmissionInfo,
+  WriteSet
 }
 import com.daml.ledger.participant.state.kvutils.tools._
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExpor
   SubmissionInfo,
   WriteSet
 }
-import com.daml.ledger.participant.state.kvutils.export.{NoopLedgerDataExporter, Serialization}
+import com.daml.ledger.participant.state.kvutils.export.{NoOpLedgerDataExporter, Serialization}
 import com.daml.ledger.participant.state.kvutils.tools._
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.batch.{
@@ -47,7 +47,7 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
       new KeyValueCommitting(engine, metrics),
       new ConflictDetection(metrics),
       metrics,
-      NoopLedgerDataExporter,
+      NoOpLedgerDataExporter,
     )
     val ComponentsForReplay(reader, commitStrategy, queryableWriteSet) =
       commitStrategySupport.createComponentsForReplay()

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/IntegrityChecker.scala
@@ -11,11 +11,12 @@ import akka.stream.Materializer
 import com.codahale.metrics.{ConsoleReporter, MetricRegistry}
 import com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting
-import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.{
-  SubmissionInfo,
-  WriteSet
+import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.WriteSet
+import com.daml.ledger.participant.state.kvutils.export.{
+  NoOpLedgerDataExporter,
+  Serialization,
+  SubmissionInfo
 }
-import com.daml.ledger.participant.state.kvutils.export.{NoOpLedgerDataExporter, Serialization}
 import com.daml.ledger.participant.state.kvutils.tools._
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.batch.{

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/LogAppendingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/LogAppendingCommitStrategySupport.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state.kvutils.tools.export
 
 import com.daml.ledger.on.memory.{InMemoryLedgerStateOperations, Index}
 import com.daml.ledger.participant.state.kvutils
-import com.daml.ledger.participant.state.kvutils.export.NoopLedgerDataExporter
 import com.daml.ledger.participant.state.kvutils.tools.export.IntegrityChecker.bytesAsHexString
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.StateKeySerializationStrategy
@@ -26,7 +25,7 @@ object LogAppendingCommitStrategySupport extends CommitStrategySupport[Index] {
       BatchedSubmissionValidatorFactory.readerAndCommitStrategyFrom(
         writeRecordingLedgerStateOperations,
         stateKeySerializationStrategy,
-        NoopLedgerDataExporter)
+      )
     ComponentsForReplay(reader, commitStrategy, writeRecordingLedgerStateOperations)
   }
 

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/WriteRecordingLedgerStateOperations.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/export/WriteRecordingLedgerStateOperations.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.export
 
-import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.WriteSet
+import com.daml.ledger.participant.state.kvutils.export.WriteSet
 import com.daml.ledger.validator.LedgerStateOperations
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
@@ -9,8 +9,7 @@ import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.participant.state.kvutils.Conversions._
-import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.SubmissionInfo
-import com.daml.ledger.participant.state.kvutils.export.Serialization
+import com.daml.ledger.participant.state.kvutils.export.{Serialization, SubmissionInfo}
 import com.daml.ledger.participant.state.kvutils.{Envelope, DamlKvutils => Proto}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.archive.{Decode, UniversalArchiveReader}
@@ -18,8 +17,9 @@ import com.daml.lf.crypto
 import com.daml.lf.data._
 import com.daml.lf.engine.Engine
 import com.daml.lf.language.{Ast, LanguageVersion, Util => AstUtil}
-import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers}
 import com.daml.lf.transaction.{
+  GlobalKey,
+  GlobalKeyWithMaintainers,
   Node,
   SubmittedTransaction,
   Transaction => Tx,

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
@@ -9,7 +9,7 @@ import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.participant.state.kvutils.Conversions._
-import com.daml.ledger.participant.state.kvutils.export.{Serialization, SubmissionInfo}
+import com.daml.ledger.participant.state.kvutils.export.{Deserialization, SubmissionInfo}
 import com.daml.ledger.participant.state.kvutils.{Envelope, DamlKvutils => Proto}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.archive.{Decode, UniversalArchiveReader}
@@ -164,7 +164,7 @@ object Replay {
 
     def go: Stream[SubmissionInfo] =
       if (ledgerExportStream.available() > 0)
-        Serialization.readEntry(ledgerExportStream)._1 #:: go
+        Deserialization.deserializeEntry(ledgerExportStream)._1 #:: go
       else {
         ledgerExportStream.close()
         Stream.empty

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheckerSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/tools/IntegrityCheckerSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.tools
 
-import com.daml.ledger.participant.state.kvutils.export.FileBasedLedgerDataExporter.WriteSet
+import com.daml.ledger.participant.state.kvutils.export.WriteSet
 import com.daml.ledger.participant.state.kvutils.tools.export.{
   CommitStrategySupport,
   IntegrityChecker


### PR DESCRIPTION
I found the `LedgerDataExporter` very difficult to understand until I traced through the various correlation IDs. In doing so, I discovered something surprising: because we process one batch at a time, a lot of the mutation and tracking of state that goes on is unnecessary.

I have replaced the mutation in `FileBasedLedgerDataExporter` with mostly-immutable types that are passed the relevant data through. This means that instead of tracking correlation IDs throughout the batch processing pipeline, we just hang onto an object, the `SubmissionAggregator`, and pass it wherever it's needed.

In general, I have favored the principle of "more, smaller things", so I have split classes and objects out where possible.

This also adds extra testing in the form of an integration test for the ledger export. This just checks it produces something that the integrity checker is not happy with; it does _not_ guarantee it produces the correct data when hit with a lot of simultaneous requests. That's something we'll add shortly.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
