### PR TITLE
Fix data-deps dictionary function name mismatches.

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -17,6 +17,7 @@ import Data.Foldable (fold)
 import Data.Hashable (Hashable)
 import qualified Data.HashMap.Strict as HMS
 import Data.List.Extra
+import Data.Ord (Down (Down))
 import Data.Semigroup.FixedPoint
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -384,7 +385,7 @@ generateSrcFromLf env = noLoc mod
     -- | Generate instance declarations from dictionary functions.
     instanceDecls :: [Gen (Maybe (LHsDecl GhcPs))]
     instanceDecls = do
-        dval@LF.DefValue {..} <- reverse . sortOn nameKey $ NM.toList $ LF.moduleValues $ envMod env
+        dval@LF.DefValue {..} <- sortOn (Down . nameKey) $ NM.toList $ LF.moduleValues $ envMod env
         Just dfunSig <- [getDFunSig dval]
         guard (shouldExposeInstance dval)
         let clsName = LF.qualObject $ dfhName $ dfsHead dfunSig

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1759,7 +1759,7 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
             callProcessSilent damlc ["build"]
 
     , testCaseSteps "Dictionary function names match despite conflicts" $ \step -> withTempDir $ \tmpDir -> do
-        -- This test checks that dictionary function names are recreated incorrectly.
+        -- This test checks that dictionary function names are recreated correctly.
         -- This is a regression test for issue #7362.
         step "building project with type definition"
         createDirectoryIfMissing True (tmpDir </> "type")
@@ -1789,9 +1789,9 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
               -- so GHC numbers them 1, 2, 3, 4, ... after the first.
               --
               -- NB: It's important to have more than 10 instances here, so we can test
-              -- how that we handle non-lexicographically ordered conflicts correctly the
-              -- (i.e. instances numbered 10, 11, 12 will not be in the correct order
-              -- just by sorting definitions by value name).
+              -- that we handle non-lexicographically ordered conflicts correctly
+              -- (i.e. instances numbered 10, 11, etc will not be in the correct order
+              -- just by sorting definitions by value name, lexicographically).
         withCurrentDirectory (tmpDir </> "type") $
             callProcessSilent damlc ["build", "-o", "type.dar"]
 

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1758,6 +1758,73 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
         withCurrentDirectory (tmpDir </> "proj") $
             callProcessSilent damlc ["build"]
 
+    , testCaseSteps "Dictionary function names match despite conflicts" $ \step -> withTempDir $ \tmpDir -> do
+        -- This test checks that dictionary function names are recreated incorrectly.
+        -- This is a regression test for issue #7362.
+        step "building project with type definition"
+        createDirectoryIfMissing True (tmpDir </> "type")
+        writeFileUTF8 (tmpDir </> "type" </> "daml.yaml") $ unlines
+            [ "sdk-version: " <> sdkVersion
+            , "name: type"
+            , "source: ."
+            , "version: 0.1.0"
+            , "dependencies: [daml-prim, daml-stdlib]"
+            ]
+        writeFileUTF8 (tmpDir </> "type" </> "P1.daml") $ unlines
+            [ "module P1 where"
+            , "data T t = T {}"
+            , "instance Show (T Int) where show T = \"T\""
+            , "instance Show (T Bool) where show T = \"T\""
+            , "instance Show (T Text) where show T = \"T\""
+            , "instance Show (T (Optional Int)) where show T = \"T\""
+            , "instance Show (T (Optional Bool)) where show T = \"T\""
+            , "instance Show (T (Optional Text)) where show T = \"T\""
+            , "instance Show (T [Int]) where show T = \"T\""
+            , "instance Show (T [Bool]) where show T = \"T\""
+            , "instance Show (T [Text]) where show T = \"T\""
+            , "instance Show (T [Optional Int]) where show T = \"T\""
+            , "instance Show (T [Optional Bool]) where show T = \"T\""
+            , "instance Show (T [Optional Text]) where show T = \"T\""
+            ] -- ^ These instances all have conflicting dictionary function names,
+              -- so GHC numbers them 1, 2, 3, 4, ... after the first.
+              --
+              -- NB: It's important to have more than 10 instances here, so we can test
+              -- how that we handle non-lexicographically ordered conflicts correctly the
+              -- (i.e. instances numbered 10, 11, 12 will not be in the correct order
+              -- just by sorting definitions by value name).
+        withCurrentDirectory (tmpDir </> "type") $
+            callProcessSilent damlc ["build", "-o", "type.dar"]
+
+        step "building project that uses it via data-dependencies"
+        createDirectoryIfMissing True (tmpDir </> "proj")
+        writeFileUTF8 (tmpDir </> "proj" </> "daml.yaml") $ unlines
+            [ "sdk-version: " <> sdkVersion
+            , "name: proj"
+            , "source: ."
+            , "version: 0.1.0"
+            , "dependencies: [daml-prim, daml-stdlib]"
+            , "data-dependencies: "
+            , "  - " <> (tmpDir </> "type" </> "type.dar")
+            ]
+        writeFileUTF8 (tmpDir </> "proj" </> "P2.daml") $ unlines
+            [ "module P2 where"
+            , "import P1"
+            , "f1 = show @(T Int)"
+            , "f2 = show @(T Bool)"
+            , "f3 = show @(T Text)"
+            , "f4 = show @(T (Optional Int))"
+            , "f5 = show @(T (Optional Bool))"
+            , "f6 = show @(T (Optional Text))"
+            , "f7 = show @(T [Int])"
+            , "f8 = show @(T [Bool])"
+            , "f9 = show @(T [Text])"
+            , "f10 = show @(T [Optional Int])"
+            , "f11 = show @(T [Optional Bool])"
+            , "f12 = show @(T [Optional Text])"
+            ]
+        withCurrentDirectory (tmpDir </> "proj") $
+            callProcessSilent damlc ["build"]
+
     , testCaseSteps "Implicit parameters" $ \step -> withTempDir $ \tmpDir -> do
         step "building project with implicit parameters"
         createDirectoryIfMissing True (tmpDir </> "dep")


### PR DESCRIPTION
Fixes #7362. Incredibly, it's possible to fix this issue in
data-dependencies by sorting instance names in a funny way.
This is definitely a hack, but it should fix this issue,
which affects overlapping instances as well.

This PR adds a regression test.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
