### PR TITLE
Add metrics for concurrent commands [KVL-583]

### DIFF
--- a/ledger/daml-on-sql/README.rst
+++ b/ledger/daml-on-sql/README.rst
@@ -490,6 +490,13 @@ A timer. Time to fully process a submission (validation, deduplication and
 interpretation) before it is handed over to the ledger to be finalized (either
 committed or rejected).
 
+``daml.commands.submissions_running``
+-------------------------------------
+
+A meter. Number of submissions that are currently being handled by the ledger
+API server (including validation, deduplication, interpretation, and handing
+the transaction to the ledger).
+
 ``daml.commands.valid_submissions``
 -----------------------------------
 
@@ -550,7 +557,18 @@ ledger effective time.
 ------------------------
 
 A timer. Time spent interpreting a valid command into a transaction ready to be
-submitted to the ledger for finalization.
+submitted to the ledger for finalization (includes executing DAML and fetching
+data).
+
+``daml.execution.total_running``
+--------------------------------
+A meter. Number of commands that are currently being interpreted (includes
+executing DAML code and fetching data).
+
+``daml.execution.engine_running``
+--------------------------------
+A meter. Number of commands that are currently being executed by the DAML engine
+(excluding fetching data).
 
 ``daml.index.db.connection.sandbox.pool``
 -----------------------------------------

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandSubmissionService.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/server/api/services/grpc/GrpcCommandSubmissionService.scala
@@ -41,8 +41,9 @@ class GrpcCommandSubmissionService(
   private val validator = new SubmitRequestValidator(new CommandsValidator(ledgerId))
 
   override def submit(request: ApiSubmitRequest): Future[Empty] =
-    Timed.future(
+    Timed.timedAndTrackedFuture(
       metrics.daml.commands.submissions,
+      metrics.daml.commands.submissionsRunning,
       Timed
         .value(
           metrics.daml.commands.validation,

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -27,6 +27,7 @@ final class Metrics(val registry: MetricRegistry) {
 
       val validation: Timer = registry.timer(Prefix :+ "validation")
       val submissions: Timer = registry.timer(Prefix :+ "submissions")
+      val submissionsRunning: Meter = registry.meter(Prefix :+ "submissions_running")
 
       val failedCommandInterpretations: Meter =
         registry.meter(Prefix :+ "failed_command_interpretations")
@@ -53,7 +54,13 @@ final class Metrics(val registry: MetricRegistry) {
         registry.histogram(Prefix :+ "lookup_contract_key_count_per_execution")
       val getLfPackage: Timer = registry.timer(Prefix :+ "get_lf_package")
       val retry: Meter = registry.meter(Prefix :+ "retry")
+
+      // Total time for command execution (including data fetching)
       val total: Timer = registry.timer(Prefix :+ "total")
+      val totalRunning: Meter = registry.meter(Prefix :+ "total_running")
+
+      // Commands being executed by the engine (not currently fetching data)
+      val engineRunning: Meter = registry.meter(Prefix :+ "engine_running")
     }
 
     object kvutils {
@@ -485,6 +492,7 @@ final class Metrics(val registry: MetricRegistry) {
         private val Prefix: MetricName = services.Prefix :+ "write"
 
         val submitTransaction: Timer = registry.timer(Prefix :+ "submit_transaction")
+        val submitTransactionRunning: Meter = registry.meter(Prefix :+ "submit_transaction_running")
         val uploadPackages: Timer = registry.timer(Prefix :+ "upload_packages")
         val allocateParty: Timer = registry.timer(Prefix :+ "allocate_party")
         val submitConfiguration: Timer = registry.timer(Prefix :+ "submit_configuration")

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Timed.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Timed.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.CompletionStage
 
 import akka.Done
 import akka.stream.scaladsl.{Keep, Source}
-import com.codahale.metrics.{Counter, Timer}
+import com.codahale.metrics.{Counter, Meter, Timer}
 import com.daml.concurrent
 import com.daml.dec.DirectExecutionContext
 
@@ -18,12 +18,38 @@ object Timed {
   def value[T](timer: Timer, value: => T): T =
     timer.time(() => value)
 
+  def trackedValue[T](meter: Meter, value: => T): T = {
+    meter.mark(+1)
+    val result = value
+    meter.mark(-1)
+    result
+  }
+
+  def timedAndTrackedValue[T](timer: Timer, meter: Meter, value: => T): T = {
+    Timed.value(timer, trackedValue(meter, value))
+  }
+
   def completionStage[T](timer: Timer, future: => CompletionStage[T]): CompletionStage[T] = {
     val ctx = timer.time()
     future.whenComplete { (_, _) =>
       ctx.stop()
       ()
     }
+  }
+
+  def trackedCompletionStage[T](meter: Meter, future: => CompletionStage[T]): CompletionStage[T] = {
+    meter.mark(+1)
+    future.whenComplete { (_, _) =>
+      meter.mark(-1)
+      ()
+    }
+  }
+
+  def timedAndTrackedCompletionStage[T](
+      timer: Timer,
+      meter: Meter,
+      future: => CompletionStage[T]): CompletionStage[T] = {
+    Timed.completionStage(timer, trackedCompletionStage(meter, future))
   }
 
   def future[T](timer: Timer, future: => Future[T]): Future[T] = {
@@ -45,8 +71,17 @@ object Timed {
     future.andThen { case _ => counter.dec() }(DirectExecutionContext)
   }
 
+  def trackedFuture[T](meter: Meter, future: => Future[T]): Future[T] = {
+    meter.mark(+1)
+    future.andThen { case _ => meter.mark(-1) }(DirectExecutionContext)
+  }
+
   def timedAndTrackedFuture[T](timer: Timer, counter: Counter, future: => Future[T]): Future[T] = {
     Timed.future(timer, trackedFuture(counter, future))
+  }
+
+  def timedAndTrackedFuture[T](timer: Timer, meter: Meter, future: => Future[T]): Future[T] = {
+    Timed.future(timer, trackedFuture(meter, future))
   }
 
   def source[Out, Mat](timer: Timer, source: => Source[Out, Mat]): Source[Out, Mat] = {

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/TimedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/TimedCommandExecutor.scala
@@ -23,6 +23,9 @@ private[apiserver] class TimedCommandExecutor(
       implicit ec: ExecutionContext,
       loggingContext: LoggingContext,
   ): Future[Either[ErrorCause, CommandExecutionResult]] =
-    Timed.future(metrics.daml.execution.total, delegate.execute(commands, submissionSeed))
+    Timed.timedAndTrackedFuture(
+      metrics.daml.execution.total,
+      metrics.daml.execution.totalRunning,
+      delegate.execute(commands, submissionSeed))
 
 }

--- a/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
+++ b/ledger/participant-state-metrics/src/main/scala/com/daml/ledger/participant/state/v1/metrics/TimedWriteService.scala
@@ -19,8 +19,9 @@ final class TimedWriteService(delegate: WriteService, metrics: Metrics) extends 
       transaction: SubmittedTransaction,
       estimatedInterpretationCost: Long
   ): CompletionStage[SubmissionResult] =
-    Timed.completionStage(
+    Timed.timedAndTrackedCompletionStage(
       metrics.daml.services.write.submitTransaction,
+      metrics.daml.services.write.submitTransactionRunning,
       delegate.submitTransaction(
         submitterInfo,
         transactionMeta,


### PR DESCRIPTION
This PR adds metrics for measuring the concurrency of the following running actions:
- Submission service submissions (`SubmissionService.submit()`, from request to response)
- Command execution (total, including data fetching and time model iterations)
- Execution engine (pure command execution, excluding data fetching)
- WriteService submissions (`WriteService.submitTransaction()`)