### PR TITLE
Write proper SDK version in DAR manifest for snapshots

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -105,8 +105,6 @@ genrule(
 module SdkVersion where
 
 import Module (stringToUnitId, UnitId)
-import qualified Data.List.Split as Split
-import qualified Data.List.Extra as List.Extra
 
 sdkVersion :: String
 sdkVersion = "{sdk}"
@@ -116,24 +114,6 @@ mvnVersion = "{mvn}"
 
 damlStdlib :: UnitId
 damlStdlib = stringToUnitId ("daml-stdlib-" ++ "{ghc}")
-
--- | Turns a SemVer string into one suitable for ghc-pkg
---
--- The DAML SDK uses semantic versioning, while internally we need a version
--- string that ghc-pkg can understand. We do that by removing the '-snapshot'
--- qualifier when present.
---
--- Expected version strings:
--- 0.13.51 -> release, no change
--- 0.13.51-snapshot.20200212.3024.04e6fa2c -> snapshot release, change to
---                                         0.13.51.20200212.3024 internally
--- This logic must stay in sync with bazel_tools/build_environment.bzl.
-toGhcPkgVersion :: String -> String
-toGhcPkgVersion rawVersion =
-    case Split.splitOn "-snapshot" rawVersion of
-      [v] -> v
-      [v, pr] -> v ++ List.Extra.dropEnd 9 pr
-      _ -> rawVersion
 EOF
     """.format(
         ghc = ghc_version,

--- a/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
+++ b/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
@@ -16,7 +16,6 @@ import qualified DA.Daml.LF.Ast as LF
 import DA.Daml.Project.Config
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Types
-import SdkVersion
 
 import Control.Exception.Safe (throwIO)
 import Control.Monad (when)
@@ -88,21 +87,12 @@ overrideSdkVersion pkgConfig = do
                     ]
             pure pkgConfig { pSdkVersion = PackageSdkVersion sdkVersion }
 
---- | replace SDK version with one ghc-pkg accepts
----
---- This should let release version unchanged, but convert snapshot versions.
---- See module SdkVersion (in //BUILD) for details.
-replaceSdkVersionWithGhcPkgVersion :: PackageConfigFields -> PackageConfigFields
-replaceSdkVersionWithGhcPkgVersion p@PackageConfigFields{ pSdkVersion = PackageSdkVersion v } =
-    p { pSdkVersion = PackageSdkVersion $ SdkVersion.toGhcPkgVersion v }
-
 withPackageConfig :: ProjectPath -> (PackageConfigFields -> IO a) -> IO a
 withPackageConfig projectPath f = do
     project <- readProjectConfig projectPath
     pkgConfig <- either throwIO pure (parseProjectConfig project)
     pkgConfig' <- overrideSdkVersion pkgConfig
-    let pkgConfig'' = replaceSdkVersionWithGhcPkgVersion pkgConfig'
-    f pkgConfig''
+    f pkgConfig'
 
 -- | Orphans because I’m too lazy to newtype everything.
 instance A.FromJSON Ghc.ModuleName where

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -70,7 +70,7 @@ import SdkVersion
 --   and then remap references to those dummy packages to the original DAML-LF
 --   package id.
 createProjectPackageDb :: NormalizedFilePath -> Options -> PackageSdkVersion -> MS.Map UnitId GHC.ModuleName -> [FilePath] -> [FilePath] -> IO ()
-createProjectPackageDb projectRoot (disableScenarioService -> opts) thisSdkVer modulePrefixes deps dataDeps
+createProjectPackageDb projectRoot (disableScenarioService -> opts) (PackageSdkVersion (SdkVersion.toGhcPkgVersion -> thisSdkVer)) modulePrefixes deps dataDeps
   | null dataDeps && all (`elem` basePackages) deps =
     -- Initializing the package db is expensive since it requires calling GenerateStablePackages and GeneratePackageMap.
     --Therefore we only do it if we actually have a dependency.
@@ -80,9 +80,9 @@ createProjectPackageDb projectRoot (disableScenarioService -> opts) thisSdkVer m
     deps <- expandSdkPackages (optDamlLfVersion opts) (filter (`notElem` basePackages) deps)
     depsExtracted <- mapM extractDar deps
 
-    let uniqSdkVersions = nubSort $ unPackageSdkVersion thisSdkVer : map edSdkVersions depsExtracted
+    let uniqSdkVersions = nubSort $ thisSdkVer : map edSdkVersions depsExtracted
     let depsSdkVersions = map edSdkVersions depsExtracted
-    unless (all (== unPackageSdkVersion thisSdkVer) depsSdkVersions) $
+    unless (all (== thisSdkVer) depsSdkVersions) $
            fail $
            "Package dependencies from different SDK versions: " ++
            intercalate ", " uniqSdkVersions

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -70,7 +70,7 @@ import SdkVersion
 --   and then remap references to those dummy packages to the original DAML-LF
 --   package id.
 createProjectPackageDb :: NormalizedFilePath -> Options -> PackageSdkVersion -> MS.Map UnitId GHC.ModuleName -> [FilePath] -> [FilePath] -> IO ()
-createProjectPackageDb projectRoot (disableScenarioService -> opts) (PackageSdkVersion (SdkVersion.toGhcPkgVersion -> thisSdkVer)) modulePrefixes deps dataDeps
+createProjectPackageDb projectRoot (disableScenarioService -> opts) (PackageSdkVersion thisSdkVer) modulePrefixes deps dataDeps
   | null dataDeps && all (`elem` basePackages) deps =
     -- Initializing the package db is expensive since it requires calling GenerateStablePackages and GeneratePackageMap.
     --Therefore we only do it if we actually have a dependency.

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -205,7 +205,7 @@ tests tools@Tools{damlc} = testGroup "Packaging" $
         archive <- Zip.toArchive <$> BSL.readFile dar
         Just entry <- pure $ Zip.findEntryByPath "META-INF/MANIFEST.MF" archive
         let lines = BSL.Char8.lines (Zip.fromEntry entry)
-            expectedLine = "Sdk-Version: " <> BSL.Char8.pack (SdkVersion.toGhcPkgVersion sdkVersion)
+            expectedLine = "Sdk-Version: " <> BSL.Char8.pack sdkVersion
         assertBool "META-INF/MANIFEST.MF picked up the wrong sdk version" (expectedLine `elem` lines)
 
     , testCase "Non-root sources files" $ withTempDir $ \projDir -> do


### PR DESCRIPTION
Currently, we don't write the actual SDK version in the DAR manifest but
rather the version that has been sanitized for `ghc-pkg`. For proper
releases, these are identical but for snapshots the latter does not
contain the `-snapshot` part and the commit hash because `ghc-pkg` can
only handle numeric components.

This PR changes this behaviour such that we write the actual
unsanitized SDK version in the DAR manifest.

The implementation might look a bit unintuitive. However, we use the
`PackageSdkVersion` type for exactly two things:

1. Writing it into the manifest.
2. Using it to initialize the package database.

As mentioned above, the former should not be sanitized whereas the
latter should. So far, we've done the sanitization right after reading
the SDK version from `daml.yaml` or `DAML_SDK_VERSION`. Now, we do the
sanitization only in the code concerned with initializing the package
database.

CHANGELOG_BEGIN
[DAML Compiler]
- Bugfix: write the proper SDK version in the DAR manifest for
  snapshot releases instead of a sanitized version
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7546)
<!-- Reviewable:end -->
