### PR TITLE
Remove reference to release-notes.rst

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,6 @@ jobs:
       - bash: |
           set -euo pipefail
           git checkout $(release_sha)
-          git checkout $(trigger_sha) -- docs/source/support/release-notes.rst
         name: checkout_release
         condition: eq(variables.is_release, 'true')
       - template: ci/build-unix.yml
@@ -143,7 +142,6 @@ jobs:
       - bash: |
           set -euo pipefail
           git checkout $(release_sha)
-          git checkout $(trigger_sha) -- docs/source/support/release-notes.rst
         name: checkout_release
         condition: eq(variables.is_release, 'true')
       - template: ci/build-unix.yml
@@ -180,7 +178,6 @@ jobs:
       - bash: |
           set -euo pipefail
           git checkout $(release_sha)
-          git checkout $(trigger_sha) -- docs/source/support/release-notes.rst
         name: checkout_release
         condition: eq(variables.is_release, 'true')
       - template: ci/build-windows.yml
@@ -289,9 +286,7 @@ jobs:
 
           changes_release_files() {
               changed="$(git diff-tree --no-commit-id --name-only -r $(fork_sha) $(branch_sha) | sort)"
-              stable=$(printf "LATEST\ndocs/source/support/release-notes.rst" | sort)
-              snapshot="LATEST"
-              [ "$snapshot" = "$changed" ] || [ "$stable" = "$changed" ]
+              [ "LATEST" = "$changed" ]
           }
 
           changes_one_line_in_latest() {

--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -103,6 +103,7 @@ build_and_push temp versions = do
         build version = do
             shell_ $ "git checkout v" <> show version
             build_helper version
+
         build_helper version = do
             robustly_download_nix_packages
             shell_ $ "DAML_SDK_RELEASE_VERSION=" <> show version <> " bazel build //docs:docs"


### PR DESCRIPTION
https://github.com/digital-asset/daml/pull/7458 shuffled this
around. While we could update it, it doesn’t really make any sense. We
post our release notes to the blog now and not in the docs so this
whole checkout procedure is redundant. This is also true if we wanted
to make a bugfix release for a release < 1.5 where this file still
existed. The trigger_sha is always on master (following our current
release process) so the file would still not exist.

I did also remove it from the docs cronjob. We never reupload old docs
so this doesn’t make a difference.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
