### PR TITLE
Add libstdc++ and ws2_32 to base on Windows

### DIFF
--- a/bazel_tools/haskell-windows-extra-libraries.patch
+++ b/bazel_tools/haskell-windows-extra-libraries.patch
@@ -18,3 +18,16 @@ index bcb83c73..46148f16 100644
          "depends": hs.package_ids,
          "exposed-modules": exposed_modules,
      })
+diff --git a/haskell/assets/ghc_8_6_5_win_base.patch b/haskell/assets/ghc_8_6_5_win_base.patch
+index d870deef..77edb1d2 100644
+--- a/haskell/assets/ghc_8_6_5_win_base.patch
++++ b/haskell/assets/ghc_8_6_5_win_base.patch
+@@ -5,7 +5,7 @@
+  hs-libraries: HSbase-4.12.0.0
+  extra-libraries:
+ -    wsock32 user32 shell32 msvcrt mingw32 mingwex
+-+    wsock32 user32 shell32 msvcrt mingw32 mingwex shlwapi
+++    wsock32 ws2_32 user32 shell32 msvcrt mingw32 mingwex shlwapi stdc++
+  include-dirs: $topdir\base-4.12.0.0\include
+  includes:
+      HsBase.h


### PR DESCRIPTION
These libraries have to appear on the linker command line after grpc and
gpr when linking against these. rules_haskell does currently not offer a
way to add extra libraries to the package configration file that are not
themselves Bazel targets. In case of libstdc++ and libws2_32 these are
system libraries that are not explicitly tracked by Bazel. As a
workaround we add these libraries to base's package configuration file.

This is to resolve linker errors on Windows on https://github.com/digital-asset/daml/pull/7794

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
