### PR TITLE
Document cookie passing in trigger service auth

### DIFF
--- a/triggers/service/authentication.md
+++ b/triggers/service/authentication.md
@@ -32,11 +32,12 @@ The auth middleware provides a few endpoints (the names don’t matter
 all that much, they just need to be fixed once).
 
 1. /auth The trigger service, will contact this endpoint with a set of
-   claims. If the user has already authenticated and is authorized for
-   those claims, it will return an access token (an opaque
-   blob to the trigger service) for at least those claims and a
-   refresh token (another opaque blob). If not, it will return an
-   unauthorized status code.
+   claims passing along all cookies in the original request. If
+   the user has already authenticated and is authorized for those
+   claims, it will return an access token (an opaque blob to the
+   trigger service) for at least those claims and a refresh token
+   (another opaque blob). If not, it will return an unauthorized
+   status code.
 
 2. /login If /auth returned unauthorized, the trigger service will
    redirect users to this. The parameters will include the requested


### PR DESCRIPTION
This has come up 2 times now so seems sensible to point this out
explicitly.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
