### PR TITLE
@daml/types: Improve Unit type

### DIFF
--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -120,7 +120,7 @@ export function lazyMemo<A>(mkDecoder: () => jtv.Decoder<A>): jtv.Decoder<A> {
 /**
  * The counterpart of DAML's `()` type.
  */
-export type Unit = {};
+export interface Unit {}
 
 /**
  * Companion obect of the [[Unit]] type.

--- a/language-support/ts/daml-types/index.ts
+++ b/language-support/ts/daml-types/index.ts
@@ -120,7 +120,16 @@ export function lazyMemo<A>(mkDecoder: () => jtv.Decoder<A>): jtv.Decoder<A> {
 /**
  * The counterpart of DAML's `()` type.
  */
-export interface Unit {}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Unit {
+  // NOTE(MH): Although eslint claims that the empty interface and the type
+  // `{}` are equivalent, that's not true. The former does not extend
+  // `{[key: string]: string}` whereas the latter does. In other words,
+  // `Unit extends {[key: string]: string} ? true : false` is `false`,
+  // whereas `{} extends {[key: string]: string} ? true : false` is `true`.
+  // This might become important for defining a better version of the
+  // `Query<T>` type in @daml/ledger.
+}
 
 /**
  * Companion obect of the [[Unit]] type.


### PR DESCRIPTION
tl;dr: If we ever want to fix the `Query<T>` type from `@daml/ledger`,
we need a better definition of `Unit`.

TypeScript's type system may not be particularly sound, but the type
`{}` still sticks out as being a very special mess. I _think_ it is
something along the lines of
```typescript
type {} = Exclude<object, null> | string | number | boolean;
```
It is definitely not the type of all records or the type of only the
empty record.

I think it is reasonable to expect that the type relation defined by
```typescrupt
type Equiv<T, U> = T extends U ? U extends T ? true : false : false;
```
is extensional equality of types. Unfortunately, it isn't. For
instance, we have
```typescript
Equiv<{}, {[key: string]: string}> == true
```
but the value `{x: 1}` is assignable to type `{}` but not to type
`{[key: string]: string}`.

The type defined by the interface
```typescript
interface Unit {}
```
is a similarly hot mess as the type `{}`. Although they might seem to
be the same, particularly since we have
```typescript
Equiv<{}, Unit> == true    and    Equiv<Unit, {}> == true
```
here's a way to tell them apart:
```typescript
Equiv<Unit, {[key: string]: string}> == false
```
Thus, I would say the `Unit` type is mildly saner than the `{}` type.

Why does this matter? If we ever want to fix the query `Query<T>` type,
we need to be able to tell the unit type and `TextMap<_>` apart on the
type level. As demonstrated above, this seems impossible if we use `{}`
as the unit type but it is possible if we use the `Unit` type defined
above as the unit type.

Since I couldn't find a single value that is assignable to only one of
`{}` and `Unit` but not the other, this change should not break
anything at all. That said, I'll refrain from a changelog entry.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7687)
<!-- Reviewable:end -->
