### PR TITLE
trigger service auth /login endpoint

### DIFF
--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -11,8 +11,41 @@ load(
 scalacopts = []
 
 da_scala_library(
+    name = "oauth-middleware",
+    srcs = glob(["src/main/scala/com/daml/oauth/middleware/**/*.scala"]),
+    scalacopts = scalacopts,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":oauth-test-server",  # TODO[AH] Extract OAuth2 request/response types
+        "//libs-scala/ports",
+        "@maven//:com_github_scopt_scopt_2_12",
+        "@maven//:com_typesafe_akka_akka_actor_2_12",
+        "@maven//:com_typesafe_akka_akka_http_2_12",
+        "@maven//:com_typesafe_akka_akka_http_core_2_12",
+        "@maven//:com_typesafe_akka_akka_http_spray_json_2_12",
+        "@maven//:com_typesafe_akka_akka_parsing_2_12",
+        "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
+        "@maven//:io_spray_spray_json_2_12",
+        "@maven//:org_slf4j_slf4j_api",
+    ],
+)
+
+da_scala_binary(
+    name = "oauth-middleware-binary",
+    main_class = "com.daml.oauth.middleware.Main",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@maven//:ch_qos_logback_logback_classic",
+    ],
+    deps = [
+        ":oauth-middleware",
+    ],
+)
+
+da_scala_library(
     name = "oauth-test-server",
-    srcs = glob(["src/main/scala/**/*.scala"]),
+    srcs = glob(["src/main/scala/com/daml/oauth/server/**/*.scala"]),
     scalacopts = scalacopts,
     visibility = ["//visibility:public"],
     deps = [
@@ -45,8 +78,8 @@ da_scala_binary(
 )
 
 da_scala_test(
-    name = "tests",
-    srcs = glob(["src/test/scala/**/*.scala"]),
+    name = "server-tests",
+    srcs = glob(["src/test/scala/com/daml/oauth/server/**/*.scala"]),
     scalacopts = scalacopts,
     deps = [
         ":oauth-test-server",
@@ -64,5 +97,24 @@ da_scala_test(
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
+    ],
+)
+
+da_scala_test(
+    name = "middleware-tests",
+    srcs = glob(["src/test/scala/com/daml/oauth/middleware/**/*.scala"]),
+    scalacopts = scalacopts,
+    deps = [
+        ":oauth-middleware",
+        ":oauth-test-server",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//libs-scala/ports",
+        "//libs-scala/resources",
+        "@maven//:com_typesafe_akka_akka_actor_2_12",
+        "@maven//:com_typesafe_akka_akka_http_core_2_12",
+        "@maven//:com_typesafe_akka_akka_parsing_2_12",
+        "@maven//:com_typesafe_akka_akka_stream_2_12",
+        "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
     ],
 )

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -116,5 +116,6 @@ da_scala_test(
         "@maven//:com_typesafe_akka_akka_parsing_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
+        "@maven//:io_spray_spray_json_2_12",
     ],
 )

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
@@ -20,7 +20,7 @@ private[middleware] object Config {
   private val Empty =
     Config(
       port = Port.Dynamic,
-      oauthUri = Uri().withScheme("http"),
+      oauthUri = null,
       clientId = null,
       clientSecret = null)
 
@@ -37,15 +37,10 @@ private[middleware] object Config {
         .required()
         .text("Port to listen on")
 
-      opt[String]("oauth-host")
-        .action((x, c) => c.copy(oauthUri = c.oauthUri.withHost(x)))
+      opt[String]("oauth-uri")
+        .action((x, c) => c.copy(oauthUri = Uri(x)))
         .required()
-        .text("Hostname of the OAuth2 server")
-
-      opt[Int]("oauth-port")
-        .action((x, c) => c.copy(oauthUri = c.oauthUri.withPort(x)))
-        .required()
-        .text("Port of the OAuth2 server")
+        .text("URI of the OAuth2 server")
 
       opt[String]("id")
         .hidden

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.middleware
+
+import akka.http.scaladsl.model.Uri
+import com.daml.ports.Port
+
+private[middleware] case class Config(
+    // Port the middleware listens on
+    port: Port,
+    // Uri of the OAuth2 server
+    oauthUri: Uri,
+    // OAuth2 client properties
+    clientId: String,
+    clientSecret: String,
+)
+
+private[middleware] object Config {
+  private val Empty =
+    Config(
+      port = Port.Dynamic,
+      oauthUri = Uri().withScheme("http"),
+      clientId = null,
+      clientSecret = null)
+
+  def parseConfig(args: Seq[String]): Option[Config] =
+    configParser.parse(args, Empty)
+
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  val configParser: scopt.OptionParser[Config] =
+    new scopt.OptionParser[Config]("oauth-middleware") {
+      head("OAuth2 Middleware")
+
+      opt[Int]("port")
+        .action((x, c) => c.copy(port = Port(x)))
+        .required()
+        .text("Port to listen on")
+
+      opt[String]("oauth-host")
+        .action((x, c) => c.copy(oauthUri = c.oauthUri.withHost(x)))
+        .required()
+        .text("Hostname of the OAuth2 server")
+
+      opt[Int]("oauth-port")
+        .action((x, c) => c.copy(oauthUri = c.oauthUri.withPort(x)))
+        .required()
+        .text("Port of the OAuth2 server")
+
+      opt[String]("id")
+        .action((x, c) => c.copy(clientId = x))
+        .required()
+        .text("OAuth2 client id")
+
+      opt[String]("secret")
+        .action((x, c) => c.copy(clientSecret = x))
+        .required()
+        .text("OAuth2 client secret")
+
+      help("help").text("Print this usage text")
+    }
+}

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
@@ -18,11 +18,7 @@ private[middleware] case class Config(
 
 private[middleware] object Config {
   private val Empty =
-    Config(
-      port = Port.Dynamic,
-      oauthUri = null,
-      clientId = null,
-      clientSecret = null)
+    Config(port = Port.Dynamic, oauthUri = null, clientId = null, clientSecret = null)
 
   def parseConfig(args: Seq[String]): Option[Config] =
     configParser.parse(args, Empty)
@@ -42,17 +38,19 @@ private[middleware] object Config {
         .required()
         .text("URI of the OAuth2 server")
 
-      opt[String]("id")
-        .hidden
+      opt[String]("id").hidden
         .action((x, c) => c.copy(clientId = x))
         .withFallback(() => sys.env.getOrElse("DAML_CLIENT_ID", ""))
-        .validate(x => if (x.isEmpty) failure("Environment variable DAML_CLIENT_ID must not be empty") else success)
+        .validate(x =>
+          if (x.isEmpty) failure("Environment variable DAML_CLIENT_ID must not be empty")
+          else success)
 
-      opt[String]("secret")
-        .hidden
+      opt[String]("secret").hidden
         .action((x, c) => c.copy(clientSecret = x))
         .withFallback(() => sys.env.getOrElse("DAML_CLIENT_SECRET", ""))
-        .validate(x => if (x.isEmpty) failure("Environment variable DAML_CLIENT_SECRET must not be empty") else success)
+        .validate(x =>
+          if (x.isEmpty) failure("Environment variable DAML_CLIENT_SECRET must not be empty")
+          else success)
 
       help("help").text("Print this usage text")
 

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
@@ -48,15 +48,23 @@ private[middleware] object Config {
         .text("Port of the OAuth2 server")
 
       opt[String]("id")
+        .hidden
         .action((x, c) => c.copy(clientId = x))
-        .required()
-        .text("OAuth2 client id")
+        .withFallback(() => sys.env.getOrElse("DAML_CLIENT_ID", ""))
+        .validate(x => if (x.isEmpty) failure("Environment variable DAML_CLIENT_ID must not be empty") else success)
 
       opt[String]("secret")
+        .hidden
         .action((x, c) => c.copy(clientSecret = x))
-        .required()
-        .text("OAuth2 client secret")
+        .withFallback(() => sys.env.getOrElse("DAML_CLIENT_SECRET", ""))
+        .validate(x => if (x.isEmpty) failure("Environment variable DAML_CLIENT_SECRET must not be empty") else success)
 
       help("help").text("Print this usage text")
+
+      note("""
+        |Environment variables:
+        |  DAML_CLIENT_ID      The OAuth2 client-id - must not be empty
+        |  DAML_CLIENT_SECRET  The OAuth2 client-secret - must not be empty
+        """.stripMargin)
     }
 }

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Main.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Main.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.middleware
+
+import akka.actor.ActorSystem
+import com.typesafe.scalalogging.StrictLogging
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
+import scala.util.{Failure, Success}
+
+object Main extends StrictLogging {
+  def main(args: Array[String]): Unit = {
+    Config.parseConfig(args) match {
+      case Some(config) => main(config)
+      case None => sys.exit(1)
+    }
+  }
+
+  private def main(config: Config): Unit = {
+    implicit val system: ActorSystem = ActorSystem("system")
+    implicit val executionContext: ExecutionContext = system.dispatcher
+
+    def terminate() = Await.result(system.terminate(), 10.seconds)
+
+    val bindingFuture = Server.start(config)
+
+    sys.addShutdownHook {
+      Server
+        .stop(bindingFuture)
+        .onComplete { _ =>
+          terminate()
+        }
+    }
+
+    logger.debug(s"Configuration $config")
+
+    bindingFuture.onComplete {
+      case Success(binding) =>
+        logger.info(s"Started server: $binding")
+      case Failure(e) =>
+        logger.error(s"Failed to start server: $e")
+        terminate()
+    }
+  }
+}

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
@@ -8,7 +8,14 @@ import spray.json.{DefaultJsonProtocol, JsString, JsValue, JsonFormat, deseriali
 
 object Request {
 
-  case class Login(redirectUri: Uri, claims: String) // TODO[AH] parse ledger claims
+  /** Login endpoint query parameters
+   *
+   * @param redirectUri Redirect target after the login flow completed. I.e. the original request URI on the trigger service.
+   * @param claims Required ledger claims.
+   */
+  case class Login(
+    redirectUri: Uri,
+    claims: String) // TODO[AH] parse ledger claims
 
 }
 

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.middleware
+
+import akka.http.scaladsl.model.Uri
+import spray.json.{DefaultJsonProtocol, JsString, JsValue, JsonFormat, deserializationError}
+
+object Request {
+
+  case class Login(redirectUri: Uri, claims: String) // TODO[AH] parse ledger claims
+
+}
+
+object Response {}
+
+object JsonProtocol extends DefaultJsonProtocol {
+  implicit object UriFormat extends JsonFormat[Uri] {
+    def read(value: JsValue) = value match {
+      case JsString(s) => Uri(s)
+      case _ => deserializationError(s"Expected Uri string but got $value")
+    }
+    def write(uri: Uri) = JsString(uri.toString)
+  }
+}

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
@@ -9,13 +9,11 @@ import spray.json.{DefaultJsonProtocol, JsString, JsValue, JsonFormat, deseriali
 object Request {
 
   /** Login endpoint query parameters
-   *
-   * @param redirectUri Redirect target after the login flow completed. I.e. the original request URI on the trigger service.
-   * @param claims Required ledger claims.
-   */
-  case class Login(
-    redirectUri: Uri,
-    claims: String) // TODO[AH] parse ledger claims
+    *
+    * @param redirectUri Redirect target after the login flow completed. I.e. the original request URI on the trigger service.
+    * @param claims Required ledger claims.
+    */
+  case class Login(redirectUri: Uri, claims: String) // TODO[AH] parse ledger claims
 
 }
 

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
@@ -27,6 +27,7 @@ import spray.json._
 object Server extends StrictLogging {
   import com.daml.oauth.server.JsonProtocol._
 
+  // TODO[AH] Make the redirect URI configurable, especially the authority. E.g. when running behind nginx.
   private def toRedirectUri(uri: Uri) =
     Uri()
       .withScheme(uri.scheme)

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
@@ -1,0 +1,125 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.middleware
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.HttpCookie
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import com.daml.oauth.server.{Request => OAuthRequest, Response => OAuthResponse}
+import com.typesafe.scalalogging.StrictLogging
+import java.util.Base64
+import java.util.UUID
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
+import scala.util.Try
+import spray.json._
+
+// This is an implementation of the trigger service authentication middleware
+// for OAuth2 as specified in `/triggers/service/authentication.md`
+object Server extends StrictLogging {
+  import com.daml.oauth.server.JsonProtocol._
+
+  private def toRedirectUri(uri: Uri) =
+    Uri()
+      .withScheme(uri.scheme)
+      .withAuthority(uri.authority)
+      .withPath(Uri.Path./("cb"))
+
+  def start(
+      config: Config)(implicit system: ActorSystem, ec: ExecutionContext): Future[ServerBinding] = {
+    implicit val unmarshal: Unmarshaller[String, Uri] = Unmarshaller.strict(Uri(_))
+    // TODO[AH] Make sure this is bounded in size - or avoid state altogether.
+    val requests = TrieMap[UUID, Uri]()
+    val route = concat(
+      path("auth") {
+        get {
+          complete((StatusCodes.NotImplemented, "The /auth endpoint is not implemented yet"))
+        }
+      },
+      path("login") {
+        get {
+          parameters(('redirect_uri.as[Uri], 'claims))
+            .as[Request.Login](Request.Login) {
+              login =>
+                extractRequest {
+                  request =>
+                    val requestId = UUID.randomUUID
+                    requests += (requestId -> login.redirectUri)
+                    val authorize = OAuthRequest.Authorize(
+                      responseType = "code",
+                      clientId = config.clientId,
+                      redirectUri = toRedirectUri(request.uri),
+                      scope = Some(login.claims),
+                      state = Some(requestId.toString))
+                    redirect(
+                      config.oauthUri
+                        .withPath(Uri.Path./("authorize"))
+                        .withQuery(authorize.toQuery),
+                      StatusCodes.Found)
+                }
+            }
+        }
+      },
+      path("cb") {
+        get {
+          parameters(('code, 'state ?))
+            .as[OAuthResponse.Authorize](OAuthResponse.Authorize) {
+              authorize =>
+                extractRequest {
+                  request =>
+                    val redirectUri = for {
+                      state <- authorize.state
+                      requestId <- Try(UUID.fromString(state)).toOption
+                      redirectUri <- requests.remove(requestId)
+                    } yield redirectUri
+                    redirectUri match {
+                      case None =>
+                        complete(StatusCodes.NotFound)
+                      case Some(redirectUri) =>
+                        val body = OAuthRequest.Token(
+                          grantType = "authorization_code",
+                          code = authorize.code,
+                          redirectUri = toRedirectUri(request.uri),
+                          clientId = config.clientId,
+                          clientSecret = config.clientSecret)
+                        val req = HttpRequest(
+                          uri = config.oauthUri.withPath(Uri.Path./("token")),
+                          entity =
+                            HttpEntity(MediaTypes.`application/json`, body.toJson.compactPrint),
+                          method = HttpMethods.POST)
+                        val tokenRequest = for {
+                          resp <- Http().singleRequest(req)
+                          tokenResp <- Unmarshal(resp).to[OAuthResponse.Token]
+                        } yield tokenResp
+                        onSuccess(tokenRequest) { token =>
+                          val encoder = Base64.getUrlEncoder()
+                          val content = encoder.encodeToString(token.toJson.compactPrint.getBytes)
+                          setCookie(HttpCookie("token", content)) {
+                            redirect(redirectUri, StatusCodes.Found)
+                          }
+                        }
+                    }
+                }
+            }
+        }
+      },
+      path("refresh") {
+        get {
+          complete((StatusCodes.NotImplemented, "The /refresh endpoint is not implemented yet"))
+        }
+      }
+    )
+
+    Http().bindAndHandle(route, "localhost", config.port.value)
+  }
+  def stop(f: Future[ServerBinding])(implicit ec: ExecutionContext): Future[Done] =
+    f.flatMap(_.unbind())
+}

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
@@ -103,7 +103,7 @@ object Server extends StrictLogging {
                         onSuccess(tokenRequest) { token =>
                           val encoder = Base64.getUrlEncoder()
                           val content = encoder.encodeToString(token.toJson.compactPrint.getBytes)
-                          setCookie(HttpCookie("token", content)) {
+                          setCookie(HttpCookie("daml-ledger-token", content)) {
                             redirect(redirectUri, StatusCodes.Found)
                           }
                         }

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
@@ -5,7 +5,7 @@ package com.daml.oauth.server
 
 import com.daml.ports.Port
 
-private[server] case class Config(
+case class Config(
     // Port the authorization server listens on
     port: Port,
     // Ledger ID of issued tokens
@@ -16,7 +16,7 @@ private[server] case class Config(
     jwtSecret: String
 )
 
-private[server] object Config {
+object Config {
   private val Empty =
     Config(port = Port.Dynamic, ledgerId = null, applicationId = null, jwtSecret = null)
 

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Resources.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.middleware
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http.ServerBinding
+import com.daml.resources.{Resource, ResourceOwner}
+import com.daml.oauth.server.{Config => OAuthConfig, Server => OAuthServer}
+
+import scala.concurrent.ExecutionContext
+
+object Resources {
+  def authServer(config: OAuthConfig)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
+    new ResourceOwner[ServerBinding] {
+      override def acquire()(implicit executionContext: ExecutionContext): Resource[ServerBinding] =
+        Resource(OAuthServer.start(config))(_.unbind().map(_ => ()))
+    }
+  def authMiddleware(config: Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
+    new ResourceOwner[ServerBinding] {
+      override def acquire()(implicit ec: ExecutionContext): Resource[ServerBinding] =
+        Resource(Server.start(config))(_.unbind().map(_ => ()))
+    }
+}

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
@@ -8,9 +8,13 @@ import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Location, `Set-Cookie`}
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.oauth.server.{Response => OAuthResponse}
+import java.util.Base64
 import org.scalatest.AsyncWordSpec
+import spray.json._
 
 class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAroundAll {
+  import com.daml.oauth.server.JsonProtocol._
   "the middleware" should {
     "redirect and set cookie after login" in {
       lazy val middlewareBinding = suiteResource.value._2.localAddress
@@ -18,10 +22,11 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
         Uri()
           .withScheme("http")
           .withAuthority(middlewareBinding.getHostString, middlewareBinding.getPort)
+      val claims = "actAs:Alice"
       val req = HttpRequest(
         uri = middlewareUri
           .withPath(Path./("login"))
-          .withQuery(Query(("redirect_uri", "http://CALLBACK"), ("claims", "actAs:Alice"))))
+          .withQuery(Query(("redirect_uri", "http://CALLBACK"), ("claims", claims))))
       for {
         resp <- Http().singleRequest(req)
         // Redirect to /authorize on authorization server
@@ -41,7 +46,11 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
         assert(resp.status == StatusCodes.Found)
         assert(resp.header[Location].get.uri == Uri("http://CALLBACK"))
         // Store token in cookie
-        assert(resp.header[`Set-Cookie`].get.cookie.name == "token")
+        val cookie = resp.header[`Set-Cookie`].get.cookie
+        assert(cookie.name == "daml-ledger-token")
+        val decoder = Base64.getUrlDecoder()
+        val token = new String(decoder.decode(cookie.value)).parseJson.convertTo[OAuthResponse.Token]
+        assert(token.tokenType == "bearer")
       }
     }
   }

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
@@ -49,7 +49,8 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
         val cookie = resp.header[`Set-Cookie`].get.cookie
         assert(cookie.name == "daml-ledger-token")
         val decoder = Base64.getUrlDecoder()
-        val token = new String(decoder.decode(cookie.value)).parseJson.convertTo[OAuthResponse.Token]
+        val token =
+          new String(decoder.decode(cookie.value)).parseJson.convertTo[OAuthResponse.Token]
         assert(token.tokenType == "bearer")
       }
     }

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.middleware
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{Location, `Set-Cookie`}
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import org.scalatest.AsyncWordSpec
+
+class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAroundAll {
+  "the middleware" should {
+    "redirect and set cookie after login" in {
+      lazy val middlewareBinding = suiteResource.value._2.localAddress
+      lazy val middlewareUri =
+        Uri()
+          .withScheme("http")
+          .withAuthority(middlewareBinding.getHostString, middlewareBinding.getPort)
+      val req = HttpRequest(
+        uri = middlewareUri
+          .withPath(Path./("login"))
+          .withQuery(Query(("redirect_uri", "http://CALLBACK"), ("claims", "actAs:Alice"))))
+      for {
+        resp <- Http().singleRequest(req)
+        // Redirect to /authorize on authorization server
+        resp <- {
+          assert(resp.status == StatusCodes.Found)
+          val req = HttpRequest(uri = resp.header[Location].get.uri)
+          Http().singleRequest(req)
+        }
+        // Redirect to /cb on middleware
+        resp <- {
+          assert(resp.status == StatusCodes.Found)
+          val req = HttpRequest(uri = resp.header[Location].get.uri)
+          Http().singleRequest(req)
+        }
+      } yield {
+        // Redirect to CALLBACK
+        assert(resp.status == StatusCodes.Found)
+        assert(resp.header[Location].get.uri == Uri("http://CALLBACK"))
+        // Store token in cookie
+        assert(resp.header[`Set-Cookie`].get.cookie.name == "token")
+      }
+    }
+  }
+}

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.oauth.middleware
+
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.model.Uri
+import com.daml.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  OwnedResource,
+  Resource,
+  SuiteResource
+}
+import com.daml.oauth.server.{Config => OAuthConfig}
+import com.daml.ports.Port
+import org.scalatest.Suite
+
+import scala.concurrent.ExecutionContext
+
+trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBinding, ServerBinding)] {
+  self: Suite =>
+  protected val ledgerId: String = "test-ledger"
+  protected val applicationId: String = "test-application"
+  protected val jwtSecret: String = "secret"
+  override protected lazy val suiteResource: Resource[(ServerBinding, ServerBinding)] = {
+    implicit val ec: ExecutionContext = system.dispatcher
+    new OwnedResource[(ServerBinding, ServerBinding)](
+      for {
+        server <- Resources.authServer(
+          OAuthConfig(
+            port = Port.Dynamic,
+            ledgerId = ledgerId,
+            applicationId = applicationId,
+            jwtSecret = jwtSecret))
+        client <- Resources.authMiddleware(
+          Config(
+            port = Port.Dynamic,
+            oauthUri = Uri()
+              .withScheme("http")
+              .withAuthority(server.localAddress.getHostString, server.localAddress.getPort),
+            clientId = "middleware",
+            clientSecret = "middleware-secret"
+          ))
+      } yield { (server, client) }
+    )
+  }
+}


### PR DESCRIPTION
Implements the `/login` endpoint of the trigger service authentication middleware as specified [here](https://github.com/digital-asset/daml/blob/7c038119aade97fcfea1753efc5aca4e5837ed68/triggers/service/authentication.md).
Adds a test-case for the `/login` endpoint following the example of the oauth-test-service test-cases.
Part of https://github.com/digital-asset/daml/issues/6923.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
