### PR TITLE
Supply jdbc string through an env variable

### DIFF
--- a/ledger/participant-state/kvutils/app/BUILD.bazel
+++ b/ledger/participant-state/kvutils/app/BUILD.bazel
@@ -64,6 +64,7 @@ da_scala_test_suite(
     srcs = glob(["src/test/**/*.scala"]),
     deps = [
         ":app",
+        "//daml-lf/data",
         "//ledger/ledger-api-health",
         "//ledger/participant-state",
         "//ledger/participant-state/kvutils",

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
@@ -3,31 +3,66 @@
 
 package com.daml.ledger.participant.state.kvutils.app
 
+import com.daml.ledger.participant.state.v1.ParticipantId
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 import scopt.OptionParser
 
 final class ConfigSpec extends FlatSpec with Matchers with OptionValues {
 
-  private val DumpIndexMetadataCommand = "dump-index-metadata"
-  private val ConfigParser: Seq[String] => Option[Config[Unit]] =
-    Config.parse("Test", (_: OptionParser[Config[Unit]]) => (), (), _)
+  private val dumpIndexMetadataCommand = "dump-index-metadata"
+  private val particiopantOption = "--participant"
+  private val participantId: ParticipantId = ParticipantId.assertFromString("dummy-participant")
+  private val defaultParticipantSubOptions = s"participant-id=$participantId,port=123"
+  private val jdbcUrlSubOption = "server-jdbc-url"
+  private val jdbcUrlEnvSubOption = "server-jdbc-url-env"
+  private def configParser(
+      parameters: Seq[String],
+      getEnvVar: String => Option[String] = (_ => None)): Option[Config[Unit]] =
+    Config.parse("Test", (_: OptionParser[Config[Unit]]) => (), (), parameters, getEnvVar)
 
   behavior of "Runner"
 
   it should "fail if a participant is not provided in run mode" in {
-    ConfigParser(Seq.empty) shouldEqual None
+    configParser(Seq.empty) shouldEqual None
   }
 
   it should "fail if a participant is not provided when dumping the index metadata" in {
-    ConfigParser(Seq(DumpIndexMetadataCommand)) shouldEqual None
+    configParser(Seq(dumpIndexMetadataCommand)) shouldEqual None
   }
 
   it should "succeed if a participant is provided when dumping the index metadata" in {
-    ConfigParser(Seq(DumpIndexMetadataCommand, "some-jdbc-url"))
+    configParser(Seq(dumpIndexMetadataCommand, "some-jdbc-url"))
   }
 
   it should "succeed if more than one participant is provided when dumping the index metadata" in {
-    ConfigParser(Seq(DumpIndexMetadataCommand, "some-jdbc-url", "some-other-jdbc-url"))
+    configParser(Seq(dumpIndexMetadataCommand, "some-jdbc-url", "some-other-jdbc-url"))
+  }
+
+  it should "get the jdbc string from the command line argument when provided" in {
+    val jdbcFromCli = "command-line-jdbc"
+    val config = configParser(
+      Seq(particiopantOption, s"$defaultParticipantSubOptions,$jdbcUrlSubOption=$jdbcFromCli"))
+      .getOrElse(fail())
+    config.participants.head.serverJdbcUrl should be(jdbcFromCli)
+  }
+
+  it should "get the jdbc string from the environment when provided" in {
+    val jdbcEnvVar = "JDBC_ENV_VAR"
+    val jdbcFromEnv = "env-jdbc"
+    val config = configParser(
+      Seq(particiopantOption, s"$defaultParticipantSubOptions,$jdbcUrlEnvSubOption=$jdbcEnvVar"),
+      { case `jdbcEnvVar` => Some(jdbcFromEnv) }
+    ).getOrElse(fail())
+    config.participants.head.serverJdbcUrl should be(jdbcFromEnv)
+  }
+
+  it should "return the default when env variable not provided" in {
+    val jdbcEnvVar = "JDBC_ENV_VAR"
+    val defaultJdbc = ParticipantConfig.defaultIndexJdbcUrl(participantId)
+    val config = configParser(
+      Seq(particiopantOption, s"$defaultParticipantSubOptions,$jdbcUrlEnvSubOption=$jdbcEnvVar")
+    ).getOrElse(fail())
+    config.participants.head.serverJdbcUrl should be(defaultJdbc)
   }
 
 }

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
@@ -10,9 +10,9 @@ import scopt.OptionParser
 final class ConfigSpec extends FlatSpec with Matchers with OptionValues {
 
   private val dumpIndexMetadataCommand = "dump-index-metadata"
-  private val particiopantOption = "--participant"
+  private val participantOption = "--participant"
   private val participantId: ParticipantId = ParticipantId.assertFromString("dummy-participant")
-  private val defaultParticipantSubOptions = s"participant-id=$participantId,port=123"
+  private val fixedParticipantSubOptions = s"participant-id=$participantId,port=123"
   private val jdbcUrlSubOption = "server-jdbc-url"
   private val jdbcUrlEnvSubOption = "server-jdbc-url-env"
   private def configParser(
@@ -41,7 +41,7 @@ final class ConfigSpec extends FlatSpec with Matchers with OptionValues {
   it should "get the jdbc string from the command line argument when provided" in {
     val jdbcFromCli = "command-line-jdbc"
     val config = configParser(
-      Seq(particiopantOption, s"$defaultParticipantSubOptions,$jdbcUrlSubOption=$jdbcFromCli"))
+      Seq(participantOption, s"$fixedParticipantSubOptions,$jdbcUrlSubOption=$jdbcFromCli"))
       .getOrElse(fail())
     config.participants.head.serverJdbcUrl should be(jdbcFromCli)
   }
@@ -50,7 +50,7 @@ final class ConfigSpec extends FlatSpec with Matchers with OptionValues {
     val jdbcEnvVar = "JDBC_ENV_VAR"
     val jdbcFromEnv = "env-jdbc"
     val config = configParser(
-      Seq(particiopantOption, s"$defaultParticipantSubOptions,$jdbcUrlEnvSubOption=$jdbcEnvVar"),
+      Seq(participantOption, s"$fixedParticipantSubOptions,$jdbcUrlEnvSubOption=$jdbcEnvVar"),
       { case `jdbcEnvVar` => Some(jdbcFromEnv) }
     ).getOrElse(fail())
     config.participants.head.serverJdbcUrl should be(jdbcFromEnv)
@@ -60,7 +60,7 @@ final class ConfigSpec extends FlatSpec with Matchers with OptionValues {
     val jdbcEnvVar = "JDBC_ENV_VAR"
     val defaultJdbc = ParticipantConfig.defaultIndexJdbcUrl(participantId)
     val config = configParser(
-      Seq(particiopantOption, s"$defaultParticipantSubOptions,$jdbcUrlEnvSubOption=$jdbcEnvVar")
+      Seq(participantOption, s"$fixedParticipantSubOptions,$jdbcUrlEnvSubOption=$jdbcEnvVar")
     ).getOrElse(fail())
     config.participants.head.serverJdbcUrl should be(defaultJdbc)
   }


### PR DESCRIPTION
CHANGELOG_BEGIN
The `--participant` command-line configuration syntax has been extended. It is now possible to use a `server-jdbc-url-env` sub-option to specify the name of an environment variable that holds the JDBC string that should be used for connecting to the index database. This approach allows avoiding passing sensitive information in the command line launching the participant process.
CHANGELOG_END
