### PR TITLE
Make trigger service auth middleware /login endpoint compatible with Auth0

### DIFF
--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Config.scala
@@ -9,8 +9,9 @@ import com.daml.ports.Port
 private[middleware] case class Config(
     // Port the middleware listens on
     port: Port,
-    // Uri of the OAuth2 server
-    oauthUri: Uri,
+    // OAuth2 server endpoints
+    oauthAuth: Uri,
+    oauthToken: Uri,
     // OAuth2 client properties
     clientId: String,
     clientSecret: String,
@@ -18,7 +19,12 @@ private[middleware] case class Config(
 
 private[middleware] object Config {
   private val Empty =
-    Config(port = Port.Dynamic, oauthUri = null, clientId = null, clientSecret = null)
+    Config(
+      port = Port.Dynamic,
+      oauthAuth = null,
+      oauthToken = null,
+      clientId = null,
+      clientSecret = null)
 
   def parseConfig(args: Seq[String]): Option[Config] =
     configParser.parse(args, Empty)
@@ -33,10 +39,15 @@ private[middleware] object Config {
         .required()
         .text("Port to listen on")
 
-      opt[String]("oauth-uri")
-        .action((x, c) => c.copy(oauthUri = Uri(x)))
+      opt[String]("oauth-auth")
+        .action((x, c) => c.copy(oauthAuth = Uri(x)))
         .required()
-        .text("URI of the OAuth2 server")
+        .text("URI of the OAuth2 authorization endpoint")
+
+      opt[String]("oauth-token")
+        .action((x, c) => c.copy(oauthToken = Uri(x)))
+        .required()
+        .text("URI of the OAuth2 token endpoint")
 
       opt[String]("id").hidden
         .action((x, c) => c.copy(clientId = x))

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
@@ -18,11 +18,10 @@ repository](https://github.com/digital-asset/ex-secure-daml-infra).
   - Provide a name (`ex-daml-api`).
   - Provide an Identifier (`https://daml.com/ledger-api`).
   - Select Signing Algorithm of `RS256`.
-* Create a new machine to machine application.
+* Create a new native application.
   - Provide a name (`ex-daml-auth-middleware`).
   - Select the authorized API (`ex-daml-api`).
   - Configure the allowed callback URLs in the settings (`http://localhost:3000`).
-  - Enable the "Authorization Code" "Grant Type" in the advanced settings.
   - Note the "Client ID" and "Client Secret" displayed in the "Basic
     Information" pane of the application settings.
   - Note the "OAuth Authorization URL" and the "OAuth Token URL" in the

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
@@ -1,0 +1,100 @@
+# Trigger Service Authentication/Authorization Middleware
+
+Implements an OAuth2 middleware according to the trigger service
+authentication/authorization specification in
+`triggers/service/authentication.md`.
+
+## Manual Testing against Auth0
+
+Apart from the automated tests defined in this repository, the middleware can
+be tested manually against an auth0 OAuth2 setup. The necessary steps are
+extracted and adapted from the [Secure DAML Infrastructure
+repository](https://github.com/digital-asset/ex-secure-daml-infra).
+
+### Setup
+
+* Sign up for an account on [Auth0](https://auth0.com).
+* Create a new API.
+  - Provide a name (`ex-daml-api`).
+  - Provide an Identifier (`https://daml.com/ledger-api`).
+  - Select Signing Algorithm of `RS256`.
+* Create a new machine to machine application.
+  - Provide a name (`ex-daml-auth-middleware`).
+  - Select the authorized API (`ex-daml-api`).
+  - Configure the allowed callback URLs in the settings (`http://localhost:3000`).
+  - Enable the "Authorization Code" "Grant Type" in the advanced settings.
+  - Note the "Client ID" and "Client Secret" displayed in the "Basic
+    Information" pane of the application settings.
+  - Note the "OAuth Authorization URL" and the "OAuth Token URL" in the
+    "Endpoints" tab of the advanced settings.
+* Create a "Hook" for "Client Credential Exchange".
+  - Provide a name (`ex-daml-claims`).
+  - Provide a script
+    ``` javascript
+    /**
+    @param {object} client - information about the client
+    @param {string} client.name - name of client
+    @param {string} client.id - client id
+    @param {string} client.tenant - Auth0 tenant name
+    @param {object} client.metadata - client metadata
+    @param {array|undefined} scope - array of strings representing the scope claim or undefined
+    @param {string} audience - token's audience claim
+    @param {object} context - additional authorization context
+    @param {object} context.webtask - webtask context
+    @param {function} cb - function (error, accessTokenClaims)
+    */
+    module.exports = function(client, scope, audience, context, cb) {
+      var access_token = {};
+      var actAs = [];
+      var readAs = [];
+      var admin = false;
+      // TODO define mapping from scope to ledger claims.
+      scope.forEach(s => {
+        if (s.startsWith("actAs:")) {
+          actAs.push(s.slice(6));
+        } else if (s.startsWith("readAs:")) {
+          readAs.push(s.slice(7));
+        } else if (s.startsWith("admin")) {
+          admin = true;
+        }
+      })
+      access_token['https://daml.com/ledger-api'] = {
+        // NOTE change the ledger ID to match your deployment.
+        "ledgerId": "2D105384-CE61-4CCC-8E0E-37248BA935A3",
+        "applicationId": client.name,
+        "actAs": actAs,
+        "readAs": readAs,
+        "admin": admin
+      };
+      cb(null, access_token);
+    };
+    ```
+* Create a new user.
+  - Provide an email address (`alice@localhost`)
+  - Provide a secure password
+  - Mark the email address as verified on the user's "Details" page.
+
+### Testing
+
+* Start the middleware by executing the following command.
+  ```
+  $ DAML_CLIENT_ID=CLIENTID \
+    DAML_CLIENT_SECRET=CLIENTSECRET \
+    bazel run //triggers/service/auth:oauth-middleware-binary -- \
+      --port 3000 \
+      --oauth-auth AUTHURL \
+      --oauth-token TOKENURL
+  ```
+  - Replace `CLIENTID` and `CLIENTSECRET` by the "Client ID" and "Client
+    Secret" from above.
+  - Replace `AUTHURL` and `TOKENURL` by the "OAuth Authorization URL"
+    and "OAuth Token URL" from above. They should look as follows:
+    ```
+    https://XYZ.auth0.com/authorize
+    https://XYZ.auth0.com/oauth/token
+    ```
+- Browse to the middleware's login endpoint.
+  - URL `http://localhost:3000/login?redirect_uri=callback&claims=actAs:Alice`
+  - Login as the new user created above.
+  - Authorize the middleware application to access the tenant.
+  - You should be redirected to `http://localhost:3000/callback`.

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
@@ -47,7 +47,7 @@ repository](https://github.com/digital-asset/ex-secure-daml-infra).
       var actAs = [];
       var readAs = [];
       var admin = false;
-      // TODO define mapping from scope to ledger claims.
+      // TODO[AH] specify mapping from scope to ledger claims.
       scope.forEach(s => {
         if (s.startsWith("actAs:")) {
           actAs.push(s.slice(6));

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
@@ -5,8 +5,10 @@ package com.daml.oauth.server
 
 import java.util.Base64
 
-import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.{FormData, HttpEntity, RequestEntity, Uri}
 import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.marshalling._
+import akka.http.scaladsl.unmarshalling._
 import spray.json._
 
 import scala.util.Try
@@ -44,6 +46,29 @@ object Request {
       clientId: String,
       clientSecret: String)
 
+  object Token {
+    implicit val marshalRequestEntity: Marshaller[Token, RequestEntity] =
+      Marshaller.combined { token =>
+        FormData(
+          "grant_type" -> token.grantType,
+          "code" -> token.code,
+          "redirect_uri" -> token.redirectUri.toString,
+          "client_id" -> token.clientId,
+          "client_secret" -> token.clientSecret
+        )
+      }
+    implicit val unmarshalHttpEntity: Unmarshaller[HttpEntity, Token] =
+      Unmarshaller.defaultUrlEncodedFormDataUnmarshaller.map { form =>
+        Token(
+          grantType = form.fields.get("grant_type").get,
+          code = form.fields.get("code").get,
+          redirectUri = form.fields.get("redirect_uri").get,
+          clientId = form.fields.get("client_id").get,
+          clientSecret = form.fields.get("client_secret").get
+        )
+      }
+  }
+
 }
 
 object Response {
@@ -60,7 +85,7 @@ object Response {
   case class Token(
       accessToken: String,
       tokenType: String,
-      expiresIn: Option[String],
+      expiresIn: Option[Int],
       refreshToken: Option[String],
       scope: Option[String]) {
     def toCookieValue: String = {
@@ -90,14 +115,6 @@ object JsonProtocol extends DefaultJsonProtocol {
     }
     def write(uri: Uri) = JsString(uri.toString)
   }
-  implicit val tokenReqFormat: RootJsonFormat[Request.Token] =
-    jsonFormat(
-      Request.Token.apply,
-      "grant_type",
-      "code",
-      "redirect_uri",
-      "client_id",
-      "client_secret")
   implicit val tokenRespFormat: RootJsonFormat[Response.Token] =
     jsonFormat(
       Response.Token.apply,

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -53,7 +53,7 @@ object Server {
       )
     }
 
-    import JsonProtocol._
+    import Request.Token.unmarshalHttpEntity
 
     implicit val unmarshal: Unmarshaller[String, Uri] = Unmarshaller.strict(Uri(_))
 

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
@@ -32,12 +32,14 @@ trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBindin
             ledgerId = ledgerId,
             applicationId = applicationId,
             jwtSecret = jwtSecret))
+        serverUri = Uri()
+          .withScheme("http")
+          .withAuthority(server.localAddress.getHostString, server.localAddress.getPort)
         client <- Resources.authMiddleware(
           Config(
             port = Port.Dynamic,
-            oauthUri = Uri()
-              .withScheme("http")
-              .withAuthority(server.localAddress.getHostString, server.localAddress.getPort),
+            oauthAuth = serverUri.withPath(Uri.Path./("authorize")),
+            oauthToken = serverUri.withPath(Uri.Path./("token")),
             clientId = "middleware",
             clientSecret = "middleware-secret"
           ))


### PR DESCRIPTION
- Make the authorization and token endpoints configurable
- Use `application/x-www-form-urlencoded` as specified in https://tools.ietf.org/html/rfc6749#section-4.1.3
- Check the status code of the token endpoint response
- Fix the type of the token's `expires_in` field (`Int` instead of `String`)
- Adds instructions for manual testing against Auth0

Part of https://github.com/digital-asset/daml/issues/6923

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
