### PR TITLE
Fix exposed packages in DAML REPL

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -454,11 +454,47 @@ EOF
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "repl-multi-test",
+    srcs = [
+        "ReplMulti.daml",
+        ":repl-test.dar",
+        ":repl-test-two.dar",
+    ],
+    outs = ["repl-multi-test.dar"],
+    cmd = """
+      set -eou pipefail
+      TMP_DIR=$$(mktemp -d)
+      mkdir -p $$TMP_DIR/daml
+      cp -L $(location ReplMulti.daml) $$TMP_DIR/daml
+      cp -L $(location repl-test-two.dar) $$TMP_DIR
+      cp -L $(location repl-test.dar) $$TMP_DIR
+      cat << EOF > $$TMP_DIR/daml.yaml
+sdk-version: {sdk}
+name: repl-multi-test
+source: daml
+version: 0.1.0
+dependencies:
+  - daml-stdlib
+  - daml-prim
+data-dependencies:
+  - repl-test.dar
+  - repl-test-two.dar
+build-options: ["--ghc-option", "-Werror"]
+EOF
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR -o $$PWD/$(location repl-multi-test.dar)
+      rm -rf $$TMP_DIR
+  """.format(sdk = sdk_version),
+    tools = ["//compiler/damlc"],
+    visibility = ["//visibility:public"],
+)
+
 da_haskell_test(
     name = "repl",
     timeout = "long",
     srcs = ["src/DA/Test/Repl.hs"],
     data = [
+        ":repl-multi-test.dar",
         ":repl-test.dar",
         "//compiler/damlc",
         "//daml-script/daml:daml-script.dar",

--- a/compiler/damlc/tests/ReplMulti.daml
+++ b/compiler/damlc/tests/ReplMulti.daml
@@ -1,0 +1,13 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module ReplMulti where
+
+import ReplTest
+import ReplTest2
+
+-- Reference both packages to make sure
+-- that they end up in the DAR.
+type T' = T
+type T2' = T2
+


### PR DESCRIPTION
To make `--import` work we also need to expose the
packages. Otherwise, we end up with a ton of confusing errors as soon
as you try anything. Luckily, we can do this fairly cheaply by using
the fact that GHC can expose both unit ids as well as just package
names. Until I realized that I started working on a different approach
of reading the DALFs first to resolve unversioned packages but that
seemed much more messy.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
