### PR TITLE
Include .proto files in ScalaPB source jar

### DIFF
--- a/ledger-api/grpc-definitions/BUILD.bazel
+++ b/ledger-api/grpc-definitions/BUILD.bazel
@@ -332,7 +332,7 @@ scaladoc_jar(
 scala_source_jar(
     name = "ledger-api-scalapb_src",
     srcs = glob(["**/*.proto"]),
-    strip_upto = "/grpc-definitions/"
+    strip_upto = ledger_api_proto_source_root,
 )
 
 proto_gen(

--- a/ledger-api/grpc-definitions/BUILD.bazel
+++ b/ledger-api/grpc-definitions/BUILD.bazel
@@ -325,10 +325,11 @@ scaladoc_jar(
     deps = [],
 ) if is_windows == False else None
 
-# Create empty Sources JAR for uploading to Maven Central
+# Allow .proto files to be used by ScalaPB for customized compilation
 scala_source_jar(
     name = "ledger-api-scalapb_src",
-    srcs = [],
+    srcs = glob(["**/*.proto"]),
+    strip_upto = "/grpc-definitions/"
 )
 
 proto_gen(

--- a/ledger-api/grpc-definitions/BUILD.bazel
+++ b/ledger-api/grpc-definitions/BUILD.bazel
@@ -15,6 +15,7 @@ load("@os_info//:os_info.bzl", "is_windows")
 
 ledger_api_proto_source_root = "ledger-api/grpc-definitions"
 
+
 proto_library(
     name = "protos",
     srcs = glob(["**/*.proto"]),
@@ -282,9 +283,12 @@ da_haskell_library(
     visibility = ["//visibility:public"],
 )
 
+# ScalaPB Ledger API plus protobuf sources for customized compilation
 scala_library(
     name = "ledger-api-scalapb",
     srcs = [":ledger-api-scalapb-sources"],
+    resources = glob(["**/*.proto"]),
+    resource_strip_prefix = ledger_api_proto_source_root,
     tags = [
         "maven_coordinates=com.daml:ledger-api-scalapb:__VERSION__",
     ],
@@ -325,7 +329,7 @@ scaladoc_jar(
     deps = [],
 ) if is_windows == False else None
 
-# Allow .proto files to be used by ScalaPB for customized compilation
+# Provide protobuf sources
 scala_source_jar(
     name = "ledger-api-scalapb_src",
     srcs = glob(["**/*.proto"]),

--- a/ledger-api/grpc-definitions/BUILD.bazel
+++ b/ledger-api/grpc-definitions/BUILD.bazel
@@ -286,8 +286,8 @@ da_haskell_library(
 scala_library(
     name = "ledger-api-scalapb",
     srcs = [":ledger-api-scalapb-sources"],
-    resources = glob(["**/*.proto"]),
     resource_strip_prefix = ledger_api_proto_source_root,
+    resources = glob(["**/*.proto"]),
     tags = [
         "maven_coordinates=com.daml:ledger-api-scalapb:__VERSION__",
     ],

--- a/ledger-api/grpc-definitions/BUILD.bazel
+++ b/ledger-api/grpc-definitions/BUILD.bazel
@@ -15,7 +15,6 @@ load("@os_info//:os_info.bzl", "is_windows")
 
 ledger_api_proto_source_root = "ledger-api/grpc-definitions"
 
-
 proto_library(
     name = "protos",
     srcs = glob(["**/*.proto"]),


### PR DESCRIPTION
Closes #7830. The `jar` of [ledger-api-scalapb](https://mvnrepository.com/artifact/com.daml/ledger-api-scalapb) should contain the original `.proto` files, which is expected by tooling. See the jar of [proto-google-common-protos](https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/2.0.0/) for an example.

[This will allow](https://scalapb.github.io/docs/faq/#how-do-i-generate-scala-code-for-protos-from-another-jar) the `.proto` files to be used by tooling such as `ScalaPB` to customise the compiled bindings, and by [Akka gRPC](https://doc.akka.io/docs/akka-grpc/current/index.html).