### PR TITLE
ci/cron/check: use fix for recursive function

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -18,6 +18,7 @@ import qualified Data.ByteString.UTF8 as BS
 import qualified Data.ByteString.Lazy.UTF8 as LBS
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Foldable
+import qualified Data.Function
 import qualified Data.HashMap.Strict as H
 import qualified Data.List
 import qualified Data.List.Split as Split
@@ -284,14 +285,13 @@ download_assets tmp release = do
               req <- add_github_contact_header <$> HTTP.parseRequest (show url)
               HTTP.withResponse req manager (\resp -> do
                   let body = HTTP.responseBody resp
-                  IO.withBinaryFile (tmp </> (last $ Network.URI.pathSegments url)) IO.AppendMode (\handle -> do
-                      let loop = do
+                  IO.withBinaryFile (tmp </> (last $ Network.URI.pathSegments url)) IO.AppendMode (\handle ->
+                      Data.Function.fix (\loop -> do
                           bs <- HTTP.brRead body
                           if Data.ByteString.null bs then return ()
                           else do
                               Data.ByteString.hPut handle bs
-                              loop
-                      loop))))
+                              loop)))))
 
 verify_signatures :: FilePath -> FilePath -> String -> IO String
 verify_signatures bash_lib tmp version_tag = do


### PR DESCRIPTION
When I first tried to implement this, I forgot the recursive call. The program compiled and ran (suspiciously fast), but then signatures didn't match. It took me some time to figure out the issue, so I looked for a static way to catch that mistake. @nickchapman-da pointed out I could use `fix` in this way and then the compiler would complain about the unused `loop` variable if I forgot the recursive call.

CHANGELOG_BEGIN
CHANGELOG_END