### PR TITLE
Undamlify assistant output

### DIFF
--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -71,7 +71,7 @@ main = do
                                 | Just v <- envSdkVersion = versionToString v
                                 | otherwise = "latest"
                         hPutStr stderr . unlines $
-                            [ "DAML SDK not installed. Cannot run command without SDK."
+                            [ "SDK not installed. Cannot run command without SDK."
                             , "To proceed, please install the SDK by running:"
                             , ""
                             , "    daml install " <> installTarget
@@ -100,7 +100,7 @@ versionChecks Env{..} =
         -- Project SDK version is outdated.
         when (not isHead && projectSdkVersionIsOld) $ do
             hPutStr stderr . unlines $
-                [ "DAML SDK " <> versionToString latestVersion <> " has been released!"
+                [ "SDK " <> versionToString latestVersion <> " has been released!"
                 , "See https://github.com/digital-asset/daml/releases/tag/v"
                   <> versionToString latestVersion <> " for details."
                 -- Carefully crafted wording to make sure it’s < 80 characters so
@@ -247,7 +247,7 @@ runCommand env@Env{..} = \case
                     ]
                 | (v,attrs) <- versionTable ]
 
-        putStr . unpack $ T.unlines ("DAML SDK versions:" : versionLines)
+        putStr . unpack $ T.unlines ("SDK versions:" : versionLines)
 
     Builtin (Install options) -> wrapErr "Installing the SDK." $ do
         install options envDamlPath envProjectPath envDamlAssistantSdkVersion

--- a/daml-assistant/get-daml.sh
+++ b/daml-assistant/get-daml.sh
@@ -5,15 +5,15 @@
 
 #
 # DAML is an open-source privacy-aware smart contract language.
-# This script downloads and installs the DAML SDK on Linux and macOS.
+# This script downloads and installs the SDK on Linux and macOS.
 # This will overwrite any existing installation in ~/.daml
 # For more information please visit https://daml.com/ and https://docs.daml.com/
 #
 
 #
 # USAGE:
-#    get-daml.sh            Download and install the latest DAML SDK release.
-#    get-daml.sh VERSION    Download and install given version of DAML SDK.
+#    get-daml.sh            Download and install the latest SDK release.
+#    get-daml.sh VERSION    Download and install given version of SDK.
 #
 
 set -eu
@@ -83,7 +83,7 @@ fi
 readonly TARBALL="daml-sdk-$VERSION-$OS.tar.gz"
 readonly URL="https://github.com/digital-asset/daml/releases/download/v$VERSION/$TARBALL"
 
-echo "$(tput setaf 3)Downloading DAML SDK $VERSION. This may take a while.$(tput sgr 0)"
+echo "$(tput setaf 3)Downloading SDK $VERSION. This may take a while.$(tput sgr 0)"
 curl -SLf $URL --output $TARBALL --progress-bar
 if [ ! -f $TARBALL ] ; then
   echo "Failed to download SDK tarball."

--- a/daml-assistant/src/DA/Daml/Assistant/Command.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Command.hs
@@ -91,8 +91,8 @@ commandParser :: [SdkCommandInfo] -> Parser Command
 commandParser cmds | (hidden, visible) <- partition isHidden cmds = asum
     [ subparser -- visible commands
         $  builtin "version" "Display DAML version information" mempty (Version <$> versionParser <**> helper)
-        <> builtin "install" "Install the specified DAML SDK version" mempty (Install <$> installParser <**> helper)
-        <> builtin "uninstall" "Uninstall the specified DAML SDK version" mempty (Uninstall <$> uninstallParser <**> helper)
+        <> builtin "install" "Install the specified SDK version" mempty (Install <$> installParser <**> helper)
+        <> builtin "uninstall" "Uninstall the specified SDK version" mempty (Uninstall <$> uninstallParser <**> helper)
         <> foldMap dispatch visible
     , subparser -- hidden commands
         $  internal

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -89,7 +89,7 @@ testDamlEnv Env{..} = firstJustM (\(test, msg) -> unlessMaybeM test (pure msg))
       <> "check the daml project config file, or run \"daml install\" to install the latest "
       <> "version of the SDK." )
     , ( maybe (pure False) (doesDirectoryExist . unwrapSdkPath) envSdkPath
-      ,  "The DAML SDK directory does not exist. Please check if DAML_SDK or DAML_SDK_VERSION "
+      ,  "The SDK directory does not exist. Please check if DAML_SDK or DAML_SDK_VERSION "
       <> "are incorrectly set, or run \"daml install\" to install the appropriate SDK version.")
     , ( maybe (pure True) (doesDirectoryExist . unwrapProjectPath) envProjectPath
       , "The project directory does not exist. Please check if DAML_PROJECT is incorrectly set.")

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -135,7 +135,7 @@ installExtracted env@InstallEnv{..} sourcePath =
                     ,  "Suggested fix:"
                     ,  "  - Go to https://github.com/digital-asset/daml/releases/latest"
                     ,  "  - Download and run Windows installer."
-                    ,  "  - Reinstall the DAML SDK from scratch."
+                    ,  "  - Reinstall the SDK from scratch."
                     ]
                 exitFailure
 
@@ -444,7 +444,7 @@ uninstallVersion Env{..} sdkVersion = wrapErr "Uninstalling SDK version." $ do
     if exists then do
         when (Just (DamlAssistantSdkVersion sdkVersion) == envDamlAssistantSdkVersion) $ do
             hPutStr stderr . unlines $
-                [ "Cannot uninstall currently activated DAML SDK version."
+                [ "Cannot uninstall currently activated SDK version."
                 , "Please activate a different SDK version and try again."
                 , "To activate a different version, run:"
                 , ""
@@ -458,7 +458,7 @@ uninstallVersion Env{..} sdkVersion = wrapErr "Uninstalling SDK version." $ do
         requiredIO "Failed to remove SDK files." $ do
             removePathForcibly path
 
-        putStrLn ("DAML SDK version " <> versionToString sdkVersion <> " has been uninstalled.")
+        putStrLn ("SDK version " <> versionToString sdkVersion <> " has been uninstalled.")
 
     else do
-        putStrLn ("DAML SDK version " <> versionToString sdkVersion <> " is not installed.")
+        putStrLn ("SDK version " <> versionToString sdkVersion <> " is not installed.")


### PR DESCRIPTION
In preparation for the renaming, we are stripping the DAML prefix. It
is still called SDK and the sdk-version variable keeps existing.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
