### PR TITLE
Avoid verbose mode in DAML Script and DAML triggers

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -170,7 +170,7 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
     val filter = transactionFilter(parties, templateId)
     val acsResponses =
       grpcClient.activeContractSetClient
-        .getActiveContracts(filter, verbose = true)
+        .getActiveContracts(filter, verbose = false)
         .runWith(Sink.seq)
     acsResponses.map(acsPages =>
       acsPages.flatMap(page =>

--- a/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
+++ b/triggers/runner/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Runner.scala
@@ -320,7 +320,7 @@ class Runner(
     // The transaction source (ledger).
     val transactionSource: Source[TriggerMsg, NotUsed] =
       client.transactionClient
-        .getTransactions(offset, None, filter, verbose = true)
+        .getTransactions(offset, None, filter, verbose = false)
         .map(TransactionMsg)
 
     // Command completion source (ledger completion stream +
@@ -514,7 +514,7 @@ class Runner(
       executionContext: ExecutionContext): Future[(Seq[CreatedEvent], LedgerOffset)] = {
     for {
       acsResponses <- client.activeContractSetClient
-        .getActiveContracts(transactionFilter, verbose = true)
+        .getActiveContracts(transactionFilter, verbose = false)
         .runWith(Sink.seq)
       offset = Array(acsResponses: _*).lastOption
         .fold(LedgerOffset().withBoundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN))(resp =>


### PR DESCRIPTION
We only expose the DAML values to users which don’t depend on this, so
we might as well avoid the unnecessary costs associated with verbose
mode especially since those are expected to increase in the
foreseeable future.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
