### PR TITLE
Migrate trigger assertion library to DAML Script

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -716,6 +716,7 @@ daml_build_test(
         ":daml-upgrade-example-v2": "path/to/coin-2.0.0.dar",
         ":daml-upgrade-example-upgrade": "path/to/coin-upgrade-1.0.0.dar",
         "//triggers/daml:daml-trigger.dar": "path/to/daml-trigger.dar",
+        "//daml-script/daml:daml-script.dar": "path/to/daml-script.dar",
     },
     project_dir = "source/upgrade/example/coin-upgrade-trigger",
 )

--- a/docs/source/upgrade/example/coin-upgrade-trigger/daml.yaml
+++ b/docs/source/upgrade/example/coin-upgrade-trigger/daml.yaml
@@ -9,6 +9,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - path/to/daml-trigger.dar
+  - path/to/daml-script.dar
 data-dependencies:
   - path/to/coin-upgrade-1.0.0.dar
   - path/to/coin-1.0.0.dar

--- a/docs/source/upgrade/example/coin-upgrade-trigger/daml/UpgradeTrigger.daml
+++ b/docs/source/upgrade/example/coin-upgrade-trigger/daml/UpgradeTrigger.daml
@@ -9,6 +9,8 @@ import qualified DA.Next.Map as Map
 import DA.Next.Map (Map)
 import Daml.Trigger
 import Daml.Trigger.Assert
+import qualified Daml.Script as Script
+import Daml.Script (script)
 
 import CoinV1
 import UpgradeFromCoinV1
@@ -40,16 +42,16 @@ triggerRule issuer acs _ _ _ = do
         [toAnyContractId coinCid]
 -- TRIGGER_RULE_END
 
--- TODO (MK) The Bazel rule atm doesn’t run this scenario, we should fix that.
-test = scenario do
-  alice <- getParty "Alice"
-  bob <- getParty "Bob"
+-- TODO (MK) The Bazel rule atm doesn’t run this script, we should fix that.
+test = script do
+  alice <- Script.allocateParty "Alice"
+  bob <- Script.allocateParty "Bob"
 
-  coinProposal <- submit alice $ create (CoinProposal alice bob)
-  coin <- submit bob $ exercise coinProposal CoinProposal_Accept
+  coinProposal <- submit alice $ Script.createCmd (CoinProposal alice bob)
+  coin <- submit bob $ Script.exerciseCmd coinProposal CoinProposal_Accept
 
-  upgradeProposal <- submit alice $ create (UpgradeCoinProposal alice bob)
-  upgradeAgreement <- submit bob $ exercise upgradeProposal Accept
+  upgradeProposal <- submit alice $ Script.createCmd (UpgradeCoinProposal alice bob)
+  upgradeAgreement <- submit bob $ Script.exerciseCmd upgradeProposal Accept
 
   let acs = toACS coin <> toACS upgradeAgreement
 

--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -17,7 +17,7 @@ DAML_LF_VERSIONS = [
 [
     genrule(
         name = "daml-trigger{}".format(suffix),
-        srcs = glob(["**/*.daml"]),
+        srcs = glob(["**/*.daml"]) + ["//daml-script/daml:daml-script{}".format(suffix)],
         outs = ["daml-trigger{}.dar".format(suffix)],
         cmd = """
           set -eou pipefail
@@ -27,6 +27,7 @@ DAML_LF_VERSIONS = [
           cp -L $(location Daml/Trigger/Assert.daml) $$TMP_DIR/daml/Daml/Trigger
           cp -L $(location Daml/Trigger/Internal.daml) $$TMP_DIR/daml/Daml/Trigger
           cp -L $(location Daml/Trigger/LowLevel.daml) $$TMP_DIR/daml/Daml/Trigger
+          cp -L $(location {daml_script}) $$TMP_DIR/daml-script.dar
           cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: daml-trigger
@@ -35,6 +36,7 @@ version: {ghc}
 dependencies:
   - daml-stdlib
   - daml-prim
+  - daml-script.dar
 build-options: {build_options}
 EOF
           $(location //compiler/damlc) build --project-root=$$TMP_DIR -o $$PWD/$@
@@ -47,6 +49,7 @@ EOF
                 "--target",
                 lf_version,
             ] if lf_version else []),
+            daml_script = "//daml-script/daml:daml-script{}".format(suffix),
             sdk = sdk_version,
             ghc = ghc_version,
         ),
@@ -68,18 +71,47 @@ filegroup(
 
 genrule(
     name = "daml-trigger-rst-docs",
-    srcs = glob(["**/*.daml"]) + [":daml-trigger-rst-template.rst"],
+    srcs = glob(["**/*.daml"]) + [
+        ":daml-trigger-rst-template.rst",
+        "//daml-script/daml:daml-script",
+    ],
     outs = ["daml-trigger.rst"],
     cmd = """
-        $(location //compiler/damlc) -- docs \
+          TMP_DIR=$$(mktemp -d)
+          mkdir -p $$TMP_DIR/daml/Daml/Trigger
+          cp -L $(location Daml/Trigger.daml) $$TMP_DIR/daml/Daml
+          cp -L $(location Daml/Trigger/Assert.daml) $$TMP_DIR/daml/Daml/Trigger
+          cp -L $(location Daml/Trigger/Internal.daml) $$TMP_DIR/daml/Daml/Trigger
+          cp -L $(location Daml/Trigger/LowLevel.daml) $$TMP_DIR/daml/Daml/Trigger
+          cp -L $$PWD/$(location {daml_script}) $$TMP_DIR/daml-script.dar
+          cat << EOF > $$TMP_DIR/daml.yaml
+sdk-version: {sdk}
+name: daml-trigger
+source: daml
+version: {ghc}
+dependencies:
+  - daml-stdlib
+  - daml-prim
+  - daml-script.dar
+EOF
+        DAMLC=$$PWD/$(location //compiler/damlc)
+        TEMPLATE=$$PWD/$(location :daml-trigger-rst-template.rst)
+        RST=$$PWD/$(location :daml-trigger.rst)
+        cd $$TMP_DIR
+        $$DAMLC init
+        $$DAMLC -- docs \
             --combine \
-            --output=$(location :daml-trigger.rst) \
+            --output=$$RST \
             --format=Rst \
-            --template=$(location :daml-trigger-rst-template.rst) \
-            $(location Daml/Trigger.daml) \
-            $(location Daml/Trigger/Assert.daml) \
-            $(location Daml/Trigger/LowLevel.daml)
-    """,
+            --template=$$TEMPLATE \
+            $$TMP_DIR/daml/Daml/Trigger.daml \
+            $$TMP_DIR/daml/Daml/Trigger/Assert.daml \
+            $$TMP_DIR/daml/Daml/Trigger/LowLevel.daml
+    """.format(
+        daml_script = "//daml-script/daml:daml-script",
+        sdk = sdk_version,
+        ghc = ghc_version,
+    ),
     tools = ["//compiler/damlc"],
     visibility = ["//visibility:public"],
 )

--- a/triggers/daml/Daml/Trigger/Assert.daml
+++ b/triggers/daml/Daml/Trigger/Assert.daml
@@ -21,18 +21,21 @@ import Daml.Trigger
 import Daml.Trigger.Internal
 import Daml.Trigger.LowLevel hiding (Trigger)
 
+import Daml.Script (Script, queryContractId)
+
 -- | Used to construct an 'ACS' for 'testRule'.
-newtype ACSBuilder = ACSBuilder [Update (AnyContractId, AnyTemplate)]
+newtype ACSBuilder = ACSBuilder (Party -> [Script (AnyContractId, AnyTemplate)])
 
 instance Semigroup ACSBuilder where
-  ACSBuilder l <> ACSBuilder r = ACSBuilder (l <> r)
+  ACSBuilder l <> ACSBuilder r =
+    ACSBuilder (\p -> l p <> r p)
 
 instance Monoid ACSBuilder where
-  mempty = ACSBuilder mempty
+  mempty = ACSBuilder (const mempty)
 
-buildACS : Party -> ACSBuilder -> Scenario ACS
+buildACS : Party -> ACSBuilder -> Script ACS
 buildACS party (ACSBuilder fetches) = do
-  activeContracts <- submit party $ sequence fetches
+  activeContracts <- sequence (fetches party)
   pure ACS
     { activeContracts = activeContracts
     , pendingContracts = Map.empty
@@ -40,8 +43,10 @@ buildACS party (ACSBuilder fetches) = do
 
 -- | Include the given contract in the 'ACS'.
 toACS : Template t => ContractId t -> ACSBuilder
-toACS cid = ACSBuilder
-  [fetch cid >>= \tpl -> pure (toAnyContractId cid, toAnyTemplate tpl)]
+toACS cid = ACSBuilder $ \p ->
+  [ do Some t <- queryContractId p cid
+       pure (toAnyContractId cid, toAnyTemplate t)
+  ]
 
 -- | Execute a trigger's rule once in a scenario.
 testRule
@@ -50,7 +55,7 @@ testRule
   -> ACSBuilder  -- ^ List these contracts in the 'ACS'.
   -> Map CommandId [Command]  -- ^ The commands in flight.
   -> s  -- ^ The trigger state.
-  -> Scenario [Commands]  -- ^ The 'Commands' emitted by the rule. The 'CommandId's will start from @"0"@.
+  -> Script [Commands]  -- ^ The 'Commands' emitted by the rule. The 'CommandId's will start from @"0"@.
 testRule trigger party acsBuilder commandsInFlight s = do
   time <- getTime
   acs <- buildACS party acsBuilder

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -152,6 +152,7 @@ genrule(
     srcs =
         glob(["test-model/*.daml"]) + [
             "//triggers/daml:daml-trigger.dar",
+            "//daml-script/daml:daml-script.dar",
         ],
     outs = ["test-model.dar"],
     cmd = """
@@ -162,6 +163,7 @@ genrule(
       cp -L $(location :test-model/ErrorTrigger.daml) $$TMP_DIR/daml
       cp -L $(location :test-model/LowLevelErrorTrigger.daml) $$TMP_DIR/daml
       cp -L $(location //triggers/daml:daml-trigger.dar) $$TMP_DIR/
+      cp -L $(location //daml-script/daml:daml-script.dar) $$TMP_DIR
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: test-model
@@ -171,6 +173,7 @@ dependencies:
   - daml-stdlib
   - daml-prim
   - daml-trigger.dar
+  - daml-script.dar
 EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR -o $$PWD/$(location test-model.dar)
       rm -rf $$TMP_DIR

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -18,6 +18,7 @@ genrule(
     srcs =
         glob(["**/*.daml"]) + [
             "//triggers/daml:daml-trigger.dar",
+            "//daml-script/daml:daml-script.dar",
             "//docs:source/triggers/template-root/src/CopyTrigger.daml",
         ],
     outs = ["acs.dar"],
@@ -37,7 +38,8 @@ genrule(
       cp -L $(location :daml/Time.daml) $$TMP_DIR/daml
       cp -L $(location :daml/Heartbeat.daml) $$TMP_DIR/daml
       cp -L $(location //docs:source/triggers/template-root/src/CopyTrigger.daml) $$TMP_DIR/daml
-      cp -L $(location //triggers/daml:daml-trigger.dar) $$TMP_DIR/
+      cp -L $(location //triggers/daml:daml-trigger.dar) $$TMP_DIR/daml-trigger.dar
+      cp -L $(location //daml-script/daml:daml-script.dar) $$TMP_DIR/daml-script.dar
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}
 name: acs
@@ -47,6 +49,7 @@ dependencies:
   - daml-stdlib
   - daml-prim
   - daml-trigger.dar
+  - daml-script.dar
 EOF
       $(location //compiler/damlc) build --project-root=$$TMP_DIR -o $$PWD/$(location acs.dar)
       rm -rf $$TMP_DIR

--- a/triggers/tests/scenarios/BUILD.bazel
+++ b/triggers/tests/scenarios/BUILD.bazel
@@ -9,11 +9,13 @@ sh_test(
         sdk_version,
         "$(rootpath //compiler/damlc)",
         "$(rootpath //triggers/daml:daml-trigger.dar)",
+        "$(rootpath //daml-script/daml:daml-script.dar)",
         "$(rootpath Rule.daml)",
     ],
     data = [
         "Rule.daml",
         "//compiler/damlc",
+        "//daml-script/daml:daml-script.dar",
         "//triggers/daml:daml-trigger.dar",
     ],
     deps = ["@bazel_tools//tools/bash/runfiles"],

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -9,6 +9,7 @@ import DA.Assert
 import qualified DA.Next.Map as Map
 import Daml.Trigger
 import Daml.Trigger.Assert
+import qualified Daml.Script as Script
 
 template T
   with
@@ -43,9 +44,9 @@ trigger = Trigger with
   registeredTemplates = RegisteredTemplates [registeredTemplate @T]
   heartbeat = None
 
-test = scenario do
-  alice <- getParty "Alice"
-  tId <- submit alice do create T with party = alice, count = 1
+test = do
+  alice <- Script.allocateParty "Alice"
+  tId <- submit alice do Script.createCmd T with party = alice, count = 1
   let activeContracts = toACS tId
   let commandsInFlight = Map.empty
   commands <- testRule trigger alice activeContracts commandsInFlight 1

--- a/triggers/tests/scenarios/test-scenarios.sh
+++ b/triggers/tests/scenarios/test-scenarios.sh
@@ -16,7 +16,8 @@ set -eou pipefail
 SDK_VERSION=$1
 DAMLC=$(rlocation $TEST_WORKSPACE/$2)
 DAML_TRIGGERS_DAR=$(rlocation $TEST_WORKSPACE/$3)
-DAML_SOURCE=$(rlocation $TEST_WORKSPACE/$4)
+DAML_SCRIPT_DAR=$(rlocation $TEST_WORKSPACE/$4)
+DAML_SOURCE=$(rlocation $TEST_WORKSPACE/$5)
 
 TMP_DIR=$(mktemp -d)
 mkdir -p $TMP_DIR/daml
@@ -29,11 +30,13 @@ dependencies:
   - daml-stdlib
   - daml-prim
   - daml-trigger.dar
+  - daml-script.dar
 EOF
-cp -L $DAML_TRIGGERS_DAR $TMP_DIR/
 cp -L $DAML_SOURCE $TMP_DIR/daml/
+cp -L $DAML_TRIGGERS_DAR $TMP_DIR/
+cp -L $DAML_SCRIPT_DAR $TMP_DIR/
 
 # We need to run build to create the package database.
 # See https://github.com/digital-asset/daml/issues/3436
-$DAMLC build --project-root=$TMP_DIR
+$DAMLC init --project-root=$TMP_DIR
 $DAMLC test --project-root=$TMP_DIR


### PR DESCRIPTION
This is clearly a breaking change but triggers are still alpha so we
can get away this (confirmed with Bernhard).

changelog_begin

- [DAML Trigger] Daml.Trigger.Assert now uses DAML Script instead of scenarios.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
