### PR TITLE
kvutils: Sort the output state before writing. [KVL-558]

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.participant.state.v1.Offset
 import com.daml.ledger.validator.BatchingLedgerStateOperations
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
-import scala.collection.mutable
+import scala.collection.{breakOut, mutable}
 import scala.concurrent.{ExecutionContext, Future}
 
 private[memory] final class InMemoryLedgerStateOperations(
@@ -20,14 +20,14 @@ private[memory] final class InMemoryLedgerStateOperations(
 
   import InMemoryLedgerStateOperations.appendEntry
 
-  override def readState(keys: Seq[Key])(
-      implicit executionContext: ExecutionContext
-  ): Future[Seq[Option[Value]]] =
-    Future.successful(keys.map(state.get))
+  override def readState(
+      keys: Iterable[Key],
+  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]] =
+    Future.successful(keys.map(state.get)(breakOut))
 
-  override def writeState(keyValuePairs: Seq[(Key, Value)])(
-      implicit executionContext: ExecutionContext
-  ): Future[Unit] = {
+  override def writeState(
+      keyValuePairs: Iterable[(Key, Value)],
+  )(implicit executionContext: ExecutionContext): Future[Unit] = {
     state ++= keyValuePairs
     Future.unit
   }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -195,14 +195,14 @@ object SqlLedgerReaderWriter {
 
   private final class SqlLedgerStateOperations(queries: Queries)
       extends BatchingLedgerStateOperations[Index] {
-    override def readState(keys: Seq[Key])(
-        implicit executionContext: ExecutionContext
-    ): Future[Seq[Option[Value]]] =
+    override def readState(
+        keys: Iterable[Key],
+    )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]] =
       Future.fromTry(queries.selectStateValuesByKeys(keys))
 
-    override def writeState(keyValuePairs: Seq[(Key, Value)])(
-        implicit executionContext: ExecutionContext
-    ): Future[Unit] =
+    override def writeState(
+        keyValuePairs: Iterable[(Key, Value)],
+    )(implicit executionContext: ExecutionContext): Future[Unit] =
       Future.fromTry(queries.updateState(keyValuePairs))
 
     override def appendToLog(key: Key, value: Value)(

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
@@ -40,12 +40,11 @@ object Queries {
     ()
   }
 
-  implicit def byteStringToStatement: ToStatement[ByteString] = new ToStatement[ByteString] {
-    override def set(s: PreparedStatement, index: Int, v: ByteString): Unit =
+  implicit val byteStringToStatement: ToStatement[ByteString] =
+    (s: PreparedStatement, index: Int, v: ByteString) =>
       s.setBinaryStream(index, v.newInput(), v.size())
-  }
 
-  implicit def columnToByteString: Column[ByteString] =
+  implicit val columnToByteString: Column[ByteString] =
     Column.nonNull { (value: Any, meta: MetaDataItem) =>
       value match {
         case blob: Blob => Right(ByteString.readFrom(blob.getBinaryStream))

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
@@ -15,5 +15,5 @@ trait ReadQueries {
 
   def selectFromLog(start: Index, end: Index): Try[immutable.Seq[(Index, LedgerRecord)]]
 
-  def selectStateValuesByKeys(keys: Seq[Key]): Try[immutable.Seq[Option[Value]]]
+  def selectStateValuesByKeys(keys: Iterable[Key]): Try[immutable.Seq[Option[Value]]]
 }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
@@ -24,7 +24,7 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
       metrics.daml.ledger.database.queries.selectFromLog,
       delegate.selectFromLog(start, end))
 
-  override def selectStateValuesByKeys(keys: Seq[Key]): Try[immutable.Seq[Option[Value]]] =
+  override def selectStateValuesByKeys(keys: Iterable[Key]): Try[immutable.Seq[Option[Value]]] =
     Timed.value(
       metrics.daml.ledger.database.queries.selectStateValuesByKeys,
       delegate.selectStateValuesByKeys(keys))
@@ -39,7 +39,7 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
       metrics.daml.ledger.database.queries.insertRecordIntoLog,
       delegate.insertRecordIntoLog(key, value))
 
-  override def updateState(stateUpdates: Seq[(Key, Value)]): Try[Unit] =
+  override def updateState(stateUpdates: Iterable[(Key, Value)]): Try[Unit] =
     Timed.value(
       metrics.daml.ledger.database.queries.updateState,
       delegate.updateState(stateUpdates))

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
@@ -14,7 +14,7 @@ trait WriteQueries {
 
   def insertRecordIntoLog(key: Key, value: Value): Try[Index]
 
-  def updateState(stateUpdates: Seq[(Key, Value)]): Try[Unit]
+  def updateState(stateUpdates: Iterable[(Key, Value)]): Try[Unit]
 
   def truncate(): Try[Unit]
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-import com.daml.ledger.participant.state.kvutils.`Bytes Ordering`
 import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.WriteSetBuilder
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
@@ -14,7 +13,7 @@ final class InMemorySubmissionAggregator(submissionInfo: SubmissionInfo, writer:
 
   import InMemorySubmissionAggregator._
 
-  private val aggregate = mutable.SortedMap.empty[Key, Value]
+  private val aggregate = mutable.Buffer.empty[(Key, Value)]
 
   override def addChild(): WriteSetBuilder = new InMemoryWriteSetBuilder(aggregate)
 
@@ -25,7 +24,7 @@ final class InMemorySubmissionAggregator(submissionInfo: SubmissionInfo, writer:
 object InMemorySubmissionAggregator {
 
   final class InMemoryWriteSetBuilder private[InMemorySubmissionAggregator] (
-      aggregate: mutable.SortedMap[Key, Value],
+      aggregate: mutable.Buffer[(Key, Value)],
   ) extends WriteSetBuilder {
     override def +=(data: WriteItem): Unit = aggregate.synchronized {
       aggregate += data

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataWriter.scala
@@ -5,8 +5,6 @@ package com.daml.ledger.participant.state.kvutils.export
 
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
-import scala.collection.SortedMap
-
 trait LedgerDataWriter {
-  def write(submissionInfo: SubmissionInfo, writeSet: SortedMap[Key, Value]): Unit
+  def write(submissionInfo: SubmissionInfo, writeSet: Seq[(Key, Value)]): Unit
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataExporter.scala
@@ -18,7 +18,6 @@ import com.daml.ledger.participant.state.kvutils.export.{
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
 import scala.collection.JavaConverters._
-import scala.collection.SortedMap
 
 final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
     extends LedgerDataExporter
@@ -30,7 +29,7 @@ final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
   override def close(): Unit = output.close()
 
   private object Writer extends LedgerDataWriter {
-    override def write(submissionInfo: SubmissionInfo, writeSet: SortedMap[Key, Value]): Unit = {
+    override def write(submissionInfo: SubmissionInfo, writeSet: Seq[(Key, Value)]): Unit = {
       val entry = LedgerExportEntry.newBuilder
         .setSubmissionInfo(buildSubmissionInfo(submissionInfo))
         .addAllWriteSet(buildWriteSet(writeSet).asJava)
@@ -51,7 +50,7 @@ final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
         .build()
 
     private def buildWriteSet(
-        writeSet: SortedMap[Key, Value],
+        writeSet: Seq[(Key, Value)],
     ): Iterable[LedgerExportEntry.WriteEntry] =
       writeSet.map(
         writeEntry =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -51,7 +51,7 @@ trait LedgerStateOperations[LogResult] {
     * @return values corresponding to the requested keys, in the same order as requested
     */
   def readState(
-      keys: Seq[Key],
+      keys: Iterable[Key],
   )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]]
 
   /**
@@ -66,7 +66,7 @@ trait LedgerStateOperations[LogResult] {
     * Writes a list of key-value pairs to the backing store.  In case a key already exists its value is overwritten.
     */
   def writeState(
-      keyValuePairs: Seq[(Key, Value)],
+      keyValuePairs: Iterable[(Key, Value)],
   )(implicit executionContext: ExecutionContext): Future[Unit]
 
   /**
@@ -104,12 +104,12 @@ abstract class BatchingLedgerStateOperations[LogResult] extends LedgerStateOpera
 abstract class NonBatchingLedgerStateOperations[LogResult]
     extends LedgerStateOperations[LogResult] {
   override final def readState(
-      keys: Seq[Key],
+      keys: Iterable[Key],
   )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]] =
-    Future.sequence(keys.map(readState))
+    Future.sequence(keys.map(readState)).map(_.toSeq)
 
   override final def writeState(
-      keyValuePairs: Seq[(Key, Value)],
+      keyValuePairs: Iterable[(Key, Value)],
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     Future
       .sequence(keyValuePairs.map {
@@ -129,7 +129,7 @@ final class TimedLedgerStateOperations[LogResult](
     Timed.future(metrics.daml.ledger.state.read, delegate.readState(key))
 
   override def readState(
-      keys: Seq[Key],
+      keys: Iterable[Key],
   )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]] =
     Timed.future(metrics.daml.ledger.state.read, delegate.readState(keys))
 
@@ -140,7 +140,7 @@ final class TimedLedgerStateOperations[LogResult](
     Timed.future(metrics.daml.ledger.state.write, delegate.writeState(key, value))
 
   override def writeState(
-      keyValuePairs: Seq[(Key, Value)],
+      keyValuePairs: Iterable[(Key, Value)],
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     Timed.future(metrics.daml.ledger.state.write, delegate.writeState(keyValuePairs))
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
@@ -31,11 +31,12 @@ class LogAppendingCommitStrategy[Index](
       outputState: Map[DamlStateKey, DamlStateValue],
       exporterWriteSet: Option[SubmissionAggregator.WriteSetBuilder] = None,
   ): Future[Index] = {
-    val serializedKeyValuePairs: SortedMap[Key, Value] = outputState
-      .map {
-        case (key, value) =>
-          (keySerializationStrategy.serializeStateKey(key), Envelope.enclose(value))
-      }(breakOut)
+    val serializedKeyValuePairs: SortedMap[Key, Value] =
+      outputState
+        .map {
+          case (key, value) =>
+            (keySerializationStrategy.serializeStateKey(key), Envelope.enclose(value))
+        }(breakOut)
     exporterWriteSet.foreach {
       _ ++= serializedKeyValuePairs
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -303,8 +303,8 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
             )
         }
       }
-      // Commit the results.
-      .mapAsync[Outputs6](params.commitParallelism) {
+      // Commit the results. This must be done serially to ensure a deterministic set of writes.
+      .mapAsync[Outputs6](1) {
         case ValidatedSubmission(
             correlatedSubmission,
             inputState,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -32,7 +32,6 @@ object BatchedSubmissionValidatorFactory {
       BatchedSubmissionValidatorParameters(
         cpuParallelism = 1,
         readParallelism = 1,
-        commitParallelism = 1
       )
     }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorParameters.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorParameters.scala
@@ -7,12 +7,10 @@ package com.daml.ledger.validator.batch
   *
   * @param cpuParallelism Amount of parallelism to use for CPU bound steps.
   * @param readParallelism Amount of parallelism to use for ledger read operations.
-  * @param commitParallelism Amount of parallelism to use for ledger commit operations.
   */
 case class BatchedSubmissionValidatorParameters(
     cpuParallelism: Int,
     readParallelism: Int,
-    commitParallelism: Int
 )
 
 object BatchedSubmissionValidatorParameters {
@@ -21,7 +19,6 @@ object BatchedSubmissionValidatorParameters {
     BatchedSubmissionValidatorParameters(
       cpuParallelism = availableProcessors,
       readParallelism = availableProcessors,
-      commitParallelism = 1
     )
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionFinalizer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionFinalizer.scala
@@ -92,7 +92,8 @@ object PostExecutionFinalizer {
 
   private def createWriteSet(
       preExecutionOutput: PreExecutionOutput[RawKeyValuePairsWithLogEntry],
-      withinTimeBounds: Boolean): Seq[(Bytes, Bytes)] =
+      withinTimeBounds: Boolean,
+  ): Iterable[(Bytes, Bytes)] =
     if (withinTimeBounds) {
       preExecutionOutput.successWriteSet.state
     } else {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
@@ -4,12 +4,12 @@
 package com.daml.ledger.validator.preexecution
 
 import com.daml.ledger.participant.state.kvutils.Bytes
-import com.daml.ledger.validator.SubmissionValidator.RawKeyValuePairs
 
 /**
   * Raw key-value pairs with a distinct log entry.
   */
 case class RawKeyValuePairsWithLogEntry(
-    state: RawKeyValuePairs,
+    state: Iterable[(Bytes, Bytes)],
     logEntryKey: Bytes,
-    logEntryValue: Bytes)
+    logEntryValue: Bytes,
+)

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
@@ -45,10 +45,10 @@ abstract class LedgerDataExportSpecBase(name: String) extends WordSpec with Matc
       actualWriteSet should be(
         Seq(
           keyValuePairOf("a", "b"),
-          keyValuePairOf("c", "d"),
-          keyValuePairOf("e", "f"),
           keyValuePairOf("g", "h"),
           keyValuePairOf("i", "j"),
+          keyValuePairOf("e", "f"),
+          keyValuePairOf("c", "d"),
         ))
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -5,14 +5,11 @@ package com.daml.ledger.participant.state.kvutils.export
 
 import java.time.Instant
 
-import com.daml.ledger.participant.state.kvutils.`Bytes Ordering`
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.google.protobuf.ByteString
 import org.mockito.Mockito
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
-
-import scala.collection.SortedMap
 
 final class InMemorySubmissionAggregatorSpec extends WordSpec with Matchers with MockitoSugar {
   "InMemorySubmissionAggregator" should {
@@ -35,11 +32,11 @@ final class InMemorySubmissionAggregatorSpec extends WordSpec with Matchers with
 
       submission.finish()
 
-      val expected = SortedMap(
+      val expected = Seq(
         keyValuePairOf("a", "b"),
-        keyValuePairOf("c", "d"),
         keyValuePairOf("e", "f"),
         keyValuePairOf("g", "h"),
+        keyValuePairOf("c", "d"),
       )
       Mockito.verify(writer).write(submissionInfo, expected)
     }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.LogAppendingCommitStrategySpec._
 import com.daml.ledger.validator.TestHelper._
 import com.google.protobuf.ByteString
-import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.mockito.MockitoSugar
@@ -42,20 +42,16 @@ class LogAppendingCommitStrategySpec extends AsyncWordSpec with Matchers with Mo
 
     "write keys serialized according to strategy" in {
       val mockLedgerStateOperations = mock[LedgerStateOperations[Long]]
-      val actualOutputStateBytesCaptor = ArgumentCaptor
-        .forClass(classOf[Seq[(Key, Value)]])
-        .asInstanceOf[ArgumentCaptor[Seq[(Key, Value)]]]
       when(
-        mockLedgerStateOperations.writeState(actualOutputStateBytesCaptor.capture())(
-          any[ExecutionContext]()))
+        mockLedgerStateOperations.writeState(any[Iterable[(Key, Value)]])(any[ExecutionContext]()))
         .thenReturn(Future.unit)
-      when(mockLedgerStateOperations.appendToLog(any[Key](), any[Value]())(any[ExecutionContext]()))
+      when(mockLedgerStateOperations.appendToLog(any[Key], any[Value])(any[ExecutionContext]()))
         .thenReturn(Future.successful(0L))
       val mockStateKeySerializationStrategy = mock[StateKeySerializationStrategy]
       val expectedStateKey = ByteString.copyFromUtf8("some key")
-      when(mockStateKeySerializationStrategy.serializeStateKey(any[DamlStateKey]()))
+      when(mockStateKeySerializationStrategy.serializeStateKey(aStateKey))
         .thenReturn(expectedStateKey)
-      val expectedOutputStateBytes = Seq((expectedStateKey, Envelope.enclose(aStateValue)))
+      val expectedOutputStateBytes = Map(expectedStateKey -> Envelope.enclose(aStateValue))
       val instance =
         new LogAppendingCommitStrategy[Long](
           mockLedgerStateOperations,
@@ -72,8 +68,8 @@ class LogAppendingCommitStrategySpec extends AsyncWordSpec with Matchers with Mo
         .map { _: Long =>
           verify(mockStateKeySerializationStrategy, times(1)).serializeStateKey(aStateKey)
           verify(mockLedgerStateOperations, times(1))
-            .writeState(any[Seq[(Key, Value)]]())(any[ExecutionContext]())
-          actualOutputStateBytesCaptor.getValue should be(expectedOutputStateBytes)
+            .writeState(ArgumentMatchers.eq(expectedOutputStateBytes))(any[ExecutionContext]())
+          succeed
         }
     }
   }

--- a/ledger/participant-state/kvutils/tools/integrity-check-v2/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/v2/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check-v2/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/v2/IntegrityChecker.scala
@@ -90,8 +90,7 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
               commitStrategy,
             )
             actualWriteSet = queryableWriteSet.getAndClearRecordedWriteSet()
-            sortedActualWriteSet = actualWriteSet.sortBy(_._1.asReadOnlyByteBuffer())
-            _ = compareWriteSets(expectedWriteSet, sortedActualWriteSet)
+            _ = compareWriteSets(expectedWriteSet, actualWriteSet)
           } yield ()
       }
       .runWith(Sink.fold(0)((n, _) => n + 1))

--- a/ledger/participant-state/kvutils/tools/integrity-check-v2/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/v2/WriteRecordingLedgerStateOperations.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check-v2/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/v2/WriteRecordingLedgerStateOperations.scala
@@ -19,7 +19,7 @@ class WriteRecordingLedgerStateOperations[LogResult](delegate: LedgerStateOperat
       implicit executionContext: ExecutionContext
   ): Future[Option[Value]] = delegate.readState(key)
 
-  override def readState(keys: Seq[Key])(
+  override def readState(keys: Iterable[Key])(
       implicit executionContext: ExecutionContext
   ): Future[Seq[Option[Value]]] =
     delegate.readState(keys)
@@ -31,7 +31,7 @@ class WriteRecordingLedgerStateOperations[LogResult](delegate: LedgerStateOperat
     delegate.writeState(key, value)
   }
 
-  override def writeState(keyValuePairs: Seq[(Key, Value)])(
+  override def writeState(keyValuePairs: Iterable[(Key, Value)])(
       implicit executionContext: ExecutionContext
   ): Future[Unit] = {
     this.synchronized(recordedWriteSet.appendAll(keyValuePairs))


### PR DESCRIPTION
We previously wrote the output state in a random order, leading to writes that could not be easily compared for integrity. Sorting them allows us to validate not just the values, but the order.

This means that the exporter no longer sorts the write set, and the integrity checker does not sort before checking.

We use a `SortedMap` to sort the output state, so I have changed the ledger state operations methods to accept an `Iterable[(Key, Value)]` instead of `Seq[(Key, Value)]`, as `Map[Key, Value]` (and therefore `SortedMap`) conforms to the first interface but not the second.

### Changelog

- **[Integration Kit]** In kvutils, state is now sorted before committing. This allows us to provide stronger guarantees with regards to the serialized write sets.

  If you have implemented your own `CommitStrategy`, you should also ensure the output state is sorted before committing.

- **[Integration Kit]** In kvutils, the `BatchedSubmissionValidator` no longer has a parameter for commit parallelism. Commits are now always written serially to preserve order.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
