### PR TITLE
daml-react: only log WS close as error on failure

### DIFF
--- a/language-support/ts/daml-react/createLedgerContext.ts
+++ b/language-support/ts/daml-react/createLedgerContext.ts
@@ -206,8 +206,12 @@ export function createLedgerContext(contextName="DamlLedgerContext"): LedgerCont
         stream.on('close', closeHandler);
       } else {
         stream.on('close', closeEvent => {
-          console.error(`${name}: web socket closed`, closeEvent);
-          setResult(result => setLoading(result, true));
+          if ( closeEvent.code === 4000 ) {
+            // deliberate call to .close, nothing to do
+          } else {
+            console.error(`${name}: WebSocket connection failed.`);
+            setResult(result => setLoading(result, true));
+          }
         });
       }
       return (): void => {


### PR DESCRIPTION
Fixes #7846.

CHANGELOG_BEGIN

- JavaScript Client Libraries: The family of React hooks `useStream*` was logging every `close` event as an error. However, there are legitimate cases for the connection to be closed (e.g. the component has been unmounted). The default behaviour will now be to log only unexpected disconnects and be silent on deliberate connection closes. The behaviour can be customized by passing a `onClose` callback; we strongly recommend passing such a callback to handle connection errors gracefully.

CHANGELOG_END