### PR TITLE
Enables fetching scala library sources

### DIFF
--- a/BAZEL.md
+++ b/BAZEL.md
@@ -300,6 +300,12 @@ Bazel command (`run`, `test`, etc.). If applicable, you can also define Bazel
 command-line flags or command-line flags to the executable. Click on "Apply",
 or "OK" to add the run configuration.
 
+#### Attaching sources to scala library
+
+If you do not have the scala library sources linked (you only see the decompiled
+ sources only), you can attach it manually by selecting the `Choose sources...` 
+ button on the yellow bar at the top, and selecting `scala-library...-src.jar`. 
+
 ### Known Issues
 
 #### Missing folders in project tree

--- a/BAZEL.md
+++ b/BAZEL.md
@@ -302,8 +302,8 @@ or "OK" to add the run configuration.
 
 #### Attaching sources to scala library
 
-If you do not have the scala library sources linked (you only see the decompiled
- sources only), you can attach it manually by selecting the `Choose sources...` 
+If you do not have the Scala library sources linked (you only see the decompiled
+ sources), you can attach it manually by selecting the `Choose sources...` 
  button on the yellow bar at the top, and selecting `scala-library...-src.jar`. 
 
 ### Known Issues
@@ -1012,4 +1012,3 @@ poisoned Nix cache. To clear that run through the following steps:
 ### Working in environments with low or intermittent connectivity
 
 Bazel tries to leverage the remote cache to speed up the build process but this can turn out to work against you if you are working in an environment with low or intermittent connectivity. To disable fetching from the remote cache in such scenario, you can use the `--noremote_accept_cached` option.
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -706,14 +706,17 @@ load(
 )
 
 # note some dependencies in bazel-jvm-deps.bzl (e.g. silencer_plugin) refer to the current scala version:
-scala_repositories((
-    "2.12.11",
-    {
-        "scala_compiler": "e901937dbeeae1715b231a7cfcd547a10d5bbf0dfb9d52d2886eae18b4d62ab6",
-        "scala_library": "dbfe77a3fc7a16c0c7cb6cb2b91fecec5438f2803112a744cb1b187926a138be",
-        "scala_reflect": "5f9e156aeba45ef2c4d24b303405db259082739015190b3b334811843bd90d6a",
-    },
-))
+scala_repositories(
+    (
+        "2.12.11",
+        {
+            "scala_compiler": "e901937dbeeae1715b231a7cfcd547a10d5bbf0dfb9d52d2886eae18b4d62ab6",
+            "scala_library": "dbfe77a3fc7a16c0c7cb6cb2b91fecec5438f2803112a744cb1b187926a138be",
+            "scala_reflect": "5f9e156aeba45ef2c4d24b303405db259082739015190b3b334811843bd90d6a",
+        },
+    ),
+    fetch_sources = True,
+)
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 


### PR DESCRIPTION
Enables fetch_sources flag for fetching scala sources.
These sources can be used for manual linking scala library if sources are not resolved otherwise.
Motivation: https://github.com/bazelbuild/rules_scala/issues/908

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
