### PR TITLE
Bump the version of ghcide we use

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -17,8 +17,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
-GHCIDE_REV = "9b6e7122516f9de9b0ba20cd37d59c58a4d634ec"
-GHCIDE_SHA256 = "e125fc97f35b418918cd29d4d70b36e46bde506d1669426d6802d8531fe3e9ac"
+GHCIDE_REV = "4bed749a37ae4138df8107835377c24cd05c08aa"
+GHCIDE_SHA256 = "84201d10e6b1c4c2d6ffa176ba80ed9085ab2b5fc7e40cee20623b9bf32a73d8"
 GHCIDE_VERSION = "0.1.0"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"
@@ -123,8 +123,8 @@ haskell_library(
             "@com_github_digital_asset_daml//bazel_tools:haskell-ghcide-expose-compat.patch",
         ],
         sha256 = GHCIDE_SHA256,
-        strip_prefix = "ghcide-%s" % GHCIDE_REV,
-        urls = ["https://github.com/digital-asset/ghcide/archive/%s.tar.gz" % GHCIDE_REV],
+        strip_prefix = "daml-ghcide-%s" % GHCIDE_REV,
+        urls = ["https://github.com/digital-asset/daml-ghcide/archive/%s.tar.gz" % GHCIDE_REV],
     )
 
     # The Bazel-provided grpc libs cause issues in GHCi so we get them from Nix on Linux and MacOS.

--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -17,8 +17,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
-GHCIDE_REV = "4bed749a37ae4138df8107835377c24cd05c08aa"
-GHCIDE_SHA256 = "84201d10e6b1c4c2d6ffa176ba80ed9085ab2b5fc7e40cee20623b9bf32a73d8"
+GHCIDE_REV = "30860c8c175732bbc9652b8e6d7dafb354380227"
+GHCIDE_SHA256 = "94afc5a3eda790956187080445a76e56b16f2e77c8f5cb3cc3450b6dd019d40a"
 GHCIDE_VERSION = "0.1.0"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -59,9 +59,9 @@ mayImportInternal =
         ]
 
 -- | Apply all necessary preprocessors
-damlPreprocessor :: Maybe GHC.UnitId -> GHC.ParsedModule -> IdePreprocessedSource
-damlPreprocessor mbUnitId (GHC.pm_parsed_source -> x)
-    | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = noPreprocessor x
+damlPreprocessor :: Maybe GHC.UnitId -> GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource
+damlPreprocessor mbUnitId dflags x
+    | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = noPreprocessor dflags x
     | otherwise = IdePreprocessedSource
         { preprocWarnings = checkDamlHeader x ++ checkVariantUnitConstructors x
         , preprocErrors = checkImports x ++ checkDataTypes x ++ checkModuleDefinition x ++ checkRecordConstructor x ++ checkModuleName x
@@ -71,17 +71,17 @@ damlPreprocessor mbUnitId (GHC.pm_parsed_source -> x)
       name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
 
 -- | Preprocessor for generated code.
-generatedPreprocessor :: GHC.ParsedModule -> IdePreprocessedSource
-generatedPreprocessor x =
+generatedPreprocessor :: GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource
+generatedPreprocessor _dflags x =
     IdePreprocessedSource
       { preprocWarnings = []
       , preprocErrors = []
-      , preprocSource = enumTypePreprocessor "CurrentSdk.GHC.Types" (GHC.pm_parsed_source x)
+      , preprocSource = enumTypePreprocessor "CurrentSdk.GHC.Types" x
       }
 
 -- | No preprocessing.
-noPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
-noPreprocessor x =
+noPreprocessor :: GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource
+noPreprocessor _dflags x =
     IdePreprocessedSource
       { preprocWarnings = []
       , preprocErrors = []

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -59,8 +59,8 @@ mayImportInternal =
         ]
 
 -- | Apply all necessary preprocessors
-damlPreprocessor :: Maybe GHC.UnitId -> GHC.ParsedSource -> IdePreprocessedSource
-damlPreprocessor mbUnitId x
+damlPreprocessor :: Maybe GHC.UnitId -> GHC.ParsedModule -> IdePreprocessedSource
+damlPreprocessor mbUnitId (GHC.pm_parsed_source -> x)
     | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = noPreprocessor x
     | otherwise = IdePreprocessedSource
         { preprocWarnings = checkDamlHeader x ++ checkVariantUnitConstructors x
@@ -71,12 +71,12 @@ damlPreprocessor mbUnitId x
       name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
 
 -- | Preprocessor for generated code.
-generatedPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
+generatedPreprocessor :: GHC.ParsedModule -> IdePreprocessedSource
 generatedPreprocessor x =
     IdePreprocessedSource
       { preprocWarnings = []
       , preprocErrors = []
-      , preprocSource = enumTypePreprocessor "CurrentSdk.GHC.Types" x
+      , preprocSource = enumTypePreprocessor "CurrentSdk.GHC.Types" (GHC.pm_parsed_source x)
       }
 
 -- | No preprocessing.


### PR DESCRIPTION
The new version gives access to the `ParsedModule` instead of only the
`ParsedSource` in the preprocessor. See
https://github.com/digital-asset/daml-ghcide/pull/3
for details.

We also need to fix a few things in `bazel-haskell-deps.bzl` to reflect
that we use our fork of `ghcide`, which lives in
`digital-asset/daml-ghcide`, instead of the old
`digital-asset/ghcide`, which we handed ove to the community, now.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7694)
<!-- Reviewable:end -->
