### PR TITLE
DAML-LF spec: Fix two minor issues around structs

### DIFF
--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -867,7 +867,6 @@ to remove dependence on the order of fields ::
    |Mod:S τ₁ … τₙ|   ↠   σ[α₁ ↦ σ₁, …, αₙ ↦ σₙ]
 
    τ₁ ↠ σ₁   ⋯   τₙ  ↠  σₙ
-   f₁, …, fₘ are mutually distinct
    [f₁, …, fₘ] sorts lexicographically to [fⱼ₁, …, fⱼₘ]
   ———————————————————————————————————————————————— RewriteStruct
    ⟨ f₁: τ₁, …, fₘ: τₘ ⟩ ↠ ⟨ fⱼ₁: σⱼ₁, …, fⱼₘ: σⱼₘ ⟩
@@ -1152,6 +1151,7 @@ Then we define *well-formed expressions*. ::
       Γ  ⊢  Mod:T:Eᵢ  :  Mod:T
 
       ⟨ f₁: τ₁, …, fₘ: τₘ ⟩ ↠ σ
+      Γ  ⊢  σ  :  ⋆
       Γ  ⊢  e₁  :  τ₁      ⋯      Γ  ⊢  eₘ  :  τₘ
     ——————————————————————————————————————————————————————————————— ExpStructCon
       Γ  ⊢  ⟨ f₁ = e₁, …, fₘ = eₘ ⟩  :  σ

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -867,6 +867,7 @@ to remove dependence on the order of fields ::
    |Mod:S τ₁ … τₙ|   ↠   σ[α₁ ↦ σ₁, …, αₙ ↦ σₙ]
 
    τ₁ ↠ σ₁   ⋯   τₙ  ↠  σₙ
+   f₁, …, fₘ are mutually distinct
    [f₁, …, fₘ] sorts lexicographically to [fⱼ₁, …, fⱼₘ]
   ———————————————————————————————————————————————— RewriteStruct
    ⟨ f₁: τ₁, …, fₘ: τₘ ⟩ ↠ ⟨ fⱼ₁: σⱼ₁, …, fⱼₘ: σⱼₘ ⟩
@@ -1150,7 +1151,7 @@ Then we define *well-formed expressions*. ::
     ——————————————————————————————————————————————————————————————— ExpEnumCon
       Γ  ⊢  Mod:T:Eᵢ  :  Mod:T
 
-      ⟨ f₁: τ₁, …, fⱼ: τⱼ ⟩ ↠ σ
+      ⟨ f₁: τ₁, …, fₘ: τₘ ⟩ ↠ σ
       Γ  ⊢  e₁  :  τ₁      ⋯      Γ  ⊢  eₘ  :  τₘ
     ——————————————————————————————————————————————————————————————— ExpStructCon
       Γ  ⊢  ⟨ f₁ = e₁, …, fₘ = eₘ ⟩  :  σ


### PR DESCRIPTION
We make it explicit that all field names in a structural record need to
be distince. We also fix a small typo in the indices for the
`ExpStructCon` typing rule.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7323)
<!-- Reviewable:end -->
