### PR TITLE
KVL-314 Add test for concurrent double spends

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
@@ -25,7 +25,7 @@ import io.grpc.Status
 import scalaz.Tag
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 final class SemanticTests extends LedgerTestSuite {
   private[this] val onePound = Amount(BigDecimal(1), "GBP")
@@ -86,12 +86,8 @@ final class SemanticTests extends LedgerTestSuite {
                     .transform(Success(_))
             })
           } yield {
-            assertLength(s"Contract $c successful archives", 1, results.collect({
-              case Success(_) => true
-            }))
-            assertLength(s"Contract $c failed archives", archives - 1, results.collect({
-              case Failure(_) => true
-            }))
+            assertLength(s"Contract $c successful archives", 1, results.filter(_.isSuccess))
+            assertLength(s"Contract $c failed archives", archives - 1, results.filter(_.isFailure))
             ()
         })
         .map(_ => ())

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
@@ -25,6 +25,7 @@ import io.grpc.Status
 import scalaz.Tag
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 final class SemanticTests extends LedgerTestSuite {
   private[this] val onePound = Amount(BigDecimal(1), "GBP")
@@ -56,6 +57,44 @@ final class SemanticTests extends LedgerTestSuite {
       } yield {
         assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "couldn't find contract")
       }
+  })
+
+  test(
+    "SemanticConcurrentDoubleSpend",
+    "Cannot concurrently double spend across transactions",
+    allocate(TwoParties, SingleParty),
+  )(implicit ec => {
+    case Participants(Participant(alpha, payer, owner1), Participant(beta, owner2)) =>
+      // This test create a contract and then concurrently archives it several times
+      // through two different participants
+      val contracts = 10 // Number of contracts to create
+      val archives = 10 // Number of concurrent archives per contract
+      Future
+        .traverse((1 to contracts).toList)(c =>
+          for {
+            shared <- alpha.create(payer, SharedContract(payer, owner1, owner2))
+            _ <- synchronize(alpha, beta)
+            results <- Future.traverse((1 to archives).toList)(i =>
+              i % 2 match {
+                case 0 =>
+                  alpha
+                    .exercise(owner1, shared.exerciseSharedContract_Consume1)
+                    .transform(Success(_))
+                case 1 =>
+                  beta
+                    .exercise(owner2, shared.exerciseSharedContract_Consume2)
+                    .transform(Success(_))
+            })
+          } yield {
+            assertLength(s"Contract $c successful archives", 1, results.collect({
+              case Success(_) => true
+            }))
+            assertLength(s"Contract $c failed archives", archives - 1, results.collect({
+              case Failure(_) => true
+            }))
+            ()
+        })
+        .map(_ => ())
   })
 
   test(


### PR DESCRIPTION
This PR adds a conformance test tool test that:
- Creates one contract and then concurrently archives it many times (10 tries across two participants)
- Repeats the above process 10 times

CHANGELOG_BEGIN
CHANGELOG_END

To check whether the test actually triggers the kvutils conflict detection, I have verified that the ledger log contains many lines like the following one:

```
11:53:59.732 ERROR c.d.l.v.b.ConflictDetection - Recovered a conflicted transaction, details='Conflict on contract 00d525918818d8782060b7c5ef2236f62c1370558ec5a198a6936980d8d366dd39' (context: {correlationId=SemanticConcurrentDoubleSpend-alpha-308a4414504b-command-39})
```