### PR TITLE
participant-integration-api: Process index updates concurrently.

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -369,6 +369,7 @@ final class Metrics(val registry: MetricRegistry) {
         val getParticipantId: DatabaseMetrics = createDbMetrics("get_participant_id")
         val getLedgerEnd: DatabaseMetrics = createDbMetrics("get_ledger_end")
         val getInitialLedgerEnd: DatabaseMetrics = createDbMetrics("get_initial_ledger_end")
+        val updateLedgerEnd: DatabaseMetrics = createDbMetrics("update_ledger_end")
         val initializeLedgerParameters: DatabaseMetrics = createDbMetrics(
           "initialize_ledger_parameters")
         val initializeParticipantId: DatabaseMetrics = createDbMetrics("initialize_participant_id")
@@ -397,7 +398,6 @@ final class Metrics(val registry: MetricRegistry) {
             registry.timer(dbPrefix :+ "insert_contract_witnesses_batch")
 
           val insertCompletion: Timer = registry.timer(dbPrefix :+ "insert_completion")
-          val updateLedgerEnd: Timer = registry.timer(dbPrefix :+ "update_ledger_end")
         }
         val storeRejectionDbMetrics
           : DatabaseMetrics = createDbMetrics("store_rejection") // FIXME Base name conflicts with storeRejection

--- a/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexConfiguration.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/configuration/IndexConfiguration.scala
@@ -7,4 +7,6 @@ object IndexConfiguration {
 
   val DefaultEventsPageSize: Int = 1000
 
+  val DefaultConcurrency: Int = 16
+
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -15,6 +15,7 @@ case class IndexerConfig(
     startupMode: IndexerStartupMode,
     restartDelay: FiniteDuration = DefaultRestartDelay,
     eventsPageSize: Int = IndexConfiguration.DefaultEventsPageSize,
+    concurrency: Int = IndexConfiguration.DefaultConcurrency,
     allowExistingSchema: Boolean = false,
 )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -52,6 +52,9 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
   /** Looks up the current external ledger end offset */
   def lookupInitialLedgerEnd()(implicit loggingContext: LoggingContext): Future[Option[Offset]]
 
+  /** Update the ledger end */
+  def updateLedgerEnd(offset: Offset)(implicit loggingContext: LoggingContext): Future[Unit]
+
   /** Looks up an active or divulged contract if it is visible for the given party. Archived contracts must not be returned by this method */
   def lookupActiveOrDivulgedContract(contractId: ContractId, forParty: Party)(
       implicit loggingContext: LoggingContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -52,6 +52,11 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
       implicit loggingContext: LoggingContext): Future[Option[Offset]] =
     Timed.future(metrics.daml.index.db.lookupLedgerEnd, ledgerDao.lookupInitialLedgerEnd())
 
+  // This does not add a timer, because the underlying ledger does exactly that.
+  override def updateLedgerEnd(offset: Offset)(
+      implicit loggingContext: LoggingContext): Future[Unit] =
+    ledgerDao.updateLedgerEnd(offset)
+
   override def lookupActiveOrDivulgedContract(
       contractId: Value.ContractId,
       forParty: Party,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
@@ -7,13 +7,13 @@ import java.time.Instant
 import java.util.UUID
 
 import akka.stream.scaladsl.Sink
-import com.daml.ledger.participant.state.v1.{Offset, RejectionReason, SubmitterInfo}
-import com.daml.lf.data.Ref.Party
 import com.daml.ledger.ApplicationId
 import com.daml.ledger.api.v1.command_completion_service.CompletionStreamResponse
+import com.daml.ledger.participant.state.v1.{Offset, RejectionReason, SubmitterInfo}
+import com.daml.lf.data.Ref.Party
 import com.daml.platform.ApiOffset
-import com.daml.platform.store.dao.JdbcLedgerDaoCompletionsSpec._
 import com.daml.platform.store.CompletionFromTransaction
+import com.daml.platform.store.dao.JdbcLedgerDaoCompletionsSpec._
 import org.scalatest.{AsyncFlatSpec, LoneElement, Matchers, OptionValues}
 
 import scala.concurrent.Future
@@ -129,6 +129,7 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
         offset = offset,
         reason = reason,
       )
+      .flatMap(_ => ledgerDao.updateLedgerEnd(offset))
       .map(_ => offset)
   }
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoConfigurationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoConfigurationSpec.scala
@@ -27,6 +27,7 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
         defaultConfig,
         None,
       )
+      _ <- ledgerDao.updateLedgerEnd(offset)
       optStoredConfig <- ledgerDao.lookupLedgerConfiguration()
       endingOffset <- ledgerDao.lookupLedgerEnd()
     } yield {
@@ -51,6 +52,7 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
         proposedConfig,
         Some("bad config"),
       )
+      _ <- ledgerDao.updateLedgerEnd(offset)
       storedConfig <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2))
       entries <- ledgerDao
         .getConfigurationEntries(startExclusive, offset)
@@ -82,6 +84,7 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
         config.copy(generation = config.generation + 1),
         None,
       )
+      _ <- ledgerDao.updateLedgerEnd(offset0)
       newConfig <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2).get)
 
       // Submission with duplicate submissionId is rejected
@@ -93,6 +96,7 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
         newConfig.copy(generation = config.generation + 1),
         None,
       )
+      _ <- ledgerDao.updateLedgerEnd(offset1)
 
       // Submission with mismatching generation is rejected
       offset2 = nextOffset()
@@ -104,6 +108,7 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
         config,
         None,
       )
+      _ <- ledgerDao.updateLedgerEnd(offset2)
 
       // Submission with unique submissionId and correct generation is accepted.
       offset3 = nextOffset()
@@ -116,6 +121,7 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
         lastConfig,
         None,
       )
+      _ <- ledgerDao.updateLedgerEnd(offset3)
       lastConfigActual <- ledgerDao.lookupLedgerConfiguration().map(_.map(_._2).get)
 
       entries <- ledgerDao.getConfigurationEntries(startExclusive, offset3).runWith(Sink.seq)

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPartiesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPartiesSpec.scala
@@ -37,6 +37,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
           partyDetails = alice,
         ),
       )
+      _ <- ledgerDao.updateLedgerEnd(offset1)
       _ = response should be(PersistenceResponse.Ok)
       offset2 = nextOffset()
       response <- ledgerDao.storePartyEntry(
@@ -47,6 +48,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
           partyDetails = bob,
         ),
       )
+      _ <- ledgerDao.updateLedgerEnd(offset2)
       _ = response should be(PersistenceResponse.Ok)
       parties <- ledgerDao.listKnownParties()
     } yield {
@@ -80,6 +82,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
           partyDetails = carol,
         ),
       )
+      _ <- ledgerDao.updateLedgerEnd(offset)
       _ = response should be(PersistenceResponse.Ok)
       carolPartyDetails <- ledgerDao.getParties(Seq(party))
       noPartyDetails <- ledgerDao.getParties(Seq(nonExistentParty))
@@ -113,6 +116,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
           partyDetails = dan,
         ),
       )
+      _ <- ledgerDao.updateLedgerEnd(offset1)
       _ = response should be(PersistenceResponse.Ok)
       offset2 = nextOffset()
       response <- ledgerDao.storePartyEntry(
@@ -123,6 +127,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
           partyDetails = eve,
         ),
       )
+      _ <- ledgerDao.updateLedgerEnd(offset2)
       _ = response should be(PersistenceResponse.Ok)
       parties <- ledgerDao.getParties(Seq(danParty, eveParty, nonExistentParty))
     } yield {
@@ -146,6 +151,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
           partyDetails = fred,
         ),
       )
+      _ <- ledgerDao.updateLedgerEnd(offset1)
       _ = response should be(PersistenceResponse.Ok)
       offset2 = nextOffset()
       response <- ledgerDao.storePartyEntry(
@@ -156,6 +162,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
           partyDetails = fred,
         ),
       )
+      _ <- ledgerDao.updateLedgerEnd(offset2)
     } yield {
       response should be(PersistenceResponse.Duplicate)
     }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -449,6 +449,9 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
         offset = offset,
         divulged = divulgedContracts.keysIterator.map(c => v1.DivulgedContract(c._1, c._2)).toList
       )
+      .flatMap { _ =>
+        ledgerDao.updateLedgerEnd(offset)
+      }
       .map(_ => offsetAndTx)
   }
 


### PR DESCRIPTION
This seems to have a decent speedup.

Basically, the thinking is that we don't need to do index updates sequentially, we just need to update the ledger end sequentially. So this PR:

1. decouples writing state updates from updating the ledger end, and
2. batches ledger end updates so we don't get bottlenecked there.

## Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
