### PR TITLE
Add a `script` helper to DAML Script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -24,6 +24,7 @@ module Daml.Script
   , getTime
   , setTime
   , sleep
+  , script
   ) where
 
 import DA.Functor
@@ -304,3 +305,11 @@ lift : Free ScriptF a -> Script a
 lift m = Script $ \s -> do
   a <- m
   pure (a, s)
+
+-- | Convenience helper to declare you are writing a Script.
+--
+-- This is only useful for readability and to improve type inference.
+-- Any expression of type `Script a` is a valid script regardless of whether
+-- it is implemented using `script` or not.
+script : Script a -> Script a
+script = identity


### PR DESCRIPTION
Factored out from #7264

We have enough cases of scenarios that don’t actually do ledger
operations and need some hint for type inference. While adding type
annotations works, this is a bit easier at least for the migration and
some people might prefer it.

No test, since this seems a bit excessive here :)

changelog_begin

- [DAML Script] Add a `script` function to aid type inference. This
  is the equivalent of `scenario`.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
