### PR TITLE
Support specifying the jdbc URL for the JSON API in an env var

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Cli.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Cli.scala
@@ -1,0 +1,152 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http
+
+import java.nio.file.{Paths}
+
+import com.daml.ledger.api.tls.TlsConfigurationCli
+import com.typesafe.scalalogging.StrictLogging
+import scopt.{Read, RenderingMode}
+
+import scala.concurrent.duration._
+import scala.util.Try
+
+object Cli extends StrictLogging {
+  private[http] def parseConfig(
+      args: Seq[String],
+      getEnvVar: String => Option[String] = sys.env.get): Option[Config] =
+    configParser(getEnvVar).parse(args, Config.Empty)
+
+  private def setJdbcConfig(
+      config: Config,
+      jdbcConfig: JdbcConfig,
+  ): Config = {
+    if (config.jdbcConfig.exists(_ != jdbcConfig)) {
+      throw new IllegalStateException(
+        "--query-store-jdbc-config and --query-store-jdbc-config-env are mutually exclusive.")
+    }
+    config.copy(jdbcConfig = Some(jdbcConfig))
+  }
+
+  private def parseJdbcConfig(s: String): Either[String, JdbcConfig] =
+    for {
+      m <- Try(implicitly[Read[Map[String, String]]].reads(s)).toEither.left.map(_ =>
+        s"Failed to parse $s into a commat-separated key-value map")
+      conf <- JdbcConfig.create(m)
+    } yield conf
+
+  private def parseJdbcConfigEnvVar(
+      envVar: String,
+      getEnvVar: String => Option[String]): Either[String, JdbcConfig] =
+    for {
+      v <- getEnvVar(envVar).toRight(s"Environment variable $envVar was not set")
+      conf <- parseJdbcConfig(v)
+    } yield conf
+
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  private def configParser(getEnvVar: String => Option[String]): scopt.OptionParser[Config] =
+    new scopt.OptionParser[Config]("http-json-binary") {
+
+      override def renderingMode: RenderingMode = RenderingMode.OneColumn
+
+      head("HTTP JSON API daemon")
+
+      help("help").text("Print this usage text")
+
+      opt[String]("ledger-host")
+        .action((x, c) => c.copy(ledgerHost = x))
+        .required()
+        .text("Ledger host name or IP address")
+
+      opt[Int]("ledger-port")
+        .action((x, c) => c.copy(ledgerPort = x))
+        .required()
+        .text("Ledger port number")
+
+      import com.daml.cliopts
+
+      cliopts.Http.serverParse(this, serviceName = "HTTP JSON API")(
+        address = (f, c) => c copy (address = f(c.address)),
+        httpPort = (f, c) => c copy (httpPort = f(c.httpPort)),
+        defaultHttpPort = None,
+        portFile = Some((f, c) => c copy (portFile = f(c.portFile))),
+      )
+
+      opt[String]("application-id")
+        .foreach(x =>
+          logger.warn(
+            s"Command-line option '--application-id' is deprecated. Please do NOT specify it. " +
+              s"Application ID: '$x' provided in the command-line is NOT used, using Application ID from JWT."))
+        .optional()
+        .hidden()
+
+      TlsConfigurationCli.parse(this, colSpacer = "        ")((f, c) =>
+        c copy (tlsConfig = f(c.tlsConfig)))
+
+      opt[Duration]("package-reload-interval")
+        .action((x, c) => c.copy(packageReloadInterval = FiniteDuration(x.length, x.unit)))
+        .optional()
+        .text(
+          s"Optional interval to poll for package updates. Examples: 500ms, 5s, 10min, 1h, 1d. " +
+            s"Defaults to ${Config.Empty.packageReloadInterval: FiniteDuration}")
+
+      opt[Int]("package-max-inbound-message-size")
+        .action((x, c) => c.copy(packageMaxInboundMessageSize = Some(x)))
+        .optional()
+        .text(
+          s"Optional max inbound message size in bytes used for uploading and downloading package updates." +
+            s" Defaults to the `max-inbound-message-size` setting.")
+
+      opt[Int]("max-inbound-message-size")
+        .action((x, c) => c.copy(maxInboundMessageSize = x))
+        .optional()
+        .text(
+          s"Optional max inbound message size in bytes. Defaults to ${Config.Empty.maxInboundMessageSize: Int}.")
+
+      opt[Map[String, String]]("query-store-jdbc-config")
+        .action((x, c) => setJdbcConfig(c, JdbcConfig.createUnsafe(x)))
+        .validate(JdbcConfig.validate)
+        .optional()
+        .valueName(JdbcConfig.usage)
+        .text(s"Optional query store JDBC configuration string." +
+          " Query store is a search index, use it if you need to query large active contract sets. " +
+          JdbcConfig.help)
+
+      opt[String]("query-store-jdbc-config-env")
+        .action((env, c) =>
+          setJdbcConfig(c, parseJdbcConfigEnvVar(env, getEnvVar).fold(sys.error(_), identity(_))))
+        .validate(parseJdbcConfigEnvVar(_, getEnvVar).map(_ => ()))
+        .optional()
+        .valueName("<ENVIRONMENT VARIABLE>")
+        .text(
+          s"Optional name of an environment variable containing the query store JDBC configuration string in the same format used by --query-store-jdbc-config." +
+            " --query-store-jdbc-config-env and --query-store-jdbc-config are mutually exclusive.")
+
+      opt[Map[String, String]]("static-content")
+        .action((x, c) => c.copy(staticContentConfig = Some(StaticContentConfig.createUnsafe(x))))
+        .validate(StaticContentConfig.validate)
+        .optional()
+        .valueName(StaticContentConfig.usage)
+        .text(s"DEV MODE ONLY (not recommended for production). Optional static content configuration string. "
+          + StaticContentConfig.help)
+
+      opt[Unit]("allow-insecure-tokens")
+        .action((_, c) => c copy (allowNonHttps = true))
+        .text(
+          "DEV MODE ONLY (not recommended for production). Allow connections without a reverse proxy providing HTTPS.")
+
+      opt[String]("access-token-file")
+        .text(
+          s"provide the path from which the access token will be read, required to interact with an authenticated ledger, no default")
+        .action((path, arguments) => arguments.copy(accessTokenFile = Some(Paths.get(path))))
+        .optional()
+
+      opt[Map[String, String]]("websocket-config")
+        .action((x, c) => c.copy(wsConfig = Some(WebsocketConfig.createUnsafe(x))))
+        .validate(WebsocketConfig.validate)
+        .optional()
+        .valueName(WebsocketConfig.usage)
+        .text(s"Optional websocket configuration string. ${WebsocketConfig.help}")
+    }
+}

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/CliSpec.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http
+
+import org.scalatest._
+
+final class CliSpec extends FreeSpec with Matchers {
+
+  private def configParser(
+      parameters: Seq[String],
+      getEnvVar: String => Option[String] = (_ => None)): Option[Config] =
+    Cli.parseConfig(parameters, getEnvVar)
+
+  val jdbcConfig = JdbcConfig(
+    "org.postgresql.Driver",
+    "jdbc:postgresql://localhost:5432/test?&ssl=true",
+    "postgres",
+    "password",
+    false)
+  val jdbcConfigString =
+    "driver=org.postgresql.Driver,url=jdbc:postgresql://localhost:5432/test?&ssl=true,user=postgres,password=password,createSchema=false"
+
+  val sharedOptions =
+    Seq("--ledger-host", "localhost", "--ledger-port", "6865", "--http-port", "7500")
+
+  "JdbcConfig" - {
+    "should get the jdbc string from the command line argument when provided" in {
+      val config = configParser(Seq("--query-store-jdbc-config", jdbcConfigString) ++ sharedOptions)
+        .getOrElse(fail())
+      config.jdbcConfig shouldBe Some(jdbcConfig)
+    }
+
+    "should get the jdbc string from the environment when provided" in {
+      val jdbcEnvVar = "JDBC_ENV_VAR"
+      val config = configParser(
+        Seq("--query-store-jdbc-config-env", jdbcEnvVar) ++ sharedOptions,
+        { case `jdbcEnvVar` => Some(jdbcConfigString) }
+      ).getOrElse(fail())
+      config.jdbcConfig shouldBe Some(jdbcConfig)
+    }
+
+    "should get None when neither CLI nor env variable are provided" in {
+      val config = configParser(sharedOptions).getOrElse(fail())
+      config.jdbcConfig shouldBe None
+    }
+  }
+
+}


### PR DESCRIPTION
This PR shuffles things around a bit to make it easier to test and
adds `--query-store-jdbc-config-env` which specifies the name of an
environment variable containing the jdbc URL. The UX for this is
modeled after #7660.

Added a test for the different formats.

fixes #7667

changelog_begin

- [JSON API] The JDBC url can now also be specified via
`--query-store-jdbc-config-env` which reads it from the given
environment variable.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
