### PR TITLE
JSON API Perf Test Runner Query Store Index Support

### DIFF
--- a/ledger-service/http-json-perf/BUILD.bazel
+++ b/ledger-service/http-json-perf/BUILD.bazel
@@ -33,6 +33,7 @@ da_scala_library(
         "//ledger-service/jwt",
         "//libs-scala/gatling-utils",
         "//libs-scala/scala-utils",
+        "//libs-scala/postgresql-testing",
         "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_fasterxml_jackson_core_jackson_databind",
         "@maven//:com_github_scopt_scopt_2_12",
@@ -47,6 +48,8 @@ da_scala_library(
         "@maven//:io_gatling_gatling_http_client",
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_slf4j_slf4j_api",
+        "@maven//:org_scalactic_scalactic_2_12",
+        "@maven//:org_scalatest_scalatest_2_12",
     ],
 )
 
@@ -91,6 +94,8 @@ da_scala_binary(
         "@maven//:io_gatling_gatling_http_client",
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_slf4j_slf4j_api",
+        "@maven//:org_scalactic_scalactic_2_12",
+        "@maven//:org_scalatest_scalatest_2_12",
     ],
 )
 

--- a/ledger-service/http-json-perf/BUILD.bazel
+++ b/ledger-service/http-json-perf/BUILD.bazel
@@ -32,8 +32,8 @@ da_scala_library(
         "//ledger-service/http-json-testing",
         "//ledger-service/jwt",
         "//libs-scala/gatling-utils",
-        "//libs-scala/scala-utils",
         "//libs-scala/postgresql-testing",
+        "//libs-scala/scala-utils",
         "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_fasterxml_jackson_core_jackson_databind",
         "@maven//:com_github_scopt_scopt_2_12",
@@ -46,10 +46,10 @@ da_scala_library(
         "@maven//:io_gatling_gatling_core",
         "@maven//:io_gatling_gatling_http",
         "@maven//:io_gatling_gatling_http_client",
-        "@maven//:org_scalaz_scalaz_core_2_12",
-        "@maven//:org_slf4j_slf4j_api",
         "@maven//:org_scalactic_scalactic_2_12",
         "@maven//:org_scalatest_scalatest_2_12",
+        "@maven//:org_scalaz_scalaz_core_2_12",
+        "@maven//:org_slf4j_slf4j_api",
     ],
 )
 
@@ -92,10 +92,10 @@ da_scala_binary(
         "@maven//:io_gatling_gatling_core",
         "@maven//:io_gatling_gatling_http",
         "@maven//:io_gatling_gatling_http_client",
-        "@maven//:org_scalaz_scalaz_core_2_12",
-        "@maven//:org_slf4j_slf4j_api",
         "@maven//:org_scalactic_scalactic_2_12",
         "@maven//:org_scalatest_scalatest_2_12",
+        "@maven//:org_scalaz_scalaz_core_2_12",
+        "@maven//:org_slf4j_slf4j_api",
     ],
 )
 

--- a/ledger-service/http-json-perf/README.md
+++ b/ledger-service/http-json-perf/README.md
@@ -1,12 +1,10 @@
 # 1. Gatling Scenarios
 
 ## 1.1. Prerequisites
-All current Gatling scenarios require `quickstart-0.0.1.dar` with IOU example.
+All current Gatling scenarios require `quickstart-model.dar` with IOU example. You can build one using:
 ```
-$ daml new quickstart-java --template quickstart-java
-$ cd quickstart-java/
-$ daml build
-$ ls ./.daml/dist/quickstart-0.0.1.dar
+bazel build //docs:quickstart-model
+ls "${PWD}/bazel-bin/docs/quickstart-model.dar"
 ```
 
 ## 1.2. List of Scenarios
@@ -30,7 +28,7 @@ $ bazel run //ledger-service/http-json-perf:http-json-perf-binary -- --help
 ```
 $ bazel run //ledger-service/http-json-perf:http-json-perf-binary -- \
 --scenario=com.daml.http.perf.scenario.CreateCommand \
---dars=<QUICKSTART_JAVA_HOME>/.daml/dist/quickstart-0.0.1.dar \
+--dars="${PWD}/bazel-bin/docs/quickstart-model.dar" \
 --reports-dir=/home/leos/tmp/results/ \
 --jwt="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU"
 ```

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Config.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Config.scala
@@ -18,15 +18,17 @@ private[perf] final case class Config[+S](
     dars: List[File],
     jwt: Jwt,
     reportsDir: File,
-    maxDuration: Option[FiniteDuration]
+    maxDuration: Option[FiniteDuration],
+    sandboxPersistence: Boolean
 ) {
   override def toString: String =
     s"Config(" +
-      s"scenario=${this.scenario}, " +
-      s"dars=${dars: List[File]}," +
-      s"jwt=..., " + // don't print the JWT
-      s"reportsDir=${reportsDir: File}," +
-      s"maxDuration=${this.maxDuration: Option[FiniteDuration]}" +
+      s"scenario=${this.scenario}" +
+      s", dars=${dars: List[File]}, " +
+      s", jwt=..." + // don't print the JWT
+      s", reportsDir=${reportsDir: File}" +
+      s", maxDuration=${this.maxDuration: Option[FiniteDuration]}" +
+      s", sandboxPersistence=${this.sandboxPersistence: Boolean}" +
       ")"
 }
 
@@ -37,7 +39,8 @@ private[perf] object Config {
       dars = List.empty,
       jwt = Jwt(""),
       reportsDir = new File(""),
-      maxDuration = None)
+      maxDuration = None,
+      sandboxPersistence = false)
 
   implicit val configInstance: Traverse[Config] = new Traverse[Config] {
     override def traverseImpl[G[_]: Applicative, A, B](fa: Config[A])(
@@ -74,6 +77,11 @@ private[perf] object Config {
         .required()
         .validate(validateJwt)
         .text("JWT token to use when connecting to JSON API.")
+
+      opt[Boolean]("sandbox-persistence")
+        .action((x, c) => c.copy(sandboxPersistence = x))
+        .required()
+        .text("Enable or disable sandbox persistence.")
 
       opt[File]("reports-dir")
         .action((x, c) => c.copy(reportsDir = x))

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Config.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Config.scala
@@ -19,7 +19,7 @@ private[perf] final case class Config[+S](
     jwt: Jwt,
     reportsDir: File,
     maxDuration: Option[FiniteDuration],
-    sandboxPersistence: Boolean
+    queryStoreIndex: Boolean,
 ) {
   override def toString: String =
     s"Config(" +
@@ -28,7 +28,7 @@ private[perf] final case class Config[+S](
       s", jwt=..." + // don't print the JWT
       s", reportsDir=${reportsDir: File}" +
       s", maxDuration=${this.maxDuration: Option[FiniteDuration]}" +
-      s", sandboxPersistence=${this.sandboxPersistence: Boolean}" +
+      s", queryStoreIndex=${this.queryStoreIndex: Boolean}" +
       ")"
 }
 
@@ -40,7 +40,7 @@ private[perf] object Config {
       jwt = Jwt(""),
       reportsDir = new File(""),
       maxDuration = None,
-      sandboxPersistence = false)
+      queryStoreIndex = false)
 
   implicit val configInstance: Traverse[Config] = new Traverse[Config] {
     override def traverseImpl[G[_]: Applicative, A, B](fa: Config[A])(
@@ -78,10 +78,10 @@ private[perf] object Config {
         .validate(validateJwt)
         .text("JWT token to use when connecting to JSON API.")
 
-      opt[Boolean]("sandbox-persistence")
-        .action((x, c) => c.copy(sandboxPersistence = x))
-        .required()
-        .text("Enable or disable sandbox persistence.")
+      opt[Boolean]("query-store-index")
+        .action((x, c) => c.copy(queryStoreIndex = x))
+        .optional()
+        .text("Enables JSON API query store index. Default is false, disabled.")
 
       opt[File]("reports-dir")
         .action((x, c) => c.copy(reportsDir = x))

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/PostgresRunner.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/PostgresRunner.scala
@@ -1,13 +1,28 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.http.perf
 
-import com.daml.testing.postgresql.PostgresAroundSuite
+import com.daml.testing.postgresql.{PostgresAroundSuite, PostgresDatabase}
 import org.scalatest.Suite
 
+import scala.util.Try
+
 class PostgresRunner {
-  private val suite = new PostgresAroundSuite with Suite {}
 
-  def createNewRandomDatabase(): Unit = {
-//    suite.c
-  }
+  private val suite = new PostgresRunnerSuite()
 
+  def start(): Try[PostgresDatabase] = suite.start()
+
+  def stop(): Try[Unit] = suite.stop()
+}
+
+private class PostgresRunnerSuite extends PostgresAroundSuite with Suite {
+  def start(): Try[PostgresDatabase] =
+    for {
+      _ <- Try(this.connectToPostgresqlServer())
+      db <- Try(this.createNewDatabase())
+    } yield db
+
+  def stop(): Try[Unit] = Try(this.disconnectFromPostgresqlServer())
 }

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/PostgresRunner.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/PostgresRunner.scala
@@ -1,0 +1,13 @@
+package com.daml.http.perf
+
+import com.daml.testing.postgresql.PostgresAroundSuite
+import org.scalatest.Suite
+
+class PostgresRunner {
+  private val suite = new PostgresAroundSuite with Suite {}
+
+  def createNewRandomDatabase(): Unit = {
+//    suite.c
+  }
+
+}


### PR DESCRIPTION
Closes: #7167

### Notes
Query Store affects only sync query scenarios hitting `/v1/query` endpoint:
- `com.daml.http.perf.scenario.SyncQueryConstantAcs`
- `com.daml.http.perf.scenario.SyncQueryNewAcs`
- `com.daml.http.perf.scenario.SyncQueryVariableAcs`

### Running with query store index (--query-store-index=true):
```
$ bazel run //ledger-service/http-json-perf:http-json-perf-binary -- \
 --query-store-index=true \
 --scenario=com.daml.http.perf.scenario.SyncQueryConstantAcs \
 --dars=$(pwd)/bazel-bin/docs/quickstart-model.dar \
 --reports-dir=/var/tmp/results \
 --jwt="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU"
```
```
================================================================================
---- SyncQueryRequest ----------------------------------------------------------
> Number of requests                                   500 (OK=500    KO=-     )
> Min. response time                                    17 (OK=17     KO=-     )
> Max. response time                                  1546 (OK=1546   KO=-     )
> Mean response time                                    27 (OK=27     KO=-     )
> Std. deviation                                        68 (OK=68     KO=-     )
> response time 90th percentile                         31 (OK=31     KO=-     )
> response time 95th percentile                         37 (OK=37     KO=-     )
> response time 99th percentile                         51 (OK=51     KO=-     )
> response time 99.9th percentile                     1546 (OK=1546   KO=-     )
> Mean requests/second                              36.724 (OK=36.724 KO=-     )
---- Response time distribution ------------------------------------------------
> t < 5000 ms                                          500 (100%)
> 5000 ms < t < 30000 ms                                 0 (  -%)
> 30000 ms < t                                           0 (  -%)
> failed                                                 0 (  -%)
================================================================================
```
### Running without query store index (--query-store-index=false):
```
$ bazel run //ledger-service/http-json-perf:http-json-perf-binary -- \
 --query-store-index=false \
 --scenario=com.daml.http.perf.scenario.SyncQueryConstantAcs \
 --dars=$(pwd)/bazel-bin/docs/quickstart-model.dar \
 --reports-dir=/var/tmp/results \
 --jwt="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJmb29iYXIiLCJhY3RBcyI6WyJBbGljZSJdfX0.VdDI96mw5hrfM5ZNxLyetSVwcD7XtLT4dIdHIOa9lcU"
```
```
================================================================================
---- SyncQueryRequest ----------------------------------------------------------
> Number of requests                                   500 (OK=500    KO=-     )
> Min. response time                                   175 (OK=175    KO=-     )
> Max. response time                                   874 (OK=874    KO=-     )
> Mean response time                                   208 (OK=208    KO=-     )
> Std. deviation                                        35 (OK=35     KO=-     )
> response time 90th percentile                        222 (OK=222    KO=-     )
> response time 95th percentile                        234 (OK=234    KO=-     )
> response time 99th percentile                        288 (OK=288    KO=-     )
> response time 99.9th percentile                      874 (OK=874    KO=-     )
> Mean requests/second                               4.809 (OK=4.809  KO=-     )
---- Response time distribution ------------------------------------------------
> t < 5000 ms                                          500 (100%)
> 5000 ms < t < 30000 ms                                 0 (  -%)
> 30000 ms < t                                           0 (  -%)
> failed                                                 0 (  -%)
================================================================================
```

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
