### PR TITLE
hoogle db as tarbal

### DIFF
--- a/infra/hoogle_server.tf
+++ b/infra/hoogle_server.tf
@@ -93,7 +93,10 @@ log() {
 log "Checking for new DAML version..."
 cd /home/hoogle/hoogle
 mkdir new-daml
-curl -s https://docs.daml.com/hoogle_db/base.txt --output new-daml/base.txt
+if ! curl --fail -s https://docs.daml.com/hoogle_db/base.txt --output new-daml/base.txt; then
+  curl -s https://docs.daml.com/hoogle_db.tar.gz --output db.tar.gz
+  tar xzf db.tar.gz -C new-daml --strip-components=1
+fi
 if ! diff -rq daml new-daml; then
   log "New version detected. Creating database..."
   rm -rf daml


### PR DESCRIPTION
We want to be able to support more than one package in our [Hoogle] instance. In order to not have to list each file individually, we assume the collection of Hoogle text files will be published as a tarball.

Note: we keep trying the existing file for now, because the deployment of this change needs to be done in separate, asynchronous steps if we want everything to keep working with no downtime:

1. We deploy the new version of the Hoogle configuration, which supports both the new and old file structure on the docs website (this PR).
2. After the next stable version (likely 1.6) is published, the docs site actually changes to the new format.
3. We can then clean-up the Hoogle configuration.

Any other sequence will require turning off Hoogle and coordinating with the docs update, which seems impractical.

[Hoogle]: https://hoogle.daml.com

CHANGELOG_BEGIN
CHANGELOG_END