### PR TITLE
Positioning the 'Next' buttonn so it doesn't overlap with other elements

### DIFF
--- a/docs/theme/da_theme_skeleton/footer.html
+++ b/docs/theme/da_theme_skeleton/footer.html
@@ -5,7 +5,7 @@
   {% if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       {% if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right btn-next" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
+        <a href="{{ next.link|e }}" class="btn btn-neutral btn-next" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
       {% endif %}
       {% if prev %}
         <a href="{{ prev.link|e }}" class="btn btn-neutral float-left btn-prev" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
@@ -52,4 +52,3 @@
   {%- block extrafooter %} {% endblock %}
 
 </footer>
-

--- a/docs/theme/sass/_theme_layout.sass
+++ b/docs/theme/sass/_theme_layout.sass
@@ -2370,3 +2370,6 @@ a.copybtn.o-tooltip--left
 
 .btn.btn-next, .btn.btn-prev
     padding: .4em .8em
+
+.btn.btn-next,
+  margin-left: 20px


### PR DESCRIPTION
This was by far the easiest and nicest solution I could come up with. The problem is that often the "Next" button in the docs would overlap with the "Feedback" button or would fall under the "In this section" content navigation. 

![image](https://user-images.githubusercontent.com/56260209/96256134-63efef80-0fb8-11eb-9ed1-fd552fb5d26e.png)

![image](https://user-images.githubusercontent.com/56260209/96256157-6c482a80-0fb8-11eb-9a1f-09ffbcfdb96c.png)

with the new placement it looks like this

![image](https://user-images.githubusercontent.com/56260209/96256224-87b33580-0fb8-11eb-9b2f-a41426d11b44.png)

![image](https://user-images.githubusercontent.com/56260209/96256193-7b2edd00-0fb8-11eb-94d6-06439d0b49fa.png)

I've tried first leaving the button where it is, but the combo of responsive placement that needed to be done wasn't really optimal. 

CHANGELOG_BEGIN
CHANGELOG_END