### PR TITLE
Support multiple parties in scenario’s ParticipantView

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/scenario/ScenarioLedger.scala
@@ -22,6 +22,8 @@ import Value.{NodeId => _, _}
 import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
 import scala.collection.immutable
+import scalaz.std.set._
+import scalaz.syntax.foldable._
 
 /** An in-memory representation of a ledger for scenarios */
 object ScenarioLedger {
@@ -181,7 +183,7 @@ object ScenarioLedger {
     /** 'True' if the given 'View' contains the given 'Node'. */
     def visibleIn(view: View): Boolean = view match {
       case OperatorView => true
-      case ParticipantView(party) => disclosures contains party
+      case ParticipantView(parties) => parties.any(disclosures.contains(_))
     }
 
     def addDisclosures(newDisclosures: Map[Party, Disclosure]): LedgerNodeInfo = {
@@ -282,7 +284,7 @@ object ScenarioLedger {
   case object OperatorView extends View
 
   /** The view of the ledger at the given party. */
-  final case class ParticipantView(party: Party) extends View
+  final case class ParticipantView(party: Set[Party]) extends View
 
   /** Result of committing a transaction is the new ledger,
     * and the enriched transaction.

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -176,6 +176,7 @@ final case class ScenarioRunner(
       cbMissing: Unit => Boolean,
       cbPresent: ContractInst[Tx.Value[ContractId]] => Unit) = {
 
+    // Once we support multi-party reads, we can drop this restriction.
     val committer =
       if (committers.size == 1) committers.head else crashTooManyCommitters(committers)
     val effectiveAt = ledger.currentTime
@@ -185,7 +186,7 @@ final case class ScenarioRunner(
         throw SRunnerException(err)
 
     ledger.lookupGlobalContract(
-      view = ScenarioLedger.ParticipantView(committer),
+      view = ScenarioLedger.ParticipantView(Set(committer)),
       effectiveAt = effectiveAt,
       acoid) match {
       case ScenarioLedger.LookupOk(_, coinst, _) =>
@@ -219,6 +220,7 @@ final case class ScenarioRunner(
       committers: Set[Party],
       canContinue: SKeyLookupResult => Boolean,
   ): Unit = {
+    // Once we support multi-party reads, we can drop this restriction.
     val committer =
       if (committers.size == 1) committers.head else crashTooManyCommitters(committers)
     val effectiveAt = ledger.currentTime
@@ -236,7 +238,7 @@ final case class ScenarioRunner(
         missingWith(SErrorCrash(s"Key $gk not found"))
       case Some(acoid) =>
         ledger.lookupGlobalContract(
-          view = ScenarioLedger.ParticipantView(committer),
+          view = ScenarioLedger.ParticipantView(Set(committer)),
           effectiveAt = effectiveAt,
           acoid) match {
           case ScenarioLedger.LookupOk(_, _, stakeholders) =>

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -127,7 +127,7 @@ class CollectAuthorityState {
         case SResultNeedContract(acoid, _, committers, _, callback) =>
           val effectiveAt = ledger.currentTime
           ledger.lookupGlobalContract(
-            ScenarioLedger.ParticipantView(committers.head),
+            ScenarioLedger.ParticipantView(committers),
             effectiveAt,
             acoid) match {
             case ScenarioLedger.LookupOk(_, result, _) =>

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -400,7 +400,7 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Seq[ScriptLedgerClient.ActiveContract]] = {
     val acs = scenarioRunner.ledger.query(
-      view = ScenarioLedger.ParticipantView(party),
+      view = ScenarioLedger.ParticipantView(Set(party)),
       effectiveAt = scenarioRunner.ledger.currentTime)
     val filtered = acs.collect {
       case ScenarioLedger.LookupOk(cid, Value.ContractInst(tpl, arg, _), stakeholders)
@@ -416,7 +416,7 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]] = {
     scenarioRunner.ledger.lookupGlobalContract(
-      view = ScenarioLedger.ParticipantView(party),
+      view = ScenarioLedger.ParticipantView(Set(party)),
       effectiveAt = scenarioRunner.ledger.currentTime,
       cid) match {
       case ScenarioLedger.LookupOk(_, Value.ContractInst(_, arg, _), stakeholders)


### PR DESCRIPTION
As part of multi-party read/write on command submissions we also need
to be able to support multi-party queries in DAML Script (we can already do this on the ledger API). Since the
queries in DAML Studio go via ParticipantView, this PR extends this as
a prerequisite to making use of this in DAML Script.

This does not yet relax any restrictions on command submissions. Those
still require a single committer.

For consistency with the surrounding code, I went for a simple Set
rather than a non-empty Set.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
