### PR TITLE
fix docs warning

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/json/JsonProtocol.scala
@@ -53,11 +53,11 @@ object JsonProtocol extends DefaultJsonProtocol with ExtraFormats {
   implicit def NonEmptyListWriter[A: JsonWriter]: JsonWriter[NonEmptyList[A]] =
     nela => JsArray(nela.map(_.toJson).list.toVector)
 
-  /** This intuitively pointless extra type is here to give it specificity
-    * so this instance will beat [[CollectionFormats#listFormat]].
-    * You would normally achieve the conflict resolution by putting this
-    * instance in a parent of [[CollectionFormats]], but that kind of
-    * extension isn't possible here.
+  /** This intuitively pointless extra type is here to give it specificity so
+    *  this instance will beat CollectionFormats#listFormat. You would normally
+    *  achieve the conflict resolution by putting this instance in a parent of
+    *  [[https://javadoc.io/static/io.spray/spray-json_2.12/1.3.5/spray/json/CollectionFormats.html CollectionFormats]],
+    *  but that kind of extension isn't possible here.
     */
   final class JsonReaderList[A: JsonReader] extends JsonReader[List[A]] {
     override def read(json: JsValue) = json match {


### PR DESCRIPTION
Apparently `[[]]` links don't work to external resources. I wanted to turn the first reference into a link too but that contains too many weird characters.

CHANGELOG_BEGIN
CHANGELOG_END