### PR TITLE
Fix partial tx and commit locs in the script service

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -384,100 +384,111 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
     compiledPackages.compiler.unsafeCompile(cmds)
   }
 
+  // unsafe version of submit that does not clear the commit.
+  private def unsafeSubmit(
+      party: SParty,
+      commands: List[ScriptLedgerClient.Command],
+      optLocation: Option[Location])(implicit ec: ExecutionContext)
+    : Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = Future {
+    // Clear state at the beginning like in SBSBeginCommit for scenarios.
+    machine.commitLocation = optLocation
+    machine.returnValue = null
+    machine.localContracts = Map.empty
+    machine.globalDiscriminators = Set.empty
+    val translated = translateCommands(commands)
+    machine.setExpressionToEvaluate(SEApp(translated, Array(SEValue.Token)))
+    machine.committers = Set(party.value)
+    var result: Seq[ScriptLedgerClient.CommandResult] = null
+    while (result == null) {
+      machine.run() match {
+        case SResultNeedContract(coid, tid @ _, committers, cbMissing, cbPresent) =>
+          scenarioRunner.lookupContract(coid, committers, cbMissing, cbPresent).toTry.get
+        case SResultNeedKey(keyWithMaintainers, committers, cb) =>
+          scenarioRunner.lookupKey(keyWithMaintainers.globalKey, committers, cb).toTry.get
+        case SResultFinalValue(SUnit) =>
+          machine.ptx.finish(
+            machine.outputTransactionVersions,
+            machine.compiledPackages.packageLanguageVersion) match {
+            case PartialTransaction.CompleteTransaction(tx) =>
+              val results: ImmArray[ScriptLedgerClient.CommandResult] = tx.roots.map { n =>
+                tx.nodes(n) match {
+                  case create: NodeCreate.WithTxValue[ContractId] =>
+                    ScriptLedgerClient.CreateResult(create.coid)
+                  case exercise: NodeExercises.WithTxValue[_, ContractId] =>
+                    ScriptLedgerClient.ExerciseResult(
+                      exercise.templateId,
+                      exercise.choiceId,
+                      exercise.exerciseResult.get.value)
+                  case n =>
+                    // Root nodes can only be creates and exercises.
+                    throw new RuntimeException(s"Unexpected node: $n")
+                }
+              }
+              ScenarioLedger.commitTransaction(
+                committer = party.value,
+                effectiveAt = scenarioRunner.ledger.currentTime,
+                optLocation = machine.commitLocation,
+                tx = tx,
+                l = scenarioRunner.ledger
+              ) match {
+                case Left(fas) =>
+                  // Capture the error and exit.
+                  throw ScenarioErrorCommitError(fas)
+                case Right(commitResult) =>
+                  scenarioRunner.ledger = commitResult.newLedger
+                  // Capture the result and exit.
+                  result = results.toSeq
+              }
+            case PartialTransaction.IncompleteTransaction(ptx) =>
+              throw new RuntimeException(s"Unexpected abort: $ptx")
+            case err: PartialTransaction.SerializationError =>
+              throw new RuntimeException(err.prettyMessage)
+          }
+        case SResultFinalValue(v) =>
+          // The final result should always be unit.
+          throw new RuntimeException(s"FATAL: Unexpected non-unit final result: $v")
+        case SResultScenarioCommit(_, _, _, _) =>
+          throw new RuntimeException("FATAL: Encountered scenario commit in DAML Script")
+        case SResultError(err) =>
+          // Capture the error and exit.
+          throw err
+        case SResultNeedTime(callback) =>
+          callback(scenarioRunner.ledger.currentTime)
+        case SResultNeedPackage(pkg, callback @ _) =>
+          throw new RuntimeException(
+            s"FATAL: Missing package $pkg should have been reported at Script compilation")
+        case SResultScenarioInsertMustFail(committers @ _, optLocation @ _) =>
+          throw new RuntimeException(
+            "FATAL: Encountered scenario instruction for submitMustFail in DAML script")
+        case SResultScenarioMustFail(ptx @ _, committers @ _, callback @ _) =>
+          throw new RuntimeException(
+            "FATAL: Encountered scenario instruction for submitMustFail in DAML Script")
+        case SResultScenarioPassTime(relTime @ _, callback @ _) =>
+          throw new RuntimeException(
+            "FATAL: Encountered scenario instruction setTime in DAML Script")
+        case SResultScenarioGetParty(partyText @ _, callback @ _) =>
+          throw new RuntimeException(
+            "FATAL: Encountered scenario instruction getParty in DAML Script")
+      }
+    }
+    Right(result)
+  }
+
   override def submit(
       party: SParty,
       commands: List[ScriptLedgerClient.Command],
       optLocation: Option[Location])(implicit ec: ExecutionContext, mat: Materializer)
-    : Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = Future {
-    try {
-      machine.commitLocation = optLocation
-      machine.returnValue = null
-      val translated = translateCommands(commands)
-      machine.setExpressionToEvaluate(SEApp(translated, Array(SEValue.Token)))
-      machine.committers = Set(party.value)
-      var result: Seq[ScriptLedgerClient.CommandResult] = null
-      while (result == null) {
-        machine.run() match {
-          case SResultNeedContract(coid, tid @ _, committers, cbMissing, cbPresent) =>
-            scenarioRunner.lookupContract(coid, committers, cbMissing, cbPresent).toTry.get
-          case SResultNeedKey(keyWithMaintainers, committers, cb) =>
-            scenarioRunner.lookupKey(keyWithMaintainers.globalKey, committers, cb).toTry.get
-          case SResultFinalValue(SUnit) =>
-            machine.ptx.finish(
-              machine.outputTransactionVersions,
-              machine.compiledPackages.packageLanguageVersion) match {
-              case PartialTransaction.CompleteTransaction(tx) =>
-                val results: ImmArray[ScriptLedgerClient.CommandResult] = tx.roots.map { n =>
-                  tx.nodes(n) match {
-                    case create: NodeCreate.WithTxValue[ContractId] =>
-                      ScriptLedgerClient.CreateResult(create.coid)
-                    case exercise: NodeExercises.WithTxValue[_, ContractId] =>
-                      ScriptLedgerClient.ExerciseResult(
-                        exercise.templateId,
-                        exercise.choiceId,
-                        exercise.exerciseResult.get.value)
-                    case n =>
-                      // Root nodes can only be creates and exercises.
-                      throw new RuntimeException(s"Unexpected node: $n")
-                  }
-                }
-                ScenarioLedger.commitTransaction(
-                  committer = party.value,
-                  effectiveAt = scenarioRunner.ledger.currentTime,
-                  optLocation = machine.commitLocation,
-                  tx = tx,
-                  l = scenarioRunner.ledger
-                ) match {
-                  case Left(fas) =>
-                    // Capture the error and exit.
-                    throw ScenarioErrorCommitError(fas)
-                  case Right(commitResult) =>
-                    scenarioRunner.ledger = commitResult.newLedger
-                    // Capture the result and exit.
-                    result = results.toSeq
-                }
-              case PartialTransaction.IncompleteTransaction(ptx) =>
-                throw new RuntimeException(s"Unexpected abort: $ptx")
-              case err: PartialTransaction.SerializationError =>
-                throw new RuntimeException(err.prettyMessage)
-            }
-          case SResultFinalValue(v) =>
-            // The final result should always be unit.
-            throw new RuntimeException(s"FATAL: Unexpected non-unit final result: $v")
-          case SResultScenarioCommit(_, _, _, _) =>
-            throw new RuntimeException("FATAL: Encountered scenario commit in DAML Script")
-          case SResultError(err) =>
-            // Capture the error and exit.
-            throw err
-          case SResultNeedTime(callback) =>
-            callback(scenarioRunner.ledger.currentTime)
-          case SResultNeedPackage(pkg, callback @ _) =>
-            throw new RuntimeException(
-              s"FATAL: Missing package $pkg should have been reported at Script compilation")
-          case SResultScenarioInsertMustFail(committers @ _, optLocation @ _) =>
-            throw new RuntimeException(
-              "FATAL: Encountered scenario instruction for submitMustFail in DAML script")
-          case SResultScenarioMustFail(ptx @ _, committers @ _, callback @ _) =>
-            throw new RuntimeException(
-              "FATAL: Encountered scenario instruction for submitMustFail in DAML Script")
-          case SResultScenarioPassTime(relTime @ _, callback @ _) =>
-            throw new RuntimeException(
-              "FATAL: Encountered scenario instruction setTime in DAML Script")
-          case SResultScenarioGetParty(partyText @ _, callback @ _) =>
-            throw new RuntimeException(
-              "FATAL: Encountered scenario instruction getParty in DAML Script")
-        }
-      }
-      Right(result)
-    } finally {
-      // Reset the machine
-      machine.commitLocation = None
-      machine.returnValue = null
-      machine.clearCommit
-      machine.localContracts = Map.empty
-      machine.globalDiscriminators = Set.empty
+    : Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] =
+    unsafeSubmit(party, commands, optLocation).map {
+      case Right(x) =>
+        // Expected successful commit so clear.
+        machine.clearCommit
+        Right(x)
+      case Left(err) =>
+        // Unexpected failure, do not clear so we can display the partial
+        // transaction.
+        Left(err)
     }
-  }
 
   override def submitMustFail(
       party: SParty,
@@ -485,14 +496,18 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       optLocation: Option[Location])(
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Either[Unit, Unit]] = {
-    submit(party, commands, optLocation)
+    unsafeSubmit(party, commands, optLocation)
       .map({
         case Right(_) => Left(())
         // We don't expect to hit this case but list it for completeness.
         case Left(_) => Right(())
       })
       .recoverWith({
-        case _: SError => Future.successful(Right(()))
+        case _: SError =>
+          // Expected failed commit so clear, we do not clear on
+          // unexpected successes to keep the partial transaction.
+          machine.clearCommit
+          Future.successful(Right(()))
       })
   }
 


### PR DESCRIPTION
It turns out we were too aggressive in resetting the state. We only
want to reset in `submit` on successful commit and in `submitMustFail`
on failed commits. I’ve also split the reset in two parts, one that is
done at the beginning every time and one at the end. I don’t think it
really makes a difference but it matches what the scenario runner does
which at least makes me stop wondering if the difference matters.

fixes #7275 fixes #7276

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
