### PR TITLE
ledger-api-test-tool: Default to a ledger clock granularity of 1 second.

### DIFF
--- a/ledger/ledger-api-test-tool/BUILD.bazel
+++ b/ledger/ledger-api-test-tool/BUILD.bazel
@@ -74,6 +74,7 @@ da_scala_library(
         "@maven//:io_netty_netty_common",
         "@maven//:io_netty_netty_handler",
         "@maven//:io_netty_netty_transport",
+        "@maven//:org_scala_lang_modules_scala_java8_compat_2_12",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -9,7 +9,6 @@ import java.nio.file.{Path, Paths}
 import com.daml.buildinfo.BuildInfo
 import com.daml.ledger.api.testtool.infrastructure.PartyAllocationConfiguration
 import com.daml.ledger.api.tls.TlsConfiguration
-import scopt.Read.{intRead, stringRead}
 import scopt.{OptionParser, Read}
 
 import scala.concurrent.duration.{Duration, DurationInt}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -12,6 +12,8 @@ import com.daml.ledger.api.tls.TlsConfiguration
 import scopt.Read.{intRead, stringRead}
 import scopt.{OptionParser, Read}
 
+import scala.concurrent.duration.Duration
+
 object Cli {
 
   private def reportUsageOfDeprecatedOption[B](
@@ -197,10 +199,10 @@ object Cli {
       .action((_, _) => { println(BuildInfo.Version); sys.exit(0) })
       .text("Prints the version on stdout and exit.")
 
-    opt[Int]("ledger-clock-granularity")
+    opt[Duration]("ledger-clock-granularity")
       .optional()
-      .action((interval, c) => c.copy(ledgerClockGranularityMs = interval))
-      .text("Specify the largest interval in ms that you will see between clock ticks on the ledger under test.  The default is 10000ms")
+      .action((x, c) => c.copy(ledgerClockGranularity = x))
+      .text("Specify the largest interval that you will see between clock ticks on the ledger under test. The default is \"10s\" (10 seconds).")
 
     opt[Unit]("skip-dar-upload")
       .optional()

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -202,7 +202,7 @@ object Cli {
     opt[Duration]("ledger-clock-granularity")
       .optional()
       .action((x, c) => c.copy(ledgerClockGranularity = x))
-      .text("Specify the largest interval that you will see between clock ticks on the ledger under test. The default is \"10s\" (10 seconds).")
+      .text("Specify the largest interval that you will see between clock ticks on the ledger under test. The default is \"1s\" (1 second).")
 
     opt[Unit]("skip-dar-upload")
       .optional()

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -50,7 +50,7 @@ object Config {
     listTestSuites = false,
     shuffleParticipants = false,
     partyAllocation = PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants,
-    ledgerClockGranularity = 10.seconds,
+    ledgerClockGranularity = 1.second,
     uploadDars = true,
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -9,6 +9,8 @@ import java.nio.file.Path
 import com.daml.ledger.api.testtool.infrastructure.PartyAllocationConfiguration
 import com.daml.ledger.api.tls.TlsConfiguration
 
+import scala.concurrent.duration.{Duration, DurationInt}
+
 final case class Config(
     participants: Vector[(String, Int)],
     darPackages: List[File],
@@ -26,7 +28,7 @@ final case class Config(
     listTestSuites: Boolean,
     shuffleParticipants: Boolean,
     partyAllocation: PartyAllocationConfiguration,
-    ledgerClockGranularityMs: Int,
+    ledgerClockGranularity: Duration,
     uploadDars: Boolean,
 )
 
@@ -48,7 +50,7 @@ object Config {
     listTestSuites = false,
     shuffleParticipants = false,
     partyAllocation = PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants,
-    ledgerClockGranularityMs = 10000,
+    ledgerClockGranularity = 10.seconds,
     uploadDars = true,
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -83,6 +83,10 @@ object LedgerApiTestTool {
   def main(args: Array[String]): Unit = {
 
     val config = Cli.parse(args).getOrElse(sys.exit(1))
+    println(config)
+    if (Math.random() < 1) {
+      sys.exit(0)
+    }
 
     val allTests: Vector[LedgerTestSuite] = Tests.all(config)
     val allTestCaseNames: Set[String] =

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -83,10 +83,6 @@ object LedgerApiTestTool {
   def main(args: Array[String]): Unit = {
 
     val config = Cli.parse(args).getOrElse(sys.exit(1))
-    println(config)
-    if (Math.random() < 1) {
-      sys.exit(0)
-    }
 
     val allTests: Vector[LedgerTestSuite] = Tests.all(config)
     val allTestCaseNames: Set[String] =

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Tests.scala
@@ -4,13 +4,11 @@
 package com.daml.ledger.api.testtool
 
 import java.nio.file.Path
-import java.util.concurrent.TimeUnit
 
 import com.daml.ledger.api.testtool.infrastructure.{BenchmarkReporter, Envelope, LedgerTestSuite}
 import com.daml.ledger.api.testtool.tests._
 
 import scala.collection.SortedSet
-import scala.concurrent.duration.Duration
 
 object Tests {
 
@@ -20,8 +18,7 @@ object Tests {
       new ClosedWorldIT,
       new CommandServiceIT,
       new CommandSubmissionCompletionIT,
-      new CommandDeduplicationIT(
-        Duration.apply(config.ledgerClockGranularityMs.toDouble, TimeUnit.MILLISECONDS)),
+      new CommandDeduplicationIT(config.ledgerClockGranularity),
       new ConfigManagementServiceIT,
       new ContractKeysIT,
       new DivulgenceIT,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/ProtobufConverters.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/ProtobufConverters.scala
@@ -5,9 +5,10 @@ package com.daml.ledger.api.testtool.infrastructure
 
 import com.google.protobuf
 
-import scala.concurrent.{duration => scalaDuration}
+import scala.compat.java8.DurationConverters._
 
 object ProtobufConverters {
+
   implicit class JavaDurationConverter(duration: java.time.Duration) {
     def asProtobuf: protobuf.duration.Duration =
       new protobuf.duration.Duration(duration.getSeconds, duration.getNano)
@@ -18,11 +19,17 @@ object ProtobufConverters {
       new protobuf.timestamp.Timestamp(instant.getEpochSecond, instant.getNano)
   }
 
+  implicit class ScalaDurationConverter(duration: scala.concurrent.duration.FiniteDuration) {
+    def asProtobuf: protobuf.duration.Duration =
+      duration.toJava.asProtobuf
+  }
+
   implicit class ProtobufDurationConverter(duration: protobuf.duration.Duration) {
     def asJava: java.time.Duration =
       java.time.Duration.ofSeconds(duration.seconds, duration.nanos.toLong)
 
-    def asScala: scalaDuration.Duration = scalaDuration.Duration.fromNanos(asJava.toNanos)
+    def asScala: scala.concurrent.duration.Duration =
+      asJava.toScala
   }
 
   implicit class ProtobufTimestampConverter(timestamp: protobuf.timestamp.Timestamp) {


### PR DESCRIPTION
The previous default, 10 seconds, means that these tests take way longer than necessary on fast ledgers (e.g. in-memory or SQL-based ledgers).

The property is still configurable for ledgers that require it.

### Changelog

- **[Integration Kit]** The ledger API test tool now defaults to a ledger clock granularity of 1 second, not 10, in line with most ledger implementations.
- **[Integration Kit]** The `--ledger-clock-granularity` option now takes a time duration (e.g. "10s" or "5m"), rather than an integer number of milliseconds.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
