### PR TITLE
kvutils: Buffer (im/ex)port streams, and simplify reading a fixed-length ByteString.

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-import java.io.DataOutputStream
+import java.io.{BufferedOutputStream, DataOutputStream}
 import java.nio.file.{Files, Paths}
 
 import com.daml.resources.{Resource, ResourceOwner}
@@ -30,7 +30,8 @@ object LedgerDataExporter {
         .map { path =>
           logger.info(s"Enabled writing ledger entries to $path.")
           ResourceOwner
-            .forCloseable(() => new DataOutputStream(Files.newOutputStream(path)))
+            .forCloseable(() =>
+              new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(path))))
             .acquire()
             .map(new SerializationBasedLedgerDataExporter(_))
         }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SerializationBasedLedgerDataImporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SerializationBasedLedgerDataImporter.scala
@@ -7,6 +7,7 @@ import java.io.DataInputStream
 import java.time.Instant
 
 import com.daml.ledger.participant.state
+import com.google.common.io.ByteStreams
 import com.google.protobuf.ByteString
 
 /**
@@ -54,9 +55,7 @@ final class SerializationBasedLedgerDataImporter(input: DataInputStream)
 
   private def readBytes(): ByteString = {
     val size = input.readInt()
-    val byteArray = new Array[Byte](size)
-    input.readFully(byteArray)
-    ByteString.copyFrom(byteArray)
+    ByteString.readFrom(ByteStreams.limit(input, size.toLong), size)
   }
 
   private def readInstant(): Instant = {

--- a/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/driver/IntegrityCheckV2.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/com/daml/ledger/participant/state/kvutils/tools/driver/IntegrityCheckV2.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.driver
 
-import java.io.DataInputStream
+import java.io.{BufferedInputStream, DataInputStream}
 import java.nio.file.{Files, Paths}
 import java.util.concurrent.Executors
 
@@ -32,7 +32,7 @@ object IntegrityCheckV2 {
     val executionContext: ExecutionContextExecutorService =
       ExecutionContext.fromExecutorService(
         Executors.newFixedThreadPool(sys.runtime.availableProcessors()))
-    val ledgerDumpStream = new DataInputStream(Files.newInputStream(path))
+    val ledgerDumpStream = new DataInputStream(new BufferedInputStream(Files.newInputStream(path)))
     new IntegrityChecker(LogAppendingCommitStrategySupport)
       .run(ledgerDumpStream)(executionContext)
       .andThen {

--- a/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/com/daml/ledger/participant/state/kvutils/test/Replay.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.test
 
-import java.io.DataInputStream
+import java.io.{BufferedInputStream, DataInputStream}
 import java.lang.System.err.println
 import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.TimeUnit
@@ -207,7 +207,7 @@ object Replay {
   private def loadBenchmarks(dumpFile: Path): Map[String, BenchmarkState] = {
     println(s"%%% load ledger export file  $dumpFile...")
     val importer = new SerializationBasedLedgerDataImporter(
-      new DataInputStream(Files.newInputStream(dumpFile)))
+      new DataInputStream(new BufferedInputStream(Files.newInputStream(dumpFile))))
     val transactions = importer.read().map(_._1).flatMap(decodeSubmissionInfo)
     if (transactions.isEmpty) sys.error("no transaction find")
 


### PR DESCRIPTION
Little attempts to make export and import a little faster.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
