### PR TITLE
Engine: add submitter arg to Engine#validate

### DIFF
--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -468,7 +468,7 @@ class EngineTest
 
     "be validated" in {
       val Right((tx, meta)) = interpretResult
-      val Right(submitter) = tx.submitter
+      val Right(submitter) = tx.guessSubmitter
       val validated = engine
         .validate(submitter, tx, let, participant, meta.submissionTime, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey)
@@ -522,7 +522,7 @@ class EngineTest
               .consume(lookupContract, lookupPackage, lookupKey)
         }
     val Right((tx, txMeta)) = interpretResult
-    val Right(submitter) = tx.submitter
+    val Right(submitter) = tx.guessSubmitter
 
     "be translated" in {
       val Right((rtx, _)) = engine
@@ -627,7 +627,7 @@ class EngineTest
               .consume(lookupContract, lookupPackage, lookupKey)
         }
     val Right((tx, txMeta)) = result
-    val Right(submitter) = tx.submitter
+    val Right(submitter) = tx.guessSubmitter
 
     "be translated" in {
       val submitResult = engine
@@ -715,7 +715,7 @@ class EngineTest
         }
 
     val Right((tx, txMeta)) = interpretResult
-    val Right(submitter) = tx.submitter
+    val Right(submitter) = tx.guessSubmitter
 
     "be translated" in {
       tx.roots should have length 2
@@ -1541,7 +1541,7 @@ class EngineTest
     "be validable in whole" in {
       def validate(tx: SubmittedTransaction, metaData: Tx.Metadata) =
         for {
-          submitter <- tx.submitter.left.map(ValidationError)
+          submitter <- tx.guessSubmitter.left.map(ValidationError)
           res <- engine
             .validate(submitter, tx, let, participant, metaData.submissionTime, submissionSeed)
             .consume(_ => None, lookupPackage, _ => None)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -468,8 +468,9 @@ class EngineTest
 
     "be validated" in {
       val Right((tx, meta)) = interpretResult
+      val Right(submitter) = tx.submitter
       val validated = engine
-        .validate(tx, let, participant, meta.submissionTime, submissionSeed)
+        .validate(submitter, tx, let, participant, meta.submissionTime, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey)
       validated match {
         case Left(e) =>
@@ -521,6 +522,7 @@ class EngineTest
               .consume(lookupContract, lookupPackage, lookupKey)
         }
     val Right((tx, txMeta)) = interpretResult
+    val Right(submitter) = tx.submitter
 
     "be translated" in {
       val Right((rtx, _)) = engine
@@ -546,7 +548,7 @@ class EngineTest
 
     "be validated" in {
       val validated = engine
-        .validate(tx, let, participant, let, submissionSeed)
+        .validate(submitter, tx, let, participant, let, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey)
       validated match {
         case Left(e) =>
@@ -625,6 +627,7 @@ class EngineTest
               .consume(lookupContract, lookupPackage, lookupKey)
         }
     val Right((tx, txMeta)) = result
+    val Right(submitter) = tx.submitter
 
     "be translated" in {
       val submitResult = engine
@@ -646,7 +649,7 @@ class EngineTest
 
     "be validated" in {
       val validated = engine
-        .validate(tx, let, participant, let, submissionSeed)
+        .validate(submitter, tx, let, participant, let, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey)
       validated match {
         case Left(e) =>
@@ -712,6 +715,7 @@ class EngineTest
         }
 
     val Right((tx, txMeta)) = interpretResult
+    val Right(submitter) = tx.submitter
 
     "be translated" in {
       tx.roots should have length 2
@@ -732,7 +736,7 @@ class EngineTest
 
     "be validated" in {
       val validated = engine
-        .validate(tx, let, participant, let, submissionSeed)
+        .validate(submitter, tx, let, participant, let, submissionSeed)
         .consume(lookupContract, lookupPackage, lookupKey)
       validated match {
         case Left(e) =>
@@ -1536,9 +1540,12 @@ class EngineTest
 
     "be validable in whole" in {
       def validate(tx: SubmittedTransaction, metaData: Tx.Metadata) =
-        engine
-          .validate(tx, let, participant, metaData.submissionTime, submissionSeed)
-          .consume(_ => None, lookupPackage, _ => None)
+        for {
+          submitter <- tx.submitter.left.map(ValidationError)
+          res <- engine
+            .validate(submitter, tx, let, participant, metaData.submissionTime, submissionSeed)
+            .consume(_ => None, lookupPackage, _ => None)
+        } yield res
 
       run(0).flatMap { case (tx, metaData) => validate(tx, metaData) } shouldBe Right(())
       run(3).flatMap { case (tx, metaData) => validate(tx, metaData) } shouldBe Right(())

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -420,10 +420,10 @@ sealed abstract class HasTxNodes[Nid, +Cid, +Val] {
     acc
   }
 
-  final def submitter: Either[String, Party] =
+  final def guessSubmitter: Either[String, Party] =
     roots.map(nodes(_).requiredAuthorizers) match {
       case ImmArray() =>
-        Left(s"Empty transaction has no authorizers")
+        Left(s"Empty transaction")
       case ImmArrayCons(head, _) if head.size != 1 =>
         Left(s"Transaction's roots do not have exactly one authorizer: $this")
       case ImmArrayCons(head, tail) if tail.toSeq.exists(_ != head) =>

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -279,6 +279,7 @@ final case class GenTransaction[Nid, +Cid, +Val](
 sealed abstract class HasTxNodes[Nid, +Cid, +Val] {
 
   def nodes: HashMap[Nid, Node.GenNode[Nid, Cid, Val]]
+
   def roots: ImmArray[Nid]
 
   /**
@@ -418,6 +419,18 @@ sealed abstract class HasTxNodes[Nid, +Cid, +Val] {
     )
     acc
   }
+
+  final def submitter: Either[String, Party] =
+    roots.map(nodes(_).requiredAuthorizers) match {
+      case ImmArray() =>
+        Left(s"Empty transaction has no authorizers")
+      case ImmArrayCons(head, _) if head.size != 1 =>
+        Left(s"Transaction's roots do not have exactly one authorizer: $this")
+      case ImmArrayCons(head, tail) if tail.toSeq.exists(_ != head) =>
+        Left(s"Transaction's roots have different authorizers: $this")
+      case ImmArrayCons(head, _) =>
+        Right(head.head)
+    }
 
 }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -227,6 +227,7 @@ private[kvutils] class TransactionCommitter(
 
         engine
           .validate(
+            transactionEntry.submitter,
             SubmittedTransaction(transactionEntry.transaction),
             transactionEntry.ledgerEffectiveTime,
             commitContext.getParticipantId,

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
@@ -34,6 +34,7 @@ import scala.collection.JavaConverters._
 final case class TxEntry(
     tx: SubmittedTransaction,
     participantId: ParticipantId,
+    submitter: Ref.Party,
     ledgerTime: Time.Timestamp,
     submissionTime: Time.Timestamp,
     submissionSeed: crypto.Hash,
@@ -83,7 +84,7 @@ class Replay {
   def bench(): Unit = {
     val result = engine
       .replay(
-        benchmark.transaction.tx.submitter.toOption.get,
+        benchmark.transaction.submitter,
         benchmark.transaction.tx,
         benchmark.transaction.ledgerTime,
         benchmark.transaction.participantId,
@@ -118,7 +119,7 @@ class Replay {
     // before running the bench, we validate the transaction first to be sure everything is fine.
     val result = engine
       .validate(
-        benchmark.transaction.tx.submitter.toOption.get,
+        benchmark.transaction.submitter,
         benchmark.transaction.tx,
         benchmark.transaction.ledgerTime,
         benchmark.transaction.participantId,
@@ -176,6 +177,7 @@ object Replay {
           TxEntry(
             tx = tx,
             participantId = participantId,
+            submitter = Ref.Party.assertFromString(entry.getSubmitterInfo.getSubmitter),
             ledgerTime = parseTimestamp(entry.getLedgerEffectiveTime),
             submissionTime = parseTimestamp(entry.getSubmissionTime),
             submissionSeed = parseHash(entry.getSubmissionSeed)

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
@@ -83,6 +83,7 @@ class Replay {
   def bench(): Unit = {
     val result = engine
       .replay(
+        benchmark.transaction.tx.submitter.toOption.get,
         benchmark.transaction.tx,
         benchmark.transaction.ledgerTime,
         benchmark.transaction.participantId,
@@ -117,6 +118,7 @@ class Replay {
     // before running the bench, we validate the transaction first to be sure everything is fine.
     val result = engine
       .validate(
+        benchmark.transaction.tx.submitter.toOption.get,
         benchmark.transaction.tx,
         benchmark.transaction.ledgerTime,
         benchmark.transaction.participantId,


### PR DESCRIPTION
Currently, the submitter is inferred from the content of the transaction. 
This PR makes explicit the submitter that has to be  used to validate the transaction. 

In particular it enforces in `TransactionCommitter#validateModelConformance` that the validation is done with the declare submitter. 

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
