### PR TITLE
Trigger monad's Submit emits a command ID instead of accepting one

### DIFF
--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -95,15 +95,12 @@ data Trigger s = Trigger
 -- a failing completion.
 emitCommands : [Command] -> [AnyContractId] -> TriggerA CommandId
 emitCommands cmds pending = do
-  state <- TriggerA get
-  let id = CommandId $ show $ state.nextCommandId
+  id <- submitCommands cmds
   let commands = Commands id cmds
   TriggerA $ modify $ \s -> s
     { emittedCommands = commands :: s.emittedCommands
     , pendingContracts = Map.insert id pending s.pendingContracts
-    , nextCommandId = s.nextCommandId + 1
     }
-  submitCommands commands
   pure id
 
 -- | Create the template if it’s not already in the list of commands
@@ -187,7 +184,7 @@ runTrigger userTrigger = LowLevel.Trigger
     initialState party (ActiveContracts createdEvents) =
       let acs = foldl (\acs created -> applyEvent (CreatedEvent created) acs) (ACS mempty Map.empty) createdEvents
           userState = userTrigger.initialize acs
-          state = TriggerState acs party userState Map.empty 0
+          state = TriggerState acs party userState Map.empty
       in TriggerSetup $ execStateT (runTriggerRule $ runRule userTrigger.rule) state
     update msg = do
       time <- getTime

--- a/triggers/daml/Daml/Trigger/Assert.daml
+++ b/triggers/daml/Daml/Trigger/Assert.daml
@@ -65,6 +65,11 @@ testRule trigger party acsBuilder commandsInFlight s = do
         , userState = s
         , commandsInFlight = commandsInFlight
         }
+  -- A sufficiently powerful `TriggerF` command will entail redoing this as a
+  -- natural transformation from `Free TriggerF` to `Free ScriptF`, which in
+  -- turn will likely require exposing `ScriptF` or both in some "internal"
+  -- fashion.  Meanwhile, it is worth pushing `simulateRule` as far as possible
+  -- to forestall that outcome. -SC
   let (_, commands, _) = simulateRule (runRule trigger.rule) time state
   pure commands
 

--- a/triggers/daml/Daml/Trigger/Assert.daml
+++ b/triggers/daml/Daml/Trigger/Assert.daml
@@ -64,7 +64,6 @@ testRule trigger party acsBuilder commandsInFlight s = do
         , party = party
         , userState = s
         , commandsInFlight = commandsInFlight
-        , nextCommandId = 0
         }
   let (_, commands, _) = simulateRule (runRule trigger.rule) time state
   pure commands

--- a/triggers/daml/Daml/Trigger/Internal.daml
+++ b/triggers/daml/Daml/Trigger/Internal.daml
@@ -108,11 +108,11 @@ runRule rule = do
   state <- get
   TriggerRule . zoom zoomIn zoomOut . runTriggerRule . runTriggerA
       $ rule state.party state.acs state.commandsInFlight state.userState
-  where zoomIn state = TriggerAState state.commandsInFlight [] state.acs.pendingContracts state.nextCommandId
+  where zoomIn state = TriggerAState state.commandsInFlight [] state.acs.pendingContracts
         zoomOut state aState =
           let commandsInFlight = foldl addCommands state.commandsInFlight aState.emittedCommands
               acs = state.acs { pendingContracts = aState.pendingContracts }
-          in state { nextCommandId = aState.nextCommandId, commandsInFlight, acs }
+          in state { commandsInFlight, acs }
 
 runTriggerA : TriggerA a -> TriggerRule TriggerAState a
 runTriggerA (TriggerA f) = do
@@ -131,8 +131,6 @@ data TriggerAState = TriggerAState
   -- ^ Emitted commands in reverse because I can’t be bothered to implement a dlist.
   , pendingContracts : Map CommandId [AnyContractId]
   -- ^ Map from command ids to the contract ids marked pending by that command.
-  , nextCommandId : Int
-  -- ^ Command id used for the next submit
   }
 
 data TriggerState s = TriggerState
@@ -140,5 +138,4 @@ data TriggerState s = TriggerState
   , party : Party
   , userState : s
   , commandsInFlight : Map CommandId [Command]
-  , nextCommandId : Int
   }

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -46,7 +46,6 @@ module Daml.Trigger.LowLevel
   ) where
 
 import qualified DA.Action.State as State
-import DA.Foldable (mapA_)
 import DA.Functor ((<&>), ($>))
 import DA.Next.Map (MapKey(..))
 import DA.Time (RelTime(..))
@@ -294,7 +293,7 @@ zoom r w (StateT smas) = StateT $ \t ->
 -- Must be kept in sync with Runner#handleStepFreeResult
 data TriggerF a =
   GetTime (Time -> a)
-  | Submit (Commands, () -> a)
+  | Submit ([Command], Text -> a)
   deriving Functor
 
 newtype TriggerSetup a = TriggerSetup { runTriggerSetup : Free TriggerF a }
@@ -307,10 +306,14 @@ newtype TriggerRule s a = TriggerRule { runTriggerRule : StateT s (Free TriggerF
 -- meant for testing purposes only.
 simulateRule : TriggerRule s a -> Time -> s -> (s, [Commands], a)
 simulateRule rule time s = (s', reverse cmds, a)
-  where ((a, s'), cmds) = State.runState (foldFree sim (runStateT (runTriggerRule rule) s)) []
-        sim : TriggerF x -> State.State [Commands] x
+  where ((a, s'), (cmds, _)) = State.runState (foldFree sim (runStateT (runTriggerRule rule) s)) ([], 0)
+        sim : TriggerF x -> State.State ([Commands], Int) x
         sim (GetTime f) = pure (f time)
-        sim (Submit (cmds, f)) = State.modify (cmds ::) $> f ()
+        sim (Submit (cmds, f)) = do
+          (pastCmds, nextId) <- State.get
+          let nextIdShown = show nextId
+          State.put (Commands (CommandId nextIdShown) cmds :: pastCmds, nextId + 1)
+          pure $ f nextIdShown
 
 deriving instance ActionState s (TriggerRule s)
 
@@ -329,5 +332,5 @@ instance HasTime TriggerSetup where
 instance HasTime (TriggerRule s) where
   getTime = liftTF (GetTime identity)
 
-submitCommands : ActionTrigger m => Commands -> m ()
-submitCommands cmds = liftTF (Submit (cmds, identity))
+submitCommands : ActionTrigger m => [Command] -> m CommandId
+submitCommands cmds = liftTF (Submit (cmds, CommandId))

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -46,7 +46,7 @@ module Daml.Trigger.LowLevel
   ) where
 
 import qualified DA.Action.State as State
-import DA.Functor ((<&>), ($>))
+import DA.Functor ((<&>))
 import DA.Next.Map (MapKey(..))
 import DA.Time (RelTime(..))
 import Daml.Script.Free (Free(..), lift, foldFree)

--- a/triggers/tests/daml/ACS.daml
+++ b/triggers/tests/daml/ACS.daml
@@ -11,14 +11,12 @@ data TriggerState = TriggerState
   { activeAssets : [ContractId Asset]
   , successfulCompletions : Int
   , failedCompletions : Int
-  , nextCommandId : Int
   , party : Party
   }
 
 initState : Party -> ActiveContracts -> TriggerState
 initState party (ActiveContracts events) = TriggerState
   { activeAssets = (foldl updateAcs [] events)
-  , nextCommandId = 0
   , party = party
   , successfulCompletions = 0
   , failedCompletions = 0
@@ -50,8 +48,8 @@ test = Trigger
       let (state', cmds) = case foldl updateEvent ([], state.activeAssets) (events t) of
             ([], acs) -> (state { activeAssets = acs }, [])
             (cmds, acs) ->
-              ( state { activeAssets = acs, nextCommandId = state.nextCommandId + 1 }
-              , [Commands (CommandId $ "command_" <> show state.nextCommandId) cmds]
+              ( state { activeAssets = acs }
+              , [cmds]
               )
       put state'
       mapA_ submitCommands cmds

--- a/triggers/tests/daml/CommandId.daml
+++ b/triggers/tests/daml/CommandId.daml
@@ -9,11 +9,11 @@ import Daml.Trigger.LowLevel
 test : Trigger [Text]
 test = Trigger
   { initialState = \party _ -> do
-      submitCommands $ Commands (CommandId "mycreateid") [createCmd (T party)]
+      submitCommands [createCmd (T party)]
       pure []
   , update = \msg -> case msg of
       MTransaction (Transaction _ (Some (CommandId cmdId)) [CreatedEvent (fromCreated @T -> Some (_, cid, _))]) -> do
-        submitCommands $ Commands (CommandId "myexerciseid") [exerciseCmd cid Archive]
+        submitCommands [exerciseCmd cid Archive]
         modify (cmdId ::)
       MTransaction (Transaction _ (Some (CommandId cmdId)) [ArchivedEvent (fromArchived @T -> Some _)]) ->
         modify (cmdId ::)

--- a/triggers/tests/daml/Numeric.daml
+++ b/triggers/tests/daml/Numeric.daml
@@ -9,7 +9,7 @@ import Daml.Trigger.LowLevel
 test : Trigger Bool
 test = Trigger
   { initialState = \party _ -> do
-      submitCommands $ Commands (CommandId "mycreate1") [createCmd (T party 1.06)]
+      submitCommands [createCmd (T party 1.06)]
       pure False
   , update = \msg -> do
       s <- get
@@ -17,8 +17,8 @@ test = Trigger
         (False, MTransaction (Transaction _ _ [CreatedEvent (fromCreated @T -> Some (_, _, t))])) -> do
           -- This verifies that t.v has the proper scale as otherwise the interpreter will
           -- throw an assertion error
+          submitCommands [createCmd (t { v = t.v + 1.0 })]
           put True
-          submitCommands $ Commands (CommandId "mycreate2") [createCmd (t { v = t.v + 1.0 })]
         _ -> pure ()
   , registeredTemplates = AllInDar
   , heartbeat = None

--- a/triggers/tests/daml/Time.daml
+++ b/triggers/tests/daml/Time.daml
@@ -4,18 +4,20 @@
 
 module Time where
 
+import DA.Functor (void)
+
 import Daml.Trigger.LowLevel
 
 test : Trigger (Bool, [Time])
 test = Trigger
   { initialState = \party _ -> do
-      submitCommands $ Commands (CommandId "a") [createCmd (T party)]
+      submitCommands [createCmd (T party)]
       pure (False, [])
   , update = \msg -> case msg of
     MTransaction (Transaction _ _ events) -> do
       (done, ts) <- get
       case (done, events) of
-        (False, [CreatedEvent (fromCreated @T -> Some (_, _, t))]) -> submitCommands $ Commands (CommandId "b") [createCmd t]
+        (False, [CreatedEvent (fromCreated @T -> Some (_, _, t))]) -> void $ submitCommands [createCmd t]
         _ -> pure ()
       time <- getTime
       put (True, time :: ts)

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
@@ -3,12 +3,12 @@
 
 package com.daml.lf.engine.trigger.test
 
-import akka.stream.scaladsl.{Flow}
+import akka.stream.scaladsl.Flow
 import com.daml.lf.data.Ref._
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.value.Value.ContractId
-import com.daml.ledger.api.testing.utils.{SuiteResourceManagementAroundAll}
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.v1.commands._
 import com.daml.ledger.api.v1.commands.CreateCommand
 import com.daml.ledger.api.v1.{value => LedgerApi}
@@ -18,6 +18,8 @@ import scalaz.syntax.traverse._
 
 import com.daml.lf.engine.trigger.TriggerMsg
 import com.daml.lf.engine.trigger.RunnerConfig
+
+import java.util.UUID
 
 abstract class AbstractFuncTests
     extends AsyncWordSpec
@@ -355,6 +357,10 @@ abstract class AbstractFuncTests
           inside(finalState) {
             case SList(commandIds) =>
               commandIds.toSet should have size 2
+              // ensure all are UUIDs
+              commandIds.map(inside(_) {
+                case SText(s) => SText(UUID.fromString(s).toString)
+              }) should ===(commandIds)
           }
         }
       }

--- a/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
+++ b/triggers/tests/src/test/scala/com/digitalasset/daml/lf/engine/trigger/test/AbstractFuncTests.scala
@@ -4,7 +4,6 @@
 package com.daml.lf.engine.trigger.test
 
 import akka.stream.scaladsl.{Flow}
-import com.daml.lf.data.FrontStack
 import com.daml.lf.data.Ref._
 import com.daml.lf.speedy.SValue
 import com.daml.lf.speedy.SValue._
@@ -24,6 +23,7 @@ abstract class AbstractFuncTests
     extends AsyncWordSpec
     with AbstractTriggerTest
     with Matchers
+    with Inside
     with SuiteResourceManagementAroundAll
     with TryValues {
   self: Suite =>
@@ -352,7 +352,10 @@ abstract class AbstractFuncTests
           // 1 for completion
           finalState <- runner.runWithACS(acs, offset, msgFlow = Flow[TriggerMsg].take(4))._2
         } yield {
-          assert(finalState == SList(FrontStack(SText("myexerciseid"), SText("mycreateid"))))
+          inside(finalState) {
+            case SList(commandIds) =>
+              commandIds.toSet should have size 2
+          }
         }
       }
     }


### PR DESCRIPTION
There are no more ID indirections; the command ID you work with in the DAML trigger looks exactly like the one submitted to the ledger.

`testRule` implements the old behavior of starting at "0" and incrementing thereafter.

Fixes #7549.

```rst
CHANGELOG_BEGIN
- [Triggers] The CommandIds as accessed from trigger DAML code are now exactly the command
  IDs used in command submission to the ledger; as such, they will vary randomly from run
  to run of the trigger rule.  To enable this, the low-level ``submitCommands`` function
  no longer accepts a command ID, instead returning one; there is no change to the
  corresponding high-level ``emitCommands`` function, so high-level triggers should only
  see improved and easier-to-understand logging.
  See `issue #7587 <https://github.com/digital-asset/daml/pull/7587>`__.
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
