### PR TITLE
getCommandsInFlight can be used in updateState

### DIFF
--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -92,6 +92,15 @@ queryContractKey : forall a k m. (Template a, HasKey a k, Eq k, ActionTriggerAny
     => k -> m (Optional (ContractId a, a))
 queryContractKey k = find (\(_, a) -> k == key a) <$> query
 
+-- | Features possible in `initialize`, `updateState`, and `rule`.
+class ActionTriggerAny m where
+  -- | Extract the contracts of a given template from the ACS.  (However, the
+  -- type parameters are in the 'm a' order, so it is not exported.)
+  implQuery : forall a. Template a => m [(ContractId a, a)]
+
+  -- | Find the contract with the given `id` in the ACS, if present.
+  queryContractId : Template a => ContractId a -> m (Optional a)
+
 instance ActionTriggerAny (TriggerA s) where
   implQuery = TriggerA $ pure . getContracts
   queryContractId id = TriggerA $ pure . getContractById id

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -8,6 +8,8 @@ module Daml.Trigger
  , queryContractId
  , queryContractKey
  , ActionTriggerAny
+ , getCommandsInFlight
+ , ActionTriggerUpdate
  , Trigger(..)
  , TriggerA
  , TriggerUpdateA
@@ -30,7 +32,6 @@ module Daml.Trigger
  , dedupCreate
  , dedupExerciseByKey
  , dedupCreateAndExercise
- , getCommandsInFlight
  , Message(..)
  , Completion(..)
  , Transaction(..)
@@ -112,6 +113,20 @@ instance ActionTriggerAny (TriggerUpdateA s) where
 instance ActionTriggerAny TriggerInitializeA where
   implQuery = TriggerInitializeA getContracts
   queryContractId = TriggerInitializeA . getContractById
+
+-- | Features possible in `updateState` and `rule`.
+class ActionTriggerAny m => ActionTriggerUpdate m where
+  -- | Retrieve command submissions made by this trigger that have not yet
+  -- completed.  If the trigger has restarted, it will not contain commands from
+  -- before the restart; therefore, this should be treated as an optimization
+  -- rather than an absolute authority on ledger state.
+  getCommandsInFlight : m (Map CommandId [Command])
+
+instance ActionTriggerUpdate (TriggerUpdateA s) where
+  getCommandsInFlight = TriggerUpdateA $ \(cif, _) -> pure cif
+
+instance ActionTriggerUpdate (TriggerA s) where
+  getCommandsInFlight = liftTriggerRule $ get <&> \s -> s.commandsInFlight
 
 -- | This is the type of your trigger. `s` is the user-defined state type which
 -- you can often leave at `()`.
@@ -224,14 +239,6 @@ dedupExerciseByKey k c = do
   let cmds = concat $ map snd (Map.toList aState.commandsInFlight)
   unless (any ((Some (k, c) ==) . fromExerciseByKey @t) cmds) $
     void $ emitCommands [exerciseByKeyCmd @t k c] []
-
--- | Retrieve command submissions made by this trigger that have not yet
--- completed.  If the trigger has restarted, it will not contain
--- commands from before the restart; therefore, this should be treated
--- as an optimization rather than an absolute authority on ledger state.
-getCommandsInFlight : TriggerA s (Map CommandId [Command])
-getCommandsInFlight = do
-  liftTriggerRule $ get <&> \s -> s.commandsInFlight
 
 -- | Transform the high-level trigger type into the one from `Daml.Trigger.LowLevel`.
 runTrigger : Trigger s -> LowLevel.Trigger (TriggerState s)

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -106,8 +106,8 @@ instance ActionTriggerAny (TriggerA s) where
   queryContractId id = TriggerA $ pure . getContractById id
 
 instance ActionTriggerAny (TriggerUpdateA s) where
-  implQuery = TriggerUpdateA $ pure . getContracts
-  queryContractId id = TriggerUpdateA $ pure . getContractById id
+  implQuery = TriggerUpdateA $ pure . getContracts . snd
+  queryContractId id = TriggerUpdateA $ pure . getContractById id . snd
 
 instance ActionTriggerAny TriggerInitializeA where
   implQuery = TriggerInitializeA getContracts
@@ -247,13 +247,15 @@ runTrigger userTrigger = LowLevel.Trigger
           userState = runTriggerInitializeA userTrigger.initialize acs
           state = TriggerState acs party userState Map.empty
       in TriggerSetup $ execStateT (runTriggerRule $ runRule userTrigger.rule) state
-    utUpdateState acs msg = execState $ flip runTriggerUpdateA acs $ userTrigger.updateState msg
+    utUpdateState commandsInFlight acs msg = execState $ flip runTriggerUpdateA (commandsInFlight, acs) $ userTrigger.updateState msg
     update msg = do
       time <- getTime
       state <- get
       case msg of
         MCompletion completion ->
-          let userState = utUpdateState state.acs (MCompletion completion) state.userState
+          -- NB: the commands-in-flight and ACS updateState sees are those
+          -- *prior* to updates incurred by the msg
+          let userState = utUpdateState state.commandsInFlight state.acs (MCompletion completion) state.userState
           in case completion.status of
             Succeeded {} ->
               -- We delete successful completions when we receive the corresponding transaction
@@ -266,7 +268,8 @@ runTrigger userTrigger = LowLevel.Trigger
                 runRule userTrigger.rule
         MTransaction transaction -> do
           let acs = applyTransaction transaction state.acs
-              userState = utUpdateState acs (MTransaction transaction) state.userState
+              -- again, we use the commands-in-flight and ACS before the update below
+              userState = utUpdateState state.commandsInFlight acs (MTransaction transaction) state.userState
               -- See the comment above for why we delete this here instead of when we receive the completion.
               (acs', commandsInFlight) = case transaction.commandId of
                 None -> (acs, state.commandsInFlight)
@@ -274,6 +277,6 @@ runTrigger userTrigger = LowLevel.Trigger
           put $ state { acs = acs', userState, commandsInFlight }
           runRule userTrigger.rule
         MHeartbeat -> do
-          let userState = utUpdateState state.acs MHeartbeat state.userState
+          let userState = utUpdateState state.commandsInFlight state.acs MHeartbeat state.userState
           put $ state { userState }
           runRule userTrigger.rule

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -261,7 +261,7 @@ runTrigger userTrigger = LowLevel.Trigger
       case msg of
         MCompletion completion ->
           -- NB: the commands-in-flight and ACS updateState sees are those
-          -- *prior* to updates incurred by the msg
+          -- prior to updates incurred by the msg
           let userState = utUpdateState state.commandsInFlight state.acs (MCompletion completion) state.userState
           in case completion.status of
             Succeeded {} ->

--- a/triggers/daml/Daml/Trigger/Assert.daml
+++ b/triggers/daml/Daml/Trigger/Assert.daml
@@ -18,7 +18,7 @@ import qualified DA.Next.Map as Map
 import qualified DA.Text as Text
 
 import Daml.Trigger hiding (queryContractId)
-import Daml.Trigger.Internal hiding (queryContractId)
+import Daml.Trigger.Internal
 import Daml.Trigger.LowLevel hiding (Trigger)
 
 import Daml.Script (Script, queryContractId)

--- a/triggers/daml/Daml/Trigger/Internal.daml
+++ b/triggers/daml/Daml/Trigger/Internal.daml
@@ -8,7 +8,6 @@ module Daml.Trigger.Internal
   , TriggerA (..)
   , TriggerUpdateA (..)
   , TriggerInitializeA (..)
-  , ActionTriggerAny (..)
   , addCommands
   , insertTpl
   , groupActiveContracts
@@ -96,15 +95,6 @@ instance ActionState s (TriggerUpdateA s) where
 -- trigger.  It can query, but not emit commands or update the state.
 newtype TriggerInitializeA a = TriggerInitializeA { runTriggerInitializeA : ACS -> a }
   deriving (Functor, Applicative, Action)
-
--- | Features possible in `initialize`, `updateState`, and `rule`.
-class ActionTriggerAny m where
-  -- | Extract the contracts of a given template from the ACS.  (However, the
-  -- type parameters are in the 'm a' order, so it is not exported.)
-  implQuery : forall a. Template a => m [(ContractId a, a)]
-
-  -- | Find the contract with the given `id` in the ACS, if present.
-  queryContractId : Template a => ContractId a -> m (Optional a)
 
 -- Internal API
 

--- a/triggers/daml/Daml/Trigger/Internal.daml
+++ b/triggers/daml/Daml/Trigger/Internal.daml
@@ -74,7 +74,7 @@ instance HasTime (TriggerA s) where
 -- | TriggerUpdateA is the type used in the `updateState` of a DAML
 -- trigger.  It has similar actions in common with `TriggerA`, but
 -- cannot use `emitCommands` or `getTime`.
-newtype TriggerUpdateA s a = TriggerUpdateA { runTriggerUpdateA : ACS -> State s a }
+newtype TriggerUpdateA s a = TriggerUpdateA { runTriggerUpdateA : (Map CommandId [Command], ACS) -> State s a }
 
 instance Functor (TriggerUpdateA s) where
   fmap f (TriggerUpdateA r) = TriggerUpdateA $ rliftFmap fmap f r
@@ -183,16 +183,16 @@ data TriggerState s = TriggerState
   }
 
 -- unboxed newtype for common Trigger*A additions
-type TriggerAT f a = ACS -> f a
+type TriggerAT r f a = r -> f a
 
-rliftFmap : ((a -> b) -> f a -> f b) -> (a -> b) -> TriggerAT f a -> TriggerAT f b
+rliftFmap : ((a -> b) -> f a -> f b) -> (a -> b) -> TriggerAT r f a -> TriggerAT r f b
 rliftFmap ub f r = ub f . r
 
-rliftPure : (a -> f a) -> a -> TriggerAT f a
+rliftPure : (a -> f a) -> a -> TriggerAT r f a
 rliftPure ub = const . ub
 
-rliftAp : (f (a -> b) -> f a -> f b) -> TriggerAT f (a -> b) -> TriggerAT f a -> TriggerAT f b
+rliftAp : (f (a -> b) -> f a -> f b) -> TriggerAT r f (a -> b) -> TriggerAT r f a -> TriggerAT r f b
 rliftAp ub ff fa r = ff r `ub` fa r
 
-rliftBind : (f a -> (a -> f b) -> f b) -> TriggerAT f a -> (a -> TriggerAT f b) -> TriggerAT f b
+rliftBind : (f a -> (a -> f b) -> f b) -> TriggerAT r f a -> (a -> TriggerAT r f b) -> TriggerAT r f b
 rliftBind ub fa f r = fa r `ub` \a -> f a r

--- a/triggers/tests/daml/TemplateIdFilter.daml
+++ b/triggers/tests/daml/TemplateIdFilter.daml
@@ -5,12 +5,15 @@
 module TemplateIdFilter where
 
 import Prelude hiding (test)
+import qualified DA.Next.Map as Map
 import Daml.Trigger
 
 test : RegisteredTemplates -> Trigger ()
 test registered = Trigger
   { initialize = pure ()
-  , updateState = \_message -> pure ()
+  , updateState = \_message -> do
+      cifs <- Map.size <$> getCommandsInFlight
+      if cifs < 2 then pure () else error "should have 1 command at a time"
   , registeredTemplates = registered
   , rule = \party -> do
       ones <- query @One


### PR DESCRIPTION
```rst
CHANGELOG_BEGIN
- [Triggers] ``getCommandsInFlight`` may be used in a high-level trigger's
  ``updateState``, as well as its ``rule``.
  See `issue #7787 <https://github.com/digital-asset/daml/pull/7787>`__.
CHANGELOG_END
```

Extends #7600; fixes #7392.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
