### PR TITLE
Support multiple --dar options in the trigger service

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -412,7 +412,7 @@ object Server {
       authConfig: AuthConfig,
       ledgerConfig: LedgerConfig,
       restartConfig: TriggerRestartConfig,
-      initialDar: Option[Dar[(PackageId, DamlLf.ArchivePayload)]],
+      initialDars: List[Dar[(PackageId, DamlLf.ArchivePayload)]],
       jdbcConfig: Option[JdbcConfig],
       initDb: Boolean,
   ): Behavior[Message] = Behaviors.setup { implicit ctx =>
@@ -466,7 +466,7 @@ object Server {
         }
     }
 
-    initialDar foreach { dar =>
+    initialDars foreach { dar =>
       server.addDar(dar) match {
         case Left(err) =>
           ctx.log.error("Failed to upload provided DAR.\n" ++ err)

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -15,9 +15,9 @@ import scala.concurrent.duration
 import scala.concurrent.duration.FiniteDuration
 
 private[trigger] final case class ServiceConfig(
-    // For convenience, we allow passing in a DAR on startup
-    // as opposed to uploading it dynamically.
-    darPath: Option[Path],
+    // For convenience, we allow passing DARs on startup
+    // as opposed to uploading them dynamically.
+    darPaths: List[Path],
     address: String,
     httpPort: Int,
     ledgerHost: String,
@@ -87,7 +87,8 @@ private[trigger] object ServiceConfig {
 
     opt[String]("dar")
       .optional()
-      .action((f, c) => c.copy(darPath = Some(Paths.get(f))))
+      .unbounded()
+      .action((f, c) => c.copy(darPaths = Paths.get(f) :: c.darPaths))
       .text("Path to the dar file containing the trigger.")
 
     cliopts.Http.serverParse(this, serviceName = "Trigger")(
@@ -161,7 +162,7 @@ private[trigger] object ServiceConfig {
     parser.parse(
       args,
       ServiceConfig(
-        darPath = None,
+        darPaths = Nil,
         address = cliopts.Http.defaultAddress,
         httpPort = DefaultHttpPort,
         ledgerHost = null,


### PR DESCRIPTION
Limiting this to a single one makes little sense and while you can
work around it by uploading more packages, that can be annoying during
development.

fixes #6332

changelog_begin

- [Triggers] The trigger service now accepts multiple `--dar`` options.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
