### PR TITLE
Regularize scala mod-parser syntax for controllers

### DIFF
--- a/daml-lf/encoder/src/test/lf/Template_all_.lf
+++ b/daml-lf/encoder/src/test/lf/Template_all_.lf
@@ -13,10 +13,10 @@ module TemplateMod {
     agreement "Agreement",
     choices {
       choice Sleep (self) (u: Unit) : ContractId TemplateMod:Person
-        by Cons @Party [TemplateMod:Person {person} this] (Nil @Party)
+        , controllers Cons @Party [TemplateMod:Person {person} this] (Nil @Party)
         to upure @(ContractId TemplateMod:Person) self,
       choice @nonConsuming Nap (self) (i : Int64) : Int64
-        by Cons @Party [TemplateMod:Person {person} this] (Nil @Party)
+        , controllers Cons @Party [TemplateMod:Person {person} this] (Nil @Party)
         to upure @Int64 i
     }
   } ;

--- a/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
+++ b/daml-lf/encoder/src/test/scala/com/digitalasset/daml/lf/archive/testing/EncodeV1Spec.scala
@@ -48,8 +48,8 @@ class EncodeV1Spec extends WordSpec with Matchers with TableDrivenPropertyChecks
               observers Cons @Party [Mod:Person {person} this] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Sleep (self) (u: Unit) : Unit by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Unit (),
-                choice @nonConsuming Nap (self) (i : Int64): Int64 by Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Int64 i
+                choice Sleep (self) (u: Unit) : Unit, controllers Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Unit (),
+                choice @nonConsuming Nap (self) (i : Int64): Int64, controllers Cons @Party [Mod:Person {person} this] (Nil @Party) to upure @Int64 i
               },
               key @Party (Mod:Person {person} this) (\ (p: Party) -> Cons @Party [p] (Nil @Party))
             };

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
@@ -45,13 +45,13 @@ class ContractDiscriminatorFreshnessCheckSpec
               observers Mod:contractParties this,
               agreement "Agreement",
               choices {
-                choice @nonConsuming Noop (self) (u: Unit) : Unit
-                  by 
+                choice @nonConsuming Noop (self) (u: Unit) : Unit,
+                  controllers 
                     Mod:contractParties this
                   to
                     upure @Unit (),
-                 choice @nonConsuming LookupByKey (self) (key: Mod:Key) : Option (ContractId Mod:Contract)
-                   by 
+                 choice @nonConsuming LookupByKey (self) (key: Mod:Key) : Option (ContractId Mod:Contract),
+                   controllers 
                      Mod:contractParties this
                    to
                      lookup_by_key @Mod:Contract key 

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Lexer.scala
@@ -38,7 +38,6 @@ private[parser] object Lexer extends RegexParsers {
     "exercise_by_key" -> `exercise_by_key`,
     "fetch_by_key" -> `fetch_by_key`,
     "lookup_by_key" -> `lookup_by_key`,
-    "by" -> `by`,
     "to" -> `to`,
     "to_any" -> `to_any`,
     "from_any" -> `from_any`,

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ModParser.scala
@@ -135,8 +135,11 @@ private[parser] class ModParser[P](parameters: ParserParameters[P]) {
     `(` ~> id <~ `)`
 
   private lazy val templateChoice: Parser[(ChoiceName, TemplateChoice)] =
-    Id("choice") ~> tags(templateChoiceTags) ~ id ~ selfBinder ~ choiceParam ~ `:` ~ typ ~ `by` ~ expr ~ `to` ~ expr ^^ {
-      case choiceTags ~ name ~ self ~ param ~ _ ~ retTyp ~ _ ~ controllers ~ _ ~ update =>
+    Id("choice") ~> tags(templateChoiceTags) ~ id ~ selfBinder ~ choiceParam ~
+      (`:` ~> typ) ~
+      (`,` ~> Id("controllers") ~> expr) ~
+      (`to` ~> expr) ^^ {
+      case choiceTags ~ name ~ self ~ param ~ retTyp ~ controllers ~ update =>
         name -> TemplateChoice(
           name,
           !choiceTags(nonConsumingTag),

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/Token.scala
@@ -49,7 +49,6 @@ private[parser] object Token {
   case object `exercise_by_key` extends Token
   case object `fetch_by_key` extends Token
   case object `lookup_by_key` extends Token
-  case object `by` extends Token
   case object `to` extends Token
   case object `to_any` extends Token
   case object `from_any` extends Token

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -456,8 +456,8 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
             observers Cons @Party ['Alice'] (Nil @Party),
             agreement "Agreement",
             choices {
-              choice Sleep (self) (u:Unit) : ContractId Mod:Person by Cons @Party [person] (Nil @Party) to upure @(ContractId Mod:Person) self,
-              choice @nonConsuming Nap (self) (i : Int64): Int64 by Cons @Party [person] (Nil @Party) to upure @Int64 i
+              choice Sleep (self) (u:Unit) : ContractId Mod:Person , controllers Cons @Party [person] (Nil @Party) to upure @(ContractId Mod:Person) self,
+              choice @nonConsuming Nap (self) (i : Int64): Int64 , controllers Cons @Party [person] (Nil @Party) to upure @Int64 i
             },
             key @Party (Mod:Person {name} this) (\ (p: Party) -> p)
           } ;
@@ -588,7 +588,6 @@ class ParsersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers 
     "create",
     "fetch",
     "exercise",
-    "by",
     "to",
   )
 

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/PartyLiteralsSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/PartyLiteralsSpec.scala
@@ -39,7 +39,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (self) (i : Unit) : Unit by party to
+                  choice Ch (self) (i : Unit) : Unit, controllers party to
                     upure @Unit ()
                 }
             } ;
@@ -63,7 +63,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (self) (i : Mod:R): Unit by party to
+                  choice Ch (self) (i : Mod:R): Unit, controllers party to
                     upure @Unit ()
                 }
             } ;
@@ -77,7 +77,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (self) (i : Mod:R): Unit by party to
+                  choice Ch (self) (i : Mod:R): Unit, controllers party to
                     upure @Unit ()
                 }
             } ;
@@ -91,7 +91,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party ['Alice'] (Nil @Party),    // disallowed party literal 'Alice'
                 agreement "Agreement",
                 choices {
-                  choice Ch (self) (i : Mod:R): Unit by 'Alice' to
+                  choice Ch (self) (i : Mod:R): Unit, controllers 'Alice' to
                     upure @Unit ()
                 }
             } ;
@@ -105,7 +105,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                   observers Cons @Party [party] (Nil @Party),
                   agreement TO_TEXT_PARTY 'Alice',               // disallowed party literal 'Alice'
                   choices {
-                    choice Ch (self) (i : Mod:R): Unit by 'Alice' to
+                    choice Ch (self) (i : Mod:R): Unit, controllers 'Alice' to
                       upure @Unit ()
                   }
               } ;
@@ -119,7 +119,7 @@ class PartyLiteralsSpec extends WordSpec with TableDrivenPropertyChecks with Mat
                 observers Cons @Party [party] (Nil @Party),
                 agreement "Agreement",
                 choices {
-                  choice Ch (self) (i : Mod:R): Party by party to
+                  choice Ch (self) (i : Mod:R): Party, controllers party to
                      upure @Party 'Alice'                        // disallowed party literal 'Alice'
                 }
             } ;

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/SerializabilitySpec.scala
@@ -157,7 +157,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
               observers Nil @Party,
               agreement "Agreement",
               choices {
-                choice Ch (self) (i : Mod:SerializableType) : Mod:SerializableType by $partiesAlice to upure @Mod:SerializableType (Mod:SerializableType {})
+                choice Ch (self) (i : Mod:SerializableType) : Mod:SerializableType, controllers $partiesAlice to upure @Mod:SerializableType (Mod:SerializableType {})
               }
             } ;
           }
@@ -172,7 +172,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
                 agreement "Agreement",
                 choices {
                   choice Ch (self) (i : Mod:SerializableType) :
-                    Mod:SerializableType by $partiesAlice
+                    Mod:SerializableType, controllers $partiesAlice
                       to upure @Mod:SerializableType (Mod:SerializableType {})
                 }
               } ;
@@ -189,7 +189,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
                 agreement "Agreement",
                 choices {
                   choice Ch (self) (i : Mod:UnserializableType) :     // disallowed unserializable type
-                   Unit by $partiesAlice to
+                   Unit, controllers $partiesAlice to
                        upure @Unit ()
                 }
               } ;
@@ -205,7 +205,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
                 agreement "Agreement",
                 choices {
                   choice Ch (self) (i : Mod:SerializableType) :
-                    Mod:UnserializableType by $partiesAlice to       // disallowed unserializable type
+                    Mod:UnserializableType, controllers $partiesAlice to       // disallowed unserializable type
                        upure @Mod:UnserializableType (Mod:UnserializableType {})
                 }
               } ;
@@ -321,7 +321,7 @@ class SerializabilitySpec extends WordSpec with TableDrivenPropertyChecks with M
             observers Cons @Party ['Alice'] (Nil @Party),
             agreement "Agreement",
             choices {
-              choice Ch (self) (x: Int64) : Decimal by 'Bob' to upure @Int64 (DECIMAL_TO_INT64 x)
+              choice Ch (self) (x: Int64) : Decimal, controllers 'Bob' to upure @Int64 (DECIMAL_TO_INT64 x)
             }
           } ;
 

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/TypingSpec.scala
@@ -475,7 +475,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (self) (i : Unit) : Unit, controllers Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               },
               key @NegativeTestCase:TBis
                   (NegativeTestCase:TBis { person = (NegativeTestCase:T {name} this), party = (NegativeTestCase:T {person} this) })
@@ -492,7 +492,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement "Agreement",
               choices {
-                choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (self) (i : Unit) : Unit, controllers Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -506,7 +506,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers (),                                  // should be of type (List Party)
               agreement "Agreement",
               choices {
-                choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (self) (i : Unit) : Unit, controllers Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -520,7 +520,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               observers Cons @Party ['Alice'] (Nil @Party),
               agreement (),                                 // should be of type Text
               choices {
-                choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                choice Ch (self) (i : Unit) : Unit, controllers Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -535,7 +535,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               agreement "Agreement",
               choices {
                 choice Ch (self) (i : List) : Unit   // the type of i (here List) should be of kind * (here it is * -> *)
-                  by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+                 , controllers Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
               }
             } ;
           }
@@ -550,7 +550,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
               agreement "Agreement",
               choices {
                 choice Ch (self) (i : Unit) : List   // the return type (here List) should be of kind * (here it is * -> *)
-                   by Cons @Party ['Alice'] (Nil @Party) to upure @(List) (/\ (tau : *). Nil @tau)
+                  , controllers Cons @Party ['Alice'] (Nil @Party) to upure @(List) (/\ (tau : *). Nil @tau)
               }
             } ;
           }
@@ -565,7 +565,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (self) (i : Unit) : Unit, controllers Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase6:TBis
               // In the next line, should use only record construction and projection, and variable. Here use string literal.
@@ -585,7 +585,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (self) (i : Unit) : Unit, controllers Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase7:TBis
           // In the next line, the declared type do not match body
@@ -605,7 +605,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (self) (i : Unit) : Unit, controllers Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase8:TBis
           (PositiveTestCase8:TBis { person = (PositiveTestCase8:T {name} this), party = (PositiveTestCase8:T {person} this) })
@@ -624,7 +624,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
           observers Cons @Party ['Alice'] (Nil @Party),
           agreement "Agreement",
           choices {
-            choice Ch (self) (i : Unit) : Unit by Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
+            choice Ch (self) (i : Unit) : Unit, controllers Cons @Party ['Alice'] (Nil @Party) to upure @Unit ()
           },
           key @PositiveTestCase9:TBis
           (PositiveTestCase9:TBis { person = (PositiveTestCase9:T {name} this), party = (PositiveTestCase9:T {person} this) })
@@ -714,7 +714,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
                observers Cons @Party ['Alice'] (Nil @Party),
                agreement "Agreement",
                choices {
-                 choice Ch (self) (record : Mod:T) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
+                 choice Ch (self) (record : Mod:T) : Unit, controllers Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
                }
              } ;
            }
@@ -757,7 +757,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
                observers Cons @Party ['Alice'] (Nil @Party),
                agreement "Agreement",
                choices {
-                 choice Ch (self) (record : Mod:T) : Unit by Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
+                 choice Ch (self) (record : Mod:T) : Unit, controllers Cons @Party [(Mod:T {party} record), 'Alice'] (Nil @Party) to upure @Unit ()
                }
              } ;
            }
@@ -915,7 +915,7 @@ class TypingSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
            observers Cons @Party ['Alice'] (Nil @Party),
            agreement "Agreement",
            choices {
-             choice Ch (self) (x: Int64) : Decimal by 'Bob' to upure @INT64 (DECIMAL_TO_INT64 x)
+             choice Ch (self) (x: Int64) : Decimal, controllers 'Bob' to upure @INT64 (DECIMAL_TO_INT64 x)
            },
            key @Party (Mod:Person {person} this) (\ (p: Party) -> Cons @Party ['Alice', p] (Nil @Party))
          } ;

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -36,7 +36,7 @@ object TestHelpers {
           observers Cons @Party [Simple:SimpleTemplate {observer} this] (Nil @Party),
           agreement "",
           choices {
-            choice Consume (self) (x: Unit) : Unit by Cons @Party [Simple:SimpleTemplate {owner} this] (Nil @Party) to upure @Unit ()
+            choice Consume (self) (x: Unit) : Unit, controllers Cons @Party [Simple:SimpleTemplate {owner} this] (Nil @Party) to upure @Unit ()
           },
           key @Party (Simple:SimpleTemplate {owner} this) (\ (p: Party) -> Cons @Party [p] (Nil @Party))
         } ;


### PR DESCRIPTION

Regularize scala mod-parser syntax for controllers in preparation for adding choice-observers.

From keyword "by" to identifier "controllers" + leading ","

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
