### PR TITLE
daml-sdk-head: add optional sha information

### DIFF
--- a/bazel_tools/build_environment.bzl
+++ b/bazel_tools/build_environment.bzl
@@ -1,6 +1,15 @@
 # Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+def is_figure(c):
+    return c == "0" or c == "1" or c == "2" or c == "3" or c == "4" or c == "5" or c == "6" or c == "7" or c == "8" or c == "9"
+
+def is_number(s):
+    for c in s.elems():
+        if not is_figure(c):
+            return False
+    return True
+
 def _impl(ctx):
     # Generates an empty BUILD file, because we do not need to build anything.
     ctx.file(
@@ -12,11 +21,17 @@ def _impl(ctx):
     # Generates a simple Bazel file that just sets a bunch of Bazel variables,
     # so they can be used in our main Bazel BUILD files.
     semver = ctx.os.environ.get("DAML_SDK_RELEASE_VERSION", default = "0.0.0")
-    if semver.find("-snapshot.") > 0:
-        ghc = semver[:-9].replace("-snapshot.", ".")
+    if semver.find("-") > 0:
+        ghc_list = []
+        for segment in semver.replace("-", ".").split("."):
+            if is_number(segment):
+                ghc_list.append(segment)
+        ghc = ghc_list[0]
+        for elem in ghc_list[1:]:
+            ghc = ghc + "." + elem
     else:
         ghc = semver
-    ctx.file(
+    return ctx.file(
         "configuration.bzl",
         content =
             """

--- a/bazel_tools/build_environment.bzl
+++ b/bazel_tools/build_environment.bzl
@@ -1,15 +1,6 @@
 # Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-def is_figure(c):
-    return c == "0" or c == "1" or c == "2" or c == "3" or c == "4" or c == "5" or c == "6" or c == "7" or c == "8" or c == "9"
-
-def is_number(s):
-    for c in s.elems():
-        if not is_figure(c):
-            return False
-    return True
-
 def _impl(ctx):
     # Generates an empty BUILD file, because we do not need to build anything.
     ctx.file(
@@ -22,16 +13,10 @@ def _impl(ctx):
     # so they can be used in our main Bazel BUILD files.
     semver = ctx.os.environ.get("DAML_SDK_RELEASE_VERSION", default = "0.0.0")
     if semver.find("-") > 0:
-        ghc_list = []
-        for segment in semver.replace("-", ".").split("."):
-            if is_number(segment):
-                ghc_list.append(segment)
-        ghc = ghc_list[0]
-        for elem in ghc_list[1:]:
-            ghc = ghc + "." + elem
+        ghc = ".".join([segment for segment in semver.replace("-", ".").split(".") if segment.isdigit()])
     else:
         ghc = semver
-    return ctx.file(
+    ctx.file(
         "configuration.bzl",
         content =
             """

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -74,14 +74,14 @@ sha_version() {
         trap "$old_trap; rm -f $index_file" EXIT
         cp -f $(git rev-parse --show-toplevel)/.git/index $index_file
         GIT_INDEX_FILE=$index_file git add --all
-        dirty="dirty.$(GIT_INDEX_FILE=$index_file git write-tree)"
+        dirty=".dirty.$(GIT_INDEX_FILE=$index_file git write-tree)"
         rm -f $index_file
         trap "$old_trap" EXIT
     fi
     date=$(git log -n1 --format=%cd --date=format:%Y%m%d HEAD)
     nr=$(git rev-list --count HEAD)
     sha8=$(git log -n1 --format=%h --abbrev=8 HEAD)
-    echo "0.0.0-head.${date}.${nr}.${sha8}.${dirty}"
+    echo "0.0.0-head.${date}.${nr}.${sha8}${dirty}"
 }
 if [ $SHA = 0 ]; then
     export DAML_SDK_RELEASE_VERSION=0.0.0

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -65,12 +65,23 @@ if [[ -d "$DAML_HOME" && "$NUKE" -ne 0 ]]; then
 fi
 
 sha_version() {
-    local dirty date nr sha8
-    dirty=$([[ -z $(git status -s) ]] && echo clean || echo dirty)
+    local dirty date nr sha8 index_file old_trap
+    if [[ -z $(git status -s) ]]; then
+        dirty=""
+    else
+        old_trap=$(trap -p EXIT)
+        index_file=$(mktemp)
+        trap "$old_trap; rm -f $index_file" EXIT
+        cp -f $(git rev-parse --show-toplevel)/.git/index $index_file
+        GIT_INDEX_FILE=$index_file git add --all
+        dirty="dirty.$(GIT_INDEX_FILE=$index_file git write-tree)"
+        rm -f $index_file
+        trap "$old_trap" EXIT
+    fi
     date=$(git log -n1 --format=%cd --date=format:%Y%m%d HEAD)
     nr=$(git rev-list --count HEAD)
     sha8=$(git log -n1 --format=%h --abbrev=8 HEAD)
-    echo "0.0.0-head.${dirty}.${date}.${nr}.${sha8}"
+    echo "0.0.0-head.${date}.${nr}.${sha8}.${dirty}"
 }
 if [ $SHA = 0 ]; then
     export DAML_SDK_RELEASE_VERSION=0.0.0

--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -20,6 +20,7 @@ NUKE=0
 PROFILING=0
 SKIP_JARS=0
 JUST_DAMLC=0
+SHA=0
 for opt in "$@"; do
   case "$opt" in
     "--nuke")
@@ -34,6 +35,9 @@ for opt in "$@"; do
     "--damlc")
       JUST_DAMLC=1
       ;;
+    "--sha")
+      SHA=1
+      ;;
     *)
       echo "Unknown option: $opt"
       echo "Available options:"
@@ -41,6 +45,8 @@ for opt in "$@"; do
       echo "  --profiling  Build Haskell executables with profiling enabled."
       echo "  --skip-jars  Skip building and installing the JARs."
       echo "  --damlc  Update damlc only, if daml-head is already installed."
+      echo "  --sha Include SHA information in version number."
+
       exit 1
   esac
 done
@@ -58,7 +64,21 @@ if [[ -d "$DAML_HOME" && "$NUKE" -ne 0 ]]; then
   rm -rf "$DAML_HOME"
 fi
 
-readonly DAML_HEAD_SDK="$DAML_HOME/sdk/0.0.0"
+sha_version() {
+    local dirty date nr sha8
+    dirty=$([[ -z $(git status -s) ]] && echo clean || echo dirty)
+    date=$(git log -n1 --format=%cd --date=format:%Y%m%d HEAD)
+    nr=$(git rev-list --count HEAD)
+    sha8=$(git log -n1 --format=%h --abbrev=8 HEAD)
+    echo "0.0.0-head.${dirty}.${date}.${nr}.${sha8}"
+}
+if [ $SHA = 0 ]; then
+    export DAML_SDK_RELEASE_VERSION=0.0.0
+else
+    export DAML_SDK_RELEASE_VERSION=$(sha_version)
+fi
+
+readonly DAML_HEAD_SDK="$DAML_HOME/sdk/$DAML_SDK_RELEASE_VERSION"
 if [[ -d "$DAML_HEAD_SDK" && "$JUST_DAMLC" -eq 0 ]]; then
   echo "$(tput setaf 3)Removing existing daml-head installation.$(tput sgr 0)"
   rm -f "${DAML_HOME}/bin/daml-head"
@@ -69,11 +89,11 @@ fi
 if [[ -d "$DAML_HEAD_SDK" && "$JUST_DAMLC" -ne 0 ]]; then
   # daml-head is installed, so just replace damlc
   echo "$(tput setaf 3)Existing daml-head installation found."
-  echo "Building damlc version 0.0.0, this may take a while ...$(tput sgr 0)"
+  echo "Building damlc version $DAML_SDK_RELEASE_VERSION, this may take a while ...$(tput sgr 0)"
   echo ""
 
   function cleanup() {
-    echo "damlc 0.0.0 failed to build/install - if you need help ask on #product-daml"
+    echo "damlc $DAML_SDK_RELEASE_VERSION failed to build/install; if you need help ask on https://discuss.daml.com"
     echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
   }
   trap cleanup EXIT
@@ -87,15 +107,15 @@ if [[ -d "$DAML_HEAD_SDK" && "$JUST_DAMLC" -ne 0 ]]; then
   tar xzf "$TARBALL" -C "${DAML_HEAD_SDK}/damlc" --strip-components 1
 
   trap - EXIT
-  echo "$(tput setaf 3)Done installing damlc 0.0.0$(tput sgr 0)"
+  echo "$(tput setaf 3)Done installing damlc $DAML_SDK_RELEASE_VERSION$(tput sgr 0)"
   exit 0
 fi
 
-echo "$(tput setaf 3)Building version 0.0.0 - this may take a while ...$(tput sgr 0)"
+echo "$(tput setaf 3)Building version $DAML_SDK_RELEASE_VERSION - this may take a while ...$(tput sgr 0)"
 echo ""
 
 function cleanup() {
-  echo "SDK 0.0.0 failed to build/install - if you need help ask on"
+  echo "SDK $DAML_SDK_RELEASE_VERSION failed to build/install - if you need help ask on"
   echo "https://discuss.daml.com"
   echo "$(tput setaf 3)FAILED TO INSTALL! $(tput sgr 0)"
 
@@ -117,7 +137,7 @@ tar xzf "$TARBALL" -C "$SDK_DIR" --strip-components 1
 
 readonly DAML_CMD="$(command -v daml)"
 if [[ -x "$DAML_CMD" && "$DAML_CMD" == "$DAML_HOME/bin/daml" ]]; then
-  # A daml installation already exists, so just install SDK version 0.0.0.
+  # A daml installation already exists, so just install SDK version $DAML_SDK_RELEASE_VERSION.
   "${DAML_HOME}/bin/daml" install "$SDK_DIR" --force
 else
   # No daml installation detected, so install the tarball normally but disable auto-install.
@@ -131,15 +151,15 @@ fi
 
 cat > "${DAML_HOME}/bin/daml-head" << EOF
 #!/bin/sh
-exec env DAML_SDK_VERSION=0.0.0 "${DAML_HEAD_SDK}/daml/daml" "\$@"
+exec env DAML_SDK_VERSION=$DAML_SDK_RELEASE_VERSION "${DAML_HEAD_SDK}/daml/daml" "\$@"
 EOF
 chmod +x "${DAML_HOME}/bin/daml-head"
 
 trap - EXIT
-echo "$(tput setaf 3)Successfully installed daml-head command.$(tput sgr 0)"
+echo "$(tput setaf 3)Successfully installed daml-head command pointing to $DAML_SDK_RELEASE_VERSION.$(tput sgr 0)"
 
 if [[ "$SKIP_JARS" -eq 0 ]]; then
-    echo "$(tput setaf 3)Installing JARs as 0.0.0...$(tput sgr 0)"
+    echo "$(tput setaf 3)Installing JARs as $DAML_SDK_RELEASE_VERSION...$(tput sgr 0)"
 
     function cleanup() {
       echo "$(tput setaf 3)FAILED TO INSTALL JARS! $(tput sgr 0)"
@@ -152,5 +172,5 @@ if [[ "$SKIP_JARS" -eq 0 ]]; then
 
     trap - EXIT
 
-    echo "$(tput setaf 3)Done installing JARs as 0.0.0.$(tput sgr 0)"
+    echo "$(tput setaf 3)Done installing JARs as $DAML_SDK_RELEASE_VERSION.$(tput sgr 0)"
 fi


### PR DESCRIPTION
This PR add an option, `--sha`, to `daml-sdk-head` so that it produces a more accurate version number including the current git sha.

The main consequence is that calling `daml-sdk-head --sha` take significantly longer than calling `daml-sdk-head`, because it needs to recompile everything that depends on the version number.

> ## Wait, but why??

I started this work in support of an internal project that needed to test against unreleased, and possibly unmerged, daml versions. However, after further discussion I believe there is a better option for their use-case. I've decided to still open this PR because the work was done and there is no downside to it. It may still be useful if one wanted to be able to maintain more than one non-released local version of daml.

CHANGELOG_BEGIN
CHANGELOG_END