### PR TITLE
backup release artifacts to gcs bucket

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -508,6 +508,27 @@ jobs:
         env:
           AUTH: $(ARTIFACTORY_USERPASS)
         condition: not(eq(variables['skip-github'], 'TRUE'))
+      - template: ci/bash-lib.yml
+        parameters:
+          var_name: bash-lib
+      - bash: |
+          set -euo pipefail
+
+          source $(bash-lib)
+
+          cd $(Build.StagingDirectory)/release
+          for f in *; do
+              save_gcp_data "$GCRED" "$f" "gs://daml-data/releases/$(release_tag)/github/$f"
+          done
+
+          cd $(Build.StagingDirectory)/artifactory
+          for f in *; do
+              save_gcp_data "$GCRED" "$f" "gs://daml-data/releases/$(release_tag)/artifactory/$f"
+          done
+        name: backup_to_gcs
+        env:
+          GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
+        condition: not(eq(variables['skip-github'], 'TRUE'))
       - bash: |
           set -euo pipefail
           pr_handler=$(head -1 release/rotation | awk '{print $1}')


### PR DESCRIPTION
Right now our artifacts are only stored on GitHub. Should they have any issue, we're toast, as we can't always rebuild old artifacts. With this change, we also store our artifacts on a GCS bucket, so we'd need both GitHub and Google to have simultaneous issues to lose data.

CHANGELOG_BEGIN
CHANGELOG_END