### PR TITLE
Refactor fun dep and overlap mode implementations.

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -47,6 +47,7 @@ import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.Ast.Alpha as LF
 import qualified DA.Daml.LF.TypeChecker.Check as LF
 import qualified DA.Daml.LF.TypeChecker.Env as LF
+import qualified DA.Daml.LFConversion.Encoding as LFC
 import DA.Daml.Options
 
 import SdkVersion
@@ -332,7 +333,7 @@ generateSrcFromLf env = noLoc mod
                 , tcdLName = noLoc $ mkRdrUnqual occName
                 , tcdTyVars = HsQTvs noExt params
                 , tcdFixity = Prefix
-                , tcdFDs = mkFunDeps name
+                , tcdFDs = mkFunDeps synName
                 , tcdSigs =
                     [ mkOpSig False name ty | (name, ty) <- methods ] ++
                     [ mkOpSig True  name ty | (name, ty, _) <- defaultMethods ]
@@ -349,38 +350,13 @@ generateSrcFromLf env = noLoc mod
                     [mkRdrName methodName]
                     (HsIB noExt (noLoc methodType))
 
-        mkFunDeps :: T.Text -> [LHsFunDep GhcPs]
+        mkFunDeps :: LF.TypeSynName -> [LHsFunDep GhcPs]
         mkFunDeps className = fromMaybe [] $ do
             let values = LF.moduleValues (envMod env)
-            LF.DefValue{..} <- NM.lookup (funDepName className) values
+            LF.DefValue{..} <- NM.lookup (LFC.funDepName className) values
             LF.TForalls _ ty <- pure (snd dvalBinder)
-            decodeTypeList decodeFunDep ty
-
-        decodeFunDep :: LF.Type -> Maybe (LHsFunDep GhcPs)
-        decodeFunDep ty = do
-            (left LF.:-> right) <- pure ty
-            left' <- decodeTypeList decodeTypeVar left
-            right' <- decodeTypeList decodeTypeVar right
-            pure (noLoc (left', right'))
-
-        decodeTypeVar :: LF.Type -> Maybe (Located RdrName)
-        decodeTypeVar ty = do
-            LF.TVar (LF.TypeVarName x) <- pure ty
-            pure (mkRdrName x)
-
-        decodeTypeList :: (LF.Type -> Maybe t) -> LF.Type -> Maybe [t]
-        decodeTypeList f ty = do
-            LF.TStruct fields <- pure ty
-            pairs <- sortOn fst <$> mapM (decodeTypeListField f) fields
-            guard (map fst pairs == [1 .. length pairs])
-            pure (map snd pairs)
-
-        decodeTypeListField :: (LF.Type -> Maybe t) -> (LF.FieldName, LF.Type) -> Maybe (Int, t)
-        decodeTypeListField f (LF.FieldName fieldName, x) = do
-            suffix <- T.stripPrefix "_" fieldName
-            i <- readMay (T.unpack suffix)
-            y <- f x
-            pure (i, y)
+            funDeps <- LFC.decodeFunDeps ty
+            pure $ map (noLoc . LFC.mapFunDep (mkRdrName . LF.unTypeVarName)) funDeps
 
     synonymDecls :: [Gen (LHsDecl GhcPs)]
     synonymDecls = do
@@ -472,19 +448,11 @@ generateSrcFromLf env = noLoc mod
             in (T.reverse tagR, readMay (T.unpack (T.reverse intR)))
 
         getOverlapMode :: LF.ExprValName -> Maybe (Located OverlapMode)
-        getOverlapMode (LF.ExprValName name) = do
-            dval <- NM.lookup (overlapModeName name) (LF.moduleValues (envMod env))
-            LF.EBuiltin (LF.BEText mode) <- Just (LF.dvalBody dval)
-            modeFn <- MS.lookup mode overlapModeFns
-            Just (noLoc (modeFn NoSourceText))
-
-        overlapModeFns :: MS.Map T.Text (SourceText -> OverlapMode)
-        overlapModeFns = MS.fromList
-            [ ("OVERLAPPING", Overlapping)
-            , ("OVERLAPPABLE", Overlappable)
-            , ("OVERLAPS", Overlaps)
-            , ("INCOHERENT", Incoherent)
-            ]
+        getOverlapMode name = do
+            dval <- NM.lookup (LFC.overlapModeName name) (LF.moduleValues (envMod env))
+            LF.EBuiltin (LF.BEText modeText) <- Just (LF.dvalBody dval)
+            mode <- LFC.decodeOverlapMode modeText
+            Just (noLoc mode)
 
     hiddenRefMap :: HMS.HashMap Ref Bool
     hiddenRefMap = envHiddenRefMap env
@@ -1130,12 +1098,6 @@ isSuperClassField (LF.FieldName fieldName) =
 
 defaultMethodName :: T.Text -> LF.ExprValName
 defaultMethodName name = LF.ExprValName ("$dm" <> name)
-
-funDepName :: T.Text -> LF.ExprValName
-funDepName x = LF.ExprValName ("$$fd" <> x)
-
-overlapModeName :: T.Text -> LF.ExprValName
-overlapModeName x = LF.ExprValName ("$$om" <> x)
 
 -- | Signature data for a dictionary function.
 data DFunSig = DFunSig

--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -47,7 +47,7 @@ import qualified DA.Daml.LF.Ast as LF
 import qualified DA.Daml.LF.Ast.Alpha as LF
 import qualified DA.Daml.LF.TypeChecker.Check as LF
 import qualified DA.Daml.LF.TypeChecker.Env as LF
-import qualified DA.Daml.LFConversion.Encoding as LFC
+import qualified DA.Daml.LFConversion.MetadataEncoding as LFC
 import DA.Daml.Options
 
 import SdkVersion

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -81,7 +81,7 @@ module DA.Daml.LFConversion
 import           DA.Daml.LFConversion.Primitives
 import           DA.Daml.LFConversion.UtilGHC
 import           DA.Daml.LFConversion.UtilLF
-import           DA.Daml.LFConversion.Encoding
+import           DA.Daml.LFConversion.MetadataEncoding
 
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -81,6 +81,7 @@ module DA.Daml.LFConversion
 import           DA.Daml.LFConversion.Primitives
 import           DA.Daml.LFConversion.UtilGHC
 import           DA.Daml.LFConversion.UtilLF
+import           DA.Daml.LFConversion.Encoding
 
 import           Development.IDE.Types.Diagnostics
 import           Development.IDE.Types.Location
@@ -113,7 +114,7 @@ import           "ghc-lib-parser" Pair hiding (swap)
 import           "ghc-lib-parser" PrelNames
 import           "ghc-lib-parser" TysPrim
 import           "ghc-lib-parser" TyCoRep
-import           "ghc-lib-parser" Class (FunDep, classHasFds)
+import           "ghc-lib-parser" Class (classHasFds)
 import qualified "ghc-lib-parser" Name
 import           Safe.Exact (zipExact, zipExactMay)
 import           SdkVersion
@@ -538,32 +539,14 @@ convertClassDef env tycon
     let funDepTyVars = [(v, KStar) | (v, _) <- tyVars]
             -- We use the the type variables as types in the fundep encoding,
             -- not as whatever kind they were previously defined.
-        funDepName = ExprValName ("$$fd" <> getOccText tycon)
         funDepType = TForalls funDepTyVars (encodeFunDeps funDeps')
         funDepExpr = EBuiltin BEError `ETyApp` funDepType `ETmApp`
             EBuiltin (BEText "undefined") -- We only care about the type, not the expr.
-        funDepDef = defValue tycon (funDepName, funDepType) funDepExpr
+        funDepDef = defValue tycon (funDepName tsynName, funDepType) funDepExpr
 
     pure $ [typeDef] ++ [funDepDef | classHasFds cls && newStyle]
         -- NOTE (SF): No reason to generate fundep metadata with old-style typeclasses,
         -- since data-dependencies support for old-style typeclasses is extremely limited.
-
-mapFunDepM :: Monad m => (a -> m b) -> (FunDep a -> m (FunDep b))
-mapFunDepM f (a, b) = liftM2 (,) (mapM f a) (mapM f b)
-
--- | Encode a list of functional dependencies as an LF type.
-encodeFunDeps :: [FunDep TypeVarName] -> LF.Type
-encodeFunDeps = encodeTypeList $ \(xs, ys) ->
-    encodeTypeList TVar xs :->
-    encodeTypeList TVar ys
-
--- | Encode a list as an LF type. Given @'map' f xs == [y1, y2, ..., yn]@
--- then @'encodeTypeList' f xs == { _1: y1, _2: y2, ..., _n: yn }@.
-encodeTypeList :: (t -> LF.Type) -> [t] -> LF.Type
-encodeTypeList f xs =
-    LF.TStruct $ zipWith
-        (\i x -> (mkField (T.pack ('_' : show @Int i)), f x))
-        [1..] xs
 
 defNewtypeWorker :: NamedThing a => LF.ModuleName -> a -> TypeConName -> DataCon
     -> [(TypeVarName, LF.Kind)] -> [(FieldName, LF.Type)] -> Definition
@@ -756,17 +739,10 @@ convertBind env (name, x)
     name' <- convValWithType env name
 
     -- OVERLAP* annotations
-    let overlapModeName = ExprValName ("$$om" <> getOccText name)
-        overlapModeValueM =
-            case MS.lookup name (envModInstanceInfo env) of
-                Nothing -> Nothing
-                Just (NoOverlap _) -> Nothing
-                Just (Overlappable _) -> Just "OVERLAPPABLE"
-                Just (Overlapping _) -> Just "OVERLAPPING"
-                Just (Overlaps _) -> Just "OVERLAPS"
-                Just (Incoherent _) -> Just "INCOHERENT"
+    let overlapModeName' = overlapModeName (fst name')
+        overlapModeValueM = MS.lookup name (envModInstanceInfo env) >>= encodeOverlapMode
         overlapModeDef =
-            [ defValue name (overlapModeName, TText) (EBuiltin (BEText mode))
+            [ defValue name (overlapModeName', TText) (EBuiltin (BEText mode))
             | Just mode <- [overlapModeValueM]
             ]
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Encoding.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Encoding.hs
@@ -1,0 +1,106 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Encoding/decoding of metadata (i.e. non-semantically-relevant bindings) in LF,
+-- such as functional dependencies and typeclass instance overlap modes. These are
+-- added in during LF conversion, and then decoded during data-dependencies to
+-- improve the reconstructed module interface.
+module DA.Daml.LFConversion.Encoding
+    ( funDepName
+    , encodeFunDeps
+    , decodeFunDeps
+    , mapFunDep
+    , mapFunDepM
+    , overlapModeName
+    , encodeOverlapMode
+    , decodeOverlapMode
+    ) where
+
+import Safe (readMay)
+import Control.Monad (guard, liftM2)
+import Data.List (sortOn)
+import qualified Data.Text as T
+
+import qualified "ghc-lib-parser" BasicTypes as GHC
+import qualified "ghc-lib-parser" Class as GHC
+
+import qualified DA.Daml.LF.Ast as LF
+
+-----------------------------
+-- FUNCTIONAL DEPENDENCIES --
+-----------------------------
+
+funDepName :: LF.TypeSynName -> LF.ExprValName
+funDepName (LF.TypeSynName xs) = LF.ExprValName ("$$fd" <> T.concat xs)
+
+-- | Encode a list of functional dependencies as an LF type.
+encodeFunDeps :: [GHC.FunDep LF.TypeVarName] -> LF.Type
+encodeFunDeps = encodeTypeList $ \(xs, ys) ->
+    encodeTypeList LF.TVar xs LF.:->
+    encodeTypeList LF.TVar ys
+
+-- | Encode a list as an LF type. Given @'map' f xs == [y1, y2, ..., yn]@
+-- then @'encodeTypeList' f xs == { _1: y1, _2: y2, ..., _n: yn }@.
+encodeTypeList :: (t -> LF.Type) -> [t] -> LF.Type
+encodeTypeList f xs =
+    LF.TStruct $ zipWith
+        (\i x -> (LF.FieldName (T.pack ('_' : show @Int i)), f x))
+        [1..] xs
+
+decodeFunDeps :: LF.Type -> Maybe [GHC.FunDep LF.TypeVarName]
+decodeFunDeps = decodeTypeList decodeFunDep
+
+decodeFunDep :: LF.Type -> Maybe (GHC.FunDep LF.TypeVarName)
+decodeFunDep ty = do
+    (left LF.:-> right) <- pure ty
+    left' <- decodeTypeList decodeTypeVar left
+    right' <- decodeTypeList decodeTypeVar right
+    pure (left', right')
+
+decodeTypeVar :: LF.Type -> Maybe LF.TypeVarName
+decodeTypeVar = \case
+    LF.TVar x -> Just x
+    _ -> Nothing
+
+decodeTypeList :: (LF.Type -> Maybe t) -> LF.Type -> Maybe [t]
+decodeTypeList f ty = do
+    LF.TStruct fields <- pure ty
+    pairs <- sortOn fst <$> mapM (decodeTypeListField f) fields
+    guard (map fst pairs == [1 .. length pairs])
+    pure (map snd pairs)
+
+decodeTypeListField :: (LF.Type -> Maybe t) -> (LF.FieldName, LF.Type) -> Maybe (Int, t)
+decodeTypeListField f (LF.FieldName fieldName, x) = do
+    suffix <- T.stripPrefix "_" fieldName
+    i <- readMay (T.unpack suffix)
+    y <- f x
+    pure (i, y)
+
+mapFunDep :: (a -> b) -> (GHC.FunDep a -> GHC.FunDep b)
+mapFunDep f (a, b) = (map f a, map f b)
+
+mapFunDepM :: Monad m => (a -> m b) -> (GHC.FunDep a -> m (GHC.FunDep b))
+mapFunDepM f (a, b) = liftM2 (,) (mapM f a) (mapM f b)
+
+-------------------
+-- OVERLAP MODES --
+-------------------
+
+overlapModeName :: LF.ExprValName -> LF.ExprValName
+overlapModeName (LF.ExprValName x) = LF.ExprValName ("$$om" <> x)
+
+encodeOverlapMode :: GHC.OverlapMode -> Maybe T.Text
+encodeOverlapMode = \case
+    GHC.NoOverlap _ -> Nothing
+    GHC.Overlappable _ -> Just "OVERLAPPABLE"
+    GHC.Overlapping _ -> Just "OVERLAPPING"
+    GHC.Overlaps _ -> Just "OVERLAPS"
+    GHC.Incoherent _ -> Just "INCOHERENT"
+
+decodeOverlapMode :: T.Text -> Maybe GHC.OverlapMode
+decodeOverlapMode mode = lookup mode
+    [ ("OVERLAPPING", GHC.Overlapping GHC.NoSourceText)
+    , ("OVERLAPPABLE", GHC.Overlappable GHC.NoSourceText)
+    , ("OVERLAPS", GHC.Overlaps GHC.NoSourceText)
+    , ("INCOHERENT", GHC.Incoherent GHC.NoSourceText)
+    ]

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/MetadataEncoding.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/MetadataEncoding.hs
@@ -5,7 +5,7 @@
 -- such as functional dependencies and typeclass instance overlap modes. These are
 -- added in during LF conversion, and then decoded during data-dependencies to
 -- improve the reconstructed module interface.
-module DA.Daml.LFConversion.Encoding
+module DA.Daml.LFConversion.MetadataEncoding
     ( funDepName
     , encodeFunDeps
     , decodeFunDeps


### PR DESCRIPTION
This PR moves the functional dependency and overlap
mode encoding/decoding functions to a single module,
separate from the rest of LF conversion or
data-dependencies, in preparation of adding more
annotations of this sort (e.g. MINIMAL).

This involves a small amount of refactoring to get
the types to line up... It should be a little easer
to write some roundtrip tests for these now.

I'm not super satisfied with how much fun dep / overlap
mode logic is still left in LFConversion.hs and
DataDependencies.hs, but this is a step in the right
direction at least.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
