### PR TITLE
LF: force `actor` field in Exercise Update to be undefined. 

### DIFF
--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -1093,7 +1093,7 @@ message Update {
     // contract id
     Expr cid = 3;
     // actors
-    // *optional since version 1.5*
+    // *Available in version < 1.5*
     Expr actor = 4;
     // argument
     Expr arg = 5;

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -1074,13 +1074,15 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
               "Update.Exercise.choice.choice"
             ),
             cidE = decodeExpr(exercise.getCid, definition),
-            actorsE =
+            actorsE = if (versionIsOlderThan(LV.Features.noExerciseActor)) {
+              if (!exercise.hasActor)
+                throw ParseError(s"Update.Exercise.actors is required by DAML-LF {1.$minor}")
+              Some(decodeExpr(exercise.getActor, definition))
+            } else {
               if (exercise.hasActor)
-                Some(decodeExpr(exercise.getActor, definition))
-              else {
-                assertSince(LV.Features.optionalExerciseActor, "Update.Exercise.actors optional")
-                None
-              },
+                throw ParseError(s"Update.Exercise.actors is not supported by DAML-LF {1.$minor}")
+              None
+            },
             argE = decodeExpr(exercise.getArg, definition)
           )
 

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1.scala
@@ -362,13 +362,16 @@ private[daml] class EncodeV1(val minor: LV.Minor) {
         case UpdateFetch(templateId, contractId) =>
           builder.setFetch(PLF.Update.Fetch.newBuilder().setTemplate(templateId).setCid(contractId))
         case UpdateExercise(templateId, choice, cid, actors, arg) =>
-          if (actors.isEmpty)
-            assertSince(LV.Features.optionalExerciseActor, "Update.Exercise.actors optional")
           val b = PLF.Update.Exercise.newBuilder()
           b.setTemplate(templateId)
           setString(choice, b.setChoiceStr, b.setChoiceInternedStr)
           b.setCid(cid)
-          actors.foreach(b.setActor(_))
+          if (versionIsOlderThan(LV.Features.noExerciseActor))
+            b.setActor(
+              actors.getOrElse(
+                throw EncodeError(s"Update.Exercise.actors is required by DAML-LF 1.$minor")))
+          else if (actors.isDefined)
+            throw EncodeError(s"Update.Exercise.actors is not supported by DAML-LF 1.$minor")
           b.setArg(arg)
           builder.setExercise(b)
         case UpdateGetTime =>

--- a/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
+++ b/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
@@ -121,9 +121,6 @@ class EncodeV1Spec extends WordSpec with Matchers with TableDrivenPropertyChecks
              create @Mod:Person person;
            val anExercise: (ContractId Mod:Person) -> Update Unit = \(cId: ContractId Mod:Person) ->
              exercise @Mod:Person Sleep cId ();
-           val anExerciseWithActor: (ContractId Mod:Person) -> List Party -> Update Int64 =
-             \(cId: ContractId Mod:Person) (parties: List Party) ->
-                exercise_with_actors @Mod:Person Nap cId parties 1;
            val aFecthByKey: Party -> Update <contract: Mod:Person, contractId: ContractId Mod:Person> = \(party: Party) ->
              fetch_by_key @Mod:Person party;
            val aLookUpByKey: Party -> Update (Option (ContractId Mod:Person)) = \(party: Party) ->

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -47,7 +47,7 @@ object LanguageVersion {
     val contractKeys = v1_3
     val textMap = v1_3
     val complexContactKeys = v1_4
-    val optionalExerciseActor = v1_5
+    val noExerciseActor = v1_5
     val numberParsing = v1_5
     val coerceContractId = v1_5
     val textPacking = v1_6

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -351,11 +351,6 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       case t ~ choice ~ cid ~ arg => UpdateExercise(t, choice, cid, None, arg)
     }
 
-  private lazy val updateExerciseWithActors =
-    `exercise_with_actors` ~! `@` ~> fullIdentifier ~ id ~ expr0 ~ expr0 ~ expr0 ^^ {
-      case t ~ choice ~ cid ~ actor ~ arg => UpdateExercise(t, choice, cid, Some(actor), arg)
-    }
-
   private lazy val updateFetchByKey =
     `fetch_by_key` ~! `@` ~> fullIdentifier ~ expr ^^ {
       case t ~ eKey => UpdateFetchByKey(RetrieveByKey(t, eKey))
@@ -380,7 +375,6 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
       updateCreate |
       updateFetch |
       updateExercise |
-      updateExerciseWithActors |
       updateFetchByKey |
       updateLookupByKey |
       updateGetTime |

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -35,7 +35,6 @@ private[parser] object Lexer extends RegexParsers {
     "create" -> `create`,
     "fetch" -> `fetch`,
     "exercise" -> `exercise`,
-    "exercise_with_actors" -> `exercise_with_actors`,
     "fetch_by_key" -> `fetch_by_key`,
     "lookup_by_key" -> `lookup_by_key`,
     "by" -> `by`,

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -46,7 +46,6 @@ private[parser] object Token {
   case object `create` extends Token
   case object `fetch` extends Token
   case object `exercise` extends Token
-  case object `exercise_with_actors` extends Token
   case object `fetch_by_key` extends Token
   case object `lookup_by_key` extends Token
   case object `by` extends Token

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -349,8 +349,6 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
           UpdateFetch(T.tycon, e"e"),
         "exercise @Mod:T Choice cid arg" ->
           UpdateExercise(T.tycon, n"Choice", e"cid", None, e"arg"),
-        "exercise_with_actors @Mod:T Choice cid actor arg" ->
-          UpdateExercise(T.tycon, n"Choice", e"cid", Some(e"actor"), e"arg"),
         "fetch_by_key @Mod:T e" ->
           UpdateFetchByKey(RetrieveByKey(T.tycon, e"e")),
         "lookup_by_key @Mod:T e" ->

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -200,7 +200,7 @@ Version: 1.5 (deprecated)
 
   + **Add** ``COERCE_CONTRACT_ID`` primitive for coercing ``ContractId``.
 
-  + **Change** ``Update.Exercise`` such that ``actor`` is dropped.
+  + **Change** ``Update.Exercise`` such that ``actor`` must not be set anymore.
 
   + **Add** ``FROM_TEXT_INT64`` and ``FROM_TEXT_DECIMAL`` primitives for
     parsing integer and decimal values.

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -200,7 +200,7 @@ Version: 1.5 (deprecated)
 
   + **Add** ``COERCE_CONTRACT_ID`` primitive for coercing ``ContractId``.
 
-  + **Change** ``Update.Exercise`` such that ``actor`` is now optional.
+  + **Change** ``Update.Exercise`` such that ``actor`` is dropped.
 
   + **Add** ``FROM_TEXT_INT64`` and ``FROM_TEXT_DECIMAL`` primitives for
     parsing integer and decimal values.

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -246,8 +246,6 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           T"Mod:T → (( Update (ContractId Mod:T) ))",
         E"λ (e₁: ContractId Mod:T) (e₂: Int64) → (( exercise @Mod:T Ch e₁ e₂ ))" ->
           T"ContractId Mod:T → Int64 → (( Update Decimal ))",
-        E"λ (e₁: ContractId Mod:T) (e₂: List Party) (e₃: Int64) → (( exercise_with_actors @Mod:T Ch e₁ e₂ e₃ ))" ->
-          T"ContractId Mod:T → List Party → Int64 → (( Update Decimal ))",
         E"λ (e: ContractId Mod:T) → (( fetch @Mod:T e ))" ->
           T"ContractId Mod:T → (( Update Mod:T ))",
         E"fetch_by_key @Mod:T 'Bob'" ->


### PR DESCRIPTION
This PR forces the field 'actor' from 'Exercise' to be undefined
starting from LF 1.5.

This breaking change is approved by @bame-da  and @shaul-da.
It will affect only handcrafted LF archives, as no compiler
from SDK 1.0.0 or latter make use of this field.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
