### PR TITLE
json-api: Aligning portfile behaviour

### DIFF
--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortFiles.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortFiles.scala
@@ -11,13 +11,10 @@ import scala.collection.JavaConverters._
 
 object PortFiles {
   sealed abstract class Error extends Serializable with Product
-  final case class FileAlreadyExists(path: Path) extends Error
   final case class CannotWriteToFile(path: Path, reason: String) extends Error
 
   object Error {
     implicit val showInstance: Show[Error] = Show.shows {
-      case FileAlreadyExists(path) =>
-        s"Port file already exists: ${path.toAbsolutePath: Path}"
       case CannotWriteToFile(path, reason) =>
         s"Cannot write to port file: ${path.toAbsolutePath: Path}, reason: $reason"
     }
@@ -31,14 +28,13 @@ object PortFiles {
     \/.fromTryCatchNonFatal {
       writeUnsafe(path, port)
     }.leftMap {
-      case _: java.nio.file.FileAlreadyExistsException => FileAlreadyExists(path)
       case e => CannotWriteToFile(path, e.toString)
     }
 
   private def writeUnsafe(path: Path, port: Port): Unit = {
-    import java.nio.file.StandardOpenOption.CREATE_NEW
+    import java.nio.file.StandardOpenOption.WRITE
     val lines: java.lang.Iterable[String] = List(port.value.toString).asJava
-    val created = Files.write(path, lines, CREATE_NEW)
+    val created = Files.write(path, lines, WRITE)
     created.toFile.deleteOnExit()
   }
 }

--- a/libs-scala/ports/src/test/suite/scala/com/digitalasset/ports/PortFilesSpec.scala
+++ b/libs-scala/ports/src/test/suite/scala/com/digitalasset/ports/PortFilesSpec.scala
@@ -20,14 +20,13 @@ class PortFilesSpec extends FreeSpec with Matchers with Inside {
     path.toFile.exists() shouldBe true
   }
 
-  "Cannot create a port file with a nonunique file name" in {
+  "Can create a port file with a nonunique file name" in {
     val path = uniquePath()
     inside(PortFiles.write(path, Port(1024))) {
       case \/-(()) =>
     }
     inside(PortFiles.write(path, Port(1024))) {
-      case -\/(FileAlreadyExists(p)) =>
-        p shouldBe path
+      case -\/-(()) =>
     }
   }
 


### PR DESCRIPTION
While the sandbox can be pointed to an existing port file to write its
port to, the http json api will fail if the port file already exists.
This is annoying in particular for testing. This PR aligns the
behaviours such that the http json api appends to existing port files
instead insisting on creating a new file.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
