### PR TITLE
Deprecate daml damlc package

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -361,7 +361,7 @@ cmdInit numProcessors =
 cmdPackage :: Int -> Mod CommandFields Command
 cmdPackage numProcessors =
     command "package" $ info (helper <*> cmd) $
-       progDesc "Compile the DAML program into a DAML Archive (DAR)"
+       progDesc "Compile the DAML program into a DAR (deprecated)"
     <> fullDesc
   where
     cmd = execPackage
@@ -674,6 +674,17 @@ execPackage projectOpts filePath opts mbOutFile dalfInput =
   Command Package (Just projectOpts) effect
   where
     effect = withProjectRoot' projectOpts $ \relativize -> do
+      hPutStrLn stderr $ unlines
+        [ "WARNING: The comannd"
+        , ""
+        , "    daml damlc package"
+        , ""
+        , "is deprecated. Please use"
+        , ""
+        , "    daml build"
+        , ""
+        , "instead."
+        ]
       loggerH <- getLogger opts "package"
       filePath <- relativize filePath
       withDamlIdeState opts loggerH diagnosticsLogger $ \ide -> do


### PR DESCRIPTION
This command will be deprecated as part of the 1.6 release.
`daml build` should be used instead to build DARs.

CHANGELOG_BEGIN
[damlc]
- Deprecate `daml damlc package` command.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7466)
<!-- Reviewable:end -->
