### PR TITLE
map ledger-api claims to scopes for auth0

### DIFF
--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -17,6 +17,9 @@ da_scala_library(
     visibility = ["//visibility:public"],
     deps = [
         ":oauth-test-server",  # TODO[AH] Extract OAuth2 request/response types
+        "//daml-lf/data",
+        "//ledger-service/jwt",
+        "//ledger/ledger-api-auth",
         "//libs-scala/ports",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
@@ -27,6 +30,7 @@ da_scala_library(
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
         "@maven//:io_spray_spray_json_2_12",
+        "@maven//:org_scalaz_scalaz_core_2_12",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )
@@ -107,8 +111,11 @@ da_scala_test(
     deps = [
         ":oauth-middleware",
         ":oauth-test-server",
+        "//daml-lf/data",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",
+        "//ledger-service/jwt",
+        "//ledger/ledger-api-auth",
         "//libs-scala/ports",
         "//libs-scala/resources",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
@@ -119,5 +126,6 @@ da_scala_test(
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
         "@maven//:io_spray_spray_json_2_12",
+        "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
@@ -3,7 +3,10 @@
 
 package com.daml.oauth.middleware
 
+import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import com.daml.lf.data.Ref.Party
 import spray.json.{
   DefaultJsonProtocol,
   JsString,
@@ -13,18 +16,60 @@ import spray.json.{
   deserializationError
 }
 
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent._
+import scala.util.Try
+
 object Request {
+
+  case class Claims(admin: Boolean, actAs: List[Party], readAs: List[Party]) {
+    def toQueryString() = {
+      val adminS = if (admin) Stream("admin") else Stream()
+      val actAsS = actAs.toStream.map(party => s"actAs:$party")
+      val readAsS = readAs.toStream.map(party => s"readAs:$party")
+      (adminS ++ actAsS ++ readAsS).mkString(" ")
+    }
+  }
+  object Claims {
+    def apply(
+        admin: Boolean = false,
+        actAs: List[Party] = List(),
+        readAs: List[Party] = List()): Claims =
+      new Claims(admin, actAs, readAs)
+    implicit val marshalRequestEntity: Marshaller[Claims, String] =
+      Marshaller.opaque(_.toQueryString)
+    implicit val unmarshalHttpEntity: Unmarshaller[String, Claims] =
+      Unmarshaller { _ => s =>
+        var admin = false
+        val actAs = ArrayBuffer[Party]()
+        val readAs = ArrayBuffer[Party]()
+        Future.fromTry(Try {
+          s.split(' ').foreach { w =>
+            if (w == "admin") {
+              admin = true
+            } else if (w.startsWith("actAs:")) {
+              actAs.append(Party.assertFromString(w.stripPrefix("actAs:")))
+            } else if (w.startsWith("readAs:")) {
+              readAs.append(Party.assertFromString(w.stripPrefix("readAs:")))
+            } else {
+              throw new IllegalArgumentException(s"Expected claim but got $w")
+            }
+          }
+          Claims(admin, actAs.toList, readAs.toList)
+        })
+      }
+  }
 
   /** Auth endpoint query parameters
     */
-  case class Auth(claims: String) // TODO[AH] parse ledger claims
+  case class Auth(claims: Claims)
 
   /** Login endpoint query parameters
     *
     * @param redirectUri Redirect target after the login flow completed. I.e. the original request URI on the trigger service.
     * @param claims Required ledger claims.
     */
-  case class Login(redirectUri: Uri, claims: String) // TODO[AH] parse ledger claims
+  case class Login(redirectUri: Uri, claims: Claims)
 
 }
 

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
@@ -21,7 +21,8 @@ object Request {
       clientId: String,
       redirectUri: Uri, // optional in oauth but we require it
       scope: Option[String],
-      state: Option[String]) {
+      state: Option[String],
+      audience: Option[Uri]) { // required by auth0 to obtain an access_token
     def toQuery: Query = {
       var params: Seq[(String, String)] =
         Seq(
@@ -33,6 +34,9 @@ object Request {
       }
       state.foreach { state =>
         params ++= Seq(("state", state))
+      }
+      audience.foreach { audience =>
+        params ++= Seq(("audience", audience.toString))
       }
       Query(params: _*)
     }
@@ -54,7 +58,7 @@ object Request {
           "code" -> token.code,
           "redirect_uri" -> token.redirectUri.toString,
           "client_id" -> token.clientId,
-          "client_secret" -> token.clientSecret
+          "client_secret" -> token.clientSecret,
         )
       }
     implicit val unmarshalHttpEntity: Unmarshaller[HttpEntity, Token] =
@@ -64,7 +68,7 @@ object Request {
           code = form.fields.get("code").get,
           redirectUri = form.fields.get("redirect_uri").get,
           clientId = form.fields.get("client_id").get,
-          clientSecret = form.fields.get("client_secret").get
+          clientSecret = form.fields.get("client_secret").get,
         )
       }
   }

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -60,7 +60,14 @@ object Server {
     val route = concat(
       path("authorize") {
         get {
-          parameters(('response_type, 'client_id, 'redirect_uri.as[Uri], 'scope ?, 'state ?))
+          parameters(
+            (
+              'response_type,
+              'client_id,
+              'redirect_uri.as[Uri],
+              'scope ?,
+              'state ?,
+              'audience.as[Uri] ?))
             .as[Request.Authorize](Request.Authorize) {
               request =>
                 val authorizationCode = UUID.randomUUID()

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Client.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Client.scala
@@ -58,7 +58,9 @@ object Client {
                     clientId = config.clientId,
                     redirectUri = redirectUri,
                     scope = Some(params.parties.map(p => "actAs:" + p).mkString(" ")),
-                    state = None)
+                    state = None,
+                    audience = Some("https://daml.com/ledger-api")
+                  )
                   redirect(
                     config.authServerUrl
                       .withQuery(authParams.toQuery)


### PR DESCRIPTION
- Add the `audience` query parameter to the OAuth2 authorization request.
  By default auth0 will only issue an opaque id token. However, for the ledger api we want a JWT with claims for `https://daml.com/ledger-api`. We need to set the `audience` parameter accordingly so that auth0 will issue such an access token.
- Add a datatype `Request.Claims` to define the mapping from DAML ledger claims to OAuth2 scopes.
  - For now this sticks to scopes of the form `actAs:Alice readAs:Bob admin`.
    This is a somewhat unusual use of scopes. Typically, scopes don't contain dynamic values such as the party name. However, at least with auth0 this seems to work without issues.
- The middleware now checks whether the access token (JWT) provides the required claims, not just whether the scopes match.
  This is more robust, since it is the access token that defines which actions the client is authorized to on the ledger.
- Update the Auth0 instructions
  - Fix a typo in the callback URI
  - Replace hook by rule. Hooks only apply to m2m applications, for a native client we need to use a rule.

Part of #6923 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
