### PR TITLE
Add archiveCmd to DAML Script

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -104,7 +104,11 @@ main =
                       "testMulti = do",
                       "  p <- allocateParty \"p\"",
                       "  (cid1, cid2) <- submit p $ (,) <$> createCmd (T p 23) <*> createCmd (T p 42)",
-                      "  submit p $ (,) <$> exerciseCmd cid1 C <*> exerciseCmd cid2 C"
+                      "  submit p $ (,) <$> exerciseCmd cid1 C <*> exerciseCmd cid2 C",
+                      "testArchive = do",
+                      "  p <- allocateParty \"p\"",
+                      "  cid <- submit p (createCmd (T p 42))",
+                      "  submit p (archiveCmd cid)"
                     ]
                 expectScriptSuccess rs (vr "testCreate") $ \r ->
                   matchRegex r "Active contracts:  #0:0\n\nReturn value: #0:0\n\n$"
@@ -121,7 +125,9 @@ main =
                         "  DA\\.Types:Tuple2@[a-z0-9]+ with",
                         "    _1 = 23; _2 = 42",
                         ""
-                      ],
+                      ]
+                expectScriptSuccess rs (vr "testArchive") $ \r ->
+                  matchRegex r "'p' exercises Archive on #0:0",
               testCase "exerciseByKeyCmd" $ do
                 rs <-
                   runScripts

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -21,6 +21,7 @@ module Daml.Script
   , exerciseCmd
   , exerciseByKeyCmd
   , createAndExerciseCmd
+  , archiveCmd
   , getTime
   , setTime
   , sleep
@@ -286,6 +287,12 @@ exerciseByKeyCmd key arg = Commands $ Ap (\f -> f (ExerciseByKey (templateTypeRe
 -- | Create a contract and exercise a choice on it in the same transacton.
 createAndExerciseCmd : forall t c r. Choice t c r => t -> c -> Commands r
 createAndExerciseCmd tplArg choiceArg = Commands $ Ap (\f -> f (CreateAndExercise (toAnyTemplate tplArg) (toAnyChoice @t choiceArg) identity) (pure fromLedgerValue))
+
+-- | Archive the given contract.
+--
+-- `archiveCmd cid` is equivalent to `exerciseCmd cid Archive`.
+archiveCmd : Choice t Archive () => ContractId t -> Commands ()
+archiveCmd cid = exerciseCmd cid Archive
 
 instance Applicative Script where
     pure a = Script $ \ s -> return (a, s)


### PR DESCRIPTION
Factored out from #7264 and added a test. Just makes the migration a
tiny bit easier.

changelog_begin

- [DAML Script] Add `archiveCmd cid` as a convenience wrapper around
`exerciseCmd cid Archive`.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
