### PR TITLE
let CI delete bazel cache items

### DIFF
--- a/infra/bazel_cache.tf
+++ b/infra/bazel_cache.tf
@@ -20,18 +20,13 @@ module "bazel_cache" {
 }
 
 // allow rw access for CI writer (see writer.tf)
-resource "google_storage_bucket_iam_member" "bazel_cache_writer_create" {
+// Note: it looks like the Bazel cache does not work properly if it does not
+// have delete permission, wich is a bit scary.
+resource "google_storage_bucket_iam_member" "bazel_cache_writer" {
   bucket = "${module.bazel_cache.bucket_name}"
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
-  role   = "roles/storage.objectCreator"
-  member = "serviceAccount:${google_service_account.writer.email}"
-}
-resource "google_storage_bucket_iam_member" "bazel_cache_writer_read" {
-  bucket = "${module.bazel_cache.bucket_name}"
-
-  # https://cloud.google.com/storage/docs/access-control/iam-roles
-  role   = "roles/storage.objectViewer"
+  role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.writer.email}"
 }
 


### PR DESCRIPTION
Recently we have been seeing lots of issues with the Bazel cache. It does not seem like it would need to delete things, but the issues cropped up about the same time we restricted the permissions, so it's worth trying to revert that.

CHANGELOG_BEGIN
CHANGELOG_END