### PR TITLE
Fix trace statement handling in DAML Script service

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -240,6 +240,7 @@ class ReplService(
       new Runner(compiledPackages, Script.Action(scriptExpr, ScriptIds(scriptPackageId)), timeMode)
     runner
       .runWithClients(clients)
+      ._2
       .map { v =>
         (v, req.getFormat match {
           case RunScriptRequest.Format.TEXT_ONLY =>

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -116,12 +116,25 @@ class ScenarioService(
                 errOrValue match {
                   case Left(err) =>
                     builder.setError(
-                      new Conversions(context.homePackageId, ledger, machine)
+                      new Conversions(
+                        context.homePackageId,
+                        ledger,
+                        machine.ptx,
+                        machine.traceLog,
+                        machine.commitLocation,
+                        machine.stackTrace())
                         .convertScenarioError(err),
                     )
                   case Right(value) =>
-                    builder.setResult(new Conversions(context.homePackageId, ledger, machine)
-                      .convertScenarioResult(value))
+                    builder.setResult(
+                      new Conversions(
+                        context.homePackageId,
+                        ledger,
+                        machine.ptx,
+                        machine.traceLog,
+                        machine.commitLocation,
+                        machine.stackTrace())
+                        .convertScenarioResult(value))
                 }
                 builder.build
             }
@@ -160,17 +173,30 @@ class ScenarioService(
           context
             .interpretScript(packageId, scenarioId.getName)
             .map(_.map {
-              case (ledger, machine, errOrValue) =>
+              case (ledger, (clientMachine, ledgerMachine), errOrValue) =>
                 val builder = RunScenarioResponse.newBuilder
                 errOrValue match {
                   case Left(err) =>
                     builder.setError(
-                      new Conversions(context.homePackageId, ledger, machine)
+                      new Conversions(
+                        context.homePackageId,
+                        ledger,
+                        ledgerMachine.ptx,
+                        clientMachine.traceLog,
+                        ledgerMachine.commitLocation,
+                        ledgerMachine.stackTrace())
                         .convertScenarioError(err),
                     )
                   case Right(value) =>
-                    builder.setResult(new Conversions(context.homePackageId, ledger, machine)
-                      .convertScenarioResult(value))
+                    builder.setResult(
+                      new Conversions(
+                        context.homePackageId,
+                        ledger,
+                        ledgerMachine.ptx,
+                        clientMachine.traceLog,
+                        ledgerMachine.commitLocation,
+                        ledgerMachine.stackTrace())
+                        .convertScenarioResult(value))
                 }
                 builder.build
             })

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -3,10 +3,10 @@
 
 package com.daml.lf.scenario
 
-import com.daml.lf.data.{Numeric, Ref}
+import com.daml.lf.data.{ImmArray, Numeric, Ref}
 import com.daml.lf.ledger.EventId
 import com.daml.lf.scenario.api.{v1 => proto}
-import com.daml.lf.speedy.{SError, SValue, Speedy, PartialTransaction => SPartialTransaction}
+import com.daml.lf.speedy.{SError, SValue, PartialTransaction => SPartialTransaction, TraceLog}
 import com.daml.lf.transaction.{GlobalKey, Node => N, NodeId, Transaction => Tx}
 import com.daml.lf.ledger._
 import com.daml.lf.value.{Value => V}
@@ -16,7 +16,10 @@ import scala.collection.JavaConverters._
 final class Conversions(
     homePackageId: Ref.PackageId,
     ledger: ScenarioLedger,
-    machine: Speedy.Machine,
+    ptx: SPartialTransaction,
+    traceLog: TraceLog,
+    commitLocation: Option[Ref.Location],
+    stackTrace: ImmArray[Ref.Location],
 ) {
 
   private val empty: proto.Empty = proto.Empty.newBuilder.build
@@ -26,7 +29,7 @@ final class Conversions(
 
   // The ledger data will not contain information from the partial transaction at this point.
   // We need the mapping for converting error message so we manually add it here.
-  private val ptxCoidToNodeId = machine.ptx.nodes
+  private val ptxCoidToNodeId = ptx.nodes
     .collect {
       case (nodeId, node: N.NodeCreate[V.ContractId, _]) =>
         node.coid -> ledger.ptxEventId(nodeId)
@@ -47,7 +50,7 @@ final class Conversions(
       .addAllScenarioSteps(steps.asJava)
       .setReturnValue(convertSValue(svalue))
       .setFinalTime(ledger.currentTime.micros)
-    machine.traceLog.iterator.foreach { entry =>
+    traceLog.iterator.foreach { entry =>
       builder.addTraceLog(convertSTraceMessage(entry))
     }
     builder.build
@@ -61,20 +64,20 @@ final class Conversions(
       .addAllScenarioSteps(steps.asJava)
       .setLedgerTime(ledger.currentTime.micros)
 
-    machine.traceLog.iterator.foreach { entry =>
+    traceLog.iterator.foreach { entry =>
       builder.addTraceLog(convertSTraceMessage(entry))
     }
 
     def setCrash(reason: String) = builder.setCrash(reason)
 
-    machine.commitLocation.foreach { loc =>
+    commitLocation.foreach { loc =>
       builder.setCommitLoc(convertLocation(loc))
     }
 
-    builder.addAllStackTrace(machine.stackTrace().map(convertLocation).toSeq.asJava)
+    builder.addAllStackTrace(stackTrace.map(convertLocation).toSeq.asJava)
 
     builder.setPartialTransaction(
-      convertPartialTransaction(machine.ptx),
+      convertPartialTransaction(ptx),
     )
 
     err match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -665,6 +665,7 @@ private[lf] object Speedy {
         outputTransactionVersions: VersionRange[TransactionVersion],
         validating: Boolean = false,
         onLedger: Boolean = true,
+        traceLog: TraceLog = RingBufferTraceLog(damlTraceLog, 100),
     ): Machine =
       new Machine(
         inputValueVersions = inputValueVersions,
@@ -680,7 +681,7 @@ private[lf] object Speedy {
         ptx = PartialTransaction.initial(submissionTime, initialSeeding),
         committers = committers,
         commitLocation = None,
-        traceLog = TraceLog(damlTraceLog, 100),
+        traceLog = traceLog,
         compiledPackages = compiledPackages,
         dependsOnTime = false,
         localContracts = Map.empty,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/TraceLog.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/TraceLog.scala
@@ -6,7 +6,12 @@ package com.daml.lf.speedy
 import com.daml.lf.data.Ref.Location
 import org.slf4j.Logger
 
-final case class TraceLog(logger: Logger, capacity: Int) {
+private[lf] trait TraceLog {
+  def add(message: String, optLocation: Option[Location]): Unit
+  def iterator: Iterator[(String, Option[Location])]
+}
+
+private[lf] final case class RingBufferTraceLog(logger: Logger, capacity: Int) extends TraceLog {
 
   private val buffer = Array.ofDim[(String, Option[Location])](capacity)
   private var pos: Int = 0

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/InterpreterTest.scala
@@ -154,11 +154,11 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
   "tracelog" should {
     val logger = LoggerFactory.getLogger("test-daml-trace-logger")
     "empty size" in {
-      val log = TraceLog(logger, 10)
+      val log = RingBufferTraceLog(logger, 10)
       log.iterator.hasNext shouldBe false
     }
     "half full" in {
-      val log = TraceLog(logger, 2)
+      val log = RingBufferTraceLog(logger, 2)
       log.add("test", None)
       val iter = log.iterator
       iter.hasNext shouldBe true
@@ -166,7 +166,7 @@ class InterpreterTest extends WordSpec with Matchers with TableDrivenPropertyChe
       iter.hasNext shouldBe false
     }
     "overflow" in {
-      val log = TraceLog(logger, 2)
+      val log = RingBufferTraceLog(logger, 2)
       log.add("test1", None)
       log.add("test2", None)
       log.add("test3", None) // should replace "test1"

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/TestMain.scala
@@ -133,7 +133,7 @@ object TestMain extends StrictLogging {
             case (id, script) =>
               val runner =
                 new Runner(compiledPackages, script, config.timeMode)
-              val testRun: Future[Unit] = runner.runWithClients(clients).map(_ => ())
+              val testRun: Future[Unit] = runner.runWithClients(clients)._2.map(_ => ())
               // Print test result and remember failure.
               testRun.onComplete {
                 case Failure(exception) =>


### PR DESCRIPTION
This PR makes sure that we get both trace statements coming from the
ledger client as well as from the ledger server. In the script service
those are two different Speedy machines so we need to interleave
them. This is a bit messy so let me explain the steps (apologies for
not splitting it up but I think it’s easier to understand the
motivation when it is a single PR):

1. Abstract over the tracelog interface. The ringbuffer doesn’t makes
   sense for our purposes and is annoying to clear.

2. Pass in the respective fields of `Machine` to `Conversions` instead
   of the whole machine. This is both a simpler design (passing around
   mutable objects scares me) and it allows us to assemble the fields
   from different machines.

3. Initialize the ledger machine with a simple ArrayBuffer tracelog.

4. After `submit` and `submitMustFail` copy the tracelog from the
   ledger to the client.

fixes #7280

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
