### PR TITLE
Fix scenario service vs struct projections bug

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -6,7 +6,7 @@ load("@os_info//:os_info.bzl", "is_windows")
 load(":util.bzl", "damlc_compile_test")
 load("//rules_daml:daml.bzl", "daml_compile")
 load("@build_environment//:configuration.bzl", "sdk_version")
-load("//compiler/damlc:util.bzl", "DAML_LF_VERSIONS", "ghc_pkg")
+load("//compiler/damlc:util.bzl", "DAML_LF_VERSIONS", "LATEST_STABLE_DAML_LF_VERSION", "ghc_pkg")
 
 # Tests for the lax CLI parser
 da_haskell_test(
@@ -156,12 +156,17 @@ da_haskell_library(
     da_haskell_test(
         # NOTE(MH): For some reason, ghc-pkg gets very unhappy if we separate
         # the components of the version number by dot, dash or underscore.
-        name = "integration-v{}".format(version.replace(".", "")),
+        name = "integration{skip}-v{version}".format(
+            version = version.replace(".", ""),
+            skip = "-unvalidated" if skip_validation else "",
+        ),
         size = "large",
         srcs = ["src/DA/Test/DamlcIntegrationMain.hs"],
         args = [
             "--daml-lf-version",
             version,
+            "--skip-validation",
+            "true" if skip_validation else "false",
         ],
         data = [
             ":bond-trading",
@@ -185,7 +190,10 @@ da_haskell_library(
             ":integration-lib",
         ],
     )
-    for version in DAML_LF_VERSIONS
+    for version, skip_validation in [(version, False) for version in DAML_LF_VERSIONS] + [
+        (LATEST_STABLE_DAML_LF_VERSION, True),
+        ("1.dev", True),
+    ]
 ]
 
 # Tests for daml-doc

--- a/compiler/damlc/util.bzl
+++ b/compiler/damlc/util.bzl
@@ -10,9 +10,11 @@ load("@os_info//:os_info.bzl", "is_windows")
 # and the tarball produced by package_app in the resources of damlc-dist.
 ghc_pkg = "@rules_haskell_ghc_windows_amd64//:bin/ghc-pkg.exe" if is_windows else "@ghc_nix//:lib/ghc-8.6.5/bin/ghc-pkg"
 
+LATEST_STABLE_DAML_LF_VERSION = "1.8"
+
 DAML_LF_VERSIONS = [
     "1.6",
     "1.7",
-    "1.8",
+    LATEST_STABLE_DAML_LF_VERSION,
     "1.dev",
 ]

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -376,16 +376,13 @@ private[lf] final class Compiler(
         )
       case structProj: EStructProj =>
         structProj.fieldIndex match {
-          case None =>
-            throw CompilationError(
-              s"structural record projection for field ${structProj.field} has no index")
+          case None => SBStructProjByName(structProj.field)(compile(structProj.struct))
           case Some(index) => SBStructProj(index)(compile(structProj.struct))
         }
       case structUpd: EStructUpd =>
         structUpd.fieldIndex match {
           case None =>
-            throw CompilationError(
-              s"structural record projection for field ${structUpd.field} has no index")
+            SBStructUpdByName(structUpd.field)(compile(structUpd.struct), compile(structUpd.update))
           case Some(index) =>
             SBStructUpd(index)(compile(structUpd.struct), compile(structUpd.update))
         }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -798,6 +798,8 @@ private[lf] object SBuiltin {
   }
 
   /** $tproj[field] :: Struct -> a */
+  // This is a slower version of `SBStructProj` for the case when we didn't run
+  // the DAML-LF type checker and hence didn't infer the field index.
   final case class SBStructProjByName(field: Ast.FieldName) extends SBuiltinPure(1) {
     override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
       args.get(0) match {
@@ -824,6 +826,8 @@ private[lf] object SBuiltin {
   }
 
   /** $tupd[field] :: Struct -> a -> Struct */
+  // This is a slower version of `SBStructUpd` for the case when we didn't run
+  // the DAML-LF type checker and hence didn't infer the field index.
   final case class SBStructUpdByName(field: Ast.FieldName) extends SBuiltinPure(2) {
     override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
       args.get(0) match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -785,7 +785,7 @@ private[lf] object SBuiltin {
     }
   }
 
-  /** $tproj[field] :: Struct -> a */
+  /** $tproj[fieldIndex] :: Struct -> a */
   final case class SBStructProj(fieldIndex: Int) extends SBuiltinPure(1) {
     override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
       args.get(0) match {
@@ -797,13 +797,39 @@ private[lf] object SBuiltin {
     }
   }
 
-  /** $tupd[field] :: Struct -> a -> Struct */
+  /** $tproj[field] :: Struct -> a */
+  final case class SBStructProjByName(field: Ast.FieldName) extends SBuiltinPure(1) {
+    override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
+        case SStruct(fields @ _, values) =>
+          values.get(fields.indexOf(field))
+        case v =>
+          crash(s"StructProj on non-struct: $v")
+      }
+    }
+  }
+
+  /** $tupd[fieldIndex] :: Struct -> a -> Struct */
   final case class SBStructUpd(fieldIndex: Int) extends SBuiltinPure(2) {
     override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
       args.get(0) match {
         case SStruct(fields, values) =>
           val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
           values2.set(fieldIndex, args.get(1))
+          SStruct(fields, values2)
+        case v =>
+          crash(s"StructUpd on non-struct: $v")
+      }
+    }
+  }
+
+  /** $tupd[field] :: Struct -> a -> Struct */
+  final case class SBStructUpdByName(field: Ast.FieldName) extends SBuiltinPure(2) {
+    override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
+      args.get(0) match {
+        case SStruct(fields, values) =>
+          val values2 = values.clone.asInstanceOf[util.ArrayList[SValue]]
+          values2.set(fields.indexOf(field), args.get(1))
           SStruct(fields, values2)
         case v =>
           crash(s"StructUpd on non-struct: $v")


### PR DESCRIPTION
In a recent change, we have sped up the projection from structural
records by means of an inference in the DAML-LF type checker. This
change was made under the assumption that users of the DAML interpreter
run through package validation before compiling to the internal Speedy
AST. Unfortunately, that assumption was wrong and not covered by our
existing tests.  Manually testing of a new release candidate reminded us
of the fact that the scenario service skips package validation for the
sake of faster response times in the IDE.

This PR drops the assumption that package validation is always run.
Instead, we add the old implementation of struct projection, which works
without DAML-LF type checking, back and use it whenever the AST has not
been annotated with the information inferred by the type checker. We do
the same for struct updates.

We improve test coverage by _additionally_ running the `damlc`
integration tests without package validation for the latest stable
version of DAML-LF and DAML-LF 1.dev. These tests would have caught the
issue we only discovered during manual testing.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7778)
<!-- Reviewable:end -->
