### PR TITLE
Damlc ITs fix pretty range

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -17,8 +17,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
-GHCIDE_REV = "30860c8c175732bbc9652b8e6d7dafb354380227"
-GHCIDE_SHA256 = "94afc5a3eda790956187080445a76e56b16f2e77c8f5cb3cc3450b6dd019d40a"
+GHCIDE_REV = "8e4f52892d88d23259547b03bb096b46f28c0afc"
+GHCIDE_SHA256 = "3fa3e23d760f1bdfb2a707d2593ea3eaedba748abfd649e8917c585780fa91db"
 GHCIDE_VERSION = "0.1.0"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"

--- a/compiler/damlc/tests/daml-test-files/ActionFail.daml
+++ b/compiler/damlc/tests/daml-test-files/ActionFail.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=9:21-9:38; Use catOptionals
+-- @INFO range=9:22-9:39; Use catOptionals
 
 module ActionFail where
 

--- a/compiler/damlc/tests/daml-test-files/AmbiguousDataType.daml
+++ b/compiler/damlc/tests/daml-test-files/AmbiguousDataType.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:0-9:16; Ambiguous data type declaration. Enums cannot have type arguments. Write data Foo x = Bar {} for a record or data Foo x = Bar () for a variant.
+-- @ERROR range=9:1-9:17; Ambiguous data type declaration. Enums cannot have type arguments. Write data Foo x = Bar {} for a record or data Foo x = Bar () for a variant.
 
 
 module AmbiguousDataType where

--- a/compiler/damlc/tests/daml-test-files/BadUTF8.daml
+++ b/compiler/damlc/tests/daml-test-files/BadUTF8.daml
@@ -1,4 +1,4 @@
--- @ERROR range=4:0-4:0; lexical error
+-- @ERROR range=4:1-4:1; lexical error
 
 
 £ -- pound symbol when saved as ASCII

--- a/compiler/damlc/tests/daml-test-files/ConstrainedRecursion.daml
+++ b/compiler/damlc/tests/daml-test-files/ConstrainedRecursion.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2020 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 --
--- @INFO range=12:0-13:20; Use foldl
--- @INFO range=16:0-17:16; Use foldl
--- @INFO range=20:0-21:16; Use foldl
+-- @INFO range=12:1-13:21; Use foldl
+-- @INFO range=16:1-17:17; Use foldl
+-- @INFO range=20:1-21:17; Use foldl
 
 module ConstrainedRecursion where
 

--- a/compiler/damlc/tests/daml-test-files/ConstraintBad.daml
+++ b/compiler/damlc/tests/daml-test-files/ConstraintBad.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=11:13-11:28; Constructors with type constraints must give explicit field names
+-- @ERROR range=11:14-11:29; Constructors with type constraints must give explicit field names
 
 {-# LANGUAGE ExistentialQuantification #-}
 

--- a/compiler/damlc/tests/daml-test-files/Cyclic.daml
+++ b/compiler/damlc/tests/daml-test-files/Cyclic.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=8:7-8:13; Cyclic module dependency between Cyclic
+-- @ERROR range=8:8-8:14; Cyclic module dependency between Cyclic
 
 module Cyclic where
 

--- a/compiler/damlc/tests/daml-test-files/DesugarWarnings.daml
+++ b/compiler/damlc/tests/daml-test-files/DesugarWarnings.daml
@@ -4,9 +4,9 @@
 {-# OPTIONS_GHC -Wincomplete-patterns -Woverlapping-patterns #-}
 -- Check that warnings from desugarer, like incomplete/overlapping pattern
 -- match warnings, show up when we turn them on.
--- @WARN range=14:20-15:13; Pattern match(es) are non-exhaustive
--- @WARN range=18:0-19:20; Pattern match(es) are non-exhaustive
--- @WARN range=24:2-24:13; Pattern match is redundant
+-- @WARN range=14:21-15:14; Pattern match(es) are non-exhaustive
+-- @WARN range=18:1-19:21; Pattern match(es) are non-exhaustive
+-- @WARN range=24:3-24:14; Pattern match is redundant
 
 module DesugarWarnings where
 

--- a/compiler/damlc/tests/daml-test-files/EmptyContractKeyMaintainers.daml
+++ b/compiler/damlc/tests/daml-test-files/EmptyContractKeyMaintainers.daml
@@ -1,6 +1,6 @@
--- @ERROR range=14:0-14:18; Attempt to create a contract key with an empty set of maintainers
--- @ERROR range=20:0-20:18; Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
--- @ERROR range=26:0-26:17; Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
+-- @ERROR range=14:1-14:19; Attempt to create a contract key with an empty set of maintainers
+-- @ERROR range=20:1-20:19; Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
+-- @ERROR range=26:1-26:18; Attempt to fetch, lookup or exercise a contract key with an empty set of maintainers
 module EmptyContractKeyMaintainers where
 
 template NoMaintainer

--- a/compiler/damlc/tests/daml-test-files/EmptyWith.daml
+++ b/compiler/damlc/tests/daml-test-files/EmptyWith.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=18:11-19:0; Empty record update
+-- @ERROR range=18:12-19:1; Empty record update
 
 module EmptyWith where
 

--- a/compiler/damlc/tests/daml-test-files/EnumFromThenTo.daml
+++ b/compiler/damlc/tests/daml-test-files/EnumFromThenTo.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:0-9:4; enumFromThenTo: from == then
+-- @ERROR range=9:1-9:5; enumFromThenTo: from == then
 
 module EnumFromThenTo where
 

--- a/compiler/damlc/tests/daml-test-files/ErrorsWithColons.daml
+++ b/compiler/damlc/tests/daml-test-files/ErrorsWithColons.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=9:34-9:41; Use list literal
--- @ERROR range=9:34-9:41; In the expression: (1 :: [])
--- @ERROR range=11:12-11:13; In the expression: 1 : Text
+-- @INFO range=9:35-9:42; Use list literal
+-- @ERROR range=9:35-9:42; In the expression: (1 :: [])
+-- @ERROR range=11:13-11:14; In the expression: 1 : Text
 module ErrorsWithColons where
 
 badIf = if True then Some 1 else (1 :: [])

--- a/compiler/damlc/tests/daml-test-files/Existential.daml
+++ b/compiler/damlc/tests/daml-test-files/Existential.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 -- @WARN Modules compiled with the ExistentialQuantification language extension might not work properly with data-dependencies.
--- @ ERROR range=15:0-15:6; Pattern match with existential type.
+-- @ ERROR range=15:1-15:7; Pattern match with existential type.
 
 
 module Existential where

--- a/compiler/damlc/tests/daml-test-files/ExistentialSum.daml
+++ b/compiler/damlc/tests/daml-test-files/ExistentialSum.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 -- @WARN Modules compiled with the ExistentialQuantification language extension might not work properly with data-dependencies.
--- @ ERROR range=17:0-17:6; Pattern match with existential type.
+-- @ ERROR range=17:1-17:7; Pattern match with existential type.
 
 
 module ExistentialSum where

--- a/compiler/damlc/tests/daml-test-files/FailedFetch.daml
+++ b/compiler/damlc/tests/daml-test-files/FailedFetch.daml
@@ -1,4 +1,4 @@
--- @ERROR range= 21:0-21:19; Attempt to fetch or exercise a contract not visible to the committer.
+-- @ERROR range= 21:1-21:20; Attempt to fetch or exercise a contract not visible to the committer.
 module FailedFetch where
 
 template T

--- a/compiler/damlc/tests/daml-test-files/GenericTemplateError.daml
+++ b/compiler/damlc/tests/daml-test-files/GenericTemplateError.daml
@@ -1,6 +1,6 @@
 -- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
--- @ERROR range=11:23-11:33; Generic templates are not supported
+-- @ERROR range=11:24-11:34; Generic templates are not supported
 
 
 module GenericTemplateError where

--- a/compiler/damlc/tests/daml-test-files/GetPartyError.daml
+++ b/compiler/damlc/tests/daml-test-files/GetPartyError.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=8:0-8:4; Invalid party name: #party
+-- @ ERROR range=8:1-8:5; Invalid party name: #party
 
 module GetPartyError where
 

--- a/compiler/damlc/tests/daml-test-files/HelloWorld.daml
+++ b/compiler/damlc/tests/daml-test-files/HelloWorld.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=9:0-9:4; Hello World!
+-- @ ERROR range=9:1-9:5; Hello World!
 
 
 module HelloWorld where

--- a/compiler/damlc/tests/daml-test-files/Import.daml
+++ b/compiler/damlc/tests/daml-test-files/Import.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=13:4-13:9; Couldn't match expected type ‘Good.T’
+-- @ ERROR range=13:5-13:10; Couldn't match expected type ‘Good.T’
 
 module Import where
 

--- a/compiler/damlc/tests/daml-test-files/IntBoundsUpper.daml
+++ b/compiler/damlc/tests/daml-test-files/IntBoundsUpper.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- Test that overflowing integer literals are detected at compile time.
--- @ ERROR range=10:0-10:6; Int literal out of bounds
+-- @ ERROR range=10:1-10:7; Int literal out of bounds
 
 module IntBoundsUpper where
 

--- a/compiler/damlc/tests/daml-test-files/InternalImport.daml
+++ b/compiler/damlc/tests/daml-test-files/InternalImport.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:0-9:27; Import of internal module DA.Internal.Template is not allowed.
+-- @ERROR range=9:1-9:28; Import of internal module DA.Internal.Template is not allowed.
 
 
 module InternalImport where

--- a/compiler/damlc/tests/daml-test-files/Lazy.daml
+++ b/compiler/damlc/tests/daml-test-files/Lazy.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=9:0-9:4; Hello World!
+-- @ ERROR range=9:1-9:5; Hello World!
 
 
 module Lazy where

--- a/compiler/damlc/tests/daml-test-files/List.daml
+++ b/compiler/damlc/tests/daml-test-files/List.daml
@@ -1,13 +1,13 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=115:16-115:31; Use dedup
--- @INFO range=301:9-301:23; Evaluate
--- @INFO range=316:37-316:47; Use sum
--- @INFO range=317:42-317:52; Use sum
--- @INFO range=318:28-318:38; Use sum
--- @INFO range=321:2-321:22; Use head
--- @INFO range=326:28-326:35; Use head
+-- @INFO range=115:17-115:32; Use dedup
+-- @INFO range=301:10-301:24; Evaluate
+-- @INFO range=316:38-316:48; Use sum
+-- @INFO range=317:43-317:53; Use sum
+-- @INFO range=318:29-318:39; Use sum
+-- @INFO range=321:3-321:23; Use head
+-- @INFO range=326:29-326:36; Use head
 
 module List where
 

--- a/compiler/damlc/tests/daml-test-files/Math.daml
+++ b/compiler/damlc/tests/daml-test-files/Math.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=47:21-47:31; Use sqrt
--- @INFO range=57:14-57:24; Use sqrt
+-- @INFO range=47:22-47:32; Use sqrt
+-- @INFO range=57:15-57:25; Use sqrt
 
 
 module Math where

--- a/compiler/damlc/tests/daml-test-files/MaybeCompat.daml
+++ b/compiler/damlc/tests/daml-test-files/MaybeCompat.daml
@@ -1,11 +1,11 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @WARN range=14:11-14:16; Maybe
--- @WARN range=17:11-17:16; maybe
--- @WARN range=17:28-17:35; Nothing
--- @WARN range=18:11-18:19; fromSome
--- @WARN range=18:21-18:25; Just
+-- @WARN range=14:12-14:17; Maybe
+-- @WARN range=17:12-17:17; maybe
+-- @WARN range=17:29-17:36; Nothing
+-- @WARN range=18:12-18:20; fromSome
+-- @WARN range=18:22-18:26; Just
 
 module MaybeCompat where
 import DA.Maybe

--- a/compiler/damlc/tests/daml-test-files/MissingFields.daml
+++ b/compiler/damlc/tests/daml-test-files/MissingFields.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=10:9-10:21; does not have the required strict field(s): baz
+-- @ ERROR range=10:10-10:22; does not have the required strict field(s): baz
 
 module MissingFields where
 

--- a/compiler/damlc/tests/daml-test-files/ModuleName.daml
+++ b/compiler/damlc/tests/daml-test-files/ModuleName.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=1:0-100001:0; Missing module name
+-- @ERROR range=1:1-100001:1; Missing module name
 
 
 

--- a/compiler/damlc/tests/daml-test-files/ModuleNameWarning.daml
+++ b/compiler/damlc/tests/daml-test-files/ModuleNameWarning.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=7:7-7:25; Module names should always match file names
+-- @ ERROR range=7:8-7:26; Module names should always match file names
 
 
 module ModuleNameMismatch where

--- a/compiler/damlc/tests/daml-test-files/MultipleFields.daml
+++ b/compiler/damlc/tests/daml-test-files/MultipleFields.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:11-9:22; Constructors with multiple fields must give explicit field names
+-- @ERROR range=9:12-9:23; Constructors with multiple fields must give explicit field names
 
 
 module MultipleFields where

--- a/compiler/damlc/tests/daml-test-files/NoCaseOfCase.daml
+++ b/compiler/damlc/tests/daml-test-files/NoCaseOfCase.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=22:13-22:51; Use if
+-- @INFO range=22:14-22:52; Use if
 
 
 module NoCaseOfCase where

--- a/compiler/damlc/tests/daml-test-files/NoControllerAsVar.daml
+++ b/compiler/damlc/tests/daml-test-files/NoControllerAsVar.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=15:0-15:10; parse error on input ‘controller’
+-- @ ERROR range=15:1-15:11; parse error on input ‘controller’
 
 
 module NoControllerAsVar where

--- a/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB.daml
@@ -5,7 +5,7 @@
 -- `NumericScale` constraint.
 --
 -- @SINCE-LF 1.7
--- @ERROR range=16:11-16:18; No instance for (NumericScale 38)
+-- @ERROR range=16:12-16:19; No instance for (NumericScale 38)
 
 
 

--- a/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB2.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitMonoScaleOOB2.daml
@@ -6,7 +6,7 @@
 -- conversion error even if we try to be clever.
 --
 -- @SINCE-LF 1.7
--- @ERROR range=17:0-17:8; type-level natural outside of supported range [0, 37]
+-- @ERROR range=17:1-17:9; type-level natural outside of supported range [0, 37]
 
 
 

--- a/compiler/damlc/tests/daml-test-files/NumericLitPoly.daml
+++ b/compiler/damlc/tests/daml-test-files/NumericLitPoly.daml
@@ -6,7 +6,7 @@
 -- conversion error even if we try to be clever.
 --
 -- @SINCE-LF 1.7
--- @ERROR range=19:0-19:7; Polymorphic numeric literal. Specify a fixed scale by giving the type, e.g. (2.71828 : Numeric 10)
+-- @ERROR range=19:1-19:8; Polymorphic numeric literal. Specify a fixed scale by giving the type, e.g. (2.71828 : Numeric 10)
 
 
 

--- a/compiler/damlc/tests/daml-test-files/PartyCompare.daml
+++ b/compiler/damlc/tests/daml-test-files/PartyCompare.daml
@@ -1,12 +1,12 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=18:11-18:30; Use >=
--- @INFO range=19:11-19:28; Use >=
--- @INFO range=22:11-22:29; Use >
--- @INFO range=25:11-25:29; Use <
--- @INFO range=27:11-27:28; Use <=
--- @INFO range=28:11-28:26; Use <=
+-- @INFO range=18:12-18:31; Use >=
+-- @INFO range=19:12-19:29; Use >=
+-- @INFO range=22:12-22:30; Use >
+-- @INFO range=25:12-25:30; Use <
+-- @INFO range=27:12-27:29; Use <=
+-- @INFO range=28:12-28:27; Use <=
 
 
 module PartyCompare where

--- a/compiler/damlc/tests/daml-test-files/PatError.daml
+++ b/compiler/damlc/tests/daml-test-files/PatError.daml
@@ -4,7 +4,7 @@
 {-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 -- Make sure the error message is useful when the interpreter is face with
 -- an incomplete pattern match.
--- @ERROR range=14:0-14:4; Non-exhaustive patterns in case
+-- @ERROR range=14:1-14:5; Non-exhaustive patterns in case
 
 module PatError where
 

--- a/compiler/damlc/tests/daml-test-files/PolymorphicTest.daml
+++ b/compiler/damlc/tests/daml-test-files/PolymorphicTest.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:0-9:4; Aborted: boom
+-- @ERROR range=9:1-9:5; Aborted: boom
 
 module PolymorphicTest where
 

--- a/compiler/damlc/tests/daml-test-files/Precondition.daml
+++ b/compiler/damlc/tests/daml-test-files/Precondition.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=22:0-22:4; Template pre-condition violated
+-- @ERROR range=22:1-22:5; Template pre-condition violated
 
 module Precondition where
 

--- a/compiler/damlc/tests/daml-test-files/PreludeTest.daml
+++ b/compiler/damlc/tests/daml-test-files/PreludeTest.daml
@@ -1,41 +1,41 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=52:26-52:42; Use uncurry
--- @INFO range=66:8-66:18; Redundant identity
--- @INFO range=67:12-67:26; Redundant identity
--- @INFO range=68:22-68:60; Redundant identity
--- @INFO range=90:8-90:17; Evaluate
--- @INFO range=94:12-94:21; Use elem
--- @INFO range=95:12-95:21; Use elem
--- @INFO range=96:10-96:19; Use elem
--- @INFO range=100:22-100:59; Redundant if
--- @INFO range=109:23-109:61; Redundant if
--- @INFO range=112:12-112:36; Use ||
--- @INFO range=114:11-114:34; Use ||
--- @INFO range=115:11-115:26; Use ||
--- @INFO range=118:12-118:37; Use &&
--- @INFO range=120:12-120:36; Use &&
--- @INFO range=121:11-121:27; Use &&
--- @INFO range=157:11-157:35; Use isNone
--- @INFO range=157:20-157:34; Use $>
--- @INFO range=163:9-163:55; Evaluate
--- @INFO range=164:9-164:58; Evaluate
--- @INFO range=177:16-177:35; Use ++
--- @INFO range=181:8-181:21; Redundant flip
--- @INFO range=182:14-182:37; Redundant flip
--- @INFO range=208:12-208:52; Evaluate
--- @INFO range=220:9-220:28; Take on a non-positive
--- @INFO range=226:9-226:28; Drop on a non-positive
--- @INFO range=292:27-292:38; Use zip
--- @INFO range=293:37-293:48; Use zip
--- @INFO range=297:37-297:50; Use zip3
--- @INFO range=298:52-298:65; Use zip3
--- @INFO range=310:8-310:20; Evaluate
--- @INFO range=313:10-313:22; Evaluate
--- @INFO range=317:12-317:19; Evaluate
--- @ERROR range=384:0-384:16; Day 29 falls outside of valid day range (1 .. 28) for Feb 2100.
--- @ERROR range=388:0-388:17; Day 0 falls outside of valid day range (1 .. 31) for Jan 2000.
+-- @INFO range=52:27-52:43; Use uncurry
+-- @INFO range=66:9-66:19; Redundant identity
+-- @INFO range=67:13-67:27; Redundant identity
+-- @INFO range=68:23-68:61; Redundant identity
+-- @INFO range=90:9-90:18; Evaluate
+-- @INFO range=94:13-94:22; Use elem
+-- @INFO range=95:13-95:22; Use elem
+-- @INFO range=96:11-96:20; Use elem
+-- @INFO range=100:23-100:60; Redundant if
+-- @INFO range=109:24-109:62; Redundant if
+-- @INFO range=112:13-112:37; Use ||
+-- @INFO range=114:12-114:35; Use ||
+-- @INFO range=115:12-115:27; Use ||
+-- @INFO range=118:13-118:38; Use &&
+-- @INFO range=120:13-120:37; Use &&
+-- @INFO range=121:12-121:28; Use &&
+-- @INFO range=157:12-157:36; Use isNone
+-- @INFO range=157:21-157:35; Use $>
+-- @INFO range=163:10-163:56; Evaluate
+-- @INFO range=164:10-164:59; Evaluate
+-- @INFO range=177:17-177:36; Use ++
+-- @INFO range=181:9-181:22; Redundant flip
+-- @INFO range=182:15-182:38; Redundant flip
+-- @INFO range=208:13-208:53; Evaluate
+-- @INFO range=220:10-220:29; Take on a non-positive
+-- @INFO range=226:10-226:29; Drop on a non-positive
+-- @INFO range=292:28-292:39; Use zip
+-- @INFO range=293:38-293:49; Use zip
+-- @INFO range=297:38-297:51; Use zip3
+-- @INFO range=298:53-298:66; Use zip3
+-- @INFO range=310:9-310:21; Evaluate
+-- @INFO range=313:11-313:23; Evaluate
+-- @INFO range=317:13-317:20; Evaluate
+-- @ERROR range=384:1-384:17; Day 29 falls outside of valid day range (1 .. 28) for Feb 2100.
+-- @ERROR range=388:1-388:18; Day 0 falls outside of valid day range (1 .. 31) for Jan 2000.
 
 module PreludeTest where
 

--- a/compiler/damlc/tests/daml-test-files/RationalLowerBoundError.daml
+++ b/compiler/damlc/tests/daml-test-files/RationalLowerBoundError.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- Test that rational negative literals bigger or equal -10^38 + 1 fail.
--- @ERROR range=13:0-13:1; Rational is out of bounds
+-- @ERROR range=13:1-13:2; Rational is out of bounds
 
 
 

--- a/compiler/damlc/tests/daml-test-files/RationalPrecisionUpperBoundError.daml
+++ b/compiler/damlc/tests/daml-test-files/RationalPrecisionUpperBoundError.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- Test that rational literals with precision higher then e^-10 fail.
--- @ERROR range=12:0-12:1; Rational is out of bounds
+-- @ERROR range=12:1-12:2; Rational is out of bounds
 
 
 

--- a/compiler/damlc/tests/daml-test-files/RationalUpperBoundError.daml
+++ b/compiler/damlc/tests/daml-test-files/RationalUpperBoundError.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 -- Test that rational positive literals fail when bigger than 10^38 -1 after multiplying with 10^10.
--- @ERROR range=13:0-13:1; Rational is out of bounds
+-- @ERROR range=13:1-13:2; Rational is out of bounds
 
 
 

--- a/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordConstructorCheck.daml
@@ -1,9 +1,9 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=10:0-10:13; Record type X has constructor Y with different name. Possible solution: Change the constructor name to X
--- @ERROR range=12:0-12:26; Newtype A has constructor B with different name. Possible solution: Change the constructor name to A
--- @ERROR range=14:0-14:17; Newtype C has constructor D with different name. Possible solution: Change the constructor name to C
+-- @ERROR range=10:1-10:14; Record type X has constructor Y with different name. Possible solution: Change the constructor name to X
+-- @ERROR range=12:1-12:27; Newtype A has constructor B with different name. Possible solution: Change the constructor name to A
+-- @ERROR range=14:1-14:18; Newtype C has constructor D with different name. Possible solution: Change the constructor name to C
 
 module RecordConstructorCheck where
 

--- a/compiler/damlc/tests/daml-test-files/RecordUpdate.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordUpdate.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=43:17-43:41; Evaluate
--- @INFO range=43:24-43:40; Use const
+-- @INFO range=43:18-43:42; Evaluate
+-- @INFO range=43:25-43:41; Use const
 -- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["p_1_0"]) | .expr.rec_upd | (lf::get_field($pkg) == "x") and (.record.val | lf::get_value_name($pkg) == ["origin"]) and (.update.prim_lit.int64 == "1")
 -- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["p_1_2"]) | .expr.rec_upd | (lf::get_field($pkg) == "y") and (.record.rec_upd | (lf::get_field($pkg) == "x") and (.record.val | lf::get_value_name($pkg) == ["origin"]) and (.update.prim_lit.int64 == "1")) and (.update.prim_lit.int64 == "2")
 

--- a/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden1.daml
+++ b/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden1.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=11:9-11:24; No instance for (DA.Internal.Record.HasField "microseconds" RelTime Int)
+-- @ ERROR range=11:10-11:25; No instance for (DA.Internal.Record.HasField "microseconds" RelTime Int)
 
 module RelTimeDetailsHidden1 where
 

--- a/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden2.daml
+++ b/compiler/damlc/tests/daml-test-files/RelTimeDetailsHidden2.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ ERROR range=11:5-11:12; Not in scope: data constructor ‘RelTime’
+-- @ ERROR range=11:6-11:13; Not in scope: data constructor ‘RelTime’
 
 module RelTimeDetailsHidden2 where
 

--- a/compiler/damlc/tests/daml-test-files/RightOfUse.daml
+++ b/compiler/damlc/tests/daml-test-files/RightOfUse.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=44:0-44:7; Scenario execution failed on commit at RightOfUse:56:5:
+-- @ERROR range=44:1-44:8; Scenario execution failed on commit at RightOfUse:56:5:
 
 
 module RightOfUse where

--- a/compiler/damlc/tests/daml-test-files/ShortCircuit.daml
+++ b/compiler/damlc/tests/daml-test-files/ShortCircuit.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=12:12-12:32; Evaluate
--- @INFO range=13:16-13:37; Evaluate
+-- @INFO range=12:13-12:33; Evaluate
+-- @INFO range=13:17-13:38; Evaluate
 
 module ShortCircuit where
 

--- a/compiler/damlc/tests/daml-test-files/Text.daml
+++ b/compiler/damlc/tests/daml-test-files/Text.daml
@@ -1,8 +1,8 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @INFO range=36:9-36:17; Evaluate
--- @INFO range=50:2-50:12; Evaluate
+-- @INFO range=36:10-36:18; Evaluate
+-- @INFO range=50:3-50:13; Evaluate
 
 module Text where
 

--- a/compiler/damlc/tests/daml-test-files/TypeFamily.daml
+++ b/compiler/damlc/tests/daml-test-files/TypeFamily.daml
@@ -2,7 +2,7 @@
 -- All rights reserved.
 
 {-# LANGUAGE TypeFamilies #-}
--- @ERROR range=11:0-11:15; Data definition, of type type family.
+-- @ERROR range=11:1-11:16; Data definition, of type type family.
 -- @WARN Modules compiled with the TypeFamilies language extension might not work properly with data-dependencies.
 -- @WARN Modules compiled with the ExplicitNamespaces language extension might not work properly with data-dependencies.
 

--- a/compiler/damlc/tests/daml-test-files/Unicode.daml
+++ b/compiler/damlc/tests/daml-test-files/Unicode.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
--- @ERROR range=9:0-9:4; ⛄ ¯\_(ツ)_/¯
+-- @ERROR range=9:1-9:5; ⛄ ¯\_(ツ)_/¯
 
 
 module Unicode where

--- a/compiler/damlc/tests/daml-test-files/Unserializable.daml
+++ b/compiler/damlc/tests/daml-test-files/Unserializable.daml
@@ -5,7 +5,7 @@
 -- We use the template typeclass and instances directly as otherwise the error
 -- is caught prior due to missing Eq and Show instances.
 
--- @ERROR range=1:0-100001:0; expected serializable type
+-- @ERROR range=1:1-100001:1; expected serializable type
 
 module Unserializable where
 

--- a/compiler/damlc/tests/daml-test-files/UnusedMatchTests.daml
+++ b/compiler/damlc/tests/daml-test-files/UnusedMatchTests.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its
 -- affiliates. All rights reserved.
 
--- @WARN range=19:2-19:3; Defined but not used
+-- @WARN range=19:3-19:4; Defined but not used
 
 {-# OPTIONS_GHC -Wunused-matches #-}
 {-# OPTIONS_GHC -Wunused-foralls #-}


### PR DESCRIPTION
The new version of `ghcide` fixes a bug in the pretty printer for
diagnostics. So far, the column number for an error/warning you would
be shown by `daml build` was always be one smaller than in DAML
Studio. Now, we show the same locations across the command line tools
and the IDE.

We also bring our test files in sync with the ranges the command line
tools print now.

CHANGELOG_BEGIN
[DAML Compiler] Show the correct column numbers in error locations
produced by command line tools like `daml build`.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7707)
<!-- Reviewable:end -->
