### PR TITLE
Tame concurrent double spend test [KVL-470]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/SemanticTests.scala
@@ -67,30 +67,36 @@ final class SemanticTests extends LedgerTestSuite {
     case Participants(Participant(alpha, payer, owner1), Participant(beta, owner2)) =>
       // This test create a contract and then concurrently archives it several times
       // through two different participants
-      val contracts = 10 // Number of contracts to create
+      val creates = 2 // Number of contracts to create
       val archives = 10 // Number of concurrent archives per contract
-      Future
-        .traverse((1 to contracts).toList)(c =>
-          for {
-            shared <- alpha.create(payer, SharedContract(payer, owner1, owner2))
-            _ <- synchronize(alpha, beta)
-            results <- Future.traverse((1 to archives).toList)(i =>
-              i % 2 match {
-                case 0 =>
-                  alpha
-                    .exercise(owner1, shared.exerciseSharedContract_Consume1)
-                    .transform(Success(_))
-                case 1 =>
-                  beta
-                    .exercise(owner2, shared.exerciseSharedContract_Consume2)
-                    .transform(Success(_))
-            })
-          } yield {
-            assertLength(s"Contract $c successful archives", 1, results.filter(_.isSuccess))
-            assertLength(s"Contract $c failed archives", archives - 1, results.filter(_.isFailure))
-            ()
-        })
-        .map(_ => ())
+      // Each created contract is archived in parallel, next contract
+      // is created only when previous is archived
+      (1 to creates).toList.foldLeft(Future(())) { (f, c) =>
+        f.flatMap(
+          _ =>
+            for {
+              shared <- alpha.create(payer, SharedContract(payer, owner1, owner2))
+              _ <- synchronize(alpha, beta)
+              results <- Future.traverse((1 to archives).toList)(i =>
+                i % 2 match {
+                  case 0 =>
+                    alpha
+                      .exercise(owner1, shared.exerciseSharedContract_Consume1)
+                      .transform(Success(_))
+                  case 1 =>
+                    beta
+                      .exercise(owner2, shared.exerciseSharedContract_Consume2)
+                      .transform(Success(_))
+              })
+            } yield {
+              assertLength(s"Contract $c successful archives", 1, results.filter(_.isSuccess))
+              assertLength(
+                s"Contract $c failed archives",
+                archives - 1,
+                results.filter(_.isFailure))
+              ()
+          })
+      }
   })
 
   test(


### PR DESCRIPTION
Previously concurrent double spend test was trying to perform 10 separate tests each firing 10 concurrent requests at the same time. The reasoning was that by having multiple tests run at the same time we would be increasing the chances of double spend conflict occurring. In fact the opposite was achieved as separate tests were competing for a limited bandwidth of the underlying ledger.

Run two double spend tests one after the other instead of ten simultaneously.  

CHANGELOG_BEGIN
CHANGELOG_END