### PR TITLE
LF: Add builtin GENMAP_TO_LIST

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -308,6 +308,7 @@ data BuiltinExpr
   | BEGenMapDelete               -- :: ∀ a b. a -> GenMap a b -> GenMap a b
   | BEGenMapKeys                 -- :: ∀ a b. GenMap a b -> List a
   | BEGenMapValues               -- :: ∀ a b. GenMap a b -> List b
+  | BEGenMapToList               -- :: ∀ a b. GenMap a b -> List ⟨key: a, value: b⟩
   | BEGenMapSize                 -- :: ∀ a b. GenMap a b -> Int64
 
   -- Text operations

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -261,6 +261,7 @@ instance Pretty BuiltinExpr where
     BEGenMapSize -> "GENMAP_SIZE"
     BEGenMapKeys -> "GENMAP_KEYS"
     BEGenMapValues -> "GENMAP_VALUES"
+    BEGenMapToList -> "GENMAP_TO_LIST"
     BEEqualList -> "EQUAL_LIST"
     BEAppendText -> "APPEND_TEXT"
     BETimestamp ts -> text (timestampToText ts)

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -185,8 +185,8 @@ pattern TNumeric n = TApp (TBuiltin BTNumeric) n
 pattern TGenMap :: Type -> Type -> Type
 pattern TGenMap t1 t2 = TApp (TApp (TBuiltin BTGenMap) t1) t2
 
-pattern TTextMapEntry :: Type -> Type
-pattern TTextMapEntry a = TStruct [(FieldName "key", TText), (FieldName "value", a)]
+pattern TGenMapEntry :: Type -> Type -> Type
+pattern TGenMapEntry a b = TStruct [(FieldName "key", a), (FieldName "value", b)]
 
 pattern TConApp :: Qualified TypeConName -> [Type] -> Type
 pattern TConApp tcon targs <- (view (leftSpine _TApp) -> (TCon tcon, targs))

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -429,6 +429,7 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionGENMAP_DELETE     -> BEGenMapDelete
   LF1.BuiltinFunctionGENMAP_KEYS       -> BEGenMapKeys
   LF1.BuiltinFunctionGENMAP_VALUES     -> BEGenMapValues
+  LF1.BuiltinFunctionGENMAP_TO_LIST    -> BEGenMapToList
   LF1.BuiltinFunctionGENMAP_SIZE       -> BEGenMapSize
 
   LF1.BuiltinFunctionEXPLODE_TEXT -> BEExplodeText

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -487,6 +487,7 @@ encodeBuiltinExpr = \case
     BEGenMapSize -> builtin P.BuiltinFunctionGENMAP_SIZE
     BEGenMapKeys -> builtin P.BuiltinFunctionGENMAP_KEYS
     BEGenMapValues -> builtin P.BuiltinFunctionGENMAP_VALUES
+    BEGenMapToList -> builtin P.BuiltinFunctionGENMAP_TO_LIST
 
     BETimestampToUnixMicroseconds -> builtin P.BuiltinFunctionTIMESTAMP_TO_UNIX_MICROSECONDS
     BEUnixMicrosecondsToTimestamp -> builtin P.BuiltinFunctionUNIX_MICROSECONDS_TO_TIMESTAMP

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -139,6 +139,7 @@ safetyStep = \case
       BEGenMapDelete      -> Safe 1 -- crash if key invalid
       BEGenMapKeys        -> Safe 1
       BEGenMapValues      -> Safe 1
+      BEGenMapToList      -> Safe 1
       BEGenMapSize        -> Safe 1
       BEEqualList         -> Safe 2 -- expects 3, 2-safe
       BEExplodeText       -> Safe 1

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -254,7 +254,7 @@ typeOfBuiltin = \case
   BETextMapInsert -> pure $ TForall (alpha, KStar) $ TText :-> tAlpha :-> TTextMap tAlpha :-> TTextMap tAlpha
   BETextMapLookup -> pure $ TForall (alpha, KStar) $ TText :-> TTextMap tAlpha :-> TOptional tAlpha
   BETextMapDelete -> pure $ TForall (alpha, KStar) $ TText :-> TTextMap tAlpha :-> TTextMap tAlpha
-  BETextMapToList -> pure $ TForall (alpha, KStar) $ TTextMap tAlpha :-> TList (TTextMapEntry tAlpha)
+  BETextMapToList -> pure $ TForall (alpha, KStar) $ TTextMap tAlpha :-> TList (TGenMapEntry TText tAlpha)
   BETextMapSize   -> pure $ TForall (alpha, KStar) $ TTextMap tAlpha :-> TInt64
   BEGenMapEmpty -> pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $ TGenMap tAlpha tBeta
   BEGenMapInsert -> pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $ tAlpha :-> tBeta :-> TGenMap tAlpha tBeta :-> TGenMap tAlpha tBeta
@@ -262,6 +262,7 @@ typeOfBuiltin = \case
   BEGenMapDelete -> pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $ tAlpha :-> TGenMap tAlpha tBeta :-> TGenMap tAlpha tBeta
   BEGenMapKeys -> pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $ TGenMap tAlpha tBeta :-> TList tAlpha
   BEGenMapValues -> pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $ TGenMap tAlpha tBeta :-> TList tBeta
+  BEGenMapToList -> pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $ TGenMap tAlpha tBeta :-> TList (TGenMapEntry tAlpha tBeta)
   BEGenMapSize -> pure $ TForall (alpha, KStar) $ TForall (beta, KStar) $ TGenMap tAlpha tBeta :-> TInt64
 
   BEEqualList -> pure $

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -158,7 +158,7 @@ convertPrim _ "BETextMapLookup" (TText :-> TTextMap a1 :-> TOptional a2) | a1 ==
   EBuiltin BETextMapLookup `ETyApp` a1
 convertPrim _ "BETextMapDelete" (TText :-> TTextMap a1 :-> TTextMap a2) | a1 == a2 =
   EBuiltin BETextMapDelete `ETyApp` a1
-convertPrim _ "BETextMapToList" (TTextMap a1 :-> TList (TTextMapEntry a2)) | a1 == a2  =
+convertPrim _ "BETextMapToList" (TTextMap a1 :-> TList (TGenMapEntry TText a2)) | a1 == a2  =
   EBuiltin BETextMapToList `ETyApp` a1
 convertPrim _ "BETextMapSize" (TTextMap a :-> TInt64) =
   EBuiltin BETextMapSize `ETyApp` a

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -457,6 +457,7 @@ enum BuiltinFunction {
   GENMAP_DELETE = 127; // *Available in versions >= 1.dev*
   GENMAP_KEYS = 128; // *Available in versions >= 1.dev*
   GENMAP_VALUES = 129; // *Available in versions >= 1.dev*
+  GENMAP_TO_LIST = 137; // *Available in versions >= 1.dev*
   GENMAP_SIZE = 130; // *Available in versions >= 1.dev*
 
   EXPLODE_TEXT = 23;
@@ -550,7 +551,7 @@ enum BuiltinFunction {
   TEXT_FROM_CODE_POINTS = 105;  // *Available in versions >= 1.6*
   TEXT_TO_CODE_POINTS = 106; // *Available in versions >= 1.6*
 
-  // Next id is 137. 136 is TO_TEXT_CONTRACT_ID.
+  // Next id is 138. 137 is GENMAP_TO_LIST.
 
   // EXPERIMENTAL TEXT PRIMITIVES -- these do not yet have stable numbers.
   TEXT_TO_UPPER = 9901; // *Available in versions >= 1.dev*

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1411,6 +1411,7 @@ private[lf] object DecodeV1 {
       BuiltinFunctionInfo(GENMAP_DELETE, BGenMapDelete, minVersion = genMap),
       BuiltinFunctionInfo(GENMAP_KEYS, BGenMapKeys, minVersion = genMap),
       BuiltinFunctionInfo(GENMAP_VALUES, BGenMapValues, minVersion = genMap),
+      BuiltinFunctionInfo(GENMAP_TO_LIST, BGenMapToList, minVersion = genMap),
       BuiltinFunctionInfo(GENMAP_SIZE, BGenMapSize, minVersion = genMap),
       BuiltinFunctionInfo(APPEND_TEXT, BAppendText),
       BuiltinFunctionInfo(ERROR, BError),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -453,6 +453,7 @@ private[lf] final case class Compiler(
           case BGenMapDelete => SBGenMapDelete
           case BGenMapKeys => SBGenMapKeys
           case BGenMapValues => SBGenMapValues
+          case BGenMapToList => SBGenMapToList
           case BGenMapSize => SBGenMapSize
 
           // Unstable Text Primitives

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SBuiltinTest.scala
@@ -876,16 +876,16 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
           Right(
             SList(
               FrontStack(
-                mapEntry("cover", SInt64(8)),
-                mapEntry("enter", SInt64(7)),
-                mapEntry("favor", SInt64(9)),
-                mapEntry("first", SInt64(3)),
-                mapEntry("patch", SInt64(4)),
-                mapEntry("ranch", SInt64(2)),
-                mapEntry("slant", SInt64(0)),
-                mapEntry("sweat", SInt64(6)),
-                mapEntry("trend", SInt64(5)),
-                mapEntry("visit", SInt64(1)),
+                textMapEntry("cover", SInt64(8)),
+                textMapEntry("enter", SInt64(7)),
+                textMapEntry("favor", SInt64(9)),
+                textMapEntry("first", SInt64(3)),
+                textMapEntry("patch", SInt64(4)),
+                textMapEntry("ranch", SInt64(2)),
+                textMapEntry("slant", SInt64(0)),
+                textMapEntry("sweat", SInt64(6)),
+                textMapEntry("trend", SInt64(5)),
+                textMapEntry("visit", SInt64(1)),
               ),
             ),
           )
@@ -1044,6 +1044,16 @@ class SBuiltinTest extends FreeSpec with Matchers with TableDrivenPropertyChecks
       "returns the values in order" in {
         eval(e"GENMAP_VALUES @Text @Int64 ${buildMap("Int64", words: _*)}") shouldBe
           Right(SList(FrontStack(sortedWords.map { case (_, v) => SInt64(v.toLong) })))
+      }
+    }
+
+    "GENMAP_TO_LIST" - {
+
+      "returns the values in order" in {
+        eval(e"GENMAP_TO_LIST @Text @Int64 ${buildMap("Int64", words: _*)}") shouldBe
+          Right(SList(FrontStack(sortedWords.map {
+            case (k, v) => mapEntry(SText(k), SInt64(v.toLong))
+          })))
       }
     }
 
@@ -1430,11 +1440,14 @@ object SBuiltinTest {
     if (xs.isEmpty) "(Nil @Int64)"
     else xs.mkString(s"(Cons @Int64 [", ", ", s"] (Nil @Int64))")
 
-  private val entryFields = Struct.assertFromNameSeq(List(keyFieldName, valueFieldName))
+  private[this] val entryFields = Struct.assertFromNameSeq(List(keyFieldName, valueFieldName))
 
-  private def mapEntry(k: String, v: SValue) = {
+  private def textMapEntry(k: String, v: SValue) =
+    mapEntry(SText(k), v)
+
+  private def mapEntry(k: SValue, v: SValue) = {
     val args = new util.ArrayList[SValue](2)
-    args.add(SText(k))
+    args.add(k)
     args.add(v)
     SStruct(entryFields, args)
   }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -365,6 +365,7 @@ object Ast {
   final case object BGenMapDelete extends BuiltinFunction(2) // : ∀ a b. a -> GenMap a b -> GenMap a b
   final case object BGenMapKeys extends BuiltinFunction(1) // : ∀ a b. GenMap a b -> [a]
   final case object BGenMapValues extends BuiltinFunction(1) // : ∀ a b. GenMap a b -> [b]
+  final case object BGenMapToList extends BuiltinFunction(1) // : ∀ a b. GenMap a b -> [Struct("key":a, "value":b)]
   final case object BGenMapSize extends BuiltinFunction(1) // : ∀ a b. GenMap a b -> Int64
 
   // Text functions

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -244,6 +244,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     "GENMAP_DELETE" -> BGenMapDelete,
     "GENMAP_KEYS" -> BGenMapKeys,
     "GENMAP_VALUES" -> BGenMapValues,
+    "GENMAP_TO_LIST" -> BGenMapToList,
     "GENMAP_SIZE" -> BGenMapSize,
     "EXPLODE_TEXT" -> BExplodeText,
     "IMPLODE_TEXT" -> BImplodeText,

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -3849,6 +3849,24 @@ ordered by keys according to the comparison function ``LESS``.
 
   [*Available in versions >= 1.dev*]
 
+* ``GENMAP_TO_LIST : ∀ α. ∀ β.  'GenMap' α β → ⟨ key: α, value: β  ⟩``
+
+  Converts to a list of key/value pairs. The output list is guaranteed to be
+   sorted according to the ordering of its keys.
+
+  [*Available in versions >= 1.dev*]
+
+  Formally the builtin function ``GENMAP_VALUES`` semantics is defined
+  by the following rules. ::
+
+    —————————————————————————————————————————————————————————————————————— EvGenMapListEmpty
+      𝕆('GENMAP_TO_LIST' @σ @τ 〚〛) = 'Ok' (Nil @⟨ key: α, value: β  ⟩)
+
+      𝕆('GENMAP_TO_LIST' @σ @τ 〚v₁ ↦ w₁; … ; vₙ ↦ wₙ〛) = 'Ok' wₗ
+    —————————————————————————————————————————————————————————————————————— EvGenMapListNonEmpty
+      𝕆('GENMAP_TO_LIST' @σ @τ 〚v₀ ↦ w₀; v₁ ↦ w₁; … ; vₙ ↦ wₙ〛) =
+        'Ok' (Cons @⟨ key: α, value: β⟩ ⟨ key = v₀ , value =  w₀ ⟩ wₗ)
+
 Type Representation function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -4377,7 +4395,7 @@ The deserialization process will reject any DAML-LF 1.7 (or earlier)
 program using the builtin type ``GENMAP`` or the functions
 ``GENMAP_EMPTY``, ``GENMAP_INSERT``, ``GENMAP_LOOKUP``,
 ``GENMAP_DELETE``, ``GENMAP_KEYS``, ``GENMAP_VALUES``,
-``GENMAP_SIZE``.
+``GENMAP_TO_LIST``, ``GENMAP_SIZE``.
 
 
 .. Local Variables:


### PR DESCRIPTION
By merging `SGenMap` and `STextMap` implementation in #7334, 
we have generalized `SBTextMapToList` to handle arbitrary `SGenMap`.

This PR exposes this internal built-in as a new LF built-in `GENMAP_TO_LIST`.
It enable the complexity of daml `Map.toList` from `O(n log n)` to `O(n)`

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
