### PR TITLE
Add healthcheck endpoints to JSON API

### DIFF
--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -1489,3 +1489,33 @@ created before the offset *unless* those contracts are identified in a
 ``contractIdAtOffset``.  By contrast, if any ``contractIdAtOffset`` is
 missing, ``archived`` event filtering will be disabled, and you will
 receive "phantom archives" as with query streams.
+
+Healthcheck Endpoints
+*********************
+
+The HTTP JSON API provides two healthcheck endpoints for integration
+with schedulers like
+`Kubernetes <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/>`_.
+
+Liveness check
+==============
+
+- URL: ``/livez``
+- Method: ``GET``
+
+A status code of ``200`` indicates a successful liveness check.
+
+This is an unauthenticated endpoint intended to be used as a liveness
+probe.
+
+Readyness check
+===============
+
+- URL: ``/readyz``
+- Method: ``GET``
+
+A status code of ``200`` indicates a successful readyness check.
+
+This is an unauthenticated endpoint intended to be used as a liveness
+probe. It validates both the ledger connection as well as the database
+connection.

--- a/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
+++ b/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
@@ -61,7 +61,7 @@ final class FailureTests
           """[-] ledger failed
             |[+] database ok
             |readyz check failed
-            |""".stripMargin
+            |""".stripMargin.replace("\r\n", "\n")
         _ <- inside(output) {
           case JsObject(fields) =>
             inside(fields.get("status")) {
@@ -251,7 +251,7 @@ final class FailureTests
         """[+] ledger ok
           |[-] database failed
           |readyz check failed
-          |""".stripMargin
+          |""".stripMargin.replace("\r\n", "\n")
       _ = dbProxy.enable()
       // eventually doesn’t handle Futures in the version of scalatest we’re using.
       _ <- RetryStrategy.constant(5, 2.seconds)((_, _) =>

--- a/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
+++ b/ledger-service/http-json/src/failure/scala/http/FailureTests.scala
@@ -55,6 +55,13 @@ final class FailureTests
           uri,
           headersWithParties(List(p.unwrap)))
         _ = status shouldBe StatusCodes.InternalServerError
+        (status, out) <- getRequestEncoded(uri.withPath(Uri.Path("/readyz")))
+        _ = status shouldBe StatusCodes.ServiceUnavailable
+        _ = out shouldBe
+          """[-] ledger failed
+            |[+] database ok
+            |readyz check failed
+            |""".stripMargin
         _ <- inside(output) {
           case JsObject(fields) =>
             inside(fields.get("status")) {
@@ -71,6 +78,8 @@ final class FailureTests
               uri,
               headersWithParties(List(p.unwrap)))
           } yield status shouldBe StatusCodes.OK)
+        (status, out) <- getRequestEncoded(uri.withPath(Uri.Path("/readyz")))
+        _ = status shouldBe StatusCodes.OK
       } yield succeed
   }
 
@@ -236,6 +245,13 @@ final class FailureTests
       }
       // TODO Document this properly or adjust it
       _ = status shouldBe StatusCodes.OK
+      (status, out) <- getRequestEncoded(uri.withPath(Uri.Path("/readyz")))
+      _ = status shouldBe StatusCodes.ServiceUnavailable
+      _ = out shouldBe
+        """[+] ledger ok
+          |[-] database failed
+          |readyz check failed
+          |""".stripMargin
       _ = dbProxy.enable()
       // eventually doesn’t handle Futures in the version of scalatest we’re using.
       _ <- RetryStrategy.constant(5, 2.seconds)((_, _) =>
@@ -252,6 +268,8 @@ final class FailureTests
               }
           }
         } yield succeed)
+      (status, _) <- getRequestEncoded(uri.withPath(Uri.Path("/readyz")))
+      _ = status shouldBe StatusCodes.OK
     } yield succeed
   }
 

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Config.scala
@@ -28,6 +28,7 @@ private[http] final case class Config(
     packageReloadInterval: FiniteDuration = HttpService.DefaultPackageReloadInterval,
     packageMaxInboundMessageSize: Option[Int] = None,
     maxInboundMessageSize: Int = HttpService.DefaultMaxInboundMessageSize,
+    healthTimeoutSeconds: Int = HttpService.DefaultHealthTimeoutSeconds,
     tlsConfig: TlsConfiguration = TlsConfiguration(enabled = false, None, None, None),
     jdbcConfig: Option[JdbcConfig] = None,
     staticContentConfig: Option[StaticContentConfig] = None,

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/Endpoints.scala
@@ -47,6 +47,7 @@ class Endpoints(
     contractsService: ContractsService,
     partiesService: PartiesService,
     packageManagementService: PackageManagementService,
+    healthService: HealthService,
     encoder: DomainJsonEncoder,
     decoder: DomainJsonDecoder,
     maxTimeToCollectRequest: FiniteDuration = FiniteDuration(5, "seconds"))(
@@ -82,6 +83,11 @@ class Endpoints(
     // format: on
     case req @ HttpRequest(POST, Uri.Path("/v1/packages"), _, _, _) =>
       httpResponse(uploadDarFile(req))
+    case HttpRequest(GET, Uri.Path("/livez"), _, _, _) =>
+      Future.successful(HttpResponse(status = StatusCodes.OK))
+    case HttpRequest(GET, Uri.Path("/readyz"), _, _, _) =>
+      healthService.ready().map(_.toHttpResponse)
+
   }
 
   def create(req: HttpRequest): ET[domain.SyncResponse[JsValue]] =

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/HealthService.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/HealthService.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http
+
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, StatusCodes}
+import com.typesafe.scalalogging.StrictLogging
+import scalaz.Scalaz._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+import scala.util.control.NonFatal
+
+private class HealthService(
+    getLedgerEnd: HealthService.GetLedgerEnd,
+    contractDao: Option[dbbackend.ContractDao],
+    timeoutSeconds: Int)
+    extends StrictLogging {
+  import HealthService._
+  def ready()(implicit ec: ExecutionContext): Future[ReadyResponse] =
+    for {
+      ledger <- getLedgerEnd().transform(r => Try(r.isSuccess))
+      _ = println("START")
+      optDb <- contractDao.traverse(opt =>
+        opt.isValid(timeoutSeconds).unsafeToFuture().recover {
+          case NonFatal(_) => false
+      })
+    } yield ReadyResponse(Seq(Check("ledger", ledger)) ++ optDb.toList.map(Check("database", _)))
+}
+
+object HealthService {
+  case class Check(name: String, result: Boolean)
+  case class ReadyResponse(checks: Seq[Check]) {
+    val ok = checks.forall(_.result)
+    private def check(c: Check) = {
+      val (checkBox, result) = if (c.result) { ("+", "ok") } else { ("-", "failed") }
+      s"[$checkBox] ${c.name} $result"
+    }
+
+    // Format modeled after k8s’ own healthchecks
+    private def render(): String =
+      (checks.map(check(_)) ++ Seq(s"readyz check ${if (ok) "passed" else "failed"}", ""))
+        .mkString("\n")
+
+    def toHttpResponse: HttpResponse =
+      HttpResponse(
+        status = if (ok) StatusCodes.OK else StatusCodes.ServiceUnavailable,
+        entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, render())
+      )
+  }
+  // We only check health so we don’t care about the offset
+  type GetLedgerEnd = () => Future[Unit]
+}

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -24,6 +24,9 @@ class ContractDao(xa: Connection.T) {
 
   def transact[A](query: ConnectionIO[A]): IO[A] =
     query.transact(xa)
+
+  def isValid(timeoutSeconds: Int): IO[Boolean] =
+    fconn.isValid(timeoutSeconds).transact(xa)
 }
 
 object ContractDao {


### PR DESCRIPTION
This PR adds /livez and /readyz (following k8s naming scheme) that can
be used as liveness and readyness check. There isn’t much we can do
for liveness apart from showing that we can still respond to http
requests but readyness can be a bit more clever and check the ledger
connection as well as the database connection.

changelog_begin

- [JSON API] Add `/livez` and `/readyz` health check endpoints for
  easier integration with k8s and other schedulers.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
