### PR TITLE
Remove refs to #public Slack channel and some general Slack refs

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -96,7 +96,7 @@ echo ""
 
 function cleanup() {
   echo "SDK 0.0.0 failed to build/install - if you need help ask on"
-  echo "https://discuss.daml.com or https://slack.daml.com"
+  echo "https://discuss.daml.com"
   echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
 
   if [[ -n "${SDK_TEMP_DIR+x}" && -d "$SDK_TEMP_DIR" ]]; then

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -25,9 +25,8 @@ For these and other features, use :doc:`the Ledger API </app-dev/ledger-api>`
 instead.
 
 We welcome feedback about the JSON API on
-`our issue tracker <https://github.com/digital-asset/daml/issues/new?milestone=HTTP+JSON+API+Maintenance>`_
-`on our forum <https://discuss.daml.com>`_, or
-`on Slack <https://slack.daml.com>`_.
+`our issue tracker <https://github.com/digital-asset/daml/issues/new?milestone=HTTP+JSON+API+Maintenance>`_, or
+`on our forum <https://discuss.daml.com>`_.
 
 .. toctree::
    :hidden:

--- a/docs/source/support/support.rst
+++ b/docs/source/support/support.rst
@@ -13,7 +13,7 @@ Have questions or feedback? You're in the right place.
   If you're not sure what makes a good question, take a look at `our guide on the topic <https://discuss.daml.com/t/how-to-ask-questions/304>`_.
 - **Feedback: Forum**
 
-  If you want to give feedback, you can make a topic in the ``General`` category `on our forum <https://discuss.daml.com>`_ or on `Slack <https://slack.daml.com>`_ in the ``#public`` channel.
+  If you want to give feedback, you can make a topic in the ``General`` category `on our forum <https://discuss.daml.com>`_.
 
 When you're in the community Forum or on Stack Overflow, please keep to our `Code of Conduct <https://github.com/digital-asset/daml/blob/master/CODE_OF_CONDUCT.md>`__.
 
@@ -25,7 +25,7 @@ For community users (ie on our Forum and Stack Overflow):
 - **Timing**: You can enjoy the support of the community, which is provided for you out of their own good will and free time. On top of that, a Digital Asset employee will try to reply to unanswered questions within two business days.
 
   Business days are affected by public holidays. Engineers contributing to DAML are mostly located in Zurich and New York, so please be mindful of the public holidays in those locations (`timeanddate.com <https://www.timeanddate.com>`_ maintains an unofficial list of holidays for both `Switzerland <https://www.timeanddate.com/holidays/switzerland/>`_ and the `United States <https://www.timeanddate.com/holidays/us/>`_).
-- **Public support**: We only offer public support - for example, in the ``Questions`` category `on our forum <https://discuss.daml.com>`_ or on `Slack <https://slack.daml.com>`_ in the ``#public`` channel.
+- **Public support**: We offer public support in the ``Questions`` category `on our forum <https://discuss.daml.com>`_.
 
   We can't answer questions in private messages or over email, so please only ask questions in public forums.
 - **Level of support**: We're happy to answer questions about error messages you're encountering, or discuss DAML design questions. However, we can't provide more extensive consultation on how to build your DAML application or the languages, frameworks, libraries and tools you may use to build it.

--- a/docs/source/tools/trigger-service.rst
+++ b/docs/source/tools/trigger-service.rst
@@ -4,7 +4,7 @@
 Trigger Service
 ###############
 
-The Trigger Service is currently an :doc:`Early Access Feature in Alpha status </support/status-definitions>`. At this time, the documentation is limited to basic usage. As more features become available the documentation will be updated to include them. We welcome feedback about the Trigger Service on our `our issue tracker <https://github.com/digital-asset/daml/issues/new>`_ or `on our forum <https://discuss.daml.com>`_, or on `on Slack <https://slack.daml.com>`_.
+The Trigger Service is currently an :doc:`Early Access Feature in Alpha status </support/status-definitions>`. At this time, the documentation is limited to basic usage. As more features become available the documentation will be updated to include them. We welcome feedback about the Trigger Service on our `our issue tracker <https://github.com/digital-asset/daml/issues/new>`_, or `on our forum <https://discuss.daml.com>`_.
 
 The `DAML triggers <../triggers/index.html#running-a-daml-trigger>`_ documentation shows a simple method using the ``daml trigger`` command to arrange for the execution of a single trigger. Using this method, a dedicated process is launched to host the trigger.
 

--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -12,7 +12,7 @@ DAML Triggers - Off-Ledger Automation in DAML
 DAML Triggers are currently an :doc:`Early Access Feature in Alpha status </support/status-definitions>`.
 We welcome feedback about DAML triggers on
 `our issue tracker <https://github.com/digital-asset/daml/issues/new?milestone=DAML+Triggers>`_,
-`our forum <https://discuss.daml.com>`_, or `on Slack <https://slack.daml.com>`_.
+or `our forum <https://discuss.daml.com>`_.
 
 In addition to the actual DAML logic which is uploaded to the Ledger
 and the UI, DAML applications often need to automate certain

--- a/release/RELEASE.md
+++ b/release/RELEASE.md
@@ -314,7 +314,7 @@ patches we backport to the 1.0 release branch).
    for this release will be added to docs.daml.com on the next hour.
 
 1. **[STABLE]** Coordinate with product (& marketing) for the relevant public
-   announcements (public Slack, Twitter, etc.).
+   announcements (DAML Forum, Twitter, etc.).
 
 1. **[STABLE]** Documentation is published automatically once the release is
    public on GitHub, though this runs on an hourly cron.


### PR DESCRIPTION
This PR removes most references to Slack but leaves the following:

- 3 references to #daml-contributors in the public Slack (2 in the contributing doc, one in the glossary that also mentions contributing)
- 2 references to our private slack in RELEASE.md

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
