### PR TITLE
kvutils: Simpler constructors for common caching classes.

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -73,13 +73,11 @@ object BatchedSubmissionValidatorFactory {
       new LedgerStateReaderAdapter[LogResult](ledgerStateOperations),
       keySerializationStrategy,
     )
-    val commitStrategy = new CachingCommitStrategy(
+    val commitStrategy = CachingCommitStrategy(
       stateCache,
-      cacheUpdatePolicy.shouldCacheOnWrite,
-      new LogAppendingCommitStrategy[LogResult](
-        ledgerStateOperations,
-        keySerializationStrategy,
-      )
+      cacheUpdatePolicy,
+      ledgerStateOperations,
+      keySerializationStrategy,
     )
     (ledgerStateReader, commitStrategy)
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -67,14 +67,11 @@ object BatchedSubmissionValidatorFactory {
       keySerializationStrategy: StateKeySerializationStrategy = DefaultStateKeySerializationStrategy,
   )(implicit executionContext: ExecutionContext)
     : (DamlLedgerStateReader with QueryableReadSet, CommitStrategy[LogResult]) = {
-    val ledgerStateReader = new CachingDamlLedgerStateReader(
+    val ledgerStateReader = CachingDamlLedgerStateReader(
       stateCache,
-      cacheUpdatePolicy.shouldCacheOnRead,
+      cacheUpdatePolicy,
+      new LedgerStateReaderAdapter[LogResult](ledgerStateOperations),
       keySerializationStrategy,
-      DamlLedgerStateReader.from(
-        new LedgerStateReaderAdapter[LogResult](ledgerStateOperations),
-        keySerializationStrategy,
-      ),
     )
     val commitStrategy = new CachingCommitStrategy(
       stateCache,


### PR DESCRIPTION
I _think_ this follows the sentiment.

Also, _use_ those constructors.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
