### PR TITLE
Speedy Compiler: factorize and clean code (fixe of #7493) 

### DIFF
--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -12,6 +12,9 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repl")
 da_scala_library(
     name = "interpreter",
     srcs = glob(["src/main/**/*.scala"]),
+    plugins = [
+        "@maven//:com_github_ghik_silencer_plugin_2_12_11",
+    ],
     scalacopts = lf_scalacopts,
     tags = ["maven_coordinates=com.daml:daml-lf-interpreter:__VERSION__"],
     visibility = [
@@ -27,6 +30,7 @@ da_scala_library(
         "//daml-lf/language",
         "//daml-lf/transaction",
         "//daml-lf/validation",
+        "@maven//:com_github_ghik_silencer_lib_2_12_11",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",

--- a/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
+++ b/daml-lf/interpreter/perf/src/main/scala/com/daml/lf/explore/Explore.scala
@@ -131,11 +131,16 @@ object PlaySpeedy {
       (
         "free", // let (a,b,c) = (30,100,21) in twice (\x -> x - (a-c)) b
         82,
-        SELet(
-          Array(num(30), num(100), num(21)),
-          SEApp(
-            twice,
-            Array(SEAbs(1, subtract2(SEVar(1), subtract2(SEVar(4), SEVar(2)))), SEVar(2)))) //100
+        SELet1General(
+          num(30),
+          SELet1General(
+            num(100),
+            SELet1General(
+              num(21),
+              SEApp(
+                twice,
+                Array(SEAbs(1, subtract2(SEVar(1), subtract2(SEVar(4), SEVar(2)))), SEVar(2)))) //100
+          ))
       )
     )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -311,7 +311,7 @@ private[lf] object Anf {
       }
 
       case SELet(rhss, body) =>
-        val expanded = expandMultiLet(rhss.toList, body)
+        val expanded = expandMultiLet(rhss, body)
         Bounce(() => transformExp(depth, env, expanded, k)(transform))
 
       case SELet1General(rhs, body) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -531,7 +531,7 @@ private[lf] object Pretty {
           })).tightBracketBy(text("let ["), char(']')) +
             lineOrSpace + text("in") & prettySExpr(index + bounds.length)(body)
         case SELet1General(rhs, body) =>
-          prettySExpr(index)(SELet(Array(rhs), body))
+          prettySExpr(index)(SELet(List(rhs), body))
         case SELet1Builtin(builtin, args, body) =>
           prettySExpr(index)(SELet1General(SEAppAtomicSaturatedBuiltin(builtin, args), body))
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -31,7 +31,6 @@ sealed abstract class SExpr extends Product with Serializable {
   override def toString: String =
     productPrefix + productIterator.map(SExpr.prettyPrint).mkString("(", ",", ")")
 }
-
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
 object SExpr {
 
@@ -307,32 +306,14 @@ object SExpr {
     }
   }
 
-  /** A non-recursive, non-parallel let block. Each bound expression
-    * is evaluated in turn and pushed into the environment one by one,
-    * with later expressions possibly referring to earlier.
+  /** A non-recursive, non-parallel let block.
+    * It is used as an intermediary data structure by the compiler,
+    * but are later explode into SELet1General and SELet1Builtin by
+    * the ANF transformation.
     */
-  final case class SELet(bounds: List[SExpr], body: SExpr) extends SExpr with SomeArrayEquals {
-    def execute(machine: Machine): Unit = {
-
-      // Evaluate the body after we've evaluated the binders
-      machine.pushKont(
-        KPushTo(
-          machine.env,
-          body,
-          machine.frame,
-          machine.actuals,
-          machine.env.size + bounds.size - 1))
-
-      // Start evaluating the let binders
-      var i = 1
-      while (i < bounds.size) {
-        val b = bounds(bounds.size - i)
-        val expectedEnvSize = machine.env.size + bounds.size - i - 1
-        machine.pushKont(KPushTo(machine.env, b, machine.frame, machine.actuals, expectedEnvSize))
-        i += 1
-      }
-      machine.ctrl = bounds.head
-    }
+  final case class SELet(bounds: List[SExpr], body: SExpr) extends SExpr {
+    def execute(machine: Machine): Unit =
+      crash("not implemented")
   }
 
   /** Location annotation. When encountered the location is stored in the 'lastLocation'

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -311,7 +311,7 @@ object SExpr {
     * is evaluated in turn and pushed into the environment one by one,
     * with later expressions possibly referring to earlier.
     */
-  final case class SELet(bounds: Array[SExpr], body: SExpr) extends SExpr with SomeArrayEquals {
+  final case class SELet(bounds: List[SExpr], body: SExpr) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
 
       // Evaluate the body after we've evaluated the binders
@@ -333,24 +333,6 @@ object SExpr {
       }
       machine.ctrl = bounds.head
     }
-  }
-
-  object SELet {
-
-    // Helpers for constructing let expressions:
-    // Instead of
-    //   SELet(Array(SEVar(4), SEVar(1)), SEVar(1))
-    // you can write:
-    //   SELet(
-    //     SEVar(4),
-    //     SEVar(1)
-    //   ) in SEVar(1)
-    case class PartialSELet(bounds: Array[SExpr]) extends SomeArrayEquals {
-      def in(body: => SExpr): SExpr = SELet(bounds, body)
-    }
-
-    def apply(bounds: SExpr*) = PartialSELet(bounds.toArray)
-
   }
 
   /** Location annotation. When encountered the location is stored in the 'lastLocation'

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -307,9 +307,9 @@ object SExpr {
   }
 
   /** A non-recursive, non-parallel let block.
-    * It is used as an intermediary data structure by the compiler,
-    * but are later exploded into SELet1General and SELet1Builtin by
-    * the ANF transformation.
+    * It is used as an intermediary data structure by the compiler to
+    * mitigate stack overflow issues, but are later exploded into
+    * [[SELet1General]] and [[SELet1Builtin]] by the ANF transformation.
     */
   final case class SELet(bounds: List[SExpr], body: SExpr) extends SExpr {
     def execute(machine: Machine): Unit =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -441,6 +441,8 @@ object SExpr {
     def ref: DefinitionRef
     def packageId: PackageId = ref.packageId
     def modName: ModuleName = ref.qualifiedName.module
+    private[this] val eval = SEVal(this)
+    def apply(args: SExpr*) = SEApp(eval, args.toArray)
   }
 
   // references to definitions that come from the archive

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -308,7 +308,7 @@ object SExpr {
 
   /** A non-recursive, non-parallel let block.
     * It is used as an intermediary data structure by the compiler,
-    * but are later explode into SELet1General and SELet1Builtin by
+    * but are later exploded into SELet1General and SELet1Builtin by
     * the ANF transformation.
     */
   final case class SELet(bounds: List[SExpr], body: SExpr) extends SExpr {


### PR DESCRIPTION
This reintroduce the change from #7493 that have been reverted by #7538

It fixes recursion issue from #7493 with `closureConvert` and `freeVars`.
The explosion of muti-binding in single binding makes the function
 `closureConvert` crash with stackoverflow in some cases.
    
It reintroduce the usage of multi-binding let in the first pass of the
compiler. The ANF transformation pass will replace them with nested
single binding let. ANF pass do not have issue with deep expression,
as it handle them with trampoline.

Similar stack overflow issues are described in  #5925

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
