### PR TITLE
remove submitCommands, ActionTrigger from high-level Trigger API

### DIFF
--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -97,7 +97,7 @@ data Trigger s = Trigger
 -- a failing completion.
 emitCommands : [Command] -> [AnyContractId] -> TriggerA CommandId
 emitCommands cmds pending = do
-  id <- submitCommands cmds
+  id <- TriggerA $ submitCommands cmds
   let commands = Commands id cmds
   TriggerA $ modify $ \s -> s
     { commandsInFlight = addCommands s.commandsInFlight commands

--- a/triggers/daml/Daml/Trigger/Internal.daml
+++ b/triggers/daml/Daml/Trigger/Internal.daml
@@ -48,7 +48,7 @@ data ACS = ACS
 -- Its main feature is that you can call `emitCommands` to
 -- send commands to the ledger.
 newtype TriggerA a = TriggerA (TriggerRule TriggerAState a)
-  deriving (Functor, Applicative, Action, HasTime, ActionTrigger)
+  deriving (Functor, Applicative, Action, HasTime)
 
 -- Internal API
 

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -317,6 +317,7 @@ simulateRule rule time s = (s', reverse cmds, a)
 
 deriving instance ActionState s (TriggerRule s)
 
+-- | Low-level trigger actions.
 class HasTime m => ActionTrigger m where
   liftTF : TriggerF a -> m a
 


### PR DESCRIPTION
Pre-#7456, you could not simply return `[Commands]` without sending them through the `emitCommands` gauntlet in the high-level Trigger API; this restores that state, so of `emitCommands` and `submitCommands`, only the former is allowed in `TriggerA`, even if you have imported the low-level API.

By consequence each `ActionTrigger` action that we wish to provide in the high-level API will have to be wrapped explicitly.

This helps users avoid confusion as alluded in #7392. We might even use the same name ultimately, as with `Trigger`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
