### PR TITLE
LF: sort fields in SStruct

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Struct.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/Struct.scala
@@ -73,12 +73,21 @@ object Struct {
         .toLeft(struct)
     }
 
-  def assertFromSeq[X](fields: Seq[(Name, X)]): Struct[X] =
-    fromSeq(fields).fold(
+  private[this] def assertSuccess[X](either: Either[String, X]) =
+    either.fold(
       name =>
         throw new IllegalArgumentException(s"name $name duplicated when trying to build Struct"),
       identity,
     )
+
+  def assertFromSeq[X](fields: Seq[(Name, X)]): Struct[X] =
+    assertSuccess(fromSeq(fields))
+
+  def fromNameSeq[X](names: Seq[Name]): Either[Name, Struct[Unit]] =
+    fromSeq(names.map(_ -> (())))
+
+  def assertFromNameSeq[X](names: Seq[Name]): Struct[Unit] =
+    assertSuccess(fromNameSeq(names))
 
   val Empty: Struct[Nothing] = new Struct(ImmArray.empty)
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -11,6 +11,7 @@ import com.daml.lf.data.Ref._
 import com.daml.lf.data._
 import com.daml.lf.data.Numeric.Scale
 import com.daml.lf.language.Ast
+import com.daml.lf.language.Ast.{keyFieldName, maintainersFieldName}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.Speedy._
@@ -19,7 +20,7 @@ import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SValue.{SValue => SV}
 import com.daml.lf.transaction.{Transaction => Tx}
 import com.daml.lf.value.{Value => V}
-import com.daml.lf.transaction.{Node, GlobalKey, GlobalKeyWithMaintainers}
+import com.daml.lf.transaction.{GlobalKey, GlobalKeyWithMaintainers, Node}
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeSet
@@ -815,12 +816,16 @@ private[lf] object SBuiltin {
     }
   }
 
+  // SBStructCon sorts the field after evaluation of its arguments to preserve
+  // evaluation order of unordered fields.
   /** $tcon[fields] :: a -> b -> ... -> Struct */
-  final case class SBStructCon(fields: ImmArray[Name])
-      extends SBuiltinPure(fields.length)
-      with SomeArrayEquals {
+  final case class SBStructCon(inputFieldsOrder: Struct[Int])
+      extends SBuiltinPure(inputFieldsOrder.size) {
+    private[this] val fieldNames = inputFieldsOrder.mapValues(_ => ())
     override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
-      SStruct(fields, args)
+      val sortedFields = new util.ArrayList[SValue](inputFieldsOrder.size)
+      inputFieldsOrder.values.foreach(i => sortedFields.add(args.get(i)))
+      SStruct(fieldNames, sortedFields)
     }
   }
 
@@ -829,7 +834,7 @@ private[lf] object SBuiltin {
     override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
       args.get(0) match {
         case SStruct(fields, values) =>
-          values.get(fields.indexWhere(_ == field))
+          values.get(fields.indexOf(field))
         case v =>
           crash(s"StructProj on non-struct: $v")
       }
@@ -842,7 +847,7 @@ private[lf] object SBuiltin {
       args.get(0) match {
         case SStruct(fields, values) =>
           val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
-          values2.set(fields.indexWhere(_ == field), args.get(1))
+          values2.set(fields.indexOf(field), args.get(1))
           SStruct(fields, values2)
         case v =>
           crash(s"StructUpd on non-struct: $v")
@@ -1637,16 +1642,21 @@ private[lf] object SBuiltin {
         crash(s"value not a list of parties or party: $v")
     }
 
+  private[this] val keyWithMaintainersStructFields: Struct[Unit] =
+    Struct.assertFromNameSeq(List(keyFieldName, maintainersFieldName))
+
+  private[this] val keyIdx = keyWithMaintainersStructFields.indexOf(keyFieldName)
+  private[this] val maintainerIdx = keyWithMaintainersStructFields.indexOf(maintainersFieldName)
+
   private[this] def extractKeyWithMaintainers(
       v: SValue,
   ): Node.KeyWithMaintainers[V[Nothing]] =
     v match {
-      case SStruct(flds, vals)
-          if flds.length == 2 && flds(0) == Ast.keyFieldName && flds(1) == Ast.maintainersFieldName =>
+      case SStruct(_, vals) =>
         rightOrCrash(
           for {
             keyVal <- vals
-              .get(0)
+              .get(keyIdx)
               .toValue
               .ensureNoCid
               .left
@@ -1654,7 +1664,7 @@ private[lf] object SBuiltin {
           } yield
             Node.KeyWithMaintainers(
               key = keyVal,
-              maintainers = extractParties(vals.get(1))
+              maintainers = extractParties(vals.get(maintainerIdx))
             ))
       case _ => crash(s"Invalid key with maintainers: $v")
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -588,8 +588,11 @@ private[lf] object Speedy {
             crash("SValue.fromValue: record missing identifier")
           case V.ValueStruct(fs) =>
             val values = new util.ArrayList[SValue](fs.size)
-            fs.values.foreach(v => values.add(go(v)))
-            SStruct(fs.names.to[ImmArray], values)
+            val fieldNames = fs.mapValues { v =>
+              values.add(go(v))
+              ()
+            }
+            SStruct(fieldNames, values)
           case V.ValueVariant(None, _variant @ _, _value @ _) =>
             crash("SValue.fromValue: variant without identifier")
           case V.ValueEnum(None, constructor @ _) =>

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ComparisonSBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ComparisonSBuiltinTest.scala
@@ -372,9 +372,9 @@ class ComparisonSBuiltinTest extends WordSpec with Matchers with TableDrivenProp
     }
 
     // FIXME: comparison is broken for struct.
-    "should not distinguish struct built in different order" ignore {
+    "should not distinguish struct built in different order" in {
 
-      val typ = t"""<first = Int64, second = Int64, third = Int64>"""
+      val typ = t"""<first: Int64, second: Int64, third: Int64>"""
 
       val values = Table(
         "expr",

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -1496,8 +1496,7 @@ object SBuiltinTest {
     if (xs.isEmpty) "(Nil @Int64)"
     else xs.mkString(s"(Cons @Int64 [", ", ", s"] (Nil @Int64))")
 
-  private val entryFields: ImmArray[Ref.Name] =
-    ImmArray(Ref.Name.assertFromString("key"), Ref.Name.assertFromString("value"))
+  private val entryFields = Struct.assertFromNameSeq(List(keyFieldName, valueFieldName))
 
   private def mapEntry(k: String, v: SValue) = {
     val args = new util.ArrayList[SValue](2)

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -8,7 +8,7 @@ import java.util
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.PureCompiledPackages
-import com.daml.lf.data.{FrontStack, ImmArray}
+import com.daml.lf.data.{FrontStack, ImmArray, Struct}
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SBuiltin._
@@ -117,7 +117,7 @@ class SpeedyTest extends WordSpec with Matchers {
         SOptional(
           Some(
             SStruct(
-              ImmArray(n"x1", n"x2"),
+              Struct.assertFromNameSeq(List(n"x1", n"x2")),
               ArrayList(SInt64(7), SList(FrontStack(SInt64(11), SInt64(13)))),
             ),
           ),

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/EqualitySpec.scala
@@ -5,7 +5,7 @@ package com.daml.lf.speedy.svalue
 
 import java.util
 
-import com.daml.lf.data.{FrontStack, ImmArray, Numeric, Ref, Time}
+import com.daml.lf.data.{FrontStack, ImmArray, Numeric, Ref, Struct, Time}
 import com.daml.lf.language.{Ast, Util => AstUtil}
 import com.daml.lf.speedy.Profile.LabelUnset
 import com.daml.lf.speedy.SValue._
@@ -44,7 +44,8 @@ class EqualitySpec extends WordSpec with Matchers with TableDrivenPropertyChecks
   private val VariantCon1: Ref.Name = "Left"
   private val VariantCon2: Ref.Name = "Right"
 
-  private val struct2Fields = ImmArray[Ref.Name]("fst", "snd")
+  private val struct2Fields =
+    Struct.assertFromNameSeq(List("fst", "snd"))
 
   private val unit = SValue.SValue.Unit
 
@@ -76,7 +77,7 @@ class EqualitySpec extends WordSpec with Matchers with TableDrivenPropertyChecks
     SEnum(EnumTypeCon, EnumCon2, 1)
   )
 
-  private val struct0 = List(SStruct(ImmArray.empty, ArrayList()))
+  private val struct0 = List(SStruct(Struct.Empty, ArrayList()))
 
   private val records0 = List(SRecord(Record0TypeCon, ImmArray.empty, ArrayList()))
 

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -65,7 +65,8 @@ class OrderingSpec
   private val VariantCon2: Ref.Name = "Middle"
   private val VariantCon3: Ref.Name = "Right"
 
-  private val struct2Fields = ImmArray[Ref.Name]("fst", "snd")
+  private val struct2Fields =
+    Struct.assertFromNameSeq(List[Ref.Name]("fst", "snd"))
 
   private val units =
     List(SValue.SValue.Unit)
@@ -99,7 +100,7 @@ class OrderingSpec
       case (con, rank) => SEnum(EnumTypeCon, con, rank)
     }
 
-  private val struct0 = List(SStruct(ImmArray.empty, ArrayList()))
+  private val struct0 = List(SStruct(Struct.Empty, ArrayList()))
 
   private val records0 = List(SRecord(Record0TypeCon, ImmArray.empty, ArrayList()))
 


### PR DESCRIPTION
This PR uses the new data structure introduced in #7220.

Additionally this fixes `svalue.Equality` and
`svalue.Ordering` which were considering <a: x, b: y>
different from <b:y, a:x>.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
