### PR TITLE
Authorize on trigger service stop endpoint

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/InMemoryTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/InMemoryTriggerDao.scala
@@ -21,6 +21,10 @@ final class InMemoryTriggerDao extends RunningTriggerDao {
     Right(())
   }
 
+  override def getRunningTrigger(triggerInstance: UUID): Either[String, Option[RunningTrigger]] = {
+    Right(triggers.get(triggerInstance))
+  }
+
   override def removeRunningTrigger(triggerInstance: UUID): Either[String, Boolean] = {
     triggers.get(triggerInstance) match {
       case None => Right(false)

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/RunningTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/RunningTriggerDao.scala
@@ -14,6 +14,7 @@ import com.daml.lf.engine.trigger.RunningTrigger
 
 trait RunningTriggerDao extends Closeable {
   def addRunningTrigger(t: RunningTrigger): Either[String, Unit]
+  def getRunningTrigger(triggerInstance: UUID): Either[String, Option[RunningTrigger]]
   def removeRunningTrigger(triggerInstance: UUID): Either[String, Boolean]
   def listRunningTriggers(party: Party): Either[String, Vector[UUID]]
   def persistPackages(dar: Dar[(PackageId, DamlLf.ArchivePayload)]): Either[String, Unit]

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -193,7 +193,7 @@ abstract class AbstractTriggerServiceTest
       method = HttpMethods.DELETE,
       uri = uri.withPath(Uri.Path(s"/v1/stop/$id")),
     )
-    Http().singleRequest(req)
+    httpRequestFollow(req)
   }
 
   def uploadDar(uri: Uri, file: File): Future[HttpResponse] = {


### PR DESCRIPTION
Adds authorization to the stop endpoint of the trigger service, if authorization via the auth middleware is enabled.

Stopping the trigger will require the same claims as starting the trigger, i.e. `actAs` the trigger party. In order to determine the trigger party we first need to query for the running trigger before we can authorize the request.

Part of https://github.com/digital-asset/daml/issues/7723

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
