### PR TITLE
ci/bash-lib: fix gcs return code

### DIFF
--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -30,7 +30,8 @@ steps:
          | curl -XPOST -i -H 'Content-Type: application/json' -d @- $channel
     }
     gcs() {
-        local args cleanup cmd cred key restore_trap
+        local args cleanup cmd cred key restore_trap ret
+        ret=1
 
         cred="$1"
         cmd="$2"
@@ -45,9 +46,11 @@ steps:
         gcloud auth activate-service-account --key-file=$key
 
         BOTO_CONFIG=/dev/null gsutil $cmd "${args[@]}"
+        ret=$?
         eval "$cleanup"
         trap - EXIT
         eval "$restore_trap"
+        return $ret
     }
     gpg_verify() {
         local key gpg_dir signature_file res


### PR DESCRIPTION
Currently the return code of the function is the return code of the `eval "$restore_trap"` line, whereas semantically we want the return code of the `gsutil` call. This is not an issue in most cases as the `set -e` should kick in, but if the function appears as the condition in an `if` statement the `-e` flag is suspended.

The main use-case right now is that the daily license check is _not_ uploading artifacts.

CHANGELOG_BEGIN
CHANGELOG_END