### PR TITLE
fix grpcurl

### DIFF
--- a/dev-env/bin/grpcurl
+++ b/dev-env/bin/grpcurl
@@ -1,1 +1,1 @@
-../lib/dade-exec-nix-bin-tool
+../lib/dade-exec-nix-tool


### PR DESCRIPTION
It looks like the structure of the nix package has changed when we updated nixpkgs in #6761, so we need to update the dev-env script to match.

CHANGELOG_BEGIN
CHANGELOG_END