### PR TITLE
fix JSON API multikey stream

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -33,6 +33,7 @@ import com.daml.http.util.FlowUtil.allowOnlyFirstInput
 import spray.json.{JsArray, JsObject, JsValue, JsonReader}
 
 import scala.collection.compat._
+import scala.collection.mutable.HashSet
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -257,11 +258,17 @@ object WebSocketService {
             .toLeftDisjunction(x.ekey.templateId)
         }
 
-      val q: Map[domain.TemplateId.RequiredPkg, LfV] = resolvedWithKey.toMap
+      val q: Map[domain.TemplateId.RequiredPkg, HashSet[LfV]] =
+        resolvedWithKey.foldLeft(Map.empty[domain.TemplateId.RequiredPkg, HashSet[LfV]])((acc, el) =>
+          acc.get(el._1) match {
+            case Some(v) => acc.updated(el._1, v += el._2)
+            case None => acc.updated(el._1, HashSet(el._2))
+        })
       val fn: domain.ActiveContract[LfV] => Option[Positive] = { a =>
-        if (q.get(a.templateId).exists(k => domain.ActiveContract.matchesKey(k)(a)))
-          Some(())
-        else None
+        a.key match {
+          case None => None
+          case Some(k) => if (q.getOrElse(a.templateId, HashSet()).contains(k)) Some(()) else None
+        }
       }
       (q.keySet, unresolved, fn)
     }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -259,11 +259,12 @@ object WebSocketService {
         }
 
       val q: Map[domain.TemplateId.RequiredPkg, HashSet[LfV]] =
-        resolvedWithKey.foldLeft(Map.empty[domain.TemplateId.RequiredPkg, HashSet[LfV]])((acc, el) =>
-          acc.get(el._1) match {
-            case Some(v) => acc.updated(el._1, v += el._2)
-            case None => acc.updated(el._1, HashSet(el._2))
-        })
+        resolvedWithKey.foldLeft(Map.empty[domain.TemplateId.RequiredPkg, HashSet[LfV]])(
+          (acc, el) =>
+            acc.get(el._1) match {
+              case Some(v) => acc.updated(el._1, v += el._2)
+              case None => acc.updated(el._1, HashSet(el._2))
+          })
       val fn: domain.ActiveContract[LfV] => Option[Positive] = { a =>
         a.key match {
           case None => None


### PR DESCRIPTION
In the current state, the JSON API only handles multiple keys _from different templates_. This makes it work for multiple keys from the same template too.

Extracted from #7066 with the following changes:

- Use of a mutable `HashSet` to test for keys, because perf.
- Addition of a test at the JSON API level.

CHANGELOG_BEGIN

- [JSON API] Fix a bug where streaming multiple keys could silently
  ignore some of the given keys.

CHANGELOG_END