### PR TITLE
Add queryContractKey to DAML Script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -8,6 +8,7 @@ module Daml.Script
   , submitMustFail
   , query
   , queryContractId
+  , queryContractKey
   , PartyIdHint (..)
   , ParticipantName (..)
   , PartyDetails(..)
@@ -89,6 +90,7 @@ data ScriptF a
   | SubmitMustFail (SubmitMustFailCmd a)
   | Query (QueryACS a)
   | QueryContractId (QueryContractIdPayload a)
+  | QueryContractKey (QueryContractKeyPayload a)
   | AllocParty (AllocateParty a)
   | ListKnownParties (ListKnownPartiesPayload a)
   | GetTime (Time -> a)
@@ -125,6 +127,24 @@ queryContractId p c = lift $ Free $ QueryContractId QueryContractIdPayload with
   tplId = templateTypeRep @t
   cid = coerceContractId c
   continue = pure . fmap (fromSome . fromAnyTemplate)
+
+data QueryContractKeyPayload a = QueryContractKeyPayload
+  { party : Party
+  , tplId : TemplateTypeRep
+  , key : AnyContractKey
+  , continue : Optional (ContractId (), AnyTemplate) -> a
+  } deriving Functor
+
+-- Returns `None` if there is no active contract with the given key that
+-- the party is a stakeholder on.
+-- This is semantically equivalent to calling `query`
+-- and filtering on the client side.
+queryContractKey : forall t k. TemplateKey t k => Party -> k -> Script (Optional (ContractId t, t))
+queryContractKey p k = lift $ Free $ QueryContractKey QueryContractKeyPayload with
+  party = p
+  tplId = templateTypeRep @t
+  key = toAnyContractKey @t k
+  continue = pure . fmap (\(cid, anyTpl) -> (coerceContractId cid, fromSome (fromAnyTemplate anyTpl)))
 
 data SetTimePayload a = SetTimePayload
   with

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -785,7 +785,7 @@ class JsonLedgerClient(
       headers = List(Authorization(OAuth2BearerToken(token.value)))
     )
     for {
-      () <- validateTokenParty(party, "queryContractKey")
+      _ <- validateTokenParty(party, "queryContractKey")
       resp <- Http().singleRequest(req)
       fetchResponse <- if (resp.status.isSuccess) {
         Unmarshal(resp.entity).to[JsonLedgerClient.FetchResponse]

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -24,6 +24,7 @@ import scala.util.{Failure, Success}
 import scalaz.{-\/, \/-}
 import scalaz.std.either._
 import scalaz.std.list._
+import scalaz.syntax.equal._
 import scalaz.syntax.tag._
 import scalaz.syntax.traverse._
 import spray.json._
@@ -45,6 +46,7 @@ import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SResult._
+import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.jwt.domain.Jwt
@@ -124,6 +126,10 @@ trait ScriptLedgerClient {
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]]
 
+  def queryContractKey(party: SParty, templateId: Identifier, key: SValue)(
+      implicit ec: ExecutionContext,
+      mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]]
+
   def submit(
       party: SParty,
       commands: List[ScriptLedgerClient.Command],
@@ -165,6 +171,14 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
   override def query(party: SParty, templateId: Identifier)(
       implicit ec: ExecutionContext,
       mat: Materializer) = {
+    queryWithKey(party, templateId).map(_.map(_._1))
+  }
+
+  // Helper shared by query, queryContractId and queryContractKey
+  private def queryWithKey(party: SParty, templateId: Identifier)(
+      implicit ec: ExecutionContext,
+      mat: Materializer)
+    : Future[Seq[(ScriptLedgerClient.ActiveContract, Option[Value[ContractId]])]] = {
     val filter = TransactionFilter(
       List((party.value, Filters(Some(InclusiveFilters(Seq(toApiIdentifier(templateId))))))).toMap)
     val acsResponses =
@@ -178,6 +192,12 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
             case Left(err) => throw new ConverterException(err.toString)
             case Right(argument) => argument
           }
+          val key: Option[Value[ContractId]] = createdEvent.contractKey.map { key =>
+            ValueValidator.validateValue(key) match {
+              case Left(err) => throw new ConverterException(err.toString)
+              case Right(argument) => argument
+            }
+          }
           val cid =
             ContractId
               .fromString(createdEvent.contractId)
@@ -185,7 +205,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
                 err => throw new ConverterException(err),
                 identity
               )
-          ScriptLedgerClient.ActiveContract(templateId, cid, argument)
+          (ScriptLedgerClient.ActiveContract(templateId, cid, argument), key)
         })))
   }
 
@@ -197,6 +217,17 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
       activeContracts <- query(party, templateId)
     } yield {
       activeContracts.find(c => c.contractId == cid)
+    }
+  }
+
+  override def queryContractKey(party: SParty, templateId: Identifier, key: SValue)(
+      implicit ec: ExecutionContext,
+      mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]] = {
+    // We cannot do better than a linear search over query here.
+    for {
+      activeContracts <- queryWithKey(party, templateId)
+    } yield {
+      activeContracts.collectFirst({ case (c, Some(k)) if k === key.toValue => c })
     }
   }
 
@@ -414,6 +445,20 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
         // and the contract not being active.
         Future.successful(None)
     }
+  }
+
+  override def queryContractKey(party: SParty, templateId: Identifier, key: SValue)(
+      implicit ec: ExecutionContext,
+      mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]] = {
+    GlobalKey
+      .build(templateId, key.toValue)
+      .fold(err => Future.failed(new ConverterException(err)), Future.successful(_))
+      .flatMap { gkey =>
+        scenarioRunner.ledger.ledgerData.activeKeys.get(gkey) match {
+          case None => Future.successful(None)
+          case Some(cid) => queryContractId(party, templateId, cid)
+        }
+      }
   }
 
   // Translate from a ledger command to an Update expression
@@ -728,6 +773,38 @@ class JsonLedgerClient(
       })
     }
   }
+  override def queryContractKey(party: SParty, templateId: Identifier, key: SValue)(
+      implicit ec: ExecutionContext,
+      mat: Materializer) = {
+    val req = HttpRequest(
+      method = HttpMethods.POST,
+      uri = uri.withPath(uri.path./("v1")./("fetch")),
+      entity = HttpEntity(
+        ContentTypes.`application/json`,
+        JsonLedgerClient.FetchKeyArgs(templateId, key.toValue).toJson.prettyPrint),
+      headers = List(Authorization(OAuth2BearerToken(token.value)))
+    )
+    for {
+      () <- validateTokenParty(party, "queryContractKey")
+      resp <- Http().singleRequest(req)
+      fetchResponse <- if (resp.status.isSuccess) {
+        Unmarshal(resp.entity).to[JsonLedgerClient.FetchResponse]
+      } else {
+        getResponseDataBytes(resp).flatMap {
+          case body => Future.failed(new RuntimeException(s"Failed to query ledger: $resp, $body"))
+        }
+      }
+    } yield {
+      val ctx = templateId.qualifiedName
+      val ifaceType = Converter.toIfaceType(ctx, TTyCon(templateId)).right.get
+      fetchResponse.result.map(r => {
+        val payload = r.payload.convertTo[Value[ContractId]](
+          LfValueCodec.apiValueJsonReader(ifaceType, damlLfTypeLookup(_)))
+        val cid = ContractId.assertFromString(r.contractId)
+        ScriptLedgerClient.ActiveContract(templateId, cid, payload)
+      })
+    }
+  }
   override def submit(
       party: SParty,
       commands: List[ScriptLedgerClient.Command],
@@ -964,6 +1041,7 @@ object JsonLedgerClient {
   final case class QueryResponse(results: List[ActiveContract])
   final case class ActiveContract(contractId: String, payload: JsValue)
   final case class FetchArgs(contractId: ContractId)
+  final case class FetchKeyArgs(templateId: Identifier, key: Value[ContractId])
   final case class FetchResponse(result: Option[ActiveContract])
 
   final case class CreateArgs(templateId: Identifier, payload: JsValue)
@@ -1011,6 +1089,10 @@ object JsonLedgerClient {
     }
     implicit val fetchWriter: JsonWriter[FetchArgs] = args =>
       JsObject("contractId" -> args.contractId.coid.toString.toJson)
+    implicit val fetchKeyWriter: JsonWriter[FetchKeyArgs] = args =>
+      JsObject(
+        "templateId" -> args.templateId.toJson,
+        "key" -> LfValueCodec.apiValueToJsValue(args.key))
     implicit val fetchReader: RootJsonReader[FetchResponse] = v =>
       v.asJsObject.getFields("result") match {
         case Seq(JsNull) => FetchResponse(None)

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -58,6 +58,7 @@ ScriptExample:initializeFixed SUCCESS
 ScriptTest:testStack SUCCESS
 ScriptTest:testMaxInboundMessageSize SUCCESS
 ScriptTest:testQueryContractId SUCCESS
+ScriptTest:testQueryContractKey SUCCESS
 EOF
 )"
 

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -281,3 +281,15 @@ jsonQueryContractId p = do
   submit p do archiveCmd cid
   optR <- queryContractId p cid
   optR === None
+
+testQueryContractKey : Script () = do
+  p <- allocateParty "p"
+  jsonQueryContractKey p
+
+jsonQueryContractKey p = do
+  cid <- submit p do createCmd (WithKey p)
+  optR <- queryContractKey @WithKey p p
+  optR === Some (cid, WithKey p)
+  submit p do archiveCmd cid
+  optR <- queryContractKey @WithKey p p
+  optR === None

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -369,5 +369,18 @@ final class JsonApiIt
         assert(result == SUnit)
       }
     }
+    "queryContractKey" in {
+      // fresh party to avoid key collisions with other tests
+      val party = "jsonQueryContractKey"
+      for {
+        clients <- getClients(parties = List(party))
+        result <- run(
+          clients,
+          QualifiedName.assertFromString("ScriptTest:jsonQueryContractKey"),
+          inputValue = Some(JsString(party)))
+      } yield {
+        assert(result == SUnit)
+      }
+    }
   }
 }

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/SingleParticipant.scala
@@ -408,12 +408,28 @@ case class TestContractId(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   }
 }
 
-case class TestLookupFetch(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+case class TestQueryContractId(dar: Dar[(PackageId, Package)], runner: TestRunner) {
   val scriptId =
     Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:testQueryContractId"))
   def runTests(): Unit = {
     runner.genericTest(
       "testQueryContractId",
+      scriptId,
+      None, {
+        // We test with assertions in the test
+        case SUnit => Right(())
+        case v => Left(s"Expected SUnit but got $v")
+      }
+    )
+  }
+}
+
+case class TestQueryContractKey(dar: Dar[(PackageId, Package)], runner: TestRunner) {
+  val scriptId =
+    Identifier(dar.main._1, QualifiedName.assertFromString("ScriptTest:testQueryContractKey"))
+  def runTests(): Unit = {
+    runner.genericTest(
+      "testQueryContractKey",
       scriptId,
       None, {
         // We test with assertions in the test
@@ -528,7 +544,8 @@ object SingleParticipant {
         val devRunner =
           new TestRunner(participantParams, devDar, config.wallclockTime, config.rootCa)
         if (!config.auth) {
-          TestLookupFetch(dar, runner).runTests()
+          TestQueryContractId(dar, runner).runTests()
+          TestQueryContractKey(dar, runner).runTests()
           TraceOrder(dar, runner).runTests()
           Test0(dar, runner).runTests()
           Test1(dar, runner).runTests()


### PR DESCRIPTION
This matches the behavior and the implementation of
`queryContractId`. We only return contracts for stakeholders and we
return an `Optional` so you can handle lookup failures. On the JSON
API and in DAML Studio this is fairly efficient, over the gRPC API it
degrades to a linear search.

changelog_begin

- [DAML Script] Add `queryContractKey` to the DAML Script API.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
