### PR TITLE
Represent overlap modes at the type level.

### DIFF
--- a/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
+++ b/compiler/damlc/daml-compiler/src/DA/Daml/Compiler/DataDependencies.hs
@@ -459,8 +459,7 @@ generateSrcFromLf env = noLoc mod
         getOverlapMode :: LF.ExprValName -> Maybe (Located OverlapMode)
         getOverlapMode name = do
             dval <- NM.lookup (LFC.overlapModeName name) (LF.moduleValues (envMod env))
-            LF.EBuiltin (LF.BEText modeText) <- Just (LF.dvalBody dval)
-            mode <- LFC.decodeOverlapMode modeText
+            mode <- LFC.decodeOverlapMode (snd (LF.dvalBinder dval))
             Just (noLoc mode)
 
     hiddenRefMap :: HMS.HashMap Ref Bool

--- a/compiler/damlc/tests/daml-test-files/OverlapPragmas.daml
+++ b/compiler/damlc/tests/daml-test-files/OverlapPragmas.daml
@@ -6,10 +6,10 @@
 
 -- @QUERY-LF [ .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$fFooOptional0"]) ] | length == 1
 -- @QUERY-LF [ .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFooOptional0"]) ] == []
--- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFooOptional"]) | .expr.prim_lit | lf::get_text($pkg) == "OVERLAPPING"
--- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFoof"]) | .expr.prim_lit | lf::get_text($pkg) == "OVERLAPPABLE"
--- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFoox"]) | .expr.prim_lit | lf::get_text($pkg) == "OVERLAPS"
--- @QUERY-LF .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFooBool"]) | .expr.prim_lit | lf::get_text($pkg) == "INCOHERENT"
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFooOptional"]) | .type.struct.fields[0] | lf::get_field($pkg) == "OVERLAPPING"
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFoof"]) | .type.struct.fields[0] | lf::get_field($pkg) == "OVERLAPPABLE"
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFoox"]) | .type.struct.fields[0] | lf::get_field($pkg) == "OVERLAPS"
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFooBool"]) | .type.struct.fields[0] | lf::get_field($pkg) == "INCOHERENT"
 
 module OverlapPragmas where
 


### PR DESCRIPTION
On request by @hurryabit, this PR changes the representation of
overlap modes by moving it to the type-level. Since the value-level
encoding never made it into a stable release, this isn't a breaking
change. Also, the data-dependency and roundtrip tests are unchanged,
only the daml-test-files overlap mode test had to be updated.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
