### PR TITLE
Haskell: Add hlint rule to suggest foldl' over foldl

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -34,6 +34,9 @@
 # Off by default hints we like
 - warn: {name: Use module export list}
 
+# Performance foot guns
+- warn: {lhs: foldl, rhs: "foldl'"}
+
 # Condemn nub and friends
 - warn: {lhs: nub (sort x), rhs: Data.List.Extra.nubSort x}
 - warn: {lhs: nub, rhs: Data.List.Extra.nubOrd}
@@ -53,7 +56,7 @@
 - warn: {lhs: Data.Text.Lazy.readFile, rhs: Data.Text.Extended.readFileUtf8}
 - warn: {lhs: Data.Text.Lazy.writeFile, rhs: Data.Text.Extended.writeFileUtf8}
 - warn: {lhs: System.Environment.setEnv, rhs: System.Environment.Blank.setEnv}
-- warn: {lhs: toNormalizedFilePath, rhs: toNormalizedFilePath'}
+- warn: {lhs: toNormalizedFilePath, rhs: "toNormalizedFilePath'"}
 
 # Hints that do not always make sense
 - ignore: {name: "Use if", within: [DA.Daml.LF.Proto3.EncodeV1, DA.Daml.LF.Ast.Pretty]}

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Util.hs
@@ -5,6 +5,7 @@
 module DA.Daml.LF.Ast.Util(module DA.Daml.LF.Ast.Util) where
 
 import Control.Monad
+import Data.List
 import Data.Maybe
 import qualified Data.Text as T
 import           Control.Lens
@@ -191,7 +192,7 @@ pattern TTextMapEntry a = TStruct [(FieldName "key", TText), (FieldName "value",
 pattern TConApp :: Qualified TypeConName -> [Type] -> Type
 pattern TConApp tcon targs <- (view (leftSpine _TApp) -> (TCon tcon, targs))
   where
-    TConApp tcon targs = foldl TApp (TCon tcon) targs
+    TConApp tcon targs = foldl' TApp (TCon tcon) targs
 
 pattern TForalls :: [(TypeVarName, Kind)] -> Type -> Type
 pattern TForalls binders ty <- (view _TForalls -> (binders, ty))

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -778,7 +778,7 @@ decodeType LF1.Type{..} = mayDecode "typeSum" typeSum $ \case
     TStruct <$> mapM (decodeFieldWithType FieldName) (V.toList flds)
   where
     decodeWithArgs :: V.Vector LF1.Type -> Decode Type -> Decode Type
-    decodeWithArgs args fun = foldl TApp <$> fun <*> traverse decodeType args
+    decodeWithArgs args fun = foldl' TApp <$> fun <*> traverse decodeType args
 
 
 decodeFieldWithType :: (T.Text -> a) -> LF1.FieldWithType -> Decode (a, Type)

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1671,7 +1671,7 @@ convertType env = go env
             erasedTy env
 
         | t == funTyCon, _:_:ts' <- ts =
-            foldl TApp TArrow <$> mapM (go env) ts'
+            foldl' TApp TArrow <$> mapM (go env) ts'
         | NameIn DA_Internal_LF "Pair" <- t
         , [StrLitTy f1, StrLitTy f2, t1, t2] <- ts = do
             t1 <- go env t1

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/Records.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor/Records.hs
@@ -167,7 +167,7 @@ onExp (L o (SectionR _ mid@(isDot -> True) rhs))
         -- don't need it when the record type is unknown. When the record type
         -- is known, the conversion to DAML-LF needs to add the lambda anyway.
         [sel] -> mkVar var_getField `mkAppType` sel
-        _:_:_ -> mkLam var_record $ foldl (\x sel -> mkVar var_getField `mkAppType` sel `mkApp` x) (mkVar var_record) sels
+        _:_:_ -> mkLam var_record $ foldl' (\x sel -> mkVar var_getField `mkAppType` sel `mkApp` x) (mkVar var_record) sels
           where
             var_record = GHC.mkRdrUnqual $ GHC.mkVarOcc "record"
 

--- a/language-support/hs/bindings/examples/chat/src/DA/Ledger/App/Chat/Interact.hs
+++ b/language-support/hs/bindings/examples/chat/src/DA/Ledger/App/Chat/Interact.hs
@@ -7,6 +7,7 @@ module DA.Ledger.App.Chat.Interact (InteractState(..), makeInteractState, runSub
 
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar
+import Data.List
 import DA.Ledger.App.Chat.ChatLedger (Handle,sendCommand,getTrans)
 import DA.Ledger.App.Chat.Contracts (ChatContract)
 import DA.Ledger.App.Chat.Domain (Party)
@@ -51,7 +52,7 @@ manageUpdates :: Handle -> Party -> Logger -> MVar State -> IO (Stream ChatContr
 manageUpdates h whoami log sv = do
     PastAndFuture{past,future} <- getTrans whoami h
     log $ "replaying " <> show (length past) <> " transactions"
-    modifyMVar_ sv (\s -> return $ foldl (applyTransQuiet whoami) s past)
+    modifyMVar_ sv (\s -> return $ foldl' (applyTransQuiet whoami) s past)
     withMVar sv $ \s -> sendShowingRejection whoami h log (introduceEveryone whoami s)
     _ <- forkIO (updateX h whoami log sv future)
     return future

--- a/libs-haskell/da-hs-base/src/Control/Lens/Ast.hs
+++ b/libs-haskell/da-hs-base/src/Control/Lens/Ast.hs
@@ -8,6 +8,7 @@ module Control.Lens.Ast
   ) where
 
 import Control.Lens
+import Data.List
 
 -- $setup
 -- The examples for 'leftSpine' and 'rightSpine' assume we have the following
@@ -34,7 +35,7 @@ leftSpine p = iso unwindl rewindl
         go e0 as = case matching p e0 of
           Left   e1     -> (e1, as)
           Right (e1, a) -> go e1 (a:as)
-    rewindl (e0, as) = foldl (curry (p #)) e0 as
+    rewindl (e0, as) = foldl' (curry (p #)) e0 as
 
 -- | Analogue of 'leftSpine' for right associative constructors.
 --

--- a/libs-haskell/da-hs-base/src/Data/NameMap.hs
+++ b/libs-haskell/da-hs-base/src/Data/NameMap.hs
@@ -132,7 +132,7 @@ traverse f (NameMap ras _) = build <$> Prelude.traverse f' (reverse ras)
     build as = NameMap (reverse as) (HMS.fromList as)
 
 instance Foldable NameMap where
-  foldr f z (NameMap ras _) = foldl f' z ras
+  foldr f z (NameMap ras _) = foldl' f' z ras
     where
       f' acc (_, x) = f x acc
 


### PR DESCRIPTION
`foldl` is lazy in a way that almost never is what you want since it
can cause space leaks without any benefit. `foldl'` does not have this
problem. See https://www.well-typed.com/blog/2014/04/fixing-foldl/ for
more details.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7897)
<!-- Reviewable:end -->
