### PR TITLE
damlc: Check DAML-LF pattern matches for exhaustiveness

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -38,7 +38,7 @@ import           Control.Lens hiding (Context, para)
 import           Control.Monad.Extra
 import           Data.Foldable
 import           Data.Functor
-import           Data.List
+import           Data.List.Extended
 import Data.Generics.Uniplate.Data (para)
 import qualified Data.HashSet as HS
 import qualified Data.Map.Strict as Map
@@ -399,14 +399,6 @@ missingMR AllRanks _ = Nothing
 missingMR (SomeRanks ks) n
     | Set.size ks == n = Nothing
     | otherwise = Set.lookupMin (Set.fromList [0..n-1] `Set.difference` ks)
-
-lookupWithIndex :: Eq a => a -> [(a, b)] -> Maybe (Int, b)
-lookupWithIndex = go 0
-  where
-    go !_ _ [] = Nothing
-    go !n a0 ((a, b):abs)
-        | a0 == a = Just (n, b)
-        | otherwise = go (n+1) a0 abs
 
 typeOfAlts :: MonadGamma m => (CaseAlternative -> m (MatchedRanks, Type)) -> [CaseAlternative] -> m (MatchedRanks, Type)
 typeOfAlts f alts = do

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -91,6 +91,7 @@ data Error
   | EKindMismatch          {foundKind :: !Kind, expectedKind :: !Kind}
   | ETypeMismatch          {foundType :: !Type, expectedType :: !Type, expr :: !(Maybe Expr)}
   | EPatternTypeMismatch   {pattern :: !CasePattern, scrutineeType :: !Type}
+  | ENonExhaustivePatterns {missingPattern :: !CasePattern, scrutineeType :: !Type}
   | EExpectedHigherKind    !Kind
   | EExpectedFunctionType  !Type
   | EExpectedUniversalType !Type
@@ -243,6 +244,14 @@ instance Pretty Error where
       [ "pattern type mismatch:"
       , "* pattern:"
       , nest 4 (pretty pattern)
+      , "* scrutinee type:"
+      , nest 4 (pretty scrutineeType)
+      ]
+    ENonExhaustivePatterns{missingPattern, scrutineeType} ->
+      vcat $
+      [ "non-exhaustive pattern match:"
+      , "* missing pattern:"
+      , nest 4 (pretty missingPattern)
       , "* scrutinee type:"
       , nest 4 (pretty scrutineeType)
       ]

--- a/libs-haskell/da-hs-base/src/Data/List/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Data/List/Extended.hs
@@ -3,7 +3,11 @@
 
 module Data.List.Extended
     ( spanMaybe
+    , lookupWithIndex
+    , module Data.List
     ) where
+
+import Data.List
 
 -- | Take from a list until a @Nothing@ is found, returning
 -- the prefix of @Just@ values, and the rest of the list.
@@ -19,3 +23,11 @@ spanMaybe f = go []
             | otherwise
             = (reverse bs, as)
 
+-- | Find a key in an associative list and return its index and value.
+lookupWithIndex :: Eq a => a -> [(a, b)] -> Maybe (Int, b)
+lookupWithIndex = go 0
+  where
+    go !_ _ [] = Nothing
+    go !n a0 ((a, b):abs)
+        | a0 == a = Just (n, b)
+        | otherwise = go (n+1) a0 abs


### PR DESCRIPTION
`damlc` has always produced exhaustive pattern matches in DAML-LF since
GHC adds a default branch with a call to `error` message as soon as a
pattern match is not exhaustive. It was a complete oversight on our
side that we did not enforce this properly in DAML-LF. Since `damlc`
has never produced non-exhaustive pattern matches, enforcing this now
and for all DAML-LF versions is only theoretically a breaking change,
namely if people hand-crafted DAML-LF, but not practically.

This check is as under-tested as the rest of our Haskell implementation
of the DAML-LF type checker. Well, all our other tests implicitly check
that the type checker does not give false errors. However, we have no
tests ensuring that the type checker is not too permissive. Fixing this
situation would require a big time investment since we currently don't
have a simple way to produce DAML-LF without going through GHC, which
will always produe well-typed DAML-LF.

I will update the DAML-LF specification wrt pattern matching
exhaustiveness in a separete PR.

This PR does not have a changelog entry since there's no impact for our
users.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7892)
<!-- Reviewable:end -->
