### PR TITLE
language: Rebuild/redeploy on key press

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -13,6 +13,7 @@ da_haskell_library(
     ),
     hackage_deps = [
         "aeson",
+        "ansi-terminal",
         "async",
         "base",
         "bytestring",

--- a/docs/source/getting-started/first-feature.rst
+++ b/docs/source/getting-started/first-feature.rst
@@ -68,16 +68,11 @@ This completes the workflow for messaging in our app.
 Running the New Feature
 =======================
 
-We need to terminate the previous ``daml start`` process and run it again, as we need to have a Sandbox instance with a DAR file containing the new feature. As a reminder, by running ``daml start`` again we will
+Navigate to the terminal window where the ``daml start`` process is running and press 'r'. This will
 
   - Compile our DAML code into a *DAR file containing the new feature*
-  - Generate a JavaScript library under ``ui/daml.js`` to connect the UI with your DAML code
-  - Run a fresh instance of the *Sandbox with the new DAR file*
-  - Start the HTTP JSON API
-
-First, navigate to the terminal window where the ``daml start`` process is running and terminate the active process by hitting ``Ctrl-C``.
-This shuts down the previous instances of the sandbox.
-Then in the root ``create-daml-app`` folder run ``daml start``.
+  - Update the JavaScript library under ``ui/daml.js`` to connect the UI with your DAML code
+  - Upload the *new DAR file* to the sandbox
 
 As mentioned at the beginning of this *Getting Started with DAML* guide, DAML Sandbox uses an
 in-memory store, which means it loses its state when stopped or restarted. That means that all user


### PR DESCRIPTION
This makes the `daml start` process listen for a key-press. When 'r' is
pressed, the package is re-build, the new package uploaded to the
in-memory sandbox and the codegen re-run.

Note: While we clean previous outputs of the code generation, there is
currently no way to drop previously uploaded packages from the in-memory
sandbox. However, it will take many re-uploads until this will become a
problem and this is a lot better than having to kill and re-run `daml start` for every code change.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
