### PR TITLE
LF: enforce non-empty maintainers in contract key in fetchByKey

### DIFF
--- a/compiler/damlc/tests/daml-test-files/EmptyContractKeyMaintainers.daml
+++ b/compiler/damlc/tests/daml-test-files/EmptyContractKeyMaintainers.daml
@@ -1,5 +1,6 @@
 -- @ERROR Attempt to create a contract key with an empty set of maintainers
--- @ERROR Attempt to fetch or lookup a contract key with an empty set of maintainers
+-- @ERROR Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
+-- @ERROR Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
 module EmptyContractKeyMaintainers where
 
 template NoMaintainer
@@ -17,8 +18,13 @@ createNoMaintainer = scenario do
   pure ()
 
 lookupNoMaintainer = scenario do
- alice <- getParty "Alice"
+  alice <- getParty "Alice"
 
- submit alice $ lookupByKey @NoMaintainer alice
- pure ()
+  submit alice $ lookupByKey @NoMaintainer alice
+  pure ()
 
+fetchNoMaintainer = scenario do
+  alice <- getParty "Alice"
+
+  submit alice $ fetchByKey @NoMaintainer alice
+  pure ()

--- a/compiler/damlc/tests/daml-test-files/EmptyContractKeyMaintainers.daml
+++ b/compiler/damlc/tests/daml-test-files/EmptyContractKeyMaintainers.daml
@@ -1,6 +1,6 @@
--- @ERROR Attempt to create a contract key with an empty set of maintainers
--- @ERROR Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
--- @ERROR Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
+-- @ERROR range=14:0-14:18; Attempt to create a contract key with an empty set of maintainers
+-- @ERROR range=20:0-20:18; Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
+-- @ERROR range=26:0-26:17; Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
 module EmptyContractKeyMaintainers where
 
 template NoMaintainer

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -246,7 +246,7 @@ prettyScenarioErrorError (Just err) =  do
         ]
     ScenarioErrorErrorFetchEmptyContractKeyMaintainers ScenarioError_FetchEmptyContractKeyMaintainers{..} ->
       pure $ vcat
-        [ "Attempt to fetch or lookup a contract key with an empty set of maintainers"
+        [ "Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers"
         , label_ "Template:"
             $ prettyMay "<missing template id>"
                 (prettyDefName world)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -677,6 +677,80 @@ class EngineTest
     }
   }
 
+  "exercise-by-key" should {
+    val seed = hash("exercise-by-key")
+
+    val now = Time.Timestamp.now
+
+    "crash if use a contract key with an empty set of maintainers" in {
+      val templateId =
+        Identifier(basicTestsPkgId, "BasicTests:NoMaintainer")
+
+      val cmds = ImmArray(
+        speedy.Command.ExerciseByKey(
+          templateId = templateId,
+          contractKey = SParty(alice),
+          choiceId = ChoiceName.assertFromString("Noop"),
+          argument = SValue.SUnit,
+        )
+      )
+
+      val result = engine
+        .interpretCommands(
+          validating = false,
+          submitters = Set(alice),
+          commands = cmds,
+          ledgerTime = now,
+          submissionTime = now,
+          seeding = InitialSeeding.TransactionSeed(seed),
+          globalCids = Set.empty,
+        )
+        .consume(_ => None, lookupPackage, lookupKey)
+
+      inside(result) {
+        case Left(err) =>
+          err.msg should include(
+            "Update failed due to a contract key with an empty sey of maintainers")
+      }
+    }
+  }
+
+  "fecth-by-key" should {
+    val seed = hash("fetch-by-key")
+
+    val now = Time.Timestamp.now
+
+    "crash if use a contract key with an empty set of maintainers" in {
+      val templateId =
+        Identifier(basicTestsPkgId, "BasicTests:NoMaintainer")
+
+      val cmds = ImmArray(
+        speedy.Command.FetchByKey(
+          templateId = templateId,
+          key = SParty(alice),
+        )
+      )
+
+      val result = engine
+        .interpretCommands(
+          validating = false,
+          submitters = Set(alice),
+          commands = cmds,
+          ledgerTime = now,
+          submissionTime = now,
+          seeding = InitialSeeding.TransactionSeed(seed),
+          globalCids = Set.empty,
+        )
+        .consume(_ => None, lookupPackage, lookupKey)
+
+      inside(result) {
+        case Left(err) =>
+          err.msg should include(
+            "Update failed due to a contract key with an empty sey of maintainers")
+      }
+    }
+  }
+
   "create-and-exercise command" should {
     val submissionSeed = hash("create-and-exercise command")
     val templateId = Identifier(basicTestsPkgId, "BasicTests:Simple")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
@@ -39,6 +39,11 @@ object Command {
       coid: SContractId,
   ) extends Command
 
+  final case class FetchByKey(
+      templateId: Identifier,
+      key: SValue,
+  ) extends Command
+
   final case class CreateAndExercise(
       templateId: Identifier,
       createArgument: SValue,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -1488,6 +1488,8 @@ private[lf] final class Compiler(
       compileExerciseByKey(templateId, SEValue(contractKey), choiceId, SEValue(argument))
     case Command.Fetch(templateId, coid) =>
       FetchDefRef(templateId)(SEValue(coid))
+    case Command.FetchByKey(templateId, key) =>
+      FetchByKeyDefRef(templateId)(SEValue(key))
     case Command.CreateAndExercise(templateId, createArg, choice, choiceArg) =>
       compileCreateAndExercise(
         templateId,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1148,6 +1148,8 @@ private[lf] object SBuiltin {
         onLedger: OnLedger
     ): Unit = {
       val keyWithMaintainers = extractKeyWithMaintainers(args.get(0))
+      if (keyWithMaintainers.maintainers.isEmpty)
+        throw DamlEFetchEmptyContractKeyMaintainers(templateId, keyWithMaintainers.key)
       val gkey = GlobalKey(templateId, keyWithMaintainers.key)
       // check if we find it locally
       onLedger.ptx.keys.get(gkey) match {

--- a/daml-lf/tests/BasicTests.daml
+++ b/daml-lf/tests/BasicTests.daml
@@ -598,3 +598,8 @@ template NoMaintainer
     signatory sig
     key sig : Party
     maintainer [] @Party
+
+    nonconsuming choice Noop: ()
+      controller sig
+      do
+        pure ()


### PR DESCRIPTION
This fixes a bug in the Speedy interpreter. With this change, the
interpreter crashes if it attempts to exercise a choice using a
contract key that has an empty set of maintainers.

This is a breaking change approved by @bame-da .

CHANGELOG_BEGIN

    [LF] (Bug fix) enforce non-empty maintainers in contract key during
        fetchByKey and exerciseByKey.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
