### PR TITLE
Print tests seed in ledger-api-test-tool report [KVL-634]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -160,7 +160,7 @@ object LedgerApiTestTool {
         new ColorizedPrintStreamReporter(
           System.out,
           config.verbose,
-        ).report(summaries)
+        ).report(summaries, identifierSuffix)
         sys.exit(exitCode(summaries, config.mustFail))
       case Failure(exception: Errors.FrameworkException) =>
         logger.error(exception.getMessage)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -8,7 +8,7 @@ import java.io.{PrintStream, PrintWriter, StringWriter}
 import scala.util.Try
 
 trait Reporter[A] {
-  def report(results: Vector[LedgerTestSummary]): A
+  def report(results: Vector[LedgerTestSummary], identifierSuffix: String): A
 }
 
 object Reporter {
@@ -102,13 +102,18 @@ object Reporter {
           }
       }
 
-    override def report(results: Vector[LedgerTestSummary]): Unit = {
+    override def report(results: Vector[LedgerTestSummary], identifierSuffix: String): Unit = {
       s.println()
       s.println(blue("#" * 80))
       s.println(blue("#"))
       s.println(blue("# TEST REPORT"))
       s.println(blue("#"))
       s.println(blue("#" * 80))
+
+      s.println()
+      s.println(yellow("### RUN INFORMATION"))
+      s.println()
+      s.println(cyan(s"identifierSuffix = $identifierSuffix"))
 
       val (successes, failures) = results.partition(_.result.isRight)
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests // Not needed
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags // Not needed
- [ ] Normal production system change, include purpose of change in description


Added tests seed value in test tool report.

Before:

```

$ ledger-api-test-tool -v 127.0.0.1:6865

################################################################################
#
# TEST REPORT
#
################################################################################

### SUCCESSES

DivulgenceIT
- [DivulgenceIT:DivulgenceTx] Divulged contracts should not be exposed by the transaction service ... Success (545 ms)
...
```

After:

```

$ ledger-api-test-tool -v 127.0.0.1:6865

################################################################################
#
# TEST REPORT
#
################################################################################

### RUN INFORMATION

identifierSuffix = f2aa3d2b2fc

### SUCCESSES

DivulgenceIT
- [DivulgenceIT:DivulgenceTx] Divulged contracts should not be exposed by the transaction service ... Success (545 ms)
...
```
