### PR TITLE
Add a --port-file option to the trigger service

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -43,6 +43,7 @@ da_scala_library(
         "//ledger/ledger-api-client",
         "//ledger/ledger-api-common",
         "//libs-scala/contextualized-logging",
+        "//libs-scala/ports",
         "//libs-scala/scala-utils",
         "//triggers/runner:trigger-runner-lib",
         "//triggers/service/auth:oauth-middleware",  # TODO[AH] Extract request/response types

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -30,6 +30,7 @@ private[trigger] final case class ServiceConfig(
     commandTtl: Duration,
     init: Boolean,
     jdbcConfig: Option[JdbcConfig],
+    portFile: Option[Path],
 )
 
 final case class JdbcConfig(
@@ -94,7 +95,7 @@ private[trigger] object ServiceConfig {
       address = (f, c) => c.copy(address = f(c.address)),
       httpPort = (f, c) => c.copy(httpPort = f(c.httpPort)),
       defaultHttpPort = Some(DefaultHttpPort),
-      portFile = None,
+      portFile = Some((f, c) => c.copy(portFile = f(c.portFile))),
     )
 
     opt[String]("ledger-host")
@@ -174,6 +175,7 @@ private[trigger] object ServiceConfig {
         commandTtl = Duration.ofSeconds(30L),
         init = false,
         jdbcConfig = None,
+        portFile = None,
       ),
     )
 }


### PR DESCRIPTION
fixes #7097

changelog_begin

- [Triggers] The trigger service now has a `--port-file` option
  matching the corresponding option in the JSON API.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
