### PR TITLE
Speedy Profiler: add labels for new SDefinitionRef

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -900,11 +900,11 @@ private[lf] final class Compiler(
     function(arity)(x => withLabel(label, body(x)))
 
   @inline
-  private[this] def topLevelFunction[RefDef <: SDefinitionRef: LabelModule.Allowed](
-      ref: RefDef,
+  private[this] def topLevelFunction[SDefRef <: SDefinitionRef: LabelModule.Allowed](
+      ref: SDefRef,
       arity: Int)(
       body: List[Position] => SExpr
-  ): (RefDef, SExpr) =
+  ): (SDefRef, SExpr) =
     ref ->
       validate(
         closureConvert(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -12,6 +12,7 @@ import com.daml.lf.speedy.SBuiltin._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.Anf.flattenToAnf
+import com.daml.lf.speedy.Profile.LabelModule
 import com.daml.lf.transaction.VersionTimeline
 import com.daml.lf.validation.{EUnknownDefinition, LEPackage, Validation, ValidationError}
 import org.slf4j.LoggerFactory
@@ -899,14 +900,16 @@ private[lf] final class Compiler(
     function(arity)(x => withLabel(label, body(x)))
 
   @inline
-  private[this] def topLevelFunction(ref: SDefinitionRef, arity: Int, label: String)(
+  private[this] def topLevelFunction[RefDef <: SDefinitionRef: LabelModule.Allowed](
+      ref: RefDef,
+      arity: Int)(
       body: List[Position] => SExpr
-  ): (SDefinitionRef, SExpr) =
+  ): (RefDef, SExpr) =
     ref ->
       validate(
         closureConvert(
           Map.empty,
-          function(arity, label)(body)
+          SEAbs(arity, withLabel(ref, body(List.fill(arity)(nextPosition()))))
         )
       )
 
@@ -922,10 +925,7 @@ private[lf] final class Compiler(
     //       <retValue> = [update] <token>
     //       _ = $endExercise[tmplId] <token> <retValue>
     //   in <retValue>
-    topLevelFunction(
-      ChoiceDefRef(tmplId, choice.name),
-      4,
-      s"exercise @${tmplId.qualifiedName} ${choice.name}") {
+    topLevelFunction(ChoiceDefRef(tmplId, choice.name), 4) {
       case List(actorsPos, cidPos, choiceArgPos, tokenPos) =>
         val tmplArg = SBUFetch(tmplId)(svar(cidPos), svar(tokenPos))
         nextPositionWithExprName(tmpl.param)
@@ -975,10 +975,7 @@ private[lf] final class Compiler(
     //       <retValue> = <updateE> <token>
     //       _ = $endExercise[tmplId] <token> <retValue>
     //   in  <retValue>
-    topLevelFunction(
-      ChoiceByKeyDefRef(tmplId, choice.name),
-      4,
-      s"exercise by key @${tmplId.qualifiedName} ${choice.name}") {
+    topLevelFunction(ChoiceByKeyDefRef(tmplId, choice.name), 4) {
       case List(actorsPos, keyPos, choiceArgPos, tokenPos) =>
         val keyWithM = encodeKeyWithMaintainers(keyPos, tmplKey)
         val keyWithMPos = nextPosition()
@@ -1380,7 +1377,7 @@ private[lf] final class Compiler(
     //   let <tmplArg> = $fetch(tmplId) <coid> <token>
     //       _ = $insertFetch(tmplId, false) coid [tmpl.signatories] [tmpl.observers] [tmpl.key] <token>
     //   in <tmplArg>
-    topLevelFunction(FetchDefRef(tmplId), 2, s"fetch @${tmplId.qualifiedName}") {
+    topLevelFunction(FetchDefRef(tmplId), 2) {
       case List(cidPos, tokenPos) =>
         val fetch = SBUFetch(tmplId)(svar(cidPos), svar(tokenPos))
         val tmplArgPos = nextPositionWithExprName(tmpl.param)
@@ -1405,7 +1402,7 @@ private[lf] final class Compiler(
     // CreateDefRef(tmplId) = \ <tmplArg> <token> ->
     //   let _ = $checkPreconf(tmplId)(<tmplArg> [tmpl.precond]
     //   in $create <tmplArg> [tmpl.agreementText] [tmpl.signatories] [tmpl.observers] [tmpl.key] <token>
-    topLevelFunction(CreateDefRef(tmplId), 2, s"create @${tmplId.qualifiedName}") {
+    topLevelFunction(CreateDefRef(tmplId), 2) {
       case List(tmplArgPos, tokenPos) =>
         addExprVar(tmpl.param, tmplArgPos)
         val precond = SBCheckPrecond(tmplId)(svar(tmplArgPos), compile(tmpl.precond))
@@ -1498,7 +1495,7 @@ private[lf] final class Compiler(
     //        <mbCid> = $lookupKey(tmplId) <keyWithM> <token>
     //        _ = $insertLookup(tmplId> <keyWithM> <mbCid> <token>
     //    in <mbCid>
-    topLevelFunction(LookupByKeyDefRef(tmplId), 2, s"lookupByKey @${tmplId.qualifiedName}") {
+    topLevelFunction(LookupByKeyDefRef(tmplId), 2) {
       case List(keyPos, tokenPos) =>
         val keyWithM = encodeKeyWithMaintainers(keyPos, tmplKey)
         val keyWithMPos = nextPosition()
@@ -1531,7 +1528,7 @@ private[lf] final class Compiler(
     //        <contract> = $fetch(tmplId) <coid> <token>
     //        _ = $insertFetch <coid> <signatories> <observers> (Some <keyWithM> )
     //    in { contractId: ContractId Foo, contract: Foo }
-    topLevelFunction(FetchByKeyDefRef(tmplId), 2, s"fetchByKey @${tmplId.qualifiedName}") {
+    topLevelFunction(FetchByKeyDefRef(tmplId), 2) {
       case List(keyPos, tokenPos) =>
         val keyWithM = encodeKeyWithMaintainers(keyPos, tmplKey)
         val keyWithMPos = nextPosition()

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -199,7 +199,12 @@ object Profile {
       private[this] val allowAll = new Allowed[Any]
       implicit val anonClosure: Allowed[AnonymousClosure.type] = allowAll
       implicit val lfDefRef: Allowed[LfDefRef] = allowAll
+      implicit val createDefRef: Allowed[CreateDefRef] = allowAll
       implicit val choiceDefRef: Allowed[ChoiceDefRef] = allowAll
+      implicit val fetchDefRef: Allowed[FetchDefRef] = allowAll
+      implicit val choiceByKeyDefRef: Allowed[ChoiceByKeyDefRef] = allowAll
+      implicit val fetchByKeyDefRef: Allowed[FetchByKeyDefRef] = allowAll
+      implicit val lookupByKeyDefRef: Allowed[LookupByKeyDefRef] = allowAll
       implicit val sebrdr: Allowed[SEBuiltinRecursiveDefinition.Reference] = allowAll
       implicit val str: Allowed[String] = allowAll
 
@@ -210,7 +215,13 @@ object Profile {
           case null => "<null>" // NOTE(MH): We should never see this but it's no problem if we do.
           case AnonymousClosure => "<lambda>"
           case LfDefRef(ref) => ref.qualifiedName.toString()
+          case CreateDefRef(tmplRef) => s"create @${tmplRef.qualifiedName}"
           case ChoiceDefRef(tmplRef, name) => s"exercise @${tmplRef.qualifiedName} ${name}"
+          case FetchDefRef(tmplRef) => s"fetch @${tmplRef.qualifiedName}"
+          case ChoiceByKeyDefRef(tmplRef, name) =>
+            s"exerciseByKey @${tmplRef.qualifiedName} ${name}"
+          case FetchByKeyDefRef(tmplRef) => s"fetchByKey @${tmplRef.qualifiedName}"
+          case LookupByKeyDefRef(tmplRef) => s"lookupByKey @${tmplRef.qualifiedName}"
           case ref: SEBuiltinRecursiveDefinition.Reference => ref.toString().toLowerCase()
           case str: String => str
           case any => s"<unknown ${any}>"


### PR DESCRIPTION
With this PR, the profiler nicely handles the new `SDefinitionRef`'s added in #7472.

We add labels for:
* 'create'
* 'exerciseByKey' 
* 'fetch'
* 'fetchByKey'
* 'lookupByKey'

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
