### PR TITLE
faster docs preview

### DIFF
--- a/docs/scripts/preview.sh
+++ b/docs/scripts/preview.sh
@@ -20,7 +20,7 @@ cleanup()
 rm -rf $BUILD_DIR
 mkdir $BUILD_DIR
 
-bazel build //docs:docs
-tar -zxf ../../bazel-bin/docs/html.tar.gz -C $BUILD_DIR
+bazel build //docs:docs-no-pdf
+tar -zxf ../../bazel-bin/docs/html-only.tar.gz -C $BUILD_DIR
 cd $BUILD_DIR/html
-python -m http.server 8000
+python -m http.server 8000 --bind 127.0.0.1


### PR DESCRIPTION
There is generally little need to preview the PDF version of the docs. Also, opening up the Python server on 0.0.0.0 (the default) triggers OS warnings on macOS.

CHANGELOG_BEGIN
CHANGELOG_END