### PR TITLE
ci/cron: move Bash cron inside Haskell script

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -190,47 +190,9 @@ jobs:
       - bash: |
           set -euo pipefail
           eval "$(dev-env/bin/dade assist)"
-          source $(bash_lib)
 
-          LOG=$(mktemp)
-
-          DIR=$(mktemp -d)
-          trap "rm -rf \"$DIR\"" EXIT
-          cd "$DIR"
-
-          shopt -s extglob # enable !() pattern: things that _don't_ match
-
-          # TODO: get all releases (GH paginates by 30)
-          RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s)
-          for i in $(seq 1 $(echo "$RELEASES" | jq length)); do
-              VERSION=$(echo "$RELEASES" | jq -r ".[$i-1].tag_name")
-              mkdir "$VERSION"
-              cd "$VERSION"
-              PIDS=""
-              for ass in $(seq 1 $(echo "$RELEASES" | jq ".[$i-1].assets | length")); do
-                  {
-                      wget --quiet "$(echo "$RELEASES" | jq -r ".[$i-1].assets[$ass-1].browser_download_url")" &
-                  } >$LOG 2>&1
-                  PIDS="$PIDS $!"
-              done
-              for pid in $PIDS; do
-                  wait $pid >$LOG 2>&1
-              done
-              for f in !(*.asc); do
-                  p=github/$VERSION/$f
-                  if ! test -f $f.asc; then
-                      echo $p: no signature file
-                  else
-                      if gpg_verify $f.asc >$LOG 2>&1; then
-                          echo $p: signature matches
-                      else
-                          echo $p: signature does not match
-                      fi
-                  fi
-              done
-              cd "$DIR"
-              rm -rf "$VERSION"
-          done
+          bazel build //ci/cron:cron
+          bazel-bin/ci/cron/cron check --bash-lib $(bash_lib)
         displayName: check releases
         env:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)


### PR DESCRIPTION
Yes, this is how I write Haskell. I'm told it's an improvement over Bash.

Jokes aside, plan is to chip away at the Bash script, starting with replacing the outermost loop with a proper "get _all_ releases" call from Haskell, but I like keeping things working in small steps, and even long-term I have no desire to reimplement the gpg signature checking code in Haskell.

I have tested that things still work (on my machine); the only difference is that we now only get the full output all at once at the end, rather than one signature at a time. I don't think anyone is looking at the output in real-time, so this should not be a huge issue.

CHANGELOG_BEGIN
CHANGELOG_END