### PR TITLE
Fix name of get_gh_auth_header

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -841,7 +841,7 @@ jobs:
 
           source $(bash-lib)
 
-          AUTH="$(get-gh-auth-header)"
+          AUTH="$(get_gh_auth_header)"
           PR=$(curl -H "$AUTH" \
                     -H "Accept: application/vnd.github.groot-preview+json" \
                     -s -f \


### PR DESCRIPTION
See
https://github.com/digital-asset/daml/blob/b812f09da9bf8a76fdd46bc12dcf2d55691a43a9/ci/bash-lib.yml#L12,
this obviously failed on CI.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
