### PR TITLE
kvutils: Change the export header from "v3" to "v2".

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExporter.scala
@@ -29,7 +29,7 @@ object LedgerDataExporter {
         .map { path =>
           logger.info(s"Enabled writing ledger entries to $path.")
           ResourceOwner
-            .forCloseable(() => v3.ProtobufBasedLedgerDataExporter.start(path))
+            .forCloseable(() => v2.ProtobufBasedLedgerDataExporter.start(path))
             .acquire()
         }
         .getOrElse(Resource.successful(NoOpLedgerDataExporter))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataExporter.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.participant.state.kvutils.export.v3
+package com.daml.ledger.participant.state.kvutils.export.v2
 
 import java.io.{BufferedOutputStream, Closeable, OutputStream}
 import java.nio.file.{Files, Path}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataImporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataImporter.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.participant.state.kvutils.export.v3
+package com.daml.ledger.participant.state.kvutils.export.v2
 
 import java.io.{BufferedInputStream, Closeable, InputStream}
 import java.nio.file.{Files, Path}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/package.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-package object v3 {
+package object v2 {
 
-  val header = new Header(version = "v3")
+  val header = new Header(version = "v2")
 
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataExportSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataExportSpec.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.participant.state.kvutils.export.v3
+package com.daml.ledger.participant.state.kvutils.export.v2
 
 import java.io.{InputStream, OutputStream}
 

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
@@ -8,7 +8,7 @@ import java.nio.file.{Path, Paths}
 import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.participant.state.kvutils.Conversions._
-import com.daml.ledger.participant.state.kvutils.export.{SubmissionInfo, v3}
+import com.daml.ledger.participant.state.kvutils.export.{SubmissionInfo, v2}
 import com.daml.ledger.participant.state.kvutils.{Envelope, DamlKvutils => Proto}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.archive.{Decode, UniversalArchiveReader}
@@ -202,7 +202,7 @@ object Replay {
 
   private def loadBenchmarks(dumpFile: Path): Map[String, BenchmarkState] = {
     println(s"%%% load ledger export file  $dumpFile...")
-    val importer = v3.ProtobufBasedLedgerDataImporter(dumpFile)
+    val importer = v2.ProtobufBasedLedgerDataImporter(dumpFile)
     try {
       val transactions = importer.read().map(_._1).flatMap(decodeSubmissionInfo)
       if (transactions.isEmpty) sys.error("no transaction find")

--- a/ledger/participant-state/kvutils/tools/integrity-check-v2/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/v2/Main.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check-v2/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/v2/Main.scala
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 import java.util.concurrent.Executors
 
 import com.daml.dec.DirectExecutionContext
-import com.daml.ledger.participant.state.kvutils.export.{LedgerDataExporter, v3}
+import com.daml.ledger.participant.state.kvutils.export.{LedgerDataExporter, v2}
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.v2.Color.color
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
@@ -27,7 +27,7 @@ object Main {
     val executionContext: ExecutionContextExecutorService =
       ExecutionContext.fromExecutorService(
         Executors.newFixedThreadPool(sys.runtime.availableProcessors()))
-    val importer = v3.ProtobufBasedLedgerDataImporter(path)
+    val importer = v2.ProtobufBasedLedgerDataImporter(path)
     new IntegrityChecker(LogAppendingCommitStrategySupport)
       .run(importer)(executionContext)
       .andThen {


### PR DESCRIPTION
The old v2 is no more. Let's pretend it never happened.

This is to be merged before we take another snapshot for the 1.5.0 RC.

If we decide not to take another snapshot, we should close this PR and live with the "v3" header. We cannot change this after a stable release.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
