### PR TITLE
ledger-on-sql: Use tagged execution contexts and data sources in `Database`.

### DIFF
--- a/ledger/ledger-on-sql/BUILD.bazel
+++ b/ledger/ledger-on-sql/BUILD.bazel
@@ -93,6 +93,7 @@ da_scala_library(
         "//ledger/metrics",
         "//ledger/participant-state",
         "//ledger/participant-state/kvutils",
+        "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",
         "//libs-scala/resources",
         "@maven//:com_google_protobuf_protobuf_java",

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/Database.scala
@@ -6,7 +6,6 @@ package com.daml.ledger.on.sql
 import java.sql.{Connection, SQLException}
 import java.util.concurrent.Executors
 
-import com.daml.concurrent.FutureOf._
 import com.daml.concurrent.{ExecutionContext, Future}
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.on.sql.Database._

--- a/ledger/metrics/BUILD.bazel
+++ b/ledger/metrics/BUILD.bazel
@@ -22,6 +22,7 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_dropwizard_metrics_metrics_jvm",
+        "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )
 
@@ -31,6 +32,7 @@ da_scala_test_suite(
     srcs = glob(["src/test/scala/**/*.scala"]),
     deps = [
         ":metrics",
+        "//libs-scala/concurrent",
         "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:org_scalatest_scalatest_2_12",
     ],

--- a/libs-scala/concurrent/src/main/scala/concurrent/package.scala
+++ b/libs-scala/concurrent/src/main/scala/concurrent/package.scala
@@ -3,10 +3,10 @@
 
 package com.daml
 
+import scalaz.Id.Id
+
 import scala.util.Try
 import scala.{concurrent => sc}
-
-import scalaz.Id.Id
 
 /** A compatible layer for `scala.concurrent` with extra type parameters to
   * control `ExecutionContext`s.  Deliberately uses the same names as the
@@ -78,6 +78,8 @@ package object concurrent {
 // keeping the companions with the same-named type aliases in same file
 package concurrent {
 
+  import java.util.concurrent.ExecutorService
+
   object Future {
 
     /** {{{
@@ -106,5 +108,8 @@ package concurrent {
       */
     def apply[EC](ec: sc.ExecutionContext): ExecutionContext[EC] =
       ExecutionContextOf.Instance.subst[Id, EC](ec)
+
+    def fromExecutorService[EC](e: ExecutorService): ExecutionContext[EC] =
+      apply(sc.ExecutionContext.fromExecutorService(e))
   }
 }


### PR DESCRIPTION
We have to deal with multiple execution contexts in `Database`. This makes it possible to use them implicitly, which I find much cleaner.

Currently we have to convert back and forth. Once we get `Resource` and `ResourceOwner` using tagged execution contexts, I think this will get easier.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
