### PR TITLE
kutils: Make the validation and the preloading of PackageCommitter parametric

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
@@ -100,6 +100,7 @@ abstract class Reader[+Pkg] {
 }
 
 object Reader extends Reader[(PackageId, DamlLf.ArchivePayload)] {
+
   final case class ParseError(error: String) extends RuntimeException(error)
 
   def damlLfCodedInputStreamFromBytes(
@@ -133,4 +134,14 @@ object Reader extends Reader[(PackageId, DamlLf.ArchivePayload)] {
       lf: DamlLf.ArchivePayload,
       version: LanguageVersion,
   ): (PackageId, DamlLf.ArchivePayload) = (hash, lf)
+
+  // archive Reader that just check package hash.
+  val HashChecker = new Reader[Unit] {
+    override protected[this] def readArchivePayloadOfVersion(
+        hash: PackageId,
+        lf: DamlLf.ArchivePayload,
+        version: LanguageVersion,
+    ): Unit = ()
+  }
+
 }

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
@@ -135,7 +135,7 @@ object Reader extends Reader[(PackageId, DamlLf.ArchivePayload)] {
       version: LanguageVersion,
   ): (PackageId, DamlLf.ArchivePayload) = (hash, lf)
 
-  // archive Reader that just check package hash.
+  // Archive Reader that just checks package hash.
   val HashChecker = new Reader[Unit] {
     override protected[this] def readArchivePayloadOfVersion(
         hash: PackageId,

--- a/daml-lf/validation/BUILD.bazel
+++ b/daml-lf/validation/BUILD.bazel
@@ -13,7 +13,10 @@ da_scala_library(
     srcs = glob(["src/main/**/*.scala"]),
     scalacopts = lf_scalacopts,
     tags = ["maven_coordinates=com.daml:daml-lf-validation:__VERSION__"],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//compiler/scenario-service:__subpackages__",
+        "//daml-lf:__subpackages__",
+    ],
     deps = [
         "//daml-lf/data",
         "//daml-lf/language",

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -117,6 +117,7 @@ final class Metrics(val registry: MetricRegistry) {
         object packageUpload {
           private val Prefix: MetricName = committer.Prefix :+ "package_upload"
 
+          val validateTimer: Timer = registry.timer(Prefix :+ "validate_timer")
           val preloadTimer: Timer = registry.timer(Prefix :+ "preload_timer")
           val decodeTimer: Timer = registry.timer(Prefix :+ "decode_timer")
           val accepts: Counter = registry.counter(Prefix :+ "accepts")

--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -15,7 +15,6 @@ compile_deps = [
     "//daml-lf/transaction",
     "//daml-lf/transaction:transaction_java_proto",
     "//daml-lf/transaction:value_java_proto",
-    "//daml-lf/validation",
     "//language-support/scala/bindings",
     "//ledger-api/rs-grpc-akka",
     "//ledger-api/rs-grpc-bridge",

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -262,6 +262,7 @@ private[daml] object ApiServices {
               transactionsService,
               writeService,
               managementServiceTimeout,
+              engine,
             )
 
         val apiConfigManagementService =

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -108,6 +108,7 @@ da_scala_library(
 da_scala_test_suite(
     name = "kvutils-tests",
     size = "small",
+    timeout = "moderate",
     srcs = glob(["src/test/suite/scala/**/*.scala"]),
     data = [
         "//ledger/test-common:model-tests.dar",
@@ -124,8 +125,11 @@ da_scala_test_suite(
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_java_proto",
         "//daml-lf/data",
+        "//daml-lf/encoder",
         "//daml-lf/engine",
+        "//daml-lf/interpreter",
         "//daml-lf/language",
+        "//daml-lf/parser",
         "//daml-lf/transaction",
         "//daml-lf/transaction:transaction_java_proto",
         "//daml-lf/transaction:value_java_proto",

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -440,9 +440,9 @@ final private[kvutils] class PackageCommitter(
         builder += "check_for_duplicate" -> checkForDuplicates
         validationMode match {
           case ValidationMode.Strict =>
-            builder += "strictly_validate_packages" -> strictlyValidatePackages
+            builder += "validate_packages" -> strictlyValidatePackages
           case _ =>
-            builder += "loosely_validate_packages" -> looselyValidatePackages
+            builder += "validate_packages" -> looselyValidatePackages
         }
     }
     preloadingMode match {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -94,7 +94,7 @@ final private[kvutils] class PackageCommitter(
         StepContinue(partialResult)
       } else {
         val msg =
-          s"Participant ID '${uploadEntry.getParticipantId}' did not match authenticated participant ID '${ctx.getParticipantId}'"
+          s"Participant ID '${uploadEntry.getParticipantId}' did not match authorized participant ID '${ctx.getParticipantId}'"
         rejectionTraceLog(msg, uploadEntry)
         reject(
           ctx.getRecordTime,
@@ -191,7 +191,7 @@ final private[kvutils] class PackageCommitter(
 
   private[this] def validatePackages(
       uploadEntry: DamlPackageUploadEntry.Builder,
-      pkgs: Map[Ref.PackageId, Ast.Package],
+      packages: Map[Ref.PackageId, Ast.Package],
   ): Either[String, Unit] =
     metrics.daml.kvutils.committer.packageUpload.validateTimer.time { () =>
       val allPkgIds = uploadEntry.getArchivesList
@@ -323,7 +323,7 @@ final private[kvutils] class PackageCommitter(
         } yield ()
         result.fold(
           msg => traceLog(s"Uploading failed: $msg", uploadEntry),
-          _ => traceLog(s"Uploading successful", uploadEntry),
+          _ => traceLog("Uploading successful", uploadEntry),
         )
         metrics.daml.kvutils.committer.packageUpload.loadedPackages(() =>
           engine.compiledPackages().packageIds.size)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -5,196 +5,122 @@ package com.daml.ledger.participant.state.kvutils.committer
 
 import java.util.concurrent.Executors
 
-import com.daml.daml_lf_dev.DamlLf.Archive
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.participant.state.kvutils.DamlKvutils
 import com.daml.ledger.participant.state.kvutils.Conversions.packageUploadDedupKey
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.committer.Committer.{
   StepInfo,
   buildLogEntryWithOptionalRecordTime
 }
-import com.daml.lf.archive.Decode
+import com.daml.lf
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.Engine
-import com.daml.lf.language.Ast
+import com.daml.lf.language.{Ast, Graphs}
 import com.daml.metrics.Metrics
+import com.google.protobuf.ByteString
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
-private[kvutils] class PackageCommitter(
+object PackageCommitter {
+
+  /** Defines the different package validation modes. */
+  sealed abstract class ValidationMode extends Product with Serializable
+
+  object ValidationMode {
+
+    /** Specifies that the committer should validate the package before
+      * committing them to the ledger.
+      * When using this mode, the packages committed to the ledger can
+      * be fully trusted and do not have to be validated when loaded
+      * into the engine.  */
+    case object Strict extends ValidationMode
+
+    /** Specifies that the committer should perform a fast validation of
+      * the packages before committing them to the ledger.
+      * This mode is useful for ledger integrations that cannot handle
+      * long-running submissions (> 10s).
+      * When using this mode, the packages committed to the ledger
+      * cannot be trusted and must be validated every time they are
+      * loaded into the engine.  */
+    case object Lenient extends ValidationMode
+
+    /** Specifies that the committer should not perform any validation the
+      * packages before committing them to the ledger.
+      * This should be used only by non distributed ledgers, like
+      * DAML-on-SQL, where the validation done in the API server is
+      * can be trusted.  */
+    case object No extends ValidationMode
+  }
+
+  /** Defines the different package preloading modes. */
+  sealed abstract class PreloadingMode extends Product with Serializable
+
+  object PreloadingMode {
+
+    /** Specifies that the packages should be preloading into the engine
+      * before committed.  */
+    case object Synchronous extends PreloadingMode
+
+    /** Specify that the packages should be preloaded into the engine
+      * asynchronously with the rest of the commit process.  This mode
+      * is useful for ledger integrations that cannot handle
+      * long-running submissions (> 10s).
+      * Failure of the preloading process will not affect the
+      * commit.  */
+    case object Asynchronous extends PreloadingMode
+
+    /** Specify that the packages should not be preloaded into the
+      * engine.  */
+    case object No extends PreloadingMode
+
+  }
+
+}
+
+final private[kvutils] class PackageCommitter(
     engine: Engine,
     override protected val metrics: Metrics,
-) extends Committer[DamlPackageUploadEntry.Builder] {
+    validationMode: PackageCommitter.ValidationMode = PackageCommitter.ValidationMode.Lenient,
+    preloadingMode: PackageCommitter.PreloadingMode = PackageCommitter.PreloadingMode.Asynchronous,
+) extends Committer[(DamlPackageUploadEntry.Builder, Map[Ref.PackageId, Ast.Package])] {
 
-  override protected val committerName = "package_upload"
+  import PackageCommitter._
 
-  metrics.daml.kvutils.committer.packageUpload.loadedPackages(() =>
-    engine.compiledPackages().packageIds.size)
-
-  private def rejectionTraceLog(
-      msg: String,
-      packageUploadEntry: DamlPackageUploadEntry.Builder,
-  ): Unit =
-    logger.trace(
-      s"Package upload rejected, $msg, correlationId=${packageUploadEntry.getSubmissionId}")
-
-  private val authorizeSubmission: Step = (ctx, uploadEntry) => {
-    if (ctx.getParticipantId == uploadEntry.getParticipantId) {
-      StepContinue(uploadEntry)
-    } else {
-      val msg =
-        s"participant id ${uploadEntry.getParticipantId} did not match authenticated participant id ${ctx.getParticipantId}"
-      rejectionTraceLog(msg, uploadEntry)
-      reject(
-        ctx.getRecordTime,
-        uploadEntry.getSubmissionId,
-        uploadEntry.getParticipantId,
-        _.setParticipantNotAuthorized(
-          ParticipantNotAuthorized.newBuilder
-            .setDetails(msg))
-      )
-    }
-  }
-
-  private val validateEntry: Step = (ctx, uploadEntry) => {
-    // NOTE(JM): Currently the proper validation is unimplemented. The package is decoded and preloaded
-    // in background and we're just checking that hash and payload are set. See comment in [[preload]].
-    val archives = uploadEntry.getArchivesList.asScala
-    val errors = if (archives.nonEmpty) {
-      archives.foldLeft(List.empty[String]) { (errors, archive) =>
-        if (archive.getHashBytes.size > 0 && archive.getPayload.size > 0)
-          errors
-        else
-          s"Invalid archive ${archive.getHash}" :: errors
-      }
-    } else {
-      List("No archives in package")
-    }
-    if (errors.isEmpty) {
-      StepContinue(uploadEntry)
-    } else {
-      val msg = errors.mkString(", ")
-      rejectionTraceLog(msg, uploadEntry)
-      reject(
-        ctx.getRecordTime,
-        uploadEntry.getSubmissionId,
-        uploadEntry.getParticipantId,
-        _.setInvalidPackage(
-          Invalid.newBuilder
-            .setDetails(msg)
-        )
-      )
-    }
-  }
-
-  private val deduplicateSubmission: Step = (ctx, uploadEntry) => {
-    val submissionKey = packageUploadDedupKey(ctx.getParticipantId, uploadEntry.getSubmissionId)
-    if (ctx.get(submissionKey).isEmpty) {
-      StepContinue(uploadEntry)
-    } else {
-      val msg = s"duplicate submission='${uploadEntry.getSubmissionId}'"
-      rejectionTraceLog(msg, uploadEntry)
-      reject(
-        ctx.getRecordTime,
-        uploadEntry.getSubmissionId,
-        uploadEntry.getParticipantId,
-        _.setDuplicateSubmission(Duplicate.newBuilder.setDetails(msg))
-      )
-    }
-  }
-
-  private val filterDuplicates: Step = (ctx, uploadEntry) => {
-    val archives = uploadEntry.getArchivesList.asScala.filter { archive =>
-      val stateKey = DamlStateKey.newBuilder
-        .setPackageId(archive.getHash)
-        .build
-      ctx.get(stateKey).isEmpty
-    }
-    StepContinue(uploadEntry.clearArchives().addAllArchives(archives.asJava))
-  }
-
-  private val preloadExecutor = {
-    Executors.newSingleThreadExecutor((runnable: Runnable) => {
-      val t = new Thread(runnable)
-      t.setDaemon(true)
-      t
-    })
-  }
-
-  private val enqueuePreload: Step = (_, uploadEntry) => {
-    preloadExecutor.execute(
-      preload(uploadEntry.getSubmissionId, uploadEntry.getArchivesList.asScala))
-    StepContinue(uploadEntry)
-  }
-
-  private[committer] val buildLogEntry: Step = (ctx, uploadEntry) => {
-    metrics.daml.kvutils.committer.packageUpload.accepts.inc()
-    logger.trace(
-      s"Packages committed, packages=[${uploadEntry.getArchivesList.asScala.map(_.getHash).mkString(", ")}] correlationId=${uploadEntry.getSubmissionId}")
-
-    uploadEntry.getArchivesList.forEach { archive =>
-      ctx.set(
-        DamlStateKey.newBuilder.setPackageId(archive.getHash).build,
-        DamlStateValue.newBuilder.setArchive(archive).build
-      )
-    }
-    ctx.set(
-      packageUploadDedupKey(ctx.getParticipantId, uploadEntry.getSubmissionId),
-      DamlStateValue.newBuilder
-        .setSubmissionDedup(DamlSubmissionDedupValue.newBuilder)
-        .build
-    )
-    val successLogEntry =
-      buildLogEntryWithOptionalRecordTime(ctx.getRecordTime, _.setPackageUploadEntry(uploadEntry))
-    if (ctx.preExecute) {
-      setOutOfTimeBoundsLogEntry(uploadEntry, ctx)
-    }
-    StepStop(successLogEntry)
-  }
-
-  private def setOutOfTimeBoundsLogEntry(
-      uploadEntry: DamlPackageUploadEntry.Builder,
-      commitContext: CommitContext): Unit = {
-    commitContext.outOfTimeBoundsLogEntry = Some(
-      buildRejectionLogEntry(
-        recordTime = None,
-        uploadEntry.getSubmissionId,
-        uploadEntry.getParticipantId,
-        identity)
-    )
-  }
-
+  /** The initial internal state passed to first step. */
   override protected def init(
       ctx: CommitContext,
       submission: DamlSubmission,
-  ): DamlPackageUploadEntry.Builder =
-    submission.getPackageUploadEntry.toBuilder
+  ): (DamlPackageUploadEntry.Builder, Map[Ref.PackageId, Ast.Package]) =
+    (submission.getPackageUploadEntry.toBuilder, Map.empty)
 
-  override protected val steps: Iterable[(StepInfo, Step)] = Iterable(
-    "authorize_submission" -> authorizeSubmission,
-    "validate_entry" -> validateEntry,
-    "deduplicate_submission" -> deduplicateSubmission,
-    "filter_duplicates" -> filterDuplicates,
-    "enqueue_preload" -> enqueuePreload,
-    "build_log_entry" -> buildLogEntry
-  )
+  def traceLog(msg: String, uploadEntry: DamlPackageUploadEntry.Builder): Unit =
+    logger.trace(s"$msg, correlationId=${uploadEntry.getSubmissionId}")
 
-  private def reject[PartialResult](
+  private[this] def rejectionTraceLog(
+      msg: String,
+      uploadEntry: DamlPackageUploadEntry.Builder,
+  ): Unit =
+    traceLog(s"Package upload rejected, $msg", uploadEntry)
+
+  private[this] def reject(
       recordTime: Option[Timestamp],
       submissionId: String,
       participantId: String,
       addErrorDetails: DamlPackageUploadRejectionEntry.Builder => DamlPackageUploadRejectionEntry.Builder,
-  ): StepResult[PartialResult] = {
+  ): StepStop = {
     metrics.daml.kvutils.committer.packageUpload.rejections.inc()
     StepStop(buildRejectionLogEntry(recordTime, submissionId, participantId, addErrorDetails))
   }
 
-  private[committer] def buildRejectionLogEntry(
+  private[this] def buildRejectionLogEntry(
       recordTime: Option[Timestamp],
       submissionId: String,
       participantId: String,
       addErrorDetails: DamlPackageUploadRejectionEntry.Builder => DamlPackageUploadRejectionEntry.Builder,
-  ): DamlLogEntry = {
+  ): DamlLogEntry =
     buildLogEntryWithOptionalRecordTime(
       recordTime,
       _.setPackageUploadRejectionEntry(
@@ -205,52 +131,330 @@ private[kvutils] class PackageCommitter(
         )
       )
     )
+
+  private[this] def setOutOfTimeBoundsLogEntry(
+      uploadEntry: DamlPackageUploadEntry.Builder,
+      commitContext: CommitContext): Unit =
+    commitContext.outOfTimeBoundsLogEntry = Some(
+      buildRejectionLogEntry(
+        recordTime = None,
+        uploadEntry.getSubmissionId,
+        uploadEntry.getParticipantId,
+        identity,
+      )
+    )
+
+  private[this] def authorizeSubmission: Step = {
+    case (ctx, partialResult @ (uploadEntry, _)) =>
+      if (ctx.getParticipantId == uploadEntry.getParticipantId) {
+        StepContinue(partialResult)
+      } else {
+        val msg =
+          s"Participant ID '${uploadEntry.getParticipantId}' did not match authenticated participant ID '${ctx.getParticipantId}'"
+        rejectionTraceLog(msg, uploadEntry)
+        reject(
+          ctx.getRecordTime,
+          uploadEntry.getSubmissionId,
+          uploadEntry.getParticipantId,
+          _.setParticipantNotAuthorized(ParticipantNotAuthorized.newBuilder.setDetails(msg))
+        )
+      }
   }
+
+  private[this] def deduplicateSubmission: Step = {
+    case (ctx, partialResult @ (uploadEntry, _)) =>
+      val submissionKey = packageUploadDedupKey(ctx.getParticipantId, uploadEntry.getSubmissionId)
+      if (ctx.get(submissionKey).isEmpty) {
+        StepContinue(partialResult)
+      } else {
+        val msg = s"duplicate submission='${uploadEntry.getSubmissionId}'"
+        rejectionTraceLog(msg, uploadEntry)
+        reject(
+          ctx.getRecordTime,
+          uploadEntry.getSubmissionId,
+          uploadEntry.getParticipantId,
+          _.setDuplicateSubmission(Duplicate.newBuilder.setDetails(msg))
+        )
+      }
+  }
+
+// Checks that packages are not repeated in the submission.
+  private[this] def checkForDuplicates: Step = {
+    case (ctx, partialResult @ (uploadEntry, _)) =>
+      val (seenOnce, duplicates) = uploadEntry.getArchivesList
+        .iterator()
+        .asScala
+        .foldLeft((Set.empty[ByteString], Set.empty[ByteString])) {
+          case ((seenOnce, duplicates), pkg) =>
+            val hash = pkg.getHashBytes
+            if (seenOnce(hash))
+              (seenOnce, duplicates + hash)
+            else
+              (seenOnce + hash, duplicates)
+        }
+
+      val mbMsg =
+        if (seenOnce.isEmpty)
+          Some("No archives in submission")
+        else if (duplicates.nonEmpty)
+          Some(
+            duplicates.iterator
+              .map(pkgId => s"package ${pkgId.toStringUtf8} appears more than once")
+              .mkString(", "))
+        else None
+
+      mbMsg match {
+        case None => StepContinue(partialResult)
+        case Some(msg) =>
+          rejectionTraceLog(msg, uploadEntry)
+          reject(
+            ctx.getRecordTime,
+            uploadEntry.getSubmissionId,
+            uploadEntry.getParticipantId,
+            _.setInvalidPackage(DamlKvutils.Invalid.newBuilder.setDetails(msg))
+          )
+      }
+  }
+
+  private[this] def decodePackages(
+      archives: Traversable[DamlLf.Archive],
+  ): Either[String, Map[Ref.PackageId, Ast.Package]] =
+    metrics.daml.kvutils.committer.packageUpload.decodeTimer.time { () =>
+      type Result = Either[List[String], Map[Ref.PackageId, Ast.Package]]
+      // toSet is constant time here.
+      val knownPackages = engine.compiledPackages().packageIds.toSet[String]
+
+      archives
+        .foldLeft[Result](Right(Map.empty)) { (acc, arch) =>
+          try {
+            if (knownPackages(arch.getHash)) {
+              // If the package is already known by the engine, we don't decode it but still verify its hash.
+              lf.archive.Reader.HashChecker.decodeArchive(arch)
+              acc
+            } else {
+              acc.map(_ + lf.archive.Decode.decodeArchive(arch))
+            }
+          } catch {
+            case NonFatal(e) =>
+              Left(
+                s"Cannot decode archive ${arch.getHash}: ${e.getMessage}" :: acc.left
+                  .getOrElse(Nil))
+          }
+        }
+        .left
+        .map(_.mkString(", "))
+    }
+
+  private[this] def validatePackages(
+      uploadEntry: DamlPackageUploadEntry.Builder,
+      pkgs: Map[Ref.PackageId, Ast.Package],
+  ): Either[String, Unit] =
+    metrics.daml.kvutils.committer.packageUpload.validateTimer.time { () =>
+      val allPkgIds = uploadEntry.getArchivesList
+        .iterator()
+        .asScala
+        .map(pkg => Ref.PackageId.assertFromString(pkg.getHash))
+        .toSet
+      engine.validatePackages(allPkgIds, pkgs).left.map(_.detailMsg)
+    }
+
+// Validate packages
+  private[this] def strictlyValidatePackages: Step = {
+    case (ctx, (uploadEntry, mbPkgs)) =>
+      val result = for {
+        pkgs <- if (mbPkgs.isEmpty) decodePackages(uploadEntry.getArchivesList.asScala)
+        else Right(mbPkgs)
+        _ <- validatePackages(uploadEntry, pkgs)
+      } yield StepContinue((uploadEntry, pkgs))
+
+      result match {
+        case Right(result) => result
+        case Left(msg) =>
+          rejectionTraceLog(msg, uploadEntry)
+          reject(
+            ctx.getRecordTime,
+            uploadEntry.getSubmissionId,
+            uploadEntry.getParticipantId,
+            _.setInvalidPackage(DamlKvutils.Invalid.newBuilder.setDetails(msg))
+          )
+      }
+  }
+
+// Minimal validation.
+// Checks that package IDs are valid and package payloads are non-empty.
+  private[this] def looselyValidatePackages: Step = {
+    case (ctx, partialResult @ (uploadEntry, _)) =>
+      val archives = uploadEntry.getArchivesList.asScala
+      val errors =
+        archives.foldLeft(List.empty[String]) { (errors, archive) =>
+          if (archive.getPayload.isEmpty)
+            s"Empty archive '${archive.getHash}'" :: errors
+          else
+            Ref.PackageId
+              .fromString(archive.getHash)
+              .fold(msg => s"Invalid hash: $msg" :: errors, _ => errors)
+        }
+
+      if (errors.isEmpty) {
+        StepContinue(partialResult)
+      } else {
+        val msg = errors.mkString(", ")
+        rejectionTraceLog(msg, uploadEntry)
+        reject(
+          ctx.getRecordTime,
+          uploadEntry.getSubmissionId,
+          uploadEntry.getParticipantId,
+          _.setInvalidPackage(Invalid.newBuilder.setDetails(msg))
+        )
+      }
+  }
+
+  def uploadPackages(pkgs: Map[Ref.PackageId, Ast.Package]): Either[String, Unit] =
+    metrics.daml.kvutils.committer.packageUpload.preloadTimer.time { () =>
+      val errors = Graphs.topoSort(pkgs.transform((_, pkg) => pkg.directDeps)) match {
+        case Left(cycles) =>
+          List(s"cycle in package definitions: ${cycles.vertices.mkString(" -> ")}")
+        case Right(pkgIds) =>
+          pkgIds.iterator.flatMap { pkgId =>
+            engine
+              .preloadPackage(pkgId, pkgs(pkgId))
+              .consume(_ => None, _ => None, _ => None)
+              .fold(err => List(err.detailMsg), _ => List.empty)
+          }.toList
+      }
+      Either.cond(
+        errors.isEmpty,
+        (),
+        errors.mkString(", ")
+      )
+    }
+
+// Preload decoded packages
+  private[this] def preload: Step = {
+    case (ctx, (uploadEntry, mbPkgs)) =>
+      val result = for {
+        pkgs <- if (mbPkgs.isEmpty) decodePackages(uploadEntry.getArchivesList.asScala)
+        else Right(mbPkgs)
+        _ <- uploadPackages(pkgs)
+      } yield StepContinue((uploadEntry, pkgs))
+
+      result match {
+        case Right(partialResult) =>
+          partialResult
+        case Left(msg) =>
+          rejectionTraceLog(msg, uploadEntry)
+          reject(
+            ctx.getRecordTime,
+            uploadEntry.getSubmissionId,
+            uploadEntry.getParticipantId,
+            _.setInvalidPackage(DamlKvutils.Invalid.newBuilder.setDetails(msg))
+          )
+      }
+  }
+
+  private[this] def preloadExecutor =
+    Executors.newSingleThreadExecutor { (runnable: Runnable) =>
+      val t = new Thread(runnable)
+      t.setDaemon(true)
+      t
+    }
 
   /** Preload the archives to the engine in a background thread.
     *
     * The background loading is a temporary workaround for handling processing of large packages. When our current
     * integrations using kvutils can handle long-running submissions this can be removed and complete
     * package type-checking and preloading can be done during normal processing.
+    *
+    * This assumes the engine validate the archive it receives.
     */
-  private def preload(submissionId: String, archives: Iterable[Archive]): Runnable = { () =>
-    val ctx = metrics.daml.kvutils.committer.packageUpload.preloadTimer.time()
-    def trace(msg: String): Unit = logger.trace(s"$msg, correlationId=$submissionId")
-    try {
-      val loadedPackages = engine.compiledPackages().packageIds
-      val packages: Map[Ref.PackageId, Ast.Package] =
-        metrics.daml.kvutils.committer.packageUpload.decodeTimer.time { () =>
-          archives
-            .filterNot(
-              a =>
-                Ref.PackageId
-                  .fromString(a.getHash)
-                  .fold(_ => false, loadedPackages.contains))
-            .map { archive =>
-              Decode.readArchiveAndVersion(archive)._1
-            }
-            .toMap
-        }
-      trace(s"Preloading engine with ${packages.size} new packages")
-      packages.foreach {
-        case (pkgId, pkg) =>
-          engine
-            .preloadPackage(pkgId, pkg)
-            .consume(
-              _ => sys.error("Unexpected request to PCS in preloadPackage"),
-              pkgId => packages.get(pkgId),
-              _ => sys.error("Unexpected request to keys in preloadPackage")
-            )
+  private[this] def enqueuePreload: Step = {
+    case (_, partialResult @ (uploadEntry, mbPkgs)) =>
+      // we need to extract the archives synchronously as other steps may modify uploadEntry
+      val archives = uploadEntry.getArchivesList.iterator().asScala.toList
+      preloadExecutor.execute { () =>
+        traceLog(s"Uploading ${uploadEntry.getArchivesCount} archive", uploadEntry)
+        val result = for {
+          pkgs <- if (mbPkgs.isEmpty) decodePackages(archives) else Right(mbPkgs)
+          _ <- uploadPackages(pkgs)
+        } yield ()
+        result.fold(
+          msg => traceLog(s"Uploading failed: $msg", uploadEntry),
+          _ => traceLog(s"Uploading successful", uploadEntry),
+        )
+        metrics.daml.kvutils.committer.packageUpload.loadedPackages(() =>
+          engine.compiledPackages().packageIds.size)
       }
-      trace("Preload complete")
-    } catch {
-      case scala.util.control.NonFatal(err) =>
-        logger.error(
-          s"Preload exception, correlationId=$submissionId error='$err' stackTrace='${err.getStackTrace
-            .mkString(", ")}'")
-    } finally {
-      val _ = ctx.stop()
-    }
+      StepContinue(partialResult)
   }
 
+// Filter out packages already on the ledger.
+// Should be done after decoding, validation or preload, as those step may
+// require packages on the ledger by not loaded by the engine.
+  private[this] def filterKnownPackages: Step = {
+    case (ctx, (uploadEntry, pkgs)) =>
+      val archives = uploadEntry.getArchivesList.asScala.filter { archive =>
+        val stateKey = DamlStateKey.newBuilder
+          .setPackageId(archive.getHash)
+          .build
+        ctx.get(stateKey).isEmpty
+      }
+      StepContinue(uploadEntry.clearArchives().addAllArchives(archives.asJava) -> pkgs)
+  }
+
+  private[committer] def buildLogEntry: Step = {
+    case (ctx, (uploadEntry, _)) =>
+      metrics.daml.kvutils.committer.packageUpload.accepts.inc()
+      logger.trace(
+        s"Packages committed, packages=[${uploadEntry.getArchivesList.asScala.map(_.getHash).mkString(", ")}] correlationId=${uploadEntry.getSubmissionId}")
+
+      uploadEntry.getArchivesList.forEach { archive =>
+        ctx.set(
+          DamlStateKey.newBuilder.setPackageId(archive.getHash).build,
+          DamlStateValue.newBuilder.setArchive(archive).build
+        )
+      }
+      ctx.set(
+        packageUploadDedupKey(ctx.getParticipantId, uploadEntry.getSubmissionId),
+        DamlStateValue.newBuilder
+          .setSubmissionDedup(DamlSubmissionDedupValue.newBuilder)
+          .build
+      )
+      val successLogEntry =
+        buildLogEntryWithOptionalRecordTime(ctx.getRecordTime, _.setPackageUploadEntry(uploadEntry))
+      if (ctx.preExecute) {
+        setOutOfTimeBoundsLogEntry(uploadEntry, ctx)
+      }
+      StepStop(successLogEntry)
+  }
+
+  override protected val committerName: String = "package_upload"
+
+  val steps = {
+    val builder = List.newBuilder[(StepInfo, Step)]
+
+    validationMode match {
+      case ValidationMode.No =>
+      case _ =>
+        builder += "authorize_submission" -> authorizeSubmission
+        builder += "deduplicate_submission" -> deduplicateSubmission
+        builder += "check_for_duplicate" -> checkForDuplicates
+        validationMode match {
+          case ValidationMode.Strict =>
+            builder += "strictly_validate_packages" -> strictlyValidatePackages
+          case _ =>
+            builder += "loosely_validate_packages" -> looselyValidatePackages
+        }
+    }
+    preloadingMode match {
+      case PreloadingMode.No =>
+      case PreloadingMode.Synchronous =>
+        builder += "synchronously_preload" -> preload
+      case PreloadingMode.Asynchronous =>
+        builder += "asynchronously_preload" -> enqueuePreload
+    }
+    builder += "filter_known_packages" -> filterKnownPackages
+    builder += "build_log_entry" -> buildLogEntry
+
+    builder.result()
+  }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackagePreloadingMode.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackagePreloadingMode.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer
+
+/** Defines the different package preloading modes. */
+sealed abstract class PackagePreloadingMode extends Product with Serializable
+
+object PackagePreloadingMode {
+
+  /** Specifies that the packages should be preloading into the engine
+    * before committed.  */
+  case object Synchronous extends PackagePreloadingMode
+
+  /** Specify that the packages should be preloaded into the engine
+    * asynchronously with the rest of the commit process.  This mode
+    * is useful for ledger integrations that cannot handle
+    * long-running submissions (> 10s).
+    * Failure of the preloading process will not affect the
+    * commit.  */
+  case object Asynchronous extends PackagePreloadingMode
+
+  /** Specify that the packages should not be preloaded into the
+    * engine.  */
+  case object No extends PackagePreloadingMode
+
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageValidationMode.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageValidationMode.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer
+
+/** Defines the different package validation modes. */
+sealed abstract class PackageValidationMode extends Product with Serializable
+
+object PackageValidationMode {
+
+  /** Specifies that the committer should validate packages before
+    * committing them to the ledger.
+    * When using this mode, the packages committed to the ledger can
+    * be fully trusted and do not have to be validated when loaded
+    * into the engine.  */
+  case object Strict extends PackageValidationMode
+
+  /** Specifies that the committer should perform a fast validation of
+    * the packages before committing them to the ledger.
+    * This mode is useful for ledger integrations that cannot handle
+    * long-running submissions (> 10s).
+    * When using this mode, the packages committed to the ledger
+    * cannot be trusted and must be validated every time they are
+    * loaded into the engine.  */
+  case object Lenient extends PackageValidationMode
+
+  /** Specifies that the committer should not perform any validation the
+    * packages before committing them to the ledger.
+    * This should be used only by non distributed ledgers, like
+    * DAML-on-SQL, where the validation done in the API server is
+    * can be trusted.  */
+  case object No extends PackageValidationMode
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageValidationMode.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageValidationMode.scala
@@ -24,10 +24,10 @@ object PackageValidationMode {
     * loaded into the engine.  */
   case object Lenient extends PackageValidationMode
 
-  /** Specifies that the committer should not perform any validation the
+  /** Specifies that the committer should not perform any validation of
     * packages before committing them to the ledger.
     * This should be used only by non distributed ledgers, like
-    * DAML-on-SQL, where the validation done in the API server is
+    * DAML-on-SQL, where the validation done in the API server
     * can be trusted.  */
   case object No extends PackageValidationMode
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/StepResult.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/StepResult.scala
@@ -8,5 +8,4 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntry
 private[kvutils] sealed trait StepResult[+PartialResult]
 private[kvutils] final case class StepContinue[PartialResult](partialResult: PartialResult)
     extends StepResult[PartialResult]
-private[kvutils] final case class StepStop[PartialResult](logEntry: DamlLogEntry)
-    extends StepResult[PartialResult]
+private[kvutils] final case class StepStop(logEntry: DamlLogEntry) extends StepResult[Nothing]

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -206,7 +206,7 @@ class CommitterSpec
     override protected val committerName: String = "test"
 
     override protected def steps: Iterable[(StepInfo, Step)] =
-      Iterable(("result", (_, _) => StepStop[Int](aLogEntry)))
+      Iterable(("result", (_, _) => StepStop(aLogEntry)))
 
     override protected def init(ctx: CommitContext, submission: DamlKvutils.DamlSubmission): Int = 0
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
@@ -240,8 +240,8 @@ class PackageCommitterSpec extends WordSpec with Matchers with ParallelTestExecu
 
     "reject submissions containing different packages with same hash" in {
       val committer = newCommitter
-      val archive = archive2.toBuilder.setHash(pkgId1).build()
-      val submission1 = buildSubmission(archive1, archive)
+      val archiveWithDuplicateHash = archive2.toBuilder.setHash(pkgId1).build()
+      val submission1 = buildSubmission(archive1, archiveWithDuplicateHash)
 
       // when archive1 and archive2 are unknown
       shouldFailWith(
@@ -261,8 +261,9 @@ class PackageCommitterSpec extends WordSpec with Matchers with ParallelTestExecu
 
     "reject submissions containing a non valid package IDs" in {
       val committer = newCommitter
-      val archive = archive2.toBuilder.setHash("This is not a valid Package ID !").build()
-      val submission = buildSubmission(archive1, archive, archive3)
+      val archiveWithInvalidPackageId =
+        archive2.toBuilder.setHash("This is not a valid Package ID !").build()
+      val submission = buildSubmission(archive1, archiveWithInvalidPackageId, archive3)
 
       //when archive2 is unknown
       shouldFailWith(
@@ -299,8 +300,8 @@ class PackageCommitterSpec extends WordSpec with Matchers with ParallelTestExecu
 
     "reject submissions containing packages with improper hashes" in {
       val committer = newCommitter
-      val archive = archive3.toBuilder.setHash(pkgId2).build()
-      val submission = buildSubmission(archive1, archive, archive3)
+      val archiveWithImproperHash = archive3.toBuilder.setHash(pkgId2).build()
+      val submission = buildSubmission(archive1, archiveWithImproperHash, archive3)
 
       //when archive2 is unknown
       shouldFailWith(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
@@ -167,7 +167,7 @@ class PackageCommitterSpec extends WordSpec with Matchers with ParallelTestExecu
       output._1.hasRecordTime shouldBe false
     }
 
-    "filter out known packages" in {
+    "filter out already known packages" in {
       val committer = newCommitter
 
       shouldSucceedWith(committer.submit(buildSubmission(archive1)), Set(pkgId1))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
@@ -167,10 +167,10 @@ class PackageCommitterSpec extends WordSpec with Matchers with ParallelTestExecu
     archives.iterator().asScala.map(_.getHash).toSet shouldBe committedPackages.toSet[String]
   }
 
-  s"PackageCommitter" should {
+  "PackageCommitter" should {
     def newCommitter = new CommitterWrapper(ValidationMode.No, PreloadingMode.No)
 
-    // Don't need to run those tests for all instance of PackageCommitter.
+    // Don't need to run the below test cases for all instances of PackageCommitter.
     "set record time in log entry if record time is available" in {
       val submission1 = buildSubmission(archive1)
       val output = newCommitter.packageCommitter.run(
@@ -212,7 +212,7 @@ class PackageCommitterSpec extends WordSpec with Matchers with ParallelTestExecu
       )
     }
 
-    "reject non authorize submissions" in {
+    "reject not authorized submissions" in {
       val committer = newCommitter
 
       val submission1 = buildSubmission(archive1)
@@ -225,7 +225,7 @@ class PackageCommitterSpec extends WordSpec with Matchers with ParallelTestExecu
       shouldFailWith(output, PARTICIPANT_NOT_AUTHORIZED)
     }
 
-    "reject double submissions" in {
+    "reject duplicate submissions" in {
       val committer = newCommitter
 
       val submission = buildSubmission(archive1)
@@ -249,7 +249,7 @@ class PackageCommitterSpec extends WordSpec with Matchers with ParallelTestExecu
       shouldFailWith(
         committer.submit(submission1),
         INVALID_PACKAGE,
-        s"${pkgId1} appears more than once",
+        s"$pkgId1 appears more than once",
       )
 
       // when archive1 is known

--- a/ledger/recovering-indexer-integration-tests/BUILD.bazel
+++ b/ledger/recovering-indexer-integration-tests/BUILD.bazel
@@ -19,6 +19,7 @@ da_scala_test_suite(
     deps = [
         "//daml-lf/data",
         "//daml-lf/engine",
+        "//daml-lf/transaction",
         "//language-support/scala/bindings",
         "//ledger/caching",
         "//ledger/ledger-api-common",


### PR DESCRIPTION
This PR creates 3 validation modes:

+ `Strict` : Specifies that the committer should validate the package
   before committing them to the ledger.  When using this mode, the
   packages committed to the ledger can be fully trusted and do not
   have to be validated when loaded into the engine.

+ `Lenient`: Specifies that the committer should perform a fast
   validation of the packages before committing them to the ledger.
   This mode is useful for ledger integrations that cannot handle
   long-running submissions (> 10s).  When using this mode, the
   packages committed to the ledger cannot be trusted and must be
   validated every time they are loaded into the engine.

+ `No` : Specifies that the committer should not perform any
   validation the packages before committing them to the ledger.  This
   should be used only by non distributed ledgers, like DAML-on-SQL,
   where the validation done in the API server can be trusted.

This PR creates 3 preloading modes:

+ `Synchronous` : Specifies that the packages should be preloading
   into the engine before committed.

+ `Asynchronous`: Specify that the packages should be preloaded into
  the engine asynchronously with the rest of the commit process.  This
  mode is useful for ledger integrations that cannot handle
  long-running submissions (> 10s).  Failure of the preloading process
  will not affect the commit.

+ `Preloading`: Specify that the packages should not be preloaded into
  the engine.

CHANGELOG_BEGIN
- [Integration Kit] In kvutils, add metric
  `daml.kvutils.committer.package_upload.validate_timer` to track
  package validation time.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
