### PR TITLE
create-daml-app: make sure errors are displayed

### DIFF
--- a/templates/create-daml-app/ui/src/components/LoginScreen.tsx.template
+++ b/templates/create-daml-app/ui/src/components/LoginScreen.tsx.template
@@ -29,7 +29,7 @@ const LoginScreen: React.FC<Props> = ({onLogin}) => {
       }
       onLogin(credentials);
     } catch(error) {
-      alert(`Unknown error:\n${JSON.stringify(error)}`);
+      alert(`Unknown error:\n${error}`);
     }
   }, [onLogin]);
 

--- a/templates/create-daml-app/ui/src/components/MainView.tsx.template
+++ b/templates/create-daml-app/ui/src/components/MainView.tsx.template
@@ -33,7 +33,7 @@ const MainView: React.FC = () => {
       await ledger.exerciseByKey(User.User.Follow, username, {userToFollow});
       return true;
     } catch (error) {
-      alert("Unknown error:\n" + JSON.stringify(error));
+      alert(`Unknown error:\n${error}`);
       return false;
     }
   }


### PR DESCRIPTION
This makes sure errors caused by missing templates during decoding are displayed. Previously only the empty object '{}' was shown as error string.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
