### PR TITLE
damlc: Rotate type checking of case expressions by 90 degrees

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -242,6 +242,9 @@ mkTFuns ts t = foldr (:->) t ts
 mkTApps :: Type -> [Type] -> Type
 mkTApps = curry (review _TApps)
 
+splitTApps :: Type -> (Type, [Type])
+splitTApps = view _TApps
+
 
 typeConAppToType :: TypeConApp -> Type
 typeConAppToType (TypeConApp tcon targs) = TConApp tcon targs

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -90,6 +90,7 @@ data Error
   | EExpectedStructType    !Type
   | EKindMismatch          {foundKind :: !Kind, expectedKind :: !Kind}
   | ETypeMismatch          {foundType :: !Type, expectedType :: !Type, expr :: !(Maybe Expr)}
+  | EPatternTypeMismatch   {pattern :: !CasePattern, scrutineeType :: !Type}
   | EExpectedHigherKind    !Kind
   | EExpectedFunctionType  !Type
   | EExpectedUniversalType !Type
@@ -236,6 +237,14 @@ instance Pretty Error where
       , nest 4 (pretty expectedKind)
       , "* found Kind:"
       , nest 4 (pretty foundKind)
+      ]
+    EPatternTypeMismatch{pattern, scrutineeType} ->
+      vcat $
+      [ "pattern type mismatch:"
+      , "* pattern:"
+      , nest 4 (pretty pattern)
+      , "* scrutinee type:"
+      , nest 4 (pretty scrutineeType)
       ]
 
     EExpectedFunctionType foundType ->


### PR DESCRIPTION
Currently, the Haskell implementation of the DAML-LF type checker
first branches on the pattern and then on the type of the scrutinee.
This PR changes it to first branch on the type of the scrutinee and
then on the pattern. This allows for destructing the type of the
scrutinee only once intead of repeating it for each pattern. This
should be good for performance, which is a nice side effect of this
change.

The main reason why I'm changing this is because we want to implement
an exhaustiveness check. This seems rather complicated to achieve with
the current implementation and will be significantly easier after this
change.

This PR is purely a refactoring and does not change the semantics of
amnything. In particular, it does not touch the decision that default
patterns match on anything, even no other pattern would match on the
value.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7873)
<!-- Reviewable:end -->
