### PR TITLE
Speedy: group compiler parameters into a Config case class.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -52,14 +52,18 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
 
   private[this] val compiledPackages =
     ConcurrentCompiledPackages(
-      allowedLanguageVersions = config.allowedLanguageVersions,
-      packageValidation =
-        if (config.packageValidation) speedy.Compiler.FullPackageValidation
-        else speedy.Compiler.NoPackageValidation,
-      stackTraceMode =
-        if (config.stackTraceMode) speedy.Compiler.FullStackTrace else speedy.Compiler.NoStackTrace,
-      profilingMode =
-        if (config.profileDir.isDefined) speedy.Compiler.FullProfile else speedy.Compiler.NoProfile,
+      config.allowedLanguageVersions,
+      speedy.Compiler.Config(
+        packageValidation =
+          if (config.packageValidation) speedy.Compiler.FullPackageValidation
+          else speedy.Compiler.NoPackageValidation,
+        stacktracing =
+          if (config.stackTraceMode) speedy.Compiler.FullStackTrace
+          else speedy.Compiler.NoStackTrace,
+        profiling =
+          if (config.profileDir.isDefined) speedy.Compiler.FullProfile
+          else speedy.Compiler.NoProfile,
+      )
     )
 
   private[this] val preprocessor = new preprocessing.Preprocessor(compiledPackages)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/MutableCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/MutableCompiledPackages.scala
@@ -14,9 +14,8 @@ import com.daml.lf.speedy.Compiler
   */
 abstract class MutableCompiledPackages(
     allowedLanguageVersions: VersionRange[LanguageVersion],
-    stackTraceMode: speedy.Compiler.StackTraceMode,
-    profilingMode: Compiler.ProfilingMode,
-) extends CompiledPackages(stackTraceMode, profilingMode) {
+    compilerConfig: Compiler.Config,
+) extends CompiledPackages(compilerConfig) {
 
   /** Add a new package and compile it to internal form. If package
     * depends on another package the call may return with [[ResultNeedPackage]].

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -65,7 +65,7 @@ object PlaySpeedy {
   }
 
   private val noPackages =
-    PureCompiledPackages(Map.empty, Map.empty, compilerConfig)
+    PureCompiledPackages(Map.empty, Map.empty, Compiler.Config.Default)
 
   def runMachine(name: String, machine: Machine, expected: Int): Unit = {
 

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -19,9 +19,12 @@ object Explore extends App {
 
 object PlaySpeedy {
 
+  private[this] val compilerConfig =
+    Compiler.Config.Default.copy(stacktracing = Compiler.FullStackTrace)
+
   def main(args0: List[String]) = {
     val config: Config = parseArgs(args0)
-    val compiler: Compiler = Compiler(Map.empty, Compiler.FullStackTrace, Compiler.NoProfile)
+    val compiler: Compiler = new Compiler(Map.empty, compilerConfig)
 
     val names: List[String] = config.names match {
       case Nil => examples.toList.map(_._1)
@@ -62,7 +65,7 @@ object PlaySpeedy {
   }
 
   private val noPackages =
-    data.assertRight(PureCompiledPackages(Map.empty, Compiler.NoStackTrace, Compiler.NoProfile))
+    PureCompiledPackages(Map.empty, Map.empty, compilerConfig)
 
   def runMachine(name: String, machine: Machine, expected: Int): Unit = {
 

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/ExploreDar.scala
@@ -80,7 +80,7 @@ object PlaySpeedy {
     println(s"Compiling packages... ${config.stacktracing}")
     val compiledPackages: CompiledPackages = PureCompiledPackages(
       packagesMap,
-      config.stacktracing
+      Compiler.Config.Default.copy(stacktracing = config.stacktracing)
     ) match {
       case Right(x) => x
       case Left(x) =>

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/LoadDarFunction.scala
@@ -24,10 +24,13 @@ object LoadDarFunction extends App {
         case (pkgId, pkgArchive) => Decode.readArchivePayloadAndVersion(pkgId, pkgArchive)._1
       }.toMap
 
-    val stacktracing: Compiler.StackTraceMode = Compiler.NoStackTrace
+    val compilerConfig =
+      Compiler.Config.Default.copy(
+        stacktracing = Compiler.NoStackTrace
+      )
 
     val compiledPackages: CompiledPackages =
-      PureCompiledPackages(packagesMap, stacktracing).right.get
+      PureCompiledPackages(packagesMap, compilerConfig).right.get
 
     def function(argValue: Long): Long = {
       val expr: SExpr = {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -428,10 +428,14 @@ object SpeedyTest {
       case Goodbye(err) => Left(err)
     }
   }
+  private val noPackages =
+    PureCompiledPackages(
+      Map.empty,
+      Map.empty,
+      Compiler.Config.Default.copy(profiling = Compiler.FullProfile))
 
   private def profile(e: Expr): java.util.ArrayList[Profile.Event] = {
-    val packages = PureCompiledPackages(Map.empty, profiling = Compiler.FullProfile).right.get
-    val machine = Speedy.Machine.fromPureExpr(packages, e)
+    val machine = Speedy.Machine.fromPureExpr(noPackages, e)
     machine.run()
     machine.profile.events
   }

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -11,6 +11,7 @@ import com.daml.lf.PureCompiledPackages
 import com.daml.lf.data.{FrontStack, ImmArray, Struct}
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
+import com.daml.lf.speedy.Compiler.FullStackTrace
 import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.SError.SError
 import com.daml.lf.speedy.SExpr._
@@ -303,6 +304,7 @@ class SpeedyTest extends WordSpec with Matchers {
       } ;
     }
   """)
+
   "record update" should {
     "use SBRecUpd for single update" in {
       val p_1_0 = recUpdPkgs.getDefinition(LfDefRef(qualify("M:p_1_0")))
@@ -315,6 +317,14 @@ class SpeedyTest extends WordSpec with Matchers {
               Array(SELocS(1), SEValue(SInt64(1))))))
 
     }
+
+    /*
+    Some(SELabelClosure(LfDefRef(-pkgId-:M:p_1_0),
+        SELet1General(SEVal(LfDefRef(-pkgId-:M:origin)),SEAppAtomicSaturatedBuiltin(SBRecUpd(-pkgId-:M:Point,0),[SELocS(1),SEValue(SInt64(1))])))) did not equal
+    Some(SELet1General(SEVal(LfDefRef(-pkgId-:M:origin)),SEAppAtomicSaturatedBuiltin(SBRecUpd(-pkgId-:M:Point,0),[SELocS(1),SEValue(SInt64(1))])))
+
+
+     */
 
     "produce expected output for single update" in {
       eval(e"M:p_1_0", recUpdPkgs) shouldEqual
@@ -432,7 +442,9 @@ object SpeedyTest {
     PureCompiledPackages(
       Map.empty,
       Map.empty,
-      Compiler.Config.Default.copy(profiling = Compiler.FullProfile))
+      Compiler.Config.Default
+        .copy(profiling = Compiler.FullProfile, stacktracing = Compiler.FullStackTrace)
+    )
 
   private def profile(e: Expr): java.util.ArrayList[Profile.Event] = {
     val machine = Speedy.Machine.fromPureExpr(noPackages, e)
@@ -450,7 +462,8 @@ object SpeedyTest {
   private def typeAndCompile(pkg: Ast.Package): PureCompiledPackages = {
     val rawPkgs = Map(defaultParserParameters.defaultPackageId -> pkg)
     Validation.checkPackage(rawPkgs, defaultParserParameters.defaultPackageId)
-    PureCompiledPackages(rawPkgs).right.get
+    data.assertRight(
+      PureCompiledPackages(rawPkgs, Compiler.Config.Default.copy(stacktracing = FullStackTrace)))
   }
 
   private def intList(xs: Long*): String =

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/svalue/OrderingSpec.scala
@@ -104,8 +104,7 @@ class OrderingSpec
     }
   }
 
-  private val noPackages =
-    PureCompiledPackages(Map.empty, Map.empty, Compiler.FullStackTrace, Compiler.NoProfile)
+  private[this] val noPackages = PureCompiledPackages(Map.empty, Map.empty, Compiler.Config.Default)
 
   private def translatePrimValue(v: Value[Value.ContractId]) = {
     val machine = Speedy.Machine.fromPureSExpr(noPackages, SEImportValue(v))

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -172,13 +172,18 @@ object Repl {
       quit: Boolean
   )
 
+  private[this] val compilerConfig =
+    Compiler.Config.Default.copy(
+      stacktracing = Compiler.FullStackTrace
+    )
+
   case class ScenarioRunnerHelper(
       packages: Map[PackageId, Package],
       devMode: Boolean,
       profiling: Compiler.ProfilingMode,
   ) {
     val (compiledPackages, compileTime) = time {
-      PureCompiledPackages(packages, Compiler.FullStackTrace, profiling).right.get
+      PureCompiledPackages(packages, compilerConfig.copy(profiling = profiling)).right.get
     }
     System.err.println(s"${packages.size} package(s) compiled in $compileTime ms.")
 
@@ -425,8 +430,7 @@ object Repl {
   }
 
   def speedyCompile(state: State, args: Seq[String]): Unit = {
-    val defs = assertRight(
-      Compiler.compilePackages(state.packages, Compiler.FullStackTrace, Compiler.NoProfile))
+    val defs = assertRight(Compiler.compilePackages(state.packages, compilerConfig))
     defs.get(idToRef(state, args(0))) match {
       case None =>
         println("Error: definition '" + args(0) + "' not found. Try :list."); usage

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -53,7 +53,7 @@ class CollectAuthorityState {
 
     // NOTE(MH): We use a static seed to get reproducible runs.
     val seeding = crypto.Hash.secureRandom(crypto.Hash.hashPrivateKey("scenario-perf"))
-    val compiledPackages = PureCompiledPackages(packagesMap, Map.empty, compilerConfig)
+    val compiledPackages = data.assertRight(PureCompiledPackages(packagesMap, compilerConfig))
     val expr = EVal(Identifier(packages.main._1, QualifiedName.assertFromString(scenario)))
 
     machine = Machine.fromScenarioExpr(

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -45,11 +45,15 @@ class CollectAuthorityState {
     val packagesMap = packages.all.map {
       case (pkgId, pkgArchive) => Decode.readArchivePayloadAndVersion(pkgId, pkgArchive)._1
     }.toMap
-    val stacktracing = Compiler.NoStackTrace
+
+    val compilerConfig =
+      Compiler.Config.Default.copy(
+        stacktracing = Compiler.NoStackTrace
+      )
 
     // NOTE(MH): We use a static seed to get reproducible runs.
     val seeding = crypto.Hash.secureRandom(crypto.Hash.hashPrivateKey("scenario-perf"))
-    val compiledPackages = PureCompiledPackages(packagesMap, stacktracing).right.get
+    val compiledPackages = PureCompiledPackages(packagesMap, Map.empty, compilerConfig)
     val expr = EVal(Identifier(packages.main._1, QualifiedName.assertFromString(scenario)))
 
     machine = Machine.fromScenarioExpr(

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -248,7 +248,7 @@ object Runner {
       esf: ExecutionSequencerFactory,
       mat: Materializer): Future[SValue] = {
     val darMap = dar.all.toMap
-    val compiledPackages = PureCompiledPackages(darMap).right.get
+    val compiledPackages = data.assertRight(PureCompiledPackages(darMap, Runner.compilerConfig))
     val script = data.assertRight(Script.fromIdentifier(compiledPackages, scriptId))
     val scriptAction: Script.Action = (script, inputValue) match {
       case (script: Script.Action, None) => script

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -172,6 +172,9 @@ object Script {
 }
 
 object Runner {
+
+  private val compilerConfig = Compiler.Config.Default.copy(stacktracing = Compiler.FullStackTrace)
+
   val DEFAULT_APPLICATION_ID: ApplicationId = ApplicationId("daml-script")
   private def connectApiParameters(
       params: ApiParameters,
@@ -284,7 +287,7 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
       case LfDefRef(id) if id == script.scriptIds.damlScript("fromLedgerValue") =>
         SEMakeClo(Array(), 1, SELocA(0))
     }
-    new CompiledPackages(Compiler.FullStackTrace, Compiler.NoProfile) {
+    new CompiledPackages(Runner.compilerConfig) {
       override def getPackage(pkgId: PackageId): Option[Package] =
         compiledPackages.getPackage(pkgId)
       override def getDefinition(dref: SDefinitionRef): Option[SExpr] =


### PR DESCRIPTION
Speedy compiler is parametrized by several option flags.  Those flags
are passed through different calls (in particular in the instance of
`CompiledPackages`.

This PR group all this configuration parameters into a case class to
pass the option in a cleaner way.

This PR is based on #7436.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
