### PR TITLE
kvutils: Use classes in the integrity checker code.

### DIFF
--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/driver/IntegrityCheck.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/driver/IntegrityCheck.scala
@@ -3,7 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.driver
 
-import java.io.{DataInputStream, FileInputStream}
+import java.io.DataInputStream
+import java.nio.file.{Files, Paths}
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
@@ -44,13 +45,13 @@ object IntegrityCheck extends App {
     sys.exit(1)
   }
 
-  val filename = args(0)
-  println(s"Verifying integrity of $filename...")
+  val path = Paths.get(args(0))
+  println(s"Verifying integrity of $path...")
 
   val metricRegistry = new MetricRegistry
   metricRegistry.registerAll(new JvmMetricSet)
 
-  val ledgerDumpStream = new DataInputStream(new FileInputStream(filename))
+  val ledgerDumpStream = new DataInputStream(Files.newInputStream(path))
 
   private val engine = new Engine(EngineConfig.Stable)
 

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/driver/IntegrityCheckV2.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/driver/IntegrityCheckV2.scala
@@ -3,7 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.driver
 
-import java.io.{DataInputStream, FileInputStream}
+import java.io.DataInputStream
+import java.nio.file.{Files, Paths}
 import java.util.concurrent.Executors
 
 import com.daml.dec.DirectExecutionContext
@@ -25,13 +26,13 @@ object IntegrityCheckV2 {
       sys.exit(1)
     }
 
-    val filename = args(0)
-    println(s"Verifying integrity of $filename...")
+    val path = Paths.get(args(0))
+    println(s"Verifying integrity of $path...")
 
     val executionContext: ExecutionContextExecutorService =
       ExecutionContext.fromExecutorService(
         Executors.newFixedThreadPool(sys.runtime.availableProcessors()))
-    val ledgerDumpStream = new DataInputStream(new FileInputStream(filename))
+    val ledgerDumpStream = new DataInputStream(Files.newInputStream(path))
     new IntegrityChecker(LogAppendingCommitStrategySupport)
       .run(ledgerDumpStream)(executionContext)
       .andThen {


### PR DESCRIPTION
Strings and integers give me the heebie-jeebies.

This factors out ledger dump timers into a class, and uses `Path`, not `String`, for file paths.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
