### PR TITLE
Force newtype constructor names to match type name.

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -156,7 +156,7 @@ checkRecordConstructor (GHC.L _ m) = mapMaybe getRecordError (GHC.hsmodDecls m)
         , let tyNameStr = GHC.occNameString (GHC.rdrNameOcc tyName)
         , let conNameStr = GHC.occNameString (GHC.rdrNameOcc conName)
         , tyNameStr /= conNameStr
-        = Just (ss, message tyNameStr conNameStr)
+        = Just (ss, message nd tyNameStr conNameStr)
 
         | otherwise
         = Nothing
@@ -169,8 +169,10 @@ checkRecordConstructor (GHC.L _ m) = mapMaybe getRecordError (GHC.hsmodDecls m)
         GHC.RecCon{} -> True
         _ -> False
 
-    message tyNameStr conNameStr = unwords
-        [ "Record type", tyNameStr, "has constructor", conNameStr
+    message :: GHC.NewOrData -> String -> String -> String
+    message nd tyNameStr conNameStr = unwords
+        [ if isNewType nd then "Newtype" else "Record type"
+        , tyNameStr, "has constructor", conNameStr
         , "with different name."
         , "Possible solution: Change the constructor name to", tyNameStr ]
 

--- a/compiler/damlc/tests/daml-test-files/NewtypePolymorphic.daml
+++ b/compiler/damlc/tests/daml-test-files/NewtypePolymorphic.daml
@@ -4,13 +4,13 @@
 
 module NewtypePolymorphic where
 
-newtype T a = MkT a
+newtype T a = T a
 
 mkT : a -> T a
-mkT x = MkT x
+mkT x = T x
 
 unT : T a -> a
-unT (MkT x) = x
+unT (T x) = x
 
 main = scenario do
   assert (unT (mkT 1) == 1)

--- a/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
@@ -2,11 +2,13 @@
 -- All rights reserved.
 
 -- @ERROR range=10:0-10:13; Record type X has constructor Y with different name. Possible solution: Change the constructor name to X
-
 -- @ERROR range=12:0-12:26; Record type A has constructor B with different name. Possible solution: Change the constructor name to A
+-- @ERROR range=14:0-14:17; Record type C has constructor D with different name. Possible solution: Change the constructor name to C
 
 module RecordConstructorCheck where
 
 data X = Y {}
 
 newtype A = B { b : Bool }
+
+newtype C = D Int

--- a/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
@@ -2,8 +2,8 @@
 -- All rights reserved.
 
 -- @ERROR range=10:0-10:13; Record type X has constructor Y with different name. Possible solution: Change the constructor name to X
--- @ERROR range=12:0-12:26; Record type A has constructor B with different name. Possible solution: Change the constructor name to A
--- @ERROR range=14:0-14:17; Record type C has constructor D with different name. Possible solution: Change the constructor name to C
+-- @ERROR range=12:0-12:26; Newtype A has constructor B with different name. Possible solution: Change the constructor name to A
+-- @ERROR range=14:0-14:17; Newtype C has constructor D with different name. Possible solution: Change the constructor name to C
 
 module RecordConstructorCheck where
 


### PR DESCRIPTION
This PR fixes the record constructor check to include newtypes, which are represented as records in DAML-LF. The non-inclusion of all newtypes was an oversight. In addition, I added a regression test.

changelog_begin

- [DAML Compiler] bugfix: Newtype constructors must have the same
  name as the newtype itself, since newtypes are record types.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
