### PR TITLE
Add MINIMAL pragma support in data-deps.

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -336,7 +336,8 @@ generateSrcFromLf env = noLoc mod
                 , tcdFDs = mkFunDeps synName
                 , tcdSigs =
                     [ mkOpSig False name ty | (name, ty) <- methods ] ++
-                    [ mkOpSig True  name ty | (name, ty, _) <- defaultMethods ]
+                    [ mkOpSig True  name ty | (name, ty, _) <- defaultMethods ] ++
+                    mkMinimalSig synName
                 , tcdMeths = listToBag
                     [ noLoc bind | (_, _, bind) <- defaultMethods ]
                 , tcdATs = [] -- associated types not supported
@@ -351,12 +352,20 @@ generateSrcFromLf env = noLoc mod
                     (HsIB noExt (noLoc methodType))
 
         mkFunDeps :: LF.TypeSynName -> [LHsFunDep GhcPs]
-        mkFunDeps className = fromMaybe [] $ do
+        mkFunDeps synName = fromMaybe [] $ do
             let values = LF.moduleValues (envMod env)
-            LF.DefValue{..} <- NM.lookup (LFC.funDepName className) values
+            LF.DefValue{..} <- NM.lookup (LFC.funDepName synName) values
             LF.TForalls _ ty <- pure (snd dvalBinder)
             funDeps <- LFC.decodeFunDeps ty
             pure $ map (noLoc . LFC.mapFunDep (mkRdrName . LF.unTypeVarName)) funDeps
+
+        mkMinimalSig :: LF.TypeSynName -> [LSig GhcPs]
+        mkMinimalSig synName = maybeToList $ do
+            let values = LF.moduleValues (envMod env)
+            LF.DefValue{..} <- NM.lookup (LFC.minimalName synName) values
+            lbf <- LFC.decodeLBooleanFormula (snd dvalBinder)
+            let lbf' = fmap (fmap mkRdrName) lbf
+            Just (noLoc (MinimalSig noExt NoSourceText lbf'))
 
     synonymDecls :: [Gen (LHsDecl GhcPs)]
     synonymDecls = do

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -547,7 +547,7 @@ convertClassDef env tycon
 
     let minimal = fmap getOccText (classMinimalDef cls)
         methodsWithNoDefault = sort [ getOccText id | (id, Nothing) <- classOpItems cls ]
-            -- ^ Used when MINIMAL pragma is not given,
+            -- Used when MINIMAL pragma is not given,
             -- i.e. the minimal sig is all methods without a default implementation.
         minimalIsDefault =
             case minimal of

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -114,8 +114,9 @@ import           "ghc-lib-parser" Pair hiding (swap)
 import           "ghc-lib-parser" PrelNames
 import           "ghc-lib-parser" TysPrim
 import           "ghc-lib-parser" TyCoRep
-import           "ghc-lib-parser" Class (classHasFds)
+import           "ghc-lib-parser" Class (classHasFds, classMinimalDef, classOpItems)
 import qualified "ghc-lib-parser" Name
+import qualified "ghc-lib-parser" BooleanFormula as BF
 import           Safe.Exact (zipExact, zipExactMay)
 import           SdkVersion
 
@@ -544,8 +545,27 @@ convertClassDef env tycon
             EBuiltin (BEText "undefined") -- We only care about the type, not the expr.
         funDepDef = defValue tycon (funDepName tsynName, funDepType) funDepExpr
 
-    pure $ [typeDef] ++ [funDepDef | classHasFds cls && newStyle]
-        -- NOTE (SF): No reason to generate fundep metadata with old-style typeclasses,
+    let minimal = fmap getOccText (classMinimalDef cls)
+        methodsWithNoDefault = sort [ getOccText id | (id, Nothing) <- classOpItems cls ]
+            -- ^ Used when MINIMAL pragma is not given,
+            -- i.e. the minimal sig is all methods without a default implementation.
+        minimalIsDefault =
+            case minimal of
+                BF.Var x -> [x] == methodsWithNoDefault
+                BF.And subclauses
+                    | names <- [ name | BF.Var name <- map unLoc subclauses ]
+                    , length names == length subclauses
+                    -> sort names == methodsWithNoDefault
+                _ -> False
+        minimalType = encodeBooleanFormula minimal
+        minimalExpr = EBuiltin BEError `ETyApp` minimalType `ETmApp`
+            EBuiltin (BEText "undefined")
+        minimalDef = defValue tycon (minimalName tsynName, minimalType) minimalExpr
+
+    pure $ [typeDef]
+        ++ [funDepDef | classHasFds cls && newStyle]
+        ++ [minimalDef | not minimalIsDefault && newStyle]
+        -- NOTE (SF): No reason to generate fundep & minimal metadata with old-style typeclasses,
         -- since data-dependencies support for old-style typeclasses is extremely limited.
 
 defNewtypeWorker :: NamedThing a => LF.ModuleName -> a -> TypeConName -> DataCon

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -553,7 +553,7 @@ convertClassDef env tycon
             case minimal of
                 BF.Var x -> [x] == methodsWithNoDefault
                 BF.And subclauses
-                    | names <- [ name | BF.Var name <- map unLoc subclauses ]
+                    | let names = [ name | BF.Var name <- map unLoc subclauses ]
                     , length names == length subclauses
                     -> sort names == methodsWithNoDefault
                 _ -> False

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/MetadataEncoding.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/MetadataEncoding.hs
@@ -93,18 +93,18 @@ mapFunDep f (a, b) = (map f a, map f b)
 mapFunDepM :: Monad m => (a -> m b) -> (GHC.FunDep a -> m (GHC.FunDep b))
 mapFunDepM f (a, b) = liftM2 (,) (mapM f a) (mapM f b)
 
--------------
--- MINIMAL --
--------------
+---------------------
+-- MINIMAL PRAGMAS --
+---------------------
 
 minimalName :: LF.TypeSynName -> LF.ExprValName
 minimalName (LF.TypeSynName xs) = LF.ExprValName ("$$minimal" <> T.concat xs)
 
-pattern TStr :: T.Text -> LF.Type
-pattern TStr x = LF.TStruct [(LF.FieldName x, LF.TUnit)]
+pattern TEncodedStr :: T.Text -> LF.Type
+pattern TEncodedStr x = LF.TStruct [(LF.FieldName x, LF.TUnit)]
 
-pattern TCon :: T.Text -> LF.Type -> LF.Type
-pattern TCon a b = LF.TStruct [(LF.FieldName a, b)]
+pattern TEncodedCon :: T.Text -> LF.Type -> LF.Type
+pattern TEncodedCon a b = LF.TStruct [(LF.FieldName a, b)]
 
 encodeLBooleanFormula :: BF.LBooleanFormula T.Text -> LF.Type
 encodeLBooleanFormula = encodeBooleanFormula . GHC.unLoc
@@ -114,17 +114,17 @@ decodeLBooleanFormula = fmap GHC.noLoc . decodeBooleanFormula
 
 encodeBooleanFormula :: BF.BooleanFormula T.Text -> LF.Type
 encodeBooleanFormula = \case
-    BF.Var x -> TCon "Var" (TStr x)
-    BF.And xs -> TCon "And" (encodeTypeList encodeLBooleanFormula xs)
-    BF.Or xs -> TCon "Or" (encodeTypeList encodeLBooleanFormula xs)
-    BF.Parens x -> TCon "Parens" (encodeLBooleanFormula x)
+    BF.Var x -> TEncodedCon "Var" (TEncodedStr x)
+    BF.And xs -> TEncodedCon "And" (encodeTypeList encodeLBooleanFormula xs)
+    BF.Or xs -> TEncodedCon "Or" (encodeTypeList encodeLBooleanFormula xs)
+    BF.Parens x -> TEncodedCon "Parens" (encodeLBooleanFormula x)
 
 decodeBooleanFormula :: LF.Type -> Maybe (BF.BooleanFormula T.Text)
 decodeBooleanFormula = \case
-    TCon "Var" (TStr x) -> Just (BF.Var x)
-    TCon "And" xs -> BF.And <$> decodeTypeList decodeLBooleanFormula xs
-    TCon "Or" xs -> BF.Or <$> decodeTypeList decodeLBooleanFormula xs
-    TCon "Parens" x -> BF.Parens <$> decodeLBooleanFormula x
+    TEncodedCon "Var" (TEncodedStr x) -> Just (BF.Var x)
+    TEncodedCon "And" xs -> BF.And <$> decodeTypeList decodeLBooleanFormula xs
+    TEncodedCon "Or" xs -> BF.Or <$> decodeTypeList decodeLBooleanFormula xs
+    TEncodedCon "Parens" x -> BF.Parens <$> decodeLBooleanFormula x
     _ -> Nothing
 
 -------------------

--- a/compiler/damlc/tests/daml-test-files/MinimalDef.daml
+++ b/compiler/damlc/tests/daml-test-files/MinimalDef.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
+-- @SINCE-LF 1.8
 -- @QUERY-LF [ .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$minimalFoo"]) ] | length == 1
 -- @QUERY-LF [ .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$minimalBar"]) ] | length == 0
 -- @QUERY-LF [ .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$minimalBaz"]) ] | length == 0

--- a/compiler/damlc/tests/daml-test-files/MinimalDef.daml
+++ b/compiler/damlc/tests/daml-test-files/MinimalDef.daml
@@ -1,0 +1,33 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @QUERY-LF [ .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$minimalFoo"]) ] | length == 1
+-- @QUERY-LF [ .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$minimalBar"]) ] | length == 0
+-- @QUERY-LF [ .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$minimalBaz"]) ] | length == 0
+-- @QUERY-LF [ .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$minimalDummy"]) ] | length == 1
+module MinimalDef where
+
+class Foo t where
+    {-# MINIMAL foo1 | foo2 #-}
+
+    foo1 : t -> Int
+    foo1 x = foo1 x + 1
+
+    foo2 : t -> Int
+    foo2 x = foo2 x + 1
+
+class Bar t where
+    bar1 : t -> Int
+    bar2 : t -> Int
+    bar2 _ = 20
+
+class Baz t where
+    baz1 : t -> Int
+    baz2 : t -> Int
+    baz3 : t -> Int
+    baz3 _ = 30
+
+-- @WARN The MINIMAL pragma does not require: 'dummy' but there is no default implementation.
+class Dummy t where
+    {-# MINIMAL #-}
+    dummy : t -> Bool

--- a/compiler/damlc/tests/src/DA/Test/Packaging.hs
+++ b/compiler/damlc/tests/src/DA/Test/Packaging.hs
@@ -1816,6 +1816,29 @@ dataDependencyTests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "D
           -- of myShow fails.
         ]
 
+    , simpleImportTest "MINIMAL pragma"
+        [ "module Lib where"
+        , "class Dummy t where"
+        , "    {-# MINIMAL #-}"
+        , "    dummy : t -> Int"
+        , "class MyClass t where"
+        , "    {-# MINIMAL foo | (bar, baz) #-}"
+        , "    foo : t -> Int"
+        , "    bar : t -> Int"
+        , "    baz : t -> Int"
+        ]
+        [ "module Main where"
+        , "import Lib"
+        , "data A = A"
+        , "data B = B"
+        , "instance Dummy A where"
+        , "instance MyClass A where"
+        , "    foo _ = 10"
+        , "instance MyClass B where"
+        , "    bar _ = 20"
+        , "    baz _ = 30"
+        ]
+
     , testCaseSteps "Implicit parameters" $ \step -> withTempDir $ \tmpDir -> do
         step "building project with implicit parameters"
         createDirectoryIfMissing True (tmpDir </> "dep")


### PR DESCRIPTION
This PR encodes MINIMAL pragmas during LF conversion and decodes them during data-dependencies. It adds appropriate tests. (Still missing roundtrip tests for all the metadata encodings.)

CHANGELOG_BEGIN

- [DAML Compiler] MINIMAL pragmas are now imported correctly
  in data-dependencies.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
