### PR TITLE
Add warning for variant constructor with unit arg.

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -63,7 +63,7 @@ damlPreprocessor :: Maybe GHC.UnitId -> GHC.ParsedSource -> IdePreprocessedSourc
 damlPreprocessor mbUnitId x
     | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = noPreprocessor x
     | otherwise = IdePreprocessedSource
-        { preprocWarnings = checkUnitVariantConstructors x
+        { preprocWarnings = checkVariantUnitConstructors x
         , preprocErrors = checkImports x ++ checkDataTypes x ++ checkModuleDefinition x ++ checkRecordConstructor x ++ checkModuleName x
         , preprocSource = recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbUnitId $ enumTypePreprocessor "GHC.Types" x
         }
@@ -122,8 +122,8 @@ checkImports x =
 
 -- | Emit a warning if a variant constructor has a single argument of unit type '()'.
 -- See issue #7207.
-checkUnitVariantConstructors :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
-checkUnitVariantConstructors (GHC.L _ m) =
+checkVariantUnitConstructors :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
+checkVariantUnitConstructors (GHC.L _ m) =
     [ (ss, message tyNameStr conNameStr)
     | GHC.L ss (GHC.TyClD _ GHC.DataDecl{tcdLName=ltyName, tcdDataDefn=dataDefn}) <- GHC.hsmodDecls m
     , GHC.HsDataDefn{dd_cons=cons} <- [dataDefn]

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -124,15 +124,15 @@ checkImports x =
 -- See issue #7207.
 checkVariantUnitConstructors :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
 checkVariantUnitConstructors (GHC.L _ m) =
-    [ (ss, message tyNameStr conNameStr)
+    [ let tyNameStr = GHC.occNameString (GHC.rdrNameOcc (GHC.unLoc ltyName))
+          conNameStr = GHC.occNameString (GHC.rdrNameOcc conName)
+      in (ss, message tyNameStr conNameStr)
     | GHC.L ss (GHC.TyClD _ GHC.DataDecl{tcdLName=ltyName, tcdDataDefn=dataDefn}) <- GHC.hsmodDecls m
     , GHC.HsDataDefn{dd_cons=cons} <- [dataDefn]
     , length cons > 1
     , GHC.L _ con <- cons
     , GHC.PrefixCon [GHC.L _ (GHC.HsTupleTy _ _ [])] <- [GHC.con_args con]
     , GHC.L _ conName <- GHC.getConNames con
-    , let tyNameStr = GHC.occNameString (GHC.rdrNameOcc (GHC.unLoc ltyName))
-    , let conNameStr = GHC.occNameString (GHC.rdrNameOcc conName)
     ]
   where
     message tyNameStr conNameStr = unwords

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -63,7 +63,7 @@ damlPreprocessor :: Maybe GHC.UnitId -> GHC.ParsedSource -> IdePreprocessedSourc
 damlPreprocessor mbUnitId x
     | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = noPreprocessor x
     | otherwise = IdePreprocessedSource
-        { preprocWarnings = []
+        { preprocWarnings = checkUnitVariantConstructors x
         , preprocErrors = checkImports x ++ checkDataTypes x ++ checkModuleDefinition x ++ checkRecordConstructor x ++ checkModuleName x
         , preprocSource = recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbUnitId $ enumTypePreprocessor "GHC.Types" x
         }
@@ -120,8 +120,29 @@ checkImports x =
     [ (ss, "Import of internal module " ++ GHC.moduleNameString m ++ " is not allowed.")
     | GHC.L ss GHC.ImportDecl{ideclName=GHC.L _ m} <- GHC.hsmodImports $ GHC.unLoc x, isInternal m]
 
--- | Emit a warning if a record constructor name does not match the record type name.
--- See issue #4718. This ought to be moved into 'checkDataTypes' before too long.
+-- | Emit a warning if a variant constructor has a single argument of unit type '()'.
+-- See issue #7207.
+checkUnitVariantConstructors :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
+checkUnitVariantConstructors (GHC.L _ m) =
+    [ (ss, message tyNameStr conNameStr)
+    | GHC.L ss (GHC.TyClD _ GHC.DataDecl{tcdLName=ltyName, tcdDataDefn=dataDefn}) <- GHC.hsmodDecls m
+    , GHC.HsDataDefn{dd_cons=cons} <- [dataDefn]
+    , length cons > 1
+    , GHC.L _ con <- cons
+    , GHC.PrefixCon [GHC.L _ (GHC.HsTupleTy _ _ [])] <- [GHC.con_args con]
+    , GHC.L _ conName <- GHC.getConNames con
+    , let tyNameStr = GHC.occNameString (GHC.rdrNameOcc (GHC.unLoc ltyName))
+    , let conNameStr = GHC.occNameString (GHC.rdrNameOcc conName)
+    ]
+  where
+    message tyNameStr conNameStr = unwords
+      [ "Variant type", tyNameStr, "constructor", conNameStr
+      , "has a single argument of type (). The argument will not be"
+      , "preserved when importing this package via data-dependencies."
+      , "Possible solution: Remove the constructor's argument." ]
+
+-- | Emit an error if a record constructor name does not match the record type name.
+-- See issue #4718.
 checkRecordConstructor :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
 checkRecordConstructor (GHC.L _ m) = mapMaybe getRecordError (GHC.hsmodDecls m)
   where

--- a/compiler/damlc/tests/daml-test-files/VariantUnitConstructor.daml
+++ b/compiler/damlc/tests/daml-test-files/VariantUnitConstructor.daml
@@ -1,0 +1,21 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @WARN Variant type Bar constructor Bar1 has a single argument of type ()
+-- @WARN Variant type Baz constructor Baz1 has a single argument of type ()
+-- @WARN Variant type Baz constructor Baz2 has a single argument of type ()
+module VariantUnitConstructor where
+
+-- This is fine (single constructor variant type can only be
+-- written with a unit type argument).
+data Foo = Foo1 ()
+
+-- This should result in warning for Bar1.
+data Bar
+    = Bar1 ()
+    | Bar2
+
+-- This should result in warning for Baz1 and Baz2.
+data Baz
+    = Baz1 ()
+    | Baz2 ()


### PR DESCRIPTION
Following up from #7207 

changelog_begin

- [DAML Compiler] The compiler will now emit a warning when you have a variant type constructor with a single argument of unit type ``()``. For example, ``data Foo = Bar () | Baz`` will result in a warning on the constructor ``Bar``.  This is because the unit type will not be preserved when importing the package via data-dependencies. The correct solution, usually, is to remove the argument from the constructor: ``data Foo = Bar | Baz``. Note that this rule does not apply when the variant type has only one constructor, since no ambiguity arises.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
