### PR TITLE
Split DecodeDar into a separate module

### DIFF
--- a/compiler/damlc/daml-compiler/BUILD.bazel
+++ b/compiler/damlc/daml-compiler/BUILD.bazel
@@ -16,6 +16,7 @@ da_haskell_library(
         "containers",
         "directory",
         "dlist",
+        "either",
         "extra",
         "filepath",
         "ghc-lib",

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DecodeDar.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DecodeDar.hs
@@ -1,0 +1,92 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module DA.Daml.Compiler.DecodeDar
+  ( DecodedDar(..)
+  , DecodedDalf(..)
+  , decodeDar
+  , decodeDalf
+  ) where
+
+import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Either.Combinators
+import Data.Set (Set)
+import qualified Data.Set as Set
+import "ghc-lib-parser" Module (UnitId)
+
+import DA.Daml.Compiler.Dar
+import DA.Daml.Compiler.ExtractDar (ExtractedDar(..))
+import qualified DA.Daml.LF.Ast as LF
+import qualified DA.Daml.LF.Proto3.Archive as Archive
+import qualified DA.Pretty
+
+data DecodedDar = DecodedDar
+    { mainDalf :: DecodedDalf
+    , dalfs :: [DecodedDalf]
+    -- ^ Like in the MANIFEST.MF definition, this includes
+    -- the main dalf.
+    }
+
+decodeDar :: Set LF.PackageId -> ExtractedDar -> Either String DecodedDar
+decodeDar dependenciesInPkgDb ExtractedDar{..} = do
+    mainDalf <-
+        decodeDalf
+            dependenciesInPkgDb
+            (ZipArchive.eRelativePath edMain)
+            (BSL.toStrict $ ZipArchive.fromEntry edMain)
+    otherDalfs <-
+        mapM decodeEntry $
+            filter
+                (\e -> ZipArchive.eRelativePath e /= ZipArchive.eRelativePath edMain)
+                edDalfs
+    let dalfs = mainDalf : otherDalfs
+    pure DecodedDar{..}
+  where
+    decodeEntry entry =         decodeDalf
+            dependenciesInPkgDb
+            (ZipArchive.eRelativePath entry)
+            (BSL.toStrict $ ZipArchive.fromEntry entry)
+
+data DecodedDalf = DecodedDalf
+    { decodedDalfPkg :: LF.DalfPackage
+    , decodedUnitId :: UnitId
+    }
+
+decodeDalf :: Set LF.PackageId -> FilePath -> BS.ByteString -> Either String DecodedDalf
+decodeDalf dependenciesInPkgDb path bytes = do
+    (pkgId, package) <-
+        mapLeft DA.Pretty.renderPretty $
+        Archive.decodeArchive Archive.DecodeAsDependency bytes
+    -- daml-prim and daml-stdlib are somewhat special:
+    --
+    -- We always have daml-prim and daml-stdlib from the current SDK and we
+    -- cannot control their unit id since that would require recompiling them.
+    -- However, we might also have daml-prim and daml-stdlib in a different version
+    -- in a DAR we are depending on. Luckily, we can control the unit id there.
+    -- To avoid colliding unit ids which will confuse GHC (or rather hide
+    -- one of them), we instead include the package hash in the unit id.
+    --
+    -- In principle, we can run into the same issue if you combine "dependencies"
+    -- (which have precompiled interface files) and
+    -- "data-dependencies". However, there you can get away with changing the
+    -- package name and version to change the unit id which is not possible for
+    -- daml-prim.
+    --
+    -- If the version of daml-prim/daml-stdlib in a data-dependency is the same
+    -- as the one we are currently compiling against, we don’t need to apply this
+    -- hack.
+    let (name, mbVersion) = case LF.packageMetadataFromFile path package pkgId of
+            (LF.PackageName "daml-prim", Nothing)
+                | pkgId `Set.notMember` dependenciesInPkgDb ->
+                  (LF.PackageName ("daml-prim-" <> LF.unPackageId pkgId), Nothing)
+            (LF.PackageName "daml-stdlib", _)
+                | pkgId `Set.notMember` dependenciesInPkgDb ->
+                  (LF.PackageName ("daml-stdlib-" <> LF.unPackageId pkgId), Nothing)
+            (name, mbVersion) -> (name, mbVersion)
+    pure DecodedDalf
+        { decodedDalfPkg = LF.DalfPackage pkgId (LF.ExternalPackage pkgId package) bytes
+        , decodedUnitId = pkgNameVersion name mbVersion
+        }
+

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -44,9 +44,9 @@ import DA.Cli.Damlc.Base
 import DA.Daml.Compiler.Dar
 import DA.Daml.Compiler.DataDependencies as DataDeps
 import DA.Daml.Compiler.ExtractDar (extractDar,ExtractedDar(..))
+import DA.Daml.Compiler.DecodeDar (DecodedDar(..), DecodedDalf(..), decodeDar, decodeDalf)
 import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.LF.Ast.Optics (packageRefs)
-import qualified DA.Daml.LF.Proto3.Archive as Archive
 import DA.Daml.Options.Packaging.Metadata
 import DA.Daml.Options.Types
 import DA.Daml.Package.Config
@@ -587,74 +587,6 @@ getDarsFromDataDependencies dependenciesInPkgDb files = do
             pure (DecodedDar decodedDalf [decodedDalf])
     pure (dars ++ dalfs)
     where (fpDars, fpDalfs) = partition ((== ".dar") . takeExtension) files
-
-data DecodedDalf = DecodedDalf
-    { decodedDalfPkg :: LF.DalfPackage
-    , decodedUnitId :: UnitId
-    }
-
-data DecodedDar = DecodedDar
-    { mainDalf :: DecodedDalf
-    , dalfs :: [DecodedDalf]
-    -- ^ Like in the MANIFEST.MF definition, this includes
-    -- the main dalf.
-    }
-
-decodeDar :: Set LF.PackageId -> ExtractedDar -> Either String DecodedDar
-decodeDar dependenciesInPkgDb ExtractedDar{..} = do
-    mainDalf <-
-        decodeDalf
-            dependenciesInPkgDb
-            (ZipArchive.eRelativePath edMain)
-            (BSL.toStrict $ ZipArchive.fromEntry edMain)
-    otherDalfs <-
-        mapM decodeEntry $
-            filter
-                (\e -> ZipArchive.eRelativePath e /= ZipArchive.eRelativePath edMain)
-                edDalfs
-    let dalfs = mainDalf : otherDalfs
-    pure DecodedDar{..}
-  where
-    decodeEntry entry =         decodeDalf
-            dependenciesInPkgDb
-            (ZipArchive.eRelativePath entry)
-            (BSL.toStrict $ ZipArchive.fromEntry entry)
-
-decodeDalf :: Set LF.PackageId -> FilePath -> BS.ByteString -> Either String DecodedDalf
-decodeDalf dependenciesInPkgDb path bytes = do
-    (pkgId, package) <-
-        mapLeft DA.Pretty.renderPretty $
-        Archive.decodeArchive Archive.DecodeAsDependency bytes
-    -- daml-prim and daml-stdlib are somewhat special:
-    --
-    -- We always have daml-prim and daml-stdlib from the current SDK and we
-    -- cannot control their unit id since that would require recompiling them.
-    -- However, we might also have daml-prim and daml-stdlib in a different version
-    -- in a DAR we are depending on. Luckily, we can control the unit id there.
-    -- To avoid colliding unit ids which will confuse GHC (or rather hide
-    -- one of them), we instead include the package hash in the unit id.
-    --
-    -- In principle, we can run into the same issue if you combine "dependencies"
-    -- (which have precompiled interface files) and
-    -- "data-dependencies". However, there you can get away with changing the
-    -- package name and version to change the unit id which is not possible for
-    -- daml-prim.
-    --
-    -- If the version of daml-prim/daml-stdlib in a data-dependency is the same
-    -- as the one we are currently compiling against, we don’t need to apply this
-    -- hack.
-    let (name, mbVersion) = case LF.packageMetadataFromFile path package pkgId of
-            (LF.PackageName "daml-prim", Nothing)
-                | pkgId `Set.notMember` dependenciesInPkgDb ->
-                  (LF.PackageName ("daml-prim-" <> LF.unPackageId pkgId), Nothing)
-            (LF.PackageName "daml-stdlib", _)
-                | pkgId `Set.notMember` dependenciesInPkgDb ->
-                  (LF.PackageName ("daml-stdlib-" <> LF.unPackageId pkgId), Nothing)
-            (name, mbVersion) -> (name, mbVersion)
-    pure DecodedDalf
-        { decodedDalfPkg = LF.DalfPackage pkgId (LF.ExternalPackage pkgId package) bytes
-        , decodedUnitId = pkgNameVersion name mbVersion
-        }
 
 getDarsFromDependencies :: Set LF.PackageId -> [ExtractedDar] -> IO [DecodedDar]
 getDarsFromDependencies dependenciesInPkgDb depsExtracted =


### PR DESCRIPTION
I originally implemented this for another change where I didn’t need it
in the end. However, it seems like a nice cleanup so spinning it out
into a standalone PR.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
