### PR TITLE
Add overlap mode annotations during LF conversion.

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -258,7 +258,7 @@ generateRawDalfRule =
                     stablePkgs <- useNoFile_ GenerateStablePackages
                     DamlEnv{envIsGenerated} <- getDamlServiceEnv
                     -- GHC Core to DAML LF
-                    case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core of
+                    case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core details of
                         Left e -> return ([e], Nothing)
                         Right v -> do
                             WhnfPackage pkg <- use_ GeneratePackageDeps file
@@ -406,7 +406,8 @@ generateSerializedDalfRule options =
                             PackageMap pkgMap <- use_ GeneratePackageMap file
                             stablePkgs <- useNoFile_ GenerateStablePackages
                             DamlEnv{envIsGenerated} <- getDamlServiceEnv
-                            case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core of
+                            let details = hm_details (tmrModInfo tm)
+                            case convertModule lfVersion pkgMap (Map.map LF.dalfPackageId stablePkgs) envIsGenerated file core details of
                                 Left e -> pure ([e], Nothing)
                                 Right rawDalf -> do
                                     -- LF postprocessing

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -776,18 +776,8 @@ convertBind env (name, x)
     | otherwise
     = withRange (convNameLoc name) $ do
     x' <- convertExpr env x
-    let sanitize = case idDetails name of
-          -- NOTE(MH): This is DICTIONARY SANITIZATION step (3).
-          -- NOTE (drsk): We only want to do the sanitization for non-newtypes. The sanitization
-          -- step 3 for newtypes is done in the convertCoercion function.
-          DFunId False ->
-              let fieldsPrism
-                    | envLfVersion env `supports` featureTypeSynonyms = _EStructCon
-                    | otherwise = _ERecCon . _2
-              in over (_ETyLams . _2 . _ETmLams . _2 . fieldsPrism . each . _2) (ETmLam (mkVar "_", TUnit))
-          _ -> id
     name' <- convValWithType env name
-    pure [defValue name name' (sanitize x')]
+    pure [defValue name name' x']
 
 -- NOTE(MH): These are the names of the builtin DAML-LF types whose Surface
 -- DAML counterpart is not defined in 'GHC.Types'. They are all defined in

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -108,6 +108,7 @@ import           Data.Tuple.Extra
 import           Data.Ratio
 import           "ghc-lib" GHC
 import           "ghc-lib" GhcPlugins as GHC hiding ((<>), notNull)
+import           "ghc-lib-parser" InstEnv (ClsInst(..), OverlapFlag(..), OverlapMode(..))
 import           "ghc-lib-parser" Pair hiding (swap)
 import           "ghc-lib-parser" PrelNames
 import           "ghc-lib-parser" TysPrim
@@ -174,6 +175,7 @@ data Env = Env
     ,envTypeVarNames :: !(S.Set TypeVarName)
         -- ^ The set of LF type variable names in scope (i.e. the set of
         -- values of 'envTypeVars').
+    , envModInstanceInfo :: !ModInstanceInfo
     }
 
 data ChoiceData = ChoiceData
@@ -348,6 +350,12 @@ scrapeTemplateBinds binds = MS.map ($ emptyTemplateBinds) $ MS.fromListWith (.)
         _ -> Nothing
     ]
 
+type ModInstanceInfo = MS.Map DFunId OverlapMode
+
+modInstanceInfoFromDetails :: ModDetails -> ModInstanceInfo
+modInstanceInfoFromDetails ModDetails{..} = MS.fromList
+    [ (is_dfun, overlapMode is_flag) | ClsInst{..} <- md_insts ]
+
 convertModule
     :: LF.Version
     -> MS.Map UnitId DalfPackage
@@ -355,8 +363,9 @@ convertModule
     -> Bool
     -> NormalizedFilePath
     -> CoreModule
+    -> ModDetails
     -> Either FileDiagnostic LF.Module
-convertModule lfVersion pkgMap stablePackages isGenerated file x = runConvertM (ConversionEnv file Nothing) $ do
+convertModule lfVersion pkgMap stablePackages isGenerated file x details = runConvertM (ConversionEnv file Nothing) $ do
     definitions <- concatMapM (convertBind env) binds
     types <- concatMapM (convertTypeDef env) (eltsUFM (cm_types x))
     templates <- convertTemplateDefs env
@@ -397,6 +406,7 @@ convertModule lfVersion pkgMap stablePackages isGenerated file x = runConvertM (
           , envIsGenerated = isGenerated
           , envTypeVars = MS.empty
           , envTypeVarNames = S.empty
+          , envModInstanceInfo = modInstanceInfoFromDetails details
           }
 
 data Consuming = PreConsuming
@@ -730,6 +740,39 @@ convertBind env (name, x)
     | ConstraintTupleProjectionName _ _ <- name
     = pure []
 
+    -- Typeclass instance dictionaries
+    | DFunId isNewtype <- idDetails name
+    = withRange (convNameLoc name) $ do
+    x' <- convertExpr env x
+    -- NOTE(MH): This is DICTIONARY SANITIZATION step (3).
+    -- The sanitization for newtype dictionaries is done in `convertCoercion`.
+    let sanitized_x'
+          | isNewtype = x'
+          | otherwise =
+            let fieldsPrism
+                  | envLfVersion env `supports` featureTypeSynonyms = _EStructCon
+                  | otherwise = _ERecCon . _2
+            in over (_ETyLams . _2 . _ETmLams . _2 . fieldsPrism . each . _2) (ETmLam (mkVar "_", TUnit)) x'
+    name' <- convValWithType env name
+
+    -- OVERLAP* annotations
+    let overlapModeName = ExprValName ("$$om" <> getOccText name)
+        overlapModeValueM =
+            case MS.lookup name (envModInstanceInfo env) of
+                Nothing -> Nothing
+                Just (NoOverlap _) -> Nothing
+                Just (Overlappable _) -> Just "OVERLAPPABLE"
+                Just (Overlapping _) -> Just "OVERLAPPING"
+                Just (Overlaps _) -> Just "OVERLAPS"
+                Just (Incoherent _) -> Just "INCOHERENT"
+        overlapModeDef =
+            [ defValue name (overlapModeName, TText) (EBuiltin (BEText mode))
+            | Just mode <- [overlapModeValueM]
+            ]
+
+    pure $ [defValue name name' sanitized_x'] ++ overlapModeDef
+
+    -- Regular functions
     | otherwise
     = withRange (convNameLoc name) $ do
     x' <- convertExpr env x

--- a/compiler/damlc/tests/daml-test-files/OverlapPragmas.daml
+++ b/compiler/damlc/tests/daml-test-files/OverlapPragmas.daml
@@ -1,0 +1,21 @@
+
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- This test checks that we produce annotations in LF for the various overlap modes.
+
+-- @QUERY-LF [ .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$fFooOptional0"]) ] | length == 1
+-- @QUERY-LF [ .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFooOptional0"]) ] == []
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFooOptional"]) | .expr.prim_lit | lf::get_text($pkg) == "OVERLAPPING"
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFoof"]) | .expr.prim_lit | lf::get_text($pkg) == "OVERLAPPABLE"
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFoox"]) | .expr.prim_lit | lf::get_text($pkg) == "OVERLAPS"
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFooBool"]) | .expr.prim_lit | lf::get_text($pkg) == "INCOHERENT"
+
+module OverlapPragmas where
+
+class Foo t where foo : t -> Int
+instance Foo (Optional t) where foo _ = 1
+instance {-# OVERLAPPING #-} Foo (Optional Int) where foo _ = 2
+instance {-# OVERLAPPABLE #-} Foo (f t) where foo _ = 3
+instance {-# OVERLAPS #-} Foo x where foo _ = 4
+instance {-# INCOHERENT #-} Foo Bool where foo _ = 5

--- a/compiler/damlc/tests/src/query-lf-interned.jq
+++ b/compiler/damlc/tests/src/query-lf-interned.jq
@@ -15,3 +15,5 @@ def get_dotted_name(pkg): .name_interned_dname | resolve_interned_dname(pkg);
 def get_field(pkg): .field_interned_str | resolve_interned_string(pkg);
 
 def get_name(pkg): .name_interned_str | resolve_interned_string(pkg);
+
+def get_text(pkg): .text_interned_str | resolve_interned_string(pkg);

--- a/compiler/damlc/tests/src/query-lf-non-interned.jq
+++ b/compiler/damlc/tests/src/query-lf-non-interned.jq
@@ -11,3 +11,5 @@ def get_dotted_name(pkg): .name_dname.segments;
 def get_field(pkg): .field_str;
 
 def get_name(pkg): .name_str;
+
+def get_text(pkg): .text_str;


### PR DESCRIPTION
This PR adds an overlap mode binding `$$om$fFoo...` during LF conversion
per typeclass instance `$fFoo...` that uses an overlap mode pragma. The
idea is that we can then pick these up during data-dependencies
(left to a separate PR).

This PR also adds a test to make sure we're capturing this information
correctly.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
