### PR TITLE
ledger-api-test-tool: Backport clearer logs to v1.6. [KVL-666]

### DIFF
--- a/docs/source/tools/ledger-api-test-tool/index.rst
+++ b/docs/source/tools/ledger-api-test-tool/index.rst
@@ -69,6 +69,7 @@ Use the following command line flags to select which tests to run:
 - ``--include``: only run the tests that match the argument
 - ``--exclude``: do not run the tests that match the argument
 - ``--perf-tests``: list performance tests to run; cannot be combined with normal tests
+- ``--skip-dar-upload``: skip upload of DAR files into ledger. DAR files should be uploaded manually before the tests.
 
 Include and exclude are matched as prefixes, e.g. ``--exclude=SemanticTests``
 will exclude all tests whose name starts with ``SemanticTests``. Test names

--- a/ledger/ledger-api-test-tool/src/main/resources/logback.xml
+++ b/ledger/ledger-api-test-tool/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
             <level>trace</level>
         </filter>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Cli.scala
@@ -202,6 +202,11 @@ object Cli {
       .action((interval, c) => c.copy(ledgerClockGranularityMs = interval))
       .text("Specify the largest interval in ms that you will see between clock ticks on the ledger under test.  The default is 10000ms")
 
+    opt[Unit]("skip-dar-upload")
+      .optional()
+      .action((_, c) => c.copy(uploadDars = false))
+      .text("Skip DARs upload into ledger before running tests")
+
     help("help").text("Prints this usage text")
 
   }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/Config.scala
@@ -27,6 +27,7 @@ final case class Config(
     shuffleParticipants: Boolean,
     partyAllocation: PartyAllocationConfiguration,
     ledgerClockGranularityMs: Int,
+    uploadDars: Boolean,
 )
 
 object Config {
@@ -48,5 +49,6 @@ object Config {
     shuffleParticipants = false,
     partyAllocation = PartyAllocationConfiguration.ClosedWorldWaitingForAllParticipants,
     ledgerClockGranularityMs = 10000,
+    uploadDars = true,
   )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -187,5 +187,6 @@ object LedgerApiTestTool {
       identifierSuffix,
       config.timeoutScaleFactor,
       concurrencyOverride.getOrElse(config.concurrentTestRuns),
+      uploadDars = config.uploadDars,
     )
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/LedgerApiTestTool.scala
@@ -160,7 +160,7 @@ object LedgerApiTestTool {
         new ColorizedPrintStreamReporter(
           System.out,
           config.verbose,
-        ).report(summaries)
+        ).report(summaries, identifierSuffix)
         sys.exit(exitCode(summaries, config.mustFail))
       case Failure(exception: Errors.FrameworkException) =>
         logger.error(exception.getMessage)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Reporter.scala
@@ -8,7 +8,7 @@ import java.io.{PrintStream, PrintWriter, StringWriter}
 import scala.util.Try
 
 trait Reporter[A] {
-  def report(results: Vector[LedgerTestSummary]): A
+  def report(results: Vector[LedgerTestSummary], identifierSuffix: String): A
 }
 
 object Reporter {
@@ -102,13 +102,18 @@ object Reporter {
           }
       }
 
-    override def report(results: Vector[LedgerTestSummary]): Unit = {
+    override def report(results: Vector[LedgerTestSummary], identifierSuffix: String): Unit = {
       s.println()
       s.println(blue("#" * 80))
       s.println(blue("#"))
       s.println(blue("# TEST REPORT"))
       s.println(blue("#"))
       s.println(blue("#" * 80))
+
+      s.println()
+      s.println(yellow("### RUN INFORMATION"))
+      s.println()
+      s.println(cyan(s"identifierSuffix = $identifierSuffix"))
 
       val (successes, failures) = results.partition(_.result.isRight)
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/participant/ParticipantTestContext.scala
@@ -116,13 +116,13 @@ private[testtool] final class ParticipantTestContext private[participant] (
     LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END))
 
   private[this] val identifierPrefix = s"$applicationId-$endpointId-$identifierSuffix"
+  private[this] def nextId(idType: String): () => String =
+    Identification.indexSuffix(s"$identifierPrefix-$idType")
 
-  private[this] val nextPartyHintId: () => String =
-    Identification.indexSuffix(s"$identifierPrefix-party")
-  private[this] val nextCommandId: () => String =
-    Identification.indexSuffix(s"$identifierPrefix-command")
-  private[this] val nextSubmissionId: () => String =
-    Identification.indexSuffix(s"$identifierPrefix-submission")
+  private[this] val nextPartyHintId: () => String = nextId("party")
+  private[this] val nextCommandId: () => String = nextId("command")
+  private[this] val nextSubmissionId: () => String = nextId("submission")
+  val nextKeyId: () => String = nextId("key")
 
   /**
     * Gets the absolute offset of the ledger end at a point in time. Use [[end]] if you need

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandDeduplicationIT.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.api.testtool.tests
 
-import java.util.UUID
-
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions.{assertGrpcError, assertSingleton}
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -119,7 +117,7 @@ final class CommandDeduplicationIT(ledgerTimeInterval: ScalaDuration) extends Le
     allocate(SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
-      val key = UUID.randomUUID().toString
+      val key = ledger.nextKeyId()
 
       for {
         // Create a helper and a text key

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/CommandSubmissionCompletionIT.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.api.testtool.tests
 
-import java.util.UUID
-
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
@@ -151,15 +149,16 @@ final class CommandSubmissionCompletionIT extends LedgerTestSuite {
     allocate(TwoParties),
   )(implicit ec => {
     case Participants(Participant(ledger, alice, bob)) =>
-      val a = UUID.randomUUID.toString
-      val b = UUID.randomUUID.toString
       val aliceRequest = ledger.submitRequest(alice, Dummy(alice).create.command)
       val bobRequest = ledger.submitRequest(bob, Dummy(bob).create.command)
+      val aliceCommandId = aliceRequest.getCommands.commandId
+      val bobCommandId = bobRequest.getCommands.commandId
       for {
-        _ <- ledger.submit(aliceRequest.update(_.commands.commandId := a))
-        _ <- ledger.submit(bobRequest.update(_.commands.commandId := b))
-        _ <- WithTimeout(5.seconds)(ledger.findCompletion(alice, bob)(_.commandId == a))
-        _ <- WithTimeout(5.seconds)(ledger.findCompletion(alice, bob)(_.commandId == b))
+        _ <- ledger.submit(aliceRequest)
+        _ <- ledger.submit(bobRequest)
+        _ <- WithTimeout(5.seconds)(
+          ledger.findCompletion(alice, bob)(_.commandId == aliceCommandId))
+        _ <- WithTimeout(5.seconds)(ledger.findCompletion(alice, bob)(_.commandId == bobCommandId))
       } yield {
         // Nothing to do, if the two completions are found the test is passed
       }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.api.testtool.tests
 
-import java.util.UUID
-
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
@@ -29,7 +27,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty, SingleParty),
   )(implicit ec => {
     case Participants(Participant(alpha, owner), Participant(beta, delegate)) =>
-      val key = s"${UUID.randomUUID.toString}-key"
+      val key = alpha.nextKeyId()
       for {
         // create contracts to work with
         delegated <- alpha.create(owner, Delegated(owner, key))
@@ -68,7 +66,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty, SingleParty),
   )(implicit ec => {
     case Participants(Participant(alpha, owner), Participant(beta, delegate)) =>
-      val key = s"${UUID.randomUUID.toString}-key"
+      val key = alpha.nextKeyId()
       for {
         // create contracts to work with
         delegated <- alpha.create(owner, Delegated(owner, key))
@@ -111,10 +109,9 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty, SingleParty),
   )(implicit ec => {
     case Participants(Participant(alpha, alice), Participant(beta, bob)) =>
-      val keyPrefix = UUID.randomUUID.toString
-      val key1 = s"$keyPrefix-some-key"
-      val key2 = s"$keyPrefix-some-other-key"
-      val unknownKey = s"$keyPrefix-unknown-key"
+      val key1 = alpha.nextKeyId()
+      val key2 = alpha.nextKeyId()
+      val unknownKey = alpha.nextKeyId()
 
       for {
         // create contracts to work with
@@ -191,7 +188,7 @@ final class ContractKeysIT extends LedgerTestSuite {
   test("CKRecreate", "Contract keys can be recreated in single transaction", allocate(SingleParty))(
     implicit ec => {
       case Participants(Participant(ledger, owner)) =>
-        val key = s"${UUID.randomUUID.toString}-key"
+        val key = ledger.nextKeyId()
         for {
           delegated1TxTree <- ledger
             .submitAndWaitForTransactionTree(
@@ -222,8 +219,8 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger, owner)) =>
-      val key = s"${UUID.randomUUID.toString}-key"
-      val key2 = s"${UUID.randomUUID.toString}-key"
+      val key = ledger.nextKeyId()
+      val key2 = ledger.nextKeyId()
 
       for {
         delegation <- ledger.create(owner, Delegation(owner, owner))
@@ -250,7 +247,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
-      val expectedKey = "some-fancy-key"
+      val expectedKey = ledger.nextKeyId()
       for {
         _ <- ledger.create(party, TextKey(party, expectedKey, List.empty))
         transactions <- ledger.flatTransactions(party)
@@ -273,7 +270,7 @@ final class ContractKeysIT extends LedgerTestSuite {
     allocate(SingleParty),
   )(implicit ec => {
     case Participants(Participant(ledger, party)) =>
-      val keyString = UUID.randomUUID.toString
+      val keyString = ledger.nextKeyId()
       val expectedKey = Value(
         Value.Sum.Record(
           Record(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -84,10 +84,14 @@ private[apiserver] final class ApiPartyManagementService private (
 
   override def allocateParty(request: AllocatePartyRequest): Future[AllocatePartyResponse] = {
     // TODO: This should do proper validation.
-    val submissionId = v1.SubmissionId.assertFromString(UUID.randomUUID().toString)
+    def randomSubmissionId(prefix: String): Ref.IdString.LedgerString =
+      v1.SubmissionId.assertFromString(s"${prefix}_${UUID.randomUUID().toString}")
+
     val party =
       if (request.partyIdHint.isEmpty) None
       else Some(Ref.Party.assertFromString(request.partyIdHint))
+    val submissionId = randomSubmissionId(prefix = party.getOrElse(""))
+
     val displayName = if (request.displayName.isEmpty) None else Some(request.displayName)
 
     synchronousResponse

--- a/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
+++ b/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class RetryStrategySpec extends AsyncWordSpec with Matchers with CustomMatchers with Inside {
+final class RetryStrategySpec extends AsyncWordSpec with Matchers with CustomMatchers with Inside {
 
   "RetryStrategy.constant" should {
     "try a number of times, with a constant delay" in {
@@ -131,7 +131,7 @@ object RetryStrategySpec {
     final class AroundDurationMatcher(expectedDuration: Duration) extends Matcher[time.Duration] {
       def apply(left: time.Duration): MatchResult = {
         val actual = left.toMillis
-        val lowerBound = expectedDuration.toMillis - 5 // Delays can sometimes be too fast.
+        val lowerBound = expectedDuration.toMillis - 20 // Delays can sometimes be too fast.
         val upperBound = expectedDuration.toMillis * 10 // Tests can run slowly in parallel.
         val result = actual >= lowerBound && actual < upperBound
         MatchResult(


### PR DESCRIPTION
This backports the following PRs to v1.6:

- #7683
- #7680
- #7697
- #7714
- #7732

There is one change to the ledger API itself: the way in which party allocation submission IDs are generated has changed (see #7697). The rest are changes to the test tool.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
