### PR TITLE
Fixing flaky Template ID resolution test

### DIFF
--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/Generators.scala
@@ -26,17 +26,17 @@ object Generators {
       e <- Gen.identifier
     } yield domain.TemplateId(p, m, e)
 
-  def nonEmptySet[A](gen: Gen[A]): Gen[Set[A]] = Gen.nonEmptyListOf(gen).map(_.toSet)
+  def nonEmptySetOf[A](gen: Gen[A]): Gen[Set[A]] = Gen.nonEmptyListOf(gen).map(_.toSet)
 
   // Generate Identifiers with unique packageId values, but the same moduleName and entityName.
-  def genDuplicateApiIdentifiers: Gen[List[lav1.value.Identifier]] =
+  def genDuplicateModuleEntityApiIdentifiers: Gen[Set[lav1.value.Identifier]] =
     for {
       id0 <- genApiIdentifier
-      otherPackageIds <- nonEmptySet(Gen.identifier.filter(x => x != id0.packageId))
-    } yield id0 :: otherPackageIds.map(a => id0.copy(packageId = a)).toList
+      otherPackageIds <- nonEmptySetOf(Gen.identifier.filter(x => x != id0.packageId))
+    } yield Set(id0) ++ otherPackageIds.map(a => id0.copy(packageId = a))
 
-  def genDuplicateDomainTemplateIdR: Gen[List[domain.TemplateId.RequiredPkg]] =
-    genDuplicateApiIdentifiers.map(xs => xs.map(domain.TemplateId.fromLedgerApi))
+  def genDuplicateModuleEntityTemplateIds: Gen[Set[domain.TemplateId.RequiredPkg]] =
+    genDuplicateModuleEntityApiIdentifiers.map(xs => xs.map(domain.TemplateId.fromLedgerApi))
 
   trait PackageIdGen[A] {
     def gen: Gen[A]

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/GeneratorsTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/GeneratorsTest.scala
@@ -3,7 +3,7 @@
 
 package com.daml.http
 
-import com.daml.http.Generators.genDuplicateApiIdentifiers
+import com.daml.http.Generators.genDuplicateModuleEntityApiIdentifiers
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -15,7 +15,7 @@ class GeneratorsTest extends FlatSpec with Matchers with GeneratorDrivenProperty
   import org.scalacheck.Shrink.shrinkAny
 
   "Generators.genDuplicateApiIdentifiers" should "generate API Identifiers with the same moduleName and entityName" in
-    forAll(genDuplicateApiIdentifiers) { ids =>
+    forAll(genDuplicateModuleEntityApiIdentifiers) { ids =>
       ids.size should be >= 2
       val (packageIds, moduleNames, entityNames) =
         ids.foldLeft((Set.empty[String], Set.empty[String], Set.empty[String])) { (b, a) =>

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/PackageServiceTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/PackageServiceTest.scala
@@ -3,10 +3,13 @@
 
 package com.daml.http
 
-import com.daml.http.Generators.{genDomainTemplateId, genDuplicateDomainTemplateIdR, nonEmptySet}
+import com.daml.http.Generators.{
+  genDomainTemplateId,
+  genDuplicateModuleEntityTemplateIds,
+  nonEmptySetOf
+}
 import com.daml.http.PackageService.TemplateIdMap
 import com.daml.ledger.api.{v1 => lav1}
-import org.scalacheck.Gen.nonEmptyListOf
 import org.scalacheck.Shrink
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FreeSpec, Inside, Matchers}
@@ -25,7 +28,7 @@ class PackageServiceTest
 
   "PackageService.buildTemplateIdMap" - {
     "identifiers with the same (moduleName, entityName) are not unique" in
-      forAll(genDuplicateDomainTemplateIdR) { ids =>
+      forAll(genDuplicateModuleEntityTemplateIds) { ids =>
         toNoPkgSet(ids) should have size 1L
         val map = PackageService.buildTemplateIdMap(ids.toSet)
         map.all shouldBe ids.toSet
@@ -58,38 +61,42 @@ class PackageServiceTest
       }
 
     "TemplateIdMap.all should contain dups and unique identifiers" in
-      forAll(nonEmptyListOf(genDomainTemplateId), genDuplicateDomainTemplateIdR) { (xs, dups) =>
-        whenever(noModuleEntityIntersection(xs, dups)) {
-          val map = PackageService.buildTemplateIdMap((xs ++ dups).toSet)
-          map.all should ===(xs.toSet ++ dups.toSet)
-          dups.foreach { x =>
-            map.all.contains(x) shouldBe true
+      forAll(nonEmptySetOf(genDomainTemplateId), genDuplicateModuleEntityTemplateIds) {
+        (xs, dups) =>
+          uniqueModuleEntity(dups) shouldBe false
+          whenever(uniqueModuleEntity(xs) && noModuleEntityIntersection(xs, dups)) {
+            val map = PackageService.buildTemplateIdMap((xs ++ dups))
+            map.all should ===(xs ++ dups)
+            dups.foreach { x =>
+              map.all.contains(x) shouldBe true
+            }
+            xs.foreach { x =>
+              map.all.contains(x) shouldBe true
+            }
           }
-          xs.foreach { x =>
-            map.all.contains(x) shouldBe true
-          }
-        }
       }
 
     "TemplateIdMap.unique should not contain dups" in
-      forAll(nonEmptyListOf(genDomainTemplateId), genDuplicateDomainTemplateIdR) { (xs, dups) =>
-        whenever(noModuleEntityIntersection(xs, dups)) {
-          val map = PackageService.buildTemplateIdMap((xs ++ dups).toSet)
-          map.all should ===(dups.toSet ++ xs.toSet)
-          xs.foreach { x =>
-            map.unique.get(PackageService.key2(x)) shouldBe Some(x)
+      forAll(nonEmptySetOf(genDomainTemplateId), genDuplicateModuleEntityTemplateIds) {
+        (xs, dups) =>
+          uniqueModuleEntity(dups) shouldBe false
+          whenever(uniqueModuleEntity(xs) && noModuleEntityIntersection(xs, dups)) {
+            val map = PackageService.buildTemplateIdMap((xs ++ dups))
+            map.all should ===(dups ++ xs)
+            xs.foreach { x =>
+              map.unique.get(PackageService.key2(x)) shouldBe Some(x)
+            }
+            dups.foreach { x =>
+              map.unique.get(PackageService.key2(x)) shouldBe None
+            }
           }
-          dups.foreach { x =>
-            map.unique.get(PackageService.key2(x)) shouldBe None
-          }
-        }
       }
   }
 
   "PackageService.resolveTemplateId" - {
 
     "should resolve unique Template ID by (moduleName, entityName)" in forAll(
-      nonEmptySet(genDomainTemplateId)) { ids =>
+      nonEmptySetOf(genDomainTemplateId)) { ids =>
       val map = PackageService.buildTemplateIdMap(ids)
       val uniqueIds: Set[domain.TemplateId.RequiredPkg] = map.unique.values.toSet
       uniqueIds.foreach { id =>
@@ -98,7 +105,7 @@ class PackageServiceTest
       }
     }
 
-    "should resolve fully qualified Template ID" in forAll(nonEmptySet(genDomainTemplateId)) {
+    "should resolve fully qualified Template ID" in forAll(nonEmptySetOf(genDomainTemplateId)) {
       ids =>
         val map = PackageService.buildTemplateIdMap(ids)
         ids.foreach { id =>
@@ -118,11 +125,14 @@ class PackageServiceTest
   private def appendToPackageId(x: String)(a: domain.TemplateId.RequiredPkg) =
     a.copy(packageId = a.packageId + x)
 
+  private def uniqueModuleEntity(as: Set[domain.TemplateId.RequiredPkg]): Boolean =
+    toNoPkgSet(as).size == as.size
+
   private def noModuleEntityIntersection(
-      as: List[domain.TemplateId.RequiredPkg],
-      bs: List[domain.TemplateId.RequiredPkg]): Boolean =
+      as: Set[domain.TemplateId.RequiredPkg],
+      bs: Set[domain.TemplateId.RequiredPkg]): Boolean =
     !(toNoPkgSet(as) exists toNoPkgSet(bs))
 
-  private def toNoPkgSet(xs: List[domain.TemplateId.RequiredPkg]): Set[domain.TemplateId.NoPkg] =
-    xs.iterator.map(_ copy (packageId = ())).toSet
+  private def toNoPkgSet(xs: Set[domain.TemplateId.RequiredPkg]): Set[domain.TemplateId.NoPkg] =
+    xs.map(_ copy (packageId = ()))
 }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/PackageServiceTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/PackageServiceTest.scala
@@ -30,8 +30,8 @@ class PackageServiceTest
     "identifiers with the same (moduleName, entityName) are not unique" in
       forAll(genDuplicateModuleEntityTemplateIds) { ids =>
         toNoPkgSet(ids) should have size 1L
-        val map = PackageService.buildTemplateIdMap(ids.toSet)
-        map.all shouldBe ids.toSet
+        val map = PackageService.buildTemplateIdMap(ids)
+        map.all shouldBe ids
         map.unique shouldBe Map.empty
       }
 


### PR DESCRIPTION
Making sure that generated domain Template IDs do not have module entity duplicates, so the resolution should work with no problem.

``` shell
$ bazel test //ledger-service/http-json:tests --test_filter=com.daml.http.PackageServiceTest \
  --cache_test_results=no --runs_per_test=50
```
Passed 3 times. We should be all right now.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
