### PR TITLE
sandbox + kvutils: Add the "read" component back to the health checks. [KVL-475] [KVL-483]

### DIFF
--- a/ledger/ledger-api-health/src/main/scala/com/digitalasset/ledger/api/health/HealthChecks.scala
+++ b/ledger/ledger-api-health/src/main/scala/com/digitalasset/ledger/api/health/HealthChecks.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.api.health
 
 import com.daml.ledger.api.health.HealthChecks._
 
-class HealthChecks(private val components: Components) {
+class HealthChecks(components: Components) {
   def this(components: Component*) = this(components.toMap)
 
   def hasComponent(componentName: ComponentName): Boolean =
@@ -16,6 +16,9 @@ class HealthChecks(private val components: Components) {
       case None => components.forall(_._2.currentHealth() == Healthy)
       case Some(name) => components(name).currentHealth() == Healthy
     }
+
+  def +(component: Component) =
+    new HealthChecks(this.components + component)
 }
 
 object HealthChecks {

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.daml.daml_lf_dev.DamlLf.Archive
+import com.daml.ledger.api.health.HealthChecks
 import com.daml.ledger.participant.state.v1.metrics.{TimedReadService, TimedWriteService}
 import com.daml.ledger.participant.state.v1.{SubmissionId, WritePackagesService}
 import com.daml.lf.archive.DarReader
@@ -113,6 +114,7 @@ final class Runner[T <: ReadWriteService, Extra](
               .acquire()
             readService = new TimedReadService(ledger, metrics)
             writeService = new TimedWriteService(ledger, metrics)
+            healthChecks = new HealthChecks("write" -> writeService)
             _ <- Resource.fromFuture(
               Future.sequence(config.archiveFiles.map(uploadDar(_, writeService))))
             _ <- new StandaloneIndexerServer(
@@ -129,6 +131,7 @@ final class Runner[T <: ReadWriteService, Extra](
               ledgerConfig = factory.ledgerConfig(config),
               optWriteService = Some(writeService),
               authService = factory.authService(config),
+              healthChecks = healthChecks,
               metrics = metrics,
               timeServiceBackend = factory.timeServiceBackend(config),
               otherInterceptors = factory.interceptors(config),

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -114,7 +114,10 @@ final class Runner[T <: ReadWriteService, Extra](
               .acquire()
             readService = new TimedReadService(ledger, metrics)
             writeService = new TimedWriteService(ledger, metrics)
-            healthChecks = new HealthChecks("write" -> writeService)
+            healthChecks = new HealthChecks(
+              "read" -> readService,
+              "write" -> writeService,
+            )
             _ <- Resource.fromFuture(
               Future.sequence(config.archiveFiles.map(uploadDar(_, writeService))))
             _ <- new StandaloneIndexerServer(

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -149,7 +149,10 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                 ledger = new KeyValueParticipantState(readerWriter, readerWriter, metrics)
                 readService = new TimedReadService(ledger, metrics)
                 writeService = new TimedWriteService(ledger, metrics)
-                healthChecks = new HealthChecks("write" -> writeService)
+                healthChecks = new HealthChecks(
+                  "read" -> readService,
+                  "write" -> writeService,
+                )
                 ledgerId <- ResourceOwner.forFuture(() =>
                   readService.getLedgerInitialConditions().runWith(Sink.head).map(_.ledgerId))
                 _ <- if (isReset) {


### PR DESCRIPTION
Also, inject health checks into the API server. 

### Changelog

- **[Integration Kit]** The ``StandaloneApiServer`` now takes a ``healthChecks`` parameter, which should identify the health checks to be exposed over the gRPC Health Checking Protocol. This will typically look something like:

  ```
  healthChecks = new HealthChecks("read" -> readService, "write" -> writeService)
  ```

  Integrators may also wish to expose the health of more components. All components wishing to report their health must implement the ``ReportsHealth`` trait.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
