### PR TITLE
read access to data bucket for appr members

### DIFF
--- a/infra/data_bucket.tf
+++ b/infra/data_bucket.tf
@@ -32,3 +32,21 @@ resource "google_storage_bucket_iam_member" "data" {
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.writer.email}"
 }
+
+// allow read access for appr team, as requested by Moritz
+variable "appr" {
+  description = "Application Runtime team members"
+  default = [
+    "user:andreas.herrmann@digitalasset.com",
+    "user:gary.verhaegen@digitalasset.com",
+    "user:leonid.shlyapnikov@digitalasset.com",
+    "user:moritz.kiefer@digitalasset.com",
+    "user:stephen.compall@digitalasset.com",
+  ]
+}
+resource "google_storage_bucket_iam_member" "appr" {
+  count  = "${length(var.appr)}"
+  bucket = "${google_storage_bucket.data.name}"
+  role   = "roles/storage.objectViewer"
+  member = "${var.appr[count.index]}"
+}


### PR DESCRIPTION
We've been saving data there but not doing anything with it. Ideally this data would be used by some sort of automated process, but in the meantime (or while developing said processes), having at least some people with read access can help.

This is a Standard Change requested by @cocreature.

CHANGELOG_BEGIN
CHANGELOG_END