### PR TITLE
DAML-LF: utility to compute duplicated keys in a transaction.

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -477,9 +477,9 @@ object GenTransaction extends value.CidContainer3[GenTransaction] {
       def created(key: GlobalKey): State =
         if (active(key)) copy(duplicates = duplicates + key) else copy(active = active + key)
       def consumed(key: GlobalKey): State =
-        if (active(key)) copy(active = active - key) else this
+        copy(active = active - key)
       def referenced(key: GlobalKey): State =
-        if (active(key)) this else copy(active = active + key)
+        copy(active = active + key)
     }
 
     tx.fold(State(Set.empty, Set.empty)) {


### PR DESCRIPTION
The Engine does not verify key duplication when construction a
transaction, this task is currently let to the ledger implementation.
This PR provides an utility function to comptute the duplicated keys
in a transaction.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
