### PR TITLE
Fix GSG environment variable setup instructions.

### DIFF
--- a/docs/source/getting-started/path-variables.rst
+++ b/docs/source/getting-started/path-variables.rst
@@ -42,8 +42,10 @@ Run the following command in your terminal::
 Verifying the changes
 =====================
 
-In order for the changes to take effect you will need to restart the terminal,
-by closing the Terminal program and starting it again.
+In order for the changes to take effect you will need to restart your computer, or, if you're using
+the Terminal app, you need to quit the Terminal app (Command+Q in the Terminal window) and
+reopen it. Afterward, please follow the instructions below to verify that everything was set
+up correctly.
 
 Please verify the JAVA_HOME variable by running::
 
@@ -59,9 +61,9 @@ Next, please verify the PATH variable by running::
 You should see a series of paths which includes the path to the DAML SDK,
 which is something like ``/Users/your_username/.daml/bin``.
 
-If you do not see the changes, you may be using ``bash`` as the default shell in your
-Terminal program. Please try these instructions again, but replace the ``~/.zprofile``
-with ``~/.bash_profile`` in the commands above.
+If you do not see the changes, you may be using ``bash`` as your default shell instead of ``zsh``.
+Please try these instructions again, but replace the ``~/.zprofile`` with ``~/.bash_profile`` in
+the commands above.
 
 Linux
 *****
@@ -85,8 +87,8 @@ Run the following command::
 Verifying the changes
 =====================
 
-In order for the changes to take effect you will need to restart the terminal,
-by closing the terminal program and starting it again.
+In order for the changes to take effect you will need to restart your computer. After the restart,
+please follow the instructions below to verify that everything was set up correctly.
 
 Please verify the JAVA_HOME variable by running::
 

--- a/docs/source/getting-started/path-variables.rst
+++ b/docs/source/getting-started/path-variables.rst
@@ -43,7 +43,7 @@ Verifying the changes
 =====================
 
 In order for the changes to take effect you will need to restart your computer, or, if you're using
-the Terminal app, you need to quit the Terminal app (Command+Q in the Terminal window) and
+the macOS Terminal app, you only need to quit the Terminal app (Command+Q in the Terminal window) and
 reopen it. Afterward, please follow the instructions below to verify that everything was set
 up correctly.
 

--- a/docs/source/getting-started/path-variables.rst
+++ b/docs/source/getting-started/path-variables.rst
@@ -33,28 +33,35 @@ Run the following command in your terminal::
 
         echo 'export JAVA_HOME="$(/usr/libexec/java_home)"' >> ~/.zprofile
 
-In order for the changes to take effect you will need to restart your computer. Note that if you will be setting up the
-``PATH`` variable as well you can restart your computer after you're done with all the changes. Upon restarting check that
-the ``JAVA_HOME`` variable is set::
-
-        echo $JAVA_HOME
-
-The result should be the path to the JDK installation, something like this::
-
-        /Library/Java/JavaVirtualMachines/jdk_version_number/Contents/Home
-
 Setting the PATH variable
 =========================
 Run the following command in your terminal::
 
-        echo 'export PATH="~/.daml/bin:$PATH"' >> ~/.zprofile
+        echo 'export PATH="$HOME/.daml/bin:$PATH"' >> ~/.zprofile
 
-In order for the changes to take effect you will need to restart your computer. Upon restarting check the ``PATH`` variable and make sure that
-the changes have been applied::
+Verifying the changes
+=====================
+
+In order for the changes to take effect you will need to restart the terminal,
+by closing the Terminal program and starting it again.
+
+Please verify the JAVA_HOME variable by running::
+
+        echo $JAVA_HOME
+
+You should see the path to the JDK installation, which is something like
+``/Library/Java/JavaVirtualMachines/jdk_version_number/Contents/Home``.
+
+Next, please verify the PATH variable by running::
 
         echo $PATH
 
-You should see ``~/.daml/bin`` in the output.
+You should see a series of paths which includes the path to the DAML SDK,
+which is something like ``/Users/your_username/.daml/bin``.
+
+If you do not see the changes, you may be using ``bash`` as the default shell in your
+Terminal program. Please try these instructions again, but replace the ``~/.zprofile``
+with ``~/.bash_profile`` in the commands above.
 
 Linux
 *****
@@ -68,28 +75,29 @@ make sure to change the ``java-version`` with the actual folder found on your co
 
         echo "export JAVA_HOME=/usr/lib/jvm/java-version" >> ~/.bash_profile
 
-In order for the changes to take effect you will need to restart your computer. Note that if you will be setting up the
-``PATH`` variable as well you can restart your computer after you're done with all the changes. Upon restarting check that
-the ``JAVA_HOME`` variable is set::
-
-        echo $JAVA_HOME
-
-The result should be the path to the JDK installation::
-
-        /usr/lib/jvm/java-version
-
 Setting the PATH variable
 =========================
 
 Run the following command::
 
-        echo 'export PATH="~/.daml/bin:$PATH"' >> ~/.bash_profile
+        echo 'export PATH="$HOME/.daml/bin:$PATH"' >> ~/.bash_profile
 
-Save the file before closing.
+Verifying the changes
+=====================
 
-In order for the changes to take effect you will need to restart your computer. Upon restarting check the ``PATH`` variable and make sure that
-the changes have been applied::
+In order for the changes to take effect you will need to restart the terminal,
+by closing the terminal program and starting it again.
+
+Please verify the JAVA_HOME variable by running::
+
+        echo $JAVA_HOME
+
+You should see the path you gave for the JDK installation, which is something like
+``/usr/lib/jvm/java-version``.
+
+Next, please verify the PATH variable by running::
 
         echo $PATH
 
-You should see ``~/.daml/bin`` in the output.
+You should see a series of paths which includes the path to the DAML SDK,
+which is something like ``/home/your_username/.daml/bin``.


### PR DESCRIPTION
Fixes #7451 by telling users to use `$HOME/.daml/bin` instead of `~/.daml/bin` when setting up the PATH variable.

In addition, this PR streamlines the instructions a bit by not telling users to restart their computers (they only need to restart the terminal) and by verifying the variables only after setting them both up, so they only need to restart the terminal once (without jumping around the instructions).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
