### PR TITLE
Hide Symbol kind from stdlib docs

### DIFF
--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -37,7 +37,8 @@ infixr 5 ::
 -- | A kind for constraints, like `Show a`
 data Constraint
 
--- | (Kind) This is the kind of type-level symbols.
+-- | HIDE
+-- (Kind) This is the kind of type-level symbols.
 -- Declared here because class IP needs it
 data Symbol
 


### PR DESCRIPTION
`Symbol` is the kind of type-level strings. We use type-level strings
as part of our record system. That's why we need the `Symbol` in the
first place. However, one can abstract over record fields using the
`HasField` typeclass without directly using the `Symbol` kind. Thus,
there's is no need for our users to ever use it. In fact, they
most likely don't want to use it since it does work work with
data-dependencies and we have no plans to support it in that way.

Given that `Symbol` is not necessary and doesn't work in all cases,
let's hide it from the docs so that nobody gets the idea to use it.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7752)
<!-- Reviewable:end -->
