### PR TITLE
Use party identifier for prefix when generating party allocation submission id [KVL-632]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -84,10 +84,14 @@ private[apiserver] final class ApiPartyManagementService private (
 
   override def allocateParty(request: AllocatePartyRequest): Future[AllocatePartyResponse] = {
     // TODO: This should do proper validation.
-    val submissionId = v1.SubmissionId.assertFromString(UUID.randomUUID().toString)
+    def randomSubmissionId(prefix: String): Ref.IdString.LedgerString =
+      v1.SubmissionId.assertFromString(s"${prefix}_${UUID.randomUUID().toString}")
+
     val party =
       if (request.partyIdHint.isEmpty) None
       else Some(Ref.Party.assertFromString(request.partyIdHint))
+    val submissionId = randomSubmissionId(prefix = party.getOrElse(""))
+
     val displayName = if (request.displayName.isEmpty) None else Some(request.displayName)
 
     synchronousResponse


### PR DESCRIPTION
changelog_begin
changelog_end

This change is intended to improve traceability of party allocations.
The party id is used as a prefix to the submission id.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
