### PR TITLE
experimenting with general-purpose trigger command retries at the user level

### DIFF
--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -55,10 +55,14 @@ trigger = Trigger with
   heartbeat = None
 
 data RetryState = RetryState
-  { pendingRetries : Map.Map CommandId Int
+  { pendingRetries : Map.Map CommandId (Int, [Command])
   }
 
 data Lens t a = Lens { getter : t -> a, setter : (a -> a) -> t -> t }
+
+infixr 9 @@
+(@@) : Lens h n -> Lens n a -> Lens h a
+hn @@ na = Lens (na.getter . hn.getter) (hn.setter . na.setter)
 
 _1 : Lens (a, b) a
 _1 = Lens fst (\f (a, b) -> (f a, b))
@@ -66,8 +70,15 @@ _1 = Lens fst (\f (a, b) -> (f a, b))
 _2 : Lens (a, b) b
 _2 = Lens snd (\f (a, b) -> (a, f b))
 
-getAt : (ActionState s m, Functor m) => Lens s a -> m a
-getAt Lens { getter } = getter <$> get
+pendingRetries' : Lens RetryState (Map.Map CommandId (Int, [Command]))
+pendingRetries' = Lens pendingRetries (\f s -> s { pendingRetries = f s.pendingRetries })
+
+infix 4 %=
+(%=) : ActionState s m => Lens s a -> (a -> a) -> m ()
+(%=) Lens { setter } = modify . setter
+
+use : (ActionState s m, Functor m) => Lens s a -> m a
+use Lens { getter } = getter <$> get
 
 bracketRetry : Int -> Lens s RetryState -> Trigger s -> Trigger s
 bracketRetry retries rs trigger =

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -7,6 +7,7 @@ module Rule where
 import DA.Action
 import DA.Action.State.Class
 import DA.Assert
+import DA.Foldable (forA_)
 import qualified DA.Next.Map as Map
 import Daml.Trigger
 import Daml.Trigger.Assert
@@ -100,11 +101,26 @@ bracketRetry retries rs trigger =
         trigger.updateState msg
 
       rule party = do
-        -- TODO use queue
-        trigger.rule party
+        retry <- use (rs @@ queuedRetry')
+        retry `forA_` \(oldCmdId, cmds) -> do
+          -- the Failed would have removed the 2nd argument from the internal
+          -- state; I have no way to rederive it
+          newCmdId <- emitCommands cmds []
+          -- fixing the command ID now simplifies the update with
+          -- commands-in-flight later
+          rs @@ pendingRetries' %= \m ->
+            optional m (\v -> Map.insert newCmdId v m) $ Map.lookup oldCmdId m
+          rs @@ queuedRetry' .= None
 
-      enqueueRetry s commandId (retries, commands) = RetryState with
-        pendingRetries = (if retries <= 1
+        trigger.rule party -- actually running the rule
+
+        cif <- getCommandsInFlight
+        -- every *new* command joins the retry list
+        rs @@ pendingRetries' %=
+          Map.merge (\_ cmds -> Some (retries, cmds)) (const Some) (\_ -> const Some) cif
+
+      enqueueRetry s commandId (retriesLeft, commands) = RetryState with
+        pendingRetries = (if retriesLeft <= 1
                           then Map.delete commandId
                           else Map.insert commandId (retriesLeft - 1, commands)) s.pendingRetries
         -- This is why we save the commands in the map, instead of using

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -56,6 +56,7 @@ trigger = Trigger with
 
 data RetryState = RetryState
   { pendingRetries : Map.Map CommandId (Int, [Command])
+  , queuedRetry : Optional [Command]
   }
 
 data Lens t a = Lens { getter : t -> a, setter : (a -> a) -> t -> t }
@@ -82,9 +83,28 @@ use Lens { getter } = getter <$> get
 
 bracketRetry : Int -> Lens s RetryState -> Trigger s -> Trigger s
 bracketRetry retries rs trigger =
-  let rule = do
-        trigger.rule
-  in trigger with rule
+  let updateState msg = do
+        case msg of
+          MCompletion (Completion { commandId, status }) -> case status of
+            Succeeded {} -> rs @@ pendingRetries' %= Map.delete commandId
+            Failed {} -> rs %= \s ->
+              optional s (enqueueRetry s commandId)
+                $ Map.lookup commandId s.pendingRetries
+          MTransaction {} -> pure ()
+        -- NB: might be worth *not* performing the updateState on msg if a retry was enqueued
+        trigger.updateState msg
+
+      rule party = do
+        -- TODO use queue
+        trigger.rule party
+
+      enqueueRetry s commandId (retries, commands) = RetryState with
+        pendingRetries = (if retries <= 1
+                          then Map.delete commandId
+                          else Map.insert commandId (retries - 1, commands)) s.pendingRetries
+        queuedRetry = Some commands
+
+  in trigger with updateState; rule
 
 test = do
   alice <- Script.allocateParty "Alice"

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -56,7 +56,7 @@ trigger = Trigger with
 
 data RetryState = RetryState
   { pendingRetries : Map.Map CommandId (Int, [Command])
-  , queuedRetry : Optional [Command]
+  , queuedRetry : Optional (CommandId, [Command])
   }
 
 data Lens t a = Lens { getter : t -> a, setter : (a -> a) -> t -> t }
@@ -106,8 +106,11 @@ bracketRetry retries rs trigger =
       enqueueRetry s commandId (retries, commands) = RetryState with
         pendingRetries = (if retries <= 1
                           then Map.delete commandId
-                          else Map.insert commandId (retries - 1, commands)) s.pendingRetries
-        queuedRetry = Some commands
+                          else Map.insert commandId (retriesLeft - 1, commands)) s.pendingRetries
+        -- This is why we save the commands in the map, instead of using
+        -- getCommandsInFlight: by the time we get to the rule where we can use
+        -- getCommandsInFlight, the association with commandId is gone.
+        queuedRetry = Some (commandId, commands)
 
   in trigger with updateState; rule
 

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -74,7 +74,12 @@ _2 = Lens snd (\f (a, b) -> (a, f b))
 pendingRetries' : Lens RetryState (Map.Map CommandId (Int, [Command]))
 pendingRetries' = Lens pendingRetries (\f s -> s { pendingRetries = f s.pendingRetries })
 
-infix 4 %=
+queuedRetry' : Lens RetryState (Optional (CommandId, [Command]))
+queuedRetry' = Lens queuedRetry (\f s -> s { queuedRetry = f s.queuedRetry })
+
+infix 4 .=, %=
+(.=) : ActionState s m => Lens s a -> a -> m ()
+(.=) Lens { setter } = modify . setter . const
 (%=) : ActionState s m => Lens s a -> (a -> a) -> m ()
 (%=) Lens { setter } = modify . setter
 

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -109,7 +109,8 @@ bracketRetry retries rs trigger =
           -- fixing the command ID now simplifies the update with
           -- commands-in-flight later
           rs @@ pendingRetries' %= \m ->
-            optional m (\v -> Map.insert newCmdId v m) $ Map.lookup oldCmdId m
+            optional m (\v -> Map.insert newCmdId v $ Map.delete oldCmdId m)
+              $ Map.lookup oldCmdId m
           rs @@ queuedRetry' .= None
 
         trigger.rule party -- actually running the rule

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -97,7 +97,6 @@ bracketRetry retries rs trigger =
               optional s (enqueueRetry s commandId)
                 $ Map.lookup commandId s.pendingRetries
           MTransaction {} -> pure ()
-        -- NB: might be worth *not* performing the updateState on msg if a retry was enqueued
         trigger.updateState msg
 
       rule party = do
@@ -113,7 +112,12 @@ bracketRetry retries rs trigger =
               $ Map.lookup oldCmdId m
           rs @@ queuedRetry' .= None
 
-        trigger.rule party -- actually running the rule
+        -- NB: might be worth *not* performing the rule on msg if a retry was
+        -- enqueued.  Consider that runTrigger only runs the rule on a Failed
+        -- completion, not a succeeded one, but we have "filtered out" the
+        -- failure in a sense.  On the other hand, commands in flight *has*
+        -- changed; the rule might react to that in some way.
+        trigger.rule party
 
         cif <- getCommandsInFlight
         -- every *new* command joins the retry list

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -5,6 +5,7 @@
 module Rule where
 
 import DA.Action
+import DA.Action.State.Class
 import DA.Assert
 import qualified DA.Next.Map as Map
 import Daml.Trigger
@@ -52,6 +53,27 @@ trigger = Trigger with
     put (-1) -- just introducing some chaos
   registeredTemplates = RegisteredTemplates [registeredTemplate @T]
   heartbeat = None
+
+data RetryState = RetryState
+  { pendingRetries : Map.Map CommandId Int
+  }
+
+data Lens t a = Lens { getter : t -> a, setter : (a -> a) -> t -> t }
+
+_1 : Lens (a, b) a
+_1 = Lens fst (\f (a, b) -> (f a, b))
+
+_2 : Lens (a, b) b
+_2 = Lens snd (\f (a, b) -> (a, f b))
+
+getAt : (ActionState s m, Functor m) => Lens s a -> m a
+getAt Lens { getter } = getter <$> get
+
+bracketRetry : Int -> Lens s RetryState -> Trigger s -> Trigger s
+bracketRetry retries rs trigger =
+  let rule = do
+        trigger.rule
+  in trigger with rule
 
 test = do
   alice <- Script.allocateParty "Alice"


### PR DESCRIPTION
The goal is to implement using only facilities available in the high-level trigger API (and standard library, of course).

Fixes #5978.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
