### PR TITLE
ci/cron: actually fail

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -305,6 +305,7 @@ check_releases bash_lib = do
                           "echo $p: signature matches",
                       "else",
                           "echo $p: signature does not match",
+                          "exit 2",
                       "fi",
                   "fi",
               "done",


### PR DESCRIPTION
At the moment, because the signature check appears in a `if` statement, failed signatures do not actually fail the script and would thus still result in "success" messages to Slack.

CHANGELOG_BEGIN
CHANGELOG_END