### PR TITLE
add env vars back to azure-cron

### DIFF
--- a/azure-cron.yml
+++ b/azure-cron.yml
@@ -102,6 +102,14 @@ jobs:
               echo "Done."
             fi
           done
+        env:
+          DOCKER_LOGIN: $(DOCKER_LOGIN)
+          DOCKER_PASSWORD: $(DOCKER_PASSWORD)
+          DOCKER_CONTENT_TRUST_KEY: $(DOCKER_CONTENT_TRUST_KEY)
+          DOCKER_CONTENT_TRUST_USERNAME: $(DOCKER_CONTENT_TRUST_USERNAME)
+          # Does not appear explicitly in the script, but is used by
+          # docker trust key load
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: $(DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE)
       - template: ci/tell-slack-failed.yml
 
   - job: vscode_marketplace


### PR DESCRIPTION
Looks like I was wrong and [secret variables](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables) do indeed require explicit mapping:

> Unlike a normal variable, they are not automatically decrypted into environment variables for scripts. You need to explicitly map secret variables.

CHANGELOG_BEGIN
CHANGELOG_END