### PR TITLE
Improve error on query failures in toACS

### DIFF
--- a/triggers/daml/Daml/Trigger/Assert.daml
+++ b/triggers/daml/Daml/Trigger/Assert.daml
@@ -41,10 +41,14 @@ buildACS party (ACSBuilder fetches) = do
     , pendingContracts = Map.empty
     }
 
--- | Include the given contract in the 'ACS'.
+-- | Include the given contract in the 'ACS'. Note that the `ContractId`
+-- must point to an active contract.
 toACS : Template t => ContractId t -> ACSBuilder
 toACS cid = ACSBuilder $ \p ->
-  [ do Some t <- queryContractId p cid
+  [ do t <-
+         queryContractId p cid >>= \case
+           None -> abort ("Failed to fetch contract passed to toACS: " <> show cid)
+           Some c -> pure c
        pure (toAnyContractId cid, toAnyTemplate t)
   ]
 


### PR DESCRIPTION
Getting a pattern match failure here if you accidentally pass in an
archived contract is a bit cruel and now that this is DAML Script
where we can handle the failure, we can do better.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
