### PR TITLE
increase Maven timeout

### DIFF
--- a/release/src/Upload.hs
+++ b/release/src/Upload.hs
@@ -376,7 +376,7 @@ uploadRetryPolicy = limitRetriesByCumulativeDelay (60 * 1000 * 1000) (exponentia
 -- The status of the staging repository can take a number of minutes to change it's
 -- status to closed.
 checkStatusRetryPolicy :: RetryPolicy
-checkStatusRetryPolicy = limitRetriesByCumulativeDelay (5 * 60 * 1000 * 1000) (constantDelay (15 * 1000 * 1000))
+checkStatusRetryPolicy = limitRetriesByCumulativeDelay (10 * 60 * 1000 * 1000) (constantDelay (15 * 1000 * 1000))
 
 handleStatusRequest :: (MonadIO m) => Request -> Manager -> m Bool
 handleStatusRequest request manager = do


### PR DESCRIPTION
We reach the timeout on pretty much every release lately and we need to retry to entire release process two or three times to get through. This is us giving up on Maven, not Maven itself crashing, so I4d like to try giving it more time.

CHANGELOG_BEGIN
CHANGELOG_END