### PR TITLE
kvutils: Remove the deprecated `v1_4` bridge for ledger state access.

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -14,8 +14,6 @@ import scala.concurrent.{ExecutionContext, Future}
   * Defines how the validator/committer can access the backing store of the ledger to perform
   * read/write operations in a transaction.
   *
-  * This trait changed API in v1.5. To access the older version, use [[LedgerStateAccess.v1_4]].
-  *
   * @tparam LogResult type of the offset used for a log entry
   */
 trait LedgerStateAccess[LogResult] {
@@ -29,36 +27,6 @@ trait LedgerStateAccess[LogResult] {
   def inTransaction[T](
       body: LedgerStateOperations[LogResult] => Future[T],
   )(implicit executionContext: ExecutionContext): Future[T]
-}
-
-object LedgerStateAccess {
-
-  /**
-    * Defines how the validator/committer can access the backing store of the ledger to perform
-    * read/write operations in a transaction.
-    *
-    * @tparam LogResult type of the offset used for a log entry
-    */
-  @deprecated("To be removed in v1.6.", since = "v1.5")
-  trait v1_4[LogResult] {
-    self =>
-
-    /**
-      * Performs read and write operations on the backing store in a single atomic transaction.
-      *
-      * @param body operations to perform
-      * @tparam T return type of the body
-      */
-    def inTransaction[T](body: LedgerStateOperations.v1_4[LogResult] => Future[T]): Future[T]
-
-    def modernize(): LedgerStateAccess[LogResult] = new LedgerStateAccess[LogResult] {
-      override def inTransaction[T](
-          body: LedgerStateOperations[LogResult] => Future[T],
-      )(implicit ignored: ExecutionContext): Future[T] =
-        self.inTransaction(operations => body(operations.modernize()))
-    }
-  }
-
 }
 
 /**
@@ -187,77 +155,5 @@ object LedgerStateOperations {
 
   type Key = Bytes
   type Value = Bytes
-
-  /**
-    * Defines how the validator/committer can access the backing store of the ledger.
-    *
-    * @tparam LogResult type of the offset used for a log entry
-    */
-  @deprecated("To be removed in v1.6.", since = "v1.5")
-  trait v1_4[LogResult] {
-    self =>
-
-    /**
-      * Reads value of a single key from the backing store.
-      *
-      * @param key key to look up data for
-      * @return value corresponding to requested key or None in case it does not exist
-      */
-    def readState(key: Key): Future[Option[Value]]
-
-    /**
-      * Reads values of a set of keys from the backing store.
-      *
-      * @param keys list of keys to look up data for
-      * @return values corresponding to the requested keys, in the same order as requested
-      */
-    def readState(keys: Seq[Key]): Future[Seq[Option[Value]]]
-
-    /**
-      * Writes a single key-value pair to the backing store.  In case the key already exists its value is overwritten.
-      */
-    def writeState(key: Key, value: Value): Future[Unit]
-
-    /**
-      * Writes a list of key-value pairs to the backing store.  In case a key already exists its value is overwritten.
-      */
-    def writeState(keyValuePairs: Seq[(Key, Value)]): Future[Unit]
-
-    /**
-      * Writes a single log entry to the backing store.  The implementation may return Future.failed in case the key
-      * (i.e., the log entry ID) already exists.
-      *
-      * @return offset of the latest log entry
-      */
-    def appendToLog(key: Key, value: Value): Future[LogResult]
-
-    def modernize(): LedgerStateOperations[LogResult] = new LedgerStateOperations[LogResult] {
-      override def readState(key: Key)(
-          implicit executionContext: ExecutionContext
-      ): Future[Option[Value]] =
-        self.readState(key)
-
-      override def readState(keys: Seq[Key])(
-          implicit executionContext: ExecutionContext
-      ): Future[Seq[Option[Value]]] =
-        self.readState(keys)
-
-      override def writeState(key: Key, value: Value)(
-          implicit executionContext: ExecutionContext
-      ): Future[Unit] =
-        self.writeState(key, value)
-
-      override def writeState(
-          keyValuePairs: Seq[(Key, Value)]
-      )(implicit executionContext: ExecutionContext): Future[Unit] =
-        self.writeState(keyValuePairs)
-
-      override def appendToLog(
-          key: Key,
-          value: Value,
-      )(implicit executionContext: ExecutionContext): Future[LogResult] =
-        self.appendToLog(key, value)
-    }
-  }
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -330,42 +330,6 @@ object SubmissionValidator {
     )
   }
 
-  @deprecated("To be removed in v1.6.", since = "v1.5")
-  def create_v1_4[LogResult](
-      ledgerStateAccess: LedgerStateAccess.v1_4[LogResult],
-      allocateNextLogEntryId: () => DamlLogEntryId = () => allocateRandomLogEntryId(),
-      checkForMissingInputs: Boolean = false,
-      stateValueCache: Cache[Bytes, DamlStateValue] = Cache.none,
-      engine: Engine,
-      metrics: Metrics,
-  ): SubmissionValidator[LogResult] =
-    new_v1_4(
-      ledgerStateAccess,
-      processSubmission(new KeyValueCommitting(engine, metrics, inStaticTimeMode = false)),
-      allocateNextLogEntryId,
-      checkForMissingInputs,
-      stateValueCache,
-      metrics,
-    )
-
-  @deprecated("To be removed in v1.6.", since = "v1.5")
-  private[validator] def new_v1_4[LogResult](
-      ledgerStateAccess: LedgerStateAccess.v1_4[LogResult],
-      processSubmission: SubmissionValidator.ProcessSubmission,
-      allocateLogEntryId: () => DamlLogEntryId,
-      checkForMissingInputs: Boolean,
-      stateValueCache: Cache[Bytes, DamlStateValue],
-      metrics: Metrics,
-  ): SubmissionValidator[LogResult] =
-    new SubmissionValidator(
-      ledgerStateAccess.modernize(),
-      processSubmission,
-      allocateLogEntryId,
-      checkForMissingInputs,
-      stateValueCache,
-      metrics,
-    )
-
   // Internal method to enable proper command dedup in sandbox with static time mode
   private[daml] def createForTimeMode[LogResult](
       ledgerStateAccess: LedgerStateAccess[LogResult],


### PR DESCRIPTION
I don't think this requires a changelog entry, as it was previously deprecated, but let me know if I'm wrong.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
