### PR TITLE
Add --navigator-port option in daml start.

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -64,6 +64,7 @@ data Command
       { sandboxPortM :: Maybe SandboxPortSpec
       , openBrowser :: OpenBrowser
       , startNavigator :: Maybe StartNavigator
+      , navigatorPortM :: Maybe NavigatorPort
       , jsonApiCfg :: JsonApiConfig
       , onStartM :: Maybe String
       , waitForSignal :: WaitForSignal
@@ -155,6 +156,7 @@ commandParser = subparser $ fold
         <$> optional (option (maybeReader (toSandboxPortSpec <=< readMaybe)) (long "sandbox-port" <> metavar "PORT_NUM" <> help "Port number for the sandbox"))
         <*> (OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser after navigator" idm)
         <*> optional navigatorFlag
+        <*> optional (NavigatorPort <$> option auto (long "navigator-port" <> metavar "PORT_NUM" <> help "Port number for navigator (default is 7500)."))
         <*> jsonApiCfg
         <*> optional (option str (long "on-start" <> metavar "COMMAND" <> help "Command to run once sandbox and navigator are running."))
         <*> (WaitForSignal <$> flagYesNoAuto "wait-for-signal" True "Wait for Ctrl+C or interrupt after starting servers." idm)
@@ -372,6 +374,7 @@ runCommand = \case
         runStart
             sandboxPortM
             startNavigator
+            navigatorPortM
             jsonApiCfg
             openBrowser
             onStartM

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -64,7 +64,7 @@ data Command
       { sandboxPortM :: Maybe SandboxPortSpec
       , openBrowser :: OpenBrowser
       , startNavigator :: Maybe StartNavigator
-      , navigatorPortM :: Maybe NavigatorPort
+      , navigatorPort :: NavigatorPort
       , jsonApiCfg :: JsonApiConfig
       , onStartM :: Maybe String
       , waitForSignal :: WaitForSignal
@@ -156,7 +156,7 @@ commandParser = subparser $ fold
         <$> optional (option (maybeReader (toSandboxPortSpec <=< readMaybe)) (long "sandbox-port" <> metavar "PORT_NUM" <> help "Port number for the sandbox"))
         <*> (OpenBrowser <$> flagYesNoAuto "open-browser" True "Open the browser after navigator" idm)
         <*> optional navigatorFlag
-        <*> optional (NavigatorPort <$> option auto (long "navigator-port" <> metavar "PORT_NUM" <> help "Port number for navigator (default is 7500)."))
+        <*> navigatorPortOption
         <*> jsonApiCfg
         <*> optional (option str (long "on-start" <> metavar "COMMAND" <> help "Command to run once sandbox and navigator are running."))
         <*> (WaitForSignal <$> flagYesNoAuto "wait-for-signal" True "Wait for Ctrl+C or interrupt after starting servers." idm)
@@ -183,6 +183,13 @@ commandParser = subparser $ fold
                 s -> Left ("Expected \"yes\", \"true\", \"no\", \"false\" or \"auto\" but got " <> show s)
             -- To make things less confusing, we do not mention yes, no and auto here.
             helpText = "Start navigator as part of daml start. Can be set to true or false. Defaults to true."
+
+    navigatorPortOption = NavigatorPort <$> option auto
+        (long "navigator-port"
+        <> metavar "PORT_NUM"
+        <> value 7500
+        <> help "Port number for navigator (default is 7500).")
+
     deployCmdInfo = mconcat
         [ progDesc $ concat
               [ "Deploy the current DAML project to a remote DAML ledger. "
@@ -374,7 +381,7 @@ runCommand = \case
         runStart
             sandboxPortM
             startNavigator
-            navigatorPortM
+            navigatorPort
             jsonApiCfg
             openBrowser
             onStartM

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -177,7 +177,7 @@ withOptsFromProjectConfig fieldName cliOpts projectConfig = do
 runStart
     :: Maybe SandboxPortSpec
     -> Maybe StartNavigator
-    -> Maybe NavigatorPort
+    -> NavigatorPort
     -> JsonApiConfig
     -> OpenBrowser
     -> Maybe String
@@ -191,7 +191,7 @@ runStart
 runStart
   sandboxPortM
   mbStartNavigator
-  navigatorPortM
+  navigatorPort
   (JsonApiConfig mbJsonApiPort)
   (OpenBrowser shouldOpenBrowser)
   onStartM
@@ -250,7 +250,6 @@ runStart
                   void $ waitAnyCancel =<< mapM (async . waitExitCode) [navigatorPh,sandboxPh,jsonApiPh]
 
     where
-        navigatorPort = fromMaybe (NavigatorPort 7500) navigatorPortM
         defaultSandboxPort = SpecifiedPort (SandboxPort 6865)
         withNavigator' shouldStartNavigator sandboxPh =
             if shouldStartNavigator

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -177,6 +177,7 @@ withOptsFromProjectConfig fieldName cliOpts projectConfig = do
 runStart
     :: Maybe SandboxPortSpec
     -> Maybe StartNavigator
+    -> Maybe NavigatorPort
     -> JsonApiConfig
     -> OpenBrowser
     -> Maybe String
@@ -190,6 +191,7 @@ runStart
 runStart
   sandboxPortM
   mbStartNavigator
+  navigatorPortM
   (JsonApiConfig mbJsonApiPort)
   (OpenBrowser shouldOpenBrowser)
   onStartM
@@ -248,7 +250,7 @@ runStart
                   void $ waitAnyCancel =<< mapM (async . waitExitCode) [navigatorPh,sandboxPh,jsonApiPh]
 
     where
-        navigatorPort = NavigatorPort 7500
+        navigatorPort = fromMaybe (NavigatorPort 7500) navigatorPortM
         defaultSandboxPort = SpecifiedPort (SandboxPort 6865)
         withNavigator' shouldStartNavigator sandboxPh =
             if shouldStartNavigator


### PR DESCRIPTION
Fixes #5777

changelog_begin

- [DAML SDK] Added a ``--navigator-port`` option in ``daml start``,
  allowing you to specify the port for navigator's web server.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
