### PR TITLE
Filter implicit parameter instances from data-dependencies

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-
 module DA.Test.Packaging (main) where
 
 import qualified "zip-archive" Codec.Archive.Zip as Zip
@@ -17,6 +16,7 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSL.Char8
 import Data.List.Extra
 import Data.Maybe
+import qualified Data.NameMap as NM
 import Module (unitIdString)
 import System.Directory.Extra
 import System.Environment.Blank
@@ -1737,10 +1737,29 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
             , "  submit p $ pure ()"
             -- This will produce two implicit instances.
             -- GHC occasionally seems to inline those instances and I don’t understand
-            -- how to reliably stop it from doing this so be careful when changing this.
+            -- how to reliably stop it from doing this therefore,
+            -- we assert that the instance actually exists.
             ]
         withCurrentDirectory (tmpDir </> "dep") $
             callProcessSilent damlc ["build", "-o", "dep.dar"]
+        Right Dalfs{..} <- readDalfs . Zip.toArchive <$> BSL.readFile (tmpDir </> "dep" </> "dep.dar")
+        (_pkgId, pkg) <- either (fail . show) pure (LFArchive.decodeArchive LFArchive.DecodeAsMain (BSL.toStrict mainDalf))
+
+        Just mod <- pure $ NM.lookup (LF.ModuleName ["Foo"]) (LF.packageModules pkg)
+        let callStackInstances = do
+                v@LF.DefValue{dvalBinder = (_, ty)} <- NM.toList (LF.moduleValues mod)
+                LF.TSynApp
+                  (LF.Qualified _ (LF.ModuleName ["GHC", "Classes"]) (LF.TypeSynName ["IP"]))
+                  [ _
+                  , LF.TCon
+                      (LF.Qualified
+                         _
+                         (LF.ModuleName ["GHC", "Stack", "Types"])
+                         (LF.TypeConName ["CallStack"])
+                      )
+                  ] <- pure ty
+                pure v
+        assertEqual "Expected two implicit CallStack" (length callStackInstances) 2
 
         step "building project that uses it via data-dependencies"
         createDirectoryIfMissing True (tmpDir </> "proj")


### PR DESCRIPTION
Occasionally GHC likes to float implicit parameters to the top-level
making them look like any other typeclass instances. Implicit
parameters are by design not unique so if we try to reconstruct them
we get an error about a duplicate instance.

I haven’t figured out when exactly GHC floats things to the top-level
but I did verify that this testcase breaks without the fix.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
