### PR TITLE
Add overlapping instances support in data-deps.

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1802,6 +1802,20 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
         -- cannot determine the output type for 'foo'.
         ]
 
+    , simpleImportTest "Using overlapping instances"
+        [ "module Lib where"
+        , "class MyShow t where myShow : t -> Text"
+        , "instance MyShow t where myShow _ = \"_\""
+        , "instance {-# OVERLAPPING #-} Show t => MyShow [t] where myShow = show"
+        ]
+        [ "module Main where"
+        , "import Lib"
+        , "useMyShow : [Int] -> Text"
+        , "useMyShow = myShow"
+          -- Without the OVERLAPPING pragma carrying over data-dependencies, this usage
+          -- of myShow fails.
+        ]
+
     , testCaseSteps "Implicit parameters" $ \step -> withTempDir $ \tmpDir -> do
         step "building project with implicit parameters"
         createDirectoryIfMissing True (tmpDir </> "dep")


### PR DESCRIPTION
Also adds a small test.

changelog_begin

- [DAML Compiler] Similar to functional dependencies, the
  compiler now builds overlapping instance pragmas into the
  DALF/DAR files. This way, overlapping instance pragmas
  will be preserved when importing typeclass instances
  via data-dependencies.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
