### PR TITLE
Preserve empty variant constructor in data-deps.

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -479,6 +479,9 @@ generateSrcFromLf env = noLoc mod
 
         convConDetails :: LF.Type -> Gen (HsConDeclDetails GhcPs)
         convConDetails = \case
+            -- empty variant constructor (see issue #7207)
+            LF.TUnit ->
+                pure $ PrefixCon []
 
             -- variant record constructor
             LF.TConApp LF.Qualified{..} _

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -450,8 +450,9 @@ generateSrcFromLf env = noLoc mod
             fields' <- mapM (uncurry (mkConDeclField env)) fields
             pure [ mkConDecl occName (RecCon (noLoc fields')) ]
         LF.DataVariant cons -> do
+            let hasExactlyOneConstructor = length cons == 1
             sequence
-                [ mkConDecl (occNameFor conName) <$> convConDetails ty
+                [ mkConDecl (occNameFor conName) <$> convConDetails hasExactlyOneConstructor ty
                 | (conName, ty) <- cons
                 ]
         LF.DataEnum cons -> do
@@ -477,10 +478,14 @@ generateSrcFromLf env = noLoc mod
             , con_args = details
             }
 
-        convConDetails :: LF.Type -> Gen (HsConDeclDetails GhcPs)
-        convConDetails = \case
-            -- empty variant constructor (see issue #7207)
-            LF.TUnit ->
+        convConDetails :: Bool -> LF.Type -> Gen (HsConDeclDetails GhcPs)
+        convConDetails hasExactlyOneConstructor = \case
+            -- nullary variant constructor (see issue #7207)
+            --
+            -- We translate a variant constructor `C ()` to `C` in DAML. But
+            -- if it's the only constructor, we leave it as `C ()` to distinguish
+            -- it from an enum type.
+            LF.TUnit | not hasExactlyOneConstructor ->
                 pure $ PrefixCon []
 
             -- variant record constructor

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1682,6 +1682,7 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
         writeFileUTF8 (tmpDir </> "type" </> "Foo.daml") $ unlines
             [ "module Foo where"
             , "data A = B | C Int"
+            , "data D = D ()" -- single-constructor case uses explicit unit
             ]
         withCurrentDirectory (tmpDir </> "type") $
             callProcessSilent damlc ["build", "-o", "type.dar"]
@@ -1707,6 +1708,12 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
             , "  case a of"
             , "    B -> 0"
             , "    C n -> n"
+            , "mkD : D"
+            , "mkD = D ()"
+            , "matchD : D -> ()"
+            , "matchD d ="
+            , "  case d of"
+            , "    D () -> ()"
             ]
         withCurrentDirectory (tmpDir </> "proj") $
             callProcessSilent damlc ["build"]


### PR DESCRIPTION
This fixes #7207 and adds a regression test. In a
separate PR I'll add a warning for variants with
single argument of unit type and add a changelog
entry.

changelog_begin
changelog_end