### PR TITLE
Support multi-party reads on the JSON API

### DIFF
--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -33,6 +33,7 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_tpolecat_doobie_core_2_12",
         "@maven//:org_tpolecat_doobie_free_2_12",
+        "@maven//:org_tpolecat_doobie_postgres_2_12",
         "@maven//:org_typelevel_cats_core_2_12",
         "@maven//:org_typelevel_cats_effect_2_12",
         "@maven//:org_typelevel_cats_free_2_12",

--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -33,7 +33,6 @@ da_scala_library(
         "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_tpolecat_doobie_core_2_12",
         "@maven//:org_tpolecat_doobie_free_2_12",
-        "@maven//:org_tpolecat_doobie_postgres_2_12",
         "@maven//:org_typelevel_cats_core_2_12",
         "@maven//:org_typelevel_cats_effect_2_12",
         "@maven//:org_typelevel_cats_free_2_12",

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -154,7 +154,7 @@ object Queries {
       tpid: SurrogateTpId,
       newOffset: String)(implicit log: LogHandler): ConnectionIO[Int] = {
     val upd = Update[(String, SurrogateTpId, String)](
-      """INSERT INTO ledger_offset VALUES(?, ?, ?) ON CONFLICT (party, tpid) DO UPDATE SET last_offset = EXCLUDED.last_offset""",
+      """INSERT INTO ledger_offset VALUES(?, ?, ?) ON CONFLICT (party, tpid) DO UPDATE SET last_offset = EXCLUDED.last_offset WHERE ledger_offset.last_offset < EXCLUDED.last_offset""",
       logHandler0 = log)
     upd.updateMany(parties.map(p => (p, tpid, newOffset)))
   }

--- a/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
+++ b/ledger-service/db-backend/src/main/scala/com/digitalasset/http/dbbackend/Queries.scala
@@ -8,7 +8,6 @@ import com.github.ghik.silencer.silent
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import scalaz.{@@, Foldable, Functor, OneAnd, Tag}
 import scalaz.syntax.foldable._
 import scalaz.syntax.functor._
@@ -124,9 +123,10 @@ object Queries {
       )
     }
 
+  @silent("pls .* never used")
   def lastOffset(parties: Set[String], tpid: SurrogateTpId)(
-      implicit log: LogHandler): ConnectionIO[Option[String]] =
-    sql"""SELECT min(last_offset), count(last_offset) FROM ledger_offset WHERE (party = ANY(${parties.toList}) AND tpid = $tpid)"""
+      implicit log: LogHandler, pls: Put[Array[String]]): ConnectionIO[Option[String]] =
+    sql"""SELECT min(last_offset), count(last_offset) FROM ledger_offset WHERE (party = ANY(${parties.toArray}) AND tpid = $tpid)"""
       .query[(Option[String], Int)]
       .unique
       .map {
@@ -199,12 +199,13 @@ object Queries {
   }
 
   @silent(" gvs .* never used")
+  @silent(" pas .* never used")
   private[http] def selectContracts(
-      parties: List[String],
+      parties: Array[String],
       tpid: SurrogateTpId,
       predicate: Fragment)(
       implicit log: LogHandler,
-      gvs: Get[Vector[String]]): Query0[DBContract[Unit, JsValue, JsValue, Vector[String]]] = {
+      gvs: Get[Vector[String]], pas: Put[Array[String]]): Query0[DBContract[Unit, JsValue, JsValue, Vector[String]]] = {
     val q = sql"""SELECT contract_id, key, payload, signatories, observers, agreement_text
                   FROM contract AS c
                   WHERE (signatories && $parties::text[] OR observers && $parties::text[])

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
@@ -173,7 +173,6 @@ object Main extends StrictLogging {
   }
 
   private def getLedgerId(jwt: Jwt): EndpointsCompanion.Unauthorized \/ LedgerId = {
-    import EndpointsCompanion.JwtPayloadInstances._
     EndpointsCompanion
       .decodeAndParsePayload[JwtPayload](jwt, HttpService.decodeJwt)
       .map { case (_, payload) => payload.ledgerId }

--- a/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
+++ b/ledger-service/http-json-perf/src/main/scala/com/daml/http/perf/Main.scala
@@ -10,7 +10,7 @@ import akka.stream.Materializer
 import com.daml.gatling.stats.{SimulationLog, SimulationLogSyntax}
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.http.HttpServiceTestFixture.withHttpService
-import com.daml.http.domain.LedgerId
+import com.daml.http.domain.{JwtPayload, LedgerId}
 import com.daml.http.perf.scenario.SimulationConfig
 import com.daml.http.util.FutureUtil._
 import com.daml.http.{EndpointsCompanion, HttpService, JdbcConfig}
@@ -172,10 +172,12 @@ object Main extends StrictLogging {
     }
   }
 
-  private def getLedgerId(jwt: Jwt): EndpointsCompanion.Unauthorized \/ LedgerId =
+  private def getLedgerId(jwt: Jwt): EndpointsCompanion.Unauthorized \/ LedgerId = {
+    import EndpointsCompanion.JwtPayloadInstances._
     EndpointsCompanion
-      .decodeAndParsePayload(jwt, HttpService.decodeJwt)
+      .decodeAndParsePayload[JwtPayload](jwt, HttpService.decodeJwt)
       .map { case (_, payload) => payload.ledgerId }
+  }
 
   private def runGatlingScenario(config: Config[String], jsonApiHost: String, jsonApiPort: Int)(
       implicit sys: ActorSystem,

--- a/ledger-service/http-json/src/it/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -111,8 +111,6 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
 
   protected val jwt: Jwt = jwtForParties(List("Alice"))
 
-  protected val multiPartyJwt: Jwt = jwtForParties(List("Alice", "Bob"))
-
   protected val jwtAdminNoParty: Jwt = {
     val decodedJwt = DecodedJwt(
       """{"alg": "HS256", "typ": "JWT"}""",

--- a/ledger-service/http-json/src/it/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -223,12 +223,13 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
       templateId: domain.TemplateId.OptionalPkg,
       contractId: domain.ContractId,
       encoder: DomainJsonEncoder,
-      uri: Uri): Future[(StatusCode, JsValue)] = {
+      uri: Uri,
+      headers: List[HttpHeader] = headersWithAuth): Future[(StatusCode, JsValue)] = {
     val ref = domain.EnrichedContractId(Some(templateId), contractId)
     val cmd = archiveCommand(ref)
     for {
       json <- toFuture(encoder.encodeExerciseCommand(cmd)): Future[JsValue]
-      result <- postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), json)
+      result <- postJsonRequest(uri.withPath(Uri.Path("/v1/exercise")), json, headers)
     } yield result
   }
 

--- a/ledger-service/http-json/src/it/scala/http/AbstractHttpServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/AbstractHttpServiceIntegrationTest.scala
@@ -17,7 +17,7 @@ import com.daml.api.util.TimestampConversion
 import com.daml.bazeltools.BazelRunfiles.requiredResource
 import com.daml.lf.data.Ref
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
-import HttpServiceTestFixture.{jsonCodecs, UseTls}
+import HttpServiceTestFixture.{UseTls, jsonCodecs}
 import com.daml.http.domain.ContractId
 import com.daml.http.domain.TemplateId.OptionalPkg
 import com.daml.http.json.SprayJson.{decode, decode1, objectField}
@@ -27,6 +27,7 @@ import com.daml.http.util.FutureUtil.toFuture
 import com.daml.http.util.{FutureUtil, TestUtil}
 import com.daml.jwt.JwtSigner
 import com.daml.jwt.domain.{DecodedJwt, Jwt}
+import com.daml.ledger.api.auth.{AuthServiceJWTPayload, AuthServiceJWTCodec}
 import com.daml.ledger.api.refinements.{ApiTypes => lar}
 import com.daml.ledger.api.v1.{value => v}
 import com.daml.ledger.client.LedgerClient
@@ -89,15 +90,28 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
   protected val metdata2: MetadataReader.LfMetadata =
     MetadataReader.readFromDar(dar2).valueOr(e => fail(s"Cannot read dar2 metadata: $e"))
 
-  protected val jwt: Jwt = {
+  protected def jwtForParties(parties: List[String]) = {
+    import AuthServiceJWTCodec.JsonImplicits._
     val decodedJwt = DecodedJwt(
       """{"alg": "HS256", "typ": "JWT"}""",
-      s"""{"https://daml.com/ledger-api": {"ledgerId": "${testId: String}", "applicationId": "test", "actAs": ["Alice"]}}"""
+      AuthServiceJWTPayload(
+        ledgerId = Some(testId),
+        applicationId = Some("test"),
+        actAs = parties,
+        participantId = None,
+        exp = None,
+        admin = false,
+        readAs = List()
+      ).toJson.prettyPrint
     )
     JwtSigner.HMAC256
       .sign(decodedJwt, "secret")
       .fold(e => fail(s"cannot sign a JWT: ${e.shows}"), identity)
   }
+
+  protected val jwt: Jwt = jwtForParties(List("Alice"))
+
+  protected val multiPartyJwt: Jwt = jwtForParties(List("Alice", "Bob"))
 
   protected val jwtAdminNoParty: Jwt = {
     val decodedJwt = DecodedJwt(
@@ -156,6 +170,9 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
 
   protected val headersWithAuth = authorizationHeader(jwt)
 
+  protected def headersWithPartyAuth(parties: List[String]) =
+    authorizationHeader(jwtForParties(parties))
+
   protected def authorizationHeader(token: Jwt): List[Authorization] =
     List(Authorization(OAuth2BearerToken(token.value)))
 
@@ -193,11 +210,12 @@ trait AbstractHttpServiceIntegrationTestFuns extends StrictLogging {
   protected def postCreateCommand(
       cmd: domain.CreateCommand[v.Record],
       encoder: DomainJsonEncoder,
-      uri: Uri): Future[(StatusCode, JsValue)] = {
+      uri: Uri,
+      headers: List[HttpHeader] = headersWithAuth): Future[(StatusCode, JsValue)] = {
     import encoder.implicits._
     for {
       json <- toFuture(SprayJson.encode1(cmd)): Future[JsValue]
-      result <- postJsonRequest(uri.withPath(Uri.Path("/v1/create")), json)
+      result <- postJsonRequest(uri.withPath(Uri.Path("/v1/create")), json, headers = headers)
     } yield result
   }
 
@@ -463,23 +481,16 @@ abstract class AbstractHttpServiceIntegrationTest
     with Inside
     with StrictLogging
     with AbstractHttpServiceIntegrationTestFuns {
+
   import json.JsonProtocol._
 
   override final def useTls = UseTls.NoTls
 
   "query GET empty results" in withHttpService { (uri: Uri, _, _) =>
-    getRequest(uri = uri.withPath(Uri.Path("/v1/query")))
-      .flatMap {
-        case (status, output) =>
-          status shouldBe StatusCodes.OK
-          assertStatus(output, StatusCodes.OK)
-          inside(output) {
-            case JsObject(fields) =>
-              inside(fields.get("result")) {
-                case Some(JsArray(vector)) => vector should have size 0L
-              }
-          }
-      }: Future[Assertion]
+    searchAllExpectOk(uri).flatMap {
+      case vector => vector should have size 0L
+    }
+
   }
 
   protected val searchDataSet: List[domain.CreateCommand[v.Record]] = List(
@@ -509,6 +520,26 @@ abstract class AbstractHttpServiceIntegrationTest
     }
   }
 
+  "multi-party query GET" in withHttpService { (uri, encoder, _) =>
+    for {
+      _ <- postCreateCommand(
+        accountCreateCommand(owner = domain.Party("Alice"), number = "42"),
+        encoder,
+        uri).map(r => r._1 shouldBe StatusCodes.OK)
+      _ <- postCreateCommand(
+        accountCreateCommand(owner = domain.Party("Bob"), number = "23"),
+        encoder,
+        uri,
+        headers = headersWithPartyAuth(List("Bob"))).map(r => r._1 shouldBe StatusCodes.OK)
+      _ <- searchAllExpectOk(uri, headersWithPartyAuth(List("Alice"))).map(cs =>
+        cs should have size 1)
+      _ <- searchAllExpectOk(uri, headersWithPartyAuth(List("Bob"))).map(cs =>
+        cs should have size 1)
+      _ <- searchAllExpectOk(uri, headersWithPartyAuth(List("Alice", "Bob"))).map(cs =>
+        cs should have size 2)
+    } yield succeed
+  }
+
   "query POST with empty query" in withHttpService { (uri, encoder, _) =>
     searchExpectOk(
       searchDataSet,
@@ -517,6 +548,45 @@ abstract class AbstractHttpServiceIntegrationTest
       encoder
     ).map { acl: List[domain.ActiveContract[JsValue]] =>
       acl.size shouldBe searchDataSet.size
+    }
+  }
+
+  "multi-party query POST with empty query" in withHttpService { (uri, encoder, _) =>
+    for {
+      aliceAccountResp <- postCreateCommand(
+        accountCreateCommand(owner = domain.Party("Alice"), number = "42"),
+        encoder,
+        uri)
+      _ = aliceAccountResp._1 shouldBe StatusCodes.OK
+      bobAccountResp <- postCreateCommand(
+        accountCreateCommand(owner = domain.Party("Bob"), number = "23"),
+        encoder,
+        uri,
+        headers = headersWithPartyAuth(List("Bob")))
+      _ = bobAccountResp._1 shouldBe StatusCodes.OK
+      _ <- searchExpectOk(
+        List(),
+        jsObject("""{"templateIds": ["Account:Account"]}"""),
+        uri,
+        encoder,
+        headers = headersWithPartyAuth(List("Alice")))
+        .map(acl => acl.size shouldBe 1)
+      _ <- searchExpectOk(
+        List(),
+        jsObject("""{"templateIds": ["Account:Account"]}"""),
+        uri,
+        encoder,
+        headers = headersWithPartyAuth(List("Bob")))
+        .map(acl => acl.size shouldBe 1)
+      _ <- searchExpectOk(
+        List(),
+        jsObject("""{"templateIds": ["Account:Account"]}"""),
+        uri,
+        encoder,
+        headers = headersWithPartyAuth(List("Alice", "Bob")))
+        .map(acl => acl.size shouldBe 2)
+    } yield {
+      assert(true)
     }
   }
 
@@ -579,6 +649,7 @@ abstract class AbstractHttpServiceIntegrationTest
 
           def queryAmountAs(s: String) =
             jsObject(s"""{"templateIds": ["Iou:Iou"], "query": {"amount": $s}}""")
+
           val queryAmountAsString = queryAmountAs("\"111.11\"")
           val queryAmountAsNumber = queryAmountAs("111.11")
 
@@ -644,36 +715,55 @@ abstract class AbstractHttpServiceIntegrationTest
     r.valueOr(e => fail(e.shows))
   }
 
+  private def expectOk[R](resp: domain.SyncResponse[R]): R = resp match {
+    case ok: domain.OkResponse[_] =>
+      ok.status shouldBe StatusCodes.OK
+      ok.warnings shouldBe 'empty
+      ok.result
+    case err: domain.ErrorResponse =>
+      fail(s"Expected OK response, got: $err")
+  }
+
   protected def searchExpectOk(
       commands: List[domain.CreateCommand[v.Record]],
       query: JsObject,
       uri: Uri,
-      encoder: DomainJsonEncoder): Future[List[domain.ActiveContract[JsValue]]] = {
-    search(commands, query, uri, encoder).map {
-      case ok: domain.OkResponse[_] =>
-        ok.status shouldBe StatusCodes.OK
-        ok.warnings shouldBe 'empty
-        ok.result
-      case err: domain.ErrorResponse =>
-        fail(s"Expected OK response, got: $err")
-    }
+      encoder: DomainJsonEncoder,
+      headers: List[HttpHeader] = headersWithAuth): Future[List[domain.ActiveContract[JsValue]]] = {
+    search(commands, query, uri, encoder, headers).map(expectOk(_))
   }
 
   protected def search(
       commands: List[domain.CreateCommand[v.Record]],
       query: JsObject,
       uri: Uri,
-      encoder: DomainJsonEncoder): Future[
+      encoder: DomainJsonEncoder,
+      headers: List[HttpHeader] = headersWithAuth): Future[
     domain.SyncResponse[List[domain.ActiveContract[JsValue]]]
   ] = {
-    commands.traverse(c => postCreateCommand(c, encoder, uri)).flatMap { rs =>
+    commands.traverse(c => postCreateCommand(c, encoder, uri, headers)).flatMap { rs =>
       rs.map(_._1) shouldBe List.fill(commands.size)(StatusCodes.OK)
-      postJsonRequest(uri.withPath(Uri.Path("/v1/query")), query).flatMap {
+      postJsonRequest(uri.withPath(Uri.Path("/v1/query")), query, headers).flatMap {
         case (_, output) =>
           FutureUtil.toFuture(
             decode1[domain.SyncResponse, List[domain.ActiveContract[JsValue]]](output))
       }
     }
+  }
+
+  protected def searchAllExpectOk(
+      uri: Uri,
+      headers: List[HttpHeader] = headersWithAuth): Future[List[domain.ActiveContract[JsValue]]] =
+    searchAll(uri, headers).map(expectOk(_))
+
+  protected def searchAll(uri: Uri, headers: List[HttpHeader])
+    : Future[domain.SyncResponse[List[domain.ActiveContract[JsValue]]]] = {
+    getRequest(uri = uri.withPath(Uri.Path("/v1/query")), headers)
+      .flatMap {
+        case (_, output) =>
+          FutureUtil.toFuture(
+            decode1[domain.SyncResponse, List[domain.ActiveContract[JsValue]]](output))
+      }
   }
 
   "create IOU" in withHttpService { (uri, encoder, _) =>

--- a/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
@@ -359,6 +359,110 @@ class WebsocketServiceIntegrationTest
         }
   }
 
+  "multi-party query should receive deltas as contracts are archived/created" in withHttpService {
+    (uri, encoder, _) =>
+      import spray.json._
+
+      val f1 =
+        postCreateCommand(
+          accountCreateCommand(domain.Party("Alice"), "abc123"),
+          encoder,
+          uri,
+          headers = headersWithPartyAuth(List("Alice")))
+      val f2 =
+        postCreateCommand(
+          accountCreateCommand(domain.Party("Bob"), "def456"),
+          encoder,
+          uri,
+          headers = headersWithPartyAuth(List("Bob")))
+
+      val query =
+        """[
+          {"templateIds": ["Account:Account"]}
+        ]"""
+
+      def resp(
+          cid1: domain.ContractId,
+          cid2: domain.ContractId): Sink[JsValue, Future[ShouldHaveEnded]] = {
+        val dslSyntax = Consume.syntax[JsValue]
+        import dslSyntax._
+        Consume.interpret(
+          for {
+            ContractDelta(Vector((account1, _)), Vector(), None) <- readOne
+            _ = Seq(cid1, cid2) should contain(account1)
+            ContractDelta(Vector((account2, _)), Vector(), None) <- readOne
+            _ = Seq(cid1, cid2) should contain(account2)
+            ContractDelta(Vector(), _, Some(liveStartOffset)) <- readOne
+            _ <- liftF(
+              postCreateCommand(
+                accountCreateCommand(domain.Party("Alice"), "abc234"),
+                encoder,
+                uri,
+                headers = headersWithPartyAuth(List("Alice"))))
+            ContractDelta(Vector((_, aliceAccount)), _, Some(_)) <- readOne
+            _ = inside(aliceAccount) {
+              case JsObject(obj) =>
+                inside((obj get "owner", obj get "number")) {
+                  case (Some(JsString(owner)), Some(JsString(number))) =>
+                    owner shouldBe "Alice"
+                    number shouldBe "abc234"
+                }
+            }
+            _ <- liftF(
+              postCreateCommand(
+                accountCreateCommand(domain.Party("Bob"), "def567"),
+                encoder,
+                uri,
+                headers = headersWithPartyAuth(List("Bob"))))
+            ContractDelta(Vector((_, bobAccount)), _, Some(lastSeenOffset)) <- readOne
+            _ = inside(bobAccount) {
+              case JsObject(obj) =>
+                inside((obj get "owner", obj get "number")) {
+                  case (Some(JsString(owner)), Some(JsString(number))) =>
+                    owner shouldBe "Bob"
+                    number shouldBe "def567"
+                }
+            }
+            heartbeats <- drain
+            hbCount = (heartbeats.iterator.map {
+              case ContractDelta(Vector(), Vector(), Some(currentOffset)) => currentOffset
+            }.toSet + lastSeenOffset).size - 1
+          } yield
+            (
+              // don't count empty events block if lastSeenOffset does not change
+              ShouldHaveEnded(
+                liveStartOffset = liveStartOffset,
+                msgCount = 5 + hbCount,
+                lastSeenOffset = lastSeenOffset
+              )
+            ))
+      }
+
+      for {
+        r1 <- f1
+        _ = r1._1 shouldBe 'success
+        cid1 = getContractId(getResult(r1._2))
+
+        r2 <- f2
+        _ = r2._1 shouldBe 'success
+        cid2 = getContractId(getResult(r2._2))
+
+        lastState <- singleClientQueryStream(jwtForParties(List("Alice", "Bob")), uri, query) via parseResp runWith resp(
+          cid1,
+          cid2)
+        liveOffset = inside(lastState) {
+          case ShouldHaveEnded(liveStart, 5, lastSeen) =>
+            lastSeen.unwrap should be > liveStart.unwrap
+            liveStart
+        }
+        rescan <- (singleClientQueryStream(jwt, uri, query, Some(liveOffset))
+          via parseResp runWith remainingDeltas)
+      } yield
+        inside(rescan) {
+          case (Vector(_), _, Some(_)) => succeed
+        }
+  }
+
   "fetch should receive deltas as contracts are archived/created, filtering out phantom archives" in withHttpService {
     (uri, encoder, _) =>
       val templateId = domain.TemplateId(None, "Account", "Account")
@@ -506,6 +610,102 @@ class WebsocketServiceIntegrationTest
       results should matchJsValues(expected)
 
     }
+  }
+
+  "multi-party fetch-by-key query should receive deltas as contracts are archived/created" in withHttpService {
+    (uri, encoder, _) =>
+      import spray.json._
+
+      val templateId = domain.TemplateId(None, "Account", "Account")
+
+      val f1 =
+        postCreateCommand(
+          accountCreateCommand(domain.Party("Alice"), "abc123"),
+          encoder,
+          uri,
+          headers = headersWithPartyAuth(List("Alice")))
+      val f2 =
+        postCreateCommand(
+          accountCreateCommand(domain.Party("Bob"), "def456"),
+          encoder,
+          uri,
+          headers = headersWithPartyAuth(List("Bob")))
+
+      val query =
+        """[
+          {"templateId": "Account:Account", "key": ["Alice", "abc123"]},
+          {"templateId": "Account:Account", "key": ["Bob", "def456"]}
+        ]"""
+
+      def resp(
+          cid1: domain.ContractId,
+          cid2: domain.ContractId): Sink[JsValue, Future[ShouldHaveEnded]] = {
+        val dslSyntax = Consume.syntax[JsValue]
+        import dslSyntax._
+        Consume.interpret(
+          for {
+            ContractDelta(Vector((account1, _)), Vector(), None) <- readOne
+            _ = Seq(cid1, cid2) should contain(account1)
+            ContractDelta(Vector((account2, _)), Vector(), None) <- readOne
+            _ = Seq(cid1, cid2) should contain(account2)
+            ContractDelta(Vector(), _, Some(liveStartOffset)) <- readOne
+            _ <- liftF(postArchiveCommand(templateId, cid1, encoder, uri))
+            ContractDelta(Vector(), Vector(archivedCid1), Some(_)) <- readOne
+            _ = archivedCid1.contractId shouldBe cid1
+            _ <- liftF(
+              postArchiveCommand(
+                templateId,
+                cid2,
+                encoder,
+                uri,
+                headers = headersWithPartyAuth(List("Bob"))))
+            ContractDelta(Vector(), Vector(archivedCid2), Some(lastSeenOffset)) <- readOne
+            _ = archivedCid2.contractId shouldBe cid2
+            heartbeats <- drain
+            hbCount = (heartbeats.iterator
+              .map {
+                case ContractDelta(Vector(), Vector(), Some(currentOffset)) => currentOffset
+              }
+              .toSet)
+              .size - 1
+          } yield
+            (
+              // don't count empty events block if lastSeenOffset does not change
+              ShouldHaveEnded(
+                liveStartOffset = liveStartOffset,
+                msgCount = 5 + hbCount,
+                lastSeenOffset = lastSeenOffset
+              )
+            ))
+      }
+
+      for {
+        r1 <- f1
+        _ = r1._1 shouldBe 'success
+        cid1 = getContractId(getResult(r1._2))
+
+        r2 <- f2
+        _ = r2._1 shouldBe 'success
+        cid2 = getContractId(getResult(r2._2))
+
+        lastState <- singleClientFetchStream(jwtForParties(List("Alice", "Bob")), uri, query) via parseResp runWith resp(
+          cid1,
+          cid2)
+        liveOffset = inside(lastState) {
+          case ShouldHaveEnded(liveStart, 5, lastSeen) =>
+            lastSeen.unwrap should be > liveStart.unwrap
+            liveStart
+        }
+        rescan <- (singleClientFetchStream(
+          jwtForParties(List("Alice", "Bob")),
+          uri,
+          query,
+          Some(liveOffset))
+          via parseResp runWith remainingDeltas)
+      } yield
+        inside(rescan) {
+          case (Vector(), Vector(_, _), Some(_)) => succeed
+        }
   }
 
   "fetch should should return an error if empty list of (templateId, key) pairs is passed" in withHttpService {

--- a/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
@@ -666,7 +666,7 @@ class WebsocketServiceIntegrationTest
               .map {
                 case ContractDelta(Vector(), Vector(), Some(currentOffset)) => currentOffset
               }
-              .toSet)
+              .toSet + lastSeenOffset)
               .size - 1
           } yield
             (

--- a/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/WebsocketServiceIntegrationTest.scala
@@ -662,12 +662,9 @@ class WebsocketServiceIntegrationTest
             ContractDelta(Vector(), Vector(archivedCid2), Some(lastSeenOffset)) <- readOne
             _ = archivedCid2.contractId shouldBe cid2
             heartbeats <- drain
-            hbCount = (heartbeats.iterator
-              .map {
-                case ContractDelta(Vector(), Vector(), Some(currentOffset)) => currentOffset
-              }
-              .toSet + lastSeenOffset)
-              .size - 1
+            hbCount = (heartbeats.iterator.map {
+              case ContractDelta(Vector(), Vector(), Some(currentOffset)) => currentOffset
+            }.toSet + lastSeenOffset).size - 1
           } yield
             (
               // don't count empty events block if lastSeenOffset does not change

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/CommandService.scala
@@ -12,7 +12,7 @@ import com.daml.http.domain.{
   CreateCommand,
   ExerciseCommand,
   ExerciseResponse,
-  JwtPayload
+  JwtWritePayload
 }
 import com.daml.http.util.ClientUtil.uniqueCommandId
 import com.daml.http.util.FutureUtil._
@@ -40,7 +40,7 @@ class CommandService(
 
   import CommandService._
 
-  def create(jwt: Jwt, jwtPayload: JwtPayload, input: CreateCommand[lav1.value.Record])
+  def create(jwt: Jwt, jwtPayload: JwtWritePayload, input: CreateCommand[lav1.value.Record])
     : Future[Error \/ ActiveContract[lav1.value.Value]] = {
 
     val et: ET[ActiveContract[lav1.value.Value]] = for {
@@ -55,7 +55,7 @@ class CommandService(
 
   def exercise(
       jwt: Jwt,
-      jwtPayload: JwtPayload,
+      jwtPayload: JwtWritePayload,
       input: ExerciseCommand[lav1.value.Value, ExerciseCommandRef])
     : Future[Error \/ ExerciseResponse[lav1.value.Value]] = {
 
@@ -73,7 +73,7 @@ class CommandService(
 
   def createAndExercise(
       jwt: Jwt,
-      jwtPayload: JwtPayload,
+      jwtPayload: JwtWritePayload,
       input: CreateAndExerciseCommand[lav1.value.Record, lav1.value.Value])
     : Future[Error \/ ExerciseResponse[lav1.value.Value]] = {
 
@@ -132,7 +132,7 @@ class CommandService(
           .createAndExercise(refApiIdentifier(tpId), input.payload, input.choice, input.argument))
 
   private def submitAndWaitRequest(
-      jwtPayload: JwtPayload,
+      jwtPayload: JwtWritePayload,
       meta: Option[domain.CommandMeta],
       command: lav1.commands.Command.Command): lav1.command_service.SubmitAndWaitRequest = {
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -459,6 +459,6 @@ private[http] object ContractsFetch {
       if (templateIds.isEmpty) Filters.defaultInstance
       else Filters(Some(lav1.transaction_filter.InclusiveFilters(templateIds.map(apiIdentifier))))
 
-    TransactionFilter(Map(parties.map(party => domain.Party.unwrap(party) -> filters).toList: _*))
+    TransactionFilter(domain.Party.unsubst(parties.iterator).map(_ -> filters).toMap)
   }
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -4,7 +4,18 @@
 package com.daml.http
 
 import akka.NotUsed
-import akka.stream.scaladsl.{Broadcast, Concat, Flow, GraphDSL, Keep, Partition, RunnableGraph, Sink, SinkQueueWithCancel, Source}
+import akka.stream.scaladsl.{
+  Broadcast,
+  Concat,
+  Flow,
+  GraphDSL,
+  Keep,
+  Partition,
+  RunnableGraph,
+  Sink,
+  SinkQueueWithCancel,
+  Source
+}
 import akka.stream.{ClosedShape, FanOutShape2, FlowShape, Graph, Materializer}
 import com.daml.scalautil.Statement.discard
 import com.daml.http.dbbackend.ContractDao.StaleOffsetException
@@ -13,7 +24,9 @@ import com.daml.http.dbbackend.Queries.{DBContract, SurrogateTpId}
 import com.daml.http.domain.TemplateId
 import com.daml.http.LedgerClientJwt.Terminates
 import com.daml.http.util.ApiValueToLfValueConverter.apiValueToLfValue
-import com.daml.http.json.JsonProtocol.LfValueDatabaseCodec.{apiValueToJsValue => lfValueToDbJsValue}
+import com.daml.http.json.JsonProtocol.LfValueDatabaseCodec.{
+  apiValueToJsValue => lfValueToDbJsValue
+}
 import com.daml.http.util.IdentifierConverters.apiIdentifier
 import util.{AbsoluteBookmark, BeginBookmark, ContractStreamStep, InsertDeleteStep, LedgerBegin}
 import com.daml.util.ExceptionOps._

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsService.scala
@@ -71,7 +71,7 @@ class ContractsService(
       case domain.EnrichedContractId(Some(templateId), contractId) =>
         Future.successful(resolveTemplateId(templateId).map(x => \/-(x -> contractId)))
       case domain.EnrichedContractId(None, contractId) =>
-        findByContractId(jwt, jwtPayload.party, None, contractId)
+        findByContractId(jwt, jwtPayload.parties, None, contractId)
           .map(_.map(a => \/-(a.templateId -> a.contractId)))
     }
 
@@ -82,14 +82,14 @@ class ContractsService(
   ): Future[Option[domain.ActiveContract[LfValue]]] =
     contractLocator match {
       case domain.EnrichedContractKey(templateId, contractKey) =>
-        findByContractKey(jwt, jwtPayload.party, templateId, contractKey)
+        findByContractKey(jwt, jwtPayload.parties, templateId, contractKey)
       case domain.EnrichedContractId(templateId, contractId) =>
-        findByContractId(jwt, jwtPayload.party, templateId, contractId)
+        findByContractId(jwt, jwtPayload.parties, templateId, contractId)
     }
 
   def findByContractKey(
       jwt: Jwt,
-      party: lar.Party,
+      parties: Set[lar.Party],
       templateId: TemplateId.OptionalPkg,
       contractKey: LfValue,
   ): Future[Option[domain.ActiveContract[LfValue]]] =
@@ -99,7 +99,7 @@ class ContractsService(
 
       predicate = domain.ActiveContract.matchesKey(contractKey) _
 
-      errorOrAc <- searchInMemoryOneTpId(jwt, party, resolvedTemplateId, Map.empty)
+      errorOrAc <- searchInMemoryOneTpId(jwt, parties, resolvedTemplateId, Map.empty)
         .collect {
           case e @ -\/(_) => e
           case a @ \/-(ac) if predicate(ac) => a
@@ -112,7 +112,7 @@ class ContractsService(
 
   def findByContractId(
       jwt: Jwt,
-      party: lar.Party,
+      parties: Set[lar.Party],
       templateId: Option[domain.TemplateId.OptionalPkg],
       contractId: domain.ContractId,
   ): Future[Option[domain.ActiveContract[LfValue]]] =
@@ -123,7 +123,7 @@ class ContractsService(
         Future.successful(allTemplateIds()),
       ): Future[Set[domain.TemplateId.RequiredPkg]]
 
-      errorOrAc <- searchInMemory(jwt, party, resolvedTemplateIds, Map.empty)
+      errorOrAc <- searchInMemory(jwt, parties, resolvedTemplateIds, Map.empty)
         .collect {
           case e @ -\/(_) => e
           case a @ \/-(ac) if isContractId(contractId)(ac) => a
@@ -147,14 +147,14 @@ class ContractsService(
       jwt: Jwt,
       jwtPayload: JwtPayload,
   ): SearchResult[Error \/ domain.ActiveContract[LfValue]] =
-    retrieveAll(jwt, jwtPayload.party)
+    retrieveAll(jwt, jwtPayload.parties)
 
   def retrieveAll(
       jwt: Jwt,
-      party: domain.Party,
+      parties: Set[domain.Party],
   ): SearchResult[Error \/ domain.ActiveContract[LfValue]] =
     domain.OkResponse(
-      Source(allTemplateIds()).flatMapConcat(x => searchInMemoryOneTpId(jwt, party, x, Map.empty))
+      Source(allTemplateIds()).flatMapConcat(x => searchInMemoryOneTpId(jwt, parties, x, Map.empty))
     )
 
   def search(
@@ -162,11 +162,11 @@ class ContractsService(
       jwtPayload: JwtPayload,
       request: GetActiveContractsRequest,
   ): SearchResult[Error \/ domain.ActiveContract[JsValue]] =
-    search(jwt, jwtPayload.party, request.templateIds, request.query)
+    search(jwt, jwtPayload.parties, request.templateIds, request.query)
 
   def search(
       jwt: Jwt,
-      party: domain.Party,
+      parties: Set[domain.Party],
       templateIds: OneAnd[Set, domain.TemplateId.OptionalPkg],
       queryParams: Map[String, JsValue],
   ): SearchResult[Error \/ domain.ActiveContract[JsValue]] = {
@@ -185,8 +185,8 @@ class ContractsService(
       )
     } else {
       val source = daoAndFetch.cata(
-        x => searchDb(x._1, x._2)(jwt, party, resolvedTemplateIds, queryParams),
-        searchInMemory(jwt, party, resolvedTemplateIds, queryParams)
+        x => searchDb(x._1, x._2)(jwt, parties, resolvedTemplateIds, queryParams),
+        searchInMemory(jwt, parties, resolvedTemplateIds, queryParams)
           .map(_.flatMap(lfAcToJsAc)),
       )
       domain.OkResponse(source, warnings)
@@ -196,14 +196,14 @@ class ContractsService(
   // we store create arguments as JSON in DB, that is why it is `domain.ActiveContract[JsValue]` in the result
   private def searchDb(dao: dbbackend.ContractDao, fetch: ContractsFetch)(
       jwt: Jwt,
-      party: domain.Party,
+      parties: Set[domain.Party],
       templateIds: Set[domain.TemplateId.RequiredPkg],
       queryParams: Map[String, JsValue],
   ): Source[Error \/ domain.ActiveContract[JsValue], NotUsed] = {
 
     // TODO use `stream` when materializing DBContracts, so we could stream ActiveContracts
     val fv: Future[Vector[domain.ActiveContract[JsValue]]] = dao
-      .transact { searchDb_(fetch, dao.logHandler)(jwt, party, templateIds, queryParams) }
+      .transact { searchDb_(fetch, dao.logHandler)(jwt, parties, templateIds, queryParams) }
       .unsafeToFuture()
 
     Source.future(fv).mapConcat(identity).map(\/.right)
@@ -211,7 +211,7 @@ class ContractsService(
 
   private def searchDb_(fetch: ContractsFetch, doobieLog: doobie.LogHandler)(
       jwt: Jwt,
-      party: domain.Party,
+      parties: Set[domain.Party],
       templateIds: Set[domain.TemplateId.RequiredPkg],
       queryParams: Map[String, JsValue],
   ): doobie.ConnectionIO[Vector[domain.ActiveContract[JsValue]]] = {
@@ -219,24 +219,24 @@ class ContractsService(
     import cats.syntax.traverse._
     import doobie.implicits._
     for {
-      _ <- fetch.fetchAndPersist(jwt, party, templateIds.toList)
+      _ <- fetch.fetchAndPersist(jwt, parties, templateIds.toList)
       cts <- templateIds.toVector
-        .traverse(tpId => searchDbOneTpId_(doobieLog)(party, tpId, queryParams))
+        .traverse(tpId => searchDbOneTpId_(doobieLog)(parties, tpId, queryParams))
     } yield cts.flatten
   }
 
   private[this] def searchDbOneTpId_(doobieLog: doobie.LogHandler)(
-      party: domain.Party,
+      parties: Set[domain.Party],
       templateId: domain.TemplateId.RequiredPkg,
       queryParams: Map[String, JsValue],
   ): doobie.ConnectionIO[Vector[domain.ActiveContract[JsValue]]] = {
     val predicate = valuePredicate(templateId, queryParams)
-    ContractDao.selectContracts(party, templateId, predicate.toSqlWhereClause)(doobieLog)
+    ContractDao.selectContracts(parties, templateId, predicate.toSqlWhereClause)(doobieLog)
   }
 
   private def searchInMemory(
       jwt: Jwt,
-      party: domain.Party,
+      parties: Set[domain.Party],
       templateIds: Set[domain.TemplateId.RequiredPkg],
       queryParams: Map[String, JsValue],
   ): Source[Error \/ domain.ActiveContract[LfValue], NotUsed] = {
@@ -248,7 +248,7 @@ class ContractsService(
     val funPredicates: Map[domain.TemplateId.RequiredPkg, LfValue => Boolean] =
       templateIds.iterator.map(tid => (tid, valuePredicate(tid, queryParams).toFunPredicate)).toMap
 
-    insertDeleteStepSource(jwt, party, templateIds.toList)
+    insertDeleteStepSource(jwt, parties, templateIds.toList)
       .map { step =>
         val (errors, converted) = step.toInsertDelete.partitionMapPreservingIds { apiEvent =>
           domain.ActiveContract
@@ -273,21 +273,21 @@ class ContractsService(
 
   private def searchInMemoryOneTpId(
       jwt: Jwt,
-      party: domain.Party,
+      parties: Set[domain.Party],
       templateId: domain.TemplateId.RequiredPkg,
       queryParams: Map[String, JsValue],
   ): Source[Error \/ domain.ActiveContract[LfValue], NotUsed] =
-    searchInMemory(jwt, party, Set(templateId), queryParams)
+    searchInMemory(jwt, parties, Set(templateId), queryParams)
 
   private[http] def insertDeleteStepSource(
       jwt: Jwt,
-      party: lar.Party,
+      parties: Set[lar.Party],
       templateIds: List[domain.TemplateId.RequiredPkg],
       startOffset: Option[domain.StartingOffset] = None,
       terminates: Terminates = Terminates.AtLedgerEnd,
   ): Source[ContractStreamStep.LAV1, NotUsed] = {
 
-    val txnFilter = util.Transactions.transactionFilterFor(party, templateIds)
+    val txnFilter = util.Transactions.transactionFilterFor(parties, templateIds)
     def source = getActiveContracts(jwt, txnFilter, true)
 
     val transactionsSince

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -6,13 +6,7 @@ package com.daml.http
 import akka.NotUsed
 import akka.http.scaladsl.model.HttpMethods.{GET, POST}
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{
-  Authorization,
-  ModeledCustomHeader,
-  ModeledCustomHeaderCompanion,
-  OAuth2BearerToken,
-  `X-Forwarded-Proto`
-}
+import akka.http.scaladsl.model.headers.{Authorization, ModeledCustomHeader, ModeledCustomHeaderCompanion, OAuth2BearerToken, `X-Forwarded-Proto`}
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Source}
 import akka.util.ByteString
@@ -20,7 +14,7 @@ import com.daml.lf
 import com.daml.http.ContractsService.SearchResult
 import com.daml.http.EndpointsCompanion._
 import com.daml.scalautil.Statement.discard
-import com.daml.http.domain.{JwtWritePayload, JwtPayload}
+import com.daml.http.domain.{JwtPayload, JwtWritePayload}
 import com.daml.http.json._
 import com.daml.http.util.Collections.toNonEmptySet
 import com.daml.http.util.FutureUtil.{either, eitherT}
@@ -32,7 +26,7 @@ import com.typesafe.scalalogging.StrictLogging
 import scalaz.std.scalaFuture._
 import scalaz.syntax.std.option._
 import scalaz.syntax.traverse._
-import scalaz.{-\/, EitherT, NonEmptyList, Show, \/, \/-}
+import scalaz.{-\/, EitherT, NonEmptyList, OneAnd, Show, \/, \/-}
 import spray.json._
 
 import scala.concurrent.duration.FiniteDuration
@@ -404,7 +398,7 @@ class Endpoints(
       reference: domain.ContractLocator[LfValue])
     : Future[Error \/ domain.ResolvedContractRef[ApiValue]] =
     contractsService
-      .resolveContractReference(jwt, jwtPayload.toReadPayload, reference)
+      .resolveContractReference(jwt, OneAnd(jwtPayload.party, Set.empty), reference)
       .map { o: Option[domain.ResolvedContractRef[LfValue]] =>
         val a: Error \/ domain.ResolvedContractRef[LfValue] =
           o.toRightDisjunction(InvalidUserInput(ErrorMessages.cannotResolveTemplateId(reference)))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -6,7 +6,13 @@ package com.daml.http
 import akka.NotUsed
 import akka.http.scaladsl.model.HttpMethods.{GET, POST}
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{Authorization, ModeledCustomHeader, ModeledCustomHeaderCompanion, OAuth2BearerToken, `X-Forwarded-Proto`}
+import akka.http.scaladsl.model.headers.{
+  Authorization,
+  ModeledCustomHeader,
+  ModeledCustomHeaderCompanion,
+  OAuth2BearerToken,
+  `X-Forwarded-Proto`
+}
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Source}
 import akka.util.ByteString

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -59,7 +59,6 @@ class Endpoints(
   import json.JsonProtocol._
   import util.ErrorOps._
   import Uri.Path._
-  import JwtPayloadInstances._
 
   lazy val all: PartialFunction[HttpRequest, Future[HttpResponse]] = {
     case req @ HttpRequest(POST, Uri.Path("/v1/create"), _, _, _) => httpResponse(create(req))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -20,7 +20,7 @@ import com.daml.lf
 import com.daml.http.ContractsService.SearchResult
 import com.daml.http.EndpointsCompanion._
 import com.daml.scalautil.Statement.discard
-import com.daml.http.domain.JwtPayload
+import com.daml.http.domain.{JwtWritePayload, JwtPayload}
 import com.daml.http.json._
 import com.daml.http.util.Collections.toNonEmptySet
 import com.daml.http.util.FutureUtil.{either, eitherT}
@@ -59,6 +59,7 @@ class Endpoints(
   import json.JsonProtocol._
   import util.ErrorOps._
   import Uri.Path._
+  import JwtPayloadInstances._
 
   lazy val all: PartialFunction[HttpRequest, Future[HttpResponse]] = {
     case req @ HttpRequest(POST, Uri.Path("/v1/create"), _, _, _) => httpResponse(create(req))
@@ -86,7 +87,7 @@ class Endpoints(
 
   def create(req: HttpRequest): ET[domain.SyncResponse[JsValue]] =
     for {
-      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtPayload, JsValue)]
+      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
 
       (jwt, jwtPayload, reqBody) = t3
 
@@ -104,7 +105,7 @@ class Endpoints(
 
   def exercise(req: HttpRequest): ET[domain.SyncResponse[JsValue]] =
     for {
-      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtPayload, JsValue)]
+      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
 
       (jwt, jwtPayload, reqBody) = t3
 
@@ -130,7 +131,7 @@ class Endpoints(
 
   def createAndExercise(req: HttpRequest): ET[domain.SyncResponse[JsValue]] =
     for {
-      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtPayload, JsValue)]
+      t3 <- inputJsValAndJwtPayload(req): ET[(Jwt, JwtWritePayload, JsValue)]
 
       (jwt, jwtPayload, reqBody) = t3
 
@@ -171,7 +172,7 @@ class Endpoints(
     } yield domain.OkResponse(jsVal)
 
   def retrieveAll(req: HttpRequest): Future[Error \/ SearchResult[Error \/ JsValue]] =
-    inputAndJwtPayload(req).map {
+    inputAndJwtPayload[JwtPayload](req).map {
       _.map {
         case (jwt, jwtPayload, _) =>
           val result: SearchResult[ContractsService.Error \/ domain.ActiveContract[LfValue]] =
@@ -186,7 +187,7 @@ class Endpoints(
     }
 
   def query(req: HttpRequest): Future[Error \/ SearchResult[Error \/ JsValue]] =
-    inputAndJwtPayload(req).map {
+    inputAndJwtPayload[JwtPayload](req).map {
       _.flatMap {
         case (jwt, jwtPayload, reqBody) =>
           SprayJson
@@ -346,16 +347,18 @@ class Endpoints(
       jsVal <- either(SprayJson.parse(t2._2).liftErr(InvalidUserInput)): ET[JsValue]
     } yield (t2._1, jsVal)
 
-  private[http] def withJwtPayload[A](fa: (Jwt, A)): Unauthorized \/ (Jwt, JwtPayload, A) =
-    decodeAndParsePayload(fa._1, decodeJwt).map(t2 => (t2._1, t2._2, fa._2))
+  private[http] def withJwtPayload[A, P](fa: (Jwt, A))(
+      implicit parse: ParsePayload[P]): Unauthorized \/ (Jwt, P, A) =
+    decodeAndParsePayload[P](fa._1, decodeJwt).map(t2 => (t2._1, t2._2, fa._2))
 
-  private[http] def inputAndJwtPayload(
+  private[http] def inputAndJwtPayload[P](
       req: HttpRequest
-  ): Future[Unauthorized \/ (Jwt, JwtPayload, String)] =
-    input(req).map(_.flatMap(withJwtPayload))
+  )(implicit parse: ParsePayload[P]): Future[Unauthorized \/ (Jwt, P, String)] =
+    input(req).map(_.flatMap(withJwtPayload[String, P]))
 
-  private[http] def inputJsValAndJwtPayload(req: HttpRequest): ET[(Jwt, JwtPayload, JsValue)] =
-    inputJsVal(req).flatMap(x => either(withJwtPayload(x)))
+  private[http] def inputJsValAndJwtPayload[P](req: HttpRequest)(
+      implicit parse: ParsePayload[P]): ET[(Jwt, P, JsValue)] =
+    inputJsVal(req).flatMap(x => either(withJwtPayload[JsValue, P](x)))
 
   private[http] def inputSource(
       req: HttpRequest
@@ -397,11 +400,11 @@ class Endpoints(
 
   private def resolveReference(
       jwt: Jwt,
-      jwtPayload: JwtPayload,
+      jwtPayload: JwtWritePayload,
       reference: domain.ContractLocator[LfValue])
     : Future[Error \/ domain.ResolvedContractRef[ApiValue]] =
     contractsService
-      .resolveContractReference(jwt, jwtPayload, reference)
+      .resolveContractReference(jwt, jwtPayload.toReadPayload, reference)
       .map { o: Option[domain.ResolvedContractRef[LfValue]] =>
         val a: Error \/ domain.ResolvedContractRef[LfValue] =
           o.toRightDisjunction(InvalidUserInput(ErrorMessages.cannotResolveTemplateId(reference)))

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
@@ -133,7 +133,7 @@ object EndpointsCompanion {
                     lar.ApplicationId(applicationId),
                     actAs = payload.actAs.map(lar.Party(_)),
                     readAs = payload.readAs.map(lar.Party(_))
-                ).toRightDisjunction(Unauthorized("No parties in actAs and readAs"))
+                  ).toRightDisjunction(Unauthorized("No parties in actAs and readAs"))
                 } yield payload
             )
         }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/EndpointsCompanion.scala
@@ -128,13 +128,13 @@ object EndpointsCompanion {
                     Unauthorized("ledgerId missing in access token"))
                   applicationId <- payload.applicationId.toRightDisjunction(
                     Unauthorized("applicationId missing in access token"))
-                } yield
-                  JwtPayload(
+                  payload <- JwtPayload(
                     lar.LedgerId(ledgerId),
                     lar.ApplicationId(applicationId),
                     actAs = payload.actAs.map(lar.Party(_)),
                     readAs = payload.readAs.map(lar.Party(_))
-                )
+                ).toRightDisjunction(Unauthorized("No parties in actAs and readAs"))
+                } yield payload
             )
         }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebSocketService.scala
@@ -27,7 +27,7 @@ import scalaz.std.map._
 import scalaz.std.option._
 import scalaz.std.set._
 import scalaz.std.tuple._
-import scalaz.{-\/, Foldable, Liskov, NonEmptyList, Tag, \/, \/-}
+import scalaz.{-\/, Foldable, Liskov, NonEmptyList, OneAnd, Tag, \/, \/-}
 import Liskov.<~<
 import com.daml.http.util.FlowUtil.allowOnlyFirstInput
 import spray.json.{JsArray, JsObject, JsValue, JsonReader}
@@ -389,7 +389,7 @@ class WebSocketService(
 
   private def getTransactionSourceForParty[A: StreamQuery](
       jwt: Jwt,
-      parties: Set[domain.Party],
+      parties: OneAnd[Set, domain.Party],
       offPrefix: Option[domain.StartingOffset],
       request: A): Source[Error \/ Message, NotUsed] = {
     val Q = implicitly[StreamQuery[A]]

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
@@ -15,10 +15,13 @@ import scalaz.\/
 
 import scala.concurrent.Future
 import EndpointsCompanion._
+import com.daml.http.domain.JwtPayload
 
 object WebsocketEndpoints {
   private[http] val tokenPrefix: String = "jwt.token."
   private[http] val wsProtocol: String = "daml.ws.auth"
+
+  import JwtPayloadInstances._
 
   private def findJwtFromSubProtocol(
       upgradeToWebSocket: UpgradeToWebSocket,
@@ -40,7 +43,7 @@ object WebsocketEndpoints {
         s"Missing required $tokenPrefix.[token] or $wsProtocol subprotocol",
       )
       jwt0 <- findJwtFromSubProtocol(req)
-      payload <- decodeAndParsePayload(jwt0, decodeJwt)
+      payload <- decodeAndParsePayload[JwtPayload](jwt0, decodeJwt)
     } yield payload
 }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/WebsocketEndpoints.scala
@@ -21,8 +21,6 @@ object WebsocketEndpoints {
   private[http] val tokenPrefix: String = "jwt.token."
   private[http] val wsProtocol: String = "daml.ws.auth"
 
-  import JwtPayloadInstances._
-
   private def findJwtFromSubProtocol(
       upgradeToWebSocket: UpgradeToWebSocket,
   ): Unauthorized \/ Jwt = {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -66,7 +66,7 @@ object ContractDao {
     import scalaz.syntax.foldable._
     val partyVector = domain.Party.unsubst(parties.toVector)
     val lastOffsetsStr: Map[String, String] = domain.Party.unsubst[Map[?, String], String](
-      domain.Offset.tag.unsubst[Map[domain.Party, ?], String](lastOffsets))
+      domain.Offset.tag.unsubst(lastOffsets))
     for {
       tpId <- Queries.surrogateTemplateId(
         templateId.packageId,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -37,7 +37,8 @@ object ContractDao {
     Queries.dropAllTablesIfExist *> Queries.initDatabase
 
   def lastOffset(parties: Set[domain.Party], templateId: domain.TemplateId.RequiredPkg)(
-      implicit log: LogHandler): ConnectionIO[Option[domain.Offset]] =
+      implicit log: LogHandler): ConnectionIO[Option[domain.Offset]] = {
+    import doobie.postgres.implicits._
     for {
       tpId <- Queries.surrogateTemplateId(
         templateId.packageId,
@@ -45,6 +46,7 @@ object ContractDao {
         templateId.entityName)
       offset <- Queries.lastOffset(parties.map(_.unwrap), tpId).map(_.map(domain.Offset(_)))
     } yield offset
+  }
 
   def updateOffset(
       parties: Set[domain.Party],
@@ -80,7 +82,7 @@ object ContractDao {
         templateId.entityName)
 
       dbContracts <- Queries
-        .selectContracts(parties.map(_.unwrap).toList, tpId, predicate)
+        .selectContracts(parties.map(_.unwrap).toArray, tpId, predicate)
         .to(Vector)
       domainContracts = dbContracts.map(toDomain(templateId))
     } yield domainContracts

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -47,8 +47,10 @@ object ContractDao {
         templateId.entityName)
       offset <- Queries
         .lastOffset(domain.Party.unsubst(parties), tpId)
-        .map(_.map { case (k, v) => (domain.Party(k), domain.Offset(v)) })
-    } yield offset
+    } yield {
+      type L[a] = Map[a, domain.Offset]
+      domain.Party.subst[L, String](domain.Offset.tag.subst(offset))
+    }
   }
 
   def updateOffset(

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -65,14 +65,14 @@ object ContractDao {
     import scalaz.std.set._
     import scalaz.syntax.foldable._
     val partyVector = domain.Party.unsubst(parties.toVector)
+    val lastOffsetsStr: Map[String, String] = domain.Party.unsubst[Map[?, String], String](
+      domain.Offset.tag.unsubst[Map[domain.Party, ?], String](lastOffsets))
     for {
       tpId <- Queries.surrogateTemplateId(
         templateId.packageId,
         templateId.moduleName,
         templateId.entityName)
-      rowCount <- Queries.updateOffset(partyVector, tpId, newOffset.unwrap, lastOffsets.map({
-        case (k, v) => (k.unwrap, v.unwrap)
-      }))
+      rowCount <- Queries.updateOffset(partyVector, tpId, newOffset.unwrap, lastOffsetsStr)
       _ <- if (rowCount == partyVector.size)
         fconn.pure(())
       else

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -65,8 +65,8 @@ object ContractDao {
     import scalaz.std.set._
     import scalaz.syntax.foldable._
     val partyVector = domain.Party.unsubst(parties.toVector)
-    val lastOffsetsStr: Map[String, String] = domain.Party.unsubst[Map[?, String], String](
-      domain.Offset.tag.unsubst(lastOffsets))
+    val lastOffsetsStr: Map[String, String] =
+      domain.Party.unsubst[Map[?, String], String](domain.Offset.tag.unsubst(lastOffsets))
     for {
       tpId <- Queries.surrogateTemplateId(
         templateId.packageId,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -45,7 +45,9 @@ object ContractDao {
         templateId.packageId,
         templateId.moduleName,
         templateId.entityName)
-      offset <- Queries.lastOffset(OneAnd(parties.head.unwrap, domain.Party.unsubst(parties.tail)), tpId).map(_.map { case (k,v) => (domain.Party(k), domain.Offset(v))})
+      offset <- Queries
+        .lastOffset(OneAnd(parties.head.unwrap, domain.Party.unsubst(parties.tail)), tpId)
+        .map(_.map { case (k, v) => (domain.Party(k), domain.Offset(v)) })
     } yield offset
   }
 
@@ -53,7 +55,8 @@ object ContractDao {
       parties: OneAnd[Set, domain.Party],
       templateId: domain.TemplateId.RequiredPkg,
       newOffset: domain.Offset,
-      lastOffsets: Map[domain.Party, domain.Offset])(implicit log: LogHandler): ConnectionIO[Unit] = {
+      lastOffsets: Map[domain.Party, domain.Offset])(
+      implicit log: LogHandler): ConnectionIO[Unit] = {
     import cats.implicits._
     import doobie.postgres.implicits._
     import scalaz.OneAnd._
@@ -65,7 +68,9 @@ object ContractDao {
         templateId.packageId,
         templateId.moduleName,
         templateId.entityName)
-      rowCount <- Queries.updateOffset(partyVector, tpId, newOffset.unwrap, lastOffsets.map({case (k, v) => (k.unwrap, v.unwrap)}))
+      rowCount <- Queries.updateOffset(partyVector, tpId, newOffset.unwrap, lastOffsets.map({
+        case (k, v) => (k.unwrap, v.unwrap)
+      }))
       _ <- if (rowCount == partyVector.size)
         fconn.pure(())
       else
@@ -87,7 +92,10 @@ object ContractDao {
         templateId.entityName)
 
       dbContracts <- Queries
-        .selectContracts(OneAnd(parties.head.unwrap, domain.Party.unsubst(parties.tail)), tpId, predicate)
+        .selectContracts(
+          OneAnd(parties.head.unwrap, domain.Party.unsubst(parties.tail)),
+          tpId,
+          predicate)
         .to(Vector)
       domainContracts = dbContracts.map(toDomain(templateId))
     } yield domainContracts

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -46,7 +46,7 @@ object ContractDao {
         templateId.moduleName,
         templateId.entityName)
       offset <- Queries
-        .lastOffset(OneAnd(parties.head.unwrap, domain.Party.unsubst(parties.tail)), tpId)
+        .lastOffset(domain.Party.unsubst(parties), tpId)
         .map(_.map { case (k, v) => (domain.Party(k), domain.Offset(v)) })
     } yield offset
   }
@@ -92,10 +92,7 @@ object ContractDao {
         templateId.entityName)
 
       dbContracts <- Queries
-        .selectContracts(
-          OneAnd(parties.head.unwrap, domain.Party.unsubst(parties.tail)),
-          tpId,
-          predicate)
+        .selectContracts(domain.Party.unsubst(parties), tpId, predicate)
         .to(Vector)
       domainContracts = dbContracts.map(toDomain(templateId))
     } yield domainContracts

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -61,11 +61,14 @@ object domain {
       applicationId: ApplicationId,
       readAs: List[Party],
       actAs: List[Party],
-      parties: OneAnd[Set, Party]) {
-  }
+      parties: OneAnd[Set, Party]) {}
 
   object JwtPayload {
-    def apply(ledgerId: LedgerId, applicationId: ApplicationId, readAs: List[Party], actAs: List[Party]): Option[JwtPayload] = {
+    def apply(
+        ledgerId: LedgerId,
+        applicationId: ApplicationId,
+        readAs: List[Party],
+        actAs: List[Party]): Option[JwtPayload] = {
       (readAs ++ actAs) match {
         case Nil => None
         case p :: ps =>

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -49,7 +49,20 @@ object domain {
 
   type LfValue = lf.value.Value[lf.value.Value.ContractId]
 
-  case class JwtPayload(ledgerId: LedgerId, applicationId: ApplicationId, party: Party)
+  // Until we get multi-party submissions, write endpoints require a single party.
+  case class JwtWritePayload(ledgerId: LedgerId, applicationId: ApplicationId, party: Party) {
+    def toReadPayload: JwtPayload = JwtPayload(ledgerId, applicationId, List(), List(party))
+  }
+
+  // JWT payload that preserves readAs and actAs and supports multiple parties. This is currently only used for
+  // read endpoints but once we get multi-party submissions, this can also be used for write endpoints.
+  case class JwtPayload(
+      ledgerId: LedgerId,
+      applicationId: ApplicationId,
+      readAs: List[Party],
+      actAs: List[Party]) {
+    val parties: Set[Party] = (readAs ++ actAs).toSet
+  }
 
   case class TemplateId[+PkgId](packageId: PkgId, moduleName: String, entityName: String)
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -13,6 +13,7 @@ import com.daml.ledger.api.{v1 => lav1}
 import scalaz.Isomorphism.{<~>, IsoFunctorTemplate}
 import scalaz.std.list._
 import scalaz.std.option._
+import scalaz.std.string._
 import scalaz.std.vector._
 import scalaz.syntax.show._
 import scalaz.syntax.std.option._
@@ -24,6 +25,7 @@ import scalaz.{
   Bitraverse,
   NonEmptyList,
   OneAnd,
+  Order,
   Semigroup,
   Show,
   Tag,
@@ -182,6 +184,7 @@ object domain {
       lav1.ledger_offset.LedgerOffset(lav1.ledger_offset.LedgerOffset.Value.Absolute(unwrap(o)))
 
     implicit val semigroup: Semigroup[Offset] = Tag.unsubst(Semigroup[Offset @@ Tags.LastVal])
+    implicit val ordering: Order[Offset] = Order.orderBy[Offset, String](Offset.unwrap(_))
   }
 
   final case class StartingOffset(offset: Offset)

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
@@ -10,6 +10,10 @@ import com.daml.ledger.api.v1.event.{ArchivedEvent, CreatedEvent}
 import com.daml.ledger.api.v1.transaction.Transaction
 import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, TransactionFilter}
 import com.daml.ledger.api.refinements.{ApiTypes => lar}
+import scalaz.OneAnd
+import scalaz.OneAnd._
+import scalaz.std.set._
+import scalaz.syntax.foldable._
 
 import scala.collection.compat._
 
@@ -23,12 +27,11 @@ object Transactions {
     transaction.events.iterator.flatMap(_.event.archived.toList).to(ImmArraySeq)
 
   def transactionFilterFor(
-      parties: Set[lar.Party],
+      parties: OneAnd[Set, lar.Party],
       templateIds: List[TemplateId.RequiredPkg]): TransactionFilter = {
-
     val filters =
       if (templateIds.isEmpty) Filters.defaultInstance
       else Filters(Some(InclusiveFilters(templateIds.map(apiIdentifier))))
-    TransactionFilter(lar.Party.unsubst(parties.iterator).map(_ -> filters).toMap) // lar.Party.unwrap(party) -> filters))
+    TransactionFilter(lar.Party.unsubst(parties.toVector).map(_ -> filters).toMap)
   }
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
@@ -23,12 +23,12 @@ object Transactions {
     transaction.events.iterator.flatMap(_.event.archived.toList).to(ImmArraySeq)
 
   def transactionFilterFor(
-      party: lar.Party,
+      parties: Set[lar.Party],
       templateIds: List[TemplateId.RequiredPkg]): TransactionFilter = {
 
     val filters =
       if (templateIds.isEmpty) Filters.defaultInstance
       else Filters(Some(InclusiveFilters(templateIds.map(apiIdentifier))))
-    TransactionFilter(Map(lar.Party.unwrap(party) -> filters))
+    TransactionFilter(Map(parties.map(party => lar.Party.unwrap(party) -> filters).toList: _*)) // lar.Party.unwrap(party) -> filters))
   }
 }

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/util/Transactions.scala
@@ -29,6 +29,6 @@ object Transactions {
     val filters =
       if (templateIds.isEmpty) Filters.defaultInstance
       else Filters(Some(InclusiveFilters(templateIds.map(apiIdentifier))))
-    TransactionFilter(Map(parties.map(party => lar.Party.unwrap(party) -> filters).toList: _*)) // lar.Party.unwrap(party) -> filters))
+    TransactionFilter(lar.Party.unsubst(parties.iterator).map(_ -> filters).toMap) // lar.Party.unwrap(party) -> filters))
   }
 }


### PR DESCRIPTION
Given that those aren’t going away and we’re instead doubling down on
this and adding multi-party writes as well, the JSON API needs to
support this. This PR only implements the read side (since the ledgers
do not yet support the write side).

This does not deviate from the approach chosen by the JSON API to
infer the parties from the token, we just don’t error out anymore when
more than one party is passed.

At the very least, this definitely needs more tests, so this is a draft for now.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
