### PR TITLE
fixup Terraform setup

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -19,7 +19,7 @@ provider "google-beta" {
 }
 
 provider "secret" {
-  version = "1.1"
+  version = "~>1.1"
 }
 
 provider "template" {


### PR DESCRIPTION
It looks like #6761 broke our Terraform setup by upgrading the nixpkgs snapshot. That this has not been caught earlier is, I suppose, a testament to how stable our infrastructure has become nowadays.

This is the same issue we had with the Google providers in #6402, i.e. we are trying to pin the provider versions both at the nix level and at the terraform level, with no way to force them to stay in sync.

I don't have a good proposal for such a way, and it seems rare and innocuous enough to not warrant the investment to fix this at a more fundamental level.

CHANGELOG_BEGIN
CHANGELOG_END