### PR TITLE
metrics: Use `Gauge#getValue` to avoid registering a metric externally.

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -3,6 +3,8 @@
 
 package com.daml.metrics
 
+import java.time.Instant
+
 import com.codahale.metrics.MetricRegistry.MetricSupplier
 import com.codahale.metrics._
 
@@ -430,8 +432,11 @@ final class Metrics(val registry: MetricRegistry) {
       val lastReceivedOffset = new VarGauge[String]("<none>")
       registry.register(Prefix :+ "last_received_offset", lastReceivedOffset)
 
-      def currentRecordTimeLag(value: () => Long): Unit =
-        register(Prefix :+ "current_record_time_lag", () => () => value())
+      registerGauge(
+        Prefix :+ "current_record_time_lag",
+        () => () => Instant.now().toEpochMilli - lastReceivedRecordTime.getValue,
+        registry,
+      )
 
       val stateUpdateProcessing: Timer = registry.timer(Prefix :+ "processed_state_updates")
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -350,9 +350,6 @@ private[indexer] class JdbcIndexer private[indexer] (
         implicit executionContext: ExecutionContext
     ): Resource[IndexFeedHandle] =
       Resource(Future {
-        metrics.daml.indexer.currentRecordTimeLag(() =>
-          Instant.now().toEpochMilli - lastReceivedRecordTime)
-
         val (killSwitch, completionFuture) = readService
           .stateUpdates(startExclusive)
           .viaMat(KillSwitches.single)(Keep.right[NotUsed, UniqueKillSwitch])


### PR DESCRIPTION
This is the same technique as `DerivativeGauge` from the metrics library, but with less code, because Scala is prettier than Java.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
