### PR TITLE
Fix Numeric encoding and decoding in Scala bindings

### DIFF
--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Value.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Value.scala
@@ -7,6 +7,7 @@ import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
 import com.daml.ledger.api.v1.value.Value.{Sum => VSum}
 import com.daml.ledger.api.v1.{value => rpcvalue}
 import com.daml.ledger.client.binding.{Primitive => P}
+import com.daml.lf.{data => lf}
 import scalaz.std.option._
 import scalaz.syntax.traverse._
 
@@ -75,7 +76,9 @@ object DamlCodecs extends encoding.ValuePrimitiveEncoding[Value] {
   }
 
   implicit override val valueNumeric: Value[P.Numeric] =
-    fromArgumentValueFuns(_.numeric map BigDecimal.exact, bd => VSum.Numeric(bd.toString))
+    fromArgumentValueFuns(
+      _.numeric map lf.Numeric.assertFromString,
+      bd => VSum.Numeric(lf.Numeric.toString(bd.bigDecimal)))
 
   implicit override val valueParty: Value[P.Party] =
     Party.subst(fromArgumentValueFuns(_.party, VSum.Party))

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Value.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Value.scala
@@ -77,7 +77,7 @@ object DamlCodecs extends encoding.ValuePrimitiveEncoding[Value] {
 
   implicit override val valueNumeric: Value[P.Numeric] =
     fromArgumentValueFuns(
-      _.numeric map lf.Numeric.assertFromString,
+      _.numeric flatMap (lf.Numeric.fromString(_).toOption.map(BigDecimal(_))),
       bd => VSum.Numeric(lf.Numeric.toString(bd.bigDecimal)))
 
   implicit override val valueParty: Value[P.Party] =

--- a/language-support/scala/codegen-testing/BUILD.bazel
+++ b/language-support/scala/codegen-testing/BUILD.bazel
@@ -36,7 +36,7 @@ testing_utils = [
     "src/test/scala/com/digitalasset/scalatest/CustomMatcher.scala",
     "src/test/scala/com/digitalasset/ledger/client/binding/encoding/LfTypeEncodingSpec.scala",
     "src/test/scala/com/digitalasset/ledger/client/binding/EncodingTestUtil.scala",
-    "src/test/scala/com/digitalasset/ledger/client/binding/ValueSpec.scala",
+    "src/test/scala/com/digitalasset/ledger/client/binding/ValueGen.scala",
 ]
 
 da_scala_library(

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/PrimitiveSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/PrimitiveSpec.scala
@@ -40,7 +40,7 @@ class PrimitiveSpec extends WordSpec with Matchers with GeneratorDrivenPropertyC
   }
 
   "Date.fromLocalDate" should {
-    import ValueSpec.dateArb
+    import ValueGen.dateArb
 
     "pass through existing dates" in forAll { d: P.Date =>
       P.Date.fromLocalDate(d: LocalDate) shouldBe Some(d)
@@ -59,7 +59,7 @@ class PrimitiveSpec extends WordSpec with Matchers with GeneratorDrivenPropertyC
   }
 
   "Timestamp.discardNanos" should {
-    import ValueSpec.timestampArb
+    import ValueGen.timestampArb
 
     "pass through existing times" in forAll { t: P.Timestamp =>
       P.Timestamp.discardNanos(t: Instant) shouldBe Some(t)

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueGen.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueGen.scala
@@ -1,0 +1,126 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.client.binding
+
+import encoding.{ValuePrimitiveEncoding, GenEncoding}
+import org.scalacheck.{Arbitrary, Gen, Shrink}
+
+import scala.language.higherKinds
+
+object ValueGen {
+
+  private[binding] sealed abstract class Exists[F[_]] {
+    type T
+    val run: F[T]
+  }
+
+  private def Exists[T0, F[_]](_run: F[T0]): Exists[F] = {
+    final case class ExistsImpl(run: F[T0]) extends Exists[F] {
+      type T = T0
+      override def productPrefix = "Exists"
+    }
+    ExistsImpl(_run)
+  }
+
+  private[binding] final case class ValueCheck[T](tName: String)(
+      implicit val TA: Arbitrary[T],
+      val TS: Shrink[T],
+      val TV: Value[T])
+
+  import com.daml.ledger.client.binding.{Primitive => P}
+
+  private[binding] implicit val dateArb: Arbitrary[P.Date] =
+    Arbitrary(GenEncoding.primitive.valueDate)
+
+  private[binding] implicit val timestampArb: Arbitrary[P.Timestamp] =
+    Arbitrary(GenEncoding.primitive.valueTimestamp)
+
+  private[this] object TautologicalValueChecks extends ValuePrimitiveEncoding[ValueCheck] {
+    override val valueInt64 = ValueCheck[P.Int64]("Int64")
+    override val valueNumeric = {
+      implicit val PA: Arbitrary[P.Numeric] = Arbitrary(GenEncoding.primitive.valueNumeric)
+      ValueCheck[P.Numeric]("Numeric")
+    }
+    override val valueParty = {
+      implicit val PA: Arbitrary[P.Party] = Arbitrary(GenEncoding.primitive.valueParty)
+      ValueCheck[P.Party]("Party")
+    }
+    override val valueText = ValueCheck[P.Text]("Text")
+    override val valueDate = ValueCheck[P.Date]("Date")
+    override val valueTimestamp = ValueCheck[P.Timestamp]("Timestamp")
+    override val valueUnit = ValueCheck[P.Unit]("Unit")
+    override val valueBool = ValueCheck[P.Bool]("Bool")
+    override def valueContractId[A] = {
+      implicit val CA: Arbitrary[P.ContractId[A]] =
+        Arbitrary(GenEncoding.primitive.valueContractId)
+      ValueCheck[P.ContractId[A]]("ContractId")
+    }
+
+    override def valueList[A](implicit vc: ValueCheck[A]) = {
+      import vc._
+      ValueCheck[P.List[A]](s"List[$tName]")
+    }
+
+    override def valueOptional[A](implicit vc: ValueCheck[A]) = {
+      import vc._
+      ValueCheck[P.Optional[A]](s"Option[$tName]")
+    }
+
+    override def valueTextMap[A](implicit vc: ValueCheck[A]) = {
+      import vc._
+      implicit val arbTM: Arbitrary[P.TextMap[A]] = Arbitrary(
+        GenEncoding.primitive.valueTextMap(TA.arbitrary))
+      ValueCheck[P.TextMap[A]](s"Map[$tName]")
+    }
+
+    override def valueGenMap[K, V](implicit vcK: ValueCheck[K], vcV: ValueCheck[V]) = {
+      import vcK.{TA => KA, TS => KS, TV => KV}
+      import vcV.{TA => VA, TS => VS, TV => VV}
+
+      ValueCheck[P.GenMap[K, V]](s"GenMap[${vcK.tName}, ${vcV.tName}]")
+    }
+  }
+
+  private val tautologicalValueChecks: Seq[Exists[ValueCheck]] =
+    ValuePrimitiveEncoding.roots(TautologicalValueChecks).map(Exists(_))
+
+  private val valueChecks: Gen[Exists[ValueCheck]] =
+    Gen.frequency(
+      (tautologicalValueChecks.size, Gen.oneOf(tautologicalValueChecks)),
+      (1, Gen.lzy {
+        valueChecks.map { vc =>
+          Exists(TautologicalValueChecks.valueList(vc.run))
+        }
+      }),
+      (1, Gen.lzy {
+        valueChecks.map { vc =>
+          Exists(TautologicalValueChecks.valueOptional(vc.run))
+        }
+      }),
+      (1, Gen.lzy {
+        valueChecks.map { vc =>
+          Exists(TautologicalValueChecks.valueTextMap(vc.run))
+        }
+      }),
+      (1, Gen.lzy {
+        valueChecks.map { vc =>
+          Exists(TautologicalValueChecks.valueGenMap(vc.run, vc.run))
+        }
+      })
+    )
+
+  private[binding] type WithValue[T] = (ValueCheck[T], T)
+
+  private[binding] implicit val withValues: Arbitrary[Exists[WithValue]] =
+    Arbitrary(valueChecks.flatMap { evc =>
+      val vc = evc.run
+      vc.TA.arbitrary map (t => Exists[evc.T, WithValue]((vc, t)))
+    })
+
+  private[binding] implicit val withValueShrink: Shrink[Exists[WithValue]] =
+    Shrink { ewv =>
+      val (vc, t) = ewv.run
+      vc.TS shrink t map (t2 => Exists[ewv.T, WithValue]((vc, t2)))
+    }
+}

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueGen.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueGen.scala
@@ -8,7 +8,7 @@ import org.scalacheck.{Arbitrary, Gen, Shrink}
 
 import scala.language.higherKinds
 
-object ValueGen {
+private[binding] object ValueGen {
 
   private[binding] sealed abstract class Exists[F[_]] {
     type T

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueSpec.scala
@@ -28,15 +28,15 @@ class ValueSpec extends WordSpec with Matchers with GeneratorDrivenPropertyCheck
     "encode Numeric without exponents" in {
       import com.daml.ledger.client.binding.{Primitive => P}
       import com.daml.ledger.api.v1.value.Value.{Sum => VSum}
-      Value.encode(BigDecimal.exact("0.0000000000001"): P.Numeric) shouldBe VSum
-        .Numeric("0.0000000000001")
+      import com.daml.ledger.api.v1.value.{Value => RpcValue}
+      Value.encode(BigDecimal.exact("0.0000000000001"): P.Numeric) shouldBe RpcValue(
+        VSum.Numeric("0.0000000000001"))
     }
     "fail to decode Numeric with exponent" in {
       import com.daml.ledger.client.binding.{Primitive => P}
       import com.daml.ledger.api.v1.value.Value.{Sum => VSum}
-      an[IllegalArgumentException] should be thrownBy Value
-        .Decoder[P.Numeric]
-        .read(VSum.Numeric("1E-13"))
+      import com.daml.ledger.api.v1.value.{Value => RpcValue}
+      Value.decode[P.Numeric](RpcValue(VSum.Numeric("1E-13"))) shouldBe None
     }
   }
 }

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueSpec.scala
@@ -28,7 +28,7 @@ class ValueSpec extends WordSpec with Matchers with GeneratorDrivenPropertyCheck
     "encode Numeric without exponents" in {
       import com.daml.ledger.client.binding.{Primitive => P}
       import com.daml.ledger.api.v1.value.Value.{Sum => VSum}
-      Value.Encoder[P.Numeric].write(BigDecimal.exact("0.0000000000001"): P.Numeric) shouldBe VSum
+      Value.encode(BigDecimal.exact("0.0000000000001"): P.Numeric) shouldBe VSum
         .Numeric("0.0000000000001")
     }
     "fail to decode Numeric with exponent" in {

--- a/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueSpec.scala
+++ b/language-support/scala/codegen-testing/src/test/scala/com/digitalasset/ledger/client/binding/ValueSpec.scala
@@ -3,15 +3,11 @@
 
 package com.daml.ledger.client.binding
 
-import encoding.{ValuePrimitiveEncoding, GenEncoding}
-import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.language.higherKinds
-
 class ValueSpec extends WordSpec with Matchers with GeneratorDrivenPropertyChecks {
-  import ValueSpec._
+  import ValueGen._
 
   "Value" should {
     "read(write(x)) yields x" in forAll { wv: Exists[WithValue] =>
@@ -29,119 +25,18 @@ class ValueSpec extends WordSpec with Matchers with GeneratorDrivenPropertyCheck
       Value.Decoder[P.List[P.Int64]]
       Value.Encoder[P.List[P.Int64]]
     }
-  }
-}
-
-object ValueSpec {
-
-  private sealed abstract class Exists[F[_]] {
-    type T
-    val run: F[T]
-  }
-
-  private def Exists[T0, F[_]](_run: F[T0]): Exists[F] = {
-    final case class ExistsImpl(run: F[T0]) extends Exists[F] {
-      type T = T0
-      override def productPrefix = "Exists"
+    "encode Numeric without exponents" in {
+      import com.daml.ledger.client.binding.{Primitive => P}
+      import com.daml.ledger.api.v1.value.Value.{Sum => VSum}
+      Value.Encoder[P.Numeric].write(BigDecimal.exact("0.0000000000001"): P.Numeric) shouldBe VSum
+        .Numeric("0.0000000000001")
     }
-    ExistsImpl(_run)
-  }
-
-  private final case class ValueCheck[T](tName: String)(
-      implicit val TA: Arbitrary[T],
-      val TS: Shrink[T],
-      val TV: Value[T])
-
-  import com.daml.ledger.client.binding.{Primitive => P}
-
-  private[binding] implicit val dateArb: Arbitrary[P.Date] =
-    Arbitrary(GenEncoding.primitive.valueDate)
-
-  private[binding] implicit val timestampArb: Arbitrary[P.Timestamp] =
-    Arbitrary(GenEncoding.primitive.valueTimestamp)
-
-  private[this] object TautologicalValueChecks extends ValuePrimitiveEncoding[ValueCheck] {
-    override val valueInt64 = ValueCheck[P.Int64]("Int64")
-    override val valueNumeric = ValueCheck[P.Numeric]("Numeric")
-    override val valueParty = {
-      implicit val PA: Arbitrary[P.Party] = Arbitrary(GenEncoding.primitive.valueParty)
-      ValueCheck[P.Party]("Party")
-    }
-    override val valueText = ValueCheck[P.Text]("Text")
-    override val valueDate = ValueCheck[P.Date]("Date")
-    override val valueTimestamp = ValueCheck[P.Timestamp]("Timestamp")
-    override val valueUnit = ValueCheck[P.Unit]("Unit")
-    override val valueBool = ValueCheck[P.Bool]("Bool")
-    override def valueContractId[A] = {
-      implicit val CA: Arbitrary[P.ContractId[A]] =
-        Arbitrary(GenEncoding.primitive.valueContractId)
-      ValueCheck[P.ContractId[A]]("ContractId")
-    }
-
-    override def valueList[A](implicit vc: ValueCheck[A]) = {
-      import vc._
-      ValueCheck[P.List[A]](s"List[$tName]")
-    }
-
-    override def valueOptional[A](implicit vc: ValueCheck[A]) = {
-      import vc._
-      ValueCheck[P.Optional[A]](s"Option[$tName]")
-    }
-
-    override def valueTextMap[A](implicit vc: ValueCheck[A]) = {
-      import vc._
-      implicit val arbTM: Arbitrary[P.TextMap[A]] = Arbitrary(
-        GenEncoding.primitive.valueTextMap(TA.arbitrary))
-      ValueCheck[P.TextMap[A]](s"Map[$tName]")
-    }
-
-    override def valueGenMap[K, V](implicit vcK: ValueCheck[K], vcV: ValueCheck[V]) = {
-      import vcK.{TA => KA, TS => KS, TV => KV}
-      import vcV.{TA => VA, TS => VS, TV => VV}
-
-      ValueCheck[P.GenMap[K, V]](s"GenMap[${vcK.tName}, ${vcV.tName}]")
+    "fail to decode Numeric with exponent" in {
+      import com.daml.ledger.client.binding.{Primitive => P}
+      import com.daml.ledger.api.v1.value.Value.{Sum => VSum}
+      an[IllegalArgumentException] should be thrownBy Value
+        .Decoder[P.Numeric]
+        .read(VSum.Numeric("1E-13"))
     }
   }
-
-  private val tautologicalValueChecks: Seq[Exists[ValueCheck]] =
-    ValuePrimitiveEncoding.roots(TautologicalValueChecks).map(Exists(_))
-
-  private val valueChecks: Gen[Exists[ValueCheck]] =
-    Gen.frequency(
-      (tautologicalValueChecks.size, Gen.oneOf(tautologicalValueChecks)),
-      (1, Gen.lzy {
-        valueChecks.map { vc =>
-          Exists(TautologicalValueChecks.valueList(vc.run))
-        }
-      }),
-      (1, Gen.lzy {
-        valueChecks.map { vc =>
-          Exists(TautologicalValueChecks.valueOptional(vc.run))
-        }
-      }),
-      (1, Gen.lzy {
-        valueChecks.map { vc =>
-          Exists(TautologicalValueChecks.valueTextMap(vc.run))
-        }
-      }),
-      (1, Gen.lzy {
-        valueChecks.map { vc =>
-          Exists(TautologicalValueChecks.valueGenMap(vc.run, vc.run))
-        }
-      })
-    )
-
-  private type WithValue[T] = (ValueCheck[T], T)
-
-  private implicit val withValues: Arbitrary[Exists[WithValue]] =
-    Arbitrary(valueChecks.flatMap { evc =>
-      val vc = evc.run
-      vc.TA.arbitrary map (t => Exists[evc.T, WithValue]((vc, t)))
-    })
-
-  private implicit val withValueShrink: Shrink[Exists[WithValue]] =
-    Shrink { ewv =>
-      val (vc, t) = ewv.run
-      vc.TS shrink t map (t2 => Exists[ewv.T, WithValue]((vc, t2)))
-    }
 }


### PR DESCRIPTION
fixes #7474

There are a few issues here:

1. We used toString which produces an exponential notation in some
cases which is not supported by the ledger API.

2. On the other hand, we used BigDecimal.exact for decoding which
isn’t completely wrong but more lax than what the ledger API supports

1 and 2 are fixed by switching to the respective functions in
daml-lf/data

3. The tests in ValueSpec were never executed! The tests are split
into a scala_library and a scala_test_suite and ValueSpec ended up in
the library. I’ve split out the utilities from the actual code.

4. The generator for Numeric produced things that are not valid
numerics (e.g. 92233720368547758070000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
showed up in one test) which now fails with the more strict requirements.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
