### PR TITLE
damlc: Use fresh names when compiling builtins

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1032,16 +1032,16 @@ convertExpr env0 e = do
     go env (VarIn GHC_Types "[]") (LType (TypeCon (Is "Char") []) : args)
         = pure $ (, args) $ EBuiltin (BEText T.empty)
     go env (VarIn GHC_Types "[]") args
-        = withTyArg env KStar args $ \_env t args -> pure (ENil t, args)
+        = withTyArg env KStar args $ \env t args -> pure (ENil t, args)
     go env (VarIn GHC_Types ":") args =
-        withTyArg env KStar args $ \_env t args ->
+        withTyArg env KStar args $ \env t args ->
         withTmArg env t args $ \x args ->
         withTmArg env (TList t) args $ \y args ->
           pure (ECons t x y, args)
     go env (VarIn DA_Internal_Prelude (IgnoreWorkerPrefixFS "None")) args
-        = withTyArg env KStar args $ \_env t args -> pure (ENone t, args)
+        = withTyArg env KStar args $ \env t args -> pure (ENone t, args)
     go env (VarIn DA_Internal_Prelude (IgnoreWorkerPrefixFS "Some")) args
-        = withTyArg env KStar args $ \_env t args ->
+        = withTyArg env KStar args $ \env t args ->
           withTmArg env t args $ \x args ->
             pure (ESome t x, args)
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -207,7 +207,7 @@ envFreshTypeVar nameHint env = try 1 (TypeVarName nameHint)
 -- | Bind a type var without shadowing its LF name.
 envBindTypeVar :: Var -> Env -> (TypeVarName, Env)
 envBindTypeVar x env0 =
-    let (n, env) = envFreshTypeVar (getOccText x) env in
+    let (n, env) = envFreshTypeVar (getOccText x) env0 in
     (n, env{envTypeVars = MS.insert x n (envTypeVars env)})
 
 -- | Bind multiple type vars without shadowing their LF names.

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -104,7 +104,7 @@ import qualified Data.Map.Strict as MS
 import qualified Data.Set as S
 import           Data.Maybe
 import qualified Data.NameMap as NM
-import qualified Data.Text as T
+import qualified Data.Text.Extended as T
 import           Data.Tuple.Extra
 import           Data.Ratio
 import           "ghc-lib" GHC
@@ -240,17 +240,37 @@ data ConversionEnv = ConversionEnv
   , convRange :: !(Maybe SourceLoc)
   }
 
-newtype ConvertM a = ConvertM (ReaderT ConversionEnv (Except FileDiagnostic) a)
-  deriving (Functor, Applicative, Monad, MonadError FileDiagnostic, MonadReader ConversionEnv)
+data ConversionState = ConversionState
+    { freshTmVarCounter :: Int
+    , freshTyVarCounter :: Int
+    }
+
+newtype ConvertM a = ConvertM (ReaderT ConversionEnv (StateT ConversionState (Except FileDiagnostic)) a)
+  deriving (Functor, Applicative, Monad, MonadError FileDiagnostic, MonadState ConversionState, MonadReader ConversionEnv)
 
 instance MonadFail ConvertM where
     fail = conversionError
 
 runConvertM :: ConversionEnv -> ConvertM a -> Either FileDiagnostic a
-runConvertM s (ConvertM a) = runExcept (runReaderT a s)
+runConvertM s (ConvertM a) = runExcept (evalStateT (runReaderT a s) st0)
+  where
+    st0 = ConversionState
+        { freshTmVarCounter = 0
+        , freshTyVarCounter = 0
+        }
 
 withRange :: Maybe SourceLoc -> ConvertM a -> ConvertM a
 withRange r = local (\s -> s { convRange = r })
+
+freshTmVar :: ConvertM LF.ExprVarName
+freshTmVar = do
+    n <- state (\st -> let k = freshTmVarCounter st + 1 in (k, st{freshTmVarCounter = k}))
+    pure $ LF.ExprVarName ("$$v" <> T.show n)
+
+freshTyVar :: ConvertM LF.TypeVarName
+freshTyVar = do
+    n <- state (\st -> let k = freshTyVarCounter st + 1 in (k, st{freshTyVarCounter = k}))
+    pure $ LF.TypeVarName ("$$t" <> T.show n)
 
 convertInt64 :: Integer -> ConvertM LF.Expr
 convertInt64 x
@@ -828,29 +848,29 @@ convertExpr env0 e = do
             let fields = [(mkField f1, t1), (mkField f2, t2)]
             tupleTyCon <- qDA_Types env $ mkTypeCon ["Tuple" <> T.pack (show $ length fields)]
             let tupleType = TypeConApp tupleTyCon (map snd fields)
-            pure $ ETmLam (varV1, TStruct fields) $ ERecCon tupleType $ zipWithFrom mkFieldProj (1 :: Int) fields
-        where
-            mkFieldProj i (name, _typ) = (mkIndexedField i, EStructProj name (EVar varV1))
+            v <- freshTmVar
+            let mkFieldProj i (name, _typ) = (mkIndexedField i, EStructProj name (EVar v))
+            pure $ ETmLam (v, TStruct fields) $ ERecCon tupleType $ zipWithFrom mkFieldProj (1 :: Int) fields
     go env (VarIn GHC_Types "primitive") (LType (isStrLitTy -> Just y) : LType t : args)
         = fmap (, args) $ convertPrim (envLfVersion env) (unpackFS y) <$> convertType env t
     -- NOTE(MH): `getFieldPrim` and `setFieldPrim` are used by the record
     -- preprocessor to magically implement the `HasField` instances for records.
     go env (VarIn DA_Internal_Record "getFieldPrim") (LType (isStrLitTy -> Just name) : LType record : LType _field : args) = do
         record' <- convertType env record
-        withTmArg env (varV1, record') args $ \x args ->
+        withTmArg env record' args $ \x args ->
             pure (ERecProj (fromTCon record') (mkField $ fsToText name) x, args)
     go env (VarIn DA_Internal_Record "setFieldPrim") (LType (isStrLitTy -> Just name) : LType record : LType field : args) = do
         record' <- convertType env record
         field' <- convertType env field
-        withTmArg env (varV1, field') args $ \x1 args ->
-            withTmArg env (varV2, record') args $ \x2 args ->
+        withTmArg env field' args $ \x1 args ->
+            withTmArg env record' args $ \x2 args ->
                 pure (ERecUpd (fromTCon record') (mkField $ fsToText name) x2 x1, args)
     -- NOTE(MH): We only inline `getField` for record types. Projections on
     -- sum-of-records types have to through the type class for `getField`.
     go env (VarIn DA_Internal_Record "getField") (LType (isStrLitTy -> Just name) : LType recordType@(TypeCon recordTyCon _) : LType _fieldType : _dict : args)
         | isSingleConType recordTyCon = do
             recordType <- convertType env recordType
-            withTmArg env (varV1, recordType) args $ \record args ->
+            withTmArg env recordType args $ \record args ->
                 pure (ERecProj (fromTCon recordType) (mkField $ fsToText name) record, args)
     -- NOTE(SF): We also need to inline `setField` in order to get the correct
     -- evaluation order (record first, then fields in order).
@@ -858,8 +878,8 @@ convertExpr env0 e = do
         | isSingleConType recordTyCon = do
             record' <- convertType env record
             field' <- convertType env field
-            withTmArg env (varV1, field') args $ \x1 args ->
-                withTmArg env (varV2, record') args $ \x2 args ->
+            withTmArg env field' args $ \x1 args ->
+                withTmArg env record' args $ \x2 args ->
                     pure (ERecUpd (fromTCon record') (mkField $ fsToText name) x2 x1, args)
         -- TODO: Also fix evaluation order for sum-of-record types.
     go env (VarIn GHC_Real "fromRational") (LExpr (VarIs ":%" `App` tyInteger `App` Lit (LitNumber _ top _) `App` Lit (LitNumber _ bot _)) : args)
@@ -1016,17 +1036,17 @@ convertExpr env0 e = do
     go env (VarIn GHC_Types "[]") (LType (TypeCon (Is "Char") []) : args)
         = pure $ (, args) $ EBuiltin (BEText T.empty)
     go env (VarIn GHC_Types "[]") args
-        = withTyArg env varT1 args $ \t args -> pure (ENil t, args)
+        = withTyArg env KStar args $ \t args -> pure (ENil t, args)
     go env (VarIn GHC_Types ":") args =
-        withTyArg env varT1 args $ \t args ->
-        withTmArg env (varV1, t) args $ \x args ->
-        withTmArg env (varV2, TList t) args $ \y args ->
+        withTyArg env KStar args $ \t args ->
+        withTmArg env t args $ \x args ->
+        withTmArg env (TList t) args $ \y args ->
           pure (ECons t x y, args)
     go env (VarIn DA_Internal_Prelude (IgnoreWorkerPrefixFS "None")) args
-        = withTyArg env varT1 args $ \t args -> pure (ENone t, args)
+        = withTyArg env KStar args $ \t args -> pure (ENone t, args)
     go env (VarIn DA_Internal_Prelude (IgnoreWorkerPrefixFS "Some")) args
-        = withTyArg env varT1 args $ \t args ->
-          withTmArg env (varV1, t) args $ \x args ->
+        = withTyArg env KStar args $ \t args ->
+          withTmArg env t args $ \x args ->
             pure (ESome t x, args)
 
     go env (VarIn GHC_Tuple "()") args = pure (EUnit, args)
@@ -1281,19 +1301,21 @@ convertArg env = \case
     Type t -> TyArg <$> convertType env t
     e -> TmArg <$> convertExpr env e
 
-withTyArg :: Env -> (LF.TypeVarName, LF.Kind) -> [LArg Var] -> (LF.Type -> [LArg Var] -> ConvertM (LF.Expr, [LArg Var])) -> ConvertM (LF.Expr, [LArg Var])
+withTyArg :: Env -> LF.Kind -> [LArg Var] -> (LF.Type -> [LArg Var] -> ConvertM (LF.Expr, [LArg Var])) -> ConvertM (LF.Expr, [LArg Var])
 withTyArg env _ (LType t:args) cont = do
     t <- convertType env t
     cont t args
-withTyArg env (v, k) args cont = do
+withTyArg env k args cont = do
+    v <- freshTyVar
     (x, args) <- cont (TVar v) args
     pure (ETyLam (v, k) x, args)
 
-withTmArg :: Env -> (LF.ExprVarName, LF.Type) -> [LArg Var] -> (LF.Expr-> [LArg Var] -> ConvertM (LF.Expr, [LArg Var])) -> ConvertM (LF.Expr, [LArg Var])
+withTmArg :: Env -> LF.Type -> [LArg Var] -> (LF.Expr-> [LArg Var] -> ConvertM (LF.Expr, [LArg Var])) -> ConvertM (LF.Expr, [LArg Var])
 withTmArg env _ (LExpr x:args) cont = do
     x <- convertExpr env x
     cont x args
-withTmArg env (v, t) args cont = do
+withTmArg env t args cont = do
+    v <- freshTmVar
     (x, args) <- cont (EVar v) args
     pure (ETmLam (v, t) x, args)
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilLF.hs
@@ -73,9 +73,6 @@ varV1 = mkVar "v1"
 varV2 = mkVar "v2"
 varV3 = mkVar "v3"
 
-varT1 :: (TypeVarName, Kind)
-varT1 = (mkTypeVar "t1", KStar)
-
 fromTCon :: HasCallStack => Type -> TypeConApp
 fromTCon (TConApp con args) = TypeConApp con args
 fromTCon t = error $ "fromTCon failed, " ++ show t

--- a/compiler/damlc/tests/daml-test-files/FreshNames.daml
+++ b/compiler/damlc/tests/daml-test-files/FreshNames.daml
@@ -1,0 +1,22 @@
+-- Test that we don't use the hard coded variable names `v1`, `v2`, ... during
+-- the conversion of some builtins to DAML-LF.
+module FreshNames where
+
+import DA.Assert
+import DA.Record
+
+data Record = Record with field: Text
+
+bugSetField = scenario do
+    let v2 = Record with field = "expected"
+    let f = setField @"field" @Record v2.field
+    let r = f (Record with field = "unexpected")
+    r.field === "expected"
+
+bugCons = scenario do
+    let hd = \case
+            x::_ -> x
+            [] -> "unexpected"
+    let v2 = ["expected"]
+    let f = (hd v2::)
+    f [] === ["expected"]


### PR DESCRIPTION
Currently, we're always using the variables names `v1`, `v2`, ... for
the lambdas we introduce during the conversion of partially applied
builtins to DAML-LF. This can lead to problems when the variable name
is already in use. The test cases used to fail because of the usage of
`v2`.

This PR fixes the issue by properly generating fresh names. There's no
test case for type variables since I don't know how to trigger an
issue. Fixing it seems a good idea nevertheless.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7809)
<!-- Reviewable:end -->
