### PR TITLE
timer-utils: Widen the bounds for duration checks.

### DIFF
--- a/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
+++ b/libs-scala/timer-utils/src/test/suite/scala/com/daml/timer/RetryStrategySpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class RetryStrategySpec extends AsyncWordSpec with Matchers with CustomMatchers with Inside {
+final class RetryStrategySpec extends AsyncWordSpec with Matchers with CustomMatchers with Inside {
 
   "RetryStrategy.constant" should {
     "try a number of times, with a constant delay" in {
@@ -131,7 +131,7 @@ object RetryStrategySpec {
     final class AroundDurationMatcher(expectedDuration: Duration) extends Matcher[time.Duration] {
       def apply(left: time.Duration): MatchResult = {
         val actual = left.toMillis
-        val lowerBound = expectedDuration.toMillis - 5 // Delays can sometimes be too fast.
+        val lowerBound = expectedDuration.toMillis - 20 // Delays can sometimes be too fast.
         val upperBound = expectedDuration.toMillis * 10 // Tests can run slowly in parallel.
         val result = actual >= lowerBound && actual < upperBound
         MatchResult(


### PR DESCRIPTION
I saw a failure in CI due to timer fluctuation.

> 94 milliseconds was not around 100 milliseconds [95, 1000)

This widens the lower bound from 5ms to 20ms to be safe.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
