### PR TITLE
DALF Reader: Refactor decoder environment

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -51,16 +51,16 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         None
       }
 
+    val env = DecoderEnv(
+      packageId,
+      internedStrings,
+      internedDottedNames,
+      Some(dependencyTracker),
+      None,
+      onlySerializableDataDefs,
+    )
     Package(
-      modules = lfPackage.getModulesList.asScala
-        .map(
-          ModuleDecoder(
-            packageId,
-            internedStrings,
-            internedDottedNames,
-            Some(dependencyTracker),
-            _,
-            onlySerializableDataDefs).decode),
+      modules = lfPackage.getModulesList.asScala.map(env.decodeModule(_)),
       directDeps = dependencyTracker.getDependencies,
       languageVersion = languageVersion,
       metadata = metadata,
@@ -102,14 +102,14 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
       throw ParseError(
         s"expected exactly one module in proto package, found ${lfScenarioModule.getModulesCount} modules")
 
-    ModuleDecoder(
+    DecoderEnv(
       packageId,
       internedStrings,
       internedDottedNames,
       None,
-      lfScenarioModule.getModules(0),
+      None,
       onlySerializableDataDefs = false
-    ).decode()
+    ).decodeModule(lfScenarioModule.getModules(0))
 
   }
 
@@ -146,17 +146,19 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
     def getDependencies: Set[PackageId] = deps.toSet
   }
 
-  case class ModuleDecoder(
+  case class DecoderEnv(
       packageId: PackageId,
       internedStrings: ImmArraySeq[String],
       internedDottedNames: ImmArraySeq[DottedName],
       optDependencyTracker: Option[PackageDependencyTracker],
-      lfModule: PLF.Module,
+      optModuleName: Option[ModuleName],
       onlySerializableDataDefs: Boolean
   ) {
 
-    private val moduleName: ModuleName =
-      handleDottedName(
+    private var currentDefinitionRef: Option[DefinitionRef] = None
+
+    def decodeModule(lfModule: PLF.Module): Module = {
+      val moduleName = handleDottedName(
         lfModule.getNameCase,
         PLF.Module.NameCase.NAME_DNAME,
         lfModule.getNameDname,
@@ -164,10 +166,10 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         lfModule.getNameInternedDname,
         "Module.name.name"
       )
+      copy(optModuleName = Some(moduleName)).decodeModuleWithName(lfModule, moduleName)
+    }
 
-    private var currentDefinitionRef: Option[DefinitionRef] = None
-
-    def decode(): Module = {
+    private def decodeModuleWithName(lfModule: PLF.Module, moduleName: ModuleName) = {
       val defs = mutable.ArrayBuffer[(DottedName, Definition)]()
       val templates = mutable.ArrayBuffer[(DottedName, Template)]()
 
@@ -416,20 +418,20 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
     private def decodeLocation(lfExpr: PLF.Expr, definition: String): Option[Location] =
       if (lfExpr.hasLocation && lfExpr.getLocation.hasRange) {
         val loc = lfExpr.getLocation
-        val (pkgId, module) =
+        val optModuleRef =
           if (loc.hasModule)
-            decodeModuleRef(loc.getModule)
+            Some(decodeModuleRef(loc.getModule))
           else
-            (packageId, moduleName)
-
-        val range = loc.getRange
-        Some(
+            optModuleName.map((packageId, _))
+        optModuleRef.map(moduleRef => {
+          val range = loc.getRange
           Location(
-            pkgId,
-            module,
+            moduleRef._1,
+            moduleRef._2,
             definition,
             (range.getStartLine, range.getStartCol),
-            (range.getEndLine, range.getEndCol)))
+            (range.getEndLine, range.getEndCol))
+        })
       } else {
         None
       }

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -423,15 +423,16 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
             Some(decodeModuleRef(loc.getModule))
           else
             optModuleName.map((packageId, _))
-        optModuleRef.map(moduleRef => {
-          val range = loc.getRange
-          Location(
-            moduleRef._1,
-            moduleRef._2,
-            definition,
-            (range.getStartLine, range.getStartCol),
-            (range.getEndLine, range.getEndCol))
-        })
+        optModuleRef.map {
+          case (pkgId, moduleName) =>
+            val range = loc.getRange
+            Location(
+              pkgId,
+              moduleName,
+              definition,
+              (range.getStartLine, range.getStartCol),
+              (range.getEndLine, range.getEndCol))
+        }
       } else {
         None
       }

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -45,28 +45,17 @@ class DecodeV1Spec
   val dummyModuleDName = DamlLf1.DottedName.newBuilder().addSegments(dummyModuleStr).build()
   val dummyModuleName = DottedName.assertFromString(dummyModuleStr)
 
-  private def dummyModule(version: LV.Minor, interningIdx: Int) = {
-    val builder = DamlLf1.Module.newBuilder()
-
-    if (LV.ordering.lt(LV(LV.Major.V1, version), LV.Features.internedDottedNames))
-      builder.setNameDname(dummyModuleDName)
-    else
-      builder.setNameInternedDname(interningIdx)
-
-    builder.build()
-  }
-
   private def moduleDecoder(
       minVersion: LV.Minor,
       stringTable: ImmArraySeq[String] = ImmArraySeq.empty,
       dottedNameTable: ImmArraySeq[DottedName] = ImmArraySeq.empty
   ) = {
-    new DecodeV1(minVersion).ModuleDecoder(
+    new DecodeV1(minVersion).DecoderEnv(
       Ref.PackageId.assertFromString("noPkgId"),
       stringTable,
-      dottedNameTable :+ dummyModuleName,
+      dottedNameTable,
       None,
-      dummyModule(minVersion, dottedNameTable.length),
+      Some(dummyModuleName),
       onlySerializableDataDefs = false
     )
   }


### PR DESCRIPTION
Currently, the module to be decoded is part of the decoder environment.
This turned out to be unpleasant during my attempts to implement
interning for types since decoding the type interning table does not
happen in the context of a module.

This PR moves the module out of the decoder environment and passes it
to the decoder function for modules directly. Unfornatunately, we still
need to keep the module name in the environment since that is used as a
default when decoding location information. We solve this problem by
making the module name in the environment optional and always filling
it in when decoding in actual module.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7891)
<!-- Reviewable:end -->
