### PR TITLE
work around Azure/GitHub disagreement

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -893,3 +893,72 @@ jobs:
           else
               echo "User $(user_id) did not opt in for notifications."
           fi
+
+  # temporary (?) workaround for Azure not reporting global build status to GitHub anymore.
+  - job: finished
+    pool:
+      name: 'linux-pool'
+      demands: assignment -equals default
+    dependsOn:
+    - git_sha
+    - check_standard_change_label
+    - check_changelog_entry
+    - Linux
+    - macOS
+    - Windows
+    - compatibility_ts_libs
+    - compatibility_linux
+    - compatibility_macos
+    - compatibility_windows
+    - check_for_release
+    - check_perf_test
+    - release
+    - compat_versions_pr
+    - compat_versions_pr_trigger_daily
+    - write_ledger_dump
+    - collect_build_data
+    - notify_release_pr
+    - notify_user
+    condition: always()
+    variables:
+      git_sha: $[ dependencies.git_sha.result ]
+      check_standard_change_label: $[ dependencies.check_standard_change_label.result ]
+      check_changelog_entry: $[ dependencies.check_changelog_entry.result ]
+      Linux: $[ dependencies.Linux.result ]
+      macOS: $[ dependencies.macOS.result ]
+      Windows: $[ dependencies.Windows.result ]
+      compatibility_ts_libs: $[ dependencies.compatibility_ts_libs.result ]
+      compatibility_linux: $[ dependencies.compatibility_linux.result ]
+      compatibility_macos: $[ dependencies.compatibility_macos.result ]
+      compatibility_windows: $[ dependencies.compatibility_windows.result ]
+      check_for_release: $[ dependencies.check_for_release.result ]
+      check_perf_test: $[ dependencies.check_perf_test.result ]
+      release: $[ dependencies.release.result ]
+      compat_versions_pr: $[ dependencies.compat_versions_pr.result ]
+      compat_versions_pr_trigger_daily: $[ dependencies.compat_versions_pr_trigger_daily.result ]
+      write_ledger_dump: $[ dependencies.write_ledger_dump.result ]
+      collect_build_data: $[ dependencies.collect_build_data.result ]
+      notify_release_pr: $[ dependencies.notify_release_pr.result ]
+      notify_user: $[ dependencies.notify_user.result ]
+    steps:
+    - bash: |
+        set -euo pipefail
+        if [ "$(git_sha)" != "Succeeded" ] && [ "$(git_sha)" != "Skipped" ]; then exit 1; fi
+        if [ "$(check_standard_change_label)" != "Succeeded" ] && [ "$(check_standard_change_label)" != "Skipped" ]; then exit 1; fi
+        if [ "$(check_changelog_entry)" != "Succeeded" ] && [ "$(check_changelog_entry)" != "Skipped" ]; then exit 1; fi
+        if [ "$(Linux)" != "Succeeded" ] && [ "$(Linux)" != "Skipped" ]; then exit 1; fi
+        if [ "$(macOS)" != "Succeeded" ] && [ "$(macOS)" != "Skipped" ]; then exit 1; fi
+        if [ "$(Windows)" != "Succeeded" ] && [ "$(Windows)" != "Skipped" ]; then exit 1; fi
+        if [ "$(compatibility_ts_libs)" != "Succeeded" ] && [ "$(compatibility_ts_libs)" != "Skipped" ]; then exit 1; fi
+        if [ "$(compatibility_linux)" != "Succeeded" ] && [ "$(compatibility_linux)" != "Skipped" ]; then exit 1; fi
+        if [ "$(compatibility_macos)" != "Succeeded" ] && [ "$(compatibility_macos)" != "Skipped" ]; then exit 1; fi
+        if [ "$(compatibility_windows)" != "Succeeded" ] && [ "$(compatibility_windows)" != "Skipped" ]; then exit 1; fi
+        if [ "$(check_for_release)" != "Succeeded" ] && [ "$(check_for_release)" != "Skipped" ]; then exit 1; fi
+        if [ "$(check_perf_test)" != "Succeeded" ] && [ "$(check_perf_test)" != "Skipped" ]; then exit 1; fi
+        if [ "$(release)" != "Succeeded" ] && [ "$(release)" != "Skipped" ]; then exit 1; fi
+        if [ "$(compat_versions_pr)" != "Succeeded" ] && [ "$(compat_versions_pr)" != "Skipped" ]; then exit 1; fi
+        if [ "$(compat_versions_pr_trigger_daily)" != "Succeeded" ] && [ "$(compat_versions_pr_trigger_daily)" != "Skipped" ]; then exit 1; fi
+        if [ "$(write_ledger_dump)" != "Succeeded" ] && [ "$(write_ledger_dump)" != "Skipped" ]; then exit 1; fi
+        if [ "$(collect_build_data)" != "Succeeded" ] && [ "$(collect_build_data)" != "Skipped" ]; then exit 1; fi
+        if [ "$(notify_release_pr)" != "Succeeded" ] && [ "$(notify_release_pr)" != "Skipped" ]; then exit 1; fi
+        if [ "$(notify_user)" != "Succeeded" ] && [ "$(notify_user)" != "Skipped" ]; then exit 1; fi


### PR DESCRIPTION
Azure used to report the status of the entire build to GitHub, which we use as the "required check" for PRs to be merged. Ir doesn't do that anymore which means we can't merge anything. It's unclear whether or not that is a deliberate change.

This attempts to work around that by creating an extra job that depends on all the other, which GitHub could depend on.

Note: I am not sure how (if) this will work with skipped jobs.

CHANGELOG_BEGIN
CHANGELOG_END