### PR TITLE
LF: explicitly mark nodes if they correspond to a "by key" operation.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -369,7 +369,6 @@ class Engine(val config: EngineConfig = EngineConfig.Stable) {
           usedPackages = Set.empty,
           dependsOnTime = onLedger.dependsOnTime,
           nodeSeeds = onLedger.ptx.nodeSeeds.toImmArray,
-          byKeyNodes = onLedger.ptx.byKeyNodes.toImmArray,
         )
         config.profileDir.foreach { dir =>
           val hash = meta.nodeSeeds(0)._2.toHexString

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/Preprocessor.scala
@@ -158,9 +158,11 @@ private[engine] final class Preprocessor(compiledPackages: MutableCompiledPackag
           controllersDifferFromActors @ _,
           children @ _,
           exerciseResult @ _,
-          key @ _) =>
+          key @ _,
+          byKey @ _,
+          ) =>
         templateId
-      case Node.NodeFetch(coid @ _, templateId, _, _, _, _, _) =>
+      case Node.NodeFetch(coid @ _, templateId, _, _, _, _, _, _) =>
         templateId
       case Node.NodeLookupByKey(templateId, _, key @ _, _) =>
         templateId

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -58,12 +58,13 @@ private[preprocessing] final class TransactionPreprocessor(
           controllersDifferFromActors @ _,
           children @ _,
           exerciseResult @ _,
-          key @ _) =>
+          key @ _,
+          byKey @ _) =>
         val templateId = template
         val (cmd, newCids) =
           commandPreprocessor.unsafePreprocessExercise(templateId, coid, choice, chosenVal.value)
         (cmd, (localCids | newCids.filterNot(globalCids), globalCids))
-      case Node.NodeFetch(coid, templateId, _, _, _, _, _) =>
+      case Node.NodeFetch(coid, templateId, _, _, _, _, _, _) =>
         val cmd = commandPreprocessor.unsafePreprocessFetch(templateId, coid)
         (cmd, acc)
       case Node.NodeLookupByKey(templateId, _, key, _) =>
@@ -88,7 +89,7 @@ private[preprocessing] final class TransactionPreprocessor(
               fail(s"invalid transaction, root refers to non-existing node $id")
             case Some(node) =>
               node match {
-                case Node.NodeFetch(_, _, _, _, _, _, _) =>
+                case Node.NodeFetch(_, _, _, _, _, _, _, _) =>
                   fail(s"Transaction contains a fetch root node $id")
                 case Node.NodeLookupByKey(_, _, _, _) =>
                   fail(s"Transaction contains a lookup by key root node $id")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -446,7 +446,7 @@ object ScenarioLedger {
                       }
                       processNodes(mbNewCache2, idsToProcess)
 
-                    case NodeFetch(referencedCoid, templateId @ _, optLoc @ _, _, _, _, _) =>
+                    case NodeFetch(referencedCoid, templateId @ _, optLoc @ _, _, _, _, _, _) =>
                       val newCacheP =
                         newCache.updateLedgerNodeInfo(referencedCoid)(info =>
                           info.copy(referencedBy = info.referencedBy + eventId))

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -185,6 +185,7 @@ object TransactionBuilder {
       consuming: Boolean,
       actingParties: Set[String],
       argument: Value,
+      byKey: Boolean = true,
   ): Exercise =
     Exercise(
       targetCoid = contract.coid,
@@ -199,9 +200,19 @@ object TransactionBuilder {
       children = ImmArray.empty,
       exerciseResult = None,
       key = contract.key,
+      byKey = byKey
     )
 
-  def fetch(contract: Create): Fetch =
+  def exerciseByKey(
+      contract: Create,
+      choice: String,
+      consuming: Boolean,
+      actingParties: Set[String],
+      argument: Value,
+  ): Exercise =
+    exercise(contract, choice, consuming, actingParties, argument, byKey = true)
+
+  def fetch(contract: Create, byKey: Boolean = true): Fetch =
     Fetch(
       coid = contract.coid,
       templateId = contract.coinst.template,
@@ -210,7 +221,11 @@ object TransactionBuilder {
       signatories = contract.signatories,
       stakeholders = contract.stakeholders,
       key = contract.key,
+      byKey = byKey,
     )
+
+  def fetchByKey(contract: Create): Fetch =
+    fetch(contract, byKey = true)
 
   def lookupByKey(contract: Create, found: Boolean): LookupByKey =
     LookupByKey(

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -292,7 +292,9 @@ object ValueGenerators {
       signatories <- genNonEmptyParties
       stakeholders <- genNonEmptyParties
       key <- Gen.option(keyWithMaintainersGen)
-    } yield NodeFetch(coid, templateId, None, Some(actingParties), signatories, stakeholders, key)
+      byKey <- Gen.oneOf(true, false)
+    } yield
+      NodeFetch(coid, templateId, None, Some(actingParties), signatories, stakeholders, key, byKey)
   }
 
   /** Makes exercise nodes with some random child IDs. */
@@ -314,6 +316,7 @@ object ValueGenerators {
       exerciseResultValue <- versionedValueGen
       key <- versionedValueGen
       maintainers <- genNonEmptyParties
+      byKey <- Gen.oneOf(true, false)
     } yield
       NodeExercises(
         targetCoid,
@@ -328,7 +331,8 @@ object ValueGenerators {
         false,
         children,
         Some(exerciseResultValue),
-        Some(KeyWithMaintainers(key, maintainers))
+        Some(KeyWithMaintainers(key, maintainers)),
+        byKey = byKey,
       )
   }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -50,6 +50,8 @@ object Node {
       */
     def requiredAuthorizers: Set[Party]
 
+    def byKey: Boolean
+
     def foreach3(fNid: Nid => Unit, fCid: Cid => Unit, fVal: Val => Unit) =
       GenNode.foreach3(fNid, fCid, fVal)(this)
   }
@@ -82,6 +84,7 @@ object Node {
             _,
             _,
             key,
+            _,
           ) =>
         self copy (
           coid = f2(coid),
@@ -101,6 +104,7 @@ object Node {
             children,
             exerciseResult,
             key,
+            _,
           ) =>
         self copy (
           targetCoid = f2(targetCoid),
@@ -145,6 +149,7 @@ object Node {
           signatoriesd @ _,
           stakeholdersd @ _,
           key,
+          _,
           ) =>
         f2(coid)
         key.foreach(KeyWithMaintainers.foreach1(f3))
@@ -162,6 +167,7 @@ object Node {
           children @ _,
           exerciseResult,
           key,
+          _,
           ) =>
         f2(targetCoid)
         f3(chosenValue)
@@ -196,7 +202,7 @@ object Node {
       with NodeInfo.Create {
 
     override def templateId: TypeConName = coinst.template
-
+    override def byKey: Boolean = false
   }
 
   object NodeCreate extends WithTxValue2[NodeCreate]
@@ -210,8 +216,9 @@ object Node {
       signatories: Set[Party],
       stakeholders: Set[Party],
       key: Option[KeyWithMaintainers[Val]],
+      override val byKey: Boolean // invariant (!byKey || exerciseResult.isDefined)
   ) extends LeafOnlyNode[Cid, Val]
-      with NodeInfo.Fetch {}
+      with NodeInfo.Fetch
 
   object NodeFetch extends WithTxValue2[NodeFetch]
 
@@ -240,6 +247,7 @@ object Node {
       children: ImmArray[Nid],
       exerciseResult: Option[Val],
       key: Option[KeyWithMaintainers[Val]],
+      override val byKey: Boolean // invariant (!byKey || exerciseResult.isDefined)
   ) extends GenNode[Nid, Cid, Val]
       with NodeInfo.Exercise {
     @deprecated("use actingParties instead", since = "1.1.2")
@@ -265,6 +273,7 @@ object Node {
         children: ImmArray[Nid],
         exerciseResult: Option[Val],
         key: Option[KeyWithMaintainers[Val]],
+        byKey: Boolean,
     ): NodeExercises[Nid, Cid, Val] =
       NodeExercises(
         targetCoid,
@@ -280,6 +289,7 @@ object Node {
         children,
         exerciseResult,
         key,
+        byKey
       )
   }
 
@@ -293,7 +303,7 @@ object Node {
 
     override def keyMaintainers: Set[Party] = key.maintainers
     override def hasResult: Boolean = result.isDefined
-
+    override def byKey: Boolean = true
   }
 
   object NodeLookupByKey extends WithTxValue2[NodeLookupByKey]
@@ -352,6 +362,7 @@ object Node {
             signatories2,
             stakeholders2,
             key2,
+            _,
             ) =>
           import nf._
           coid === coid2 && templateId == templateId2 &&
@@ -374,6 +385,7 @@ object Node {
             _,
             exerciseResult2,
             key2,
+            _,
             ) =>
           import ne._
           targetCoid === targetCoid2 && templateId == templateId2 && choiceId == choiceId2 &&

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -362,9 +362,9 @@ sealed abstract class HasTxNodes[Nid, +Cid, +Val] {
     */
   final def inputContracts[Cid2 >: Cid]: Set[Cid2] =
     fold(Set.empty[Cid2]) {
-      case (acc, (_, Node.NodeExercises(coid, _, _, _, _, _, _, _, _, _, _, _, _))) =>
+      case (acc, (_, Node.NodeExercises(coid, _, _, _, _, _, _, _, _, _, _, _, _, _))) =>
         acc + coid
-      case (acc, (_, Node.NodeFetch(coid, _, _, _, _, _, _))) =>
+      case (acc, (_, Node.NodeFetch(coid, _, _, _, _, _, _, _))) =>
         acc + coid
       case (acc, (_, Node.NodeLookupByKey(_, _, _, Some(coid)))) =>
         acc + coid
@@ -501,11 +501,11 @@ object GenTransaction extends value.CidContainer3[GenTransaction] {
           node match {
             case Node.NodeCreate(_, c, _, _, _, Some(key)) =>
               state.created(globalKey(c.template, key.key.value))
-            case Node.NodeExercises(_, tmplId, _, _, true, _, _, _, _, _, _, _, Some(key)) =>
+            case Node.NodeExercises(_, tmplId, _, _, true, _, _, _, _, _, _, _, Some(key), _) =>
               state.consumed(globalKey(tmplId, key.key.value))
-            case Node.NodeExercises(_, tmplId, _, _, false, _, _, _, _, _, _, _, Some(key)) =>
+            case Node.NodeExercises(_, tmplId, _, _, false, _, _, _, _, _, _, _, Some(key), _) =>
               state.referenced(globalKey(tmplId, key.key.value))
-            case Node.NodeFetch(_, tmplId, _, _, _, _, Some(key)) =>
+            case Node.NodeFetch(_, tmplId, _, _, _, _, Some(key), _) =>
               state.referenced(globalKey(tmplId, key.key.value))
             case Node.NodeLookupByKey(tmplId, _, key, Some(_)) =>
               state.referenced(globalKey(tmplId, key.key.value))
@@ -560,9 +560,6 @@ object Transaction {
     *        time.
     * @param nodeSeeds: An association list that maps to each ID of create and exercise
     *        nodes its seeds.
-    * @param byKeyNodes: The list of the IDs of each node that corresponds to a FetchByKey,
-    *        LookupByKey, or ExerciseByKey commands. Empty in case of validation or
-    *        reinterpretation
     */
   final case class Metadata(
       submissionSeed: Option[crypto.Hash],
@@ -570,7 +567,6 @@ object Transaction {
       usedPackages: Set[PackageId],
       dependsOnTime: Boolean,
       nodeSeeds: ImmArray[(transaction.NodeId, crypto.Hash)],
-      byKeyNodes: ImmArray[transaction.NodeId],
   )
 
   @deprecated("Use com.daml.lf.transaction.SubmittedTransaction", since = "1.4.0")

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -174,7 +174,7 @@ object TransactionCoder {
           nodeBuilder.setCreate(createBuilder).build()
         }
 
-      case nf @ NodeFetch(_, _, _, _, _, _, _) =>
+      case nf @ NodeFetch(_, _, _, _, _, _, _, _) =>
         val fetchBuilder = TransactionOuterClass.NodeFetch
           .newBuilder()
           .setTemplateId(ValueCoder.encodeIdentifier(nf.templateId))
@@ -203,7 +203,7 @@ object TransactionCoder {
           nodeBuilder.setFetch(fetchBuilder).build()
         }
 
-      case ne @ NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _) =>
+      case ne @ NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
         for {
           argValue <- encodeValue(encodeCid, ne.chosenValue)
           retValue <- ne.exerciseResult traverse (v => encodeValue(encodeCid, v))
@@ -354,7 +354,8 @@ object TransactionCoder {
           else if (txVersion precedes minContractKeyInFetch)
             Left(DecodeError(s"$txVersion is too old to support NodeFetch's `key` field"))
           else decodeKeyWithMaintainers(decodeCid, protoFetch.getKeyWithMaintainers).map(Some(_))
-        } yield (ni, NodeFetch(c, templateId, None, actingParties, signatories, stakeholders, key))
+        } yield
+          (ni, NodeFetch(c, templateId, None, actingParties, signatories, stakeholders, key, false))
 
       case NodeTypeCase.EXERCISE =>
         val protoExe = protoNode.getExercise
@@ -437,6 +438,7 @@ object TransactionCoder {
               children = children,
               exerciseResult = rv,
               key = keyWithMaintainers,
+              byKey = false,
             ),
           )
       case NodeTypeCase.LOOKUP_BY_KEY =>

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -234,6 +234,7 @@ object TransactionSpec {
       children = children,
       exerciseResult = if (hasExerciseResult) Some(V.ValueUnit) else None,
       key = None,
+      byKey = false
     )
 
   val dummyCid = V.ContractId.V1.assertBuild(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.api.domain.{Commands => ApiCommands}
 import com.daml.ledger.participant.state.index.v2.{ContractStore, IndexPackagesService}
 import com.daml.ledger.participant.state.v1.{SubmitterInfo, TransactionMeta}
 import com.daml.lf.crypto
-import com.daml.lf.data.Ref
+import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.engine.{
   Engine,
   Result,
@@ -70,7 +70,10 @@ private[apiserver] final class StoreBackedCommandExecutor(
               submissionSeed,
               Some(meta.usedPackages),
               Some(meta.nodeSeeds),
-              Some(meta.byKeyNodes),
+              Some(
+                updateTx.nodes
+                  .collect { case (nodeId, node) if node.byKey => nodeId }
+                  .to[ImmArray]),
             ),
             transaction = updateTx,
             dependsOnLedgerTime = meta.dependsOnTime,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
@@ -68,6 +68,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
           children = ImmArray.empty,
           exerciseResult = None,
           key = None,
+          byKey = false,
         )
       )
       builder.add(
@@ -81,6 +82,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
           key = Some(
             KeyWithMaintainers(ValueParty(bob), Set(bob))
           ),
+          byKey = false
         ),
         parent = rootExercise,
       )
@@ -100,6 +102,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
           key = Some(
             KeyWithMaintainers(ValueParty(bob), Set(bob))
           ),
+          byKey = false,
         ),
         parent = rootExercise,
       )

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -128,7 +128,8 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       signatories = Set(alice, bob),
       children = ImmArray.empty,
       exerciseResult = Some(ValueText("some exercise result")),
-      key = None
+      key = None,
+      byKey = false,
     )
 
   // All non-transient contracts created in a transaction
@@ -187,6 +188,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         children = ImmArray.empty,
         exerciseResult = Some(ValueUnit),
         key = None,
+        byKey = false,
       )
     )
     txBuilder.add(
@@ -198,6 +200,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         signatories = Set(alice),
         stakeholders = Set(alice),
         None,
+        byKey = false,
       ),
       exerciseId,
     )
@@ -514,7 +517,8 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         controllersDifferFromActors = false,
         children = ImmArray.empty,
         exerciseResult = Some(ValueUnit),
-        key = maybeKey.map(k => KeyWithMaintainers(ValueText(k), Set(party)))
+        key = maybeKey.map(k => KeyWithMaintainers(ValueText(k), Set(party))),
+        byKey = false,
       ))
     nextOffset() -> LedgerEntry.Transaction(
       commandId = Some(UUID.randomUUID().toString),
@@ -570,6 +574,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         signatories = Set(party),
         stakeholders = Set(party),
         None,
+        byKey = false,
       ))
     nextOffset() -> LedgerEntry.Transaction(
       commandId = Some(UUID.randomUUID().toString),

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
@@ -27,7 +27,7 @@ class StoreBackedCommandExecutorSpec extends AsyncWordSpec with MockitoSugar wit
     usedPackages = Set.empty,
     dependsOnTime = false,
     nodeSeeds = ImmArray.empty,
-    byKeyNodes = ImmArray.empty)
+  )
 
   "execute" should {
     "add interpretation time to result" in {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -79,7 +79,7 @@ private[kvutils] object InputsAndEffects {
     tx.foreach {
       case (_, node) =>
         node match {
-          case fetch @ Node.NodeFetch(_, _, _, _, _, _, _) =>
+          case fetch @ Node.NodeFetch(_, _, _, _, _, _, _, _) =>
             addContractInput(fetch.coid)
             fetch.key.foreach { keyWithMaintainers =>
               inputs += globalKeyToStateKey(
@@ -92,7 +92,7 @@ private[kvutils] object InputsAndEffects {
                 GlobalKey(create.coinst.template, forceNoContractIds(keyWithMaintainers.key.value)))
             }
 
-          case exe @ Node.NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _) =>
+          case exe @ Node.NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
             addContractInput(exe.targetCoid)
 
           case lookup @ Node.NodeLookupByKey(_, _, _, _) =>
@@ -116,7 +116,7 @@ private[kvutils] object InputsAndEffects {
     tx.fold(Effects.empty) {
       case (effects, (nodeId @ _, node)) =>
         node match {
-          case Node.NodeFetch(_, _, _, _, _, _, _) =>
+          case Node.NodeFetch(_, _, _, _, _, _, _, _) =>
             effects
           case create @ Node.NodeCreate(_, _, _, _, _, _) =>
             effects.copy(
@@ -141,7 +141,7 @@ private[kvutils] object InputsAndEffects {
                 )
             )
 
-          case exe @ Node.NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _) =>
+          case exe @ Node.NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _, _) =>
             if (exe.consuming) {
               effects.copy(
                 consumedContracts = contractIdToStateKey(exe.targetCoid) :: effects.consumedContracts,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -281,7 +281,7 @@ private[kvutils] class TransactionCommitter(
       .fold((true, keys)) {
         case (
             (allUnique, existingKeys),
-            (_, exe @ Node.NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _)))
+            (_, exe @ Node.NodeExercises(_, _, _, _, _, _, _, _, _, _, _, _, _, _)))
             if exe.key.isDefined && exe.consuming =>
           val stateKey = Conversions.globalKeyToStateKey(
             GlobalKey(exe.templateId, Conversions.forceNoContractIds(exe.key.get.key.value)))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -50,7 +50,8 @@ class ProjectionsSpec extends WordSpec with Matchers {
       signatories = signatories,
       children = ImmArray.empty,
       exerciseResult = None,
-      key = None
+      key = None,
+      byKey = false,
     )
 
   def project(tx: Transaction) = {

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/TransactionMeta.scala
@@ -39,5 +39,5 @@ final case class TransactionMeta(
     submissionSeed: crypto.Hash,
     optUsedPackages: Option[Set[Ref.PackageId]],
     optNodeSeeds: Option[ImmArray[(NodeId, crypto.Hash)]],
-    optByKeyNodes: Option[ImmArray[NodeId]]
+    optByKeyNodes: Option[ImmArray[NodeId]],
 )


### PR DESCRIPTION
Currently we track the list of node that correspond to a "by key"
operation in the Transaction metadata. We move this information into
the nodes themself.

This is a preparatory work to include this information in the serialization 
format for  transactions

This advances the state of  #7622

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
