### PR TITLE
Move CallStack, HasCallStack docs to DA.Stack

### DIFF
--- a/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
@@ -3,6 +3,8 @@
 
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+
+-- | MOVE DA.Stack
 module GHC.Stack.Types where
 
 import GHC.Classes ()
@@ -11,42 +13,59 @@ import GHC.Err
 import GHC.Tuple ()
 import GHC.Types
 
--- | Request a CallStack.
+-- | Request a `CallStack`. Use this as a constraint in type signatures in order
+-- to get nicer callstacks for error and debug messages.
 --
--- Calls to functions with this constraint will be added to the callstack.
--- You can get access to the current call stack with `callStack`.
+-- For example, instead of declaring the following type signature:
 --
--- Note that if the call stack is reset if any function in between does not
--- have a `HasCallStack` constraint.
+-- ```
+-- myFunction : Int -> Update ()
+-- ```
+--
+-- You can declare a type signature with the `HasCallStack` constraint:
+--
+-- ```
+-- myFunction : HasCallStack => Int -> Update ()
+-- ```
+--
+-- The function `myFunction` will still be called the same way, but it will also show up
+-- as an entry in the current callstack, which you can obtain with `callStack`.
+--
+-- Only calls to functions with this constraint will be added to the callstack.
+-- Note that if any intermediate function does not have the `HasCallStack` constraint,
+-- the callstack will be reset.
 type HasCallStack = (?callStack : CallStack)
 
 -- NOTE (MK): Note that everything in this module
 -- needs to use `TextLit`. Otherwise, you will get core linting errors
 -- due to mismatch between TextLit and Text.
 
--- | Type of `CallStack`s constructed automatically from `HasCallStack` constraints.
+-- | Type of call stacks constructed automatically from `HasCallStack` constraints.
 --
 -- Use `getCallStack` to deconstruct the `CallStack`.
 data CallStack
-  = EmptyCallStack
-  | PushCallStack (TextLit, SrcLoc, CallStack)
-  | FreezeCallStack CallStack
+  = EmptyCallStack -- ^ HIDE
+  | PushCallStack (TextLit, SrcLoc, CallStack) -- ^ HIDE
+  | FreezeCallStack CallStack -- ^ HIDE
 
+-- | HIDE
 emptyCallStack : CallStack
 emptyCallStack = EmptyCallStack
 
+-- | HIDE
 pushCallStack : (TextLit, SrcLoc) -> CallStack -> CallStack
 pushCallStack (fn, loc) stk = case stk of
   FreezeCallStack _ -> stk
   _                 -> PushCallStack (fn, loc, stk)
 
+-- | HIDE
 popCallStack : CallStack -> CallStack
 popCallStack stk = case stk of
   EmptyCallStack         -> error "popCallStack: empty stack"
   PushCallStack (_, _, stk') -> stk'
   FreezeCallStack _      -> stk
 
--- | Location in the source code.
+-- | HIDE Location in the source code.
 --
 -- Line and column are 1-based.
 data SrcLoc = SrcLoc
@@ -58,4 +77,3 @@ data SrcLoc = SrcLoc
   , srcLocEndLine   : Int
   , srcLocEndCol    : Int
   }
-

--- a/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
@@ -40,7 +40,7 @@ type HasCallStack = (?callStack : CallStack)
 -- needs to use `TextLit`. Otherwise, you will get core linting errors
 -- due to mismatch between TextLit and Text.
 
--- | Type of callstacks constructed automatically from `HasCallStack` constraint.
+-- | Type of callstacks constructed automatically from `HasCallStack` constraints.
 --
 -- Use `callStack` to get the current callstack, and use `getCallStack`
 -- to deconstruct the `CallStack`.

--- a/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Stack/Types.daml
@@ -31,18 +31,19 @@ import GHC.Types
 -- The function `myFunction` will still be called the same way, but it will also show up
 -- as an entry in the current callstack, which you can obtain with `callStack`.
 --
--- Only calls to functions with this constraint will be added to the callstack.
--- Note that if any intermediate function does not have the `HasCallStack` constraint,
--- the callstack will be reset.
+-- Note that only functions with the `HasCallStack` constraint will be added to the
+-- current callstack, and if any function does not have the `HasCallStack` constraint,
+-- the callstack will be reset within that function.
 type HasCallStack = (?callStack : CallStack)
 
 -- NOTE (MK): Note that everything in this module
 -- needs to use `TextLit`. Otherwise, you will get core linting errors
 -- due to mismatch between TextLit and Text.
 
--- | Type of call stacks constructed automatically from `HasCallStack` constraints.
+-- | Type of callstacks constructed automatically from `HasCallStack` constraint.
 --
--- Use `getCallStack` to deconstruct the `CallStack`.
+-- Use `callStack` to get the current callstack, and use `getCallStack`
+-- to deconstruct the `CallStack`.
 data CallStack
   = EmptyCallStack -- ^ HIDE
   | PushCallStack (TextLit, SrcLoc, CallStack) -- ^ HIDE

--- a/compiler/damlc/daml-stdlib-src/DA/Stack.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Stack.daml
@@ -16,7 +16,7 @@ import DA.Text
 import GHC.Stack.Types hiding (SrcLoc(..))
 import qualified GHC.Stack.Types as GHC
 
--- Pretty-print a `CallStack`.
+-- | Pretty-print a `CallStack`.
 prettyCallStack : CallStack -> Text
 prettyCallStack = intercalate "\n" . prettyCallStackLines
 
@@ -78,4 +78,3 @@ convSrcLoc GHC.SrcLoc{..} =
     , srcLocEndLine = srcLocEndLine - 1
     , srcLocEndCol = srcLocEndCol - 1
     }
-


### PR DESCRIPTION
This PR only modifies the docs. In particular, it:

- moves the `CallStack` and `HasCallStack` docs to `DA.Stack`
- hides the rest of `GHC.Stack.Types` from the standard library docs
- gives an example of adding the `HasCallStack` constraint
- fixes this formatting bug in the docs: 
![image](https://user-images.githubusercontent.com/63245722/96449983-8890d500-120d-11eb-98e0-96c712f9a2e6.png)

Rationale: `GHC.Stack.Types` has a lot of `TextLit` stuff that
we don't want people to use directly, and we want people to
import `DA.Stack` instead anyway.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
