### PR TITLE
Ensure shortIdentifier for ledger api tests do not overlap partially with other shortIdentifiers

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -22,7 +22,7 @@ import scala.util.{Failure, Success}
 final class CommandDeduplicationIT extends LedgerTestSuite {
 
   test(
-    "CDSimpleDeduplication",
+    "CDSimpleDeduplicationBasic",
     "Deduplicate commands within the deduplication time window",
     allocate(SingleParty),
   )(implicit ec => {
@@ -191,7 +191,7 @@ final class CommandDeduplicationIT extends LedgerTestSuite {
   })
 
   test(
-    "CDDeduplicateSubmitter",
+    "CDDeduplicateSubmitterBasic",
     "Commands with identical submitter and command identifier should be deduplicated by the submission client",
     allocate(TwoParties),
   )(implicit ec => {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
@@ -120,7 +120,7 @@ final class CommandServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "CSsubmitAndWaitForTransactionTree",
+    "CSsubmitAndWaitForTransactionTreeBasic",
     "SubmitAndWaitForTransactionTree returns a transaction tree",
     allocate(SingleParty),
   )(implicit ec => {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
@@ -41,7 +41,7 @@ final class CommandServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "CSsubmitAndWaitForTransactionId",
+    "CSsubmitAndWaitForTransactionIdBasic",
     "SubmitAndWaitForTransactionId returns a valid transaction identifier",
     allocate(SingleParty),
   )(implicit ec => {
@@ -90,7 +90,7 @@ final class CommandServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "CSsubmitAndWaitForTransaction",
+    "CSsubmitAndWaitForTransactionBasic",
     "SubmitAndWaitForTransaction returns a transaction",
     allocate(SingleParty),
   )(implicit ec => {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandServiceIT.scala
@@ -24,7 +24,7 @@ import scalaz.syntax.tag._
 
 final class CommandServiceIT extends LedgerTestSuite {
   test(
-    "CSsubmitAndWait",
+    "CSsubmitAndWaitBasic",
     "SubmitAndWait creates a contract of the expected template",
     allocate(SingleParty),
   )(implicit ec => {
@@ -150,7 +150,7 @@ final class CommandServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "CSduplicateSubmitAndWait",
+    "CSduplicateSubmitAndWaitBasic",
     "SubmitAndWait should fail on duplicate requests",
     allocate(SingleParty),
   )(implicit ec => {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
@@ -43,7 +43,7 @@ final class SemanticTests extends LedgerTestSuite {
    */
 
   test(
-    "SemanticDoubleSpend",
+    "SemanticDoubleSpendBasic",
     "Cannot double spend across transactions",
     allocate(TwoParties, TwoParties),
   )(implicit ec => {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionServiceIT.scala
@@ -756,7 +756,7 @@ class TransactionServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "TXAgreementText",
+    "TXAgreementTextExplicit",
     "Expose the agreement text for templates with an explicit agreement text",
     allocate(SingleParty),
   )(implicit ec => {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/TransactionServiceIT.scala
@@ -817,7 +817,7 @@ class TransactionServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "TXMultiActorChoiceOk",
+    "TXMultiActorChoiceOkBasic",
     "Accept exercising a well-authorized multi-actor choice",
     allocate(TwoParties, SingleParty),
   )(implicit ec => {
@@ -946,7 +946,7 @@ class TransactionServiceIT extends LedgerTestSuite {
     })
 
   test(
-    "TXSingleMultiSame",
+    "TXSingleMultiSameBasic",
     "The same transaction should be served regardless of subscribing as one or multiple parties",
     allocate(TwoParties),
   )(implicit ec => {
@@ -1172,7 +1172,7 @@ class TransactionServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "TXTransactionTreeById",
+    "TXTransactionTreeByIdBasic",
     "Expose a visible transaction tree by identifier",
     allocate(SingleParty),
   )(implicit ec => {
@@ -1251,7 +1251,7 @@ class TransactionServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "TXFlatTransactionById",
+    "TXFlatTransactionByIdBasic",
     "Expose a visible transaction by identifier",
     allocate(SingleParty))(implicit ec => {
     case Participants(Participant(ledger, party)) =>
@@ -1328,7 +1328,7 @@ class TransactionServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "TXTransactionTreeByEventId",
+    "TXTransactionTreeByEventIdBasic",
     "Expose a visible transaction tree by event identifier",
     allocate(SingleParty),
   )(implicit ec => {
@@ -1398,7 +1398,7 @@ class TransactionServiceIT extends LedgerTestSuite {
   })
 
   test(
-    "TXFlatTransactionByEventId",
+    "TXFlatTransactionByEventIdBasic",
     "Expose a visible flat transaction by event identifier",
     allocate(SingleParty),
   )(implicit ec => {


### PR DESCRIPTION
Unique shortIdentifier for each test in ledger-api-test-tool suite that does not contain a partial overlap with others, to facilitate running each test in isolation, if need be.

At present, the tests to run are matched as a pattern against the concatenation of class name + shortIdentifier

The pattern matching works well when you want to run multiple tests in a suite, or even when you want to run multiple tests that share a common partial name.

There are a few tests that are named in a way that their unique name also matches partially with the names of others -- this we want to avoid so there is always a way to run a specific test (and only that test) when trying to isolate an issue or troubleshoot that particular test.

A simple suggestion to do this is just to make sure that the shortIdentifier of each test is unique and does not include an overlap on partial name with any other test.

First cut is a manual update to do this - a broader automated suggestion from @SamirTalwar is to make sure that no test name is a prefix of any other test