### PR TITLE
ledger-api-client: Rename `maxInboundMessageSize` to `maxInboundMetadataSize`.

### DIFF
--- a/extractor/BUILD.bazel
+++ b/extractor/BUILD.bazel
@@ -112,7 +112,6 @@ da_scala_library(
         "@maven//:io_circe_circe_core_2_12",
         "@maven//:io_circe_circe_generic_2_12",
         "@maven//:io_circe_circe_parser_2_12",
-        "@maven//:io_grpc_grpc_netty",
         "@maven//:io_netty_netty_handler",
         "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HttpService.scala
@@ -12,7 +12,6 @@ import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.Materializer
 import com.daml.auth.TokenHolder
 import com.daml.grpc.adapter.ExecutionSequencerFactory
-import com.daml.scalautil.Statement.discard
 import com.daml.http.dbbackend.ContractDao
 import com.daml.http.json.{
   ApiValueToJsValueConverter,
@@ -21,7 +20,6 @@ import com.daml.http.json.{
   JsValueToApiValueConverter
 }
 import com.daml.http.util.ApiValueToLfValueConverter
-import com.daml.util.ExceptionOps._
 import com.daml.http.util.FutureUtil._
 import com.daml.http.util.IdentifierConverters.apiLedgerId
 import com.daml.jwt.JwtDecoder
@@ -38,8 +36,9 @@ import com.daml.ledger.client.services.pkg.PackageClient
 import com.daml.ledger.service.LedgerReader
 import com.daml.ledger.service.LedgerReader.PackageStore
 import com.daml.ports.{Port, PortFiles}
+import com.daml.scalautil.Statement.discard
+import com.daml.util.ExceptionOps._
 import com.typesafe.scalalogging.StrictLogging
-import io.grpc.netty.NettyChannelBuilder
 import scalaz.Scalaz._
 import scalaz._
 
@@ -107,20 +106,21 @@ object HttpService extends StrictLogging {
       commandClient = CommandClientConfiguration.default,
       sslContext = tlsConfig.client,
       token = tokenHolder.flatMap(_.token),
+      maxInboundMessageSize = maxInboundMessageSize,
     )
 
     val bindingEt: EitherT[Future, Error, ServerBinding] = for {
       client <- eitherT(
-        ledgerClient(ledgerHost, ledgerPort, clientConfig, maxInboundMessageSize)
+        ledgerClient(ledgerHost, ledgerPort, clientConfig)
       ): ET[LedgerClient]
 
       pkgManagementClient <- eitherT(
         ledgerClient(
           ledgerHost,
           ledgerPort,
-          clientConfig,
-          packageMaxInboundMessageSize.getOrElse(maxInboundMessageSize))
-      ): ET[LedgerClient]
+          packageMaxInboundMessageSize.fold(clientConfig)(size =>
+            clientConfig.copy(maxInboundMessageSize = size)),
+        )): ET[LedgerClient]
 
       ledgerId = apiLedgerId(client.ledgerId): lar.LedgerId
 
@@ -304,15 +304,9 @@ object HttpService extends StrictLogging {
       ledgerHost: String,
       ledgerPort: Int,
       clientConfig: LedgerClientConfiguration,
-      maxInboundMessageSize: Int,
   )(implicit ec: ExecutionContext, aesf: ExecutionSequencerFactory): Future[Error \/ LedgerClient] =
     LedgerClient
-      .fromBuilder(
-        NettyChannelBuilder
-          .forAddress(ledgerHost, ledgerPort)
-          .maxInboundMessageSize(maxInboundMessageSize),
-        clientConfig,
-      )
+      .singleHost(ledgerHost, ledgerPort, clientConfig)
       .map(_.right)
       .recover {
         case NonFatal(e) =>

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/GrpcChannel.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/GrpcChannel.scala
@@ -21,7 +21,7 @@ object GrpcChannel {
   ): ManagedChannel = {
     configuration.sslContext
       .fold(builder.usePlaintext())(builder.sslContext(_).negotiationType(NegotiationType.TLS))
-    builder.maxInboundMetadataSize(configuration.maxInboundMessageSize)
+    builder.maxInboundMetadataSize(configuration.maxInboundMetadataSize)
     builder.build()
   }
 

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/GrpcChannel.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/GrpcChannel.scala
@@ -22,6 +22,7 @@ object GrpcChannel {
     configuration.sslContext
       .fold(builder.usePlaintext())(builder.sslContext(_).negotiationType(NegotiationType.TLS))
     builder.maxInboundMetadataSize(configuration.maxInboundMetadataSize)
+    builder.maxInboundMessageSize(configuration.maxInboundMessageSize)
     builder.build()
   }
 

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
@@ -7,12 +7,12 @@ import io.grpc.internal.GrpcUtil
 import io.netty.handler.ssl.SslContext
 
 /**
-  * @param applicationId         The string that will be used as an application identifier when issuing commands and retrieving transactions
-  * @param ledgerIdRequirement   A [[LedgerIdRequirement]] specifying how the ledger identifier must be checked against the one returned by the LedgerIdentityService
-  * @param commandClient         The [[CommandClientConfiguration]] that defines how the command client should be setup with regards to timeouts, commands in flight and command TTL
-  * @param sslContext            If defined, the context will be passed on to the underlying gRPC code to ensure the communication channel is secured by TLS
-  * @param token                 If defined, the access token that will be passed by default, unless overridden in individual calls (mostly useful for short-lived applications)
-  * @param maxInboundMessageSize The maximum size of the response headers.
+  * @param applicationId          The string that will be used as an application identifier when issuing commands and retrieving transactions
+  * @param ledgerIdRequirement    A [[LedgerIdRequirement]] specifying how the ledger identifier must be checked against the one returned by the LedgerIdentityService
+  * @param commandClient          The [[CommandClientConfiguration]] that defines how the command client should be setup with regards to timeouts, commands in flight and command TTL
+  * @param sslContext             If defined, the context will be passed on to the underlying gRPC code to ensure the communication channel is secured by TLS
+  * @param token                  If defined, the access token that will be passed by default, unless overridden in individual calls (mostly useful for short-lived applications)
+  * @param maxInboundMetadataSize The maximum size of the response headers.
   */
 final case class LedgerClientConfiguration(
     applicationId: String,
@@ -20,5 +20,5 @@ final case class LedgerClientConfiguration(
     commandClient: CommandClientConfiguration,
     sslContext: Option[SslContext],
     token: Option[String] = None,
-    maxInboundMessageSize: Int = GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
+    maxInboundMetadataSize: Int = GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
 )

--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/configuration/LedgerClientConfiguration.scala
@@ -13,6 +13,7 @@ import io.netty.handler.ssl.SslContext
   * @param sslContext             If defined, the context will be passed on to the underlying gRPC code to ensure the communication channel is secured by TLS
   * @param token                  If defined, the access token that will be passed by default, unless overridden in individual calls (mostly useful for short-lived applications)
   * @param maxInboundMetadataSize The maximum size of the response headers.
+  * @param maxInboundMessageSize  The maximum (uncompressed) size of the response body.
   */
 final case class LedgerClientConfiguration(
     applicationId: String,
@@ -21,4 +22,5 @@ final case class LedgerClientConfiguration(
     sslContext: Option[SslContext],
     token: Option[String] = None,
     maxInboundMetadataSize: Int = GrpcUtil.DEFAULT_MAX_HEADER_LIST_SIZE,
+    maxInboundMessageSize: Int = GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE,
 )

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -56,7 +56,6 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
         "@maven//:com_zaxxer_HikariCP",
-        "@maven//:io_grpc_grpc_netty",
         "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_flywaydb_flyway_core",
         "@maven//:org_scalaz_scalaz_core_2_12",


### PR DESCRIPTION
### Changelog

- **[Scala Bindings]** Rename a field in the `LedgerClientConfiguration` to `maxInboundMetadataSize`, to match the builder Netty channel builder. It was incorrectly named `maxInboundMessageSize`, which is a different channel property that configures the maximum message size, not the header size.
- **[Scala Bindings]** Replace the `LedgerClientConfiguration.maxInboundMessageSize` property with a new one that represents the maximum size of the response body.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
