### PR TITLE
Warn on potentially un-upgradable language extensions

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -14,11 +14,13 @@ import           DA.Daml.Preprocessor.EnumType
 
 import Development.IDE.Types.Options
 import qualified "ghc-lib" GHC
+import qualified "ghc-lib-parser" EnumSet as ES
 import qualified "ghc-lib-parser" SrcLoc as GHC
 import qualified "ghc-lib-parser" Module as GHC
 import qualified "ghc-lib-parser" RdrName as GHC
 import qualified "ghc-lib-parser" OccName as GHC
 import qualified "ghc-lib-parser" FastString as GHC
+import qualified "ghc-lib-parser" GHC.LanguageExtensions.Type as GHC
 import Outputable
 
 import           Control.Monad.Extra
@@ -59,11 +61,11 @@ mayImportInternal =
         ]
 
 -- | Apply all necessary preprocessors
-damlPreprocessor :: Maybe GHC.UnitId -> GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource
-damlPreprocessor mbUnitId dflags x
+damlPreprocessor :: ES.EnumSet GHC.Extension -> Maybe GHC.UnitId -> GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource
+damlPreprocessor dataDependableExtensions mbUnitId dflags x
     | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = noPreprocessor dflags x
     | otherwise = IdePreprocessedSource
-        { preprocWarnings = checkDamlHeader x ++ checkVariantUnitConstructors x
+        { preprocWarnings = checkDamlHeader x ++ checkVariantUnitConstructors x ++ checkLanguageExtensions dataDependableExtensions dflags x
         , preprocErrors = checkImports x ++ checkDataTypes x ++ checkModuleDefinition x ++ checkRecordConstructor x ++ checkModuleName x
         , preprocSource = recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbUnitId $ enumTypePreprocessor "GHC.Types" x
         }
@@ -243,6 +245,26 @@ checkModuleDefinition x
           , "Missing module name, e.g. 'module ... where'.")
         ]
     | otherwise = []
+
+checkLanguageExtensions :: ES.EnumSet GHC.Extension -> GHC.DynFlags -> GHC.ParsedSource -> [(GHC.SrcSpan, String)]
+checkLanguageExtensions dataDependableExtensions dflags x =
+    let exts = ES.toList (GHC.extensionFlags dflags)
+        badExts = filter (\ext -> not (ext `ES.member` dataDependableExtensions)) exts
+    in
+    [ (modNameLoc, warning ext) | ext <- badExts ]
+  where
+    warning ext = unlines
+        [ "Modules compiled with the " ++ show ext ++ " language extension"
+        , "might not work properly with data-dependencies. This might stop the"
+        , "whole package from being extensible or upgradable using other versions"
+        , "of the SDK. Please use this language extension at your own risk."
+        ]
+    -- NOTE(MH): Neither the `DynFlags` nor the `ParsedSource` contain
+    -- information about where a `{-# LANGUAGE ... #-}` pragma has been used.
+    -- In fact, there might not even be such a pragma if a `-X...` flag has been
+    -- used on the command line. Thus, we always put the warning at the location
+    -- of the module name.
+    modNameLoc = maybe GHC.noSrcSpan GHC.getLoc (GHC.hsmodName (GHC.unLoc x))
 
 -- Extract all data constructors with their locations
 universeConDecl :: GHC.ParsedSource -> [GHC.LConDecl GHC.GhcPs]

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -257,7 +257,7 @@ checkLanguageExtensions dataDependableExtensions dflags x =
         [ "Modules compiled with the " ++ show ext ++ " language extension"
         , "might not work properly with data-dependencies. This might stop the"
         , "whole package from being extensible or upgradable using other versions"
-        , "of the SDK. Please use this language extension at your own risk."
+        , "of the SDK. Use this language extension at your own risk."
         ]
     -- NOTE(MH): Neither the `DynFlags` nor the `ParsedSource` contain
     -- information about where a `{-# LANGUAGE ... #-}` pragma has been used.

--- a/compiler/damlc/tests/daml-test-files/BadExtensionOption.daml
+++ b/compiler/damlc/tests/daml-test-files/BadExtensionOption.daml
@@ -1,0 +1,8 @@
+-- Test that we get a warning when using a problematic extension.
+{-# OPTIONS_GHC -XPatternSynonyms #-}
+-- @WARN Modules compiled with the PatternSynonyms language extension might not work properly with data-dependencies.
+-- @INFO Use LANGUAGE pragmas
+
+module BadExtensionOption where
+
+pattern Nil = []

--- a/compiler/damlc/tests/daml-test-files/BadExtensionPragma.daml
+++ b/compiler/damlc/tests/daml-test-files/BadExtensionPragma.daml
@@ -1,0 +1,7 @@
+-- Test that we get a warning when using a problematic extension.
+{-# LANGUAGE PatternSynonyms #-}
+-- @WARN Modules compiled with the PatternSynonyms language extension might not work properly with data-dependencies.
+
+module BadExtensionPragma where
+
+pattern Nil = []

--- a/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.daml
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedClassMethod.daml
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstrainedClassMethods #-}
+-- @WARN Modules compiled with the ConstrainedClassMethods language extension might not work properly with data-dependencies.
 
 -- | This module tests the case where a class method contains a constraint
 -- not present in the class itself.

--- a/compiler/damlc/tests/daml-test-files/Constraint.daml
+++ b/compiler/damlc/tests/daml-test-files/Constraint.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 {-# LANGUAGE ExistentialQuantification #-}
-
+-- @WARN Modules compiled with the ExistentialQuantification language extension might not work properly with data-dependencies.
 
 module Constraint where
 

--- a/compiler/damlc/tests/daml-test-files/Existential.daml
+++ b/compiler/damlc/tests/daml-test-files/Existential.daml
@@ -3,8 +3,8 @@
 
 {-# LANGUAGE ExistentialQuantification #-}
 
+-- @WARN Modules compiled with the ExistentialQuantification language extension might not work properly with data-dependencies.
 -- @ ERROR range=15:0-15:6; Pattern match with existential type.
--- @ TODO Existential quantification
 
 
 module Existential where

--- a/compiler/damlc/tests/daml-test-files/ExistentialSum.daml
+++ b/compiler/damlc/tests/daml-test-files/ExistentialSum.daml
@@ -3,8 +3,8 @@
 
 {-# LANGUAGE ExistentialQuantification #-}
 
+-- @WARN Modules compiled with the ExistentialQuantification language extension might not work properly with data-dependencies.
 -- @ ERROR range=17:0-17:6; Pattern match with existential type.
--- @ TODO Existential quantification
 
 
 module ExistentialSum where

--- a/compiler/damlc/tests/daml-test-files/Generics.daml
+++ b/compiler/damlc/tests/daml-test-files/Generics.daml
@@ -2,7 +2,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE EmptyCase #-}
-
+-- @WARN Modules compiled with the EmptyCase language extension might not work properly with data-dependencies.
 
 module Generics where
 

--- a/compiler/damlc/tests/daml-test-files/GoodExtensionOption.daml
+++ b/compiler/damlc/tests/daml-test-files/GoodExtensionOption.daml
@@ -1,0 +1,5 @@
+-- Test that we don't get a warning when using an unproblematic extension.
+{-# OPTIONS_GHC -XPartialTypeSignatures #-}
+-- @INFO Use LANGUAGE pragmas
+
+module GoodExtensionOption where

--- a/compiler/damlc/tests/daml-test-files/GoodExtensionPragma.daml
+++ b/compiler/damlc/tests/daml-test-files/GoodExtensionPragma.daml
@@ -1,0 +1,4 @@
+-- Test that we don't get a warning when using an unproblematic extension.
+{-# LANGUAGE PartialTypeSignatures #-}
+
+module GoodExtensionPragma where

--- a/compiler/damlc/tests/daml-test-files/GoodExtensionUseless.daml
+++ b/compiler/damlc/tests/daml-test-files/GoodExtensionUseless.daml
@@ -1,0 +1,4 @@
+-- Test that we don't get a warning when using a default extension.
+{-# LANGUAGE ImplicitPrelude #-}
+
+module GoodExtensionUseless where

--- a/compiler/damlc/tests/daml-test-files/PatternSynonyms.daml
+++ b/compiler/damlc/tests/daml-test-files/PatternSynonyms.daml
@@ -2,6 +2,7 @@
 -- All rights reserved.
 
 {-# LANGUAGE PatternSynonyms #-}
+-- @WARN Modules compiled with the PatternSynonyms language extension might not work properly with data-dependencies.
 
 module PatternSynonyms where
 

--- a/compiler/damlc/tests/daml-test-files/Records.daml
+++ b/compiler/damlc/tests/daml-test-files/Records.daml
@@ -2,7 +2,6 @@
 -- All rights reserved.
 
 -- @ ERROR B's Company is run by B and they are 3 years old
-{-# LANGUAGE FlexibleContexts #-}
 
 module Records where
 

--- a/compiler/damlc/tests/daml-test-files/TypeFamily.daml
+++ b/compiler/damlc/tests/daml-test-files/TypeFamily.daml
@@ -2,9 +2,9 @@
 -- All rights reserved.
 
 {-# LANGUAGE TypeFamilies #-}
-
 -- @ERROR range=11:0-11:15; Data definition, of type type family.
-
+-- @WARN Modules compiled with the TypeFamilies language extension might not work properly with data-dependencies.
+-- @WARN Modules compiled with the ExplicitNamespaces language extension might not work properly with data-dependencies.
 
 module TypeFamily where
 


### PR DESCRIPTION
We issue a warning whenever a module is compiled with a language
extension enabled for which we are not certain that it works with
data-dependencies. Currently, we consider all extensions except for
the ones enables by default, `ApplicativeDo` and
`PartialTypeSignatures` problematic in this regard. The list of
extensions that work fine with data-dependencies might extend over
time but we need to do further research and add further tests before we
add any extensions.

The warning is always put at the location of the module name regardless
of where the `{-# LANGUAGE ... #-}` pragma is actually used. This is due
to the fact that the `ParsedModule` we get from GHC does not contain
the location information of these pragmas. We should probably improve
this over time but I think it is acceptable for now.

CHANGELOG_BEGIN
[DAML Compiler] Warn when a module uses a language extension that
might not work with data-dependencies.
CHANGELOG_END

CHANGELOG_BEGIN
[DAML Compiler] Warn when a module uses a language extension that
might not work with `data-dependencies`.
CHANGELOG_END

Here's how it looks in action:

<img width="535" alt="Screenshot 2020-10-15 at 18 27 35" src="https://user-images.githubusercontent.com/11665611/96159962-9c8abd00-0f15-11eb-8263-55314614aba8.png">

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7662)
<!-- Reviewable:end -->
