### PR TITLE
Split ledger-on-memory Main into multiple files

### DIFF
--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/InMemoryLedgerFactory.scala
@@ -1,0 +1,125 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.on.memory
+
+import akka.stream.Materializer
+import com.daml.caching
+import com.daml.ledger.participant.state.kvutils.api.{
+  BatchingLedgerWriterConfig,
+  KeyValueLedger,
+  KeyValueParticipantState
+}
+import com.daml.ledger.participant.state.kvutils.app.batch.BatchingLedgerWriterConfigReader
+import com.daml.ledger.participant.state.kvutils.app.batch.BatchingLedgerWriterConfigReader.optionsReader
+import com.daml.ledger.participant.state.kvutils.app.{Config, LedgerFactory, ParticipantConfig}
+import com.daml.ledger.participant.state.kvutils.caching.`Message Weight`
+import com.daml.ledger.validator.DefaultStateKeySerializationStrategy
+import com.daml.ledger.validator.caching.CachingDamlLedgerStateReaderWithFingerprints.`Message-Fingerprint Pair Weight`
+import com.daml.lf.engine.Engine
+import com.daml.logging.LoggingContext
+import com.daml.platform.akkastreams.dispatcher.Dispatcher
+import com.daml.platform.configuration.LedgerConfiguration
+import com.daml.resources.ResourceOwner
+import scopt.OptionParser
+
+private[memory] class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state: InMemoryState)
+    extends LedgerFactory[KeyValueParticipantState, ExtraConfig] {
+
+  override final def readWriteServiceOwner(
+      config: Config[ExtraConfig],
+      participantConfig: ParticipantConfig,
+      engine: Engine,
+  )(
+      implicit materializer: Materializer,
+      loggingContext: LoggingContext,
+  ): ResourceOwner[KeyValueParticipantState] =
+    for {
+      readerWriter <- owner(config, participantConfig, engine)
+    } yield
+      new KeyValueParticipantState(
+        readerWriter,
+        readerWriter,
+        createMetrics(participantConfig, config),
+      )
+
+  def owner(config: Config[ExtraConfig], participantConfig: ParticipantConfig, engine: Engine)(
+      implicit materializer: Materializer,
+  ): ResourceOwner[KeyValueLedger] = {
+    val metrics = createMetrics(participantConfig, config)
+    if (config.extra.alwaysPreExecute)
+      new InMemoryLedgerReaderWriter.PreExecutingOwner(
+        ledgerId = config.ledgerId,
+        participantId = participantConfig.participantId,
+        keySerializationStrategy = DefaultStateKeySerializationStrategy,
+        metrics = metrics,
+        stateValueCacheForPreExecution = caching.WeightedCache.from(
+          configuration = config.stateValueCache,
+          metrics = metrics.daml.kvutils.submission.validator.stateValueCache,
+        ),
+        dispatcher = dispatcher,
+        state = state,
+        engine = engine,
+      )
+    else
+      new InMemoryLedgerReaderWriter.BatchingOwner(
+        ledgerId = config.ledgerId,
+        batchingLedgerWriterConfig = config.extra.batchingLedgerWriterConfig,
+        participantId = participantConfig.participantId,
+        metrics = metrics,
+        stateValueCache = caching.WeightedCache.from(
+          configuration = config.stateValueCache,
+          metrics = metrics.daml.kvutils.submission.validator.stateValueCache,
+        ),
+        dispatcher = dispatcher,
+        state = state,
+        engine = engine,
+      )
+  }
+
+  override def ledgerConfig(config: Config[ExtraConfig]): LedgerConfiguration =
+    LedgerConfiguration.defaultLocalLedger
+
+  override def extraConfigParser(parser: OptionParser[Config[ExtraConfig]]): Unit =
+    InMemoryLedgerFactory.extraConfigParser(parser)
+
+  override val defaultExtraConfig: ExtraConfig = InMemoryLedgerFactory.defaultExtraConfig
+}
+
+private[memory] object InMemoryLedgerFactory {
+  val defaultExtraConfig: ExtraConfig = ExtraConfig.reasonableDefault
+
+  final def extraConfigParser(parser: OptionParser[Config[ExtraConfig]]): Unit = {
+    parser
+      .opt[BatchingLedgerWriterConfig]("batching")
+      .optional()
+      .text(BatchingLedgerWriterConfigReader.UsageText)
+      .action {
+        case (parsedBatchingConfig, config) =>
+          config.copy(
+            extra = config.extra.copy(
+              batchingLedgerWriterConfig = parsedBatchingConfig
+            )
+          )
+      }
+    parser
+      .opt[Boolean]("force-pre-execution")
+      .optional()
+      .text("Force pre-execution (mutually exclusive with batching)")
+      .action {
+        case (preExecute, config) =>
+          config.copy(
+            extra = config.extra.copy(
+              alwaysPreExecute = preExecute
+            )
+          )
+      }
+    parser.checkConfig { config =>
+      if (config.extra.alwaysPreExecute && config.extra.batchingLedgerWriterConfig.enableBatching)
+        Left("Either pre-executing can be forced or batching can be enabled, but not both.")
+      else
+        Right(())
+    }
+    ()
+  }
+}

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Main.scala
@@ -3,134 +3,19 @@
 
 package com.daml.ledger.on.memory
 
-import akka.stream.Materializer
-import com.daml.caching
-import com.daml.ledger.participant.state.kvutils.api.{
-  BatchingLedgerWriterConfig,
-  KeyValueLedger,
-  KeyValueParticipantState
-}
-import com.daml.ledger.participant.state.kvutils.app.batch.BatchingLedgerWriterConfigReader
-import com.daml.ledger.participant.state.kvutils.app.batch.BatchingLedgerWriterConfigReader.optionsReader
-import com.daml.ledger.participant.state.kvutils.app.{
-  Config,
-  LedgerFactory,
-  ParticipantConfig,
-  Runner
-}
-import com.daml.ledger.participant.state.kvutils.caching.`Message Weight`
-import com.daml.ledger.validator.DefaultStateKeySerializationStrategy
-import com.daml.ledger.validator.caching.CachingDamlLedgerStateReaderWithFingerprints.`Message-Fingerprint Pair Weight`
-import com.daml.lf.engine.Engine
-import com.daml.logging.LoggingContext
-import com.daml.platform.akkastreams.dispatcher.Dispatcher
-import com.daml.platform.configuration.LedgerConfiguration
-import com.daml.resources.{ProgramResource, ResourceOwner}
-import scopt.OptionParser
+import com.daml.ledger.participant.state.kvutils.app.Config
+import com.daml.resources.ProgramResource
 
 object Main {
   def main(args: Array[String]): Unit = {
     val resource = for {
-      dispatcher <- dispatcherOwner
-      sharedState = InMemoryState.empty
-      factory = new InMemoryLedgerFactory(dispatcher, sharedState)
-      runner <- new Runner("In-Memory Ledger", factory).owner(args)
-    } yield runner
-
+      config <- Config.owner(
+        RunnerName,
+        InMemoryLedgerFactory.extraConfigParser,
+        InMemoryLedgerFactory.defaultExtraConfig,
+        args)
+      owner <- Owner(config)
+    } yield owner
     new ProgramResource(resource).run()
-  }
-
-  class InMemoryLedgerFactory(dispatcher: Dispatcher[Index], state: InMemoryState)
-      extends LedgerFactory[KeyValueParticipantState, ExtraConfig] {
-
-    override final def readWriteServiceOwner(
-        config: Config[ExtraConfig],
-        participantConfig: ParticipantConfig,
-        engine: Engine,
-    )(
-        implicit materializer: Materializer,
-        loggingContext: LoggingContext,
-    ): ResourceOwner[KeyValueParticipantState] =
-      for {
-        readerWriter <- owner(config, participantConfig, engine)
-      } yield
-        new KeyValueParticipantState(
-          readerWriter,
-          readerWriter,
-          createMetrics(participantConfig, config),
-        )
-
-    def owner(config: Config[ExtraConfig], participantConfig: ParticipantConfig, engine: Engine)(
-        implicit materializer: Materializer,
-    ): ResourceOwner[KeyValueLedger] = {
-      val metrics = createMetrics(participantConfig, config)
-      if (config.extra.alwaysPreExecute)
-        new InMemoryLedgerReaderWriter.PreExecutingOwner(
-          ledgerId = config.ledgerId,
-          participantId = participantConfig.participantId,
-          keySerializationStrategy = DefaultStateKeySerializationStrategy,
-          metrics = metrics,
-          stateValueCacheForPreExecution = caching.WeightedCache.from(
-            configuration = config.stateValueCache,
-            metrics = metrics.daml.kvutils.submission.validator.stateValueCache,
-          ),
-          dispatcher = dispatcher,
-          state = state,
-          engine = engine,
-        )
-      else
-        new InMemoryLedgerReaderWriter.BatchingOwner(
-          ledgerId = config.ledgerId,
-          batchingLedgerWriterConfig = config.extra.batchingLedgerWriterConfig,
-          participantId = participantConfig.participantId,
-          metrics = metrics,
-          stateValueCache = caching.WeightedCache.from(
-            configuration = config.stateValueCache,
-            metrics = metrics.daml.kvutils.submission.validator.stateValueCache,
-          ),
-          dispatcher = dispatcher,
-          state = state,
-          engine = engine,
-        )
-    }
-
-    override def ledgerConfig(config: Config[ExtraConfig]): LedgerConfiguration =
-      LedgerConfiguration.defaultLocalLedger
-
-    override val defaultExtraConfig: ExtraConfig = ExtraConfig.reasonableDefault
-
-    override final def extraConfigParser(parser: OptionParser[Config[ExtraConfig]]): Unit = {
-      parser
-        .opt[BatchingLedgerWriterConfig]("batching")
-        .optional()
-        .text(BatchingLedgerWriterConfigReader.UsageText)
-        .action {
-          case (parsedBatchingConfig, config) =>
-            config.copy(
-              extra = config.extra.copy(
-                batchingLedgerWriterConfig = parsedBatchingConfig
-              )
-            )
-        }
-      parser
-        .opt[Boolean]("force-pre-execution")
-        .optional()
-        .text("Force pre-execution (mutually exclusive with batching)")
-        .action {
-          case (preExecute, config) =>
-            config.copy(
-              extra = config.extra.copy(
-                alwaysPreExecute = preExecute
-              )
-            )
-        }
-      parser.checkConfig { config =>
-        if (config.extra.alwaysPreExecute && config.extra.batchingLedgerWriterConfig.enableBatching)
-          Left("Either pre-executing can be forced or batching can be enabled, but not both.")
-        else
-          Right(())
-      }
-      ()
-    }
   }
 }

--- a/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Owner.scala
+++ b/ledger/ledger-on-memory/src/app/scala/com/daml/ledger/on/memory/Owner.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.on.memory
+
+import com.daml.ledger.participant.state.kvutils.app.{Config, Runner}
+import com.daml.resources.ResourceOwner
+
+object Owner {
+  // Utily if you want to spin this up as a library.
+  def apply(config: Config[ExtraConfig]): ResourceOwner[Unit] =
+    for {
+      dispatcher <- dispatcherOwner
+      sharedState = InMemoryState.empty
+      factory = new InMemoryLedgerFactory(dispatcher, sharedState)
+      runner <- new Runner(RunnerName, factory).owner(config)
+    } yield runner
+}

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/package.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/package.scala
@@ -17,4 +17,6 @@ package object memory {
       zeroIndex = StartIndex,
       headAtInitialization = StartIndex,
     )
+
+  private[memory] val RunnerName = "In-Memory Ledger"
 }


### PR DESCRIPTION
I’d like to use this in a test fixture so this PR splits up the main
and exposes an API that gives you back the resource without having to
import Main.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
