### PR TITLE
LF: validate transaction containing Nodes with byKey flag.

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -67,6 +67,16 @@ private[lf] final class CommandPreprocessor(compiledPackages: CompiledPackages) 
   ): speedy.Command.Fetch =
     speedy.Command.Fetch(templateId, SValue.SContractId(coid))
 
+  def unsafePreprocessFetchByKey(
+      templateId: Ref.Identifier,
+      contractKey: Value[Value.ContractId],
+  ): (speedy.Command.FetchByKey, Set[Value.ContractId]) = {
+    val template = unsafeGetTemplate(templateId)
+    val ckTtype = unsafeGetContractKeyType(templateId, template)
+    val (key, keyCids) = valueTranslator.unsafeTranslateValue(ckTtype, contractKey)
+    speedy.Command.FetchByKey(templateId, key) -> keyCids
+  }
+
   @throws[PreprocessorException]
   def unsafePreprocessExercise(
       templateId: Ref.Identifier,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -70,7 +70,7 @@ private[preprocessing] final class TransactionPreprocessor(
       case fetchByKey: Node.NodeFetch[_, _] if fetchByKey.byKey.getOrElse(false) =>
         val (cmd, newCids) = commandPreprocessor.unsafePreprocessFetchByKey(
           fetchByKey.templateId,
-          fetchByKey.key.fold(fail("unexpected exerciseByKey without key."))(_.key.value))
+          fetchByKey.key.fold(fail("unexpected fetchByKey without key."))(_.key.value))
         (cmd, (localCids | newCids.filterNot(globalCids), globalCids))
       case fetch: Node.NodeFetch[_, _] =>
         val cmd = commandPreprocessor.unsafePreprocessFetch(fetch.templateId, fetch.coid)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Command.scala
@@ -39,6 +39,11 @@ object Command {
       coid: SContractId,
   ) extends Command
 
+  final case class FetchByKey(
+      templateId: Identifier,
+      contractKey: SValue,
+  ) extends Command
+
   final case class CreateAndExercise(
       templateId: Identifier,
       createArgument: SValue,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -1489,6 +1489,8 @@ private[lf] final class Compiler(
       compileExerciseByKey(templateId, SEValue(contractKey), choiceId, SEValue(argument))
     case Command.Fetch(templateId, coid) =>
       FetchDefRef(templateId)(SEValue(coid))
+    case Command.FetchByKey(templateId, coid) =>
+      FetchByKeyDefRef(templateId)(SEValue(coid))
     case Command.CreateAndExercise(templateId, createArg, choice, choiceArg) =>
       compileCreateAndExercise(
         templateId,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -319,7 +319,7 @@ private[lf] case class PartialTransaction(
       signatories,
       stakeholders,
       key,
-      byKey
+      Some(byKey)
     )
     mustBeActive(
       coid,
@@ -420,7 +420,7 @@ private[lf] case class PartialTransaction(
           children = context.children.toImmArray,
           exerciseResult = Some(value),
           key = ec.contractKey,
-          byKey = ec.byKey,
+          byKey = Some(ec.byKey),
         )
         val nodeId = ec.nodeId
         val nodeSeed = ec.parent.nextChildrenSeed

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -185,7 +185,7 @@ object TransactionBuilder {
       consuming: Boolean,
       actingParties: Set[String],
       argument: Value,
-      byKey: Boolean = true,
+      byKey: Option[Boolean] = Some(false),
   ): Exercise =
     Exercise(
       targetCoid = contract.coid,
@@ -210,9 +210,9 @@ object TransactionBuilder {
       actingParties: Set[String],
       argument: Value,
   ): Exercise =
-    exercise(contract, choice, consuming, actingParties, argument, byKey = true)
+    exercise(contract, choice, consuming, actingParties, argument, byKey = Some(true))
 
-  def fetch(contract: Create, byKey: Boolean = true): Fetch =
+  def fetch(contract: Create, byKey: Option[Boolean] = Some(false)): Fetch =
     Fetch(
       coid = contract.coid,
       templateId = contract.coinst.template,
@@ -225,7 +225,7 @@ object TransactionBuilder {
     )
 
   def fetchByKey(contract: Create): Fetch =
-    fetch(contract, byKey = true)
+    fetch(contract, byKey = Some(true))
 
   def lookupByKey(contract: Create, found: Boolean): LookupByKey =
     LookupByKey(

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -292,7 +292,7 @@ object ValueGenerators {
       signatories <- genNonEmptyParties
       stakeholders <- genNonEmptyParties
       key <- Gen.option(keyWithMaintainersGen)
-      byKey <- Gen.oneOf(true, false)
+      byKey <- Gen.option(Gen.oneOf(true, false))
     } yield
       NodeFetch(coid, templateId, None, Some(actingParties), signatories, stakeholders, key, byKey)
   }
@@ -316,7 +316,7 @@ object ValueGenerators {
       exerciseResultValue <- versionedValueGen
       key <- versionedValueGen
       maintainers <- genNonEmptyParties
-      byKey <- Gen.oneOf(true, false)
+      byKey <- Gen.option(Gen.oneOf(true, false))
     } yield
       NodeExercises(
         targetCoid,

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -292,7 +292,8 @@ object ValueGenerators {
       signatories <- genNonEmptyParties
       stakeholders <- genNonEmptyParties
       key <- Gen.option(keyWithMaintainersGen)
-      byKey <- Gen.option(Gen.oneOf(true, false))
+      byKey <- key.fold[Gen[Option[Boolean]]](Gen.const(None))(_ =>
+        Gen.option(Gen.oneOf(true, false)))
     } yield
       NodeFetch(coid, templateId, None, Some(actingParties), signatories, stakeholders, key, byKey)
   }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -214,9 +214,12 @@ object Node {
       stakeholders: Set[Party],
       key: Option[KeyWithMaintainers[Val]],
       byKey: Option[Boolean] // None if unknown
-      // invariant (!byKey || exerciseResult.isDefined)
   ) extends LeafOnlyNode[Cid, Val]
-      with NodeInfo.Fetch
+      with NodeInfo.Fetch {
+
+    require(byKey.forall(!_ || key.isDefined))
+
+  }
 
   object NodeFetch extends WithTxValue2[NodeFetch]
 
@@ -246,9 +249,10 @@ object Node {
       exerciseResult: Option[Val],
       key: Option[KeyWithMaintainers[Val]],
       byKey: Option[Boolean] // None if unknown
-      // invariant (byKey.forall( ! _  || exerciseResult.isDefined))
   ) extends GenNode[Nid, Cid, Val]
       with NodeInfo.Exercise {
+
+    require(byKey.forall(!_ || key.isDefined))
 
     @deprecated("use actingParties instead", since = "1.1.2")
     private[daml] def controllers: actingParties.type = actingParties

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -67,7 +67,7 @@ final case class VersionedTransaction[Nid, +Cid] private[lf] (
 
 object VersionedTransaction extends value.CidContainer2[VersionedTransaction] {
 
-  override private[lf] def map2[A1, B1, C1, A2, B2, C2](
+  override private[lf] def map2[A1, B1, A2, B2](
       f1: A1 => A2,
       f2: B1 => B2,
   ): VersionedTransaction[A1, B1] => VersionedTransaction[A2, B2] = {
@@ -282,6 +282,13 @@ sealed abstract class HasTxNodes[Nid, +Cid, +Val] {
   def nodes: HashMap[Nid, Node.GenNode[Nid, Cid, Val]]
 
   def roots: ImmArray[Nid]
+
+  def byKeyNodes: Set[Nid] =
+    nodes.collect {
+      case (nodeId, node: Node.NodeExercises[_, _, _]) if node.byKey.getOrElse(false) => nodeId
+      case (nodeId, node: Node.NodeFetch[_, _]) if node.byKey.getOrElse(false) => nodeId
+      case (nodeId, _: Node.NodeLookupByKey[_, _]) => nodeId
+    }.toSet
 
   /**
     * This function traverses the transaction tree in pre-order traversal (i.e. exercise node are traversed before their children).

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -355,7 +355,7 @@ object TransactionCoder {
             Left(DecodeError(s"$txVersion is too old to support NodeFetch's `key` field"))
           else decodeKeyWithMaintainers(decodeCid, protoFetch.getKeyWithMaintainers).map(Some(_))
         } yield
-          (ni, NodeFetch(c, templateId, None, actingParties, signatories, stakeholders, key, false))
+          (ni, NodeFetch(c, templateId, None, actingParties, signatories, stakeholders, key, None))
 
       case NodeTypeCase.EXERCISE =>
         val protoExe = protoNode.getExercise
@@ -438,7 +438,7 @@ object TransactionCoder {
               children = children,
               exerciseResult = rv,
               key = keyWithMaintainers,
-              byKey = false,
+              byKey = None,
             ),
           )
       case NodeTypeCase.LOOKUP_BY_KEY =>

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/CidContainer.scala
@@ -116,7 +116,7 @@ trait CidContainer2[F[_, _]] {
 
   import CidMapper._
 
-  private[lf] def map2[A1, B1, C1, A2, B2, C2](
+  private[lf] def map2[A1, B1, A2, B2](
       f1: A1 => A2,
       f2: B1 => B2,
   ): F[A1, B1] => F[A2, B2]
@@ -126,17 +126,17 @@ trait CidContainer2[F[_, _]] {
       f2: B => Unit,
   ): F[A, B] => Unit
 
-  protected final def cidMapperInstance[A1, B1, C1, A2, B2, C2, In, Out](
+  protected final def cidMapperInstance[A1, B1, A2, B2, In, Out](
       implicit mapper1: CidMapper[A1, A2, In, Out],
       mapper2: CidMapper[B1, B2, In, Out],
   ): CidMapper[F[A1, B1], F[A2, B2], In, Out] =
     new CidMapper[F[A1, B1], F[A2, B2], In, Out] {
       override def map(f: In => Out): F[A1, B1] => F[A2, B2] = {
-        map2[A1, B1, C1, A2, B2, C2](mapper1.map(f), mapper2.map(f))
+        map2[A1, B1, A2, B2](mapper1.map(f), mapper2.map(f))
       }
     }
 
-  final implicit def cidSuffixerInstance[A1, B1, C1, A2, B2, C2](
+  final implicit def cidSuffixerInstance[A1, B1, A2, B2](
       implicit suffixer1: CidSuffixer[A1, A2],
       suffixer2: CidSuffixer[B1, B2],
   ): CidSuffixer[F[A1, B1], F[A2, B2]] =

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -399,9 +399,9 @@ class TransactionCoderSpec
   def withoutByKeyFlag[Nid, Cid, Val](gn: GenNode[Nid, Cid, Val]): GenNode[Nid, Cid, Val] =
     gn match {
       case ne: NodeExercises[Nid, Cid, Val] =>
-        ne.copy(byKey = false)
+        ne.copy(byKey = None)
       case fe: NodeFetch[Cid, Val] =>
-        fe.copy(byKey = false)
+        fe.copy(byKey = None)
       case _ => gn
     }
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -234,7 +234,7 @@ object TransactionSpec {
       children = children,
       exerciseResult = if (hasExerciseResult) Some(V.ValueUnit) else None,
       key = None,
-      byKey = false
+      byKey = Some(false)
     )
 
   val dummyCid = V.ContractId.V1.assertBuild(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/execution/StoreBackedCommandExecutor.scala
@@ -70,10 +70,7 @@ private[apiserver] final class StoreBackedCommandExecutor(
               submissionSeed,
               Some(meta.usedPackages),
               Some(meta.nodeSeeds),
-              Some(
-                updateTx.nodes
-                  .collect { case (nodeId, node) if node.byKey => nodeId }
-                  .to[ImmArray]),
+              Some(updateTx.byKeyNodes.to[ImmArray]),
             ),
             transaction = updateTx,
             dependsOnLedgerTime = meta.dependsOnTime,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
@@ -68,7 +68,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
           children = ImmArray.empty,
           exerciseResult = None,
           key = None,
-          byKey = false,
+          byKey = None,
         )
       )
       builder.add(
@@ -82,7 +82,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
           key = Some(
             KeyWithMaintainers(ValueParty(bob), Set(bob))
           ),
-          byKey = false
+          byKey = None,
         ),
         parent = rootExercise,
       )
@@ -102,7 +102,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
           key = Some(
             KeyWithMaintainers(ValueParty(bob), Set(bob))
           ),
-          byKey = false,
+          byKey = None,
         ),
         parent = rootExercise,
       )

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -129,7 +129,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
       children = ImmArray.empty,
       exerciseResult = Some(ValueText("some exercise result")),
       key = None,
-      byKey = false,
+      byKey = None,
     )
 
   // All non-transient contracts created in a transaction
@@ -188,7 +188,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         children = ImmArray.empty,
         exerciseResult = Some(ValueUnit),
         key = None,
-        byKey = false,
+        byKey = None,
       )
     )
     txBuilder.add(
@@ -200,7 +200,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         signatories = Set(alice),
         stakeholders = Set(alice),
         None,
-        byKey = false,
+        byKey = None,
       ),
       exerciseId,
     )
@@ -518,7 +518,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         children = ImmArray.empty,
         exerciseResult = Some(ValueUnit),
         key = maybeKey.map(k => KeyWithMaintainers(ValueText(k), Set(party))),
-        byKey = false,
+        byKey = None,
       ))
     nextOffset() -> LedgerEntry.Transaction(
       commandId = Some(UUID.randomUUID().toString),
@@ -574,7 +574,7 @@ private[dao] trait JdbcLedgerDaoSuite extends AkkaBeforeAndAfterAll with JdbcLed
         signatories = Set(party),
         stakeholders = Set(party),
         None,
-        byKey = false,
+        byKey = None,
       ))
     nextOffset() -> LedgerEntry.Transaction(
       commandId = Some(UUID.randomUUID().toString),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -51,7 +51,7 @@ class ProjectionsSpec extends WordSpec with Matchers {
       children = ImmArray.empty,
       exerciseResult = None,
       key = None,
-      byKey = false,
+      byKey = None,
     )
 
   def project(tx: Transaction) = {


### PR DESCRIPTION
This adapates and test the validation of transactions containing nodes
with `byKey` flag.

With respect to #7617, the type of `byKey` is changed from `Boolean` 
to `Option[Boolean]`. The idea is that for old transactions the flag will
be set to `None` (because we don't know if the node was actually done
"by key" or not) while for the next transaction version the flag will
be set to `Some(true)` or `Some(false)` (to be done in an upcoming
PR). This allows us to validate old transaction in a backward
compatible way and check new transaction without injecting the 
serialization version in the node comparison.

This advances the state of #7622

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
