### PR TITLE
Compiler: Add more tests for record projection conversion

### DIFF
--- a/compiler/damlc/tests/daml-test-files/RecordProjection.daml
+++ b/compiler/damlc/tests/daml-test-files/RecordProjection.daml
@@ -1,0 +1,33 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- The tests here check that we compile all syntactic variants of DAML record
+-- projection into the DAML-LF builtin for record projection as soon as we know
+-- the record type and the field name.
+module RecordProjection where
+
+import DA.Record (getField)
+
+data Foo = Foo with quux: Int
+
+data Bar = Bar with quux: Int
+
+foo: Foo
+foo = Foo with quux = 1
+
+
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["dotSyntax"]) | .expr.rec_proj | (lf::get_field($pkg) == "quux") and (.tycon.tycon | lf::get_dotted_name($pkg) == ["Foo"])
+dotSyntax: Int
+dotSyntax = foo.quux
+
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["dotSection"]) | .expr.abs.body.rec_proj | (lf::get_field($pkg) == "quux") and (.tycon.tycon | lf::get_dotted_name($pkg) == ["Foo"])
+dotSection: Foo -> Int
+dotSection = (.quux)
+
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["getFieldFull"]) | .expr.rec_proj | (lf::get_field($pkg) == "quux") and (.tycon.tycon | lf::get_dotted_name($pkg) == ["Foo"])
+getFieldFull: Int
+getFieldFull = getField @"quux" foo
+
+-- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["getFieldPartial"]) | .expr.abs.body.rec_proj | (lf::get_field($pkg) == "quux") and (.tycon.tycon | lf::get_dotted_name($pkg) == ["Foo"])
+getFieldPartial: Foo -> Int
+getFieldPartial = getField @"quux"


### PR DESCRIPTION
This PR adds a couple of tests that ensure that various syntactic
variants of record projection all get translated into the according
DAML-LF primitive as soon as we know the record type and field name.

This PR also fixes some inconsistencies in the translations of
`getField` and `getFieldPrim`. The change for `getField` does not have
any impact if the simplifier is run since the simplifier would perform
the inlining for a partially applied `getField` we perform here.

Nevertheless, performing this inlining in the conversion to DAML-LF has
some advantages. First of all, we also run it in cases where the
simplifier is turned off, like incremental computation. Second, this is
such a crucial optimization that I want to be as sure as possible that
it is run. Third, doing the inlining in the conversion is cheap and
removes a bit of load from the simplifier. Fourth, the consistency with
the other record primitives is quite nice too.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7786)
<!-- Reviewable:end -->
