### PR TITLE
allow Disputed and Inconsistent as reasons for key lookup failures

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
@@ -56,7 +56,7 @@ final class ContractKeysIT extends LedgerTestSuite {
           .failed
       } yield {
         assertGrpcError(fetchFailure, Status.Code.INVALID_ARGUMENT, "couldn't find key")
-        assertGrpcError(lookupByKeyFailure, Status.Code.INVALID_ARGUMENT, "Disputed")
+        assertGrpcError(lookupByKeyFailure, Status.Code.INVALID_ARGUMENT, "Disputed|Inconsistent")
       }
   })
 
@@ -99,7 +99,7 @@ final class ContractKeysIT extends LedgerTestSuite {
           "dependency error: couldn't find contract",
         )
         assertGrpcError(fetchByKeyFailure, Status.Code.INVALID_ARGUMENT, "couldn't find key")
-        assertGrpcError(lookupByKeyFailure, Status.Code.INVALID_ARGUMENT, "Disputed")
+        assertGrpcError(lookupByKeyFailure, Status.Code.INVALID_ARGUMENT, "Disputed|Inconsistent")
       }
   })
 
@@ -165,7 +165,7 @@ final class ContractKeysIT extends LedgerTestSuite {
           .create(alice, MaintainerNotSignatory(alice, bob))
           .failed
       } yield {
-        assertGrpcError(duplicateKeyFailure, Status.Code.INVALID_ARGUMENT, "DuplicateKey")
+        assertGrpcError(duplicateKeyFailure, Status.Code.INVALID_ARGUMENT, "DuplicateKey|Inconsistent")
         assertGrpcError(
           bobLooksUpTextKeyFailure,
           Status.Code.INVALID_ARGUMENT,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/tests/ContractKeysIT.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.api.testtool.tests
 
+import java.util.regex.Pattern
+
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
 import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.Eventually.eventually
@@ -56,7 +58,10 @@ final class ContractKeysIT extends LedgerTestSuite {
           .failed
       } yield {
         assertGrpcError(fetchFailure, Status.Code.INVALID_ARGUMENT, "couldn't find key")
-        assertGrpcError(lookupByKeyFailure, Status.Code.INVALID_ARGUMENT, "Disputed|Inconsistent")
+        assertGrpcError(
+          lookupByKeyFailure,
+          Status.Code.INVALID_ARGUMENT,
+          Some(Pattern.compile("Disputed|Inconsistent")))
       }
   })
 
@@ -99,7 +104,10 @@ final class ContractKeysIT extends LedgerTestSuite {
           "dependency error: couldn't find contract",
         )
         assertGrpcError(fetchByKeyFailure, Status.Code.INVALID_ARGUMENT, "couldn't find key")
-        assertGrpcError(lookupByKeyFailure, Status.Code.INVALID_ARGUMENT, "Disputed|Inconsistent")
+        assertGrpcError(
+          lookupByKeyFailure,
+          Status.Code.INVALID_ARGUMENT,
+          Some(Pattern.compile("Disputed|Inconsistent")))
       }
   })
 
@@ -165,7 +173,10 @@ final class ContractKeysIT extends LedgerTestSuite {
           .create(alice, MaintainerNotSignatory(alice, bob))
           .failed
       } yield {
-        assertGrpcError(duplicateKeyFailure, Status.Code.INVALID_ARGUMENT, "DuplicateKey|Inconsistent")
+        assertGrpcError(
+          duplicateKeyFailure,
+          Status.Code.INVALID_ARGUMENT,
+          Some(Pattern.compile("DuplicateKey|Inconsistent")))
         assertGrpcError(
           bobLooksUpTextKeyFailure,
           Status.Code.INVALID_ARGUMENT,


### PR DESCRIPTION
`Inconsistent` makes more sense semantically as wrong key lookups may be due to contention on keys.
However, it seems difficult to change the error reason in all existing DAML-on-X implementations in one go. Conversely, it would be a lot of work to retrofit Canton to generate Disputed as the reason (without hacking the test case).

First step towards #7825 .

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [X] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
