### PR TITLE
Parametrized performance envelope tests

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Envelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Envelope.scala
@@ -22,7 +22,7 @@ object Envelope {
 
   val All: immutable.Seq[Envelope] = Latency.All ++ Throughput.All ++ TransactionSize.All
 
-  sealed abstract class Latency(name: String, val latency: Duration)
+  sealed abstract class Latency(name: String, val latency: Duration, val numPings: Int)
       extends Envelope(Latency.Prefix :+ name)
 
   object Latency {
@@ -32,10 +32,17 @@ object Envelope {
     val All: immutable.Seq[Latency] =
       Vector(SixtySeconds, ThreeSeconds, OneSecond, HalfSecond)
 
-    case object SixtySeconds extends Latency("60000ms", latency = Duration(60, TimeUnit.SECONDS))
-    case object ThreeSeconds extends Latency("3000ms", latency = Duration(3, TimeUnit.SECONDS))
-    case object OneSecond extends Latency("1000ms", latency = Duration(1, TimeUnit.SECONDS))
-    case object HalfSecond extends Latency("500ms", latency = Duration(500, TimeUnit.MILLISECONDS))
+    case object SixtySeconds
+        extends Latency("60000ms", latency = Duration(60, TimeUnit.SECONDS), numPings = 20)
+    case object ThreeSeconds
+        extends Latency("3000ms", latency = Duration(3, TimeUnit.SECONDS), numPings = 20)
+    case object OneSecond
+        extends Latency("1000ms", latency = Duration(1, TimeUnit.SECONDS), numPings = 20)
+    case object HalfSecond
+        extends Latency("500ms", latency = Duration(500, TimeUnit.MILLISECONDS), numPings = 40)
+    case object QuarterSecond
+        extends Latency("250ms", latency = Duration(250, TimeUnit.MILLISECONDS), numPings = 40)
+
   }
 
   sealed abstract class Throughput(name: String, val operationsPerSecond: Int)
@@ -53,6 +60,7 @@ object Envelope {
     case object TwentyPerSecond extends Throughput("TwentyOPS", operationsPerSecond = 20)
     case object FiftyPerSecond extends Throughput("FiftyOPS", operationsPerSecond = 50)
     case object FiveHundredPerSecond extends Throughput("FiveHundredOPS", operationsPerSecond = 500)
+
   }
 
   sealed abstract class TransactionSize(name: String, val kilobytes: Int)

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
@@ -302,7 +302,7 @@ object PerformanceEnvelope {
         val numPings = Math.max(20, e.operationsPerSecond * 15) // test should run at least 15 seconds
         new ThroughputTest(
           envelope = e,
-          maxInflight = e.operationsPerSecond * 4, // aiming for a latency of 4 seconds
+          maxInflight = e.operationsPerSecond * 5, // aiming for a latency of 5 seconds
           numPings = numPings,
           numWarmupPings = numPings,
           reporter = reporter)
@@ -317,9 +317,9 @@ object PerformanceEnvelope {
     */
   private final class ThroughputTest(
       override protected val envelope: Envelope.Throughput,
-      override protected val maxInflight: Int = 40,
-      numPings: Int = 200,
-      numWarmupPings: Int = 40,
+      override protected val maxInflight: Int,
+      numPings: Int,
+      numWarmupPings: Int,
       reporter: (String, Double) => Unit,
   ) extends LedgerTestSuite
       with PerformanceEnvelope[Envelope.Throughput] {
@@ -360,8 +360,8 @@ object PerformanceEnvelope {
 
   private final class LatencyTest(
       override protected val envelope: Envelope.Latency,
-      numPings: Int = 20,
-      numWarmupPings: Int = 10,
+      numPings: Int,
+      numWarmupPings: Int,
       reporter: (String, Double) => Unit,
   ) extends LedgerTestSuite
       with PerformanceEnvelope[Envelope.Latency] {

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/PerformanceEnvelope.scala
@@ -296,8 +296,16 @@ object PerformanceEnvelope {
       reporter: (String, Double) => Unit,
   ): LedgerTestSuite =
     envelope match {
-      case e: Envelope.Latency => new LatencyTest(e, reporter = reporter)
-      case e: Envelope.Throughput => new ThroughputTest(e, reporter = reporter)
+      case e: Envelope.Latency =>
+        new LatencyTest(e, numPings = e.numPings, numWarmupPings = e.numPings, reporter = reporter)
+      case e: Envelope.Throughput =>
+        val numPings = Math.max(20, e.operationsPerSecond * 15) // test should run at least 15 seconds
+        new ThroughputTest(
+          envelope = e,
+          maxInflight = e.operationsPerSecond * 4, // aiming for a latency of 4 seconds
+          numPings = numPings,
+          numWarmupPings = numPings,
+          reporter = reporter)
       case e: Envelope.TransactionSize => new TransactionSizeScaleTest(e)
     }
 


### PR DESCRIPTION
Before this change, the performance envelope tests used a hard-coded
number of pings and warmup pings for the tests, in particular for the
throughput test. As a result, a performance test with 100tps was only
running 2 seconds. Now, the number is derived from the target throughput
numbers.

CHANGELOG_BEGIN
CHANGELOG_END

Fixes https://github.com/DACH-NY/canton/issues/4521


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
