### PR TITLE
Fix qualified name handling in DAML REPL

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -375,7 +375,7 @@ runRepl
     -> IO ()
 runRepl importPkgs opts replClient logger ideState = do
     imports <- loadPackages importPkgs replClient ideState
-    -- Typecheck ones to get the GlobalRdrEnv
+    -- Typecheck once to get the GlobalRdrEnv
     let initialLineNumber = 0
     dflags <- liftIO $
          hsc_dflags . hscEnv <$>

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/Repl.hs
@@ -10,6 +10,7 @@ module DA.Daml.Compiler.Repl
     , ReplLogger(..)
     ) where
 
+import TcRnTypes (tcg_rdr_env)
 import BasicTypes (Boxity(..))
 import Bag (bagToList, unitBag)
 import Control.Applicative
@@ -55,13 +56,13 @@ import GHC
 import HsExpr (Stmt, StmtLR(..), LHsExpr)
 import HsExtension (GhcPs, GhcTc)
 import HsPat (Pat(..))
-import HscTypes (HscEnv(..))
+import HscTypes (HscEnv(..), mkPrintUnqualified)
 import Language.Haskell.GhclibParserEx.Parse
 import Language.Haskell.LSP.Messages
 import Lexer (ParseResult(..))
 import Module (unitIdString)
 import OccName (OccSet, occName, elemOccSet, mkOccSet, mkVarOcc)
-import Outputable (ppr, showSDoc)
+import Outputable (ppr, showSDoc, showSDocForUser)
 import qualified Outputable
 import RdrName (mkRdrUnqual)
 import SrcLoc (unLoc)
@@ -279,6 +280,7 @@ importToList (Imports imports) = concat $ Map.elems imports
 
 data ReplState = ReplState
   { imports :: !Imports
+  , printUnqualified :: PrintUnqualified
   , bindings :: ![(LPat GhcPs, Type)]
   , lineNumber :: !Int
   }
@@ -373,10 +375,24 @@ runRepl
     -> IO ()
 runRepl importPkgs opts replClient logger ideState = do
     imports <- loadPackages importPkgs replClient ideState
+    -- Typecheck ones to get the GlobalRdrEnv
+    let initialLineNumber = 0
+    dflags <- liftIO $
+         hsc_dflags . hscEnv <$>
+         runAction ideState (use_ GhcSession $ lineFilePath initialLineNumber)
+    (_, tcr) <-
+        (runExceptT $ printDelayedDiagnostics $ tryTypecheck initialLineNumber $
+         T.pack (unlines $ moduleHeader dflags (importFromList imports) initialLineNumber)
+        ) >>= \case
+        Left err -> do
+            renderError dflags err
+            exitFailure
+        Right r -> pure r
     let initReplState = ReplState
           { imports = importFromList imports
           , bindings = []
           , lineNumber = 0
+          , printUnqualified = getPrintUnqualified dflags tcr
           }
     -- TODO[AH] Use Repl.evalReplOpts once we're using repline >= 0.2.2
     let replM = Repl.evalRepl banner command options prefix tabComplete initialiser
@@ -396,9 +412,9 @@ runRepl importPkgs opts replClient logger ideState = do
         -> ReplClient.ReplResponseType
         -> ExceptT Error ReplM ()
     handleStmt dflags line stmt rspType = do
-        ReplState {imports, bindings, lineNumber} <- State.get
+        ReplState {imports, bindings, lineNumber, printUnqualified} <- State.get
         supportedStmt <- maybe (throwError (UnsupportedStatement line)) pure (validateStmt stmt)
-        let rendering = renderModule dflags imports lineNumber bindings supportedStmt
+        let rendering = renderModule dflags printUnqualified imports lineNumber bindings supportedStmt
         (lfMod, tmrModule -> tcMod) <- printDelayedDiagnostics $ case (rspType, rendering) of
             (ReplClient.ReplText, BindingRendering t) ->
                 tryTypecheck lineNumber (T.pack t)
@@ -424,7 +440,7 @@ runRepl importPkgs opts replClient logger ideState = do
         liftIO $ whenJust mbResult T.putStrLn
         let boundVars = stmtBoundVars supportedStmt
             boundVars' = mkOccSet $ map occName boundVars
-        State.put $! ReplState
+        State.modify' $ \s -> s
           { imports = imports
           , bindings = map (first (shadowPat boundVars')) bindings <> [(toTuplePat boundVars, stmtTy)]
           , lineNumber = lineNumber + 1
@@ -437,7 +453,7 @@ runRepl importPkgs opts replClient logger ideState = do
                 liftIO $ mapM_ (printDiagnostics stdout) diags
                 pure (Left err)
             Right r -> pure (Right r)
-    tryTypecheck :: Int -> T.Text -> ExceptT (Error, [[FileDiagnostic]]) ReplM (LF.Module, TcModuleResult)
+    tryTypecheck :: (MonadIO m, MonadError (Error, [[FileDiagnostic]]) m) => Int -> T.Text -> m (LF.Module, TcModuleResult)
     tryTypecheck lineNumber t = do
         liftIO $ setBufferModified ideState (lineFilePath lineNumber) $ Just t
         -- We need to temporarily suppress diagnostics since we use type errors
@@ -506,8 +522,8 @@ runRepl importPkgs opts replClient logger ideState = do
         case input of
             ReplStatement stmt -> handleStmt dflags line stmt ReplClient.ReplJson
             ReplImport _ -> throwError (ExpectedExpression line)
-    optModule _dflags ("-" : names) =
-        removeImports $ map mkModuleName names
+    optModule dflags ("-" : names) =
+        removeImports dflags $ map mkModuleName names
     optModule dflags ("+" : names) =
         addImports dflags $ map (simpleImportDecl . mkModuleName) names
     optModule dflags names =
@@ -524,19 +540,32 @@ runRepl importPkgs opts replClient logger ideState = do
     addImports dflags additional = do
         ReplState {imports, lineNumber} <- State.get
         let newImports = foldl' (flip importInsert) imports additional
-        _ <- printDelayedDiagnostics $ tryTypecheck lineNumber $
+        (_, tcr) <- printDelayedDiagnostics $ tryTypecheck lineNumber $
             T.pack (unlines $ moduleHeader dflags newImports lineNumber)
-        State.modify $ \s -> s { imports = newImports }
+        State.modify $ \s -> s
+            { imports = newImports
+            , printUnqualified = getPrintUnqualified dflags tcr
+            }
     removeImports
-        :: [ModuleName]
+        :: DynFlags
+        -> [ModuleName]
         -> ExceptT Error ReplM ()
-    removeImports modules = do
-        ReplState {imports} <- lift State.get
+    removeImports dflags modules = do
+        ReplState {imports, lineNumber} <- lift State.get
         let unknown = [name | name <- modules, not $ name `importMember` imports]
             newImports = foldl' (flip importDelete) imports modules
         unless (null unknown) $
             throwError $ NotImportedModules unknown
-        lift $ State.modify $ \s -> s { imports = newImports }
+        (_, tcr) <- printDelayedDiagnostics $ tryTypecheck lineNumber $
+            T.pack (unlines $ moduleHeader dflags newImports lineNumber)
+        lift $ State.modify $ \s -> s
+            { imports = newImports
+            , printUnqualified = getPrintUnqualified dflags tcr
+            }
+
+    getPrintUnqualified dflags tcr =
+        let gblRdrEnv = tcg_rdr_env $ fst $ tm_internals_ $ tmrModule tcr
+        in mkPrintUnqualified dflags gblRdrEnv
 
 exprTy :: LHsBinds GhcTc -> Maybe Type
 exprTy binds = listToMaybe
@@ -599,18 +628,19 @@ moduleHeader dflags imports line =
 
 renderModule
     :: DynFlags
+    -> PrintUnqualified
     -> Imports
     -> Int
     -> [(LPat GhcPs, Type)]
     -> SupportedStatement
     -> ModuleRenderings
-renderModule dflags imports line binds stmt = case stmt of
+renderModule dflags printUnqualified imports line binds stmt = case stmt of
     BindStatement pat expr ->
         BindingRendering $ unlines $
             moduleHeader dflags imports line <>
             [ exprTy "Script _"
             , exprLhs
-            , showSDoc dflags $ Outputable.nest 2 $ ppr (scriptStmt (Just pat) expr returnAp)
+            , showSDoc' $ Outputable.nest 2 $ ppr (scriptStmt (Just pat) expr returnAp)
             ]
     BodyStatement expr ->
         BodyRenderings
@@ -618,32 +648,32 @@ renderModule dflags imports line binds stmt = case stmt of
               moduleHeader dflags imports line <>
               [ exprTy "Script ()"
               , exprLhs
-              , showSDoc dflags $ Outputable.nest 2 $ ppr (scriptStmt Nothing expr returnAp)
+              , showSDoc' $ Outputable.nest 2 $ ppr (scriptStmt Nothing expr returnAp)
               ]
           , printableScript = unlines $
               moduleHeader dflags imports line <>
               [ exprTy "Script Text"
               , exprLhs
-              , showSDoc dflags $ Outputable.nest 2 $ ppr (scriptStmt Nothing expr returnShowAp)
+              , showSDoc' $ Outputable.nest 2 $ ppr (scriptStmt Nothing expr returnShowAp)
               ]
           , arbitraryScript = unlines $
               moduleHeader dflags imports line <>
               [ exprTy "Script _"
               , exprLhs
-              , showSDoc dflags $ Outputable.nest 2 $ ppr (scriptStmt Nothing expr returnAp)
+              , showSDoc' $ Outputable.nest 2 $ ppr (scriptStmt Nothing expr returnAp)
               ]
           , purePrintableExpr = unlines $
               moduleHeader dflags imports line <>
               [ exprTy "Script Text"
               , exprLhs
-              , showSDoc dflags $ Outputable.nest 2 $ ppr $
+              , showSDoc' $ Outputable.nest 2 $ ppr $
                 returnShowAp expr
               ]
           , pureArbitraryExpr = unlines $
               moduleHeader dflags imports line <>
               [ exprTy "Script _"
               , exprLhs
-              , showSDoc dflags $ Outputable.nest 2 $ ppr $
+              , showSDoc' $ Outputable.nest 2 $ ppr $
                 returnAp $ noLoc $ HsPar noExt expr
               ]
           }
@@ -655,14 +685,15 @@ renderModule dflags imports line binds stmt = case stmt of
           moduleHeader dflags imports line <>
           [ exprTy "Script _"
           , exprLhs
-          , showSDoc dflags $ Outputable.nest 2 $ ppr $ HsDo noExt DoExpr $ noLoc
+          , showSDoc' $ Outputable.nest 2 $ ppr $ HsDo noExt DoExpr $ noLoc
               [ noLoc $ LetStmt noExt $ toLocalBinds binding
               , noLoc $ LastStmt noExt (returnAp retExpr) False noSyntaxExpr
               ]
           ]
   where
-        renderPat pat = showSDoc dflags (ppr pat)
-        renderTy ty = "(" <> showSDoc dflags (ppr ty) <> ") -> "
+        showSDoc' = showSDocForUser dflags printUnqualified
+        renderPat pat = showSDoc' (ppr pat)
+        renderTy ty = "(" <> showSDoc' (ppr ty) <> ") -> "
         -- build a script statement using the given wrapper (either `return` or `show`)
         -- to wrap the final result.
         scriptStmt mbPat expr wrapper =

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -399,6 +399,7 @@ genrule(
     name = "repl-test",
     srcs = [
         "ReplTest.daml",
+        "Colliding.daml",
         "repl-test-indirect.dar",
     ],
     outs = ["repl-test.dar"],
@@ -407,6 +408,7 @@ genrule(
       TMP_DIR=$$(mktemp -d)
       mkdir -p $$TMP_DIR/daml
       cp -L $(location ReplTest.daml) $$TMP_DIR/daml
+      cp -L $(location Colliding.daml) $$TMP_DIR/daml
       cp -L $(location repl-test-indirect.dar) $$TMP_DIR
       cat << EOF > $$TMP_DIR/daml.yaml
 sdk-version: {sdk}

--- a/compiler/damlc/tests/Colliding.daml
+++ b/compiler/damlc/tests/Colliding.daml
@@ -1,0 +1,10 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+module Colliding where
+
+data NameCollision = NameCollision
+  with
+    field : Int
+  deriving Show
+

--- a/compiler/damlc/tests/ReplTest.daml
+++ b/compiler/damlc/tests/ReplTest.daml
@@ -29,3 +29,8 @@ data D = D
     x : Int
     y : Int
   deriving Show
+
+data NameCollision = NameCollision
+  with
+    field : Text
+  deriving Show

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -226,7 +226,7 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , matchOutput "^Message:.*error: Variable not in scope: days.*$"
           ]
     , testInteraction' ":show imports"
-          [ input ":module - ReplTest ReplTest2"
+          [ input ":module - ReplTest ReplTest2 Colliding"
           , input ":module + DA.Assert"
           , input ":show imports"
           , matchOutput "^import Daml.Script -- implicit$"
@@ -326,6 +326,15 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , input "let x = 1"
           , input ":json x"
           , matchOutput "1"
+          ]
+    , testInteraction' "collision"
+      -- Test that collisions are handled correctly if users qualify names.
+          [ input "let x = ReplTest.NameCollision \"abc\""
+          , input "x"
+          , matchOutput "NameCollision {field = \"abc\"}"
+          , input "y <- pure $ Colliding.NameCollision 42"
+          , input "y"
+          , matchOutput "NameCollision {field = 42}"
           ]
     ]
   where


### PR DESCRIPTION
This fixes the issue reported in
https://discuss.daml.com/t/how-to-use-qualified-template-names-in-repl-queries/1329/7

We need to print names qualified otherwise, the type signature for
following lines will be ambiguous even if users qualified the name in
their input. Figuring out the right name to use in qualification is
tricky but Luckily GHC provides this already so we just have to make
sure to plug it into the right places.

changelog_begin

- [DAML REPL] Fix a bug where you got an error about a name being
  ambiguous even if you used a qualified name.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
