### PR TITLE
UTC date format in ledger-api-test-tool logs [KVL-626]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/resources/logback.xml
+++ b/ledger/ledger-api-test-tool/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
             <level>trace</level>
         </filter>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX", UTC} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/ledger-api-test-tool/src/main/resources/logback.xml
+++ b/ledger/ledger-api-test-tool/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
             <level>trace</level>
         </filter>
         <encoder>
-            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX", UTC} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
This PR changes formatting of the log timestamp for ledger-api-test-tool to the UTC format.
Before:
```
14:30:01.282 INFO  c.d.l.a.t.i.p.ParticipantSessionManager@[main] - Connecting to participant at localhost:6865...
```
After:
```
2020-10-14T13:01:51.512Z INFO  c.d.l.a.t.i.p.ParticipantSessionManager@[main] - Connecting to participant at localhost:6865...
```

CHANGELOG_BEGIN
- [Integration Kit] UTC date format in logs of ledger-api-test-tool

CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] ~~Include appropriate tests~~ not required
- [x] Set a descriptive title and thorough description
- [ ] ~~Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate~~
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
