### PR TITLE
participant-integration-api: Create the metrics CSV directory.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/MetricsReporter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/MetricsReporter.scala
@@ -4,7 +4,7 @@
 package com.daml.platform.configuration
 
 import java.net.{InetSocketAddress, URI}
-import java.nio.file.{Path, Paths}
+import java.nio.file.{Files, Path, Paths}
 
 import com.codahale.metrics
 import com.codahale.metrics.{MetricRegistry, ScheduledReporter}
@@ -26,10 +26,12 @@ object MetricsReporter {
   }
 
   final case class Csv(directory: Path) extends MetricsReporter {
-    override def register(registry: MetricRegistry): ScheduledReporter =
+    override def register(registry: MetricRegistry): ScheduledReporter = {
+      Files.createDirectories(directory)
       metrics.CsvReporter
         .forRegistry(registry)
         .build(directory.toFile)
+    }
   }
 
   final case class Graphite(address: InetSocketAddress, prefix: Option[String] = None)


### PR DESCRIPTION
It turns out that if you give the CSV reporter a non-existent directory, it crashes. I did not expect this.

This constructs the directory so you don't have to worry about that.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
