### PR TITLE
Track source locations on Daml.Script.submit

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -886,7 +886,7 @@ convertExpr env0 e = do
         = fmap (, args) $ mkIf <$> convertExpr env x <*> convertExpr env y <*> mkPure env monad dict TUnit EUnit
     go env (VarIn DA_Action "unless") (LType monad : LExpr dict : LExpr x : LExpr y : args)
         = fmap (, args) $ mkIf <$> convertExpr env x <*> mkPure env monad dict TUnit EUnit <*> convertExpr env y
-    go env submit@(VarIn DA_Internal_LF "submit") (LType m : LType cmds : LExpr dict : LType typ : LExpr pty : LExpr upd : args) = fmap (, args) $ do
+    go env submit@(VarIn DA_Internal_LF "submit") (LType m : LType cmds : LExpr dict : LType typ : LExpr callstack : LExpr pty : LExpr upd : args) = fmap (, args) $ do
          m' <- convertType env m
          typ' <- convertType env typ
          pty' <- convertExpr env pty
@@ -897,8 +897,9 @@ convertExpr env0 e = do
              submit' <- convertExpr env submit
              cmds' <- convertType env cmds
              dict' <- convertExpr env dict
-             pure $ mkEApps submit' [TyArg m', TyArg cmds', TmArg dict', TyArg typ', TmArg pty', TmArg upd']
-    go env submitMustFail@(VarIn DA_Internal_LF "submitMustFail") (LType m : LType cmds : LExpr dict : LType typ : LExpr pty : LExpr upd : args) = fmap (, args) $ do
+             callstack' <- convertExpr env callstack
+             pure $ mkEApps submit' [TyArg m', TyArg cmds', TmArg dict', TyArg typ', TmArg callstack', TmArg pty', TmArg upd']
+    go env submitMustFail@(VarIn DA_Internal_LF "submitMustFail") (LType m : LType cmds : LExpr dict : LType typ : LExpr callstack : LExpr pty : LExpr upd : args) = fmap (, args) $ do
          m' <- convertType env m
          typ' <- convertType env typ
          pty' <- convertExpr env pty
@@ -909,7 +910,8 @@ convertExpr env0 e = do
              submitMustFail' <- convertExpr env submitMustFail
              cmds' <- convertType env cmds
              dict' <- convertExpr env dict
-             pure $ mkEApps submitMustFail' [TyArg m', TyArg cmds', TmArg dict', TyArg typ', TmArg pty', TmArg upd']
+             callstack' <- convertExpr env callstack
+             pure $ mkEApps submitMustFail' [TyArg m', TyArg cmds', TmArg dict', TyArg typ', TmArg callstack', TmArg pty', TmArg upd']
 
     -- custom conversion because they correspond to builtins in DAML-LF, so can make the output more readable
     go env (VarIn DA_Internal_Prelude "pure") (LType monad : LExpr dict : LType t : LExpr x : args)

--- a/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
@@ -1,13 +1,24 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 module GHC.Stack.Types where
 
+import GHC.Classes ()
 import GHC.CString
 import GHC.Err
 import GHC.Tuple ()
 import GHC.Types
+
+-- | Request a CallStack.
+--
+-- Calls to functions with this constraint will be added to the callstack.
+-- You can get access to the current call stack with `callStack`.
+--
+-- Note that if the call stack is reset if any function in between does not
+-- have a `HasCallStack` constraint.
+type HasCallStack = (?callStack : CallStack)
 
 -- NOTE (MK): Note that everything in this module
 -- needs to use `TextLit`. Otherwise, you will get core linting errors

--- a/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
@@ -46,6 +46,9 @@ popCallStack stk = case stk of
   PushCallStack (_, _, stk') -> stk'
   FreezeCallStack _      -> stk
 
+-- | Location in the source code.
+--
+-- Line and column are 1-based.
 data SrcLoc = SrcLoc
   { srcLocPackage   : TextLit
   , srcLocModule    : TextLit

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -47,6 +47,7 @@ module DA.Internal.LF
   , TypeRep
   ) where
 
+import GHC.Stack.Types (HasCallStack)
 import GHC.Types (Opaque, Symbol, primitive, magic)
 import DA.Internal.Prelude
 
@@ -212,13 +213,13 @@ class HasSubmit m cmds | m -> cmds, cmds -> m where
   -- from party `p` and returns the value returned by `cmds`.
   --
   -- If the transaction fails, `submit` also fails.
-  submit : Party -> cmds a -> m a
+  submit : HasCallStack => Party -> cmds a -> m a
 
   -- | `submitMustFail p cmds` submits the commands `cmds` as a single transaction
   -- from party `p`.
   --
   -- It only succeeds if the submitting the transaction fails.
-  submitMustFail : Party -> cmds a -> m ()
+  submitMustFail : HasCallStack => Party -> cmds a -> m ()
 
 instance HasSubmit Scenario Update where
   submit = primitive @"SCommit"

--- a/compiler/damlc/daml-stdlib-src/DA/Stack.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Stack.daml
@@ -55,7 +55,7 @@ callStack =
 
 -- | Location in the source code.
 --
--- Line and column are 1-based.
+-- Line and column are 0-based.
 data SrcLoc = SrcLoc
 -- User-facing type using Text instead of TextLit.
   { srcLocPackage   : Text
@@ -73,9 +73,9 @@ convSrcLoc GHC.SrcLoc{..} =
     { srcLocPackage = fromString srcLocPackage
     , srcLocModule = fromString srcLocModule
     , srcLocFile = fromString srcLocFile
-    , srcLocStartLine
-    , srcLocStartCol
-    , srcLocEndLine
-    , srcLocEndCol
+    , srcLocStartLine = srcLocStartLine - 1
+    , srcLocStartCol = srcLocStartCol - 1
+    , srcLocEndLine = srcLocEndLine - 1
+    , srcLocEndCol = srcLocEndCol - 1
     }
 

--- a/compiler/damlc/daml-stdlib-src/DA/Stack.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Stack.daml
@@ -16,15 +16,6 @@ import DA.Text
 import GHC.Stack.Types hiding (SrcLoc(..))
 import qualified GHC.Stack.Types as GHC
 
--- | Request a CallStack.
---
--- Calls to functions with this constraint will be added to the callstack.
--- You can get access to the current call stack with `callStack`.
---
--- Note that if the call stack is reset if any function in between does not
--- have a `HasCallStack` constraint.
-type HasCallStack = (?callStack : CallStack)
-
 -- Pretty-print a `CallStack`.
 prettyCallStack : CallStack -> Text
 prettyCallStack = intercalate "\n" . prettyCallStackLines

--- a/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
+++ b/compiler/damlc/tests/src/DA/Test/ShakeIdeClient.hs
@@ -1165,9 +1165,9 @@ scenarioTests mbScenarioService = Tasty.testGroup "Scenario tests"
           setFilesOfInterest [foo]
           setOpenVirtualResources [vr]
           expectVirtualResourceRegex vr $ T.concat
-            [ "  c, called at .*Foo.daml:6:8 in main:Foo<br>"
-            , "  b, called at .*Foo.daml:4:8 in main:Foo<br>"
-            , "  a, called at .*Foo.daml:10:10 in main:Foo<br>"
+            [ "  c, called at .*Foo.daml:5:7 in main:Foo<br>"
+            , "  b, called at .*Foo.daml:3:7 in main:Foo<br>"
+            , "  a, called at .*Foo.daml:9:9 in main:Foo<br>"
             ]
     , testCase' "debug is lazy" $ do
         let goodScenario =

--- a/compiler/lsp-tests/BUILD.bazel
+++ b/compiler/lsp-tests/BUILD.bazel
@@ -30,6 +30,7 @@ da_haskell_test(
         "network-uri",
         "parser-combinators",
         "process",
+        "regex-tdfa",
         "tasty",
         "tasty-hunit",
         "text",

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -472,6 +472,18 @@ scenarioTests run = testGroup "scenarios"
           expectScenarioContent "Return value: &quot;ok&quot"
           closeDoc scenario
           closeDoc main'
+    , testCase "submit location" $ run $ do
+          main' <- openDoc' "Main.daml" damlId $ T.unlines
+              [ "module Main where"
+              , "template T with party : Party where signatory party"
+              , "main = scenario $ do"
+              , "  alice <- getParty \"Alice\""
+              , "  submit alice do create (T alice)"
+              ]
+          script <- openScript "Main.daml" "main"
+          expectScenarioContent "title=\"Main:5:3\">Main:5:3</a>"
+          closeDoc script
+          closeDoc main'
     ]
 
 scriptTests :: FilePath -> FilePath -> TestTree
@@ -525,6 +537,21 @@ scriptTests damlcPath scriptDarPath = testGroup "scripts"
               ]
           script <- openScript "spaces in path/Main.daml" "main"
           expectScriptContent "Return value: &quot;ok&quot"
+          closeDoc script
+          closeDoc main'
+    , testCase "submit location" $ run $ do
+          main' <- openDoc' "Main.daml" damlId $ T.unlines
+              [ "{-# LANGUAGE ApplicativeDo #-}"
+              , "module Main where"
+              , "import Daml.Script"
+              , "template T with party : Party where signatory party"
+              , "main : Script (ContractId T)"
+              , "main = do"
+              , "  alice <- allocateParty \"Alice\""
+              , "  submit alice do createCmd (T alice)"
+              ]
+          script <- openScript "Main.daml" "main"
+          expectScriptContent "title=\"Main:8:3\">Main:8:3</a>"
           closeDoc script
           closeDoc main'
     ]

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -479,9 +479,11 @@ scenarioTests run = testGroup "scenarios"
               , "main = scenario $ do"
               , "  alice <- getParty \"Alice\""
               , "  submit alice do create (T alice)"
+              , "  submitCreateT alice"
+              , "submitCreateT party = submit party do create (T party)"
               ]
-          script <- openScript "Main.daml" "main"
-          expectScenarioContent "title=\"Main:5:3\">Main:5:3</a>"
+          script <- openScenario "Main.daml" "main"
+          expectScenarioContentMatch "title=\"Main:5:3\">Main:5:3</a>.*title=\"Main:7:1\">Main:7:1</a>"
           closeDoc script
           closeDoc main'
     ]
@@ -549,9 +551,11 @@ scriptTests damlcPath scriptDarPath = testGroup "scripts"
               , "main = do"
               , "  alice <- allocateParty \"Alice\""
               , "  submit alice do createCmd (T alice)"
+              , "  submitCreateT alice"
+              , "submitCreateT party = submit party do createCmd (T party)"
               ]
           script <- openScript "Main.daml" "main"
-          expectScriptContent "title=\"Main:8:3\">Main:8:3</a>"
+          expectScriptContentMatch "title=\"Main:8:3\">Main:8:3</a>.*title=\"Main:10:23\">Main:10:23</a>"
           closeDoc script
           closeDoc main'
     ]

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -27,7 +27,9 @@ module Daml.Script
   ) where
 
 import DA.Functor
+import DA.List.Total (head)
 import DA.Optional
+import DA.Stack
 import DA.Time
 
 -- | A free monad
@@ -234,11 +236,11 @@ data SubmitFailure = SubmitFailure
 -- The @handleFailure@ field is kept on @submit@ for backwards compatibility.
 -- Older versions of the DAML SDK didn't distinguish @Submit@ and
 -- @SubmitMustFail@ in the script runner.
-data SubmitCmd a = SubmitCmd { party : Party, commands : Commands a, handleFailure : SubmitFailure -> a }
+data SubmitCmd a = SubmitCmd { party : Party, commands : Commands a, handleFailure : SubmitFailure -> a, optLocation : Optional (Text, SrcLoc) }
   deriving Functor
 
 -- | Details of the @submitMustFail@ command.
-data SubmitMustFailCmd a = SubmitMustFailCmd { party : Party, commands : Commands a, continue : () -> a }
+data SubmitMustFailCmd a = SubmitMustFailCmd { party : Party, commands : Commands a, continue : () -> a, optLocation : Optional (Text, SrcLoc) }
   deriving Functor
 
 -- | Submit the commands as a single transaction.
@@ -246,10 +248,10 @@ data SubmitMustFailCmd a = SubmitMustFailCmd { party : Party, commands : Command
 -- This will error if the submission fails.
 
 instance HasSubmit Script Commands where
-  submit p cmds = lift $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail)
+  submit p cmds = lift $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail (head $ getCallStack callStack))
     where fail (SubmitFailure status msg) = error $ "Submit failed with code " <> show status <> ": " <> msg
 
-  submitMustFail p cmds = lift $ Free (fmap pure $ SubmitMustFail $ SubmitMustFailCmd p (void cmds) (const ()))
+  submitMustFail p cmds = lift $ Free (fmap pure $ SubmitMustFail $ SubmitMustFailCmd p (void cmds) (const ()) (head $ getCallStack callStack))
 
 -- | This is the type of A DAML script. `Script` is an instance of `Action`,
 -- so you can use `do` notation.

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -27,7 +27,6 @@ module Daml.Script
   ) where
 
 import DA.Functor
-import DA.List.Total (head)
 import DA.Optional
 import DA.Stack
 import DA.Time
@@ -236,11 +235,11 @@ data SubmitFailure = SubmitFailure
 -- The @handleFailure@ field is kept on @submit@ for backwards compatibility.
 -- Older versions of the DAML SDK didn't distinguish @Submit@ and
 -- @SubmitMustFail@ in the script runner.
-data SubmitCmd a = SubmitCmd { party : Party, commands : Commands a, handleFailure : SubmitFailure -> a, optLocation : Optional (Text, SrcLoc) }
+data SubmitCmd a = SubmitCmd { party : Party, commands : Commands a, handleFailure : SubmitFailure -> a, locations : [(Text, SrcLoc)] }
   deriving Functor
 
 -- | Details of the @submitMustFail@ command.
-data SubmitMustFailCmd a = SubmitMustFailCmd { party : Party, commands : Commands a, continue : () -> a, optLocation : Optional (Text, SrcLoc) }
+data SubmitMustFailCmd a = SubmitMustFailCmd { party : Party, commands : Commands a, continue : () -> a, locations : [(Text, SrcLoc)] }
   deriving Functor
 
 -- | Submit the commands as a single transaction.
@@ -248,10 +247,10 @@ data SubmitMustFailCmd a = SubmitMustFailCmd { party : Party, commands : Command
 -- This will error if the submission fails.
 
 instance HasSubmit Script Commands where
-  submit p cmds = lift $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail (head $ getCallStack callStack))
+  submit p cmds = lift $ Free (fmap pure $ Submit $ SubmitCmd p cmds fail (getCallStack callStack))
     where fail (SubmitFailure status msg) = error $ "Submit failed with code " <> show status <> ": " <> msg
 
-  submitMustFail p cmds = lift $ Free (fmap pure $ SubmitMustFail $ SubmitMustFailCmd p (void cmds) (const ()) (head $ getCallStack callStack))
+  submitMustFail p cmds = lift $ Free (fmap pure $ SubmitMustFail $ SubmitMustFailCmd p (void cmds) (const ()) (getCallStack callStack))
 
 -- | This is the type of A DAML script. `Script` is an instance of `Action`,
 -- so you can use `do` notation.

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -404,6 +404,7 @@ object Converter {
             for {
               // TODO[AH] This should be the outer definition. E.g. `main` in `main = do submit ...`.
               //   However, the call-stack only gives us access to the inner definition, `submit` in this case.
+              //   The definition is not used when pretty printing locations. So, we can ignore this.
               definition <- toText(vals.get(0))
               loc <- vals.get(1) match {
                 case SRecord(_, _, vals) if vals.size == 7 =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -397,42 +397,44 @@ object Converter {
       knownPackages: Map[String, PackageId],
       v: SValue): Either[String, Option[Location]] =
     v match {
-      case SList(list) => list.pop match {
-        case None => Right(None)
-        case Some((pair, _)) => pair match {
-          case SRecord(_, _, vals) if vals.size == 2 =>
-            for {
-              // TODO[AH] This should be the outer definition. E.g. `main` in `main = do submit ...`.
-              //   However, the call-stack only gives us access to the inner definition, `submit` in this case.
-              //   The definition is not used when pretty printing locations. So, we can ignore this.
-              definition <- toText(vals.get(0))
-              loc <- vals.get(1) match {
-                case SRecord(_, _, vals) if vals.size == 7 =>
-                  for {
-                    packageId <- toText(vals.get(0)).flatMap {
-                      // GHC uses unit-id "main" for the current package,
-                      // but the scenario context expects "-homePackageId-".
-                      case "main" => PackageId.fromString("-homePackageId-")
-                      case id => knownPackages.get(id).toRight(s"Unknown package $id")
-                    }
-                    module <- toText(vals.get(1)).flatMap(ModuleName.fromString(_))
-                    startLine <- toInt(vals.get(3))
-                    startCol <- toInt(vals.get(4))
-                    endLine <- toInt(vals.get(5))
-                    endCol <- toInt(vals.get(6))
-                  } yield
-                    Location(
-                      packageId,
-                      module,
-                      definition,
-                      (startLine, startCol),
-                      (endLine, endCol))
-                case _ => Left("Expected SRecord of Daml.Script.SrcLoc")
-              }
-            } yield Some(loc)
-          case _ => Left("Expected SRecord of a pair")
+      case SList(list) =>
+        list.pop match {
+          case None => Right(None)
+          case Some((pair, _)) =>
+            pair match {
+              case SRecord(_, _, vals) if vals.size == 2 =>
+                for {
+                  // TODO[AH] This should be the outer definition. E.g. `main` in `main = do submit ...`.
+                  //   However, the call-stack only gives us access to the inner definition, `submit` in this case.
+                  //   The definition is not used when pretty printing locations. So, we can ignore this.
+                  definition <- toText(vals.get(0))
+                  loc <- vals.get(1) match {
+                    case SRecord(_, _, vals) if vals.size == 7 =>
+                      for {
+                        packageId <- toText(vals.get(0)).flatMap {
+                          // GHC uses unit-id "main" for the current package,
+                          // but the scenario context expects "-homePackageId-".
+                          case "main" => PackageId.fromString("-homePackageId-")
+                          case id => knownPackages.get(id).toRight(s"Unknown package $id")
+                        }
+                        module <- toText(vals.get(1)).flatMap(ModuleName.fromString(_))
+                        startLine <- toInt(vals.get(3))
+                        startCol <- toInt(vals.get(4))
+                        endLine <- toInt(vals.get(5))
+                        endCol <- toInt(vals.get(6))
+                      } yield
+                        Location(
+                          packageId,
+                          module,
+                          definition,
+                          (startLine, startCol),
+                          (endLine, endCol))
+                    case _ => Left("Expected SRecord of Daml.Script.SrcLoc")
+                  }
+                } yield Some(loc)
+              case _ => Left("Expected SRecord of a pair")
+            }
         }
-      }
       case _ => Left(s"Expected SList but got $v")
     }
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -397,9 +397,9 @@ object Converter {
       knownPackages: Map[String, PackageId],
       v: SValue): Either[String, Option[Location]] =
     v match {
-      case SOptional(None) => Right(None)
-      case SOptional(Some(pair)) =>
-        pair match {
+      case SList(list) => list.pop match {
+        case None => Right(None)
+        case Some((pair, _)) => pair match {
           case SRecord(_, _, vals) if vals.size == 2 =>
             for {
               // TODO[AH] This should be the outer definition. E.g. `main` in `main = do submit ...`.
@@ -432,7 +432,8 @@ object Converter {
             } yield Some(loc)
           case _ => Left("Expected SRecord of a pair")
         }
-      case _ => Left(s"Expected SOptional but got $v")
+      }
+      case _ => Left(s"Expected SList but got $v")
     }
 
   // Helper to construct a record

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -416,7 +416,6 @@ object Converter {
                       case id => knownPackages.get(id).toRight(s"Unknown package $id")
                     }
                     module <- toText(vals.get(1)).flatMap(ModuleName.fromString(_))
-                    // Lines and columns are 1-based in the call stack.
                     startLine <- toInt(vals.get(3))
                     startCol <- toInt(vals.get(4))
                     endLine <- toInt(vals.get(5))
@@ -426,8 +425,8 @@ object Converter {
                       packageId,
                       module,
                       definition,
-                      (startLine - 1, startCol - 1),
-                      (endLine - 1, endCol - 1))
+                      (startLine, startCol),
+                      (endLine, endCol))
                 case _ => Left("Expected SRecord of Daml.Script.SrcLoc")
               }
             } yield Some(loc)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -367,6 +367,7 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
             v match {
               case SVariant(_, "Submit", _, v) => {
                 v match {
+                  // For backwards compatibility we support SubmitCmd without a callstack.
                   case SRecord(_, _, vals) if vals.size == 3 || vals.size == 4 => {
                     for {
                       freeAp <- vals.get(1) match {
@@ -433,6 +434,7 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
               }
               case SVariant(_, "SubmitMustFail", _, v) => {
                 v match {
+                  // For backwards compatibility we support SubmitCmd without a callstack.
                   case SRecord(_, _, vals) if vals.size == 3 || vals.size == 4 => {
                     for {
                       freeAp <- vals.get(1) match {


### PR DESCRIPTION
Closes #7192

Tracks source locations on `Daml.Script.submit` and `Daml.Script.submitMustFail` such that the transaction view in the IDE contains clickable links to the source location of the commit.

Adds a `HasCallStack` constraint on `HasSubmit.submit` and `HasSubmit.submitMustfail`.

We need to move the definition of `HasCallStack` to `GHC.Stack.Types` to avoid a cyclic dependency between `DA.Stack` and `DA.Internal.LF`. Alternatively, we could inline `HasCallStack` in `DA.Internal.LF` but it seems preferable to use the alias on the signature of `submit(MustFail)`.

We need to adapt the type of the builtins for scenario `submit` and `submitMustfail`.

Adds test cases to the lsp-tests that check for the presence of source locations. Adds tests for both DAML Script and scenarios for completeness.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
