### PR TITLE
ci/bash_lib: generalize save_gcp_data

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -495,12 +495,12 @@ jobs:
 
           cd $(Build.StagingDirectory)/release
           for f in *; do
-              save_gcp_data "$GCRED" "$f" "gs://daml-data/releases/$(release_tag)/github/$f"
+              gcs "$GCRED" cp "$f" "gs://daml-data/releases/$(release_tag)/github/$f"
           done
 
           cd $(Build.StagingDirectory)/artifactory
           for f in *; do
-              save_gcp_data "$GCRED" "$f" "gs://daml-data/releases/$(release_tag)/artifactory/$f"
+              gcs "$GCRED" cp "$f" "gs://daml-data/releases/$(release_tag)/artifactory/$f"
           done
         name: backup_to_gcs
         env:
@@ -774,7 +774,7 @@ jobs:
           # expression Azure would otherwise substitute, i.e. the literal value
           # of the string in the `env:` block below.
           if [[ "${GCRED:1:${#GCRED}-1}" != '(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)' ]]; then
-              save_gcp_data "$GCRED" "$REPORT_GZ" "gs://daml-data/builds/$(Build.BuildId)_$(date -u +%Y%m%d_%H%M%SZ).json.gz"
+              gcs "$GCRED" cp "$REPORT_GZ" "gs://daml-data/builds/$(Build.BuildId)_$(date -u +%Y%m%d_%H%M%SZ).json.gz"
           else
               echo "Could not save build data: no credentials."
           fi

--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -29,12 +29,12 @@ steps:
         jq -n --arg message "$message" '{"text": $message}' \
          | curl -XPOST -i -H 'Content-Type: application/json' -d @- $channel
     }
-    save_gcp_data() {
-        local restore_trap cred local_file remote_path key cleanup
+    gcs() {
+        local args cleanup cmd cred key restore_trap
 
         cred="$1"
-        local_file="$2"
-        remote_path="$3"
+        cmd="$2"
+        args=(${@:3})
 
         key=$(mktemp)
         # There may already be a trap; this will save it
@@ -44,7 +44,7 @@ steps:
         echo "$cred" > $key
         gcloud auth activate-service-account --key-file=$key
 
-        BOTO_CONFIG=/dev/null gsutil cp "$local_file" "$remote_path"
+        BOTO_CONFIG=/dev/null gsutil $cmd "${args[@]}"
         eval "$cleanup"
         trap - EXIT
         eval "$restore_trap"

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -108,7 +108,7 @@ jobs:
               echo "Baseline no longer valid, needs manual correction." > "$OUT"
           fi
 
-          save_gcp_data "$GCRED" "$OUT" gs://daml-data/perf/speedy/$START.json
+          gcs "$GCRED" cp "$OUT" gs://daml-data/perf/speedy/$START.json
 
         displayName: measure perf
         env:
@@ -169,7 +169,7 @@ jobs:
 
           tar -zcvf ${OUT}.tgz ${OUT}
 
-          save_gcp_data "$GCRED" "$OUT.tgz" "gs://daml-data/perf/http-json/${REPORT_ID}.tgz"
+          gcs "$GCRED" cp "$OUT.tgz" "gs://daml-data/perf/http-json/${REPORT_ID}.tgz"
 
         displayName: measure http-json performance
         env:


### PR DESCRIPTION
This PR extends the existing `save_gcp_data` function to handle any `gsutil` command. This is done to support existence checking using `gsutil ls` for private artifacts in release checking (`ci/cron`).

CHANGELOG_BEGIN
CHANGELOG_END