### PR TITLE
kvutils: Flush export files after each write. [KVL-530]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/v2/ProtobufBasedLedgerDataExporter.scala
@@ -36,6 +36,7 @@ final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
         .build
       output.synchronized {
         entry.writeDelimitedTo(output)
+        output.flush()
       }
     }
 

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
@@ -3,9 +3,16 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-import java.io.{InputStream, OutputStream, PipedInputStream, PipedOutputStream}
+import java.io.{
+  BufferedOutputStream,
+  InputStream,
+  OutputStream,
+  PipedInputStream,
+  PipedOutputStream
+}
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.export.LedgerDataExportSpecBase._
 import com.daml.ledger.participant.state.v1
 import com.google.protobuf.ByteString
 import org.scalatest.{Matchers, WordSpec}
@@ -17,28 +24,21 @@ abstract class LedgerDataExportSpecBase(name: String) extends WordSpec with Matc
 
   name should {
     "serialize a submission to something deserializable" in {
-      val submissionInfo = SubmissionInfo(
-        participantId = v1.ParticipantId.assertFromString("id"),
-        correlationId = "parent",
-        submissionEnvelope = ByteString.copyFromUtf8("an envelope"),
-        recordTimeInstant = Instant.ofEpochSecond(123456, 123456789),
-      )
-
       val inputStream = new PipedInputStream()
       val outputStream = new PipedOutputStream(inputStream)
       val exporter = newExporter(outputStream)
+      val importer = newImporter(inputStream)
 
+      val submissionInfo = someSubmissionInfo()
       val submission = exporter.addSubmission(submissionInfo)
       val writeSetA1 = submission.addChild()
       writeSetA1 ++= Seq(keyValuePairOf("a", "b"), keyValuePairOf("g", "h"))
       val writeSetA2 = submission.addChild()
       writeSetA2 ++= Seq(keyValuePairOf("i", "j"), keyValuePairOf("e", "f"))
       writeSetA2 += keyValuePairOf("c", "d")
-
       submission.finish()
-      outputStream.close()
 
-      val importer = newImporter(inputStream)
+      outputStream.close()
 
       val (actualSubmissionInfo, actualWriteSet) = importer.read().head
       actualSubmissionInfo should be(submissionInfo)
@@ -51,7 +51,35 @@ abstract class LedgerDataExportSpecBase(name: String) extends WordSpec with Matc
           keyValuePairOf("c", "d"),
         ))
     }
+
+    "flush between writes" in {
+      val inputStream = new PipedInputStream()
+      val outputStream = new BufferedOutputStream(new PipedOutputStream(inputStream))
+      val exporter = newExporter(outputStream)
+      val importer = newImporter(inputStream)
+
+      val submissionInfo = someSubmissionInfo()
+      val submission = exporter.addSubmission(submissionInfo)
+      val writeSet = submission.addChild()
+      writeSet += keyValuePairOf("a", "b")
+      submission.finish()
+
+      val (actualSubmissionInfo, actualWriteSet) = importer.read().head
+      actualSubmissionInfo should be(submissionInfo)
+      actualWriteSet should be(Seq(keyValuePairOf("a", "b")))
+
+      outputStream.close()
+    }
   }
+}
+
+object LedgerDataExportSpecBase {
+  private def someSubmissionInfo(): SubmissionInfo = SubmissionInfo(
+    participantId = v1.ParticipantId.assertFromString("id"),
+    correlationId = "parent",
+    submissionEnvelope = ByteString.copyFromUtf8("an envelope"),
+    recordTimeInstant = Instant.ofEpochSecond(123456, 123456789),
+  )
 
   private def keyValuePairOf(key: String, value: String): (ByteString, ByteString) =
     ByteString.copyFromUtf8(key) -> ByteString.copyFromUtf8(value)


### PR DESCRIPTION
This will allow consumers to stream writes as they're written.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
