### PR TITLE
Add a dummy OAuth2 authorization server

### DIFF
--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -1,0 +1,68 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+    "da_scala_library",
+    "da_scala_test",
+)
+
+scalacopts = []
+
+da_scala_library(
+    name = "oauth-test-server",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scalacopts = scalacopts,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//ledger-service/jwt",
+        "//ledger/ledger-api-auth",
+        "//libs-scala/ports",
+        "@maven//:com_github_scopt_scopt_2_12",
+        "@maven//:com_typesafe_akka_akka_actor_2_12",
+        "@maven//:com_typesafe_akka_akka_http_2_12",
+        "@maven//:com_typesafe_akka_akka_http_core_2_12",
+        "@maven//:com_typesafe_akka_akka_http_spray_json_2_12",
+        "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
+        "@maven//:io_spray_spray_json_2_12",
+        "@maven//:org_scalaz_scalaz_core_2_12",
+        "@maven//:org_slf4j_slf4j_api",
+    ],
+)
+
+da_scala_binary(
+    name = "oauth-test-server-binary",
+    main_class = "com.daml.oauth.server.Main",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@maven//:ch_qos_logback_logback_classic",
+    ],
+    deps = [
+        ":oauth-test-server",
+    ],
+)
+
+da_scala_test(
+    name = "tests",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    scalacopts = scalacopts,
+    deps = [
+        ":oauth-test-server",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger-service/jwt",
+        "//ledger/ledger-api-auth",
+        "//libs-scala/ports",
+        "//libs-scala/resources",
+        "@maven//:com_typesafe_akka_akka_actor_2_12",
+        "@maven//:com_typesafe_akka_akka_http_2_12",
+        "@maven//:com_typesafe_akka_akka_http_core_2_12",
+        "@maven//:com_typesafe_akka_akka_http_spray_json_2_12",
+        "@maven//:com_typesafe_akka_akka_parsing_2_12",
+        "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:io_spray_spray_json_2_12",
+        "@maven//:org_scalaz_scalaz_core_2_12",
+    ],
+)

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.server
+
+import com.daml.ports.Port
+
+private[server] case class Config(
+    // Port the authorization server listens on
+    port: Port,
+    // Ledger ID of issued tokens
+    ledgerId: String,
+    // Application ID of issued tokens
+    applicationId: String,
+    // Secret used to sign JWTs
+    jwtSecret: String
+)
+
+private[server] object Config {
+  private val Empty =
+    Config(port = Port.Dynamic, ledgerId = null, applicationId = null, jwtSecret = null)
+
+  def parseConfig(args: Seq[String]): Option[Config] =
+    configParser.parse(args, Empty)
+
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  val configParser: scopt.OptionParser[Config] =
+    new scopt.OptionParser[Config]("oauth-test-server") {
+      head("OAuth2 TestServer")
+
+      opt[Int]("port")
+        .action((x, c) => c.copy(port = Port(x)))
+        .required()
+        .text("Port to listen on")
+
+      opt[String]("ledger-id")
+        .action((x, c) => c.copy(ledgerId = x))
+
+      opt[String]("application-id")
+        .action((x, c) => c.copy(applicationId = x))
+
+      opt[String]("secret")
+        .action((x, c) => c.copy(jwtSecret = x))
+
+      help("help").text("Print this usage text")
+    }
+}

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Main.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Main.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.server
+
+import akka.actor.ActorSystem
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
+import scala.util.{Failure, Success}
+
+object Main extends StrictLogging {
+  def main(args: Array[String]): Unit = {
+    Config.parseConfig(args) match {
+      case Some(config) => main(config)
+      case None => sys.exit(1)
+    }
+  }
+
+  private def main(config: Config): Unit = {
+    implicit val system: ActorSystem = ActorSystem("system")
+    implicit val executionContext: ExecutionContext = system.dispatcher
+
+    def terminate() = Await.result(system.terminate(), 10.seconds)
+
+    val bindingFuture = Server.start(config)
+
+    sys.addShutdownHook {
+      Server
+        .stop(bindingFuture)
+        .onComplete { _ =>
+          terminate()
+        }
+    }
+
+    bindingFuture.onComplete {
+      case Success(binding) =>
+        logger.info(s"Started server: $binding")
+      case Failure(e) =>
+        logger.error(s"Failed to start server: $e")
+        terminate()
+    }
+  }
+}

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.server
+
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Query
+import spray.json.{
+  DefaultJsonProtocol,
+  JsString,
+  JsValue,
+  JsonFormat,
+  RootJsonFormat,
+  deserializationError
+}
+
+object Request {
+
+  // https://tools.ietf.org/html/rfc6749#section-4.1.1
+  case class Authorize(
+      responseType: String,
+      clientId: String,
+      redirectUri: Uri, // optional in oauth but we require it
+      scope: Option[String],
+      state: Option[String]) {
+    def toQuery: Query = {
+      var params: Seq[(String, String)] =
+        Seq(
+          ("response_type", responseType),
+          ("client_id", clientId),
+          ("redirect_uri", redirectUri.toString))
+      scope.foreach { scope =>
+        params ++= Seq(("scope", scope))
+      }
+      state.foreach { state =>
+        params ++= Seq(("state", state))
+      }
+      Query(params: _*)
+    }
+  }
+
+  // https://tools.ietf.org/html/rfc6749#section-4.1.3
+  case class Token(
+      grantType: String,
+      code: String,
+      redirectUri: Option[Uri],
+      clientId: String,
+      clientSecret: String)
+
+}
+
+object Response {
+
+  // https://tools.ietf.org/html/rfc6749#section-4.1.2
+  case class Authorize(code: String, state: Option[String]) {
+    def toQuery: Query = state match {
+      case None => Query(("code", code))
+      case Some(state) => Query(("code", code), ("state", state))
+    }
+  }
+
+  // https://tools.ietf.org/html/rfc6749#section-4.1.1
+  case class Token(
+      accessToken: String,
+      tokenType: String,
+      expiresIn: Option[String],
+      refreshToken: Option[String],
+      scope: Option[String])
+
+}
+
+object JsonProtocol extends DefaultJsonProtocol {
+  implicit object UriFormat extends JsonFormat[Uri] {
+    def read(value: JsValue) = value match {
+      case JsString(s) => Uri(s)
+      case _ => deserializationError(s"Expected Uri string but got $value")
+    }
+    def write(uri: Uri) = JsString(uri.toString)
+  }
+  implicit val tokenReqFormat: RootJsonFormat[Request.Token] =
+    jsonFormat(Request.Token, "grant_type", "code", "redirect_uri", "client_id", "client_secret")
+  implicit val tokenRespFormat: RootJsonFormat[Response.Token] =
+    jsonFormat(Response.Token, "access_token", "token_type", "expires_in", "refresh_token", "scope")
+}

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
@@ -43,7 +43,7 @@ object Request {
   case class Token(
       grantType: String,
       code: String,
-      redirectUri: Option[Uri],
+      redirectUri: Uri,
       clientId: String,
       clientSecret: String)
 
@@ -59,7 +59,7 @@ object Response {
     }
   }
 
-  // https://tools.ietf.org/html/rfc6749#section-4.1.1
+  // https://tools.ietf.org/html/rfc6749#section-5.1
   case class Token(
       accessToken: String,
       tokenType: String,

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -1,0 +1,112 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.server
+
+import java.util.UUID
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import com.daml.jwt.JwtSigner
+import com.daml.jwt.domain.DecodedJwt
+import com.daml.ledger.api.auth.{AuthServiceJWTCodec, AuthServiceJWTPayload}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
+
+// This is a test authorization server that implements the OAuth2 authorization code flow.
+// This is primarily intended for use in the trigger service tests but could also serve
+// as a useful ground for experimentation.
+// Given scopes of the form `actAs:$party`, the authorization server will issue
+// tokens with the respective claims. All requests will be accepted and request to
+// /authorize are immediately redirected to the redirect_uri.
+object Server {
+  private val jwtHeader = """{"alg": "HS256", "typ": "JWT"}"""
+  def start(config: Config)(implicit system: ActorSystem): Future[ServerBinding] = {
+    // To keep things as simple as possible, we use a UUID as the authorization code
+    // and in the /authorize request we already pre-compute the JWT payload based on the scope.
+    // The token request then only does a lookup and signs the token.
+    var requests = Map.empty[UUID, AuthServiceJWTPayload]
+
+    def toPayload(req: Request.Authorize): AuthServiceJWTPayload = {
+      val parties: List[String] =
+        req.scope.fold(List.empty[String])(s => List[String](s.split(" "): _*)).collect {
+          case s if s.startsWith("actAs:") => s.stripPrefix("actAs:")
+        }
+      AuthServiceJWTPayload(
+        ledgerId = Some(config.ledgerId),
+        applicationId = Some(config.applicationId),
+        // Not required by the default auth service
+        participantId = None,
+        // Only for testing, expire never.
+        exp = None,
+        // no admin claim for now.
+        admin = false,
+        actAs = parties,
+        readAs = List()
+      )
+    }
+
+    import JsonProtocol._
+
+    implicit val unmarshal: Unmarshaller[String, Uri] = Unmarshaller.strict(Uri(_))
+
+    val route = concat(
+      path("authorize") {
+        get {
+          parameters(('response_type, 'client_id, 'redirect_uri.as[Uri], 'scope ?, 'state ?))
+            .as[Request.Authorize](Request.Authorize) {
+              request =>
+                val authorizationCode = UUID.randomUUID()
+                val params =
+                  Response
+                    .Authorize(code = authorizationCode.toString, state = request.state)
+                    .toQuery
+                requests += (authorizationCode -> toPayload(request))
+                // We skip any actual consent screen since this is only intended for testing and
+                // this is outside of the scope of the trigger service anyway.
+                redirect(request.redirectUri.withQuery(params), StatusCodes.Found)
+            }
+        }
+      },
+      path("token") {
+        post {
+          entity(as[Request.Token]) {
+            request =>
+              // No validation to keep things simple
+              requests.get(UUID.fromString(request.code)) match {
+                case None => sys.exit(2)
+                case Some(payload) =>
+                  import JsonProtocol._
+                  complete(
+                    Response.Token(
+                      accessToken = JwtSigner.HMAC256
+                        .sign(
+                          DecodedJwt(jwtHeader, AuthServiceJWTCodec.compactPrint(payload)),
+                          config.jwtSecret)
+                        .getOrElse(
+                          throw new IllegalArgumentException("Failed to sign a token")
+                        )
+                        .value,
+                      refreshToken = None,
+                      expiresIn = None,
+                      scope = None,
+                      tokenType = "bearer"
+                    ))
+              }
+          }
+        }
+      }
+    )
+
+    Http().bindAndHandle(route, "localhost", config.port.value)
+  }
+  def stop(f: Future[ServerBinding])(implicit ec: ExecutionContext): Future[Done] =
+    f.flatMap(_.unbind())
+}

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Client.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Client.scala
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.server
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import com.daml.ports.Port
+import spray.json._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
+
+// This is a test client (using terminology from oauth) terminology.
+// The trigger service would also take the role of a client.
+object Client {
+  import com.daml.oauth.server.JsonProtocol._
+
+  case class Config(
+      port: Port,
+      authServerUrl: Uri,
+      clientId: String,
+      clientSecret: String
+  )
+
+  object JsonProtocol extends DefaultJsonProtocol {
+    implicit val accessParamsFormat: RootJsonFormat[AccessParams] = jsonFormat1(AccessParams)
+    implicit val accessResponseFormat: RootJsonFormat[AccessResponse] = jsonFormat1(AccessResponse)
+  }
+
+  case class AccessParams(parties: Seq[String])
+  case class AccessResponse(token: String)
+
+  def start(
+      config: Config)(implicit asys: ActorSystem, ec: ExecutionContext): Future[ServerBinding] = {
+    import JsonProtocol._
+    val route = concat(
+      // Some parameter that requires authorization for some parties. This will in the end return the token
+      // produced by the authorization server.
+      path("access") {
+        post {
+          entity(as[AccessParams]) {
+            params =>
+              extractRequest {
+                request =>
+                  val redirectUri = request.uri.withPath(Path./("cb"))
+                  val authParams = Request.Authorize(
+                    responseType = "code",
+                    clientId = config.clientId,
+                    redirectUri = redirectUri,
+                    scope = Some(params.parties.map(p => "actAs:" + p).mkString(" ")),
+                    state = None)
+                  redirect(
+                    config.authServerUrl
+                      .withQuery(authParams.toQuery)
+                      .withPath(Path./("authorize")),
+                    StatusCodes.Found)
+              }
+          }
+        }
+      },
+      path("cb") {
+        get {
+          parameters(('code, 'state ?)).as[Response.Authorize](Response.Authorize) {
+            resp =>
+              // We got the code, now request a token
+              val body = Request.Token(
+                grantType = "authorization_code",
+                code = resp.code,
+                redirectUri = None,
+                clientId = config.clientId,
+                clientSecret = config.clientSecret)
+              val req = HttpRequest(
+                uri = config.authServerUrl.withPath(Path./("token")),
+                entity = HttpEntity(MediaTypes.`application/json`, body.toJson.compactPrint),
+                method = HttpMethods.POST,
+              )
+              val f = for {
+                resp <- Http().singleRequest(req)
+                tokenResp <- Unmarshal(resp).to[Response.Token]
+              } yield tokenResp
+              onSuccess(f) { tokenResp =>
+                // Now we have the access_token and potentially the refresh token. At this point,
+                // we would start the trigger.
+                complete(AccessResponse(tokenResp.accessToken))
+              }
+          }
+        }
+      }
+    )
+    Http().bindAndHandle(route, "localhost", config.port.value)
+  }
+
+}

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Resources.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.server
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http.ServerBinding
+import com.daml.resources.{Resource, ResourceOwner}
+
+import scala.concurrent.ExecutionContext
+
+object Resources {
+  def authServer(config: Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
+    new ResourceOwner[ServerBinding] {
+      override def acquire()(implicit executionContext: ExecutionContext): Resource[ServerBinding] =
+        Resource(Server.start(config))(_.unbind().map(_ => ()))
+    }
+  def authClient(config: Client.Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
+    new ResourceOwner[ServerBinding] {
+      override def acquire()(implicit ec: ExecutionContext): Resource[ServerBinding] =
+        Resource(Client.start(config))(_.unbind().map(_ => ()))
+    }
+}

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.server
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.Location
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import com.daml.jwt.JwtDecoder
+import com.daml.jwt.domain.Jwt
+import com.daml.ledger.api.auth.{AuthServiceJWTCodec, AuthServiceJWTPayload}
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import org.scalatest.AsyncWordSpec
+import spray.json._
+
+import scala.concurrent.Future
+
+class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAroundAll {
+  import Client.JsonProtocol._
+  private def requestToken(parties: Seq[String]): Future[AuthServiceJWTPayload] = {
+    lazy val clientBinding = suiteResource.value._2.localAddress
+    lazy val clientUri = Uri().withAuthority(clientBinding.getHostString, clientBinding.getPort)
+    val req = HttpRequest(
+      uri = clientUri.withPath(Path./("access")).withScheme("http"),
+      method = HttpMethods.POST,
+      entity =
+        HttpEntity(MediaTypes.`application/json`, Client.AccessParams(parties).toJson.compactPrint)
+    )
+    for {
+      resp <- Http().singleRequest(req)
+      // Redirect to /authorize on authorization server (No automatic redirect handling in akka-http)
+      resp <- {
+        assert(resp.status == StatusCodes.Found)
+        val req = HttpRequest(uri = resp.header[Location].get.uri)
+        Http().singleRequest(req)
+      }
+      // Redirect to /cb on client.
+      resp <- {
+        assert(resp.status == StatusCodes.Found)
+        val req = HttpRequest(uri = resp.header[Location].get.uri)
+        Http().singleRequest(req)
+      }
+      // Actual token response (proxied from auth server to us via the client)
+      body <- Unmarshal(resp).to[Client.AccessResponse]
+      decodedJwt <- JwtDecoder
+        .decode(Jwt(body.token))
+        .fold((e => Future.failed(new IllegalArgumentException(e.toString))), Future.successful(_))
+      payload <- Future.fromTry(AuthServiceJWTCodec.readFromString(decodedJwt.payload))
+    } yield payload
+  }
+
+  "the auth server" should {
+    "issue a token with no parties" in {
+      for {
+        token <- requestToken(Seq())
+      } yield {
+        assert(token.actAs == Seq())
+      }
+    }
+    "issue a token with 1 party" in {
+      for {
+        token <- requestToken(Seq("Alice"))
+      } yield {
+        assert(token.actAs == Seq("Alice"))
+      }
+    }
+    "issue a token with multiple parties" in {
+      for {
+        token <- requestToken(Seq("Alice", "Bob"))
+      } yield {
+        assert(token.actAs == Seq("Alice", "Bob"))
+      }
+    }
+  }
+}

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.server
+
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.model.Uri
+import com.daml.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  OwnedResource,
+  Resource,
+  SuiteResource
+}
+import com.daml.ports.Port
+import org.scalatest.Suite
+
+import scala.concurrent.ExecutionContext
+
+trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBinding, ServerBinding)] {
+  self: Suite =>
+  protected val ledgerId: String = "test-ledger"
+  protected val applicationId: String = "test-application"
+  protected val jwtSecret: String = "secret"
+  override protected lazy val suiteResource: Resource[(ServerBinding, ServerBinding)] = {
+    implicit val ec: ExecutionContext = system.dispatcher
+    new OwnedResource[(ServerBinding, ServerBinding)](
+      for {
+        server <- Resources.authServer(
+          Config(
+            port = Port.Dynamic,
+            ledgerId = ledgerId,
+            applicationId = applicationId,
+            jwtSecret = jwtSecret))
+        client <- Resources.authClient(
+          Client.Config(
+            port = Port.Dynamic,
+            authServerUrl = Uri()
+              .withScheme("http")
+              .withAuthority(server.localAddress.getHostString, server.localAddress.getPort),
+            clientId = "test-client",
+            clientSecret = "test-client-secret"
+          ))
+      } yield { (server, client) }
+    )
+  }
+}


### PR DESCRIPTION
This is intended for use in the trigger service integration tests not
as an artifact that we ship to users.

For now the functionality is deliberately limited but as we need more in the tests, this might also be extended.

I did spend a bit of time searching for existing services for testing but couldn’t really find anything that I liked and this also served as a useful exercise for me to clarify some things and could serve as an easy reference for others.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
