### PR TITLE
damlc: Don't use uniques for type vars during conversion to LF

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -189,12 +189,10 @@ envLookupAlias x = MS.lookup x . envAliases
 
 -- | Bind a type var without shadowing its LF name.
 envBindTypeVar :: Var -> Env -> (TypeVarName, Env)
-envBindTypeVar x env = try 1 (TypeVarName (prefix <> suffix))
+envBindTypeVar x env = try 1 (TypeVarName occName)
     where
-        prefix = getOccText x
-        suffix = "_" <> T.pack (show (varUnique x))
-            -- NOTE: Workaround for #3777. Remove suffix once issue fixed.
-        nameFor i = TypeVarName (prefix <> T.pack (show i) <> suffix)
+        occName = getOccText x
+        nameFor i = TypeVarName (occName <> T.pack (show i))
 
         try :: Int -> TypeVarName -> (TypeVarName, Env)
         try !i name =


### PR DESCRIPTION
We had some issues with shadowing of type variables in our DAML-LF type
checkers because of some bugs in our implementations of substitution. As
a workaround for these issues, we suffixed each type variable with its
GHC unique during conversion to DAML-LF. Unfortunately, this leads to
new problems when using parametrized variant types and record
projections in combination with data-dependencies.

This PR, drops the unique suffix when converting to DAML-LF. This
change is possible since we fixed the bugs in the substitutions a while
ago. Fortunately, this also fixes the aforementioned problem regarding
data-dependencies.

This fixes #7284.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7361)
<!-- Reviewable:end -->
