### PR TITLE
Warn when importing DA.Generics

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -281,7 +281,7 @@ checkImportsWrtDataDependencies x =
     warning = unlines
         [ "Modules importing DA.Generics do not work with data-dependencies."
         , "This will prevent the whole package from being extensible or upgradable"
-        , "using other versionsof the SDK. Use DA.Generics at your own risk."
+        , "using other versions of the SDK. Use DA.Generics at your own risk."
         ]
 
 -- Extract all data constructors with their locations

--- a/compiler/damlc/tests/daml-test-files/Generics.daml
+++ b/compiler/damlc/tests/daml-test-files/Generics.daml
@@ -3,6 +3,7 @@
 
 {-# LANGUAGE EmptyCase #-}
 -- @WARN Modules compiled with the EmptyCase language extension might not work properly with data-dependencies.
+-- @WARN Modules importing DA.Generics do not work with data-dependencies.
 
 module Generics where
 


### PR DESCRIPTION
The module `DA.Generics` is hidden from the docs of `daml-stdlib`
because we consider it experimental. On top of that, the comments at the
top of the module make it clear that this module does _not_ work across
different SDK versions. Nevertheless, let's make it crystal clear that
`DA.Generics` does not work with data-dependencies and will stop you
from upgrading your package.

I've decided against using the a `{-# WARNING ... #-}` annotation
on the `DA.Generics` module declaration since that issues a warning for
every single time an enitity from the module is used rather than once
when importing the module. To me, that's a bit over the top since it is
conceivable that people still want to use the module during some stages
of their development. Another thing we might need to consider soon is a
`-fno-data-dependencies-warnings` flag which suppresses warning related
to data-dependencies. This would be impossible with a
`{-# WARNING ... #-}` annotation.

CHANGELOG_BEGIN
[DAML Stdlib] Issue a warning when importing the `DA.Generics` module,
which does not work with data-dependencies.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7705)
<!-- Reviewable:end -->
