### PR TITLE
participant-integration-api: Increase the migration connection timeout.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
@@ -63,7 +63,7 @@ private[platform] class FlywayMigrations(jdbcUrl: String)(implicit loggingContex
       jdbcUrl = jdbcUrl,
       minimumIdle = 2,
       maxPoolSize = 2,
-      connectionTimeout = 250.millis,
+      connectionTimeout = 5.seconds,
       metrics = None,
     )
 }


### PR DESCRIPTION
250ms is a bit low for CI when our database might be overloaded.

5 seconds seems like a decent balance between a quick response and being sympathetic to slow/overloaded machines.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
