### PR TITLE
Deprecating noop '--application-id' command-line option in JSON API

### DIFF
--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -134,7 +134,6 @@ trait JsonApiFixture
               val config = new HttpService.DefaultStartSettings {
                 override val ledgerHost = "localhost"
                 override val ledgerPort = server.port.value
-                override val applicationId = Runner.DEFAULT_APPLICATION_ID
                 override val address = "localhost"
                 override val httpPort = 0
                 override val portFile = None

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -75,7 +75,7 @@ With Query Store
 
 To improve the performance of the JSON API you can configure it to use a PostgreSQL backend as a cache. This is particularly beneficial if your ACS changes only very little (compared to the whole ACS size) between queries. Note that the PostgreSQL backend acts purely as a cache. It is save to reinitialize the database at any time.
 
-To enable the PostgreSQL backend you can use the ``--query-store-jdbc-config`` flag, an example of which is below. 
+To enable the PostgreSQL backend you can use the ``--query-store-jdbc-config`` flag, an example of which is below.
 
 .. note:: When you use the Query Store you'll want your first run to specify ``createSchema=true`` so that all the necessary tables are created. After the first run make sure ``createSchema=false`` so that it doesn't attempt to create the tables again.
 
@@ -112,7 +112,7 @@ Once you have retrieved your access token, you can provide it to the JSON API by
 and starting ``daml json-api`` with the flag ``--access-token-file /path/to/your/token.file``.
 
 If the token cannot be read from the provided path or the Ledger API reports an authentication error
-(for example due to token expiration), the JSON API will report the error via logging. 
+(for example due to token expiration), the JSON API will report the error via logging.
 
 .. note:: If the token file is updated with a new token it will be picked up at the next attempt to send a request. You can use this to handle cases where an old token expires without restarting your JSON API service.
 
@@ -173,9 +173,9 @@ Auth via HTTP
 
 Set HTTP header ``Authorization: Bearer paste-jwt-here``
 
-Example: 
+Example:
 
-.. code-block:: none 
+.. code-block:: none
 
     Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJIVFRQLUpTT04tQVBJLUdhdGV3YXkiLCJhY3RBcyI6WyJBbGljZSJdfX0.34zzF_fbWv7p60r5s1kKzwndvGdsJDX-W4Xhm4oVdpk
 
@@ -192,7 +192,7 @@ For HTTP JSON requests, you must pass two subprotocols:
 - ``daml.ws.auth``
 - ``jwt.token.paste-jwt-here``
 
-Example: 
+Example:
 
 .. code-block:: none
 

--- a/ledger-service/http-json/src/it/scala/http/HttpServiceTestFixture.scala
+++ b/ledger-service/http-json/src/it/scala/http/HttpServiceTestFixture.scala
@@ -73,7 +73,6 @@ object HttpServiceTestFixture {
       config = Config(
         ledgerHost = "localhost",
         ledgerPort = ledgerPort.value,
-        applicationId = applicationId,
         address = "localhost",
         httpPort = 0,
         portFile = None,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
@@ -10,7 +10,6 @@ import java.util.concurrent.TimeUnit
 import akka.stream.ThrottleMode
 import com.daml.util.ExceptionOps._
 import com.daml.ledger.api.tls.TlsConfiguration
-import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import scalaz.std.option._
 import scalaz.syntax.traverse._
 import scalaz.{Show, \/}
@@ -26,7 +25,6 @@ private[http] final case class Config(
     address: String = com.daml.cliopts.Http.defaultAddress,
     httpPort: Int,
     portFile: Option[Path] = None,
-    applicationId: ApplicationId = ApplicationId("HTTP-JSON-API-Gateway"),
     packageReloadInterval: FiniteDuration = HttpService.DefaultPackageReloadInterval,
     packageMaxInboundMessageSize: Option[Int] = None,
     maxInboundMessageSize: Int = HttpService.DefaultMaxInboundMessageSize,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -52,6 +52,8 @@ object HttpService extends StrictLogging {
   val DefaultPackageReloadInterval: FiniteDuration = FiniteDuration(5, "s")
   val DefaultMaxInboundMessageSize: Int = 4194304
 
+  private val DummyApplicationId: ApplicationId = ApplicationId("HTTP-JSON-API-Gateway")
+
   private type ET[A] = EitherT[Future, Error, A]
 
   final case class Error(message: String)
@@ -62,7 +64,6 @@ object HttpService extends StrictLogging {
   trait StartSettings {
     val ledgerHost: String
     val ledgerPort: Int
-    val applicationId: ApplicationId
     val address: String
     val httpPort: Int
     val portFile: Option[Path]
@@ -100,7 +101,7 @@ object HttpService extends StrictLogging {
     val tokenHolder = accessTokenFile.map(new TokenHolder(_))
 
     val clientConfig = LedgerClientConfiguration(
-      applicationId = ApplicationId.unwrap(applicationId),
+      applicationId = ApplicationId.unwrap(DummyApplicationId),
       ledgerIdRequirement = LedgerIdRequirement.none,
       commandClient = CommandClientConfiguration.default,
       sslContext = tlsConfig.client,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -52,6 +52,7 @@ object HttpService extends StrictLogging {
   val DefaultPackageReloadInterval: FiniteDuration = FiniteDuration(5, "s")
   val DefaultMaxInboundMessageSize: Int = 4194304
 
+  // used only to populate a required field in LedgerClientConfiguration
   private val DummyApplicationId: ApplicationId = ApplicationId("HTTP-JSON-API-Gateway")
 
   private type ET[A] = EitherT[Future, Error, A]

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Main.scala
@@ -12,13 +12,11 @@ import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFact
 import com.daml.scalautil.Statement.discard
 import com.daml.http.dbbackend.ContractDao
 import com.daml.ledger.api.tls.TlsConfigurationCli
-import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.typesafe.scalalogging.StrictLogging
 import scalaz.{-\/, \/, \/-}
 import scalaz.std.anyVal._
 import scalaz.std.option._
 import scalaz.syntax.show._
-import scalaz.syntax.tag._
 import scopt.RenderingMode
 
 import scala.concurrent.duration._
@@ -47,7 +45,6 @@ object Main extends StrictLogging {
       s"Config(ledgerHost=${config.ledgerHost: String}, ledgerPort=${config.ledgerPort: Int}" +
         s", address=${config.address: String}, httpPort=${config.httpPort: Int}" +
         s", portFile=${config.portFile: Option[Path]}" +
-        s", applicationId=${config.applicationId.unwrap: String}" +
         s", packageReloadInterval=${config.packageReloadInterval: FiniteDuration}" +
         s", packageMaxInboundMessageSize=${config.packageMaxInboundMessageSize: Option[Int]}" +
         s", maxInboundMessageSize=${config.maxInboundMessageSize: Int}" +
@@ -154,10 +151,12 @@ object Main extends StrictLogging {
       )
 
       opt[String]("application-id")
-        .action((x, c) => c.copy(applicationId = ApplicationId(x)))
+        .foreach(x =>
+          logger.warn(
+            s"Command-line option '--application-id' is deprecated. Please do NOT specify it. " +
+              s"Application ID: '$x' provided in the command-line is NOT used, using Application ID from JWT."))
         .optional()
-        .text(
-          s"Optional application ID to use for ledger registration. Defaults to ${Config.Empty.applicationId.unwrap: String}")
+        .hidden()
 
       TlsConfigurationCli.parse(this, colSpacer = "        ")((f, c) =>
         c copy (tlsConfig = f(c.tlsConfig)))


### PR DESCRIPTION
This is not a braking change. `--application-id` is still being accepted by JSON API.
However JSON API logs a warning message when `--application-id` provided in the command-line:

> 17:51:10.074 [main] WARN com.daml.http.Main$ - Command-line option '--application-id' is deprecated. Please do NOT specify it. Application ID: '11111111111111111' provided in the command-line is NOT used, using Application ID from JWT.

Closes: #7162

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
