### PR TITLE
Speedy: Add more tests for multi record updates

### DIFF
--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/SpeedyTest.scala
@@ -293,6 +293,7 @@ class SpeedyTest extends WordSpec with Matchers {
   val recUpdPkgs = typeAndCompile(p"""
     module M {
       record Point = { x: Int64, y: Int64 } ;
+      val f: Int64 -> Int64 = \(x: Int64) -> MUL_INT64 2 x ;
       val origin: M:Point = M:Point { x = 0, y = 0 } ;
       val p_1_0: M:Point = M:Point { M:origin with x = 1 } ;
       val p_1_2: M:Point = M:Point { M:Point { M:origin with x = 1 } with y = 2 } ;
@@ -301,6 +302,8 @@ class SpeedyTest extends WordSpec with Matchers {
           loc(M,p_3_4_loc,2,2,2,2) M:origin with x = 3
         } with y = 4
       } ;
+      val p_6_8: M:Point = M:Point { M:Point { M:origin with x = M:f 3 } with y = M:f 4 } ;
+      val p_3_2: M:Point = M:Point { M:Point { M:Point { M:origin with x = 1 } with y = 2 } with x = 3 } ;
     }
   """)
 
@@ -397,6 +400,79 @@ class SpeedyTest extends WordSpec with Matchers {
             qualify("M:Point"),
             ImmArray(n"x", n"y"),
             ArrayList(SInt64(3), SInt64(4)),
+          )
+        )
+    }
+
+    "use SBRecUpdMulti for non-atomic multi update" in {
+      recUpdPkgs.getDefinition(LfDefRef(qualify("M:p_6_8"))) shouldEqual
+        Some(
+          SDefinition(
+            SELet1General(
+              SEVal(LfDefRef(qualify("M:origin"))),
+              SELet1General(
+                SEVal(LfDefRef(qualify("M:f"))),
+                SELet1General(
+                  SEAppAtomicGeneral(SELocS(1), Array(SEValue(SInt64(3)))),
+                  SELet1General(
+                    SEVal(LfDefRef(qualify("M:f"))),
+                    SELet1General(
+                      SEAppAtomicGeneral(SELocS(1), Array(SEValue(SInt64(4)))),
+                      SEAppAtomicSaturatedBuiltin(
+                        SBRecUpdMulti(qualify("M:Point"), Array(0, 1)),
+                        Array(
+                          SELocS(5),
+                          SELocS(3),
+                          SELocS(1),
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+    }
+
+    "produce expected output for non-atomic multi update" in {
+      eval(e"M:p_6_8", recUpdPkgs) shouldEqual
+        Right(
+          SRecord(
+            qualify("M:Point"),
+            ImmArray(n"x", n"y"),
+            ArrayList(SInt64(6), SInt64(8)),
+          )
+        )
+    }
+
+    "use SBRecUpdMulti for overwriting multi update" in {
+      recUpdPkgs.getDefinition(LfDefRef(qualify("M:p_3_2"))) shouldEqual
+        Some(
+          SDefinition(
+            SELet1General(
+              SEVal(LfDefRef(qualify("M:origin"))),
+              SEAppAtomicSaturatedBuiltin(
+                SBRecUpdMulti(qualify("M:Point"), Array(0, 1, 0)),
+                Array(
+                  SELocS(1),
+                  SEValue(SInt64(1)),
+                  SEValue(SInt64(2)),
+                  SEValue(SInt64(3)),
+                ),
+              )
+            )
+          )
+        )
+    }
+
+    "produce expected output for overwriting multi update" in {
+      eval(e"M:p_3_2", recUpdPkgs) shouldEqual
+        Right(
+          SRecord(
+            qualify("M:Point"),
+            ImmArray(n"x", n"y"),
+            ArrayList(SInt64(3), SInt64(2)),
           )
         )
     }


### PR DESCRIPTION
Add two more tests for the following cases:
1. The Expressions the values should be updated with are non-atomoic.
   This tests that our internal ANF transformation doesn't destroy the
   omptimization. (In fact, it can't really do that because it is run
   after the phase which does the optimization. But better safe than
   sorry.)
2. A single record field is updated multiple times. This tests that
   the last update wins. Unfortunately, we cannot drop the earlier
   updates, or at least computing their values, since these values
   might be bottom. (We could add an optimization _after_ we've
   transformed into ANF but I don't expect any benefits from this in
   practice and would hence not do it.)

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7848)
<!-- Reviewable:end -->
