### PR TITLE
DAML-LF: Add interning for type to DAML-LF 1.dev

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -135,6 +135,14 @@ featureChoiceObservers = Feature
     , featureCppFlag = "DAML_CHOICE_OBSERVERS"
     }
 
+featureTypeInterning :: Feature
+featureTypeInterning = Feature
+    { featureName = "Type interning"
+    -- TODO Change as part of #7139
+    , featureMinVersion = versionDev
+    , featureCppFlag = "DAML_TYPE_INTERNING"
+    }
+
 allFeatures :: [Feature]
 allFeatures =
     [ featureNumeric

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/Error.hs
@@ -23,5 +23,6 @@ data Error
   | UnsupportedMinorVersion T.Text
   | BadStringId Int32
   | BadDottedNameId Int32
+  | BadTypeId Int32
   | ExpectedTCon Type
   deriving (Show, Eq)

--- a/compiler/damlc/tests/daml-test-files/FunctionalDependencies.daml
+++ b/compiler/damlc/tests/daml-test-files/FunctionalDependencies.daml
@@ -4,8 +4,8 @@
 -- Check that functional dependency metadata is added when available.
 
 -- @SINCE-LF 1.8
--- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$fdFoo"]) | .type | .forall | select(.vars | length == 2) | .body | .struct | .fields | length == 1
--- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$fdBar"]) | .type | .forall | select(.vars | length == 5) | .body | .struct | .fields | length == 3
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$fdFoo"]) | .type | lf::norm_ty($pkg) | .forall | select(.vars | length == 2) | .body | lf::norm_ty($pkg) | .struct | .fields | length == 1
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$fdBar"]) | .type | lf::norm_ty($pkg) | .forall | select(.vars | length == 5) | .body | lf::norm_ty($pkg) | .struct | .fields | length == 3
 module FunctionalDependencies where
 
 class Foo a b | a -> b where

--- a/compiler/damlc/tests/daml-test-files/InternedTypes.daml
+++ b/compiler/damlc/tests/daml-test-files/InternedTypes.daml
@@ -1,0 +1,24 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- Test that interning of types using hash-consing works. We particularly
+-- test that sharing works.
+-- The code below should produce the following type interning table:
+-- 0: a
+-- 1: b
+-- 2: $0 -> $1
+-- 3: $2 -> $2
+-- 4: forall a b. $3
+
+-- @TODO Change as part of #7139
+-- @SINCE-LF 1.dev
+-- @QUERY-LF .interned_types | (length == 5) and (.[0] | .var.var_interned_str | isnormal) and (.[1] | .var.var_interned_str | isnormal) and (.[2].prim | (.args | map(.interned) == [0, 1]) and (.prim == "ARROW")) and (.[3].prim | (.args | map(.interned) == [2, 2]) and (.prim == "ARROW")) and (.[4].forall.body.interned == 3)
+
+module InternedTypes where
+
+ap1: (a -> b) -> a -> b
+ap1 f x = f x
+
+-- A second copy to make sure we share across functions.
+ap2: (a -> b) -> (a -> b)
+ap2 f x = f x

--- a/compiler/damlc/tests/daml-test-files/InternedTypes.daml
+++ b/compiler/damlc/tests/daml-test-files/InternedTypes.daml
@@ -13,6 +13,7 @@
 -- @TODO Change as part of #7139
 -- @SINCE-LF 1.dev
 -- @QUERY-LF .interned_types | (length == 5) and (.[0] | .var.var_interned_str | isnormal) and (.[1] | .var.var_interned_str | isnormal) and (.[2].prim | (.args | map(.interned) == [0, 1]) and (.prim == "ARROW")) and (.[3].prim | (.args | map(.interned) == [2, 2]) and (.prim == "ARROW")) and (.[4].forall.body.interned == 3)
+-- @QUERY-LF [.modules[].values[]] | all(.name_with_type.type.interned == 4)
 
 module InternedTypes where
 

--- a/compiler/damlc/tests/daml-test-files/OverlapPragmas.daml
+++ b/compiler/damlc/tests/daml-test-files/OverlapPragmas.daml
@@ -6,10 +6,10 @@
 
 -- @QUERY-LF [ .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$fFooOptional0"]) ] | length == 1
 -- @QUERY-LF [ .modules[] | .values[] | select(.name_with_type | lf::get_value_name($pkg) == ["$$$$om$$fFooOptional0"]) ] == []
--- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFooOptional"]) | .type.struct.fields[0] | lf::get_field($pkg) == "OVERLAPPING"
--- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFoof"]) | .type.struct.fields[0] | lf::get_field($pkg) == "OVERLAPPABLE"
--- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFoox"]) | .type.struct.fields[0] | lf::get_field($pkg) == "OVERLAPS"
--- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFooBool"]) | .type.struct.fields[0] | lf::get_field($pkg) == "INCOHERENT"
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFooOptional"]) | .type | lf::norm_ty($pkg) | .struct.fields[0] | lf::get_field($pkg) == "OVERLAPPING"
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFoof"]) | .type | lf::norm_ty($pkg) | .struct.fields[0] | lf::get_field($pkg) == "OVERLAPPABLE"
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFoox"]) | .type | lf::norm_ty($pkg) | .struct.fields[0] | lf::get_field($pkg) == "OVERLAPS"
+-- @QUERY-LF .modules[] | .values[] | .name_with_type | select(lf::get_value_name($pkg) == ["$$$$om$$fFooBool"]) | .type | lf::norm_ty($pkg) | .struct.fields[0] | lf::get_field($pkg) == "INCOHERENT"
 
 module OverlapPragmas where
 

--- a/compiler/damlc/tests/src/query-lf-interned.jq
+++ b/compiler/damlc/tests/src/query-lf-interned.jq
@@ -17,3 +17,5 @@ def get_field(pkg): .field_interned_str | resolve_interned_string(pkg);
 def get_name(pkg): .name_interned_str | resolve_interned_string(pkg);
 
 def get_text(pkg): .text_interned_str | resolve_interned_string(pkg);
+
+def norm_ty(pkg): if has("interned") then pkg.interned_types[.interned] else . end;

--- a/compiler/damlc/tests/src/query-lf-non-interned.jq
+++ b/compiler/damlc/tests/src/query-lf-non-interned.jq
@@ -13,3 +13,5 @@ def get_field(pkg): .field_str;
 def get_name(pkg): .name_str;
 
 def get_text(pkg): .text_str;
+
+def norm_ty(pkg): .;

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -44,8 +44,9 @@
 //        2019-11-12: Add Generic Map (GenMap)
 //        2019-12-03: Add (experimental) text primitives.
 //        2019-12-05: Add Generic Equality builtin
-//        2019-13-10: Add ExerciseByKey Update
-//        2020-10-??: Add choice-observers
+//        2019-10-13: Add ExerciseByKey Update
+//        2020-11-04: Add interning of types
+//        2020-11-??: Add choice-observers
 
 syntax = "proto3";
 package daml_lf_1;
@@ -397,6 +398,8 @@ message Type {
     // use standard signed long for future usage.
     sint64 nat = 11;
     Syn syn = 12; // *Available in versions >= 1.8*
+
+    int32 interned = 13; // *Available in versions >= 1.dev*
   }
 
   reserved 6; // This was list. Removed in favour of PrimType.LIST
@@ -1480,4 +1483,8 @@ message Package {
   repeated string interned_strings = 2; // *Available in versions >= 1.6*
   repeated InternedDottedName interned_dotted_names = 3; // *Available in versions >= 1.7*
   PackageMetadata metadata = 4; // *Available and required in versions >= 1.8*
+
+  // Types in the interning table are only allowed to refer to interned types
+  // at smaller indices.
+  repeated Type interned_types = 5; // *Available in versions >= 1.dev*
 }

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -55,7 +55,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
       packageId,
       internedStrings,
       internedDottedNames,
-      IndexedSeq(),
+      IndexedSeq.empty,
       Some(dependencyTracker),
       None,
       onlySerializableDataDefs,
@@ -110,7 +110,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
       packageId,
       internedStrings,
       internedDottedNames,
-      IndexedSeq(),
+      IndexedSeq.empty,
       None,
       None,
       onlySerializableDataDefs = false
@@ -680,11 +680,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
                 identity
               ))
         case PLF.Type.SumCase.INTERNED =>
-          val index = lfType.getInterned
-          if (internedTypes.isDefinedAt(index))
-            internedTypes(index)
-          else
-            throw ParseError(s"invalid internedTypes table index $index")
+          internedTypes.applyOrElse(lfType.getInterned, (index: Int) => throw ParseError(s"invalid internedTypes table index $index"))
         case PLF.Type.SumCase.SUM_NOT_SET =>
           throw ParseError("Type.SUM_NOT_SET")
       }

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -54,6 +54,7 @@ class DecodeV1Spec
       Ref.PackageId.assertFromString("noPkgId"),
       stringTable,
       dottedNameTable,
+      IndexedSeq(),
       None,
       Some(dummyModuleName),
       onlySerializableDataDefs = false

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -65,6 +65,7 @@ object LanguageVersion {
     val scenarioMustFailAtMsg = v1_dev
     val contractIdTextConversions = v1_dev
     val exerciseByKey = v1_dev
+    val internedTypes = v1_dev
 
     /** Unstable, experimental features. This should stay in 1.dev forever.
       * Features implemented with this flag should be moved to a separate

--- a/libs-haskell/da-hs-base/src/Data/Vector/Extended.hs
+++ b/libs-haskell/da-hs-base/src/Data/Vector/Extended.hs
@@ -1,0 +1,31 @@
+-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+module Data.Vector.Extended (
+    module Data.Vector,
+    constructNE,
+) where
+
+import Control.Monad.ST
+import Data.Vector
+import qualified Data.Vector.Mutable as M
+
+-- | /O(n)/ Construct a vector with @n@ elements by repeatedly applying the
+-- generator function to the already constructed part of the vector and the
+-- index of the current element to construct.
+constructNE :: forall a e. Int -> (Vector a -> Int -> Either e a) -> Either e (Vector a)
+-- NOTE(MH): This is a copy of `Data.Vector.constructN` with small modifications
+-- to pass the current index to `f` and to run in the `Either` monad.
+constructNE !n f = runST $ do
+    v  <- M.new n
+    v' <- unsafeFreeze v
+    fill v' 0
+  where
+    fill :: forall s. Vector a -> Int -> ST s (Either e (Vector a))
+    fill !v i | i < n = case f (unsafeTake i v) i of
+        Left e -> return (Left e)
+        Right x -> seq x $ do
+            v'  <- unsafeThaw v
+            M.unsafeWrite v' i x
+            v'' <- unsafeFreeze v'
+            fill v'' (i+1)
+    fill v _ = return (Right v)


### PR DESCRIPTION
We add two new features to DAML-LF 1.dev:

* a per package list (or table) of `Type` messages, and
* a new case in the `Type` message which is an index into this table.

In combination, these two features can be used to allow DAML-LF
encoders to perform hash-consing of `Type` messages. We also change the
Haskell implementation of our DAML-LF encoder to do exactly that when
targetting DAML-LF 1.dev.

Doing this has a few benefits:

1. The DALFs produced by `damlc` get smaller: I've seen a case where
   the size dropped from 69MB to 45MB.
2. DAML-LF decoders need to decode less data.
3. Decoded packages use less memory because identical structures are
   now shared. This is particularly helpful in situations where we need
   to keep the interface (or signature) of a package in memory for a
   long time.

This PR mostly takes care of the Haskell implementation. However, we
need to make the Scala implementation of the decoder aware of the new
features as well since we have tests that load DAML-LF 1.dev into the
engine. A decoder and _targeted_ tests on the Scala side will follow
in a separate PR.

CHANGELOG_BEGIN
CHANGELOG_END