### PR TITLE
kvutils: Fix flaky runs of BatchingQueueSpec.

### DIFF
--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueueSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueueSpec.scala
@@ -46,7 +46,9 @@ class BatchingQueueSpec
         res <- queue.offer(correlatedSubmission)
       } yield {
         res should be(SubmissionResult.Acknowledged)
-        queue.alive should be(false)
+        eventually {
+          queue.alive should be(false)
+        }
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueueSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueueSpec.scala
@@ -152,7 +152,7 @@ class BatchingQueueSpec
       val correlatedSubmission2 = createCorrelatedSubmission("2")
       val batches = mutable.ListBuffer.empty[Seq[CorrelatedSubmission]]
 
-      val maxWaitDuration = 50.millis
+      val maxWaitDuration = 500.millis
 
       // Queue that can fit a single submission plus tiny bit more
       val queue =


### PR DESCRIPTION
Testing async behavior is hard.

Saw this in CI twice and could reproduce it locally with `--runs_per_test=100`. It seems to be a lot more common now that the kvutils tests run in parallel.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
