### PR TITLE
Upgrade msys

### DIFF
--- a/dev-env/windows/manifests/msys2.json
+++ b/dev-env/windows/manifests/msys2.json
@@ -1,8 +1,8 @@
 {
     "homepage": "http://msys2.github.io",
-    "version": "20180531",
+    "version": "20200903",
     "url": [
-        "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20180531.tar.xz",
+        "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200903.tar.xz",
         "https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-jq-1.6-2-any.pkg.tar.xz#/jq.msys2",
         "https://repo.msys2.org/msys/x86_64/gnu-netcat-0.7.1-1-x86_64.pkg.tar.xz#/netcat.msys2",
         "https://repo.msys2.org/msys/x86_64/patch-2.7.6-1-x86_64.pkg.tar.xz#/patch.msys2",
@@ -11,7 +11,7 @@
         "https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-postgresql-12.2-1-any.pkg.tar.xz#/pgsql.msys2"
     ],
     "hash": [
-        "4e799b5c3efcf9efcb84923656b7bcff16f75a666911abd6620ea8e5e1e9870c",
+        "9d5700a2a8148837bd3869f4940f53d2e46ebfa4148de35c21ca49bf2c239f27",
         "da8a3b88d6ad1f5d28bc190405de9ca0f802ebcae19080a5b5b2b30a7614272b",
         "32fa739d26fd49a3f8c22717ae338472d71d4798844cbc0db5e7780131fe69aa",
         "5c18ce8979e9019d24abd2aee7ddcdf8824e31c4c7e162a204d4dc39b3b73776",


### PR DESCRIPTION
There are two reasons for this:

1. 2018 was a long time ago and there seems to be no particular reason
   for sticking to that version.

2. We have seen a bunch of issues where we get 404s when fetching msys
   packages. The newer version has a larger mirrorlist which might help
   with this. We could in principle try to patch the mirrorlist for
   the old version but given that upgrading seems like a good idea
   anyway, this seems easier.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
