### PR TITLE
nix: Pin `scala` to v2.12.11, the same version we use in Bazel.

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -48,6 +48,13 @@ let
         })
       ];
     });
+    scala_2_12 = pkgs.scala_2_12.overrideAttrs (oldAttrs: rec {
+      name = "scala-2.12.11";
+      src = pkgs.fetchurl {
+        url = "https://www.scala-lang.org/files/archive/${name}.tgz";
+        sha256 = "25afefb0f1a8c2cdc2a35eb7166de2276a4a1f95986d9bfbe18c60183ab36b85";
+      };
+    });
   };
 
   nixpkgs = import src {


### PR DESCRIPTION
The version in nixpkgs is v2.12.10, which means that the Scala REPL we used was not the same version as we use in our code.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
