### PR TITLE
Warn about un-upgradability of fancy kinds

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -260,11 +260,11 @@ generateRawDalfRule =
                     -- GHC Core to DAML LF
                     case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core of
                         Left e -> return ([e], Nothing)
-                        Right v -> do
+                        Right (v, warnings) -> do
                             WhnfPackage pkg <- use_ GeneratePackageDeps file
                             pkgs <- getExternalPackages file
                             let world = LF.initWorldSelf pkgs pkg
-                            return ([], Just $ LF.simplifyModule world lfVersion v)
+                            return (warnings, Just $ LF.simplifyModule world lfVersion v)
 
 getExternalPackages :: NormalizedFilePath -> Action [LF.ExternalPackage]
 getExternalPackages file = do
@@ -408,7 +408,7 @@ generateSerializedDalfRule options =
                             DamlEnv{envIsGenerated} <- getDamlServiceEnv
                             case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core of
                                 Left e -> pure ([e], Nothing)
-                                Right rawDalf -> do
+                                Right (rawDalf, warnings) -> fmap (first (warnings ++)) $ do
                                     -- LF postprocessing
                                     pkgs <- getExternalPackages file
                                     let selfPkg = buildPackage (optMbPackageName options) (optMbPackageVersion options) lfVersion dalfDeps

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -118,7 +118,7 @@ import           Safe.Exact (zipExact, zipExactMay)
 import           SdkVersion
 
 ---------------------------------------------------------------------
--- FAILURE REPORTING
+-- FAILURE and WARNING REPORTING
 
 conversionError :: String -> ConvertM e
 conversionError msg = do
@@ -149,6 +149,29 @@ unknown unitId pkgMap = conversionError errMsg
 
 unhandled :: (HasCallStack, Data a, Outputable a) => String -> a -> ConvertM e
 unhandled typ x = unsupported (typ ++ " with " ++ lower (show (toConstr x))) x
+
+warn :: String -> ConvertM ()
+warn msg = do
+    ConversionEnv{..} <- ask
+    let diag = (convModuleFilePath, ShowDiag, Diagnostic
+            { _range = maybe noRange sourceLocToRange convRange
+            , _severity = Just DsWarning
+            , _source = Just "Core to DAML-LF"
+            , _message = T.pack msg
+            , _code = Nothing
+            , _relatedInformation = Nothing
+            , _tags = Nothing
+            })
+    modify' $ \st -> ConversionState (diag : convWarnings st)
+
+warnNotDataDependable :: String -> ConvertM ()
+warnNotDataDependable what =
+    warn $ unlines
+        [ "Using " ++ what ++ " in combination with type classes"
+        , "does not work properly with data-dependencies. This will stop the"
+        , "whole package from being extensible or upgradable using other versions"
+        , "of the SDK. Use this feature at your own risk."
+        ]
 
 ---------------------------------------------------------------------
 -- FUNCTIONS ON THE ENVIRONMENT
@@ -234,16 +257,23 @@ data ConversionError
 data ConversionEnv = ConversionEnv
   { convModuleFilePath :: !NormalizedFilePath
   , convRange :: !(Maybe SourceLoc)
+  , convWarnOnTypeErasure :: Bool
   }
 
-newtype ConvertM a = ConvertM (ReaderT ConversionEnv (Except FileDiagnostic) a)
-  deriving (Functor, Applicative, Monad, MonadError FileDiagnostic, MonadReader ConversionEnv)
+newtype ConversionState = ConversionState { convWarnings :: [FileDiagnostic] }
+
+newtype ConvertM a = ConvertM (ReaderT ConversionEnv (StateT ConversionState (Except FileDiagnostic)) a)
+  deriving (Functor, Applicative, Monad, MonadError FileDiagnostic, MonadReader ConversionEnv, MonadState ConversionState)
 
 instance MonadFail ConvertM where
     fail = conversionError
 
-runConvertM :: ConversionEnv -> ConvertM a -> Either FileDiagnostic a
-runConvertM s (ConvertM a) = runExcept (runReaderT a s)
+runConvertM :: ConversionEnv -> ConvertM a -> Either FileDiagnostic (a, [FileDiagnostic])
+runConvertM env (ConvertM act) = case runExcept (runStateT (runReaderT act env) st0) of
+    Left err -> Left err
+    Right (res, st) -> Right (res, reverse (convWarnings st))
+  where
+    st0 = ConversionState []
 
 withRange :: Maybe SourceLoc -> ConvertM a -> ConvertM a
 withRange r = local (\s -> s { convRange = r })
@@ -355,13 +385,18 @@ convertModule
     -> Bool
     -> NormalizedFilePath
     -> CoreModule
-    -> Either FileDiagnostic LF.Module
-convertModule lfVersion pkgMap stablePackages isGenerated file x = runConvertM (ConversionEnv file Nothing) $ do
+    -> Either FileDiagnostic (LF.Module, [FileDiagnostic])
+convertModule lfVersion pkgMap stablePackages isGenerated file x = runConvertM convEnv0 $ do
     definitions <- concatMapM (convertBind env) binds
     types <- concatMapM (convertTypeDef env) (eltsUFM (cm_types x))
     templates <- convertTemplateDefs env
     pure (LF.moduleFromDefinitions lfModName (Just $ fromNormalizedFilePath file) flags (types ++ templates ++ definitions))
     where
+        convEnv0 = ConversionEnv
+            { convModuleFilePath = file
+            , convRange = Nothing
+            , convWarnOnTypeErasure = False
+            }
         ghcModName = GHC.moduleName $ cm_module x
         thisUnitId = GHC.moduleUnitId $ cm_module x
         lfModName = convertModuleName ghcModName
@@ -506,7 +541,8 @@ convertClassDef env tycon
         labels = ctorLabels con
         (_, theta, args, _) = dataConSig con
 
-    (env', tyVars) <- bindTypeVars env (tyConTyVars tycon)
+    (env', tyVars) <- local (\convEnv -> convEnv{convWarnOnTypeErasure = True}) $ do
+        bindTypeVars env (tyConTyVars tycon)
     fieldTypes <- mapM (convertType env') (theta ++ args)
 
     let fields = zipExact labels (map sanitize fieldTypes)
@@ -729,21 +765,36 @@ convertBind env (name, x)
     | ConstraintTupleProjectionName _ _ <- name
     = pure []
 
+    -- Typeclass instance dictionaries
+    | DFunId isNewtype <- idDetails name
+    = withRange (convNameLoc name) $ do
+    x' <- convertExpr env x
+    -- NOTE(MH): This is DICTIONARY SANITIZATION step (3).
+    -- The sanitization for newtype dictionaries is done in `convertCoercion`.
+    let sanitized_x'
+          | isNewtype = x'
+          | otherwise =
+            let fieldsPrism
+                  | envLfVersion env `supports` featureTypeSynonyms = _EStructCon
+                  | otherwise = _ERecCon . _2
+            in over (_ETyLams . _2 . _ETmLams . _2 . fieldsPrism . each . _2) (ETmLam (mkVar "_", TUnit)) x'
+    -- NOTE(MH): We don't warn on advanced kinds for `HasField` instances
+    -- because they need to use type-level strings and are handled special
+    -- in data-dependencies.
+    let isHasFieldDict
+          | (_, ty) <- splitForAllTys (varType name)
+          , Just (NameIn DA_Internal_Record "HasField", _) <- splitTyConApp_maybe ty = True
+          | otherwise = False
+    name' <- local (\convEnv -> convEnv{convWarnOnTypeErasure = not isHasFieldDict}) $ do
+        convValWithType env name
+    pure [defValue name name' sanitized_x']
+
+    -- Regular functions
     | otherwise
     = withRange (convNameLoc name) $ do
     x' <- convertExpr env x
-    let sanitize = case idDetails name of
-          -- NOTE(MH): This is DICTIONARY SANITIZATION step (3).
-          -- NOTE (drsk): We only want to do the sanitization for non-newtypes. The sanitization
-          -- step 3 for newtypes is done in the convertCoercion function.
-          DFunId False ->
-              let fieldsPrism
-                    | envLfVersion env `supports` featureTypeSynonyms = _EStructCon
-                    | otherwise = _ERecCon . _2
-              in over (_ETyLams . _2 . _ETmLams . _2 . fieldsPrism . each . _2) (ETmLam (mkVar "_", TUnit))
-          _ -> id
     name' <- convValWithType env name
-    pure [defValue name name' (sanitize x')]
+    pure [defValue name name' x']
 
 -- NOTE(MH): These are the names of the builtin DAML-LF types whose Surface
 -- DAML counterpart is not defined in 'GHC.Types'. They are all defined in
@@ -1493,11 +1544,22 @@ qDA_Types env a = do
 
 -- | Types of a kind not supported in DAML-LF, e.g., the DataKinds stuff from GHC.Generics
 -- are translated to a special uninhabited Erased type. This allows us to easily catch these
--- cases in data-dependencies.
-erasedTy :: Env -> ConvertM LF.Type
-erasedTy env = do
+-- cases in data-dependencies. In combination with typeclasses causes trouble.
+erasedTy :: Env -> GHC.TyCon -> ConvertM LF.Type
+erasedTy env t = do
+    whenM (asks convWarnOnTypeErasure) $ do
+        warnNotDataDependable ("the type " ++ prettyPrint t)
     pkgRef <- packageNameToPkgRef env primUnitId
     pure $ TCon $ rewriteStableQualified env (Qualified pkgRef (mkModName ["DA", "Internal", "Erased"]) (mkTypeCon ["Erased"]))
+
+-- | Kinds not supported in DAML-LF, like the `Symbol` kind or the stuff in
+-- `DA.Generics`, are translated to `KStar`. In combination with typeclasses
+-- this does not work with data-dependencies.
+erasedKind :: GHC.TyCon -> ConvertM LF.Kind
+erasedKind k = do
+    whenM (asks convWarnOnTypeErasure) $ do
+        warnNotDataDependable ("the kind " ++ prettyPrint k)
+    pure KStar
 
 -- | Type-level strings are represented in DAML-LF via the PromotedText type. This is
 -- For example, the type-level string @"foo"@ will be represented by the type
@@ -1564,8 +1626,8 @@ convertTyCon env t
     | t == boolTyCon = pure TBool
     | t == intTyCon || t == intPrimTyCon = pure TInt64
     | t == charTyCon = unsupported "Type GHC.Types.Char" t
-    | t == liftedRepDataConTyCon = erasedTy env
-    | t == typeSymbolKindCon = erasedTy env
+    | t == liftedRepDataConTyCon = erasedTy env t
+    | t == typeSymbolKindCon = erasedTy env t
     | NameIn GHC_Types n <- t =
         case n of
             "Text" -> pure TText
@@ -1619,14 +1681,14 @@ convertType env = go env
             pure TText
         | NameIn DA_Generics n <- t
         , n `elementOfUniqSet` metadataTys
-        , [_] <- ts = erasedTy env
+        , [_] <- ts = erasedTy env t
         | t == anyTyCon, [_] <- ts =
             -- used for type-zonking
             -- We translate this to Erased instead of TUnit since we do
             -- not want to translate this back to `()` for `data-dependencies`
             -- and because we never actually have values of type `Any xs` which
             -- is made explicit by translating it to an uninhabited type.
-            erasedTy env
+            erasedTy env t
 
         | t == funTyCon, _:_:ts' <- ts =
             foldl TApp TArrow <$> mapM (go env) ts'
@@ -1658,7 +1720,10 @@ convertType env = go env
         = TVar . fst <$> convTypeVar env v
 
     go env t | Just s <- isStrLitTy t
-        = promotedTextTy env (fsToText s)
+        = do
+            whenM (asks convWarnOnTypeErasure) $
+                warnNotDataDependable "type-level strings"
+            promotedTextTy env (fsToText s)
 
     go env t | Just m <- isNumLitTy t
         = case typeLevelNatE m of
@@ -1675,11 +1740,10 @@ convertType env = go env
 
 convertKind :: GHC.Kind -> ConvertM LF.Kind
 convertKind x@(TypeCon t ts)
-    | t == typeSymbolKindCon, null ts = pure KStar
-    | t == tYPETyCon, [_] <- ts = pure KStar
-    | t == runtimeRepTyCon, null ts = pure KStar
-    -- TODO (drsk): We want to check that the 'Meta' constructor really comes from GHC.Generics.
-    | getOccFS t == "Meta", null ts = pure KStar
+    | t == tYPETyCon, [_] <- ts = pure KStar  -- This is the actual `*` kind.
+    | t == typeSymbolKindCon, null ts = erasedKind t
+    | t == runtimeRepTyCon, null ts = erasedKind t
+    | NameIn DA_Generics "Meta" <- t, null ts = erasedKind t
     | Just m <- nameModule_maybe (getName t)
     , GHC.moduleName m == mkModuleName "GHC.Types"
     , getOccFS t == "Nat", null ts = pure KNat

--- a/compiler/damlc/tests/daml-test-files/ErasedTypesWarnings.daml
+++ b/compiler/damlc/tests/daml-test-files/ErasedTypesWarnings.daml
@@ -1,0 +1,31 @@
+-- @WARN range=9:1-9:19; Modules importing DA.Generics do not work with data-dependencies.
+-- @WARN range=13:1-13:46; Using the kind Symbol in combination with type classes
+-- @WARN range=16:10-16:27; Using type-level strings in combination with type classes
+-- @WARN range=19:1-19:51; Using the kind Symbol in combination with type classes
+-- @WARN range=22:1-22:34; Using the kind Meta in combination with type classes
+-- @WARN range=25:10-25:59; Using the type 'MetaData in combination with type classes
+module ErasedTypesWarnings where
+
+import DA.Generics
+import DA.Record
+
+-- We warn about explicitly using `Symbol` in a class definition.
+class KnownSymbol (x: GHC.Types.Symbol) where
+
+-- We warn about using a type-evel string in an instance.
+instance KnownSymbol "foo" where
+
+-- We warn about implicitly using `Symbol` in a class definition.
+class HasField x r a => ReallyHasField x r a where
+
+-- We warn about using generics stuff in a class definition.
+class Generically (a: Meta) where
+
+-- We warn about using generics stuff in an instance.
+instance Generically (MetaData ('MetaData0 "" "" "" True)) where
+
+-- We do not warn about the imlicitly created `HasField` instance.
+data MonoRec = MonoRec with mono: Int
+
+-- We do not warn about `HasField` even for polymorphic records.
+data PolyRec a = PolyRec with poly: a

--- a/compiler/damlc/tests/daml-test-files/Generics.daml
+++ b/compiler/damlc/tests/daml-test-files/Generics.daml
@@ -2,8 +2,39 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE EmptyCase #-}
--- @WARN Modules compiled with the EmptyCase language extension might not work properly with data-dependencies.
--- @WARN Modules importing DA.Generics do not work with data-dependencies.
+-- @WARN range=39:8-39:16; Modules compiled with the EmptyCase language extension
+-- @WARN range=41:1-41:19; Modules importing DA.Generics do not work with data-dependencies.
+-- @WARN range=47:6-47:10; Using the type 'MetaData in combination with type classes
+-- @WARN range=49:6-49:20; Using the type 'MetaCons in combination with type classes
+-- @WARN range=49:6-49:20; Using the type 'MetaData in combination with type classes
+-- @WARN range=49:6-49:20; Using the type 'MetaSel in combination with type classes
+-- @WARN range=51:6-51:13; Using the type 'MetaCons in combination with type classes
+-- @WARN range=51:6-51:13; Using the type 'MetaData in combination with type classes
+-- @WARN range=53:6-53:63; Using the type 'MetaCons in combination with type classes
+-- @WARN range=53:6-53:63; Using the type 'MetaData in combination with type classes
+-- @WARN range=53:6-53:63; Using the type 'MetaSel in combination with type classes
+-- @WARN range=53:6-53:63; Using the type 'MetaSel in combination with type classes
+-- @WARN range=55:6-55:40; Using the type 'MetaCons in combination with type classes
+-- @WARN range=55:6-55:40; Using the type 'MetaData in combination with type classes
+-- @WARN range=55:6-55:40; Using the type 'MetaSel in combination with type classes
+-- @WARN range=57:6-57:39; Using the type 'MetaCons in combination with type classes
+-- @WARN range=57:6-57:39; Using the type 'MetaCons in combination with type classes
+-- @WARN range=57:6-57:39; Using the type 'MetaData in combination with type classes
+-- @WARN range=57:6-57:39; Using the type 'MetaSel in combination with type classes
+-- @WARN range=63:6-63:38; Using the type 'MetaCons in combination with type classes
+-- @WARN range=63:6-63:38; Using the type 'MetaCons in combination with type classes
+-- @WARN range=63:6-63:38; Using the type 'MetaData in combination with type classes
+-- @WARN range=63:6-63:38; Using the type 'MetaSel in combination with type classes
+-- @WARN range=63:6-63:38; Using the type 'MetaSel in combination with type classes
+-- @WARN range=64:6-64:45; Using the type 'MetaCons in combination with type classes
+-- @WARN range=64:6-64:45; Using the type 'MetaData in combination with type classes
+-- @WARN range=64:6-64:45; Using the type 'MetaSel in combination with type classes
+-- @WARN range=64:6-64:45; Using the type 'MetaSel in combination with type classes
+
+
+
+-- Some extra space for more warnings here...
+
 
 module Generics where
 


### PR DESCRIPTION
Haskell allows for promoting types to the kind level with the
`DataKinds` extension. Since DAML-LF has no similar concept (and
frankly speaking should't have one), this does not work well with
data-dependencies. Unfortunately, we need to enable the `DataKinds`
extension by default in `damlc` since our record system and the
`Numeric` type depend on it. Thus, issuing a warning that the
`DataKinds` is not supported with data-dependencies is not an option
and we need more refined warnings.

Most uses of promoted kinds won't even compile to DAML-LF and there's
no need to warn about those since they cause hard failures. However,
we need some limited support for type-level strings and the `Symbol`
kind, for type-level numbers and the `Nat` kind, as well as for some
stuff from `DA.Generics`. Type-level numbers and the `Nat` kind work
reasonable well since we have them in DAML-LF too. The `Symbol` kind,
and the types and kinds from `DA.Generics` are "erased" during
conversion to DAML-LF by replacing them with either a special `Erased`
type or the star kind. Thus, these entities are not restored properly
with data-dependencies. In combination with type classes this leads
easily to instances that for different types in the original code but
are at conflict during interface reconstruction. Long story short,
erased types/kinds and type classes don't work with data-dependencies.

We have a hack to somehow preserve type-level string since we need that
for our record system and the `HasField` type class. I have no desire
to support this hack for arbitrary type classes coming from the user.
Thus, I consider type-level strings to be erased as well here.

This PR adds a warning whenever a user is attempting to define a type
class that involves a kind that will be erased or an instance that
involves a type that will be erased. The warning tells the user that
this does not work with data-dependencies and is hence not upgradable.

There is one caveat: the `HasField` instances produced by the
propressor fall in the category we should warn about as well. Since not
supporting them would make our record system unusable, we need to give
them special treatment in data-dependencies. Thus, warning about them
would be unjustified noise and we explicitly exclude them in the code
producing the warnings.

CHANGELOG_BEGIN
[DAML Compiler] Issue warning when advanced types are with type classes
in a way that is supported by data-dependencies.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7725)
<!-- Reviewable:end -->
