### PR TITLE
Replace com.digitalasset.platform with com.daml.platform

### DIFF
--- a/BAZEL.md
+++ b/BAZEL.md
@@ -402,24 +402,25 @@ detailed information.
 - Execute a specific Scala test-suite class
 
     ```
-    bazel test //ledger/sandbox:sandbox-scala-tests_test_suite_src_test_suite_scala_com_digitalasset_platform_sandbox_stores_ledger_sql_JdbcLedgerDaoSpec.scala
+    bazel test //ledger/participant-integration-api:participant-integration-api-tests_test_suite_src_test_suite_scala_platform_store_dao_JdbcLedgerDaoPostgresqlSpec.scala
     ```
 
 - Execute a test with a specific name
 
     ```
     bazel test \
-    //ledger/sandbox:sandbox-scala-tests_test_suite_src_test_suite_scala_com_digitalasset_platform_sandbox_stores_ledger_sql_JdbcLedgerDaoSpec.scala \
+    //ledger/participant-integration-api:participant-integration-api-tests_test_suite_src_test_suite_scala_platform_store_dao_JdbcLedgerDaoPostgresqlSpec.scala \
       --test_arg=-t \
-      --test_arg="JDBC Ledger DAO should be able to persist and load contracts without external offset"
+      --test_arg="JdbcLedgerDao (divulgence) should preserve divulged contracts"
     ```
 
-- Pass an argument to a test case in a Scala test-suite
+- Execute tests that include a string in their name
 
     ```
-    bazel test //ledger/sandbox:sandbox-scala-tests_test_suite_src_test_suite_scala_com_digitalasset_platform_sandbox_stores_ledger_sql_JdbcLedgerDaoSpec.scala \
+    bazel test \
+    //ledger/participant-integration-api:participant-integration-api-tests_test_suite_src_test_suite_scala_platform_store_dao_JdbcLedgerDaoPostgresqlSpec.scala \
       --test_arg=-z \
-      --test_arg="should return true"
+      --test_arg="preserve divulged"
     ```
 
     More broadly, for Scala tests you can pass through any of the args outlined in http://www.scalatest.org/user_guide/using_the_runner, separating into two instances of the --test-arg parameter as shown in the two examples above.

--- a/docs/source/daml-integration-kit/index.rst
+++ b/docs/source/daml-integration-kit/index.rst
@@ -250,7 +250,7 @@ this section is best read jointly with the code in
   See documentation in
   `package.scala <https://github.com/digital-asset/daml/blob/master/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala>`__
 
-``ledger-api-server.jar`` (`source code for API server <https://github.com/digital-asset/daml/blob/master/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala>`__, `source code for indexer <https://github.com/digital-asset/daml/blob/master/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala>`__)
+``ledger-api-server.jar`` (`source code for API server <https://github.com/digital-asset/daml/blob/master/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala>`__, `source code for indexer <https://github.com/digital-asset/daml/blob/master/ledger/sandbox/src/main/scala/com/daml/platform/indexer/StandaloneIndexerServer.scala>`__)
   Contains code that implements a DAML Ledger API server and the SQL-backed indexer
   given implementations of the interfaces in ``participant-state.jar``.
 
@@ -313,10 +313,10 @@ of their qualified names where unambiguous):
   is a class implementing the ``ReadService`` and the
   ``WriteService`` on top of the ``<X> services``. You need to implement this
   for your DAML on `X` ledger.
-``StandaloneIndexerServer`` (`source code <https://github.com/digital-asset/daml/blob/master/ledger/sandbox/src/main/scala/com/digitalasset/platform/indexer/StandaloneIndexerServer.scala>`__)
+``StandaloneIndexerServer`` (`source code <https://github.com/digital-asset/daml/blob/master/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala>`__)
   is a standalone service that subscribe to ledger changes using ``ReadService`` and inserts
   the data into a SQL backend ("index") for the purpose of serving the data over the Ledger API.
-``StandaloneIndexServer`` (`source code <https://github.com/digital-asset/daml/blob/master/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/StandaloneApiServer.scala>`__)
+``StandaloneIndexServer`` (`source code <https://github.com/digital-asset/daml/blob/master/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala>`__)
   is a class containing all the code to implement the
   Ledger API on top of an ledger backend. It serves the data from a SQL database populated by the ``StandaloneIndexerServer``.
 
@@ -350,7 +350,7 @@ do the following modifications to your code:
 - Instantiate a ``com.daml.ledger.api.auth.interceptor.AuthorizationInterceptor`` (`source code <https://github.com/digital-asset/daml/blob/master/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/interceptor/AuthorizationInterceptor.scala>`__),
   and pass it an instance of your AuthService implementation.
   This interceptor will be responsible for storing the decoded Claims in a place where ledger API services can access them.
-- When starting the ``com.daml.platform.apiserver.LedgerApiServer`` (`source code <https://github.com/digital-asset/daml/blob/master/ledger/sandbox/src/main/scala/com/digitalasset/platform/apiserver/LedgerApiServer.scala>`__),
+- When starting the ``com.daml.platform.apiserver.LedgerApiServer`` (`source code <https://github.com/digital-asset/daml/blob/master/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala>`__),
   add the above AuthorizationInterceptor to the list of interceptors (see ``interceptors`` parameter of ``LedgerApiServer.create``).
 
 For reference, you can have a look at how authorization is implemented in the sandbox:

--- a/ledger/participant-state/kvutils/app/src/main/resources/com/daml/ledger/participant/state/kvutils/app/logback.base.xml
+++ b/ledger/participant-state/kvutils/app/src/main/resources/com/daml/ledger/participant/state/kvutils/app/logback.base.xml
@@ -16,13 +16,13 @@
     </root>
 
     <!-- Disable noisy DB logging at the start of sandbox -->
-    <logger name="com.digitalasset.platform.store.FlywayMigrations" level="WARN" />
+    <logger name="com.daml.platform.store.FlywayMigrations" level="WARN" />
     <logger name="org.flywaydb" level="ERROR" />
     <logger name="com.zaxxer.hikari" level="ERROR" />
-    <logger name="com.digitalasset.platform" level="WARN" />
+    <logger name="com.daml.platform" level="WARN" />
 
     <!-- raising the command tracker logging level -->
-    <logger name="com.digitalasset.platform.apiserver.services.tracking.TrackerMap" level="WARN" />
+    <logger name="com.daml.platform.apiserver.services.tracking.TrackerMap" level="WARN" />
 
     <logger name="io.netty" level="WARN" additivity="false">
         <appender-ref ref="STDOUT"/>

--- a/ledger/sandbox-common/src/main/resources/logback.xml
+++ b/ledger/sandbox-common/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
     </appender>
 
     <!-- Disable noisy DB logging at the start of sandbox -->
-    <logger name="com.digitalasset.platform.store.FlywayMigrations" level="WARN" />
+    <logger name="com.daml.platform.store.FlywayMigrations" level="WARN" />
     <logger name="org.flywaydb" level="ERROR" />
     <logger name="com.zaxxer.hikari" level="ERROR" />
     <logger name="com.daml.ledger.on.sql" level="WARN" />


### PR DESCRIPTION
Replace straggler references to com.digitalasset.platform to com.daml.platform in logback configs and documentations