### PR TITLE
Relax SQL exception constraints in ReadOnlySqlLedger

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/ReadOnlySqlLedger.scala
@@ -3,6 +3,7 @@
 
 package com.daml.platform.index
 
+import java.sql.SQLException
 import java.time.Instant
 
 import akka.actor.Cancellable
@@ -62,9 +63,10 @@ private[platform] object ReadOnlySqlLedger {
         loggingContext: LoggingContext,
     ): Future[LedgerId] = {
       val predicate: PartialFunction[Throwable, Boolean] = {
-        // If the index database schema is not yet fully created, querying for the
-        // ledger ID will throw SQL errors.
-        case _: java.sql.SQLNonTransientException => true
+        // If the index database is not yet fully initialized,
+        // querying for the ledger ID will throw different errors,
+        // depending on the database, and how far the initialization is.
+        case _: SQLException => true
         case _: LedgerIdNotFoundException => true
         case _: MismatchException.LedgerId => false
         case _ => false


### PR DESCRIPTION
Relax SQL exception constraints in `ReadOnlySqlLedger`

This was motivated by the fact that PostgreSQL errors do not inherit from `java.sql.SQLNonTransientException`. We do not want to rely on database implementations throwing specific errors.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
