### PR TITLE
Cache computation of top-level values at definition level

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -13,7 +13,7 @@ import com.daml.lf.engine.script._
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{Ast, LanguageVersion, Util => AstUtil}
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.{Compiler, SValue, SExpr, SError}
+import com.daml.lf.speedy.{Compiler, SDefinition, SValue, SExpr, SError}
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.tls.{TlsConfiguration, TlsConfigurationCli}
@@ -183,7 +183,7 @@ class ReplService(
     extends ReplServiceGrpc.ReplServiceImplBase
     with StrictLogging {
   var signatures: Map[PackageId, PackageSignature] = Map.empty
-  var compiledDefinitions: Map[SDefinitionRef, SExpr] = Map.empty
+  var compiledDefinitions: Map[SDefinitionRef, SDefinition] = Map.empty
   var results: Seq[SValue] = Seq()
   implicit val ec_ = ec
   implicit val esf_ = esf

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -18,8 +18,7 @@ import com.daml.lf.speedy.Compiler
 import com.daml.lf.speedy.ScenarioRunner
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.Speedy
-import com.daml.lf.speedy.SExpr
-import com.daml.lf.speedy.SValue
+import com.daml.lf.speedy.{SExpr, SValue, SDefinition}
 import com.daml.lf.speedy.SExpr.{LfDefRef, SDefinitionRef}
 import com.daml.lf.validation.Validation
 import com.google.protobuf.ByteString
@@ -73,10 +72,10 @@ class Context(val contextId: Context.ContextId, languageVersion: LanguageVersion
   val homePackageId: PackageId = PackageId.assertFromString("-homePackageId-")
 
   private var extSignatures: Map[PackageId, Ast.PackageSignature] = HashMap.empty
-  private var extDefns: Map[SDefinitionRef, SExpr] = HashMap.empty
+  private var extDefns: Map[SDefinitionRef, SDefinition] = HashMap.empty
   private var modules: Map[ModuleName, Ast.Module] = HashMap.empty
-  private var modDefns: Map[ModuleName, Map[SDefinitionRef, SExpr]] = HashMap.empty
-  private var defns: Map[SDefinitionRef, SExpr] = HashMap.empty
+  private var modDefns: Map[ModuleName, Map[SDefinitionRef, SDefinition]] = HashMap.empty
+  private var defns: Map[SDefinitionRef, SDefinition] = HashMap.empty
 
   def loadedModules(): Iterable[ModuleName] = modules.keys
   def loadedPackages(): Iterable[PackageId] = extSignatures.keys
@@ -172,7 +171,7 @@ class Context(val contextId: Context.ContextId, languageVersion: LanguageVersion
       Speedy.Machine.fromScenarioSExpr(
         compiledPackages,
         txSeeding,
-        defn,
+        defn.body,
         value.ValueVersions.DevOutputVersions,
         transaction.TransactionVersions.DevOutputVersions,
       )

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ConcurrentCompiledPackages.scala
@@ -23,13 +23,13 @@ private[lf] final class ConcurrentCompiledPackages(compilerConfig: Compiler.Conf
     extends MutableCompiledPackages(compilerConfig) {
   private[this] val _signatures: ConcurrentMap[PackageId, PackageSignature] =
     new ConcurrentHashMap().asScala
-  private[this] val _defns: ConcurrentHashMap[speedy.SExpr.SDefinitionRef, speedy.SExpr] =
+  private[this] val _defns: ConcurrentHashMap[speedy.SExpr.SDefinitionRef, speedy.SDefinition] =
     new ConcurrentHashMap()
   private[this] val _packageDeps: ConcurrentHashMap[PackageId, Set[PackageId]] =
     new ConcurrentHashMap()
 
   override def getSignature(pId: PackageId): Option[PackageSignature] = _signatures.get(pId)
-  override def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SExpr] =
+  override def getDefinition(dref: speedy.SExpr.SDefinitionRef): Option[speedy.SDefinition] =
     Option(_defns.get(dref))
 
   /** Might ask for a package if the package you're trying to add references it.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/CompiledPackages.scala
@@ -7,7 +7,7 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.language.Ast.{Package, PackageSignature}
 import com.daml.lf.language.{LanguageVersion, Util}
 import com.daml.lf.speedy.SExpr.SDefinitionRef
-import com.daml.lf.speedy.{Compiler, SExpr}
+import com.daml.lf.speedy.{Compiler, SDefinition}
 
 /** Trait to abstract over a collection holding onto DAML-LF package definitions + the
   * compiled speedy expressions.
@@ -16,11 +16,11 @@ private[lf] abstract class CompiledPackages(
     compilerConfig: Compiler.Config,
 ) {
   def getSignature(pkgId: PackageId): Option[PackageSignature]
-  def getDefinition(dref: SDefinitionRef): Option[SExpr]
+  def getDefinition(dref: SDefinitionRef): Option[SDefinition]
 
   def signatures: PartialFunction[PackageId, PackageSignature] = Function.unlift(this.getSignature)
   def packageIds: Set[PackageId]
-  def definitions: PartialFunction[SDefinitionRef, SExpr] =
+  def definitions: PartialFunction[SDefinitionRef, SDefinition] =
     Function.unlift(this.getDefinition)
 
   def packageLanguageVersion: PartialFunction[PackageId, LanguageVersion] =
@@ -34,12 +34,12 @@ private[lf] abstract class CompiledPackages(
   */
 private[lf] final class PureCompiledPackages(
     signatures: Map[PackageId, PackageSignature],
-    defns: Map[SDefinitionRef, SExpr],
+    defns: Map[SDefinitionRef, SDefinition],
     compilerConfig: Compiler.Config,
 ) extends CompiledPackages(compilerConfig) {
   override def packageIds: Set[PackageId] = signatures.keySet
   override def getSignature(pkgId: PackageId): Option[PackageSignature] = signatures.get(pkgId)
-  override def getDefinition(dref: SDefinitionRef): Option[SExpr] = defns.get(dref)
+  override def getDefinition(dref: SDefinitionRef): Option[SDefinition] = defns.get(dref)
 }
 
 private[lf] object PureCompiledPackages {
@@ -49,7 +49,7 @@ private[lf] object PureCompiledPackages {
     */
   def apply(
       signatures: Map[PackageId, PackageSignature],
-      defns: Map[SDefinitionRef, SExpr],
+      defns: Map[SDefinitionRef, SDefinition],
       compilerConfig: Compiler.Config,
   ): PureCompiledPackages =
     new PureCompiledPackages(signatures, defns, compilerConfig)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SDefinition.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SDefinition.scala
@@ -16,8 +16,7 @@ final case class SDefinition(
     body: SExpr,
 ) {
   private var _cached: Option[(SValue, List[Location])] = None
-  def cached: Option[(SValue, List[Location])] = _cached
-
-  def setCached(sValue: SValue, stack_trace: List[Location]): Unit =
+  private[speedy] def cached: Option[(SValue, List[Location])] = _cached
+  private[speedy] def setCached(sValue: SValue, stack_trace: List[Location]): Unit =
     _cached = Some((sValue, stack_trace))
 }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SDefinition.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SDefinition.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy
+
+import com.daml.lf.data.Ref.Location
+
+/** Top-level speedy definition.
+  *
+  * The computation of the definition is cached to avoid expensive
+  * re-evaluation of complex definitions. When evaluating SEVal we
+  * further memoize the cached value in SEVal to avoid the definition
+  * lookup.
+  */
+final case class SDefinition(
+    body: SExpr,
+) {
+  private var _cached: Option[(SValue, List[Location])] = None
+  def cached: Option[(SValue, List[Location])] = _cached
+
+  def setCached(sValue: SValue, stack_trace: List[Location]): Unit =
+    _cached = Some((sValue, stack_trace))
+}

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -7,7 +7,6 @@ package speedy
 import java.util
 
 import com.daml.lf.data.Ref._
-import com.daml.lf.PureCompiledPackages
 import com.daml.lf.data.{FrontStack, ImmArray, Struct}
 import com.daml.lf.language.Ast
 import com.daml.lf.language.Ast._
@@ -310,11 +309,12 @@ class SpeedyTest extends WordSpec with Matchers {
       val p_1_0 = recUpdPkgs.getDefinition(LfDefRef(qualify("M:p_1_0")))
       p_1_0 shouldEqual
         Some(
-          SELet1General(
-            SEVal(LfDefRef(qualify("M:origin"))),
-            SEAppAtomicSaturatedBuiltin(
-              SBRecUpd(qualify("M:Point"), 0),
-              Array(SELocS(1), SEValue(SInt64(1))))))
+          SDefinition(
+            SELet1General(
+              SEVal(LfDefRef(qualify("M:origin"))),
+              SEAppAtomicSaturatedBuiltin(
+                SBRecUpd(qualify("M:Point"), 0),
+                Array(SELocS(1), SEValue(SInt64(1)))))))
 
     }
 
@@ -333,15 +333,17 @@ class SpeedyTest extends WordSpec with Matchers {
       val p_1_2 = recUpdPkgs.getDefinition(LfDefRef(qualify("M:p_1_2")))
       p_1_2 shouldEqual
         Some(
-          SELet1General(
-            SEVal(LfDefRef(qualify("M:origin"))),
-            SEAppAtomicSaturatedBuiltin(
-              SBRecUpdMulti(qualify("M:Point"), Array(0, 1)),
-              Array(
-                SELocS(1),
-                SEValue(SInt64(1)),
-                SEValue(SInt64(2)),
-              ),
+          SDefinition(
+            SELet1General(
+              SEVal(LfDefRef(qualify("M:origin"))),
+              SEAppAtomicSaturatedBuiltin(
+                SBRecUpdMulti(qualify("M:Point"), Array(0, 1)),
+                Array(
+                  SELocS(1),
+                  SEValue(SInt64(1)),
+                  SEValue(SInt64(2)),
+                ),
+              )
             )
           )
         )
@@ -370,18 +372,20 @@ class SpeedyTest extends WordSpec with Matchers {
       val p_3_4 = recUpdPkgs.getDefinition(LfDefRef(qualify("M:p_3_4_loc")))
       p_3_4 shouldEqual
         Some(
-          SELet1General(
-            SELocation(mkLocation(2), SEVal(LfDefRef(qualify("M:origin")))),
-            SELocation(
-              mkLocation(0),
-              SEAppAtomicSaturatedBuiltin(
-                SBRecUpdMulti(qualify("M:Point"), Array(0, 1)),
-                Array(
-                  SELocS(1),
-                  SEValue(SInt64(3)),
-                  SEValue(SInt64(4)),
-                ),
-              )),
+          SDefinition(
+            SELet1General(
+              SELocation(mkLocation(2), SEVal(LfDefRef(qualify("M:origin")))),
+              SELocation(
+                mkLocation(0),
+                SEAppAtomicSaturatedBuiltin(
+                  SBRecUpdMulti(qualify("M:Point"), Array(0, 1)),
+                  Array(
+                    SELocS(1),
+                    SEValue(SInt64(3)),
+                    SEValue(SInt64(4)),
+                  ),
+                )),
+            )
           )
         )
     }

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -440,8 +440,8 @@ object Repl {
     defs.get(idToRef(state, args(0))) match {
       case None =>
         println("Error: definition '" + args(0) + "' not found. Try :list."); usage
-      case Some(expr) =>
-        println(Pretty.SExpr.prettySExpr(0)(expr).render(80))
+      case Some(defn) =>
+        println(Pretty.SExpr.prettySExpr(0)(defn.body).render(80))
     }
   }
 


### PR DESCRIPTION
Earlier the computation of a top-level value was only cached at the
use-site in SEVal. This introduces SDefinition which contains the same
mechanism as SEVal to cache the computation.

As expected this does not impact performance much:

```
before: CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt   40  44.267 ± 0.728  ms/op
after: CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt   40  43.693 ± 0.702  ms/op
```

What this does have a significant impact is on reducing the number of distinct
SValues for things like type class dictionaries etc, so that now we have one
SValue per dictionary rather than one per SEVal.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
