### PR TITLE
Hide RelTime constructor from the docs.

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Time/Types.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Time/Types.daml
@@ -8,5 +8,5 @@ module DA.Time.Types
   ) where
 
 -- | The `RelTime` type describes a time offset, i.e. relative time.
-newtype RelTime =
+newtype RelTime = -- | HIDE
   RelTime with microseconds : Int


### PR DESCRIPTION
The `RelTime` constructor is not exposed to the user of `DA.Time`, so it should be hidden in the docs.

Reported by @leonidr-da.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
