### PR TITLE
Backport #7593: Bump hardcoded timeout for party alloc/package upload

### DIFF
--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
@@ -47,7 +47,8 @@ trait MultiParticipantFixture
     portFile = Some(participant1Portfile),
     serverJdbcUrl = ParticipantConfig.defaultIndexJdbcUrl(participantId1),
     allowExistingSchemaForIndex = false,
-    maxCommandsInFlight = None
+    maxCommandsInFlight = None,
+    managementServiceTimeout = ParticipantConfig.defaultManagementServiceTimeout,
   )
   private val participantId2 = v1.ParticipantId.assertFromString("participant2")
   private val participant2 = ParticipantConfig(
@@ -57,7 +58,8 @@ trait MultiParticipantFixture
     portFile = Some(participant2Portfile),
     serverJdbcUrl = ParticipantConfig.defaultIndexJdbcUrl(participantId2),
     allowExistingSchemaForIndex = false,
-    maxCommandsInFlight = None
+    maxCommandsInFlight = None,
+    managementServiceTimeout = ParticipantConfig.defaultManagementServiceTimeout,
   )
   override protected lazy val suiteResource = {
     implicit val ec: ExecutionContext = system.dispatcher

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServerConfig.scala
@@ -5,10 +5,11 @@ package com.daml.platform.apiserver
 
 import java.io.File
 import java.nio.file.Path
+import java.time.Duration
 
+import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.participant.state.v1.SeedService.Seeding
-import com.daml.ledger.api.tls.TlsConfiguration
 import com.daml.platform.configuration.IndexConfiguration
 import com.daml.ports.Port
 
@@ -23,4 +24,5 @@ case class ApiServerConfig(
     eventsPageSize: Int = IndexConfiguration.DefaultEventsPageSize,
     portFile: Option[Path],
     seeding: Seeding,
+    managementServiceTimeout: Duration,
 )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -3,6 +3,8 @@
 
 package com.daml.platform.apiserver
 
+import java.time.Duration
+
 import akka.stream.Materializer
 import com.daml.api.util.TimeProvider
 import com.daml.grpc.adapter.ExecutionSequencerFactory
@@ -23,13 +25,13 @@ import com.daml.platform.apiserver.execution.{
   StoreBackedCommandExecutor,
   TimedCommandExecutor
 }
+import com.daml.platform.apiserver.services._
 import com.daml.platform.apiserver.services.admin.{
   ApiConfigManagementService,
   ApiPackageManagementService,
   ApiPartyManagementService
 }
 import com.daml.platform.apiserver.services.transaction.ApiTransactionService
-import com.daml.platform.apiserver.services._
 import com.daml.platform.configuration.{
   CommandConfiguration,
   LedgerConfiguration,
@@ -80,7 +82,8 @@ private[daml] object ApiServices {
       optTimeServiceBackend: Option[TimeServiceBackend],
       metrics: Metrics,
       healthChecks: HealthChecks,
-      seedService: SeedService
+      seedService: SeedService,
+      managementServiceTimeout: Duration,
   )(
       implicit mat: Materializer,
       esf: ExecutionSequencerFactory,
@@ -244,11 +247,21 @@ private[daml] object ApiServices {
         )
         val apiPartyManagementService =
           ApiPartyManagementService
-            .createApiService(partyManagementService, transactionsService, writeService)
+            .createApiService(
+              partyManagementService,
+              transactionsService,
+              writeService,
+              managementServiceTimeout,
+            )
 
         val apiPackageManagementService =
           ApiPackageManagementService
-            .createApiService(indexService, transactionsService, writeService)
+            .createApiService(
+              indexService,
+              transactionsService,
+              writeService,
+              managementServiceTimeout,
+            )
 
         val apiConfigManagementService =
           ApiConfigManagementService

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -98,6 +98,7 @@ final class StandaloneApiServer(
         metrics = metrics,
         healthChecks = healthChecksWithIndexService,
         seedService = SeedService(config.seeding),
+        managementServiceTimeout = config.managementServiceTimeout,
       )(materializer, executionSequencerFactory, loggingContext)
         .map(_.withServices(otherServices))
       apiServer <- new LedgerApiServer(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiConfigManagementService.scala
@@ -3,6 +3,8 @@
 
 package com.daml.platform.apiserver.services.admin
 
+import java.time.{Duration => JDuration}
+
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.daml.api.util.{DurationConversion, TimeProvider, TimestampConversion}
@@ -110,7 +112,7 @@ private[apiserver] final class ApiConfigManagementService private (
           index,
           ledgerEndBeforeRequest,
         ),
-        timeToLive = params.timeToLive,
+        timeToLive = JDuration.ofMillis(params.timeToLive.toMillis),
       )
       entry <- synchronousResponse.submitAndWait(
         submissionId,

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPackageManagementService.scala
@@ -4,6 +4,7 @@
 package com.daml.platform.apiserver.services.admin
 
 import java.io.ByteArrayInputStream
+import java.time.Duration
 import java.util.UUID
 import java.util.zip.ZipInputStream
 
@@ -30,7 +31,6 @@ import com.google.protobuf.timestamp.Timestamp
 import io.grpc.{ServerServiceDefinition, StatusRuntimeException}
 
 import scala.compat.java8.FutureConverters._
-import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -38,6 +38,7 @@ private[apiserver] final class ApiPackageManagementService private (
     packagesIndex: IndexPackagesService,
     transactionsService: IndexTransactionsService,
     packagesWrite: WritePackagesService,
+    managementServiceTimeout: Duration,
     materializer: Materializer,
 )(implicit loggingContext: LoggingContext)
     extends PackageManagementService
@@ -54,7 +55,7 @@ private[apiserver] final class ApiPackageManagementService private (
       packagesIndex,
       packagesWrite,
     ),
-    timeToLive = 30.seconds,
+    timeToLive = managementServiceTimeout,
   )
 
   override def close(): Unit = ()
@@ -122,9 +123,16 @@ private[apiserver] object ApiPackageManagementService {
       readBackend: IndexPackagesService,
       transactionsService: IndexTransactionsService,
       writeBackend: WritePackagesService,
+      managementServiceTimeout: Duration,
   )(implicit mat: Materializer, loggingContext: LoggingContext)
     : PackageManagementServiceGrpc.PackageManagementService with GrpcApiService =
-    new ApiPackageManagementService(readBackend, transactionsService, writeBackend, mat)
+    new ApiPackageManagementService(
+      readBackend,
+      transactionsService,
+      writeBackend,
+      managementServiceTimeout,
+      mat,
+    )
 
   private final class SynchronousResponseStrategy(
       ledgerEndService: LedgerEndService,

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -56,6 +56,7 @@ trait ConfigProvider[ExtraConfig] {
       eventsPageSize = config.eventsPageSize,
       portFile = participantConfig.portFile,
       seeding = config.seeding,
+      managementServiceTimeout = participantConfig.managementServiceTimeout,
     )
 
   def commandConfig(

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/ParticipantConfig.scala
@@ -8,6 +8,8 @@ import java.nio.file.Path
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ports.Port
 
+import java.time.Duration
+
 final case class ParticipantConfig(
     participantId: ParticipantId,
     address: Option[String],
@@ -16,9 +18,12 @@ final case class ParticipantConfig(
     serverJdbcUrl: String,
     allowExistingSchemaForIndex: Boolean,
     maxCommandsInFlight: Option[Int],
+    managementServiceTimeout: Duration,
 )
 
 object ParticipantConfig {
   def defaultIndexJdbcUrl(participantId: ParticipantId): String =
     s"jdbc:h2:mem:$participantId;db_close_delay=-1;db_close_on_exit=false"
+
+  val defaultManagementServiceTimeout: Duration = Duration.ofMinutes(2)
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -333,6 +333,7 @@ final class SandboxServer(
         metrics = metrics,
         healthChecks = healthChecks,
         seedService = seedingService,
+        managementServiceTimeout = config.managementServiceTimeout,
       )(materializer, executionSequencerFactory, loggingContext)
         .map(_.withServices(List(resetService)))
       apiServer <- new LedgerApiServer(

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCli.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCli.scala
@@ -296,6 +296,13 @@ class CommonCli(name: LedgerName) {
         .text(
           s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${v1.TimeModel.reasonableDefault.minSkew.getSeconds}.")
 
+      opt[Duration]("management-service-timeout")
+        .hidden()
+        .optional()
+        .action((value, config) => config.copy(managementServiceTimeout = value))
+        .text(
+          s"The timeout used for requests by management services of the Ledger API. The default is set to ${SandboxConfig.DefaultManagementServiceTimeout.getSeconds} seconds.")
+
       help("help").text("Print the usage text")
 
       checkConfig(c => {

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -48,6 +48,7 @@ final case class SandboxConfig(
     profileDir: Option[Path],
     stackTraces: Boolean,
     devMode: Boolean,
+    managementServiceTimeout: Duration
 )
 
 object SandboxConfig {
@@ -64,6 +65,8 @@ object SandboxConfig {
 
   val DefaultParticipantId: v1.ParticipantId =
     v1.ParticipantId.assertFromString("sandbox-participant")
+
+  val DefaultManagementServiceTimeout: Duration = Duration.ofMinutes(2)
 
   lazy val defaultConfig: SandboxConfig =
     SandboxConfig(
@@ -93,6 +96,7 @@ object SandboxConfig {
       profileDir = None,
       stackTraces = true,
       devMode = true,
+      managementServiceTimeout = DefaultManagementServiceTimeout,
     )
 
 }

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -209,6 +209,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     eventsPageSize = config.eventsPageSize,
                     portFile = config.portFile,
                     seeding = config.seeding.get,
+                    managementServiceTimeout = config.managementServiceTimeout,
                   ),
                   engine = engine,
                   commandConfig = config.commandConfig,


### PR DESCRIPTION
Make the hardcoded timeout for party allocaction/package upload configurable
This is a short term fix to remediate issues with uploading packages
that take a considerable amount of time to decode and validate and
therefore exhausting the 30 seconds.

Adding a maximum record parameter to the ledger API like we already have
for the config management service is not as straight forward for the
package upload, because one has to account for the time in transit as
well. This topic needs further analysis, but in the meantime making the
timeout configurable and setting the default to 2 minutes should provide
enough headroom to alleviate existing issues with package upload timing.

Contributes to #6880

CHANGELOG_BEGIN
[Integration Kit]: The hardcoded timeout for party
allocation and package uploads in the Ledger API Server can be configured via ParticipantConfig and
the default value is now set to 2 minutes. See
`issue #6880 <https://github.com/digital-asset/daml/issues/6880>`__.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
