### PR TITLE
adjust quickstart-java release smoketest instructions for prior changes

### DIFF
--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -264,19 +264,19 @@ patches we backport to the 1.0 release branch).
 
     1. Open `daml/Main.daml`.
 
-    1. Click on `Scenario results` above `setup` and wait for the scenario
+    1. Click on `Script results` above `setup` and wait for the script
        results to appear.
 
-    1. Add `+` at the end of line 12, after `"Alice"` and confirm you get an
-       error in line 13.
+    1. Add `+` at the end of line 14, after `"Alice")` and confirm you get an
+       error in line 15.
 
-    1. Add `1` after the `+` and confirm you get an error in line 12.
+    1. Add `1` after the `+` and confirm you get an error in line 14.
 
-    1. Delete the `+1` and the `e` in `Alice` and verify that the scenario
-       results are updated to the misspelled name.
+    1. Delete the `+1` and the `e` in the second `"Alice"` and verify
+       that the script results are updated to the misspelled name.
 
-    1. Right click on `eurBank` in line 18 and verify that "Go to Definition"
-       takes you to the definition in line 15.
+    1. Right click on `eurBank` in line 20 and verify that "Go to Definition"
+       takes you to the definition in line 17.
 
     1. Close all files.
 


### PR DESCRIPTION
Followup to #7338, adjusting release test instructions for changes to the Java quickstart, mismatches found testing #7462.  Compare to [Main.daml](https://github.com/digital-asset/daml/blob/b538c1fb591053ed426f7a334ea3a3d49808353e/docs/source/app-dev/bindings-java/quickstart/template-root/daml/Main.daml) for line # references.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
