### PR TITLE
add silent_annotations option to da_scala bazel functions

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -468,20 +468,21 @@ Arguments:
   doctitle: title for Scalaadoc's index.html. Typically the name of the library
 """
 
-def _create_scaladoc_jar(**kwargs):
+def _create_scaladoc_jar(name, srcs, plugins = [], deps = [], scalacopts = [], generated_srcs = [], silent_annotations = False, **kwargs):
     # Limit execution to Linux and MacOS
     if is_windows == False:
-        plugins = []
-        if "plugins" in kwargs:
-            plugins = kwargs["plugins"]
-
+        if silent_annotations:
+            # as with _wrap_rule
+            scalacopts = ["-P:silencer:checkUnused"] + scalacopts
+            plugins = [silencer_plugin] + plugins
+            deps = [silencer_lib] + deps
         scaladoc_jar(
-            name = kwargs["name"] + "_scaladoc",
-            deps = kwargs.get("deps", []),
+            name = name + "_scaladoc",
+            deps = deps,
             plugins = plugins,
-            srcs = kwargs["srcs"],
-            scalacopts = kwargs.get("scalacopts", []),
-            generated_srcs = kwargs.get("generated_srcs", []),
+            srcs = srcs,
+            scalacopts = scalacopts,
+            generated_srcs = generated_srcs,
             tags = ["scaladoc"],
         )
 

--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -139,6 +139,9 @@ default_compile_arguments = {
     "unused_dependency_checker_mode": "error",
 }
 
+silencer_plugin = "@maven//:com_github_ghik_silencer_plugin_2_12_12"
+silencer_lib = "@maven//:com_github_ghik_silencer_lib_2_12_12"
+
 default_initial_heap_size = "128m"
 default_max_heap_size = "1g"
 default_scalac_stack_size = "2m"
@@ -173,11 +176,24 @@ def _set_jvm_flags(
     })
     return result
 
-def _wrap_rule(rule, name = "", scalacopts = [], plugins = [], generated_srcs = [], **kwargs):
+def _wrap_rule(
+        rule,
+        name = "",
+        scalacopts = [],
+        plugins = [],
+        generated_srcs = [],  # hiding from the underlying rule
+        deps = [],
+        silent_annotations = False,
+        **kwargs):
+    if silent_annotations:
+        scalacopts = ["-P:silencer:checkUnused"] + scalacopts
+        plugins = [silencer_plugin] + plugins
+        deps = [silencer_lib] + deps
     rule(
         name = name,
         scalacopts = common_scalacopts + plugin_scalacopts + scalacopts,
         plugins = common_plugins + plugins,
+        deps = deps,
         **kwargs
     )
 

--- a/daml-lf/interpreter/BUILD.bazel
+++ b/daml-lf/interpreter/BUILD.bazel
@@ -12,10 +12,8 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repl")
 da_scala_library(
     name = "interpreter",
     srcs = glob(["src/main/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
     scalacopts = lf_scalacopts,
+    silent_annotations = True,
     tags = ["maven_coordinates=com.daml:daml-lf-interpreter:__VERSION__"],
     visibility = [
         "//compiler/repl-service:__subpackages__",
@@ -30,7 +28,6 @@ da_scala_library(
         "//daml-lf/language",
         "//daml-lf/transaction",
         "//daml-lf/validation",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",

--- a/daml-lf/transaction/BUILD.bazel
+++ b/daml-lf/transaction/BUILD.bazel
@@ -68,10 +68,8 @@ da_scala_test(
     name = "transaction-test",
     size = "medium",
     srcs = glob(["src/test/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = lf_scalacopts + ["-P:silencer:checkUnused"],
+    scalacopts = lf_scalacopts,
+    silent_annotations = True,
     deps = [
         ":transaction",
         ":transaction_java_proto",
@@ -82,7 +80,6 @@ da_scala_test(
         "//daml-lf/transaction-test-lib",
         "//libs-scala/scalatest-utils",
         "@maven//:com_chuusai_shapeless_2_12",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_scalacheck_scalacheck_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",

--- a/language-support/scala/bindings-akka/BUILD.bazel
+++ b/language-support/scala/bindings-akka/BUILD.bazel
@@ -11,13 +11,10 @@ da_scala_library(
     name = "bindings-akka",
     srcs = glob(["src/main/**/*.scala"]),
     plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
         "@maven//:org_spire_math_kind_projector_2_12",
     ],
     resources = glob(["src/main/resources/**/*"]),
-    scalacopts = [
-        "-P:silencer:checkUnused",
-    ],
+    silent_annotations = True,
     tags = ["maven_coordinates=com.daml:bindings-akka:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -52,7 +49,6 @@ da_scala_library(
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:ch_qos_logback_logback_core",
         "@maven//:com_chuusai_shapeless_2_12",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_github_pureconfig_pureconfig_2_12",
         "@maven//:com_google_api_grpc_proto_google_common_protos",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
@@ -74,12 +70,7 @@ da_scala_test_suite(
             "src/test/**/*.scala",
         ],
     ),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = [
-        "-P:silencer:checkUnused",
-    ],
+    silent_annotations = True,
     visibility = [
         "//visibility:public",
     ],
@@ -92,7 +83,6 @@ da_scala_test_suite(
         "//language-support/scala/bindings-akka-testing",
         "//ledger-api/rs-grpc-bridge",
         "//ledger/ledger-api-client",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_google_api_grpc_proto_google_common_protos",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/language-support/scala/bindings/BUILD.bazel
+++ b/language-support/scala/bindings/BUILD.bazel
@@ -11,10 +11,9 @@ da_scala_library(
     name = "bindings",
     srcs = glob(["src/main/**/*.scala"]),
     plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
         "@maven//:org_spire_math_kind_projector_2_12",
     ],
-    scalacopts = ["-P:silencer:checkUnused"],
+    silent_annotations = True,
     tags = ["maven_coordinates=com.daml:bindings-scala:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -28,7 +27,6 @@ da_scala_library(
     deps = [
         "//daml-lf/data",
         "//ledger-api/grpc-definitions:ledger-api-scalapb",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:io_grpc_grpc_core",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -5,6 +5,7 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
     "da_scala_test",
+    "silencer_plugin",
 )
 load(
     "//rules_daml:daml.bzl",
@@ -47,7 +48,7 @@ da_scala_library(
     name = "daml-lf-codegen-sample-app",
     srcs = [":MyMain.srcjar"] + glob(["src/main/**/*.scala"]),
     plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
+        silencer_plugin,
         "@maven//:org_spire_math_kind_projector_2_12",
     ],
     scalacopts = [
@@ -71,7 +72,7 @@ da_scala_library(
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
         # silencer warns if this is absent, but we don't use it here;
-        # buildozer errors if you add it
+        # buildozer errors if you add it, so silent_annotations can't be used
         # "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],

--- a/language-support/scala/codegen-testing/BUILD.bazel
+++ b/language-support/scala/codegen-testing/BUILD.bazel
@@ -70,18 +70,12 @@ da_scala_test_suite(
         ],
         exclude = testing_utils,
     ),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = [
-        "-P:silencer:checkUnused",
-    ],
+    silent_annotations = True,
     deps = [
         ":codegen-testing",
         ":codegen-testing-testing",
         "//language-support/scala/bindings",
         "@maven//:com_chuusai_shapeless_2_12",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:org_apache_commons_commons_text",
         "@maven//:org_scalacheck_scalacheck_2_12",
         "@maven//:org_scalatest_scalatest_2_12",

--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -11,12 +11,8 @@ load(
 da_scala_library(
     name = "db-backend",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = [
-        "-P:silencer:checkUnused",
-    ] + lf_scalacopts,
+    scalacopts = lf_scalacopts,
+    silent_annotations = True,
     tags = ["maven_coordinates=com.daml:http-json-db-backend:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -27,7 +23,6 @@ da_scala_library(
     ],
     deps = [
         "@maven//:com_chuusai_shapeless_2_12",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_lihaoyi_sourcecode_2_12",
         "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",

--- a/ledger-service/db-backend/BUILD.bazel
+++ b/ledger-service/db-backend/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "da_scala_library",
     "da_scala_test",
     "lf_scalacopts",
+    "silencer_lib",
 )
 
 da_scala_library(
@@ -49,7 +50,7 @@ da_scala_test(
         "//daml-lf/transaction-test-lib",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:com_chuusai_shapeless_2_12",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
+        silencer_lib,
         "@maven//:com_lihaoyi_sourcecode_2_12",
         "@maven//:com_typesafe_akka_akka_slf4j_2_12",
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",

--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -162,11 +162,11 @@ da_scala_test(
         "//ledger/test-common/test-certificates",
     ],
     plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
         "@maven//:org_spire_math_kind_projector_2_12",
     ],
     resources = glob(["src/it/resources/**/*"]),
-    scalacopts = hj_scalacopts + ["-P:silencer:checkUnused"],
+    scalacopts = hj_scalacopts,
+    silent_annotations = True,
     deps = [
         ":http-json",
         "//bazel_tools/runfiles:scala_runfiles",
@@ -186,7 +186,6 @@ da_scala_test(
         "//libs-scala/postgresql-testing",
         "//libs-scala/scala-utils",
         "@maven//:com_chuusai_shapeless_2_12",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_lihaoyi_sourcecode_2_12",
         "@maven//:com_typesafe_akka_akka_http_core_2_12",
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",

--- a/ledger/ledger-api-client/BUILD.bazel
+++ b/ledger/ledger-api-client/BUILD.bazel
@@ -37,10 +37,7 @@ da_scala_library(
 da_scala_test_suite(
     name = "ledger-api-client-tests",
     srcs = glob(["src/test/suite/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = ["-P:silencer:checkUnused"],
+    silent_annotations = True,
     deps = [
         ":ledger-api-client",
         "//language-support/scala/bindings",
@@ -48,7 +45,6 @@ da_scala_test_suite(
         "//ledger-api/testing-utils",
         "//ledger/caching",
         "//libs-scala/concurrent",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:com_typesafe_akka_akka_stream_testkit_2_12",

--- a/ledger/ledger-api-common/BUILD.bazel
+++ b/ledger/ledger-api-common/BUILD.bazel
@@ -12,9 +12,8 @@ da_scala_library(
     srcs = glob(["src/main/scala/**/*.scala"]),
     plugins = [
         "@maven//:org_spire_math_kind_projector_2_12",
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
     ],
-    scalacopts = ["-P:silencer:checkUnused"],
+    silent_annotations = True,
     tags = ["maven_coordinates=com.daml:ledger-api-common:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -34,7 +33,6 @@ da_scala_library(
         "//ledger/metrics",
         "//libs-scala/concurrent",
         "//libs-scala/resources",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_dropwizard_metrics_metrics_core",

--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -3,7 +3,14 @@
 
 load("@os_info//:os_info.bzl", "is_windows")
 load("//rules_daml:daml.bzl", "daml_compile")
-load("//bazel_tools:scala.bzl", "da_scala_binary", "da_scala_library", "da_scala_test_suite", "scaladoc_jar")
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+    "da_scala_library",
+    "da_scala_test_suite",
+    "scaladoc_jar",
+    "silencer_plugin",
+)
 load("//bazel_tools:pom_file.bzl", "pom_file")
 
 compile_deps = [
@@ -228,7 +235,7 @@ scaladoc_jar(
     ],
     doctitle = "DAML participant integration API",
     plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
+        silencer_plugin,
     ],
     root_content = "rootdoc.txt",
     scalacopts = ["-P:silencer:checkUnused"],

--- a/ledger/participant-state/kvutils/BUILD.bazel
+++ b/ledger/participant-state/kvutils/BUILD.bazel
@@ -20,10 +20,7 @@ load("@os_info//:os_info.bzl", "is_windows")
 da_scala_library(
     name = "kvutils",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = ["-P:silencer:checkUnused"],
+    silent_annotations = True,
     tags = ["maven_coordinates=com.daml:participant-state-kvutils:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -50,7 +47,6 @@ da_scala_library(
         "//libs-scala/contextualized-logging",
         "//libs-scala/resources",
         "//libs-scala/timer-utils",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
@@ -113,10 +109,8 @@ da_scala_test_suite(
     data = [
         "//ledger/test-common:model-tests.dar",
     ],
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
     resources = glob(["src/test/resources/*"]),
+    silent_annotations = True,
     deps = [
         ":daml_kvutils_java_proto",
         ":kvutils",
@@ -143,7 +137,6 @@ da_scala_test_suite(
         "//ledger/participant-state",
         "//ledger/participant-state/protobuf:ledger_configuration_java_proto",
         "//libs-scala/contextualized-logging",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_typesafe_akka_akka_actor_2_12",

--- a/ledger/participant-state/kvutils/app/BUILD.bazel
+++ b/ledger/participant-state/kvutils/app/BUILD.bazel
@@ -12,13 +12,8 @@ load("//ledger/ledger-api-test-tool:conformance.bzl", "conformance_test")
 da_scala_library(
     name = "app",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
     resources = glob(["src/main/resources/**/*"]),
-    scalacopts = [
-        "-P:silencer:checkUnused",
-    ],
+    silent_annotations = True,
     tags = ["maven_coordinates=com.daml:participant-state-kvutils-app:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -47,7 +42,6 @@ da_scala_library(
         "//libs-scala/ports",
         "//libs-scala/resources",
         "//libs-scala/resources-akka",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_typesafe_akka_akka_actor_2_12",

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -11,12 +11,10 @@ load("@build_environment//:configuration.bzl", "mvn_version")
 da_scala_library(
     name = "sandbox-classic",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
     # Do not include logback.xml into the library: let the user
     # of the sandbox-as-a-library decide how to log.
     resources = ["//ledger/sandbox-common:src/main/resources/banner.txt"],
+    silent_annotations = True,
     tags = ["maven_coordinates=com.daml:sandbox-classic:__VERSION__"],
     visibility = [
         "//visibility:public",
@@ -56,7 +54,6 @@ da_scala_library(
         "//libs-scala/resources",
         "//libs-scala/resources-akka",
         "@maven//:ch_qos_logback_logback_classic",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/ledger/sandbox-perf/BUILD.bazel
+++ b/ledger/sandbox-perf/BUILD.bazel
@@ -14,10 +14,7 @@ load(
 da_scala_library(
     name = "sandbox-perf-lib",
     srcs = glob(["src/perf/lib/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = ["-P:silencer:checkUnused"],
+    silent_annotations = True,
     visibility = ["//visibility:public"],
     deps = [
         "//bazel_tools/runfiles:scala_runfiles",
@@ -45,7 +42,6 @@ da_scala_library(
         "//libs-scala/postgresql-testing",
         "//libs-scala/resources",
         "@maven//:ch_qos_logback_logback_classic",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/libs-scala/concurrent/BUILD.bazel
+++ b/libs-scala/concurrent/BUILD.bazel
@@ -32,14 +32,11 @@ da_scala_library(
 da_scala_test(
     name = "test",
     srcs = glob(["src/test/scala/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = scalacopts + ["-P:silencer:checkUnused"],
+    scalacopts = scalacopts,
+    silent_annotations = True,
     deps = [
         ":concurrent",
         "@maven//:com_chuusai_shapeless_2_12",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )

--- a/libs-scala/contextualized-logging/BUILD.bazel
+++ b/libs-scala/contextualized-logging/BUILD.bazel
@@ -10,17 +10,14 @@ load(
 da_scala_library(
     name = "contextualized-logging",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
     scalacopts = ["-Xsource:2.13"],
+    silent_annotations = True,
     tags = ["maven_coordinates=com.daml:contextualized-logging:__VERSION__"],
     visibility = [
         "//visibility:public",
     ],
     deps = [
         "//libs-scala/grpc-utils",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:io_grpc_grpc_api",

--- a/libs-scala/resources/BUILD.bazel
+++ b/libs-scala/resources/BUILD.bazel
@@ -30,15 +30,9 @@ da_scala_library(
 da_scala_test_suite(
     name = "resources-tests",
     srcs = glob(["src/test/suite/**/*.scala"]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = [
-        "-P:silencer:checkUnused",
-    ],
+    silent_annotations = True,
     deps = [
         ":resources",
         ":resources-test-lib",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
     ],
 )

--- a/navigator/backend/BUILD.bazel
+++ b/navigator/backend/BUILD.bazel
@@ -37,10 +37,8 @@ da_scala_library(
     srcs = glob([
         "src/main/scala/**/*.scala",
     ]),
-    plugins = [
-        "@maven//:com_github_ghik_silencer_plugin_2_12_12",
-    ],
-    scalacopts = navigator_scalacopts + ["-P:silencer:checkUnused"],
+    scalacopts = navigator_scalacopts,
+    silent_annotations = True,
     visibility = ["//visibility:public"],
     runtime_deps = [
         "@maven//:ch_qos_logback_logback_classic",
@@ -65,7 +63,6 @@ da_scala_library(
         "//libs-scala/build-info",
         "//libs-scala/grpc-utils",
         "@maven//:com_chuusai_shapeless_2_12",
-        "@maven//:com_github_ghik_silencer_lib_2_12_12",
         "@maven//:com_github_pureconfig_pureconfig_2_12",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_lihaoyi_sourcecode_2_12",


### PR DESCRIPTION
During #6907 it became obvious that a simpler way to declare that a build rule wished to enable `@silent` would be very nice, but that PR was already quite large enough.  #7661's effective requirement of sed-based build file editing clarified that we should resolve this boilerplate.

So here it is: add `silent_annotations = True` to your Scala build if you want access to the `@silent` annotation, delete it if you don't need it anymore.

As a (desired) side effect of abstracting this, every use of silencer also acquires the `checkUnused` option in this PR to ensure that we clean up stray `@silent`s.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
