### PR TITLE
kvutils: Make the RawToDamlLedgerStateReaderAdapter constructor visible.

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DamlLedgerStateReader.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DamlLedgerStateReader.scala
@@ -20,10 +20,10 @@ trait DamlLedgerStateReader {
   def readState(keys: Seq[DamlStateKey]): Future[Seq[Option[DamlStateValue]]]
 }
 
-private[validator] object DamlLedgerStateReader {
+object DamlLedgerStateReader {
   def from(
       ledgerStateReader: LedgerStateReader,
-      keySerializationStrategy: StateKeySerializationStrategy)(
-      implicit executionContext: ExecutionContext): DamlLedgerStateReader =
+      keySerializationStrategy: StateKeySerializationStrategy,
+  )(implicit executionContext: ExecutionContext): DamlLedgerStateReader =
     new RawToDamlLedgerStateReaderAdapter(ledgerStateReader, keySerializationStrategy)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
@@ -8,11 +8,12 @@ import com.daml.ledger.participant.state.kvutils.Envelope
 
 import scala.concurrent.{ExecutionContext, Future}
 
-private[validator] class RawToDamlLedgerStateReaderAdapter(
+final class RawToDamlLedgerStateReaderAdapter(
     ledgerStateReader: LedgerStateReader,
-    keySerializationStrategy: StateKeySerializationStrategy)(
-    implicit executionContext: ExecutionContext)
+    keySerializationStrategy: StateKeySerializationStrategy,
+)(implicit executionContext: ExecutionContext)
     extends DamlLedgerStateReader {
+
   import RawToDamlLedgerStateReaderAdapter.deserializeDamlStateValue
 
   override def readState(keys: Seq[DamlStateKey]): Future[Seq[Option[DamlStateValue]]] =
@@ -21,8 +22,8 @@ private[validator] class RawToDamlLedgerStateReaderAdapter(
       .map(_.map(_.map(deserializeDamlStateValue)))
 }
 
-private[validator] object RawToDamlLedgerStateReaderAdapter {
-  val deserializeDamlStateValue: LedgerStateOperations.Value => DamlStateValue =
+object RawToDamlLedgerStateReaderAdapter {
+  private[validator] val deserializeDamlStateValue: LedgerStateOperations.Value => DamlStateValue =
     Envelope
       .openStateValue(_)
       .getOrElse(sys.error("Opening enveloped DamlStateValue failed"))


### PR DESCRIPTION
Consumers of kvutils need to use this, and they shouldn't have to jump through hoops.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
