### PR TITLE
gRPC error codes documentation [KVL-429]

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/active_contracts_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/active_contracts_service.proto
@@ -21,6 +21,11 @@ service ActiveContractsService {
   // If there are no active contracts, the stream returns a single GetActiveContractsResponse message with the offset at which the snapshot has been taken.
   // Clients SHOULD use the offset in the last GetActiveContractsResponse message to continue streaming transactions with the transaction service.
   // Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields (filters by party cannot be empty)
   rpc GetActiveContracts (GetActiveContractsRequest) returns (stream GetActiveContractsResponse);
 
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/config_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/config_management_service.proto
@@ -14,24 +14,30 @@ import "google/protobuf/timestamp.proto";
 
 // Status: experimental interface, will change before it is deemed production
 // ready
-
+//
 // Ledger configuration management service provides methods for the ledger administrator
 // to change the current ledger configuration. The services provides methods to modify
 // different aspects of the configuration.
 service ConfigManagementService {
+
   // Return the currently active time model and the current configuration generation.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
   rpc GetTimeModel (GetTimeModelRequest) returns (GetTimeModelResponse);
 
   // Set the ledger time model.
-  // In case of failure this method responds with:
-  // - INVALID_ARGUMENT if arguments are invalid, or the provided configuration generation
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``INVALID_ARGUMENT``: if arguments are invalid, or the provided configuration generation
   //   does not match the current active configuration generation. The caller is expected
   //   to retry by again fetching current time model using 'GetTimeModel', applying changes
   //   and resubmitting.
-  // - ABORTED if the request is rejected or times out. Note that a timed out request may
+  // - ``ABORTED``: if the request is rejected or times out. Note that a timed out request may
   //   have still been committed to the ledger. Application should re-query the current
   //   time model before retrying.
-  // - UNIMPLEMENTED if this method is not supported by the backing ledger.
+  // - ``UNIMPLEMENTED``: if this method is not supported by the backing ledger.
   rpc SetTimeModel (SetTimeModelRequest) returns (SetTimeModelResponse);
 }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/package_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/package_management_service.proto
@@ -13,21 +13,16 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1.Admin";
 
 // Status: experimental interface, will change before it is deemed production
 // ready
-
+//
 // Query the DAML-LF packages supported by the ledger participant and upload
 // DAR files. We use 'backing participant' to refer to this specific participant
 // in the methods of this API.
-// When the participant is run in mode requiring authentication, all the calls 
-// in this interface will respond with UNAUTHENTICATED, if the caller fails
-// to provide a valid access token, and will respond with PERMISSION_DENIED, if
-// the claims in the token are insufficient to perform a given operation.
-// Subsequently, only specific errors of individual calls not related to 
-// authorization will be described.
 service PackageManagementService {
 
-  // Returns the details of all DAML-LF packages known to the backing
-  // participant.
-  // This request will always succeed.
+  // Returns the details of all DAML-LF packages known to the backing participant.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
   rpc ListKnownPackages (ListKnownPackagesRequest) returns
     (ListKnownPackagesResponse);
 
@@ -38,11 +33,13 @@ service PackageManagementService {
   // is not sufficient to render it usable, it must be activated first.
   // This call may:
   // - Succeed, if the package was successfully uploaded, or if the same package
-  //   was already uploaded before. 
-  // - Respond with UNIMPLEMENTED, if DAR package uploading is not supported by
-  //   the backing participant.
-  // - Respond with INVALID_ARGUMENT, if the DAR file is too big or malformed.
-  // The maximum supported size is implementation specific.
+  //   was already uploaded before.
+  // - Respond with a gRPC error
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``UNIMPLEMENTED``: if DAR package uploading is not supported by the backing participant
+  // - ``INVALID_ARGUMENT``: if the DAR file is too big or malformed. The maximum supported size is implementation specific.
   rpc UploadDarFile (UploadDarFileRequest) returns (UploadDarFileResponse);
 }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/party_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/party_management_service.proto
@@ -12,36 +12,35 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1.Admin";
 
 // Status: experimental interface, will change before it is deemed production
 // ready
-
+//
 // Inspect the party management state of a ledger participant and modify the
 // parts that are modifiable. We use 'backing participant' to refer to this
 // specific participant in the methods of this API.
-// When the participant is run in mode requiring authentication, all the calls 
-// in this interface will respond with UNAUTHENTICATED, if the caller fails
-// to provide a valid access token, and will respond with PERMISSION_DENIED, if
-// the claims in the token are insufficient to perform a given operation.
-// Subsequently, only specific errors of individual calls not related to 
-// authorization will be described.
 service PartyManagementService {
 
   // Return the identifier of the backing participant.
   // All horizontally scaled replicas should return the same id.
-  // This method is expected to succeed provided the backing participant is 
-  // healthy, otherwise it responds with INTERNAL grpc error.
   // daml-on-sql: returns an identifier supplied on command line at launch time
   // daml-on-kv-ledger: as above
   // canton: returns globally unique identifier of the backing participant
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
   rpc GetParticipantId (GetParticipantIdRequest) returns (GetParticipantIdResponse);
 
   // Get the party details of the given parties. Only known parties will be
   // returned in the list.
-  // This request will always succeed.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
   rpc GetParties (GetPartiesRequest) returns (GetPartiesResponse);
 
   // List the parties known by the backing participant.
   // The list returned contains parties whose ledger access is facilitated by
   // backing participant and the ones maintained elsewhere.
-  // This request will always succeed.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
   rpc ListKnownParties (ListKnownPartiesRequest) returns (ListKnownPartiesResponse);
 
   // Adds a new party to the set managed by the backing participant.
@@ -50,12 +49,13 @@ service PartyManagementService {
   // This call may:
   // - Succeed, in which case the actual allocated identifier is visible in
   //   the response.
-  // - Respond with UNIMPLEMENTED if synchronous party allocation is not
-  //   supported by the backing participant.
-  // - Respond with INVALID_ARGUMENT if the provided hint and/or display name
-  //   is invalid on the given ledger (see below).
-  // daml-on-sql: suggestion's uniqueness is checked and call rejected if the
-  // identifier is already present
+  // - Respond with a gRPC error
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``UNIMPLEMENTED``: if synchronous party allocation is not supported by the backing participant
+  // - ``INVALID_ARGUMENT``: if the provided hint and/or display name is invalid on the given ledger (see below).
+  // daml-on-sql: suggestion's uniqueness is checked and call rejected if the identifier is already present
   // daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in
   // the consensus layer and call rejected if the identifier is already present.
   // canton: completely different globally unique identifier is allocated.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
@@ -19,12 +19,13 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 // Allows clients to observe the status of their submissions.
 // Commands may be submitted via the Command Submission Service.
 // The on-ledger effects of their submissions are disclosed by the Transaction Service.
-// Commands may fail in 4 distinct manners:
 //
-// 1. ``INVALID_PARAMETER`` gRPC error on malformed payloads and missing required fields.
-// 2. Failure communicated in the gRPC error.
-// 3. Failure communicated in a Completion.
-// 4. A Checkpoint with ``record_time`` > command ``mrt`` arrives through the Completion Stream, and the command's Completion was not visible before. In this case the command is lost.
+// Commands may fail in 2 distinct manners:
+//
+// 1. Failure communicated in the gRPC error of the submission.
+// 2. Failure communicated in a Completion.
+//
+// Only successfully submitted commands may produce a completion event.
 //
 // Clients that do not receive a successful completion about their submission MUST NOT assume that it was successful.
 // Clients SHOULD subscribe to the CompletionStream before starting to submit commands to prevent race conditions.
@@ -34,9 +35,19 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 service CommandCompletionService {
 
   // Subscribe to command completion events.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields
+  // - ``OUT_OF_RANGE``: if the absolute offset is not before the end of the ledger
   rpc CompletionStream (CompletionStreamRequest) returns (stream CompletionStreamResponse);
 
   // Returns the offset after the latest completion.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
   rpc CompletionEnd (CompletionEndRequest) returns (CompletionEndResponse);
 
 }
@@ -92,8 +103,8 @@ message Checkpoint {
 
 message CompletionEndRequest {
   // Must correspond to the ledger ID reported by the Ledger Identification Service.
-  // Required
   // Must be a valid LedgerString (as described in ``value.proto``).
+  // Required
   string ledger_id = 1;
 
   // Server side tracing will be registered as a child of the submitted context.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_service.proto
@@ -20,23 +20,47 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 service CommandService {
 
   // Submits a single composite command and waits for its result.
-  // Returns ``RESOURCE_EXHAUSTED`` if the number of in-flight commands reached the maximum (if a limit is configured).
   // Propagates the gRPC error of failed submissions including DAML interpretation errors.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields
+  // - ``RESOURCE_EXHAUSTED``: if the number of in-flight commands reached the maximum (if a limit is configured)
+  // - ``UNAVAILABLE``: if the participant is not yet ready to submit commands or if the service has been shut down.
   rpc SubmitAndWait (SubmitAndWaitRequest) returns (google.protobuf.Empty);
 
   // Submits a single composite command, waits for its result, and returns the transaction id.
-  // Returns ``RESOURCE_EXHAUSTED`` if the number of in-flight commands reached the maximum (if a limit is configured).
   // Propagates the gRPC error of failed submissions including DAML interpretation errors.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields
+  // - ``RESOURCE_EXHAUSTED``: if the number of in-flight commands reached the maximum (if a limit is configured)
+  // - ``UNAVAILABLE``: if the participant is not yet ready to submit commands or if the service has been shut down.
   rpc SubmitAndWaitForTransactionId (SubmitAndWaitRequest) returns (SubmitAndWaitForTransactionIdResponse);
 
   // Submits a single composite command, waits for its result, and returns the transaction.
-  // Returns ``RESOURCE_EXHAUSTED`` if the number of in-flight commands reached the maximum (if a limit is configured).
   // Propagates the gRPC error of failed submissions including DAML interpretation errors.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields
+  // - ``RESOURCE_EXHAUSTED``: if the number of in-flight commands reached the maximum (if a limit is configured)
+  // - ``UNAVAILABLE``: if the participant is not yet ready to submit commands or if the service has been shut down.
   rpc SubmitAndWaitForTransaction (SubmitAndWaitRequest) returns (SubmitAndWaitForTransactionResponse);
 
   // Submits a single composite command, waits for its result, and returns the transaction tree.
-  // Returns ``RESOURCE_EXHAUSTED`` if the number of in-flight commands reached the maximum (if a limit is configured).
   // Propagates the gRPC error of failed submissions including DAML interpretation errors.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields
+  // - ``RESOURCE_EXHAUSTED``: if the number of in-flight commands reached the maximum (if a limit is configured)
+  // - ``UNAVAILABLE``: if the participant is not yet ready to submit commands or if the service has been shut down.
   rpc SubmitAndWaitForTransactionTree (SubmitAndWaitRequest) returns (SubmitAndWaitForTransactionTreeResponse);
 }
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_submission_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_submission_service.proto
@@ -18,12 +18,13 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 // Allows clients to attempt advancing the ledger's state by submitting commands.
 // The final states of their submissions are disclosed by the Command Completion Service.
 // The on-ledger effects of their submissions are disclosed by the Transaction Service.
-// Commands may fail in 4 distinct manners:
 //
-// 1) ``INVALID_PARAMETER`` gRPC error on malformed payloads and missing required fields.
-// 2) Failure communicated in the gRPC error.
-// 3) Failure communicated in a Completion.
-// 4) A Checkpoint with ``record_time`` > command ``mrt`` arrives through the Completion Stream, and the command's Completion was not visible before. In this case the command is lost.
+// Commands may fail in 2 distinct manners:
+//
+// 1. Failure communicated in the gRPC error of the submission.
+// 2. Failure communicated in a Completion.
+//
+// Only successfully submitted commands may produce a completion event.
 //
 // Clients that do not receive a successful completion about their submission MUST NOT assume that it was successful.
 // Clients SHOULD subscribe to the CompletionStream before starting to submit commands to prevent race conditions.
@@ -33,6 +34,13 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 service CommandSubmissionService {
 
   // Submit a single composite command.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields
+  // - ``UNAVAILABLE``: if the participant is not yet ready to submit commands or if the service has been shut down.
+  // - ``RESOURCE_EXHAUSTED``: if the participant or the ledger is overloaded. Clients should back off exponentially and retry.
   rpc Submit (SubmitRequest) returns (google.protobuf.Empty);
 
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/ledger_configuration_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/ledger_configuration_service.proto
@@ -17,6 +17,10 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 service LedgerConfigurationService {
 
   // Returns the latest configuration as the first response, and publishes configuration updates in the same stream.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
   rpc GetLedgerConfiguration (GetLedgerConfigurationRequest) returns (stream GetLedgerConfigurationResponse);
 
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/ledger_identity_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/ledger_identity_service.proto
@@ -17,6 +17,9 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 service LedgerIdentityService {
 
   // Clients may call this RPC to return the identifier of the ledger they are connected to.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
   rpc GetLedgerIdentity (GetLedgerIdentityRequest) returns (GetLedgerIdentityResponse);
 
 }
@@ -32,7 +35,6 @@ message GetLedgerIdentityRequest {
 message GetLedgerIdentityResponse {
 
   // The ID of the ledger exposed by the server.
-  // Requests submitted with the wrong ledger ID will result in ``NOT_FOUND`` gRPC errors.
   // Must be a valid LedgerString (as described in ``value.proto``).
   // Required
   string ledger_id = 1;

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/package_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/package_service.proto
@@ -16,12 +16,24 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 service PackageService {
 
   // Returns the identifiers of all supported packages.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
   rpc ListPackages (ListPackagesRequest) returns (ListPackagesResponse);
 
-  // Returns the contents of a single package, or a ``NOT_FOUND`` error if the requested package is unknown.
+  // Returns the contents of a single package.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the requested package is unknown
   rpc GetPackage (GetPackageRequest) returns (GetPackageResponse);
 
   // Returns the status of a single package.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the requested package is unknown
   rpc GetPackageStatus (GetPackageStatusRequest) returns (GetPackageStatusResponse);
 
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/testing/time_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/testing/time_service.proto
@@ -22,6 +22,8 @@ service TimeService {
   rpc GetTime (GetTimeRequest) returns (stream GetTimeResponse);
 
   // Allows clients to change the ledger's clock in an atomic get-and-set operation.
+  // Errors:
+  // - ``INVALID_ARGUMENT``: if ``current_time`` is invalid (it MUST precisely match the current time as it's known to the ledger server)
   rpc SetTime (SetTimeRequest) returns (google.protobuf.Empty);
 
 }
@@ -48,7 +50,6 @@ message SetTimeRequest {
   string ledger_id = 1;
 
   // MUST precisely match the current time as it's known to the ledger server.
-  // On mismatch, an ``INVALID_PARAMETER`` gRPC error will be returned.
   google.protobuf.Timestamp current_time = 2;
 
   // The time the client wants to set on the ledger.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -19,31 +19,63 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 service TransactionService {
 
   // Read the ledger's filtered transaction stream for a set of parties.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields (e.g. if ``before`` is not before ``end``)
+  // - ``OUT_OF_RANGE``: if the ``begin`` parameter value is not before the end of the ledger
   rpc GetTransactions (GetTransactionsRequest) returns (stream GetTransactionsResponse);
 
   // Read the ledger's complete transaction tree stream for a set of parties.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields (e.g. if ``before`` is not before ``end``)
+  // - ``OUT_OF_RANGE``: if the ``begin`` parameter value is not before the end of the ledger
   rpc GetTransactionTrees (GetTransactionsRequest) returns (stream GetTransactionTreesResponse);
 
   // Lookup a transaction tree by the ID of an event that appears within it.
-  // Returns ``NOT_FOUND`` if no such transaction exists.
   // For looking up a transaction instead of a transaction tree, please see GetFlatTransactionByEventId
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id or no such transaction exists
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields (e.g. if requesting parties are invalid or empty)
   rpc GetTransactionByEventId (GetTransactionByEventIdRequest) returns (GetTransactionResponse);
 
   // Lookup a transaction tree by its ID.
-  // Returns ``NOT_FOUND`` if no such transaction exists.
   // For looking up a transaction instead of a transaction tree, please see GetFlatTransactionById
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id or no such transaction exists
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields (e.g. if requesting parties are invalid or empty)
   rpc GetTransactionById (GetTransactionByIdRequest) returns (GetTransactionResponse);
 
   // Lookup a transaction by the ID of an event that appears within it.
-  // Returns ``NOT_FOUND`` if no such transaction exists.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id or no such transaction exists
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields (e.g. if requesting parties are invalid or empty)
   rpc GetFlatTransactionByEventId (GetTransactionByEventIdRequest) returns (GetFlatTransactionResponse);
 
   // Lookup a transaction by its ID.
-  // Returns ``NOT_FOUND`` if no such transaction exists.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id or no such transaction exists
+  // - ``INVALID_ARGUMENT``: if the payload is malformed or is missing required fields (e.g. if requesting parties are invalid or empty)
   rpc GetFlatTransactionById (GetTransactionByIdRequest) returns (GetFlatTransactionResponse);
 
   // Get the current ledger end.
   // Subscriptions started with the returned offset will serve transactions created after this RPC was called.
+  // Errors:
+  // - ``UNAUTHENTICATED``: if the request does not include a valid access token
+  // - ``PERMISSION_DENIED``: if the claims in the token are insufficient to perform a given operation
+  // - ``NOT_FOUND``: if the request does not include a valid ledger id or no such transaction exists
   rpc GetLedgerEnd (GetLedgerEndRequest) returns (GetLedgerEndResponse);
 
 }


### PR DESCRIPTION
Updated definitions of gRPC services with information about error codes that services may return.
[KVL-429]

CHANGELOG_BEGIN

- improved gRPC error codes documentation in .proto definitions

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.


[KVL-429]: https://digitalasset.atlassian.net/browse/KVL-429