### PR TITLE
Allow more language extensions wrt data-dependencies

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -282,6 +282,15 @@ dataDependableExtensions = ES.fromList $ xExtensionsSet ++
     -- used in daml-stdlib and triggers and a very reasonable
     -- extension in general in the presence of TypeApplications
   , AllowAmbiguousTypes
+    -- helpful for documentation purposes
+  , InstanceSigs
+    -- convenient syntactic sugar that does not impact the type level at all
+  , MultiWayIf
+    -- there's no way for our users to actually use this and listing it here
+    -- removes a lot of warning from out stdlib, script and trigger builds
+    -- NOTE: This should not appear on any list of extensions that are
+    -- compatible with data-dependencies since this would spur wrong hopes.
+  , Cpp
   ]
 
 -- | Language settings _disabled_ ($-XNo...$) in the DAML-1.2 compilation


### PR DESCRIPTION
Stop emitting warnings about un-upgradability when our users use the
`InstanceSigs` or `MultiWayIf` extensions. These are safe.

Also don't issue warnings for `Cpp`, which can only be used internally.

CHANGELOG_BEGIN
[DAML Compiler] Add `InstanceSigs` and `MultiWayIf` to the list of
language extensions that don't cause problems with data-dependencies.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7728)
<!-- Reviewable:end -->
