### PR TITLE
Deprecate specifying the template in daml new positional

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -54,6 +54,7 @@ da_haskell_binary(
         "base",
         "extra",
         "filepath",
+        "process",
         "safe-exceptions",
         "typed-process",
     ],

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -13,6 +13,7 @@ import System.Environment
 import System.Exit
 import System.FilePath
 import System.IO
+import System.Process (showCommandForUser)
 import System.Process.Typed
 import Text.Read (readMaybe)
 
@@ -54,7 +55,7 @@ data Command
         , logbackConfig :: FilePath
         , shutdownStdinClose :: Bool
         }
-    | New { targetFolder :: FilePath, templateNameM :: Maybe String }
+    | New { targetFolder :: FilePath, appTemplate :: AppTemplate }
     | CreateDamlApp { targetFolder :: FilePath }
     -- ^ CreateDamlApp is sufficiently special that in addition to
     -- `daml new foobar create-daml-app` we also make `daml create-daml-app foobar` work.
@@ -82,6 +83,11 @@ data Command
     | LedgerFetchDar { flags :: LedgerFlags, pid :: String, saveAs :: FilePath }
     | LedgerNavigator { flags :: LedgerFlags, remainingArguments :: [String] }
     | Codegen { lang :: Lang, remainingArguments :: [String] }
+
+data AppTemplate
+  = AppTemplateDefault
+  | AppTemplateViaOption String
+  | AppTemplateViaArgument String
 
 data Lang = Java | Scala | JavaScript
 
@@ -131,18 +137,18 @@ commandParser = subparser $ fold
         <*> stdinCloseOpt
 
     newCmd =
-        let tplOpts :: HasMetavar a => Mod a String
-            tplOpts =
-                metavar "TEMPLATE" <>
-                help ("Name of the template used to create the project (default: " <> defaultProjectTemplate <> ")")
+        let templateHelpStr = "Name of the template used to create the project (default: " <> defaultProjectTemplate <> ")"
+            appTemplateFlag = asum
+              [ AppTemplateViaOption
+                  <$> strOption (long "template" <> metavar "TEMPLATE" <> help templateHelpStr)
+              , AppTemplateViaArgument <$> argument str (metavar "TEMPLATE_ARG" <> help ("Deprecated. " <> templateHelpStr))
+              , pure AppTemplateDefault
+              ]
         in asum
         [ ListTemplates <$ flag' () (long "list" <> help "List the available project templates.")
         , New
             <$> argument str (metavar "TARGET_PATH" <> help "Path where the new project should be located")
-            <*> optional
-                  (strOption (long "template" <> tplOpts) <|>
-                   argument str tplOpts
-                  )
+            <*> appTemplateFlag
         ]
 
     createDamlAppCmd =
@@ -372,7 +378,22 @@ runCommand = \case
     RunPlatformJar {..} ->
         (if shutdownStdinClose then withCloseOnStdin else id) $
         runPlatformJar args logbackConfig
-    New {..} -> runNew targetFolder templateNameM
+    New {..} -> do
+        templateNameM <- case appTemplate of
+            AppTemplateDefault -> pure Nothing
+            AppTemplateViaOption templateName -> pure (Just templateName)
+            AppTemplateViaArgument templateName -> do
+                hPutStrLn stderr $ unlines
+                    [ "WARNING: Specifying the template via"
+                    , ""
+                    , "    " <> showCommandForUser "daml" ["new", targetFolder, templateName]
+                    , ""
+                    , "is deprecated. The recommended way of specifying the template is"
+                    , ""
+                    , "    " <> showCommandForUser "daml" ["new", targetFolder, "--template", templateName]
+                    ]
+                pure (Just templateName)
+        runNew targetFolder templateNameM
     CreateDamlApp{..} -> runNew targetFolder (Just "create-daml-app")
     Init {..} -> runInit targetFolderM
     ListTemplates -> runListTemplates

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/New.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/New.hs
@@ -68,7 +68,7 @@ runNew targetFolder templateNameM = do
                 [ "Template name " <> projectName <> " was given as project name."
                 , "Please specify a project name separately, for example:"
                 , ""
-                , "    " <> showCommandForUser "daml" ["new", "myproject", projectName]
+                , "    " <> showCommandForUser "daml" ["new", "myproject", "--template", projectName]
                 , ""
                 ]
             exitFailure

--- a/docs/source/daml/intro/1_Token.rst
+++ b/docs/source/daml/intro/1_Token.rst
@@ -14,7 +14,7 @@ To begin with, you're going to write a very small DAML template, which represent
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder ``1_Token`` by running ``daml new 1_Token daml-intro-1``
+  Remember that you can load all the code for this section into a folder ``1_Token`` by running ``daml new 1_Token --template daml-intro-1``
 
 DAML ledger basics
 ------------------

--- a/docs/source/daml/intro/2_DamlScript.rst
+++ b/docs/source/daml/intro/2_DamlScript.rst
@@ -15,7 +15,7 @@ In this section you will test the ``Token`` model from :doc:`1_Token` using the 
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``daml-intro-2`` by running ``daml new daml-intro-2 --template=daml-intro-2``
+  Remember that you can load all the code for this section into a folder called ``daml-intro-2`` by running ``daml new daml-intro-2 --template daml-intro-2``
 
 .. script_basics:
 

--- a/docs/source/daml/intro/3_Data.rst
+++ b/docs/source/daml/intro/3_Data.rst
@@ -27,7 +27,7 @@ After this section, you should be able to use a DAML ledger as a simple database
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``3_Data`` by running ``daml new 3_Data daml-intro-3``
+  Remember that you can load all the code for this section into a folder called ``3_Data`` by running ``daml new 3_Data --template daml-intro-3``
 
 Native types
 ------------

--- a/docs/source/daml/intro/4_Transformations.rst
+++ b/docs/source/daml/intro/4_Transformations.rst
@@ -12,7 +12,7 @@ In this section you will learn about how to define simple data transformations u
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``4_Transformations`` by running ``daml new 4_Transformations daml-intro-4``
+  Remember that you can load all the code for this section into a folder called ``4_Transformations`` by running ``daml new 4_Transformations --template daml-intro-4``
 
 Choices as methods
 ------------------

--- a/docs/source/daml/intro/5_Restrictions.rst
+++ b/docs/source/daml/intro/5_Restrictions.rst
@@ -15,7 +15,7 @@ Lastly, you will learn about time on the ledger and in DAML Script.
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``5_Restrictions`` by running ``daml new 5_Restrictions daml-intro-5``
+  Remember that you can load all the code for this section into a folder called ``5_Restrictions`` by running ``daml new 5_Restrictions --template daml-intro-5``
 
 Template preconditions
 ----------------------

--- a/docs/source/daml/intro/6_Parties.rst
+++ b/docs/source/daml/intro/6_Parties.rst
@@ -14,7 +14,7 @@ In this section you will learn about DAML's authorization rules and how to devel
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``6_Parties`` by running ``daml new 6_Parties daml-intro-6``
+  Remember that you can load all the code for this section into a folder called ``6_Parties`` by running ``daml new 6_Parties --template daml-intro-6``
 
 Preventing IOU revocation
 -------------------------

--- a/docs/source/daml/intro/7_Composing.rst
+++ b/docs/source/daml/intro/7_Composing.rst
@@ -16,7 +16,7 @@ The model in this section is not a single DAML file, but a DAML project consisti
 
 .. hint::
 
-  Remember that you can load all the code for this section into a folder called ``7_Composing`` by running ``daml new 7_Composing daml-intro-7``
+  Remember that you can load all the code for this section into a folder called ``7_Composing`` by running ``daml new 7_Composing --template daml-intro-7``
 
 DAML projects
 -------------

--- a/templates/README.txt
+++ b/templates/README.txt
@@ -16,7 +16,7 @@ This gives an executable DAML assistant called `daml-head` in your path.
 Next, instantiate the `create-daml-app` template as follows:
 
 ```
-daml-head new create-daml-app
+daml-head new create-daml-app --template create-daml-app
 cd create-daml-app
 ```
 


### PR DESCRIPTION
We deprecate specifying the template when calling `daml new` via a
positional argument, as in
```sh
daml new foo skeleton
```
The new syntax is
```sh
daml new foo --template skeleton
```
Whenever the former version is used, we now print a not that it is
deprecated and that the latter version is the recommended way.

CHANGELOG_BEGIN
[DAML Assistant]
- Deprecate specifying the template for `daml new` via a positional
  argument.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7490)
<!-- Reviewable:end -->
