### PR TITLE
Remove redundant --force from npm invocations

### DIFF
--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/CreateDamlAppTests.hs
@@ -111,8 +111,8 @@ tests =
           forM_ [file | file <- genFiles, takeFileName file == "package.json"] (patchTsDependencies uiDir)
         withCurrentDirectory uiDir $ do
           patchTsDependencies uiDir "package.json"
-          step "Install UI dependencies again, forcing rebuild of generated code"
-          callCommandSilent "npm-cli.js install --force --frozen-lockfile"
+          step "Install UI dependencies again to incorporate the changes"
+          callCommandSilent "npm-cli.js install --frozen-lockfile"
           step "Run linter again"
           callCommandSilent "npm-cli.js run-script lint -- --max-warnings 0"
           step "Build the new UI"

--- a/docs/source/getting-started/first-feature.rst
+++ b/docs/source/getting-started/first-feature.rst
@@ -81,7 +81,7 @@ The result is an up-to-date TypeScript interface to our DAML model, in particula
 To make sure that Yarn picks up the newly generated JavaScript code,
 we have to run the following command in the ``ui`` directory::
 
-  npm install --force --frozen-lockfile
+  npm install --frozen-lockfile
 
 Once that command finishes, you have to close Visual Studio Code
 and restart it by running ``daml studio`` from the root directory of

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -68,7 +68,7 @@ In order to connect the UI code to this DAML, we need to run a code generation s
 Now, changing to the ``ui`` folder, use ``npm`` to install the project dependencies::
 
     cd ui
-    npm install --force --frozen-lockfile
+    npm install --frozen-lockfile
 
 This step may take a couple of moments (it's worth it!).
 You should see ``success Saved lockfile.`` in the output if everything worked as expected.

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -162,7 +162,7 @@ patches we backport to the 1.0 release branch).
 
     1. Run `daml build` then `daml codegen js .daml/dist/create-daml-app-0.1.0.dar -o daml.js` from the project root.
 
-    1. From the `ui` directory run `npm install --force --frozen-lockfile`.
+    1. From the `ui` directory run `npm install --frozen-lockfile`.
 
     1. Run `code .` from the project root directory (the extension is
        already installed, no need to use `daml studio`).


### PR DESCRIPTION
NPM doesn’t actually need this (at least it didn’t for me locally and
hopefully CI agrees) to pick up changes and it emits a very
scary-looking warning if you do pass it.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
