### PR TITLE
Fix error handling in ledger-upload-dar

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -177,13 +177,13 @@ runLedgerUploadDar flags darPathM = do
       getDarPath
   putStrLn $ "Uploading " <> darPath <> " to " <> showHostAndPort args
   bytes <- BS.readFile darPath
-  uploadDarFile args bytes `catch` \(e :: SomeException) ->
-    putStrLn $
-    unlines
+  uploadDarFile args bytes `catch` \(e :: SomeException) -> do
+    putStrLn $ unlines
       [ "An exception was thrown when during the upload-dar command"
       , "- " <> show e
       , "One reason for this to occur is if the size of DAR file being uploaded exceeds the gRPC maximum message size. The default value for this is 4Mb, but it may be increased when the ledger is (re)started. Please check with your ledger operator."
       ]
+    exitFailure
   putStrLn "DAR upload succeeded."
   where
     uploadDarFile args bytes =


### PR DESCRIPTION
Currently we catch the exception and then print out "DAR upload
succeeded.". That’s clearly not what is intended here.

changelog_begin

- [DAML Assistant] `daml ledger upload-dar` now exits with a non-zero
  exit code on failures and no longer prints "DAR upload succeeded"
  in error cases.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
