### PR TITLE
Sandbox: Migrate Pre SDK 1.0 values

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V38__Update_value_versions.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V38__Update_value_versions.scala
@@ -1,0 +1,156 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform
+package db.migration.postgres
+
+import java.sql.{Connection, ResultSet}
+
+import anorm.{BatchSql, NamedParameter}
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+
+private[migration] final class V38__Update_value_versions extends BaseJavaMigration {
+
+  import com.daml.lf
+  import lf.value.Value.ContractId
+  import store.serialization.ValueSerializer
+
+  private[this] type Value = lf.value.Value.VersionedValue[ContractId]
+
+  private[this] val batchSize = 1000
+
+  private[this] val stableValueVersion = lf.value.ValueVersion("6")
+  private[this] val stableValueVersionAsInt = stableValueVersion.protoValue.toInt
+
+  private[this] val SELECT_EVENTS =
+    """SELECT
+         event_id,
+         create_argument,
+         create_key_value,
+         exercise_argument,
+         exercise_result
+       FROM
+         participant_events
+    """
+
+  private[this] val UPDATE_EVENTS =
+    """UPDATE participant_events SET
+         create_argument = {create_argument},
+         create_key_value = {create_key_value},
+         exercise_argument = {exercise_argument},
+         exercise_result = {exercise_result}
+       WHERE
+         event_id = {event_id}
+    """
+
+  private[this] val SELECT_CONTRACTS =
+    """SELECT
+         contract_id,
+         create_argument
+       FROM
+         participant_contracts
+    """
+
+  private[this] val UPDATE_CONTRACTS =
+    """UPDATE participant_contracts SET
+         create_argument = {create_argument}
+       WHERE
+         contract_id = {contract_id}
+    """
+
+  private[this] val EmptyArray: Array[Byte] = Array.empty
+
+  private[this] def readValue(
+      rows: ResultSet,
+      label: String,
+  ): (String, Option[Value]) =
+    label -> Option(rows.getBinaryStream(label)).map(ValueSerializer.deserializeValue)
+
+  private[this] def valueNeedUpdate(namedValue: (String, Option[Value])): Boolean =
+    namedValue._2.exists(_.version.protoValue.toInt < stableValueVersionAsInt)
+
+  private[this] def updateAndSerialize(
+      nameValue: (String, Option[Value]),
+      tableName: String,
+      rowKey: String
+  ): NamedParameter =
+    nameValue match {
+      case (label, Some(value)) =>
+        NamedParameter(
+          label,
+          ValueSerializer
+            .serializeValue(
+              value.copy(stableValueVersion),
+              s"failed to serialize $label for $tableName $rowKey"))
+      case (label, None) =>
+        NamedParameter(label, EmptyArray)
+    }
+
+  private[this] def readAndUpdate(
+      rows: ResultSet,
+      tableName: String,
+      rowKeyLabel: String,
+      valueLabels: List[String],
+  ): List[NamedParameter] = {
+    val rowKey = rows.getString(rowKeyLabel)
+    val values = valueLabels.map(readValue(rows, _))
+    if (values.exists(valueNeedUpdate))
+      NamedParameter(rowKeyLabel, rowKey) :: values.map(updateAndSerialize(_, tableName, rowKey))
+    else
+      List.empty
+  }
+
+  private[this] def readAndUpdate(
+      sqlQuery: String,
+      rowType: String,
+      rowKeyLabel: String,
+      valueLabels: List[String],
+  )(implicit connection: Connection): Stream[List[NamedParameter]] = {
+    val rows: ResultSet = connection.createStatement().executeQuery(sqlQuery)
+    def updates: Stream[List[NamedParameter]] =
+      if (rows.next())
+        readAndUpdate(rows, rowType, rowKeyLabel, valueLabels) #:: updates
+      else
+        Stream.empty
+    updates.filter(_.nonEmpty)
+  }
+
+  private[this] def save(
+      sqlUpdate: String,
+      statements: Stream[List[NamedParameter]]
+  )(implicit connection: Connection): Unit =
+    statements.grouped(batchSize).foreach { batch =>
+      BatchSql(
+        sqlUpdate,
+        batch.head,
+        batch.tail: _*
+      ).execute()
+    }
+
+  @throws[Exception]
+  override def migrate(context: Context): Unit = {
+    implicit val connection: Connection = context.getConnection
+
+    save(
+      UPDATE_EVENTS,
+      readAndUpdate(
+        sqlQuery = SELECT_EVENTS,
+        rowType = "event",
+        rowKeyLabel = "event_id",
+        valueLabels =
+          List("create_argument", "create_key_value", "exercise_argument", "exercise_result")
+      )
+    )
+
+    save(
+      UPDATE_CONTRACTS,
+      readAndUpdate(
+        sqlQuery = SELECT_CONTRACTS,
+        rowType = "contract",
+        rowKeyLabel = "contract_id",
+        valueLabels = List("create_argument"),
+      )
+    )
+  }
+
+}


### PR DESCRIPTION
Starting from SDK 1.0, the engine produces only values of version 6. We keep code to deserialize values of older version to preserve backward compatibility with sandbox for SDK < 1.0.

With the PR, we migrate all values of deprecated versions (version < 6) to the stable version 6. 
Hence we do not need any more to maintain deserialization of old value format.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
