### PR TITLE
fix periodic-killer permissions

### DIFF
--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -8,16 +8,9 @@ resource "google_service_account" "periodic-killer" {
   account_id = "periodic-killer"
 }
 
-resource "google_project_iam_member" "periodic-killer" {
-  # should reference google_project_iam_custom_role.periodic-killer.id or
-  # something, but for whatever reason that's not exposed.
-  role   = "projects/da-dev-gcp-daml-language/roles/killCiNodesEveryNight"
-  member = "serviceAccount:${google_service_account.periodic-killer.email}"
-}
-
 resource "google_project_iam_custom_role" "periodic-killer" {
-  role_id = "killCiNodesEveryNight"
-  title   = "Permissions to list & kill CI nodes every night"
+  role_id = "killCiNodes"
+  title   = "Permissions to list & kill CI nodes"
   permissions = [
     "compute.instances.delete",
     "compute.instances.list",
@@ -26,12 +19,21 @@ resource "google_project_iam_custom_role" "periodic-killer" {
   ]
 }
 
-resource "google_project_iam_binding" "machine_managers" {
-  role = "${google_project_iam_custom_role.periodic-killer.id}"
-  members = [
+locals {
+  accounts_that_can_kill_machines = [
+    # should reference google_project_iam_custom_role.periodic-killer.id or
+    # something, but for whatever reason that's not exposed.
+    "serviceAccount:${google_service_account.periodic-killer.email}",
+
     "user:gary.verhaegen@digitalasset.com",
     "user:moritz.kiefer@digitalasset.com",
   ]
+}
+
+resource "google_project_iam_member" "periodic-killer" {
+  count  = "${length(local.accounts_that_can_kill_machines)}"
+  role   = "${google_project_iam_custom_role.periodic-killer.id}"
+  member = "${local.accounts_that_can_kill_machines[count.index]}"
 }
 
 resource "google_compute_instance" "periodic-killer" {


### PR DESCRIPTION
I screwed up in #7771: `google_project_iam_binding` is defined as _the_ authoritative list of accounts for that role, not just a list of accounts to add the role to. So in applying that rule yesterday, I inadvertently stripped the periodic-killer machine of its role, and therefore nothing got reset last night. The Terraform plan did not mention this, unfortunately (though, arguably, consistently with the semantics of the Terraform rules).

This is the same intent as #7771, but this one actually works. (Or at least does not fail in the same way.)

CHANGELOG_BEGIN
CHANGELOG_END