### PR TITLE
Disable lsp-tests script tests on Windows

### DIFF
--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -529,7 +529,8 @@ scriptTests damlcPath scriptDarPath = testGroup "scripts"
           closeDoc main'
     ]
   where
-    run s = withTempDir $ \dir -> do
+    run s | isWindows = pure ()
+          | otherwise = withTempDir $ \dir -> do
         copyFile scriptDarPath (dir </> "daml-script.dar")
         writeFileUTF8 (dir </> "daml.yaml") $ unlines
             [ "sdk-version: " <> sdkVersion


### PR DESCRIPTION
The similar scenario tests are also disabled on Windows and the script tests are flaky on Windows due to timeouts.

Failure on Azure: https://dev.azure.com/digitalasset/daml/_build/results?buildId=53183
The issue for which the scenario tests are disabled, https://github.com/digital-asset/daml/issues/1354, has been fixed a while ago. But, the tests where never re-enabled.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
