### PR TITLE
Disable multipackage LSP tests on Windows.

### DIFF
--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -868,6 +868,7 @@ includePathTests damlc = testGroup "include-path"
     ]
 
 multiPackageTests :: FilePath -> TestTree
+multiPackageTests damlc | isWindows = testGroup "multi-package (skipped)" []
 multiPackageTests damlc = testGroup "multi-package"
     [ testCaseSteps "IDE in root directory" $ \step -> withTempDir $ \dir -> do
           step "build a"

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -868,8 +868,9 @@ includePathTests damlc = testGroup "include-path"
     ]
 
 multiPackageTests :: FilePath -> TestTree
-multiPackageTests damlc | isWindows = testGroup "multi-package (skipped)" []
-multiPackageTests damlc = testGroup "multi-package"
+multiPackageTests damlc
+  | isWindows = testGroup "multi-package (skipped)" [] -- see issue #4904
+  | otherwise = testGroup "multi-package"
     [ testCaseSteps "IDE in root directory" $ \step -> withTempDir $ \dir -> do
           step "build a"
           createDirectoryIfMissing True (dir </> "a")


### PR DESCRIPTION
These are consistently timing out on Windows for unknown reasons. I've confirmed experimentally that disabling these tests makes the timeouts go away. Let's disable them until we figure out how to fix the tests.

See issue #4904