### PR TITLE
sign SDK Docker image

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -69,8 +69,14 @@ jobs:
 
           eval "$(dev-env/bin/dade-assist)"
           HEAD=$(git rev-parse HEAD)
-          while ! nix-build -A tools.sed -A tools.jq -A tools.curl nix; do :; done
+          while ! nix-build -A tools.sed -A tools.jq -A tools.curl -A tools.base64 nix; do :; done
+
+          trap 'rm -rf ~/.docker' EXIT
           echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
+          echo $DOCKER_CONTENT_TRUST_KEY | base64 -d > ~/.docker/da_automation.key
+          chmod 600 ~/.docker/da_automation.key
+          docker trust key load ~/.docker/da_automation.key --name $DOCKER_CONTENT_TRUST_USERNAME
+
           RELEASES=$(curl https://api.github.com/repos/digital-asset/daml/releases -s | jq -r '.[] | .tag_name')
           DIR=$(pwd)
           VERSIONS=$(curl 'https://hub.docker.com/v2/repositories/digitalasset/daml-sdk/tags/?page_size=10000' -s)
@@ -87,15 +93,15 @@ jobs:
               git checkout "$version"
               cd ci/docker/daml-sdk
               docker build -t digitalasset/daml-sdk:${version#v} --build-arg VERSION=${version#v} .
-              docker push digitalasset/daml-sdk:${version#v}
+              # Despite the name not suggesting it at all, this actually signs
+              # _and pushes_ the image; see
+              # https://docs.docker.com/engine/security/trust/#signing-images-with-docker-content-trust
+              docker trust sign digitalasset/daml-sdk:${version#v}
               cd "$DIR"
               git checkout $HEAD
               echo "Done."
             fi
           done
-        env:
-          DOCKER_LOGIN: $(DOCKER_LOGIN)
-          DOCKER_PASSWORD: $(DOCKER_PASSWORD)
       - template: ci/tell-slack-failed.yml
 
   - job: vscode_marketplace


### PR DESCRIPTION
Nobody should be using it anyway, but at least now they can trust it's from us. If they bother to check.

CHANGELOG_BEGIN

- The SDK Docker image is now signed. Reminder: this is a dev-only image, with absolutely no support for any kind of production use-case. To verify the signature, use the `docker trust inspect` command. You can also set the `DOCKER_CONTENT_TRUST` environment variable to 1 to instruct Docker commands to only pull and run signed images. Keep in mind, however, that this only checks that there is a signature, not that the signer is who you expect it to be. For optimal security, you should manually check the signature once with `docker trust inspect --pretty` and then pin the image hash rather than relying on tags.

  The expected output of the `docker sign inspect` command should mention a signer named `automation` with a public key ID matching 533a6e09faa512f974f217668580da1ceb6aa5b00aad34ea1240afc7d249703f (note that the `--pretty` output only shows the first 12 chars) and a repository key matching f5dc2aee6aed2d05d7eda75db7aa2b3fac7fc67afbb880d03535d5a5295a0d3b.

CHANGELOG_END