### PR TITLE
Draft for multi-party submissions related changes in the participant state API

### DIFF
--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
@@ -12,10 +12,6 @@ import java.time.Instant
   *
   * @param actAs: the set of parties that submitted the change.
   *
-  * @param readAs: the set of parties on whose behalf (in addition to all
-  *   parties listed in `actAs`) contracts can be retrieved.
-  *   This affects DAML operations such as `fetch`, `fetchByKey`, `lookupByKey`,
-  *   `exercise`, and `exerciseByKey`.
   *
   * @param applicationId: an identifier for the DAML application that
   *   submitted the command. This is used for monitoring and to allow DAML
@@ -36,7 +32,6 @@ import java.time.Instant
   */
 final case class SubmitterInfo(
     actAs: List[Party],
-    readAs: List[Party],
     applicationId: ApplicationId,
     commandId: CommandId,
     deduplicateUntil: Instant,

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
@@ -10,7 +10,7 @@ import java.time.Instant
   * Note that this is used for party-originating changes only. They are
   * usually issued via the Ledger API.
   *
-  * @param actAs: the set of parties that submitted the change.
+  * @param actAs: the non-empty set of parties that submitted the change.
   *
   *
   * @param applicationId: an identifier for the DAML application that

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
@@ -10,7 +10,12 @@ import java.time.Instant
   * Note that this is used for party-originating changes only. They are
   * usually issued via the Ledger API.
   *
-  * @param submitter: the party that submitted the change.
+  * @param actAs: the set of parties that submitted the change.
+  *
+  * @param readAs: the set of parties on whose behalf (in addition to all
+  *   parties listed in `actAs`) contracts can be retrieved.
+  *   This affects DAML operations such as `fetch`, `fetchByKey`, `lookupByKey`,
+  *   `exercise`, and `exerciseByKey`.
   *
   * @param applicationId: an identifier for the DAML application that
   *   submitted the command. This is used for monitoring and to allow DAML
@@ -26,11 +31,12 @@ import java.time.Instant
   *   command deduplication. If it chooses to do so, it must follow the
   *   same rules as the participant:
   *   - Deduplication is based on the (submitter, commandId) tuple.
-  *   - Commands must not be deduplicated after the `deduplicateUntil` time has passed.
+  *   - Commands must not be deduplicated after the deduplicateUntil time has passed.
   *   - Commands should not be deduplicated after the command was rejected.
   */
 final case class SubmitterInfo(
-    submitter: Party,
+    actAs: List[Party],
+    readAs: List[Party],
     applicationId: ApplicationId,
     commandId: CommandId,
     deduplicateUntil: Instant,

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Update.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/Update.scala
@@ -54,6 +54,9 @@ object Update {
 
   /** Signal that a party is hosted at a participant.
     *
+    * If a party with the given party identifier is already hosted at the given participant,
+    * then this update signals changes to party details (displayName, readOnly).
+    *
     * @param party
     *   The newly allocated party identifier.
     *
@@ -69,14 +72,18 @@ object Update {
     * @param submissionId
     *   The submissionId of the command which requested party to be added.
     *
+    * @param readOnly
+    *   True if the party is hosted in read-only mode.
+    *
     */
   final case class PartyAddedToParticipant(
       party: Party,
       displayName: String,
       participantId: ParticipantId,
       recordTime: Timestamp,
-      submissionId: Option[SubmissionId])
-      extends Update {
+      submissionId: Option[SubmissionId],
+      readOnly: Boolean,
+  ) extends Update {
     override def description: String =
       s"Add party '$party' to participant"
   }

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePartyService.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/WritePartyService.scala
@@ -27,13 +27,16 @@ trait WritePartyService {
     *
     * @param displayName  : A human readable name of the new party
     *
-    * @param submissionId: Client picked submission identifier for matching the responses with the request.
+    * @param submissionId : Client picked submission identifier for matching the responses with the request.
+    *
+    * @param readOnly     : True if the party should be hosted in read-only mode.
     *
     * @return an async result of a SubmissionResult
     */
   def allocateParty(
       hint: Option[Party],
       displayName: Option[String],
-      submissionId: SubmissionId
+      submissionId: SubmissionId,
+      readOnly: Boolean,
   ): CompletionStage[SubmissionResult]
 }


### PR DESCRIPTION
DO NOT MERGE

This draft serves as a base for discussions around multi-party submissions.

Note: this draft only contains changes to the participant state API. It will fail to build.

## Migration

Ledger implementations can use the following snippet to upgrade to the new `SubmitterInfo`:

```scala
if (submitterInfo.actAs.length == 1) {
  val submitter = submitterInfo.actAs.head
  // Previous code based on a single submitter
} else {
  grpcError(Status.UNIMPLEMENTED.withDescription("This ledger does not support multi-party submissions"))
}
```