### PR TITLE
http-json: When testing, filter out empty events in WebSocket responses.

### DIFF
--- a/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
@@ -482,28 +482,19 @@ class WebsocketServiceIntegrationTest
       _ <- archive(cid1)
       results <- futureResults
     } yield {
-      val expected: Seq[JsValue] = {
-        import spray.json._
-        Seq(
-          """
-            |{"events": []}
-            |""".stripMargin.parseJson,
-          """
-            |{"events":[{"created":{"payload":{"number":"abc123"}}}]}
-            |""".stripMargin.parseJson,
-          """
-            |{"events":[{"created":{"payload":{"number":"def456"}}}]}
-            |""".stripMargin.parseJson,
-          """
-            |{"events":[{"archived":{}}]}
-            |""".stripMargin.parseJson,
-          """
-            |{"events":[{"archived":{}}]}
-            |""".stripMargin.parseJson
-        )
-      }
-      results should matchJsValues(expected)
+      import spray.json._
 
+      val expected: Seq[JsValue] = Seq(
+        """{"events": [{"created": {"payload": {"number": "abc123"}}}]}""",
+        """{"events": [{"created": {"payload": {"number": "def456"}}}]}""",
+        """{"events": [{"archived": {}}]}""",
+        """{"events": [{"archived": {}}]}""",
+      ).map(_.parseJson)
+
+      val actual: Seq[JsValue] =
+        results.filterNot(_.asJsObject.fields("events").asInstanceOf[JsArray].elements.isEmpty)
+
+      actual should matchJsValues(expected)
     }
   }
 

--- a/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
@@ -16,6 +16,7 @@ import com.daml.jwt.domain.Jwt
 import com.typesafe.scalalogging.StrictLogging
 import org.scalacheck.Gen
 import org.scalatest._
+import org.scalatest.matchers.{MatchResult, Matcher}
 import scalaz.{-\/, \/, \/-}
 import scalaz.std.option._
 import scalaz.std.vector._
@@ -451,27 +452,6 @@ class WebsocketServiceIntegrationTest
   }
 
   "fetch multiple keys should work" in withHttpService { (uri, encoder, _) =>
-    def matches(expected: Seq[JsValue], actual: Seq[JsValue]): Boolean =
-      expected.length == actual.length && (expected, actual).zipped.forall {
-        case (exp, act) => matchesJs(exp, act)
-      }
-    // matches if all the values specified in expected appear with the same
-    // value in actual; actual is allowed to have extra fields. Arrays must
-    // have the same length.
-    def matchesJs(expected: spray.json.JsValue, actual: spray.json.JsValue): Boolean = {
-      import spray.json._
-      (expected, actual) match {
-        case (JsArray(expected), JsArray(actual)) =>
-          expected.length == actual.length && matches(expected, actual)
-        case (JsObject(expected), JsObject(actual)) =>
-          expected.keys.forall(k => matchesJs(expected(k), actual(k)))
-        case (JsString(expected), JsString(actual)) => expected == actual
-        case (JsNumber(expected), JsNumber(actual)) => expected == actual
-        case (JsBoolean(expected), JsBoolean(actual)) => expected == actual
-        case (JsNull, JsNull) => true
-        case _ => false
-      }
-    }
     def create(account: String): Future[domain.ContractId] =
       for {
         r <- postCreateCommand(accountCreateCommand(domain.Party("Alice"), account), encoder, uri)
@@ -522,7 +502,7 @@ class WebsocketServiceIntegrationTest
             |""".stripMargin.parseJson
         )
       }
-      assert(matches(expected, results))
+      results should matchJsValues(expected)
 
     }
   }
@@ -941,4 +921,36 @@ private[http] object WebsocketServiceIntegrationTest extends StrictLogging {
 
   def eventsBlockVector(msgs: Vector[String]): SprayJson.JsonReaderError \/ Vector[EventsBlock] =
     msgs.traverse(SprayJson.decode[EventsBlock])
+
+  def matchJsValue(expected: JsValue) = new JsValueMatcher(expected)
+
+  def matchJsValues(expected: Seq[JsValue]) = new MultipleJsValuesMatcher(expected)
+
+  final class JsValueMatcher(right: JsValue) extends Matcher[JsValue] {
+    override def apply(left: JsValue): MatchResult = {
+      import spray.json._
+      val result = (left, right) match {
+        case (JsArray(l), JsArray(r)) =>
+          l.length == r.length && matchJsValues(r)(l).matches
+        case (JsObject(l), JsObject(r)) =>
+          r.keys.forall(k => matchJsValue(r(k))(l(k)).matches)
+        case (JsString(l), JsString(r)) => l == r
+        case (JsNumber(l), JsNumber(r)) => l == r
+        case (JsBoolean(l), JsBoolean(r)) => l == r
+        case (JsNull, JsNull) => true
+        case _ => false
+      }
+      MatchResult(result, s"$left did not match $right", s"$left matched $right")
+    }
+  }
+
+  final class MultipleJsValuesMatcher(right: Seq[JsValue]) extends Matcher[Seq[JsValue]] {
+    override def apply(left: Seq[JsValue]): MatchResult = {
+      val result = left.length == right.length && (left, right).zipped.forall {
+        case (l, r) => matchJsValue(r)(l).matches
+      }
+      MatchResult(result, s"$left did not match $right", s"$left matched $right")
+    }
+  }
+
 }


### PR DESCRIPTION
It appears that the WebSocket stream may spuriously emit empty event responses. I have seen them before, during and after the events containing emissions. This results in a flaky test case in WebsocketServiceIntegrationTest, which I have observed both on CI and by running the tests in parallel on my own machine.

As I don't believe we can predict these, I think it's safer to just filter them out.

I turned some assertions into ScalaTest matchers in order to better diagnose the issue.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
