### PR TITLE
daml/ledger: close ws on stream close

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -331,7 +331,12 @@ test("multi-{key,query} stream", async () => {
     await ledger.archiveByKey(buildAndLint.Main.Counter, {_1: ALICE_PARTY, _2: t});
   }
   function sleep(ms: number): Promise<void> {
-        return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+  async function close<T extends object, K, I extends string, State>(s: Stream<T, K, I, State>): Promise<void> {
+    const p = pEvent(s, 'close');
+    s.close();
+    await p;
   }
   // Add support for comparison queries
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -364,6 +369,9 @@ test("multi-{key,query} stream", async () => {
   await create("included");
 
   await sleep(500);
+
+  await close(q);
+  await close(ks);
 
   expect(queryResult).toMatchObject(
     [[[{"payload": {"c": "0", "t": "included"}}],


### PR DESCRIPTION
The notion of `close` on `Stream` seems a bit confused at the moment. As the code stands (without this PR), if you register a listener for `'close'` events, you get notified when the underlying WebSocket closes (even though the stream will then try to open a new one and, if it manages to reconnect, will keep sending `'change'` events), and you do not get notified when the stream itself gets closed (by calling `.close()` on it), because the code in `.close()` removes the listeners before closing the WebSocket connection, and so also before trying to send a message to `'close'` listeners.  Further, calling `.close()` also does not seem to work as expected, or at least as I would expect: it will remove all listeners and close the WebSocket connection, but then it will immediately open it up again (provided that `reconnectThreshold` milliseconds have elapsed since the WS was last opened), leaking an open WebSocket connection.

As part of the same confusion, the current implementation also expects `'close'` listeners on the stream to receive a WebSocket close event, i.e. of the form `{code, reason}`.

This PR changes the behaviour such that listeners on the _stream_ `'close'` event:

* do not get notified if the WS connection drops but manages to reconnect.
* do get notified if the stream closes due to a connection error we cannot recover from, with a `4001` status code.
* do get notified if the stream is closed by calling the `.close()` method, with a `4000` status code.

This PR also changes the WS termination logic such that calling the `.close()` method on the stream actually closes the underlying WebSocket connection.

CHANGELOG_BEGIN

* JavaScript Client Libraries: fix a bug where, upon closing a stream, the underlying WebSocket connection may not be properly closed.

CHANGELOG_END