### PR TITLE
LF: sort fields ValueStruct

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -624,12 +624,15 @@ final class Conversions(
         builder.setTuple(
           proto.Tuple.newBuilder
             .addAllFields(
-              fields.toSeq.map { field =>
-                proto.Field.newBuilder
-                  .setLabel(field._1)
-                  .setValue(convertValue(field._2))
-                  .build
-              }.asJava,
+              fields.iterator
+                .map { field =>
+                  proto.Field.newBuilder
+                    .setLabel(field._1)
+                    .setValue(convertValue(field._2))
+                    .build
+                }
+                .toSeq
+                .asJava,
             )
             .build,
         )

--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Struct.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Struct.scala
@@ -4,7 +4,14 @@
 package com.daml.lf
 package data
 
-import com.daml.lf.data.Ref.Name
+import IdString.`Name order instance`
+import Ref.Name
+import ScalazEqual._
+
+import scalaz.std.iterable._
+import scalaz.std.tuple._
+import scalaz.syntax.order._
+import scalaz.{Equal, Order}
 
 /** We use this container to describe structural record as sorted flat list in various parts of the codebase.
     `entries` are sorted by their first component without duplicate.
@@ -76,5 +83,15 @@ object Struct {
   val Empty: Struct[Nothing] = new Struct(ImmArray.empty)
 
   private[this] val rightEmpty = Right(Empty)
+
+  implicit def structEqualInstance[X: Equal]: Equal[Struct[X]] =
+    _.toImmArray === _.toImmArray
+
+  implicit def structOrderInstance[X: Order]: Order[Struct[X]] =
+    // following daml-lf specification, this considers first names, then values.
+    orderBy(
+      s => (toIterableForScalazInstances(s.names), toIterableForScalazInstances(s.values)),
+      true,
+    )
 
 }

--- a/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/StructSpec.scala
+++ b/daml-lf/data/src/test/scala/com/digitalasset/daml/lf/data/StructSpec.scala
@@ -62,4 +62,37 @@ class StructSpec extends WordSpec with Matchers with PropertyChecks {
     }
   }
 
+  "Struct.structOrderInstance" should {
+
+    "order as expected (first consider all names, then consider values)" in {
+
+      import Struct.structOrderInstance
+      import scalaz.Scalaz._
+
+      val testCases =
+        Table(
+          "value" -> "index",
+          List(
+            List(),
+            List(f1 -> 1),
+            List(f1 -> 2),
+            List(f1 -> 1, f2 -> 1),
+            List(f1 -> 1, f2 -> 2),
+            List(f1 -> 2, f2 -> 1),
+            List(f1 -> 2, f2 -> 2),
+            List(f1 -> 1, f2 -> 2, f3 -> 3),
+            List(f2 -> 2),
+            List(f2 -> 2, f3 -> 3),
+            List(f3 -> 3)
+          ).map(Struct.assertFromSeq).zipWithIndex: _*,
+        )
+
+      forEvery(testCases) { (x, i) =>
+        forEvery(testCases) { (y, j) =>
+          (x ?|? y) shouldBe (i ?|? j)
+        }
+      }
+    }
+  }
+
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -323,9 +323,7 @@ object ScenarioLedger {
             case (_, v) => collect(v)
           }
         case ValueStruct(fs) =>
-          fs.foreach {
-            case (_, v) => collect(v)
-          }
+          fs.values.foreach(collect)
         case ValueVariant(_, _, arg) => collect(arg)
         case _: ValueEnum => ()
         case ValueList(vs) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -407,7 +407,7 @@ private[lf] object Pretty {
           char('}')
       case ValueStruct(fs) =>
         char('{') &
-          fill(text(", "), fs.toList.map {
+          fill(text(", "), fs.toImmArray.toSeq.map {
             case (k, v) => text(k) & char('=') & prettyValue(true)(v)
           }) &
           char('}')

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -35,10 +35,8 @@ sealed trait SValue {
       case SDate(x) => V.ValueDate(x)
       case SStruct(fields, svalues) =>
         V.ValueStruct(
-          ImmArray(
-            fields.toSeq
-              .zip(svalues.asScala)
-              .map { case (fld, sv) => (fld, sv.toValue) },
+          Struct.assertFromSeq(
+            (fields.iterator zip svalues.iterator().asScala.map(_.toValue)).toSeq
           ),
         )
       case SRecord(id, fields, svalues) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -587,13 +587,9 @@ private[lf] object Speedy {
           case V.ValueRecord(None, _) =>
             crash("SValue.fromValue: record missing identifier")
           case V.ValueStruct(fs) =>
-            val values = new util.ArrayList[SValue](fs.length)
-            val names = fs.map {
-              case (k, v) =>
-                values.add(go(v))
-                k
-            }
-            SStruct(names, values)
+            val values = new util.ArrayList[SValue](fs.size)
+            fs.values.foreach(v => values.add(go(v)))
+            SStruct(fs.names.to[ImmArray], values)
           case V.ValueVariant(None, _variant @ _, _value @ _) =>
             crash("SValue.fromValue: variant without identifier")
           case V.ValueEnum(None, constructor @ _) =>

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -157,9 +157,7 @@ object Value extends CidContainer1[Value] {
             case (lbl, value) => (lbl, go(value))
           }))
         case ValueStruct(fs) =>
-          ValueStruct(fs.map[(Name, Value[Cid2])] {
-            case (lbl, value) => (lbl, go(value))
-          })
+          ValueStruct(fs.mapValues(go))
         case ValueVariant(id, variant, value) =>
           ValueVariant(id, variant, go(value))
         case x: ValueCidlessLeaf => x
@@ -183,7 +181,7 @@ object Value extends CidContainer1[Value] {
         case ValueRecord(id @ _, fs) =>
           fs.foreach { case (_, value) => go(value) }
         case ValueStruct(fs) =>
-          fs.foreach { case (_, value) => go(value) }
+          fs.values.foreach(go)
         case ValueVariant(id @ _, variant @ _, value) =>
           go(value)
         case _: ValueCidlessLeaf =>
@@ -285,7 +283,7 @@ object Value extends CidContainer1[Value] {
   // this is present here just because we need it in some internal code --
   // specifically the scenario interpreter converts committed values to values and
   // currently those can be structs, although we should probably ban that.
-  final case class ValueStruct[+Cid](fields: ImmArray[(Name, Value[Cid])]) extends Value[Cid]
+  final case class ValueStruct[+Cid](fields: Struct[Value[Cid]]) extends Value[Cid]
 
   /** The data constructors of a variant or enum, if defined. */
   type LookupVariantEnum = Identifier => Option[ImmArray[Name]]

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueCoderSpec.scala
@@ -174,7 +174,8 @@ class ValueCoderSpec extends WordSpec with Matchers with EitherAssertions with P
     }
 
     "don't struct" in {
-      val struct = ValueStruct(ImmArray((Ref.Name.assertFromString("foo"), ValueInt64(42))))
+      val fields = List(Ref.Name.assertFromString("foo") -> ValueInt64(42))
+      val struct = ValueStruct(Struct.assertFromSeq(fields))
       val res =
         ValueCoder.encodeValue[ContractId](ValueCoder.CidEncoder, defaultValueVersion, struct)
       res.left.get.errorMessage should include("serializable")

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -4,7 +4,7 @@
 package com.daml.lf
 package value
 
-import data.{Bytes, FrontStack, ImmArray, Ref}
+import data.{Bytes, FrontStack, ImmArray, Ref, Struct}
 import Value._
 import Ref.{Identifier, Name}
 import test.ValueGenerators.{coidGen, idGen, nameGen}
@@ -31,8 +31,8 @@ class ValueSpec
   import ValueSpec._
 
   "serialize" - {
-    val emptyStruct = ValueStruct(ImmArray.empty)
-    val emptyStructError = "contains struct ValueStruct(ImmArray())"
+    val emptyStruct = ValueStruct(Struct.Empty)
+    val emptyStructError = "contains struct ValueStruct(Struct())"
     val exceedsNesting = (1 to MAXIMUM_NESTING + 1).foldRight[Value[Nothing]](ValueInt64(42)) {
       case (_, v) => ValueVariant(None, Ref.Name.assertFromString("foo"), v)
     }
@@ -58,7 +58,7 @@ class ValueSpec
     }
 
     "outputs both error messages, without duplication" in {
-      ValueList(FrontStack(exceedsNesting, ValueStruct(ImmArray.empty), exceedsNesting)).serializable shouldBe
+      ValueList(FrontStack(exceedsNesting, ValueStruct(Struct.Empty), exceedsNesting)).serializable shouldBe
         ImmArray(exceedsNestingError, emptyStructError)
     }
   }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/ApiValueToLfValueConverterTest.scala
@@ -61,7 +61,7 @@ object ApiValueToLfValueConverterTest {
       case _: V.ValueCidlessLeaf | V.ValueContractId(_) => fa
       case r @ V.ValueRecord(_, fields) => r copy (fields = fields map (_ rightMap go))
       case v @ V.ValueVariant(_, _, value) => v copy (value = go(value))
-      case s @ V.ValueStruct(fields) => s copy (fields = fields map (_ rightMap go))
+      case s @ V.ValueStruct(fields) => s copy (fields = fields mapValues go)
       case V.ValueList(fs) => V.ValueList(fs map go)
       case V.ValueOptional(o) => V.ValueOptional(o map go)
       case V.ValueTextMap(m) => V.ValueTextMap(m mapValue go)

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Adapter.scala
@@ -88,7 +88,7 @@ private[benchmark] final class Adapter(
       case Value.ValueGenMap(entries) =>
         Value.ValueGenMap(entries.map { case (k, v) => adapt(k) -> adapt(v) })
       case Value.ValueStruct(fields) =>
-        Value.ValueStruct(fields.map { case (f, v) => f -> adapt(v) })
+        Value.ValueStruct(fields.mapValues(adapt))
       case _: Value.ValueCidlessLeaf | _: Value.ValueContractId[ContractId] =>
         value
     }


### PR DESCRIPTION
This PR uses the new data structure introduced in #7220.

Additionally this fixes `` `Value Equal instance` `` and 
`` `Value Order instance` `` which were considering `<a: x, b: y>` 
different from `<b:y, a:x>`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
