### PR TITLE
ledger-api-test-tool: Only create sessions once.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -172,7 +172,7 @@ object LedgerApiTestTool {
       cases: Iterable[LedgerTestCase],
       concurrencyOverride: Option[Int] = None): LedgerTestCasesRunner =
     new LedgerTestCasesRunner(
-      LedgerSessionConfiguration(
+      new LedgerSessionConfiguration(
         config.participants,
         config.tlsConfig,
         config.partyAllocation,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -174,9 +174,9 @@ object LedgerApiTestTool {
     new LedgerTestCasesRunner(
       LedgerSessionConfiguration(
         config.participants,
-        config.shuffleParticipants,
         config.tlsConfig,
         config.partyAllocation,
+        config.shuffleParticipants,
       ),
       cases.toVector,
       identifierSuffix,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -12,9 +12,9 @@ import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Random
 
-private[infrastructure] final class LedgerSession(
-    shuffleParticipants: Boolean,
+private[infrastructure] final class LedgerSession private (
     participantSessions: immutable.Seq[(String, ParticipantSession)],
+    shuffleParticipants: Boolean,
 )(implicit val executionContext: ExecutionContext) {
   private[infrastructure] def createTestContext(
       applicationId: String,
@@ -34,15 +34,12 @@ private[infrastructure] final class LedgerSession(
 
 object LedgerSession {
   def apply(
-      config: LedgerSessionConfiguration,
       participantSessionManager: ParticipantSessionManager,
+      shuffleParticipants: Boolean,
   )(implicit executionContext: ExecutionContext): LedgerSession = {
     val endpointIdProvider =
       Identification.circularWithIndex(Identification.greekAlphabet)
-    val participantSessions = participantSessionManager.all.map(endpointIdProvider() -> _)
-    new LedgerSession(
-      shuffleParticipants = config.shuffleParticipants,
-      participantSessions = participantSessions,
-    )
+    val participantSessions = participantSessionManager.allSessions.map(endpointIdProvider() -> _)
+    new LedgerSession(participantSessions, shuffleParticipants)
   }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSession.scala
@@ -3,38 +3,49 @@
 
 package com.daml.ledger.api.testtool.infrastructure
 
-import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessionManager
+import com.daml.ledger.api.testtool.infrastructure.participant.{
+  ParticipantSession,
+  ParticipantSessionManager
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-private[testtool] final class LedgerSession(
-    val config: LedgerSessionConfiguration,
-    participantSessionManager: ParticipantSessionManager,
+private[infrastructure] final class LedgerSession(
+    shuffleParticipants: Boolean,
+    participantSessions: Vector[(String, ParticipantSession)],
 )(implicit val executionContext: ExecutionContext) {
-
-  private[this] val endpointIdProvider =
-    Identification.circularWithIndex(Identification.greekAlphabet)
-
-  private[this] val participantSessions =
-    Future
-      .sequence(config.participants.map(hostAndPort =>
-        participantSessionManager.getOrCreate(config.forParticipant(hostAndPort))))
-      .map(_.map(endpointIdProvider() -> _))
-
-  private[testtool] def createTestContext(
+  private[infrastructure] def createTestContext(
       applicationId: String,
       identifierSuffix: String,
   ): Future[LedgerTestContext] =
-    participantSessions.flatMap { sessions =>
-      Future
-        .sequence(
-          (if (config.shuffleParticipants) scala.util.Random.shuffle(sessions) else sessions)
-            .map {
-              case (endpointId, session) =>
-                session.createTestContext(endpointId, applicationId, identifierSuffix)
-            }
-        )
-        .map(new LedgerTestContext(_))
-    }
+    Future
+      .sequence(
+        (if (shuffleParticipants) scala.util.Random.shuffle(participantSessions)
+         else participantSessions)
+          .map {
+            case (endpointId, session) =>
+              session.createTestContext(endpointId, applicationId, identifierSuffix)
+          }
+      )
+      .map(new LedgerTestContext(_))
+}
 
+object LedgerSession {
+  def apply(
+      config: LedgerSessionConfiguration,
+      participantSessionManager: ParticipantSessionManager,
+  )(implicit executionContext: ExecutionContext): Future[LedgerSession] = {
+    val endpointIdProvider =
+      Identification.circularWithIndex(Identification.greekAlphabet)
+    for {
+      participantSessions <- Future
+        .sequence(config.participants.map(hostAndPort =>
+          participantSessionManager.getOrCreate(config.forParticipant(hostAndPort))))
+        .map(_.map(endpointIdProvider() -> _))
+    } yield
+      new LedgerSession(
+        shuffleParticipants = config.shuffleParticipants,
+        participantSessions = participantSessions,
+      )
+  }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
@@ -7,11 +7,14 @@ import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessio
 import com.daml.ledger.api.tls.TlsConfiguration
 
 private[testtool] final case class LedgerSessionConfiguration(
-    participants: Vector[(String, Int)],
+    participantAddresses: Vector[(String, Int)],
     shuffleParticipants: Boolean,
     ssl: Option[TlsConfiguration],
     partyAllocation: PartyAllocationConfiguration,
 ) {
+  lazy val participants: Vector[ParticipantSessionConfiguration] =
+    participantAddresses.map(forParticipant)
+
   def forParticipant(hostAndPort: (String, Int)): ParticipantSessionConfiguration = {
     val (host, port) = hostAndPort
     ParticipantSessionConfiguration(host, port, ssl, partyAllocation)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
@@ -6,15 +6,13 @@ package com.daml.ledger.api.testtool.infrastructure
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessionConfiguration
 import com.daml.ledger.api.tls.TlsConfiguration
 
-private[testtool] final case class LedgerSessionConfiguration(
-    private val participantAddresses: Vector[(String, Int)],
-    private val ssl: Option[TlsConfiguration],
-    private val partyAllocation: PartyAllocationConfiguration,
-    shuffleParticipants: Boolean,
+private[testtool] final class LedgerSessionConfiguration(
+    participantAddresses: Vector[(String, Int)],
+    ssl: Option[TlsConfiguration],
+    partyAllocation: PartyAllocationConfiguration,
+    val shuffleParticipants: Boolean,
 ) {
-  lazy val participants: Vector[ParticipantSessionConfiguration] =
-    participantAddresses.map {
-      case (host, port) =>
-        ParticipantSessionConfiguration(host, port, ssl, partyAllocation)
-    }
+  val participants: Vector[ParticipantSessionConfiguration] =
+    for ((host, port) <- participantAddresses)
+      yield ParticipantSessionConfiguration(host, port, ssl, partyAllocation)
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerSessionConfiguration.scala
@@ -7,16 +7,14 @@ import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantSessio
 import com.daml.ledger.api.tls.TlsConfiguration
 
 private[testtool] final case class LedgerSessionConfiguration(
-    participantAddresses: Vector[(String, Int)],
+    private val participantAddresses: Vector[(String, Int)],
+    private val ssl: Option[TlsConfiguration],
+    private val partyAllocation: PartyAllocationConfiguration,
     shuffleParticipants: Boolean,
-    ssl: Option[TlsConfiguration],
-    partyAllocation: PartyAllocationConfiguration,
 ) {
   lazy val participants: Vector[ParticipantSessionConfiguration] =
-    participantAddresses.map(forParticipant)
-
-  def forParticipant(hostAndPort: (String, Int)): ParticipantSessionConfiguration = {
-    val (host, port) = hostAndPort
-    ParticipantSessionConfiguration(host, port, ssl, partyAllocation)
-  }
+    participantAddresses.map {
+      case (host, port) =>
+        ParticipantSessionConfiguration(host, port, ssl, partyAllocation)
+    }
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestCasesRunner.scala
@@ -171,7 +171,7 @@ final class LedgerTestCasesRunner(
 
         testResults
           .recover { case NonFatal(e) => throw new LedgerTestCasesRunner.UncaughtExceptionError(e) }
-          .andThen { case _ => participantSessionManager.closeAll() }
+          .andThen { case _ => participantSessionManager.disconnectAll() }
       }
       .andThen {
         case _ =>

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/LedgerTestContext.scala
@@ -11,9 +11,10 @@ import com.daml.ledger.api.testtool.infrastructure.Allocation.{
 import com.daml.ledger.api.testtool.infrastructure.participant.ParticipantTestContext
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.collection.immutable
 
 private[testtool] final class LedgerTestContext private[infrastructure] (
-    participants: Vector[ParticipantTestContext],
+    participants: immutable.Seq[ParticipantTestContext],
 )(implicit ec: ExecutionContext) {
 
   require(participants.nonEmpty, "At least one participant must be provided.")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
-private[infrastructure] final class ParticipantSession(
+private[infrastructure] final class ParticipantSession private (
     config: ParticipantSessionConfiguration,
     services: LedgerServices,
     // The ledger ID is retrieved only once when the participant session is created.

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory
 import scala.concurrent.duration.{DurationInt, SECONDS}
 import scala.concurrent.{ExecutionContext, Future}
 
-private[participant] final class ParticipantSession(
+private[infrastructure] final class ParticipantSession(
     val config: ParticipantSessionConfiguration,
     channel: ManagedChannel,
     eventLoopGroup: NioEventLoopGroup,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSession.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration.{DurationInt, SECONDS}
 import scala.concurrent.{ExecutionContext, Future}
 
 private[infrastructure] final class ParticipantSession(
-    val config: ParticipantSessionConfiguration,
+    config: ParticipantSessionConfiguration,
     channel: ManagedChannel,
     eventLoopGroup: NioEventLoopGroup,
     services: LedgerServices,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionConfiguration.scala
@@ -12,5 +12,5 @@ private[testtool] final case class ParticipantSessionConfiguration(
     ssl: Option[TlsConfiguration],
     partyAllocation: PartyAllocationConfiguration,
 ) {
-  lazy val address: String = s"$host:$port"
+  val address: String = s"$host:$port"
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionConfiguration.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionConfiguration.scala
@@ -11,4 +11,6 @@ private[testtool] final case class ParticipantSessionConfiguration(
     port: Int,
     ssl: Option[TlsConfiguration],
     partyAllocation: PartyAllocationConfiguration,
-)
+) {
+  lazy val address: String = s"$host:$port"
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionManager.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionManager.scala
@@ -44,7 +44,7 @@ private[infrastructure] final class ParticipantSessionManager(
 object ParticipantSessionManager {
   private type SessionParts = (ParticipantSession, ManagedChannel, EventLoopGroup)
 
-  private val logger = LoggerFactory.getLogger(classOf[ParticipantSession])
+  private val logger = LoggerFactory.getLogger(classOf[ParticipantSessionManager])
 
   def apply(configs: immutable.Seq[ParticipantSessionConfiguration])(
       implicit executionContext: ExecutionContext


### PR DESCRIPTION
The `ParticipantSessionManager` had a race condition that meant that we could create two connections to the participant and use both, but only shut down one. This meant scary errors in the logs when the test tool stopped.

Fixed by waiting for the results of futures before constructing the various classes.

### Changelog

- **[Ledger API Test Tool]** Fix a race condition in which multiple connections were created to a single participant, and only one was shut down properly. This error was likely benign but may cause  spurious errors to show up when the test tool finishes and shuts down.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
