### PR TITLE
Set custom patienceConfig in TrackerImplTest [KVL-609]

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
@@ -8,6 +8,7 @@ import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Keep, Source, SourceQueueWithComplete}
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
+import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
   IsStatusException,
@@ -16,7 +17,6 @@ import com.daml.ledger.api.testing.utils.{
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands.Commands
 import com.daml.ledger.api.v1.completion.Completion
-import com.daml.dec.DirectExecutionContext
 import com.daml.logging.LoggingContext
 import com.google.rpc.status.{Status => RpcStatus}
 import io.grpc.Status
@@ -24,6 +24,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterEach, Matchers, Succeeded, WordSpec}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
 
 class TrackerImplTest
     extends WordSpec
@@ -31,6 +32,8 @@ class TrackerImplTest
     with BeforeAndAfterEach
     with ScalaFutures
     with AkkaBeforeAndAfterAll {
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 1.second)
 
   private var sut: Tracker = _
   private var consumer: TestSubscriber.Probe[NotUsed] = _


### PR DESCRIPTION
TrackerImplTests caused a few flaky test failures due to a low timeout configuration.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
