### PR TITLE
Properly prefixed command ids ledger api test tool tests [KVL-658]

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -114,9 +114,10 @@ private[testtool] final class ParticipantTestContext private[participant] (
     */
   val end: LedgerOffset =
     LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END))
-  
+
+  private[this] val identifierPrefix = s"$applicationId-$endpointId-$identifierSuffix"
   private[this] def nextId(idType: String): () => String =
-    Identification.indexSuffix(s"$applicationId-$endpointId-$identifierSuffix-$idType")
+    Identification.indexSuffix(s"$identifierPrefix-$idType")
 
   private[this] val nextPartyHintId: () => String = nextId("party")
   private[this] val nextCommandId: () => String = nextId("command")

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -114,17 +114,14 @@ private[testtool] final class ParticipantTestContext private[participant] (
     */
   val end: LedgerOffset =
     LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END))
+  
+  private[this] def nextId(idType: String): () => String =
+    Identification.indexSuffix(s"$applicationId-$endpointId-$identifierSuffix-$idType")
 
-  private[this] val identifierPrefix = s"$applicationId-$endpointId-$identifierSuffix"
-
-  private[this] val nextPartyHintId: () => String =
-    Identification.indexSuffix(s"$identifierPrefix-party")
-  private[this] val nextCommandId: () => String =
-    Identification.indexSuffix(s"$identifierPrefix-command")
-  private[this] val nextSubmissionId: () => String =
-    Identification.indexSuffix(s"$identifierPrefix-submission")
-  val nextKeyId: () => String =
-    Identification.indexSuffix(s"$identifierPrefix-key")
+  private[this] val nextPartyHintId: () => String = nextId("party")
+  private[this] val nextCommandId: () => String = nextId("command")
+  private[this] val nextSubmissionId: () => String = nextId("submission")
+  val nextKeyId: () => String = nextId("key")
 
   /**
     * Gets the absolute offset of the ledger end at a point in time. Use [[end]] if you need

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -123,6 +123,8 @@ private[testtool] final class ParticipantTestContext private[participant] (
     Identification.indexSuffix(s"$identifierPrefix-command")
   private[this] val nextSubmissionId: () => String =
     Identification.indexSuffix(s"$identifierPrefix-submission")
+  val nextKeyId: () => String =
+    Identification.indexSuffix(s"$identifierPrefix-key")
 
   /**
     * Gets the absolute offset of the ledger end at a point in time. Use [[end]] if you need

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.api.testtool.tests
 
-import java.util.UUID
-
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions.{assertGrpcError, assertSingleton}
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -119,7 +117,7 @@ final class CommandDeduplicationIT(ledgerTimeInterval: ScalaDuration) extends Le
     allocate(SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
-      val key = UUID.randomUUID().toString
+      val key = ledger.nextKeyId()
 
       for {
         // Create a helper and a text key

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.api.testtool.tests
 
-import java.util.UUID
-
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -151,15 +149,15 @@ final class CommandSubmissionCompletionIT extends LedgerTestSuite {
     allocate(TwoParties),
   )(implicit ec => {
     case Participants(Participant(ledger, alice, bob)) =>
-      val a = UUID.randomUUID.toString
-      val b = UUID.randomUUID.toString
       val aliceRequest = ledger.submitRequest(alice, Dummy(alice).create.command)
       val bobRequest = ledger.submitRequest(bob, Dummy(bob).create.command)
+      val aliceCommandId = aliceRequest.getCommands.commandId
+      val bobCommandId = bobRequest.getCommands.commandId
       for {
-        _ <- ledger.submit(aliceRequest.update(_.commands.commandId := a))
-        _ <- ledger.submit(bobRequest.update(_.commands.commandId := b))
-        _ <- WithTimeout(5.seconds)(ledger.findCompletion(alice, bob)(_.commandId == a))
-        _ <- WithTimeout(5.seconds)(ledger.findCompletion(alice, bob)(_.commandId == b))
+        _ <- ledger.submit(aliceRequest)
+        _ <- ledger.submit(bobRequest)
+        _ <- WithTimeout(5.seconds)(ledger.findCompletion(alice, bob)(_.commandId == aliceCommandId))
+        _ <- WithTimeout(5.seconds)(ledger.findCompletion(alice, bob)(_.commandId == bobCommandId))
       } yield {
         // Nothing to do, if the two completions are found the test is passed
       }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
@@ -156,7 +156,8 @@ final class CommandSubmissionCompletionIT extends LedgerTestSuite {
       for {
         _ <- ledger.submit(aliceRequest)
         _ <- ledger.submit(bobRequest)
-        _ <- WithTimeout(5.seconds)(ledger.findCompletion(alice, bob)(_.commandId == aliceCommandId))
+        _ <- WithTimeout(5.seconds)(
+          ledger.findCompletion(alice, bob)(_.commandId == aliceCommandId))
         _ <- WithTimeout(5.seconds)(ledger.findCompletion(alice, bob)(_.commandId == bobCommandId))
       } yield {
         // Nothing to do, if the two completions are found the test is passed

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.api.testtool.tests
 
-import java.util.UUID
-
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
@@ -29,7 +27,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty, SingleParty),
   )(implicit ec => {
     case Participants(Participant(alpha, owner), Participant(beta, delegate)) =>
-      val key = s"${UUID.randomUUID.toString}-key"
+      val key = alpha.nextKeyId()
       for {
         // create contracts to work with
         delegated <- alpha.create(owner, Delegated(owner, key))
@@ -68,7 +66,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty, SingleParty),
   )(implicit ec => {
     case Participants(Participant(alpha, owner), Participant(beta, delegate)) =>
-      val key = s"${UUID.randomUUID.toString}-key"
+      val key = alpha.nextKeyId()
       for {
         // create contracts to work with
         delegated <- alpha.create(owner, Delegated(owner, key))
@@ -111,10 +109,9 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty, SingleParty),
   )(implicit ec => {
     case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
-      val keyPrefix = UUID.randomUUID.toString
-      val key1 = s"$keyPrefix-some-key"
-      val key2 = s"$keyPrefix-some-other-key"
-      val unknownKey = s"$keyPrefix-unknown-key"
+      val key1 = alpha.nextKeyId()
+      val key2 = alpha.nextKeyId()
+      val unknownKey = alpha.nextKeyId()
 
       for {
         // create contracts to work with
@@ -191,7 +188,7 @@ final class ContractKeysIT extends LedgerTestSuite {
   test("CKRecreate", "Contract keys can be recreated in single transaction", allocate(SingleParty))(
     implicit ec => {
       case Participants(Participant(ledger, owner)) =>
-        val key = s"${UUID.randomUUID.toString}-key"
+        val key = ledger.nextKeyId()
         for {
           delegated1TxTree <- ledger
             .submitAndWaitForTransactionTree(
@@ -222,8 +219,8 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger, owner)) =>
-      val key = s"${UUID.randomUUID.toString}-key"
-      val key2 = s"${UUID.randomUUID.toString}-key"
+      val key = ledger.nextKeyId()
+      val key2 = ledger.nextKeyId()
 
       for {
         delegation <- ledger.create(owner, Delegation(owner, owner))
@@ -250,7 +247,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
-      val expectedKey = "some-fancy-key"
+      val expectedKey = ledger.nextKeyId()
       for {
         _ <- ledger.create(party, TextKey(party, expectedKey, List.empty))
         transactions <- ledger.flatTransactions(party)
@@ -273,7 +270,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
-      val keyString = UUID.randomUUID.toString
+      val keyString = ledger.nextKeyId()
       val expectedKey = Value(
         Value.Sum.Record(
           Record(


### PR DESCRIPTION
Removed ad hoc usages of `UUID` in `ledger-api-test-tool` for id generation for commands and keys.
This change should facilitate debugging.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
