### PR TITLE
react: let user specify a 'close' event handler

### DIFF
--- a/language-support/ts/daml-react/defaultLedgerContext.ts
+++ b/language-support/ts/daml-react/defaultLedgerContext.ts
@@ -3,7 +3,7 @@
 
 import { createLedgerContext, FetchResult, QueryResult, LedgerProps } from "./createLedgerContext";
 import { ContractId, Party, Template } from '@daml/types';
-import Ledger, { Query } from '@daml/ledger';
+import Ledger, { Query, StreamCloseEvent } from '@daml/ledger';
 
 /**
  * @internal
@@ -90,14 +90,13 @@ export function useFetchByKey<T extends object, K, I extends string>(template: T
  *
  * @param template The template of the contracts to match.
  * @param queryFactory A function returning a query. If the query is omitted, all visible contracts of the given template are returned.
- * @param queryDeps The dependencies of the query (for which a change triggers an update of the result)
+ * @param queryDeps The dependencies of the query (for which a change triggers an update of the result).
+ * @param closeHandler A callback that will be called if the underlying WebSocket connection fails in an unrecoverable way.
  *
  * @return The matching contracts.
  */
-export function useStreamQuery<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory: () => Query<T>, queryDeps: readonly unknown[]): QueryResult<T, K, I>
-export function useStreamQuery<T extends object, K, I extends string>(template: Template<T, K, I>): QueryResult<T, K, I>
-export function useStreamQuery<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory?: () => Query<T>, queryDeps?: readonly unknown[]): QueryResult<T, K, I> {
-  return ledgerContext.useStreamQuery(template, queryFactory, queryDeps);
+export function useStreamQuery<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory?: () => Query<T>, queryDeps?: readonly unknown[], closeHandler?: (e: StreamCloseEvent) => void): QueryResult<T, K, I> {
+  return ledgerContext.useStreamQuery(template, queryFactory, queryDeps, closeHandler);
 }
 
 /**
@@ -109,7 +108,8 @@ export function useStreamQuery<T extends object, K, I extends string>(template: 
  *
  * @param template The template of the contracts to match.
  * @param queryFactory A function returning a contract key.
- * @param queryDeps The dependencies of the query (for which a change triggers an update of the result)
+ * @param queryDeps The dependencies of the query (for which a change triggers an update of the result).
+ * @param closeHandler A callback that will be called if the underlying WebSocket connection fails in an unrecoverable way.
  *
  * @return The matching (unique) contract.
  */

--- a/language-support/ts/daml-react/index.test.ts
+++ b/language-support/ts/daml-react/index.test.ts
@@ -346,6 +346,25 @@ describe('useStreamQuery', () => {
     expect(hookResult.result.current).toEqual({contracts: [], loading: false});
   });
 
+  test('closeHandler gets called', () => {
+    // setup
+    const query = 'foo-query';
+    const [stream, emitter] = mockStream();
+    mockStreamQueries.mockReturnValueOnce(stream);
+    const closeHandler = jest.fn();
+    const hookResult = renderDamlHook(() => useStreamQuery(Foo, () => ({query}), [query], closeHandler));
+    expect(mockStreamQueries).toHaveBeenCalledTimes(1);
+    expect(mockStreamQueries).toHaveBeenLastCalledWith(Foo, [{query}]);
+
+    // no events have been emitted.
+    expect(hookResult.result.current).toEqual({contracts: [], loading:true});
+
+    expect(closeHandler).toHaveBeenCalledTimes(0);
+    act(() => void emitter.emit('close', {code: 4000, reason: ''}));
+    expect(closeHandler).toHaveBeenCalledTimes(1);
+    expect(closeHandler).toHaveBeenLastCalledWith({code: 4000, reason: ''});
+  });
+
   test('empty stream', () => {
     // setup
     const query = 'foo-query';


### PR DESCRIPTION
As requested on [the forum].

[the forum]:
https://discuss.daml.com/t/usestreamquery-disconnecting/1325

```
CHANGELOG_BEGIN
* JavaScript Client Libraries: `useStreamQuery` and
  `useStreamFetchByKey` now accept an optional `closeHandler` callback,
  which will be called if the underlying WebSocket connection fails.
CHANGELOG_END
```