### PR TITLE
hlint: Suggest fmap f . V.fromList over V.fromList . map f

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -37,6 +37,13 @@
 # Performance foot guns
 - warn: {lhs: foldl, rhs: "foldl'"}
 
+# Mapping over a vector uses less memory than mapping over a list
+- warn: {name: Map vector not list, lhs: Data.Vector.fromList (map f x), rhs: fmap f (Data.Vector.fromList x)}
+- warn: {name: Map vector not list, lhs: fmap Data.Vector.fromList (mapM f x), rhs: mapM f (Data.Vector.fromList x)}
+- warn: {name: Map vector not list, lhs: Data.Vector.fromList <$> mapM f x, rhs: mapM f (Data.Vector.fromList x)}
+- warn: {name: Map vector not list, lhs: fmap Data.Vector.fromList (traverse f x), rhs: traverse f (Data.Vector.fromList x)}
+- warn: {name: Map vector not list, lhs: Data.Vector.fromList <$> traverse f x, rhs: traverse f (Data.Vector.fromList x)}
+
 # Condemn nub and friends
 - warn: {lhs: nub (sort x), rhs: Data.List.Extra.nubSort x}
 - warn: {lhs: nub, rhs: Data.List.Extra.nubOrd}

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -189,10 +189,10 @@ encodePackageRef = fmap (Just . P.PackageRef . Just) . \case
 ------------------------------------------------------------------------
 
 encodeList :: (a -> Encode b) -> [a] -> Encode (V.Vector b)
-encodeList encodeElem = fmap V.fromList . mapM encodeElem
+encodeList encodeElem = mapM encodeElem . V.fromList
 
 encodeNameMap :: NM.Named a => (a -> Encode b) -> NM.NameMap a -> Encode (V.Vector b)
-encodeNameMap encodeElem = fmap V.fromList . mapM encodeElem . NM.toList
+encodeNameMap encodeElem = mapM encodeElem . V.fromList . NM.toList
 
 encodeQualTypeSynName' :: Qualified TypeSynName -> Encode P.TypeSynName
 encodeQualTypeSynName' (Qualified pref mname syn) = do
@@ -858,9 +858,9 @@ encodePackage (Package version mods metadata) =
         ((packageModules, packageMetadata), EncodeEnv{internedStrings, internedDottedNames}) =
             runState ((,) <$> encodeNameMap encodeModule mods <*> traverse encodePackageMetadata metadata) env
         packageInternedStrings =
-            V.fromList $ map (encodeString . fst) $ L.sortOn snd $ HMS.toList internedStrings
+            fmap (encodeString . fst) $ V.fromList $ L.sortOn snd $ HMS.toList internedStrings
         packageInternedDottedNames =
-            V.fromList $ map (P.InternedDottedName . V.fromList . fst) $ L.sortOn snd $ HMS.toList internedDottedNames
+            fmap (P.InternedDottedName . V.fromList . fst) $ V.fromList $ L.sortOn snd $ HMS.toList internedDottedNames
     in
     P.Package{..}
 

--- a/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/ScenarioServiceClient/LowLevel.hs
@@ -282,7 +282,7 @@ gcCtxs Handle{..} ctxIds = do
         performRequest
             (SS.scenarioServiceGCContexts hClient)
             (optRequestTimeout hOptions)
-            (SS.GCContextsRequest (V.fromList (map getContextId ctxIds)))
+            (SS.GCContextsRequest (fmap getContextId (V.fromList ctxIds)))
     pure (void res)
 
 updateCtx :: Handle -> ContextId -> ContextUpdate -> IO (Either BackendError ())
@@ -300,12 +300,12 @@ updateCtx Handle{..} (ContextId ctxId) ContextUpdate{..} = do
   where
     updModules =
       SS.UpdateContextRequest_UpdateModules
-        (V.fromList (map convModule updLoadModules))
-        (V.fromList (map encodeName updUnloadModules))
+        (fmap convModule (V.fromList updLoadModules))
+        (fmap encodeName (V.fromList updUnloadModules))
     updPackages =
       SS.UpdateContextRequest_UpdatePackages
-        (V.fromList (map snd updLoadPackages))
-        (V.fromList (map (TL.fromStrict . LF.unPackageId) updUnloadPackages))
+        (fmap snd (V.fromList updLoadPackages))
+        (fmap (TL.fromStrict . LF.unPackageId) (V.fromList updUnloadPackages))
     encodeName = TL.fromStrict . mangleModuleName
     convModule :: (LF.ModuleName, BS.ByteString) -> SS.ScenarioModule
     convModule (_, bytes) = SS.ScenarioModule bytes

--- a/language-support/hs/bindings/src/DA/Ledger/Services/CommandCompletionService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/CommandCompletionService.hs
@@ -33,7 +33,7 @@ mkCompletionStreamRequest :: LedgerId -> ApplicationId -> [Party] -> Maybe Ledge
 mkCompletionStreamRequest (LedgerId id) aid parties offsetOpt = CompletionStreamRequest {
     completionStreamRequestLedgerId = id,
     completionStreamRequestApplicationId = unApplicationId aid,
-    completionStreamRequestParties = Vector.fromList (map unParty parties),
+    completionStreamRequestParties = fmap unParty (Vector.fromList parties),
 
     -- From: command_completion_service.proto
     -- // Optional, if not set the ledger uses the current ledger end offset instead.

--- a/language-support/hs/bindings/src/DA/Ledger/Services/TransactionService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/TransactionService.hs
@@ -166,7 +166,7 @@ mkByEventIdRequest lid eid parties =
     LL.GetTransactionByEventIdRequest
     (unLedgerId lid)
     (unEventId eid)
-    (Vector.fromList $ map unParty parties)
+    (fmap unParty $ Vector.fromList parties)
     noTrace
 
 mkByIdRequest :: LedgerId -> TransactionId -> [Party] -> LL.GetTransactionByIdRequest
@@ -174,5 +174,5 @@ mkByIdRequest lid trid parties =
     LL.GetTransactionByIdRequest
     (unLedgerId lid)
     (unTransactionId trid)
-    (Vector.fromList $ map unParty parties)
+    (fmap unParty $ Vector.fromList parties)
     noTrace

--- a/language-support/hs/bindings/test/DA/Ledger/Tests.hs
+++ b/language-support/hs/bindings/test/DA/Ledger/Tests.hs
@@ -678,7 +678,7 @@ makeSignedJwt secret tid = do
   let parties = [ T.pack $ TL.unpack $ unParty $ p tid | p <- [alice,bob] ]
   let urc = JWT.ClaimsMap $ Map.fromList
         [ ("admin", Aeson.Bool True)
-        , ("actAs", Aeson.Array $ Vector.fromList $ map Aeson.String parties)
+        , ("actAs", Aeson.Array $ fmap Aeson.String $ Vector.fromList parties)
         ]
   let cs = mempty { JWT.unregisteredClaims = urc }
   let key = JWT.hmacSecret $ T.pack $ getSecret secret


### PR DESCRIPTION
I somehow had a hunch that calling `V.fromList . map f`, where `V` is
`Data.Vector`, uses more memory than `fmap f . V.fromList`. My
reasoning was that in the former, allocating the vector needs to force
the spine of the list in order to get its length. This would mean, we
have to allocate a new cons cell for each element in the original list
and GHC cannot eliminate via deforestation. In contrast, with
`fmap f . V.fromList` we only need to allocate a single slot in a new
vector rather than a full cons cell. Also, garbage collecting the
intermediate vector should be faster than garbage collecting an
intermediate list since with the vector we only need to follow one
pointer for each element of the original list, whereas with a list we
have to follow two pointers.

Experiments confirm my suspicion. I've run both of the above examples
wth `f = (+1)` as well as a simple `V.fromList` on a list with
1,000,000 elements. The total allocated memory was as follows:

* `V.fromList` - 97MB
* `fmap f . V.fromList` - 137MB
* `V.fromList . map f` - 201MB

In other words, in `fmap f . V.fromList` mapping a single element takes
40 bytes, whereas in `V.fromList . map f` it takes 104 bytes. I would
call that difference significant.

Having learned that, I thought it would be a good idea to encode this
knowledge in an `hlint` rule.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/7918)
<!-- Reviewable:end -->
