### PR TITLE
Require authorization on list and status endpoints

### DIFF
--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -172,7 +172,7 @@ abstract class AbstractTriggerServiceTest
         s"""{"party": "$party"}"""
       )
     )
-    Http().singleRequest(req)
+    httpRequestFollow(req)
   }
 
   def triggerStatus(uri: Uri, triggerInstance: UUID): Future[HttpResponse] = {
@@ -181,7 +181,7 @@ abstract class AbstractTriggerServiceTest
       method = HttpMethods.GET,
       uri = uri.withPath(Uri.Path(s"/v1/status/$id")),
     )
-    Http().singleRequest(req)
+    httpRequestFollow(req)
   }
 
   def stopTrigger(uri: Uri, triggerInstance: UUID, party: Party): Future[HttpResponse] = {


### PR DESCRIPTION
Requires authorization for `readAs:<party>` claims for the list and status endpoints of the trigger service. In case of list the party is provided by the request entity. However, in case of status the party is determined by querying for the running trigger instance in the same way as for the stop endpoint.

Part of #7723 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
