### PR TITLE
Speed up updates of structural records

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -381,8 +381,14 @@ private[lf] final class Compiler(
               s"structural record projection for field ${structProj.field} has no index")
           case Some(index) => SBStructProj(index)(compile(structProj.struct))
         }
-      case EStructUpd(field, struct, update) =>
-        SBStructUpd(field)(compile(struct), compile(update))
+      case structUpd: EStructUpd =>
+        structUpd.fieldIndex match {
+          case None =>
+            throw CompilationError(
+              s"structural record projection for field ${structUpd.field} has no index")
+          case Some(index) =>
+            SBStructUpd(index)(compile(structUpd.struct), compile(structUpd.update))
+        }
       case ECase(scrut, alts) =>
         compileECase(scrut, alts)
       case ENil(_) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -798,12 +798,12 @@ private[lf] object SBuiltin {
   }
 
   /** $tupd[field] :: Struct -> a -> Struct */
-  final case class SBStructUpd(field: Ast.FieldName) extends SBuiltinPure(2) {
+  final case class SBStructUpd(fieldIndex: Int) extends SBuiltinPure(2) {
     override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
       args.get(0) match {
         case SStruct(fields, values) =>
           val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
-          values2.set(fields.indexOf(field), args.get(1))
+          values2.set(fieldIndex, args.get(1))
           SStruct(fields, values2)
         case v =>
           crash(s"StructUpd on non-struct: $v")

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -84,13 +84,17 @@ object Ast {
   /** Struct construction. */
   final case class EStructCon(fields: ImmArray[(FieldName, Expr)]) extends Expr
 
-  /** Struct projection. The value for `fieldIndex` is fillen in by the type checker. */
+  /** Struct projection. */
   final case class EStructProj(field: FieldName, struct: Expr) extends Expr {
+    // The actual index is filled in by the type checker.
     private[lf] var fieldIndex: Option[Int] = None
   }
 
   /** Non-destructive struct update. */
-  final case class EStructUpd(field: FieldName, struct: Expr, update: Expr) extends Expr
+  final case class EStructUpd(field: FieldName, struct: Expr, update: Expr) extends Expr {
+    // The actual index is filled in by the type checker.
+    private[lf] var fieldIndex: Option[Int] = None
+  }
 
   /** Expression application. Function can be an abstraction or a builtin function. */
   final case class EApp(fun: Expr, arg: Expr) extends Expr


### PR DESCRIPTION
This is pretty much a verbatim copy of
https://github.com/digital-asset/daml/pull/7740, but for updates of
structural records instead of projections.

This has no immediate performance impacts since the DAML compiler does
_currently_ not produce any structural record updates. Having both,
projections and updates, have the same runtime characteristics seems to
be a desirable property nevertheless, simply to avoid nasty surprises
should we ever start to use these updates.

Since the compiler does not produce any structural record updates, I
have no way to benchmark this. However, since the code is changed here
in the same way it was changed in the PR mentioned above, I expect the
same saving, which were roughly 80 ns per operation, where the previous
cost of an operation was _at most_ 210 ns.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7742)
<!-- Reviewable:end -->
