### PR TITLE
Expose Event from the high-level trigger API

### DIFF
--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -35,6 +35,11 @@ module Daml.Trigger
  , Message(..)
  , Completion(..)
  , Transaction(..)
+ , Event(..)
+ , Created
+ , Archived
+ , fromCreated
+ , fromArchived
  , CompletionStatus(..)
  , RegisteredTemplates(..)
  , registeredTemplate


### PR DESCRIPTION
This allows you to write somewhat useful update functions since you
can inspect the transactions. Created and Archived are kept abstract
but we expose fromCreated/fromArchived to interact with them.

fixes #6968

changelog_begin

- [DAML Triggers] The `Daml.Trigger` module now reexports `Event`
  which avoids having to import `Daml.Trigger.LowLevel` for implementing
  a non-trivial `updateState` function.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
