### PR TITLE
ci/patch_bazel_windows: fail on curl failure

### DIFF
--- a/ci/patch_bazel_windows/compile.yml
+++ b/ci/patch_bazel_windows/compile.yml
@@ -17,8 +17,9 @@ jobs:
       CACHE_KEY="$(find ci/patch_bazel_windows -type f -print0 | sort -z | xargs -r0 md5sum | md5sum | awk '{print $1}')"
       TARGET="patch_bazel_windows/bazel-$CACHE_KEY.zip"
       TARGET_URL="https://daml-binaries.da-ext.net/$TARGET"
+      STATUS="$(curl -Is "$TARGET_URL" | head -1 | awk '{print $2}')"
 
-      if [ "200" = "$(curl -Is "$TARGET_URL" | head -1 | awk '{print $2}')" ]; then
+      if [ "200" = "$STATUS" ]; then
           SHOULD_RUN=false
       else
           SHOULD_RUN=true

--- a/dev-env/windows/manifests/bazel.json
+++ b/dev-env/windows/manifests/bazel.json
@@ -5,8 +5,8 @@
   "bin": "bazel.exe",
   "architecture": {
     "64bit": {
-      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-1dac3221f72f5d22a0b79f0531af1f63.zip",
-      "hash": "4fcf4fa37018bbbe4d1712129734b230ffea4ca879a8b4c83d7b463f26f96558"
+      "url": "https://daml-binaries.da-ext.net/patch_bazel_windows/bazel-d35eaf58b847cc6adba694d1b0744ac1.zip",
+      "hash": "a62884b3be00d0440e8065e2570a4ce084bae2fcf6ef4d1edc13367e1d90a72e"
     }
   },
   "depends": [


### PR DESCRIPTION
At the moment, with the `curl` call comfortably nested inside an `if` statement, `curl` failures are interpreted as simply going down the `else` branch of the conditional. Hoisting it up to a separate variable declaration makes the script fail on the curl call itself.

CHANGELOG_BEGIN
CHANGELOG_END