### PR TITLE
LF: version transaction node independently

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -94,7 +94,7 @@ object BlindingTransaction {
     }
 
     val finalState =
-      tx.transaction.roots.foldLeft(BlindState.Empty) { (s, nodeId) =>
+      tx.roots.foldLeft(BlindState.Empty) { (s, nodeId) =>
         processNode(s, initialParentExerciseWitnesses, nodeId)
       }
 

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -6,7 +6,7 @@ package transaction
 package test
 
 import com.daml.lf.data.{ImmArray, Ref}
-import transaction.Node.GenNode
+import transaction.Node.{GenNode, VersionedNode}
 import transaction.{Transaction => Tx}
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 
@@ -41,13 +41,19 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
   def add(node: Node, parent: NodeId): NodeId = ids.synchronized {
     lazy val nodeId = newNode(node) // lazy to avoid getting the next id if the method later throws
     nodes = nodes.mapResult { ns =>
-      val exercise = ns(parent) match {
+      val VersionedNode(version, node) = ns(parent)
+      val exercise = node match {
         case exe: TxExercise => exe
         case _ =>
           throw new IllegalArgumentException(
             s"Node ${parent.index} either does not exist or is not an exercise")
       }
-      ns.updated(parent, exercise.copy(children = exercise.children.slowSnoc(nodeId)))
+      ns.updated(
+        parent,
+        VersionedNode(
+          version,
+          exercise.copy(children = exercise.children.slowSnoc(nodeId))
+        ))
     }
     nodeId
   }
@@ -58,12 +64,12 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
     val builtRoots = roots.result()
     val nodesVersions =
       builtRoots.reverseIterator
-        .map(n => nodeTxVersion(builtNodes(n)): VersionTimeline.SpecifiedVersion)
+        .map(n => builtNodes(n).version: VersionTimeline.SpecifiedVersion)
         .toSeq
     val txVersion =
       VersionTimeline
         .latestWhenAllPresent(TransactionVersions.StableOutputVersions.min, nodesVersions: _*)
-    VersionedTransaction(txVersion, GenTransaction(nodes.result(), roots.result()))
+    VersionedTransaction(txVersion, nodes.result(), roots.result())
   }
 
   def buildSubmitted(): SubmittedTransaction = SubmittedTransaction(build())
@@ -71,9 +77,6 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
   def buildCommitted(): CommittedTransaction = CommittedTransaction(build())
 
   def newCid: ContractId = ContractId.V1(newHash())
-
-  private[this] def nodeTxVersion(n: GenNode[_, _, _]) =
-    pkgTxVersion(n.templateId.packageId)
 
   private[this] def pkgValVersion(pkgId: Ref.PackageId) = {
     import VersionTimeline.Implicits._
@@ -89,8 +92,10 @@ final class TransactionBuilder(pkgTxVersion: Ref.PackageId => TransactionVersion
     value.Value.VersionedValue(pkgValVersion(templateId.packageId), _)
 
   private[this] def versionN(node: Node): TxNode =
-    GenNode.map3(identity[NodeId], identity[ContractId], versionValue(node.templateId))(node)
-
+    VersionedNode(
+      pkgTxVersion(node.templateId.packageId),
+      GenNode.map3(identity[NodeId], identity[ContractId], versionValue(node.templateId))(node)
+    )
 }
 
 object TransactionBuilder {
@@ -99,7 +104,7 @@ object TransactionBuilder {
   type TxValue = value.Value.VersionedValue[ContractId]
   type NodeId = transaction.NodeId
   type Node = Node.GenNode[NodeId, ContractId, Value]
-  type TxNode = Node.GenNode[NodeId, ContractId, TxValue]
+  type TxNode = VersionedNode[NodeId, ContractId]
 
   type Create = Node.NodeCreate[ContractId, Value]
   type Exercise = Node.NodeExercises[NodeId, ContractId, Value]
@@ -255,7 +260,8 @@ object TransactionBuilder {
   val Empty: Tx.Transaction =
     VersionedTransaction(
       TransactionVersions.StableOutputVersions.min,
-      GenTransaction(HashMap.empty, ImmArray.empty),
+      HashMap.empty,
+      ImmArray.empty,
     )
   val EmptySubmitted: SubmittedTransaction = SubmittedTransaction(Empty)
   val EmptyCommitted: CommittedTransaction = CommittedTransaction(Empty)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -33,9 +33,13 @@ final case class VersionedTransaction[Nid, +Cid] private[lf] (
     )
   }
 
+  // O(1)
   override def nodes: Map[Nid, Node.GenNode.WithTxValue[Nid, Cid]] =
+    // Here we use intentionally `mapValues` to get the time/memory complexity of the method constant.
+    // It is fine since the function `_.node` is very cheap.
     versionedNodes.mapValues(_.node)
 
+  // O(1)
   def transaction: GenTransaction[Nid, Cid, Transaction.Value[Cid]] =
     GenTransaction(nodes, roots)
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -6,9 +6,7 @@ package transaction
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data._
-import com.daml.lf.language.LanguageVersion
 import com.daml.lf.ledger.FailedAuthorization
-import com.daml.lf.transaction.GenTransaction.WithTxValue
 import com.daml.lf.value.Value
 import scalaz.Equal
 
@@ -17,7 +15,8 @@ import scala.collection.immutable.HashMap
 
 final case class VersionedTransaction[Nid, +Cid] private[lf] (
     version: TransactionVersion,
-    private[lf] val transaction: GenTransaction.WithTxValue[Nid, Cid],
+    versionedNodes: Map[Nid, Node.VersionedNode[Nid, Cid]],
+    override val roots: ImmArray[Nid],
 ) extends HasTxNodes[Nid, Cid, Transaction.Value[Cid]]
     with value.CidContainer[VersionedTransaction[Nid, Cid]]
     with NoCopy {
@@ -25,44 +24,21 @@ final case class VersionedTransaction[Nid, +Cid] private[lf] (
   override protected def self: this.type = this
 
   @deprecated("use resolveRelCid/ensureNoCid/ensureNoRelCid", since = "0.13.52")
-  def mapContractId[Cid2](f: Cid => Cid2): VersionedTransaction[Nid, Cid2] =
+  def mapContractId[Cid2](f: Cid => Cid2): VersionedTransaction[Nid, Cid2] = {
+    val versionNode = Node.VersionedNode.map2(identity[Nid], f)
     VersionedTransaction(
       version,
-      transaction = GenTransaction.map3(identity[Nid], f, Value.VersionedValue.map1(f))(transaction)
-    )
-
-  /** Increase the `version` if appropriate for `languageVersions`.
-    *
-    * This does not recur into the values herein; it is safe to apply
-    * [[VersionedValue#typedBy]] to any subset of this `languageVersions` for all
-    * values herein, unlike most [[value.Value]] operations.
-    *
-    * {{{
-    *   val vt2 = vt.typedBy(someVers:_*)
-    *   // safe if and only if vx() yields a subset of someVers
-    *   vt2.copy(transaction = vt2.transaction
-    *              .mapContractIdAndValue(identity, _.typedBy(vx():_*)))
-    * }}}
-    *
-    * However, applying the ''same'' version set is probably not what you mean,
-    * because the set of language versions that types a whole transaction is
-    * probably not the same set as those language version[s] that type each
-    * value, since each value can be typed by different modules.
-    */
-  def typedBy(languageVersions: LanguageVersion*): VersionedTransaction[Nid, Cid] = {
-    import VersionTimeline._
-    import Implicits._
-    VersionedTransaction(
-      latestWhenAllPresent(version, languageVersions map (a => a: SpecifiedVersion): _*),
-      transaction,
+      versionedNodes = versionedNodes.transform((_, node) => versionNode(node)),
+      roots,
     )
   }
 
-  override def nodes: HashMap[Nid, Node.GenNode.WithTxValue[Nid, Cid]] =
-    transaction.nodes
+  override def nodes: Map[Nid, Node.GenNode.WithTxValue[Nid, Cid]] =
+    versionedNodes.mapValues(_.node)
 
-  override def roots: ImmArray[Nid] =
-    transaction.roots
+  def transaction: GenTransaction[Nid, Cid, Transaction.Value[Cid]] =
+    GenTransaction(nodes, roots)
+
 }
 
 object VersionedTransaction extends value.CidContainer2[VersionedTransaction] {
@@ -71,22 +47,29 @@ object VersionedTransaction extends value.CidContainer2[VersionedTransaction] {
       f1: A1 => A2,
       f2: B1 => B2,
   ): VersionedTransaction[A1, B1] => VersionedTransaction[A2, B2] = {
-    case VersionedTransaction(version, transaction) =>
-      VersionedTransaction(version, transaction.map3(f1, f2, Value.VersionedValue.map1(f2)))
+    case VersionedTransaction(version, versionedNodes, roots) =>
+      val mapNode = Node.VersionedNode.map2(f1, f2)
+      VersionedTransaction(
+        version,
+        versionedNodes.map {
+          case (nid, node) => f1(nid) -> mapNode(node)
+        },
+        roots.map(f1),
+      )
   }
 
   override private[lf] def foreach2[A, B](
       f1: A => Unit,
       f2: B => Unit,
   ): VersionedTransaction[A, B] => Unit = {
-    case VersionedTransaction(_, transaction) =>
-      transaction.foreach3(f1, f2, Value.VersionedValue.foreach1(f2))
+    case VersionedTransaction(_, versionedNodes, _) =>
+      val foreachNode = Node.VersionedNode.foreach2(f1, f2)
+      versionedNodes.foreach {
+        case (nid, node) =>
+          f1(nid)
+          foreachNode(node)
+      }
   }
-
-  private[lf] def unapply[Nid, Cid](
-      arg: VersionedTransaction[Nid, Cid],
-  ): Some[(TransactionVersion, WithTxValue[Nid, Cid])] =
-    Some((arg.version, arg.transaction))
 
 }
 
@@ -102,7 +85,7 @@ object VersionedTransaction extends value.CidContainer2[VersionedTransaction] {
   * Therefore, it is '''forbidden''' to create ill-formed instances, i.e., instances with `!isWellFormed.isEmpty`.
   */
 final case class GenTransaction[Nid, +Cid, +Val](
-    nodes: HashMap[Nid, Node.GenNode[Nid, Cid, Val]],
+    nodes: Map[Nid, Node.GenNode[Nid, Cid, Val]],
     roots: ImmArray[Nid],
 ) extends HasTxNodes[Nid, Cid, Val]
     with value.CidContainer[GenTransaction[Nid, Cid, Val]] {
@@ -279,7 +262,7 @@ final case class GenTransaction[Nid, +Cid, +Val](
 
 sealed abstract class HasTxNodes[Nid, +Cid, +Val] {
 
-  def nodes: HashMap[Nid, Node.GenNode[Nid, Cid, Val]]
+  def nodes: Map[Nid, Node.GenNode[Nid, Cid, Val]]
 
   def roots: ImmArray[Nid]
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionVersion.scala
@@ -66,11 +66,13 @@ private[lf] object TransactionVersions
       roots.iterator.map(nid => pkgLangVersions(nodes(nid).templateId.packageId))
 
     val txVersion = assignVersions(langVersions.toList)
+
     val versionNode: UnversionedNode => VersionedNode =
       Node.GenNode.map3(identity, identity, VersionedValue(assignValueVersion(txVersion), _))
     VersionedTransaction(
-      assignVersions(langVersions.toList),
-      GenTransaction(nodes = nodes.transform((_, n) => versionNode(n)), roots = roots)
+      txVersion,
+      versionedNodes = nodes.transform((_, n) => Node.VersionedNode(txVersion, versionNode(n))),
+      roots = roots
     )
   }
 


### PR DESCRIPTION
This PR prepares the change of inference algorithm described #7788
where each node is version independently. This PR associates to each
node of `VersionedTransaction` a version. In the current state, all
nodes are associated to the version of the transaction itself. The
inference algorithm (that will make those versions potentially
distinct) will be implemented in an upcoming PR.
    
CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
