### PR TITLE
Bump timeout in HikariJdbcConnectionPool

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
@@ -166,7 +166,7 @@ private[platform] object HikariJdbcConnectionProvider {
         jdbcUrl,
         maxConnections,
         maxConnections,
-        250.millis,
+        5000.millis,
         Some(metrics),
       )
       healthPoller <- ResourceOwner.forTimer(() =>


### PR DESCRIPTION
We’ve seen a bunch of timeouts on CI recetnly so let’s relax this a bit.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
