### PR TITLE
let dependabot bypass changelog check

### DIFF
--- a/ci/check-changelog.sh
+++ b/ci/check-changelog.sh
@@ -16,13 +16,46 @@ contains_changelog () {
     [[ 2 == $(git show -s --format=%B $1 | awk "$awk_script") ]]
 }
 
-for sha in $(git rev-list ${1:-origin/master}..); do
-    if contains_changelog $sha; then
-        echo "Commit $sha contains a changelog entry."
-        exit 0
+is_dependabot_pr() {
+    local key gpg_dir
+    if [ "1" = "$(git rev-list ${1:-origin/master}.. | wc -l)" ] && [ "dependabot[bot]" = "$(git show -s --format=%an)" ]; then
+        key=$(mktemp)
+        cat > $key <<DEPENDABOT
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQENBFmUaEEBCACzXTDt6ZnyaVtueZASBzgnAmK13q9Urgch+sKYeIhdymjuMQta
+x15OklctmrZtqre5kwPUosG3/B2/ikuPYElcHgGPL4uL5Em6S5C/oozfkYzhwRrT
+SQzvYjsE4I34To4UdE9KA97wrQjGoz2Bx72WDLyWwctD3DKQtYeHXswXXtXwKfjQ
+7Fy4+Bf5IPh76dA8NJ6UtjjLIDlKqdxLW4atHe6xWFaJ+XdLUtsAroZcXBeWDCPa
+buXCDscJcLJRKZVc62gOZXXtPfoHqvUPp3nuLA4YjH9bphbrMWMf810Wxz9JTd3v
+yWgGqNY0zbBqeZoGv+TuExlRHT8ASGFS9SVDABEBAAG0NUdpdEh1YiAod2ViLWZs
+b3cgY29tbWl0IHNpZ25pbmcpIDxub3JlcGx5QGdpdGh1Yi5jb20+iQEiBBMBCAAW
+BQJZlGhBCRBK7hj4Ov3rIwIbAwIZAQAAmQEH/iATWFmi2oxlBh3wAsySNCNV4IPf
+DDMeh6j80WT7cgoX7V7xqJOxrfrqPEthQ3hgHIm7b5MPQlUr2q+UPL22t/I+ESF6
+9b0QWLFSMJbMSk+BXkvSjH9q8jAO0986/pShPV5DU2sMxnx4LfLfHNhTzjXKokws
++8ptJ8uhMNIDXfXuzkZHIxoXk3rNcjDN5c5X+sK8UBRH092BIJWCOfaQt7v7wig5
+4Ra28pM9GbHKXVNxmdLpCFyzvyMuCmINYYADsC848QQFFwnd4EQnupo6QvhEVx1O
+j7wDwvuH5dCrLuLwtwXaQh0onG4583p0LGms2Mf5F+Ick6o/4peOlBoZz48=
+=Bvzs
+-----END PGP PUBLIC KEY BLOCK-----
+DEPENDABOT
+        gpg_dir=$(mktemp -d)
+        GNUPGHOME=$gpg_dir gpg --no-tty --quiet --import $key
+        GNUPGHOME=$gpg_dir git verify-commit HEAD
+        return $?
+    else
+        return 1
     fi
-done
-echo "
+}
+
+has_a_changelog() {
+    for sha in $(git rev-list ${1:-origin/master}..); do
+        if contains_changelog $sha; then
+            echo "Commit $sha contains a changelog entry."
+            return 0
+        fi
+    done
+    echo "
 No changelog entry found; please add one. If your PR does not need a
 changelog entry, please add an explicit, empty one, i.e. add
 
@@ -31,4 +64,7 @@ CHANGELOG_END
 
 to your commit message.
 "
-exit 1
+    return 1
+}
+
+has_a_changelog $1 || is_dependabot_pr $1


### PR DESCRIPTION
Currently, when Dependabot makes a PR, not only do we need to manually trigger CI through `/azp run`, we also need to either change the commit or add a new one to pass the changelog check. This addresses that second part by making a exception for PRs signed by dependabot.

This is also a bit of an excuse to play with git signatures and gpg.

CHANGELOG_BEGIN
CHANGELOG_END