### PR TITLE
ledger-api-test-tool: Retry the participant connection for a minute.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -9,6 +9,7 @@ import java.nio.file.{Files, Paths, StandardCopyOption}
 import com.daml.ledger.api.testtool.infrastructure.Reporter.ColorizedPrintStreamReporter
 import com.daml.ledger.api.testtool.infrastructure.{
   Dars,
+  Errors,
   LedgerSessionConfiguration,
   LedgerTestCase,
   LedgerTestCasesRunner,
@@ -161,8 +162,12 @@ object LedgerApiTestTool {
           config.verbose,
         ).report(summaries)
         sys.exit(exitCode(summaries, config.mustFail))
-      case Failure(e) =>
-        logger.error(e.getMessage, e)
+      case Failure(exception: Errors.FrameworkException) =>
+        logger.error(exception.getMessage)
+        logger.debug(exception.getMessage, exception)
+        sys.exit(1)
+      case Failure(exception) =>
+        logger.error(exception.getMessage, exception)
         sys.exit(1)
     }
   }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Errors.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Errors.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.infrastructure
+
+object Errors {
+
+  sealed abstract class FrameworkException(message: String, cause: Throwable)
+      extends RuntimeException(message, cause)
+
+  final class ParticipantConnectionException(address: String, cause: Throwable)
+      extends FrameworkException(s"Could not connect to the participant at $address.", cause)
+
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionManager.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantSessionManager.scala
@@ -69,9 +69,10 @@ object ParticipantSessionManager {
     }
     channelBuilder.maxInboundMessageSize(10000000)
     val channel = channelBuilder.build()
-    logger.info(s"Connected to participant at ${config.address}.")
-    ParticipantSession(config, channel).map(session =>
-      new Session(config, session, channel, eventLoopGroup))
+    ParticipantSession(config, channel).map { session =>
+      logger.info(s"Connected to participant at ${config.address}.")
+      new Session(config, session, channel, eventLoopGroup)
+    }
   }
 
   private final class Session(


### PR DESCRIPTION
This means we can stop writing loops to wait for the ledger to come up wherever this is used.

This is not used in this repository yet, but hopefully I'll get to it some time soon.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
