### PR TITLE
Allow speedy execution without performing authorization checks.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -8,6 +8,7 @@ import com.daml.lf.command._
 import com.daml.lf.data._
 import com.daml.lf.data.Ref.{PackageId, ParticipantId, Party}
 import com.daml.lf.language.Ast._
+import com.daml.lf.ledger.CheckAuthorizationMode
 import com.daml.lf.speedy.{InitialSeeding, PartialTransaction, Pretty, SExpr}
 import com.daml.lf.speedy.Speedy.Machine
 import com.daml.lf.speedy.SResult._
@@ -138,7 +139,7 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
       nodeSeed: Option[crypto.Hash],
       submissionTime: Time.Timestamp,
       ledgerEffectiveTime: Time.Timestamp,
-      checkAuthorization: Boolean = true,
+      checkAuthorization: CheckAuthorizationMode = CheckAuthorizationMode.On,
   ): Result[(SubmittedTransaction, Tx.Metadata)] =
     for {
       commandWithCids <- preprocessor.translateNode(node)
@@ -269,7 +270,7 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
       submissionTime: Time.Timestamp,
       seeding: speedy.InitialSeeding,
       globalCids: Set[Value.ContractId],
-      checkAuthorization: Boolean = true,
+      checkAuthorization: CheckAuthorizationMode = CheckAuthorizationMode.On,
   ): Result[(SubmittedTransaction, Tx.Metadata)] =
     runSafely(
       loadPackages(commands.foldLeft(Set.empty[PackageId])(_ + _.templateId.packageId).toList)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -79,7 +79,7 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
     * [[transactionSeed]] is the master hash used to derive node and contractId discriminator.
     * If left undefined, no discriminator will be generated.
     *
-    * This method does NOT perform authorization checks; ResultDone can contain a transaction that's not well-authorized.
+    * This method does perform authorization checks
     *
     * The resulting transaction is annotated with packages required to validate it.
     */
@@ -138,6 +138,7 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
       nodeSeed: Option[crypto.Hash],
       submissionTime: Time.Timestamp,
       ledgerEffectiveTime: Time.Timestamp,
+      checkAuthorization: Boolean = true,
   ): Result[(SubmittedTransaction, Tx.Metadata)] =
     for {
       commandWithCids <- preprocessor.translateNode(node)
@@ -150,7 +151,8 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
         ledgerTime = ledgerEffectiveTime,
         submissionTime = submissionTime,
         seeding = InitialSeeding.RootNodeSeeds(ImmArray(nodeSeed)),
-        globalCids,
+        globalCids = globalCids,
+        checkAuthorization = checkAuthorization,
       )
       (tx, meta) = result
     } yield (tx, meta)
@@ -267,6 +269,7 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
       submissionTime: Time.Timestamp,
       seeding: speedy.InitialSeeding,
       globalCids: Set[Value.ContractId],
+      checkAuthorization: Boolean = true,
   ): Result[(SubmittedTransaction, Tx.Metadata)] =
     runSafely(
       loadPackages(commands.foldLeft(Set.empty[PackageId])(_ + _.templateId.packageId).toList)
@@ -282,6 +285,7 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
         inputValueVersions = config.allowedInputValueVersions,
         outputTransactionVersions = config.allowedOutputTransactionVersions,
         validating = validating,
+        checkAuthorization = checkAuthorization,
       )
       interpretLoop(machine, ledgerTime)
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -12,7 +12,7 @@ import com.daml.lf.data._
 import com.daml.lf.data.Numeric.Scale
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast.{keyFieldName, maintainersFieldName}
-import com.daml.lf.ledger.Authorize
+import com.daml.lf.ledger.{Authorize, CheckAuthorizationMode}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.Speedy._
@@ -860,7 +860,10 @@ private[lf] object SBuiltin {
         case None =>
           machine.committers
       }
-      val auth = if (machine.checkAuthorization) Some(Authorize(contextActors)) else None
+      val auth = machine.checkAuthorization match {
+        case CheckAuthorizationMode.On => Some(Authorize(contextActors))
+        case CheckAuthorizationMode.Off => None
+      }
 
       val (coid, newPtx) = machine.ptx
         .insertCreate(
@@ -928,7 +931,10 @@ private[lf] object SBuiltin {
         case None =>
           machine.committers
       }
-      val auth = if (machine.checkAuthorization) Some(Authorize(contextActors)) else None
+      val auth = machine.checkAuthorization match {
+        case CheckAuthorizationMode.On => Some(Authorize(contextActors))
+        case CheckAuthorizationMode.Off => None
+      }
 
       machine.ptx = machine.ptx
         .beginExercises(
@@ -1049,7 +1055,10 @@ private[lf] object SBuiltin {
         case None =>
           machine.committers
       }
-      val auth = if (machine.checkAuthorization) Some(Authorize(contextActors)) else None
+      val auth = machine.checkAuthorization match {
+        case CheckAuthorizationMode.On => Some(Authorize(contextActors))
+        case CheckAuthorizationMode.Off => None
+      }
 
       machine.ptx = machine.ptx.insertFetch(
         auth,
@@ -1142,7 +1151,10 @@ private[lf] object SBuiltin {
         case None =>
           machine.committers
       }
-      val auth = if (machine.checkAuthorization) Some(Authorize(contextActors)) else None
+      val auth = machine.checkAuthorization match {
+        case CheckAuthorizationMode.On => Some(Authorize(contextActors))
+        case CheckAuthorizationMode.Off => None
+      }
 
       machine.ptx = machine.ptx.insertLookup(
         auth,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -860,7 +860,7 @@ private[lf] object SBuiltin {
         case None =>
           machine.committers
       }
-      val auth = Authorize(contextActors)
+      val auth = if (machine.checkAuthorization) Some(Authorize(contextActors)) else None
 
       val (coid, newPtx) = machine.ptx
         .insertCreate(
@@ -928,7 +928,7 @@ private[lf] object SBuiltin {
         case None =>
           machine.committers
       }
-      val auth = Authorize(contextActors)
+      val auth = if (machine.checkAuthorization) Some(Authorize(contextActors)) else None
 
       machine.ptx = machine.ptx
         .beginExercises(
@@ -1049,7 +1049,7 @@ private[lf] object SBuiltin {
         case None =>
           machine.committers
       }
-      val auth = Authorize(contextActors)
+      val auth = if (machine.checkAuthorization) Some(Authorize(contextActors)) else None
 
       machine.ptx = machine.ptx.insertFetch(
         auth,
@@ -1142,7 +1142,7 @@ private[lf] object SBuiltin {
         case None =>
           machine.committers
       }
-      val auth = Authorize(contextActors)
+      val auth = if (machine.checkAuthorization) Some(Authorize(contextActors)) else None
 
       machine.ptx = machine.ptx.insertLookup(
         auth,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -12,7 +12,6 @@ import com.daml.lf.data._
 import com.daml.lf.data.Numeric.Scale
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast.{keyFieldName, maintainersFieldName}
-import com.daml.lf.ledger.{Authorize, CheckAuthorizationMode}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.Speedy._
@@ -852,19 +851,7 @@ private[lf] object SBuiltin {
       val sigs = extractParties(args.get(2))
       val obs = extractParties(args.get(3))
       val key = extractOptionalKeyWithMaintainers(args.get(4))
-
-      // TODO: refact/share the following 7 lines which occurs a number of times
-      val contextActors = machine.ptx.context.exeContext match {
-        case Some(ctx) =>
-          ctx.actingParties union ctx.signatories
-        case None =>
-          machine.committers
-      }
-      val auth = machine.checkAuthorization match {
-        case CheckAuthorizationMode.On => Some(Authorize(contextActors))
-        case CheckAuthorizationMode.Off => None
-      }
-
+      val auth = machine.auth
       val (coid, newPtx) = machine.ptx
         .insertCreate(
           auth = auth,
@@ -922,20 +909,8 @@ private[lf] object SBuiltin {
       val sigs = extractParties(args.get(4))
       val obs = extractParties(args.get(5))
       val ctrls = extractParties(args.get(6))
-
       val mbKey = extractOptionalKeyWithMaintainers(args.get(7))
-
-      val contextActors = machine.ptx.context.exeContext match {
-        case Some(ctx) =>
-          ctx.actingParties union ctx.signatories
-        case None =>
-          machine.committers
-      }
-      val auth = machine.checkAuthorization match {
-        case CheckAuthorizationMode.On => Some(Authorize(contextActors))
-        case CheckAuthorizationMode.Off => None
-      }
-
+      val auth = machine.auth
       machine.ptx = machine.ptx
         .beginExercises(
           auth = auth,
@@ -1047,19 +1022,9 @@ private[lf] object SBuiltin {
       val signatories = extractParties(args.get(1))
       val observers = extractParties(args.get(2))
       val key = extractOptionalKeyWithMaintainers(args.get(3))
-
       val stakeholders = observers union signatories
-      val contextActors = machine.ptx.context.exeContext match {
-        case Some(ctx) =>
-          ctx.actingParties union ctx.signatories
-        case None =>
-          machine.committers
-      }
-      val auth = machine.checkAuthorization match {
-        case CheckAuthorizationMode.On => Some(Authorize(contextActors))
-        case CheckAuthorizationMode.Off => None
-      }
-
+      val contextActors = machine.contextActors
+      val auth = machine.auth
       machine.ptx = machine.ptx.insertFetch(
         auth,
         coid,
@@ -1144,18 +1109,7 @@ private[lf] object SBuiltin {
           }
         case _ => crash(s"Non option value when inserting lookup node")
       }
-
-      val contextActors = machine.ptx.context.exeContext match {
-        case Some(ctx) =>
-          ctx.actingParties union ctx.signatories
-        case None =>
-          machine.committers
-      }
-      val auth = machine.checkAuthorization match {
-        case CheckAuthorizationMode.On => Some(Authorize(contextActors))
-        case CheckAuthorizationMode.Off => None
-      }
-
+      val auth = machine.auth
       machine.ptx = machine.ptx.insertLookup(
         auth,
         templateId,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -106,6 +106,8 @@ private[lf] object Speedy {
        * it. If this is false, the committers must be a singleton set.
        */
       val validating: Boolean,
+      /* Controls if authorization checks are performed during evaluation */
+      val checkAuthorization: Boolean,
       /* The control is what the machine should be evaluating. If this is not
        * null, then `returnValue` must be null.
        */
@@ -660,6 +662,7 @@ private[lf] object Speedy {
         inputValueVersions: VersionRange[ValueVersion],
         outputTransactionVersions: VersionRange[TransactionVersion],
         validating: Boolean = false,
+        checkAuthorization: Boolean = true,
         onLedger: Boolean = true,
         traceLog: TraceLog = RingBufferTraceLog(damlTraceLog, 100),
     ): Machine =
@@ -667,6 +670,7 @@ private[lf] object Speedy {
         inputValueVersions = inputValueVersions,
         outputTransactionVersions = outputTransactionVersions,
         validating = validating,
+        checkAuthorization = checkAuthorization,
         ctrl = expr,
         returnValue = null,
         frame = null,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -9,6 +9,7 @@ import java.util
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
 import com.daml.lf.language.Ast._
+import com.daml.lf.ledger.CheckAuthorizationMode
 import com.daml.lf.speedy.Compiler.{CompilationError, PackageNotFound}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
@@ -107,7 +108,7 @@ private[lf] object Speedy {
        */
       val validating: Boolean,
       /* Controls if authorization checks are performed during evaluation */
-      val checkAuthorization: Boolean,
+      val checkAuthorization: CheckAuthorizationMode,
       /* The control is what the machine should be evaluating. If this is not
        * null, then `returnValue` must be null.
        */
@@ -662,7 +663,7 @@ private[lf] object Speedy {
         inputValueVersions: VersionRange[ValueVersion],
         outputTransactionVersions: VersionRange[TransactionVersion],
         validating: Boolean = false,
-        checkAuthorization: Boolean = true,
+        checkAuthorization: CheckAuthorizationMode = CheckAuthorizationMode.On,
         onLedger: Boolean = true,
         traceLog: TraceLog = RingBufferTraceLog(damlTraceLog, 100),
     ): Machine =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/CheckAuthorization.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/CheckAuthorization.scala
@@ -23,8 +23,7 @@ private[lf] object CheckAuthorization {
       List(failWith)
   }
 
-  private[lf] def authorizeCreate(
-      create: NodeCreate[_, _],
+  private[lf] def authorizeCreate(create: NodeCreate[_, _])(
       auth: Authorize,
   ): List[FailedAuthorization] = {
     authorize(
@@ -56,9 +55,8 @@ private[lf] object CheckAuthorization {
       })
   }
 
-  private[lf] def authorizeFetch(
-      fetch: NodeFetch[_, _],
-      auth: Authorize,
+  private[lf] def authorizeFetch(fetch: NodeFetch[_, _])(
+      auth: Authorize
   ): List[FailedAuthorization] = {
     authorize(
       passIf = fetch.stakeholders.intersect(auth.authParties).nonEmpty,
@@ -71,8 +69,7 @@ private[lf] object CheckAuthorization {
     )
   }
 
-  private[lf] def authorizeLookupByKey(
-      lbk: NodeLookupByKey[_, _],
+  private[lf] def authorizeLookupByKey(lbk: NodeLookupByKey[_, _])(
       auth: Authorize,
   ): List[FailedAuthorization] = {
     authorize(
@@ -86,8 +83,7 @@ private[lf] object CheckAuthorization {
     )
   }
 
-  private[lf] def authorizeExercise(
-      ex: ExercisesContext,
+  private[lf] def authorizeExercise(ex: ExercisesContext)(
       auth: Authorize,
   ): List[FailedAuthorization] = {
     val controllersDifferFromActors = ex.controllers != ex.actingParties

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/Authorization.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/ledger/Authorization.scala
@@ -5,6 +5,13 @@ package com.daml.lf.ledger
 
 import com.daml.lf.data.Ref.{ChoiceName, Identifier, Location, Party}
 
+sealed abstract class CheckAuthorizationMode extends Product with Serializable
+
+object CheckAuthorizationMode {
+  case object On extends CheckAuthorizationMode
+  case object Off extends CheckAuthorizationMode
+}
+
 /** Authorize the transaction using the provided parties as initial authorizers for the dynamic authorization. */
 final case class Authorize(authParties: Set[Party])
 


### PR DESCRIPTION
Allow speedy execution without performing authorization checks.
This is a temporary measure for canton.

This is controlled by a new Speedy machine member:
```
      /* Controls if authorization checks are performed during evaluation */
      val checkAuthorization: CheckAuthorizationMode,
```
The default value for `Machine.checkAuthorization` is `On`, but can be set `Off` when execution is called from `Engine.reinterpret`, by passing `checkAuthorization = CheckAuthorizationMode.Off` to `reinterpret`.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
