### PR TITLE
Provide configurable clock interval to cater for ledger differences with deduplication tests

### DIFF
--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -193,6 +193,18 @@ Use the command line option ``--timeout-scale-factor`` to tune timeouts applied
   implementation under test. Conversely use values smaller than 1.0 to make it
   wait shorter.
 
+Accomodating different ledger clock intervals
+========================================
+
+Use the command line option ``--ledger-clock-granularity`` to change the maximum
+ interval at which the ledger's clock will increment.
+
+- If running on a ledger where ledger time increments in a time period greater than 10s,
+  set ``--ledger-clock-granularity`` to a value higher than 10000 (10,000ms).  Tests
+  that are sensitive to the ledger clock will then wait for a corresponding longer period
+  of time to ensure completion of operations, avoiding timeouts and premature failures.
+  The command deduplication test suite is particularly sensitive to this value
+
 Verbose output
 ==============
 

--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -194,7 +194,7 @@ Use the command line option ``--timeout-scale-factor`` to tune timeouts applied
   wait shorter.
 
 Accomodating different ledger clock intervals
-========================================
+=============================================
 
 Use the command line option ``--ledger-clock-granularity`` to indicate the maximum
  interval at which the ledger's clock will increment.
@@ -203,7 +203,7 @@ Use the command line option ``--ledger-clock-granularity`` to indicate the maxim
   set ``--ledger-clock-granularity`` to a value higher than 10000 (10,000ms).  Tests
   that are sensitive to the ledger clock will then wait for a corresponding longer period
   of time to ensure completion of operations, avoiding timeouts and premature failures.
-  The command deduplication test suite is particularly sensitive to this value
+  The command deduplication test suite is particularly sensitive to this value.
 
 Verbose output
 ==============

--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -196,7 +196,7 @@ Use the command line option ``--timeout-scale-factor`` to tune timeouts applied
 Accomodating different ledger clock intervals
 ========================================
 
-Use the command line option ``--ledger-clock-granularity`` to change the maximum
+Use the command line option ``--ledger-clock-granularity`` to indicate the maximum
  interval at which the ledger's clock will increment.
 
 - If running on a ledger where ledger time increments in a time period greater than 10s,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -197,6 +197,11 @@ object Cli {
       .action((_, _) => { println(BuildInfo.Version); sys.exit(0) })
       .text("Prints the version on stdout and exit.")
 
+    opt[Int]("ledger-clock-tick-interval")
+      .optional()
+      .action((interval, c) => c.copy(ledgerClockTickIntervalMs = interval))
+      .text("Specify the interval in ms at which the clock of the ledger under test ticks.")
+
     help("help").text("Prints this usage text")
 
   }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -200,7 +200,7 @@ object Cli {
     opt[Int]("ledger-clock-granularity")
       .optional()
       .action((interval, c) => c.copy(ledgerClockGranularityMs = interval))
-      .text("Specify the largest interval in ms that you will see between clock ticks on the ledger under test")
+      .text("Specify the largest interval in ms that you will see between clock ticks on the ledger under test.  The default is 10000ms")
 
     help("help").text("Prints this usage text")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -197,10 +197,10 @@ object Cli {
       .action((_, _) => { println(BuildInfo.Version); sys.exit(0) })
       .text("Prints the version on stdout and exit.")
 
-    opt[Int]("ledger-clock-tick-interval")
+    opt[Int]("ledger-clock-granularity")
       .optional()
-      .action((interval, c) => c.copy(ledgerClockTickIntervalMs = interval))
-      .text("Specify the interval in ms at which the clock of the ledger under test ticks.")
+      .action((interval, c) => c.copy(ledgerClockGranularityMs = interval))
+      .text("Specify the largest interval in ms that you will see between clock ticks on the ledger under test")
 
     help("help").text("Prints this usage text")
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -26,7 +26,7 @@ final case class Config(
     listTestSuites: Boolean,
     shuffleParticipants: Boolean,
     partyAllocation: PartyAllocationConfiguration,
-    ledgerClockGranularityMs: Int
+    ledgerClockGranularityMs: Int,
 )
 
 object Config {
@@ -47,6 +47,6 @@ object Config {
     listTestSuites = false,
     shuffleParticipants = false,
     partyAllocation = PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants,
-    ledgerClockGranularityMs = 10000
+    ledgerClockGranularityMs = 10000,
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -26,6 +26,7 @@ final case class Config(
     listTestSuites: Boolean,
     shuffleParticipants: Boolean,
     partyAllocation: PartyAllocationConfiguration,
+    ledgerClockTickIntervalMs: Int
 )
 
 object Config {
@@ -46,5 +47,6 @@ object Config {
     listTestSuites = false,
     shuffleParticipants = false,
     partyAllocation = PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants,
+    ledgerClockTickIntervalMs = 10000
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -26,7 +26,7 @@ final case class Config(
     listTestSuites: Boolean,
     shuffleParticipants: Boolean,
     partyAllocation: PartyAllocationConfiguration,
-    ledgerClockTickIntervalMs: Int
+    ledgerClockGranularityMs: Int
 )
 
 object Config {
@@ -47,6 +47,6 @@ object Config {
     listTestSuites = false,
     shuffleParticipants = false,
     partyAllocation = PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants,
-    ledgerClockTickIntervalMs = 10000
+    ledgerClockGranularityMs = 10000
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -51,14 +51,14 @@ object LedgerApiTestTool {
     println()
     Tests.PerformanceTestsKeys.foreach(println(_))
   }
-  private def printAvailableTestSuites(): Unit = {
+  private def printAvailableTestSuites(config: Config): Unit = {
     println("Listing test suites. Run with --list-all to see individual tests.")
-    printListOfTests(Tests.all)(_.name)
+    printListOfTests(Tests.all(config))(_.name)
   }
 
-  private def printAvailableTests(): Unit = {
+  private def printAvailableTests(config: Config): Unit = {
     println("Listing all tests. Run with --list to only see test suites.")
-    printListOfTests(Tests.all.flatMap(_.tests))(_.name)
+    printListOfTests(Tests.all(config).flatMap(_.tests))(_.name)
   }
 
   private def extractResources(resources: Seq[String]): Unit = {
@@ -84,12 +84,12 @@ object LedgerApiTestTool {
     val config = Cli.parse(args).getOrElse(sys.exit(1))
 
     if (config.listTestSuites) {
-      printAvailableTestSuites()
+      printAvailableTestSuites(config)
       sys.exit(0)
     }
 
     if (config.listTests) {
-      printAvailableTests()
+      printAvailableTests(config)
       sys.exit(0)
     }
 
@@ -104,7 +104,7 @@ object LedgerApiTestTool {
     }
 
     val allTestCaseNames: Set[String] =
-      (Tests.all ++ Tests.retired).flatMap(_.tests).map(_.name).toSet
+      (Tests.all(config) ++ Tests.retired).flatMap(_.tests).map(_.name).toSet
     val missingTests = (config.included ++ config.excluded).filterNot(prefix =>
       allTestCaseNames.exists(_.startsWith(prefix)))
     if (missingTests.nonEmpty) {
@@ -130,7 +130,7 @@ object LedgerApiTestTool {
         sys.exit(1)
       })
 
-    val allCases = Tests.all.flatMap(_.tests)
+    val allCases = Tests.all(config).flatMap(_.tests)
     val retiredCases = Tests.retired.flatMap(_.tests)
 
     val includedTests =

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -20,7 +20,7 @@ object Tests {
       new ClosedWorldIT,
       new CommandServiceIT,
       new CommandSubmissionCompletionIT,
-      new CommandDeduplicationIT(Duration(config.ledgerClockGranularityMs, TimeUnit.MILLISECONDS)),
+      new CommandDeduplicationIT(Duration.apply(config.ledgerClockGranularityMs.toDouble, TimeUnit.MILLISECONDS)),
       new ConfigManagementServiceIT,
       new ContractKeysIT,
       new DivulgenceIT,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -4,11 +4,13 @@
 package com.daml.ledger.api.testtool
 
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.api.testtool.infrastructure.{BenchmarkReporter, Envelope, LedgerTestSuite}
 import com.daml.ledger.api.testtool.tests._
 
 import scala.collection.SortedSet
+import scala.concurrent.duration.Duration
 
 object Tests {
 
@@ -18,7 +20,7 @@ object Tests {
       new ClosedWorldIT,
       new CommandServiceIT,
       new CommandSubmissionCompletionIT,
-      new CommandDeduplicationIT(config.ledgerClockGranularityMs),
+      new CommandDeduplicationIT(Duration(config.ledgerClockGranularityMs, TimeUnit.MILLISECONDS)),
       new ConfigManagementServiceIT,
       new ContractKeysIT,
       new DivulgenceIT,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -20,7 +20,8 @@ object Tests {
       new ClosedWorldIT,
       new CommandServiceIT,
       new CommandSubmissionCompletionIT,
-      new CommandDeduplicationIT(Duration.apply(config.ledgerClockGranularityMs.toDouble, TimeUnit.MILLISECONDS)),
+      new CommandDeduplicationIT(
+        Duration.apply(config.ledgerClockGranularityMs.toDouble, TimeUnit.MILLISECONDS)),
       new ConfigManagementServiceIT,
       new ContractKeysIT,
       new DivulgenceIT,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -18,7 +18,7 @@ object Tests {
       new ClosedWorldIT,
       new CommandServiceIT,
       new CommandSubmissionCompletionIT,
-      new CommandDeduplicationIT(config.ledgerClockTickIntervalMs),
+      new CommandDeduplicationIT(config.ledgerClockGranularityMs),
       new ConfigManagementServiceIT,
       new ContractKeysIT,
       new DivulgenceIT,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -12,13 +12,13 @@ import scala.collection.SortedSet
 
 object Tests {
 
-  val all: Vector[LedgerTestSuite] =
+  def all(config: Config): Vector[LedgerTestSuite] =
     Vector(
       new ActiveContractsServiceIT,
       new ClosedWorldIT,
       new CommandServiceIT,
       new CommandSubmissionCompletionIT,
-      new CommandDeduplicationIT,
+      new CommandDeduplicationIT(config.ledgerClockTickIntervalMs),
       new ConfigManagementServiceIT,
       new ContractKeysIT,
       new DivulgenceIT,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -18,10 +18,10 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 import scala.concurrent.duration.{Duration => ScalaDuration}
-import com.google.protobuf.duration.{Duration => ProtoDuration}
+import com.google.protobuf.duration.{Duration => ProtobufDuration}
 
 final class CommandDeduplicationIT(ledgerTimeInterval: ScalaDuration) extends LedgerTestSuite {
-  private val deduplicationTime = ProtoDuration.of(ledgerTimeInterval.toSeconds, 0)
+  private val deduplicationTime = ProtobufDuration.of(ledgerTimeInterval.toSeconds, 0)
   private val deduplicationWindowWait = ledgerTimeInterval * 2
 
   test(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -30,7 +30,6 @@ final class CommandDeduplicationIT(ledgerTimeInterval: ScalaDuration) extends Le
     allocate(SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
-
       val requestA1 = ledger
         .submitRequest(party, DummyWithAnnotation(party, "First submission").create.command)
         .update(

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -19,10 +19,9 @@ import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
 
-class CommandDeduplicationIT(ledgerTimeIntervalMs: Int) extends LedgerTestSuite {
-  private val timeInterval = ledgerTimeIntervalMs / 1000
-  private val deduplicationSeconds = 1 * timeInterval
-  private val deduplicationWindowWait = 2 * timeInterval
+final class CommandDeduplicationIT(ledgerTimeIntervalMs: Int) extends LedgerTestSuite {
+  private val deduplicationSeconds = ledgerTimeIntervalMs / 1000
+  private val deduplicationWindowWait = 2 * deduplicationSeconds
 
   test(
     "CDSimpleDeduplicationBasic",

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -19,8 +19,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
 
-final class CommandDeduplicationIT extends LedgerTestSuite {
-  private val timeInterval = 5
+class CommandDeduplicationIT(ledgerTimeIntervalMs: Int) extends LedgerTestSuite {
+  private val timeInterval = ledgerTimeIntervalMs / 1000
   private val deduplicationSeconds = 1 * timeInterval
   private val deduplicationWindowWait = 2 * timeInterval
 
@@ -270,5 +270,4 @@ final class CommandDeduplicationIT extends LedgerTestSuite {
         )
       }
   })
-
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -17,9 +17,12 @@ import io.grpc.Status
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-final class CommandDeduplicationIT(ledgerTimeIntervalMs: scala.concurrent.duration.Duration) extends LedgerTestSuite {
-  private val deduplicationTime = com.google.protobuf.duration.Duration.of(ledgerTimeIntervalMs.toSeconds, 0)
-  private val deduplicationWindowWait = ledgerTimeIntervalMs * 2
+import scala.concurrent.duration.{Duration => ScalaDuration}
+import com.google.protobuf.duration.{Duration => ProtoDuration}
+
+final class CommandDeduplicationIT(ledgerTimeInterval: ScalaDuration) extends LedgerTestSuite {
+  private val deduplicationTime = ProtoDuration.of(ledgerTimeInterval.toSeconds, 0)
+  private val deduplicationWindowWait = ledgerTimeInterval * 2
 
   test(
     "CDSimpleDeduplicationBasic",


### PR DESCRIPTION
The `CDSimpleDeduplication` and `CDSimpleDeduplicationCommandClient` tests frequently and periodically fail for the distributed ledger Besu and Sawtooth implementations as there is not a sufficient delay between the dedupe period specified in the test (5s) and the wait time given for this to be fully processed before the fresh subsequent command submission comes through (6s)

To rehash what the tests are doing, they are:

1) Submit a command1 with a deduplication time of 5s - expect this to be accepted
2) Submit a dupe of command1 - expect this to be treated as a dupe with corresponding ALREADY_EXISTS grpc response

Wait 6s

3) Submit a command1 again with a deduplication time of 5s -- since the original deduplication time has now expired - expect this to be accepted
4) Submit a dupe of command1 - expect this to be treated as a dupe of step 3

In several of the distributed ledger implementations steps 3 and 4 are not working, because the deduplication window of 1/2 has not expired by the time these are processed.

In this PR the wait time between 2 and 3 has been extended to 2x the deduplication time - so 10s wait for 5s deduplication

As different distributed ledgers will tick time at different configurable intervals, we should also make this ledger clock tick configurable.  This PR also includes the addition of an optional variable to specify ledger clock interval.