### PR TITLE
protect GCS bucket items

### DIFF
--- a/infra/bazel_cache.tf
+++ b/infra/bazel_cache.tf
@@ -20,11 +20,18 @@ module "bazel_cache" {
 }
 
 // allow rw access for CI writer (see writer.tf)
-resource "google_storage_bucket_iam_member" "bazel_cache_writer" {
+resource "google_storage_bucket_iam_member" "bazel_cache_writer_create" {
   bucket = "${module.bazel_cache.bucket_name}"
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.writer.email}"
+}
+resource "google_storage_bucket_iam_member" "bazel_cache_writer_read" {
+  bucket = "${module.bazel_cache.bucket_name}"
+
+  # https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.writer.email}"
 }
 

--- a/infra/binaries.tf
+++ b/infra/binaries.tf
@@ -12,6 +12,10 @@ resource "google_storage_bucket" "binaries" {
 
   # Use a normal region since the storage_class is regional
   location = "${local.region}"
+
+  versioning {
+    enabled = true
+  }
 }
 
 resource "google_storage_bucket_acl" "binaries" {
@@ -26,11 +30,18 @@ resource "google_storage_bucket_acl" "binaries" {
 }
 
 // allow rw access for CI writer (see writer.tf)
-resource "google_storage_bucket_iam_member" "binaries-ci-rw" {
+resource "google_storage_bucket_iam_member" "binaries-ci-create" {
   bucket = "${google_storage_bucket.binaries.name}"
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.writer.email}"
+}
+resource "google_storage_bucket_iam_member" "binaries-ci-read" {
+  bucket = "${google_storage_bucket.binaries.name}"
+
+  # https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.writer.email}"
 }
 

--- a/infra/data_bucket.tf
+++ b/infra/data_bucket.tf
@@ -12,6 +12,10 @@ resource "google_storage_bucket" "data" {
 
   # Use a normal region since the storage_class is regional
   location = "${local.region}"
+
+  versioning {
+    enabled = true
+  }
 }
 
 resource "google_storage_bucket_acl" "data" {
@@ -25,11 +29,18 @@ resource "google_storage_bucket_acl" "data" {
 }
 
 // allow rw access for CI writer (see writer.tf)
-resource "google_storage_bucket_iam_member" "data" {
+resource "google_storage_bucket_iam_member" "data_create" {
   bucket = "${google_storage_bucket.data.name}"
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.writer.email}"
+}
+resource "google_storage_bucket_iam_member" "data_read" {
+  bucket = "${google_storage_bucket.data.name}"
+
+  # https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.writer.email}"
 }
 

--- a/infra/dumps_bucket.tf
+++ b/infra/dumps_bucket.tf
@@ -33,10 +33,17 @@ resource "google_storage_bucket_acl" "dumps" {
 }
 
 # allow rw access for CI writer (see writer.tf)
-resource "google_storage_bucket_iam_member" "dumps" {
+resource "google_storage_bucket_iam_member" "dumps_create" {
   bucket = "${google_storage_bucket.dumps.name}"
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.writer.email}"
+}
+resource "google_storage_bucket_iam_member" "dumps_read" {
+  bucket = "${google_storage_bucket.dumps.name}"
+
+  # https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.writer.email}"
 }

--- a/infra/nix_cache.tf
+++ b/infra/nix_cache.tf
@@ -20,11 +20,18 @@ module "nix_cache" {
 }
 
 // allow rw access for CI writer (see writer.tf)
-resource "google_storage_bucket_iam_member" "nix_cache_writer" {
+resource "google_storage_bucket_iam_member" "nix_cache_writer_create" {
   bucket = "${module.nix_cache.bucket_name}"
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.writer.email}"
+}
+resource "google_storage_bucket_iam_member" "nix_cache_writer_read" {
+  bucket = "${module.nix_cache.bucket_name}"
+
+  # https://cloud.google.com/storage/docs/access-control/iam-roles
+  role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.writer.email}"
 }
 


### PR DESCRIPTION
Yesterday, a certificate expiration triggered the `patch_bazel_windows` job to run when it shouldn't, and it overrode an artifact we depend on. This was build from the same sources, but the build is not reproducible so we ended up with a hash mismatch.

As far as I know, there is no good reason for CI to ever delete or overwrite anything from our GCS buckets, so I'm removing its rights to do so.

As an added safety measure, this PR also enables versioning on all non-cache buckets (GCS does not support versioning on buckets with an expiration policy).

CHANGELOG_BEGIN
CHANGELOG_END