### PR TITLE
Expose Script in data-dependencies

### DIFF
--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -157,8 +157,10 @@ packagingTests = testGroup "packaging"
           ]
         writeFileUTF8 (tmpDir </> "proj" </> "A.daml") $ unlines
           [ "module A where"
-          , "import Main (Asset)"
-          , "type X = Asset"
+          , "import Daml.Script"
+          , "import Main"
+          , "f = setup >> allocateParty \"foobar\""
+          -- This also checks that we get the same Script type within an SDK version.
           ]
         withCurrentDirectory (tmpDir </> "proj") $ callCommandSilent "daml build"
      , testCase "DAML Script --input-file and --output-file" $ withTempDir $ \projDir -> do

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -315,14 +315,19 @@ instance HasSubmit Script Commands where
 
 -- | This is the type of A DAML script. `Script` is an instance of `Action`,
 -- so you can use `do` notation.
-newtype Script a = Script { runScript : () -> (Free ScriptF (a, ())) }
--- We use an inlined StateT () to separate evaluation of something of type Script from execution and to ensure
--- proper sequencing of evaluation. This is mainly so that `debug` does something
--- slightly more sensible.
+data Script a = Script with
+    runScript : () -> (Free ScriptF (a, ()))
+    -- We use an inlined StateT () to separate evaluation of
+    -- something of type Script from execution and to ensure
+    -- proper sequencing of evaluation. This is mainly so that `debug` does something
+    -- slightly more sensible.
+    dummy : ()
+    -- Dummy field to make sure damlc does not consider this an old-style
+    -- typeclass.
   deriving Functor
 
 instance CanAbort Script where
-  abort s = Script (\_ -> error s)
+  abort s = Script (\_ -> error s) ()
 
 instance ActionFail Script where
   fail = abort
@@ -355,22 +360,28 @@ archiveCmd : Choice t Archive () => ContractId t -> Commands ()
 archiveCmd cid = exerciseCmd cid Archive
 
 instance Applicative Script where
-    pure a = Script $ \ s -> return (a, s)
+    pure a = Script (\s -> return (a, s)) ()
 
-    Script mf <*> Script mx = Script $ \ s -> do
+    Script mf _ <*> Script mx _ = Script with
+      runScript = \ s -> do
         (f, s') <- mf s
         (x, s'') <- mx s'
         return (f x, s'')
+      dummy = ()
 
 instance Action Script where
-    m >>= k  = Script $ \ s -> do
+    m >>= k  = Script with
+      runScript = \ s -> do
         (a, s') <- runScript m s
         runScript (k a) s'
+      dummy = ()
 
 lift : Free ScriptF a -> Script a
-lift m = Script $ \s -> do
-  a <- m
-  pure (a, s)
+lift m = Script with
+  runScript = \s -> do
+    a <- m
+    pure (a, s)
+  dummy = ()
 
 -- | Convenience helper to declare you are writing a Script.
 --

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -723,8 +723,9 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
       _ <- Future.unit // We want the evaluation of following stepValue() to happen in a future.
       result <- stepToValue().fold(Future.failed, Future.successful)
       expr <- result match {
-        // Unwrap Script newtype and apply to ()
-        case SRecord(_, _, vals) if vals.size == 1 => {
+        // Unwrap Script type and apply to ()
+        // For backwards-compatibility we support the 1 and the 2-field versions.
+        case SRecord(_, _, vals) if vals.size == 1 || vals.size == 2 => {
           vals.get(0) match {
             case SPAP(_, _, _) =>
               Future(SEApp(SEValue(vals.get(0)), Array(SEValue(SUnit))))


### PR DESCRIPTION
Previously, it was filtered out by accident since damlc considered it
to be an old-style typeclass. This PR fixes this by adding a dummy
field.

This is primarily useful in DAML REPL since all DARs there are
importad as data-dependencies atm. It’s not actually all that useful
across SDK versions since you end up with multiple daml-script
libraries but at least within an SDK you can use it and don’t have to
think about whether your project is a dependency or data-dependency.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
