### PR TITLE
[NO MERGE] Remove LookupByKey and Fetch nodes from TransactionCommitter

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -183,9 +183,9 @@ private[apiserver] final class ApiSubmissionService private (
       ledgerConfig: Configuration,
   )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     for {
-      result <- commandExecutor.execute(commands, submissionSeed) // daml_execution_total_mean
+      result <- commandExecutor.execute(commands, submissionSeed)
       transactionInfo <- handleCommandExecutionResult(result)
-      partyAllocationResults <- allocateMissingInformees(transactionInfo.transaction) // allocate party MAX
+      partyAllocationResults <- allocateMissingInformees(transactionInfo.transaction)
       submissionResult <- submitTransaction(transactionInfo, partyAllocationResults, ledgerConfig)
     } yield submissionResult
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -183,9 +183,9 @@ private[apiserver] final class ApiSubmissionService private (
       ledgerConfig: Configuration,
   )(implicit loggingContext: LoggingContext): Future[SubmissionResult] =
     for {
-      result <- commandExecutor.execute(commands, submissionSeed)
+      result <- commandExecutor.execute(commands, submissionSeed) // daml_execution_total_mean
       transactionInfo <- handleCommandExecutionResult(result)
-      partyAllocationResults <- allocateMissingInformees(transactionInfo.transaction)
+      partyAllocationResults <- allocateMissingInformees(transactionInfo.transaction) // allocate party MAX
       submissionResult <- submitTransaction(transactionInfo, partyAllocationResults, ledgerConfig)
     } yield submissionResult
 


### PR DESCRIPTION
This *draft* PR is meant for assessing the impact that _slimmed-down_ transaction trees have downstream (after the execution engine, especially on the read-path of the participant) in terms of throughput and other related metrics. A complete description can be found in [the JIRA task](https://digitalasset.atlassian.net/jira/software/projects/KVL/boards/494?selectedIssue=KVL-627)

As discussed with @gerolf-da and @meiersi-da , the removal of `LookupByKey` and `Fetch` are impending the contract divulgence computation, hence the failing tests. However, the benchmarked scenario is not impacted by this.

For means of correctness checking, there's a new test case in `TransactionCommitterSpec`

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
