### PR TITLE
Add a representation of functional dependencies during LF conversion.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -112,6 +112,7 @@ import           "ghc-lib-parser" Pair hiding (swap)
 import           "ghc-lib-parser" PrelNames
 import           "ghc-lib-parser" TysPrim
 import           "ghc-lib-parser" TyCoRep
+import           "ghc-lib-parser" Class (FunDep, classHasFds)
 import qualified "ghc-lib-parser" Name
 import           Safe.Exact (zipExact, zipExactMay)
 import           SdkVersion
@@ -497,7 +498,9 @@ convertTypeSynonym env tycon
     = pure []
 
 convertClassDef :: Env -> TyCon -> ConvertM [Definition]
-convertClassDef env tycon = do
+convertClassDef env tycon
+    | Just cls <- tyConClass_maybe tycon
+    = do
     let con = tyConSingleDataCon tycon
         sanitize = (TUnit :->) -- DICTIONARY SANITIZATION step (1)
         labels = ctorLabels con
@@ -509,14 +512,48 @@ convertClassDef env tycon = do
     let fields = zipExact labels (map sanitize fieldTypes)
         tconName = mkTypeCon [getOccText tycon]
         tsynName = mkTypeSyn [getOccText tycon]
+        newStyle = envLfVersion env `supports` featureTypeSynonyms
+            -- "new-style typeclasses" are type synonyms
+            -- "old-style typeclasses" were record types
         typeDef
-            | envLfVersion env `supports` featureTypeSynonyms =
-              -- Structs must have > 0 fields, therefore we simply make a typeclass a synonym for Unit
-              -- if it has no fields
-              defTypeSyn tsynName tyVars (if null fields then TUnit else TStruct fields)
+            | newStyle =
+                -- LF structs must have > 0 fields, therefore we define the
+                -- typeclass as a synonym for Unit if it has no fields.
+                defTypeSyn tsynName tyVars (if null fields then TUnit else TStruct fields)
             | otherwise = defDataType tconName tyVars (DataRecord fields)
 
-    pure [typeDef]
+    let funDeps = snd (classTvsFds cls)
+    funDeps' <- mapM (mapFunDepM (convTypeVarName env')) funDeps
+
+    let funDepTyVars = [(v, KStar) | (v, _) <- tyVars]
+            -- We use the the type variables as types in the fundep encoding,
+            -- not as whatever kind they were previously defined.
+        funDepName = ExprValName ("$fd" <> getOccText tycon)
+        funDepType = TForalls funDepTyVars (encodeFunDeps funDeps')
+        funDepExpr = EBuiltin BEError `ETyApp` funDepType `ETmApp`
+            EBuiltin (BEText "undefined")
+        funDepDef = defValue tycon (funDepName, funDepType) funDepExpr
+
+    pure $ [typeDef] ++ [funDepDef | classHasFds cls && newStyle]
+        -- NOTE (SF): No reason to generate fundep metadata with old-style typeclasses,
+        -- since data-dependencies support for old-style typeclasses is extremely limited.
+
+mapFunDepM :: Monad m => (a -> m b) -> (FunDep a -> m (FunDep b))
+mapFunDepM f (a, b) = liftM2 (,) (mapM f a) (mapM f b)
+
+-- | Encode a list of functional dependencies as an LF type.
+encodeFunDeps :: [FunDep TypeVarName] -> LF.Type
+encodeFunDeps = encodeTypeList $ \(xs, ys) ->
+    encodeTypeList TVar xs :->
+    encodeTypeList TVar ys
+
+-- | Encode a list as an LF type. Given @'map' f xs == [y1, y2, ..., yn]@
+-- then @'encodeTypeList' f xs == { _1: y1, _2: y2, ..., _n: yn }@.
+encodeTypeList :: (t -> LF.Type) -> [t] -> LF.Type
+encodeTypeList f xs =
+    LF.TStruct $ zipWith
+        (\i x -> (mkField (T.pack ('_' : show @Int i)), f x))
+        [1..] xs
 
 defNewtypeWorker :: NamedThing a => LF.ModuleName -> a -> TypeConName -> DataCon
     -> [(TypeVarName, LF.Kind)] -> [(FieldName, LF.Type)] -> Definition

--- a/compiler/damlc/tests/daml-test-files/FunctionalDependencies.daml
+++ b/compiler/damlc/tests/daml-test-files/FunctionalDependencies.daml
@@ -1,0 +1,18 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Check that functional dependency metadata is added when available.
+
+-- @SINCE-LF 1.8
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$fdFoo"]) | .type | .forall | select(.vars | length == 2) | .body | .struct | .fields | length == 1
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$fdBar"]) | .type | .forall | select(.vars | length == 5) | .body | .struct | .fields | length == 3
+module FunctionalDependencies where
+
+class Foo a b | a -> b where
+    foo : a -> b
+
+-- The crazy kinds here are to make sure that the functional dependency metadata works
+-- regardless of the kind. (A naïve implementation falls over when the type variables
+-- are not of kind star.)
+class Bar a (b: GHC.Types.Nat) c (d: GHC.Types.Nat -> *) (e: * -> *) | a -> b c, a d -> e, d -> a where
+    bar : a -> d b -> e c


### PR DESCRIPTION
This PR adds a new value definition during LF conversion, for type classes with functional dependencies. The binding is a representation of the functional dependency, so we can later pick it up in data-dependencies.

For example, given a typeclass `Foo a b c` with the functional dependency `a -> b, c -> a b` will give rise to a new value definition `$fdFoo` (`$$fdFoo` after name mangling) of type:

```
forall (a : *) (b : *) (c : *).
  { _1: {_1: a} -> {_1: b}
  , _2: {_1: c} -> {_1: a, _2: b}
  }
```

where the `{ ... }` are LF structs. This is a simple encoding of the underlying representations for functional dependencies (which is `[([TyVar], [TyVar])]`).

The PR also adds a test to make sure the functional dependency metadata is exposed, and handles kinds other than kind star correctly. The use of this metadata in data-dependencies is left to a separate PR.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
