### PR TITLE
LF: Rotate type checking of case expressions by 90 degrees

### DIFF
--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -256,6 +256,16 @@ final case class ETypeMismatch(
        | * expected type: ${expectedType.pretty}
        | * found type: ${foundType.pretty}""".stripMargin
 }
+final case class EPatternTypeMismatch(
+    context: Context,
+    pattern: CasePat,
+    scrutineeType: Type,
+) extends ValidationError {
+  protected def prettyInternal: String =
+    s"""pattern type mismatch:
+       | * pattern: $pattern
+       | *  scrutinee type: ${scrutineeType.pretty}""".stripMargin
+}
 final case class EExpectedAnyType(context: Context, typ: Type) extends ValidationError {
   protected def prettyInternal: String =
     s"expected a type containing neither type variables nor quantifiers, but found: ${typ.pretty}"


### PR DESCRIPTION
reproduce changes made to the Haskell type checker (in #7873) in the
Scala type cheker.

CAHNGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
