### PR TITLE
Add passTime to DAML Script

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -343,6 +343,7 @@ main =
                       "import Daml.Script",
                       "import DA.Date",
                       "import DA.Time",
+                      "import DA.Assert",
                       "template T",
                       "  with",
                       "    p : Party",
@@ -362,7 +363,16 @@ main =
                       "  t0 <- submit p $ exerciseCmd cid GetTime",
                       "  setTime (time (date 2000 Feb 2) 0 1 2)",
                       "  t1 <- submit p $ exerciseCmd cid GetTime",
-                      "  pure (t0, t1)"
+                      "  pure (t0, t1)",
+                      "testPassTime = do",
+                      "  p <- allocateParty \"p\"",
+                      "  t0 <- getTime",
+                      "  passTime (days 1)",
+                      "  t1 <- getTime",
+                      "  t1 === addRelTime t0 (days 1)",
+                      "  cid <- submit p $ createCmd (T p)",
+                      "  passTime (days (-1))",
+                      "  submit p $ exerciseCmd cid Archive"
                     ]
                 expectScriptSuccess rs (vr "testTime") $ \r ->
                     matchRegex r $
@@ -379,7 +389,10 @@ main =
                           "  DA\\.Types:Tuple2@[a-z0-9]+ with",
                           "    _1 = 1970-01-01T00:00:00Z; _2 = 2000-02-02T00:01:02Z",
                           ""
-                        ],
+                        ]
+                expectScriptFailure rs (vr "testPassTime") $ \r ->
+                    matchRegex r "Attempt to fetch or exercise a contract not yet effective"
+            ,
               testCase "partyManagement" $ do
                 rs <-
                   runScripts

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -23,6 +23,7 @@ module Daml.Script
   , createAndExerciseCmd
   , getTime
   , setTime
+  , passTime
   , sleep
   ) where
 
@@ -112,11 +113,26 @@ data SetTimePayload a = SetTimePayload
 --
 -- This is only supported in static time mode when running over the gRPC API.
 --
--- Note that the time service does not support going backwards in time.
+-- Note that the ledger time service does not support going backwards in time.
+-- However, you can go back in time in DAML Studio.
 setTime : Time -> Script ()
 setTime time = lift $ Free $ SetTime $ SetTimePayload with
   time
   continue = pure
+
+-- | Advance ledger time by the given interval.
+--
+-- Only supported in static time mode when running over the gRPC API
+-- and in DAML Studio. Note that this is not an atomic operation over the
+-- gRPC API so no other clients should try to change time while this is
+-- running.
+--
+-- Note that the ledger time service does not support going backwards in time.
+-- However, you can go back in time in DAML Studio.
+passTime : RelTime -> Script ()
+passTime rt = do
+  t <- getTime
+  setTime (addRelTime t rt)
 
 data AllocateParty a = AllocateParty
   { displayName : Text

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -547,13 +547,10 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       esf: ExecutionSequencerFactory,
       mat: Materializer): Future[Unit] = {
     val diff = time.micros - scenarioRunner.ledger.currentTime.micros
-    // ScenarioLedger only provides pass, so we have to check the difference.
-    if (diff < 0) {
-      Future.failed(new RuntimeException("Time cannot be set backwards"))
-    } else {
-      scenarioRunner.ledger = scenarioRunner.ledger.passTime(diff)
-      Future.unit
-    }
+    // ScenarioLedger only provides pass, so we have to calculate the diff.
+    // Note that ScenarioLedger supports going backwards in time.
+    scenarioRunner.ledger = scenarioRunner.ledger.passTime(diff)
+    Future.unit
   }
 }
 


### PR DESCRIPTION
I’ve also removed the restriction to only support going forward since
scenarios don’t have that restriction and it seems potentially useful
for tests.

factored out from #7264

changelog_begin

- [DAML Script] Add `passTime` helper to advance the time by the
  given interval.

- [DAML Script] In DAML Studio, you can now set the time to the
  past. This is not supported when running against a ledger.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
