### PR TITLE
Functional dependency support in data-dependencies

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1783,6 +1783,25 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
         , "eqD x y = eq x y"
         ]
 
+    , simpleImportTest "Using functional dependencies"
+        -- This test checks that functional dependencies are imported via data-dependencies.
+        [ "module Lib where"
+        , "class MyClass a b | a -> b where"
+        , "   foo : a -> b"
+        , "instance MyClass Int Int where foo x = x"
+        , "instance MyClass Text Text where foo x = x"
+        ]
+        [ "module Main where"
+        , "import Lib"
+        , "useFooInt : Int -> Text"
+        , "useFooInt x = show (foo x)"
+        , "useFooText : Text -> Text"
+        , "useFooText x = show (foo x)"
+        -- If functional dependencies were not imported, we'd get a ton of
+        -- "ambiguous type variable" errors from GHC, since type inference
+        -- cannot determine the output type for 'foo'.
+        ]
+
     , testCaseSteps "Implicit parameters" $ \step -> withTempDir $ \tmpDir -> do
         step "building project with implicit parameters"
         createDirectoryIfMissing True (tmpDir </> "dep")


### PR DESCRIPTION
This PR adds support for functional dependencies in data-dependencies.
It also adds a small test to make sure these are imported. 

changelog_begin

- [DAML Compiler] Functional dependencies are now saved
  by the DAML compiler in the DALF file / DAR package. When
  importing a file with the functional dependency data via
  data-dependencies, these will be picked up automatically.

changelog_end