### PR TITLE
Add default method support in data-dependencies.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -193,6 +193,10 @@ pattern TConApp tcon targs <- (view (leftSpine _TApp) -> (TCon tcon, targs))
   where
     TConApp tcon targs = foldl TApp (TCon tcon) targs
 
+pattern TForalls :: [(TypeVarName, Kind)] -> Type -> Type
+pattern TForalls binders ty <- (view _TForalls -> (binders, ty))
+  where TForalls binders ty = mkTForalls binders ty
+
 _TList :: Prism' Type Type
 _TList = prism' TList $ \case
   TList typ -> Just typ


### PR DESCRIPTION
This PR adds default method support in data-dependencies,
including default method signatures (the DefaultSignatures
extension). This also adds tests for simple default methods,
and for default methods with signatures.

changelog_begin

- [DAML Compiler] `data-dependencies` now support default
  methods in typeclasses, including default method
  type signatures.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
