### PR TITLE
kvutils: Close GzipInputStream after decompressing message [KVL-485]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
@@ -132,7 +132,7 @@ object Envelope {
       case msg => Left(s"Expected state value, got ${msg.getClass}")
     }
 
-  private def compress(payload: ByteString): ByteString = {
+  private[kvutils] def compress(payload: ByteString): ByteString = {
     val out = ByteString.newOutput
     val gzipOut = new GZIPOutputStream(out)
     gzipOut.write(payload.toByteArray)
@@ -140,9 +140,11 @@ object Envelope {
     out.toByteString
   }
 
-  private def decompress(payload: ByteString): ByteString = {
+  private[kvutils] def decompress(payload: ByteString): ByteString = {
     val gzipIn = new GZIPInputStream(payload.newInput)
-    ByteString.readFrom(gzipIn)
+    val decompressed = ByteString.readFrom(gzipIn)
+    gzipIn.close()
+    decompressed
   }
 
   private def parseMessageSafe[T](callParser: () => T): Either[String, T] =


### PR DESCRIPTION
This may help avoiding OOM errors as the native inflater may be leaking:
https://github.com/akka/akka/issues/19766

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
