### PR TITLE
Add an exclusion for Out of Range tests

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -83,6 +83,21 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        "start": "0.0.0",  # TODO Update to first snapshot after 1.5.0-snapshot.20200825.5071.0.d33e130f
+        "platform_ranges": [
+            {
+                "start": "1.0.0",
+                "end": "1.3.0",
+                "exclusions": [
+                    # See https://github.com/digital-asset/daml/pull/7251
+                    "CommandSubmissionCompletionIT:CSCAfterEnd",
+                    "TransactionServiceIT:TXAfterEnd",
+                    "TransactionServiceIT:TXTreesAfterEnd",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):


### PR DESCRIPTION
The new behavior here was only added in SDK 1.4.0 so the tests
fail (as expected) for older SDK releases. We only test against the
latest stable release on each PR so we didn’t catch this directly on CI.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
