### PR TITLE
ci/cron: upload artifact to daml-data if missing

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -192,7 +192,7 @@ jobs:
           eval "$(dev-env/bin/dade assist)"
 
           bazel build //ci/cron:cron
-          bazel-bin/ci/cron/cron check --bash-lib $(bash_lib)
+          bazel-bin/ci/cron/cron check --bash-lib $(bash_lib) --gcp-creds "$GCRED"
         displayName: check releases
         env:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)

--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -312,18 +312,49 @@ verify_signatures bash_lib tmp version_tag = do
        "done",
        "'"]
 
-check_releases :: String -> IO ()
-check_releases bash_lib = do
+does_backup_exist :: String -> FilePath -> FilePath -> IO Bool
+does_backup_exist gcp_credentials bash_lib path = do
+    out <- shell $ unlines ["bash -c '",
+        "set -euo pipefail",
+        "eval \"$(dev-env/bin/dade assist)\"",
+        "source \"" <> bash_lib <> "\"",
+        "if gcs \"" <> gcp_credentials <> "\" ls \"" <> path <> "\"; then",
+            "echo True",
+        "else",
+            "echo False",
+        "fi",
+        "'"]
+    return $ read out
+
+push_to_gcp :: String -> FilePath -> FilePath  -> FilePath -> IO ()
+push_to_gcp gcp_credentials bash_lib local_path remote_path = do
+    shell_ $ unlines ["bash -c '",
+        "set -euo pipefail",
+        "eval \"$(dev-env/bin/dade assist)\"",
+        "source \"" <> bash_lib <> "\"",
+        "gcs \"" <> gcp_credentials <> "\" cp \"" <> local_path <> "\" \"" <> remote_path <> "\"",
+        "'"]
+
+check_releases :: String -> String -> IO ()
+check_releases gcp_credentials bash_lib = do
     releases <- fetch_gh_paginated "https://api.github.com/repos/digital-asset/daml/releases"
     Data.Foldable.for_ releases (\release -> do
         let v = show $ tag release
         putStrLn $ "Checking release " <> v <> " ..."
         IO.withTempDir $ \temp_dir -> do
             download_assets temp_dir release
-            out <- verify_signatures bash_lib temp_dir v
-            putStrLn out)
+            verify_signatures bash_lib temp_dir v >>= putStrLn
+            Directory.listDirectory temp_dir >>= Data.Foldable.traverse_ (\f -> do
+                let gcp_path = "gs://daml-data/releases/github/" <> v <> "/" <> f
+                exists <- does_backup_exist gcp_credentials bash_lib gcp_path
+                if exists then do
+                    putStrLn $ gcp_path <> " already exists."
+                else do
+                    putStr $ gcp_path <> " does not exist; pushing..."
+                    push_to_gcp gcp_credentials bash_lib f gcp_path
+                    putStrLn " done."))
 
-data CliArgs = Docs | Check { bash_lib :: String }
+data CliArgs = Docs | Check { bash_lib :: String, gcp_credentials :: String }
 
 parser :: Opt.ParserInfo CliArgs
 parser = info "This program is meant to be run by CI cron. You probably don't have sufficient access rights to run it locally."
@@ -335,11 +366,14 @@ parser = info "This program is meant to be run by CI cron. You probably don't ha
         check = info "Check existing releases."
                      (Check <$> Opt.strOption (Opt.long "bash-lib"
                                          <> Opt.metavar "PATH"
-                                         <> Opt.help "Path to Bash library file."))
+                                         <> Opt.help "Path to Bash library file.")
+                            <*> Opt.strOption (Opt.long "gcp-creds"
+                                         <> Opt.metavar "CRED_STRING"
+                                         <> Opt.help "GCP credentials as a string."))
 
 main :: IO ()
 main = do
     opts <- Opt.execParser parser
     case opts of
       Docs -> docs
-      Check { bash_lib } -> check_releases bash_lib
+      Check { bash_lib, gcp_credentials } -> check_releases gcp_credentials bash_lib


### PR DESCRIPTION
If we don't already have a copy of an artifact in our "disaster recovery" storage box, put one.

Note: as implemented, this upload mechanism happens only if the release was successfully verified signature-wise, so this should not result in us saving broken artifacts. Also, CI does not have deletion or overwrite access to this bucket, so overall this should be pretty safe.

CHANGELOG_BEGIN
CHANGELOG_END