### PR TITLE
@daml/types: add encoders

### DIFF
--- a/language-support/ts/daml-ledger/index.test.ts
+++ b/language-support/ts/daml-ledger/index.test.ts
@@ -74,7 +74,9 @@ jest.mock('isomorphic-ws', () => class {
 const Foo: Template<Foo, string, "foo-id"> = {
   templateId: "foo-id",
   keyDecoder: jtv.string(),
+  keyEncode: (s: string): unknown => s,
   decoder: jtv.object({key: jtv.string()}),
+  encode: (o) => o,
   Archive: {} as unknown as Choice<Foo, {}, {}, string>,
 };
 

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -150,6 +150,16 @@ export function assert(b: boolean, m: string): void {
 export type Query<T> = T extends object ? {[K in keyof T]?: Query<T[K]>} : T;
 // TODO(MH): Support comparison queries.
 
+/** @internal
+ *
+ */
+function encodeQuery<T extends object, K, I extends string>(template: Template<T, K, I>, query?: Query<T>): unknown {
+  // TODO: actually implement this.
+  // I could not get the "unused" warning silenced, but this seems to count as "used"
+  [template];
+  return query;
+}
+
 
 /**
  * Status code and result returned by a call to the ledger.
@@ -316,7 +326,7 @@ class Ledger {
    *
    */
   async query<T extends object, K, I extends string>(template: Template<T, K, I>, query?: Query<T>): Promise<CreateEvent<T, K, I>[]> {
-    const payload = {templateIds: [template.templateId], query};
+    const payload = {templateIds: [template.templateId], query: encodeQuery(template, query)};
     const json = await this.submit('v1/query', payload);
     return jtv.Result.withException(jtv.array(decodeCreateEvent(template)).run(json));
   }
@@ -335,7 +345,7 @@ class Ledger {
   async fetch<T extends object, K, I extends string>(template: Template<T, K, I>, contractId: ContractId<T>): Promise<CreateEvent<T, K, I> | null> {
     const payload = {
       templateId: template.templateId,
-      contractId,
+      contractId: ContractId(template).encode(contractId),
     };
     const json = await this.submit('v1/fetch', payload);
     return jtv.Result.withException(jtv.oneOf(jtv.constant(null), decodeCreateEvent(template)).run(json));
@@ -360,7 +370,7 @@ class Ledger {
     }
     const payload = {
       templateId: template.templateId,
-      key,
+      key: template.keyEncode(key),
     };
     const json = await this.submit('v1/fetch', payload);
     return jtv.Result.withException(jtv.oneOf(jtv.constant(null), decodeCreateEvent(template)).run(json));
@@ -380,7 +390,7 @@ class Ledger {
   async create<T extends object, K, I extends string>(template: Template<T, K, I>, payload: T): Promise<CreateEvent<T, K, I>> {
     const command = {
       templateId: template.templateId,
-      payload,
+      payload: template.encode(payload),
     };
     const json = await this.submit('v1/create', command);
     return jtv.Result.withException(decodeCreateEvent(template).run(json));
@@ -403,9 +413,9 @@ class Ledger {
   async exercise<T extends object, C, R>(choice: Choice<T, C, R>, contractId: ContractId<T>, argument: C): Promise<[R , Event<object>[]]> {
     const payload = {
       templateId: choice.template().templateId,
-      contractId,
+      contractId: ContractId(choice.template()).encode(contractId),
       choice: choice.choiceName,
-      argument,
+      argument: choice.argumentEncode(argument),
     };
     const json = await this.submit('v1/exercise', payload);
     // Decode the server response into a tuple.
@@ -441,9 +451,9 @@ class Ledger {
     }
     const payload = {
       templateId: choice.template().templateId,
-      key,
+      key: choice.template().keyEncode(key),
       choice: choice.choiceName,
-      argument,
+      argument: choice.argumentEncode(argument),
     };
     const json = await this.submit('v1/exercise', payload);
     // Decode the server response into a tuple.
@@ -645,7 +655,7 @@ class Ledger {
   ): Stream<T, K, I, readonly CreateEvent<T, K, I>[]> {
     const request = queries.length == 0 ?
         [{templateIds: [template.templateId]}]
-        : queries.map(q => ({templateIds: [template.templateId], query: q}));
+        : queries.map(q => ({templateIds: [template.templateId], query: encodeQuery(template, q)}));
     const reconnectRequest = (): object[] => request;
     const change = (contracts: readonly CreateEvent<T, K, I>[], events: readonly Event<T, K, I>[]): CreateEvent<T, K, I>[] => {
       const archiveEvents: Set<ContractId<T>> = new Set();
@@ -710,8 +720,8 @@ class Ledger {
     // given key be in output format, whereas existing implementation supports
     // input format.
     let lastContractId: ContractId<T> | null = null;
-    const request = [{templateId: template.templateId, key}];
-    const reconnectRequest = (): object[] => [{...request[0], 'contractIdAtOffset': lastContractId}]
+    const request = [{templateId: template.templateId, key: template.keyEncode(key)}];
+    const reconnectRequest = (): object[] => [{...request[0], 'contractIdAtOffset': lastContractId && ContractId(template).encode(lastContractId)}]
     const change = (contract: CreateEvent<T, K, I> | null, events: readonly Event<T, K, I>[]): CreateEvent<T, K, I> | null => {
       for (const event of events) {
         if ('created' in event) {
@@ -790,8 +800,11 @@ class Ledger {
     const lastContractIds: (ContractId<T> | null)[] = Array(keys.length).fill(null);
     const keysCopy = _.cloneDeep(keys);
     const initState: (CreateEvent<T, K, I> | null)[] = Array(keys.length).fill(null);
-    const request = keys.map(k => ({templateId: template.templateId, key: k}));
-    const reconnectRequest = (): object[] => request.map((r, idx) => ({...r, 'contractIdAtOffset': lastContractIds[idx]}));
+    const request = keys.map(k => ({templateId: template.templateId, key: template.keyEncode(k)}));
+    const reconnectRequest = (): object[] => request.map((r, idx) => {
+      const lastId = lastContractIds[idx];
+      return {...r, 'contractIdAtOffset': lastId && ContractId(template).encode(lastId)}
+    });
     const change = (state: (CreateEvent<T, K, I> | null)[], events: readonly Event<T, K, I>[]): (CreateEvent<T, K, I> | null)[] => {
       const newState: (CreateEvent<T, K, I> | null)[] = Array.from(state);
       for (const event of events) {


### PR DESCRIPTION
This PR adds encoders to the various types defined in `@daml/types`. The serde mechanism did not need one so far because all of the types we're currently exposing map one-to-one to an appropriate (or, I suppose, tolerable) JS equivalent. This will not be the case anymore with generic maps, which means that if we want to provide our users with decent types (I do), we'll need some real encoding/decoding moving forward.

CHANGELOG_BEGIN
CHANGELOG_END