### PR TITLE
Only include stakeholder contracts in result of query

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -593,11 +593,11 @@ case class ScenarioLedger(
 
   def query(
       view: View,
-      effectiveAt: Time.Timestamp): Seq[(ContractId, ContractInst[Tx.Value[ContractId]])] = {
+      effectiveAt: Time.Timestamp): Seq[LookupOk] = {
     ledgerData.activeContracts.toList
       .map(cid => lookupGlobalContract(view, effectiveAt, cid))
       .collect {
-        case LookupOk(cid, coinst, _) => (cid, coinst)
+        case l @ LookupOk(_ , _, _) => l
       }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -594,11 +594,11 @@ case class ScenarioLedger(
   def query(
       view: View,
       effectiveAt: Time.Timestamp,
-    ): Seq[LookupOk] = {
+  ): Seq[LookupOk] = {
     ledgerData.activeContracts.toList
       .map(cid => lookupGlobalContract(view, effectiveAt, cid))
       .collect {
-        case l @ LookupOk(_ , _, _) => l
+        case l @ LookupOk(_, _, _) => l
       }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -593,7 +593,8 @@ case class ScenarioLedger(
 
   def query(
       view: View,
-      effectiveAt: Time.Timestamp): Seq[LookupOk] = {
+      effectiveAt: Time.Timestamp,
+    ): Seq[LookupOk] = {
     ledgerData.activeContracts.toList
       .map(cid => lookupGlobalContract(view, effectiveAt, cid))
       .collect {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -351,7 +351,7 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       effectiveAt = scenarioRunner.ledger.currentTime)
     // Filter to contracts of the given template id.
     val filtered = acs.collect {
-      case (cid, Value.ContractInst(tpl, arg, _)) if tpl == templateId => (cid, arg)
+      case ScenarioLedger.LookupOk(cid, Value.ContractInst(tpl, arg, _), stakeholders) if tpl == templateId && stakeholders.contains(party.value) => (cid, arg)
     }
     Future.successful(filtered.map {
       case (cid, c) => ScriptLedgerClient.ActiveContract(templateId, cid, c.value)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -350,7 +350,9 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       view = ScenarioLedger.ParticipantView(party.value),
       effectiveAt = scenarioRunner.ledger.currentTime)
     val filtered = acs.collect {
-      case ScenarioLedger.LookupOk(cid, Value.ContractInst(tpl, arg, _), stakeholders) if tpl == templateId && stakeholders.contains(party.value) => (cid, arg)
+      case ScenarioLedger.LookupOk(cid, Value.ContractInst(tpl, arg, _), stakeholders)
+          if tpl == templateId && stakeholders.contains(party.value) =>
+        (cid, arg)
     }
     Future.successful(filtered.map {
       case (cid, c) => ScriptLedgerClient.ActiveContract(templateId, cid, c.value)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -349,7 +349,6 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
     val acs = scenarioRunner.ledger.query(
       view = ScenarioLedger.ParticipantView(party.value),
       effectiveAt = scenarioRunner.ledger.currentTime)
-    // Filter to contracts of the given template id.
     val filtered = acs.collect {
       case ScenarioLedger.LookupOk(cid, Value.ContractInst(tpl, arg, _), stakeholders) if tpl == templateId && stakeholders.contains(party.value) => (cid, arg)
     }


### PR DESCRIPTION
This fixes a bug in the script service. We need to filter out divulged
contracts since this should behave exactly like the ACS endpoint on
the ledger API.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
