### PR TITLE
Spell out bazel directories in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,12 @@ target
 
 # Bazel
 .bazel-cache
-/bazel-*
+/bazel-bin
+/bazel-daml
+/bazel-out
+/bazel-testlogs
 /compatibility/bazel-*
+!/compatibility/bazel-haskell-deps.bzl
 /compatibility/.bazelrc
 /compatibility/head_sdk/
 .bazelrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,9 @@ target
 
 # Bazel
 .bazel-cache
-/bazel-bin
-/bazel-daml
-/bazel-out
-/bazel-testlogs
+/bazel-*
+!/bazel-haskell-deps.bzl
+!/bazel-java-deps.bzl
 /compatibility/bazel-*
 !/compatibility/bazel-haskell-deps.bzl
 /compatibility/.bazelrc


### PR DESCRIPTION
With the old `/bazel-*` pattern in there, `rg` also ignores files like
`bazel-haskell-deps.bzl`, which is quite inconvenient.

I obtained the list of what should be hidden by uncommenting the
`/bazel-*` line and adding evering `git status` showed as new files.
Thus, the list is hopefully complete.

We have a similar issue with `/compatibility/bazel-haskell-deps.bzl`.
Since I could figure out what exactly we want to ignore there, I just
added an un-ignore for that single file.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7688)
<!-- Reviewable:end -->
