### PR TITLE
ci/check_changelog: reduce race condition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,13 +74,17 @@ jobs:
       - git_sha
     variables:
       fork_sha: $[ dependencies.git_sha.outputs['out.fork_point'] ]
+      pr_commit: $[ dependencies.git_sha.outputs['out.branch'] ]
     condition: eq(variables['Build.Reason'], 'PullRequest')
     pool:
       name: 'linux-pool'
       demands: assignment -equals default
     steps:
       - checkout: self
-      - bash: ci/check-changelog.sh $(fork_sha)
+      - bash: |
+          set -euo pipefail
+          git checkout $(pr_commit)
+          ci/check-changelog.sh $(fork_sha)
 
   - template: ci/da-ghc-lib/compile.yml
     parameters:


### PR DESCRIPTION
~We've had an example on #7732 where the changelog check erroneously accepted a PR because its own refernce to `origin/master` was not up to date. This should make that sort of issue impossible, though concurrency is hard, so I'll go for declaring that this reduces the window for race conditions.~

PR #7732 illustrated a bug in our current changelog check: it only worked if the PR was up-to-date with `master` at the time of pushing. This was not the intention. Fortunately, the fix is fairly easy: check out the PR commit before running the check, rather than run it from the merge commit (as Azure does by default).

Huge thanks to Samir for pushing me to properly investigate this instead of committing non-sense.

CHANGELOG_BEGIN
CHANGELOG_END