### PR TITLE
damlc: Don't warn on TypeOperators and UndecidableInstances

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -286,6 +286,10 @@ dataDependableExtensions = ES.fromList $ xExtensionsSet ++
   , InstanceSigs
     -- convenient syntactic sugar that does not impact the type level at all
   , MultiWayIf
+    -- the two extensions don't require any additional support for
+    -- data-dependencies to work, except for putting them into the files used
+    -- for reconstructing the interfaces, which we already do
+  , TypeOperators, UndecidableInstances
     -- there's no way for our users to actually use this and listing it here
     -- removes a lot of warning from out stdlib, script and trigger builds
     -- NOTE: This should not appear on any list of extensions that are


### PR DESCRIPTION
Currently, we're warning that both extensions might not work with
`data-dependencies`. However, we have tests that demonstrate that both
extensions actually do work with `data-dependencies`. Since there's
been customer demand to remove these warnings, we'll do so.

CHANGELOG_BEGIN
[damlc] Don't warn anymore that the language extensions TypeOperators
and UndecidableInstances might not work with `data-dependencies`.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7909)
<!-- Reviewable:end -->
