### PR TITLE
Handle authorization failure in the auth middleware and trigger service

### DIFF
--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -55,6 +55,7 @@ da_scala_library(
     scalacopts = scalacopts,
     visibility = ["//visibility:public"],
     deps = [
+        "//language-support/scala/bindings",
         "//ledger-service/jwt",
         "//ledger/ledger-api-auth",
         "//libs-scala/ports",
@@ -89,6 +90,7 @@ da_scala_test(
     scalacopts = scalacopts,
     deps = [
         ":oauth-test-server",
+        "//language-support/scala/bindings",
         "//ledger-api/rs-grpc-bridge",
         "//ledger-api/testing-utils",
         "//ledger-service/jwt",

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
@@ -141,39 +141,40 @@ object Server extends StrictLogging {
     concat(
       parameters(('code, 'state ?))
         .as[OAuthResponse.Authorize](OAuthResponse.Authorize) { authorize =>
-          popRequest(authorize.state) { redirectUri =>
-            extractRequest {
-              request =>
-                val body = OAuthRequest.Token(
-                  grantType = "authorization_code",
-                  code = authorize.code,
-                  redirectUri = toRedirectUri(request.uri),
-                  clientId = config.clientId,
-                  clientSecret = config.clientSecret)
-                import com.daml.oauth.server.Request.Token.marshalRequestEntity
-                val tokenRequest =
-                  for {
-                    entity <- Marshal(body).to[RequestEntity]
-                    req = HttpRequest(
-                      uri = config.oauthToken,
-                      entity = entity,
-                      method = HttpMethods.POST)
-                    resp <- Http().singleRequest(req)
-                    tokenResp <- if (resp.status != StatusCodes.OK) {
-                      Unmarshal(resp).to[String].flatMap { msg =>
-                        Future.failed(new RuntimeException(
-                          s"Failed to retrieve token at ${req.uri} (${resp.status}): $msg"))
+          popRequest(authorize.state) {
+            redirectUri =>
+              extractRequest {
+                request =>
+                  val body = OAuthRequest.Token(
+                    grantType = "authorization_code",
+                    code = authorize.code,
+                    redirectUri = toRedirectUri(request.uri),
+                    clientId = config.clientId,
+                    clientSecret = config.clientSecret)
+                  import com.daml.oauth.server.Request.Token.marshalRequestEntity
+                  val tokenRequest =
+                    for {
+                      entity <- Marshal(body).to[RequestEntity]
+                      req = HttpRequest(
+                        uri = config.oauthToken,
+                        entity = entity,
+                        method = HttpMethods.POST)
+                      resp <- Http().singleRequest(req)
+                      tokenResp <- if (resp.status != StatusCodes.OK) {
+                        Unmarshal(resp).to[String].flatMap { msg =>
+                          Future.failed(new RuntimeException(
+                            s"Failed to retrieve token at ${req.uri} (${resp.status}): $msg"))
+                        }
+                      } else {
+                        Unmarshal(resp).to[OAuthResponse.Token]
                       }
-                    } else {
-                      Unmarshal(resp).to[OAuthResponse.Token]
+                    } yield tokenResp
+                  onSuccess(tokenRequest) { token =>
+                    setCookie(HttpCookie(cookieName, token.toCookieValue)) {
+                      redirect(redirectUri, StatusCodes.Found)
                     }
-                  } yield tokenResp
-                onSuccess(tokenRequest) { token =>
-                  setCookie(HttpCookie(cookieName, token.toCookieValue)) {
-                    redirect(redirectUri, StatusCodes.Found)
                   }
-                }
-            }
+              }
           }
         },
       parameters(('error, 'error_description ?, 'error_uri.as[Uri] ?, 'state ?))

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
@@ -21,7 +21,12 @@ case class Config(
 
 object Config {
   private val Empty =
-    Config(port = Port.Dynamic, ledgerId = null, applicationId = None, jwtSecret = null, parties = None)
+    Config(
+      port = Port.Dynamic,
+      ledgerId = null,
+      applicationId = None,
+      jwtSecret = null,
+      parties = None)
 
   def parseConfig(args: Seq[String]): Option[Config] =
     configParser.parse(args, Empty)

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
@@ -16,7 +16,7 @@ case class Config(
     // Secret used to sign JWTs
     jwtSecret: String,
     // Only authorize requests for these parties, if set.
-    parties: Option[Seq[Party]]
+    parties: Option[Set[Party]]
 )
 
 object Config {
@@ -46,7 +46,7 @@ object Config {
         .action((x, c) => c.copy(jwtSecret = x))
 
       opt[Seq[String]]("parties")
-        .action((x, c) => c.copy(parties = Some(x.map(Party(_)))))
+        .action((x, c) => c.copy(parties = Some(Party.subst(x).toSet)))
         .text("Only authorize requests for these parties")
 
       help("help").text("Print this usage text")

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
@@ -3,6 +3,7 @@
 
 package com.daml.oauth.server
 
+import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ports.Port
 
 case class Config(
@@ -13,12 +14,14 @@ case class Config(
     // Application ID of issued tokens
     applicationId: Option[String],
     // Secret used to sign JWTs
-    jwtSecret: String
+    jwtSecret: String,
+    // Only authorize requests for these parties, if set.
+    parties: Option[Seq[Party]]
 )
 
 object Config {
   private val Empty =
-    Config(port = Port.Dynamic, ledgerId = null, applicationId = None, jwtSecret = null)
+    Config(port = Port.Dynamic, ledgerId = null, applicationId = None, jwtSecret = null, parties = None)
 
   def parseConfig(args: Seq[String]): Option[Config] =
     configParser.parse(args, Empty)
@@ -41,6 +44,10 @@ object Config {
 
       opt[String]("secret")
         .action((x, c) => c.copy(jwtSecret = x))
+
+      opt[Seq[String]]("parties")
+        .action((x, c) => c.copy(parties = Some(x.map(Party(_)))))
+        .text("Only authorize requests for these parties")
 
       help("help").text("Print this usage text")
     }

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
@@ -85,6 +85,21 @@ object Response {
     }
   }
 
+  // https://tools.ietf.org/html/rfc6749#section-4.1.2.1
+  case class Error(
+      error: String,
+      errorDescription: Option[String],
+      errorUri: Option[Uri],
+      state: Option[String]) {
+    def toQuery: Query = {
+      var params: Seq[(String, String)] = Seq("error" -> error)
+      errorDescription.foreach(x => params ++= Seq("error_description" -> x))
+      errorUri.foreach(x => params ++= Seq("error_uri" -> x.toString))
+      state.foreach(x => params ++= Seq("state" -> x))
+      Query(params: _*)
+    }
+  }
+
   // https://tools.ietf.org/html/rfc6749#section-5.1
   case class Token(
       accessToken: String,

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
@@ -170,12 +170,12 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
       } yield {
         // Redirect to CALLBACK
         assert(resp.status == StatusCodes.Found)
-        assert(resp.header[Location].get.uri == Uri("http://CALLBACK"))
-        // Store token in cookie
-        val cookie = resp.header[`Set-Cookie`].get.cookie
-        assert(cookie.name == "daml-ledger-token")
-        val token = OAuthResponse.Token.fromCookieValue(cookie.value).get
-        assert(token.tokenType == "bearer")
+        assert(resp.header[Location].get.uri.withQuery(Uri.Query()) == Uri("http://CALLBACK"))
+        // with error parameter set
+        assert(resp.header[Location].get.uri.query().toMap.get("error") == Some("access_denied"))
+        // Without token in cookie
+        val cookie = resp.header[`Set-Cookie`]
+        assert(cookie == None)
       }
     }
   }

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
@@ -31,7 +31,8 @@ trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBindin
             port = Port.Dynamic,
             ledgerId = ledgerId,
             applicationId = Some(applicationId),
-            jwtSecret = jwtSecret))
+            jwtSecret = jwtSecret,
+            parties = None))
         serverUri = Uri()
           .withScheme("http")
           .withAuthority(server.localAddress.getHostString, server.localAddress.getPort)

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
@@ -6,12 +6,8 @@ package com.daml.oauth.middleware
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.Uri
 import com.daml.jwt.HMAC256Verifier
-import com.daml.ledger.api.testing.utils.{
-  AkkaBeforeAndAfterAll,
-  OwnedResource,
-  Resource,
-  SuiteResource
-}
+import com.daml.ledger.api.refinements.ApiTypes
+import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, OwnedResource, Resource, SuiteResource}
 import com.daml.ledger.resources.ResourceContext
 import com.daml.oauth.server.{Config => OAuthConfig}
 import com.daml.ports.Port
@@ -32,7 +28,7 @@ trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBindin
             ledgerId = ledgerId,
             applicationId = Some(applicationId),
             jwtSecret = jwtSecret,
-            parties = None))
+            parties = Some(ApiTypes.Party.subst(Set("Alice", "Bob")))))
         serverUri = Uri()
           .withScheme("http")
           .withAuthority(server.localAddress.getHostString, server.localAddress.getPort)

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
@@ -7,7 +7,12 @@ import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.Uri
 import com.daml.jwt.HMAC256Verifier
 import com.daml.ledger.api.refinements.ApiTypes
-import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, OwnedResource, Resource, SuiteResource}
+import com.daml.ledger.api.testing.utils.{
+  AkkaBeforeAndAfterAll,
+  OwnedResource,
+  Resource,
+  SuiteResource
+}
 import com.daml.ledger.resources.ResourceContext
 import com.daml.oauth.server.{Config => OAuthConfig}
 import com.daml.ports.Port

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
@@ -98,7 +98,7 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
       for {
         error <- expectError(Seq("Alice", "Eve"))
       } yield {
-        assert(error == "unauthorized")
+        assert(error == "access_denied")
       }
     }
   }

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
@@ -20,7 +20,7 @@ import scala.concurrent.Future
 
 class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAroundAll {
   import Client.JsonProtocol._
-  private def requestToken(parties: Seq[String]): Future[AuthServiceJWTPayload] = {
+  private def requestToken(parties: Seq[String]): Future[Either[String, AuthServiceJWTPayload]] = {
     lazy val clientBinding = suiteResource.value._2.localAddress
     lazy val clientUri = Uri().withAuthority(clientBinding.getHostString, clientBinding.getPort)
     val req = HttpRequest(
@@ -44,34 +44,61 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
         Http().singleRequest(req)
       }
       // Actual token response (proxied from auth server to us via the client)
-      body <- Unmarshal(resp).to[Client.AccessResponse]
-      decodedJwt <- JwtDecoder
-        .decode(Jwt(body.token))
-        .fold((e => Future.failed(new IllegalArgumentException(e.toString))), Future.successful(_))
-      payload <- Future.fromTry(AuthServiceJWTCodec.readFromString(decodedJwt.payload))
-    } yield payload
+      body <- Unmarshal(resp).to[Client.Response]
+      result <- body match {
+        case Client.AccessResponse(token) =>
+          for {
+            decodedJwt <- JwtDecoder
+              .decode(Jwt(token))
+              .fold(
+                e => Future.failed(new IllegalArgumentException(e.toString)),
+                Future.successful(_))
+            payload <- Future.fromTry(AuthServiceJWTCodec.readFromString(decodedJwt.payload))
+          } yield Right(payload)
+        case Client.ErrorResponse(error) => Future(Left(error))
+      }
+    } yield result
   }
+
+  private def expectToken(parties: Seq[String]): Future[AuthServiceJWTPayload] =
+    requestToken(parties).flatMap {
+      case Left(error) => fail(s"Expected token but got error-code $error")
+      case Right(token) => Future(token)
+    }
+
+  private def expectError(parties: Seq[String]): Future[String] =
+    requestToken(parties).flatMap {
+      case Left(error) => Future(error)
+      case Right(_) => fail("Expected an error but got a token")
+    }
 
   "the auth server" should {
     "issue a token with no parties" in {
       for {
-        token <- requestToken(Seq())
+        token <- expectToken(Seq())
       } yield {
         assert(token.actAs == Seq())
       }
     }
     "issue a token with 1 party" in {
       for {
-        token <- requestToken(Seq("Alice"))
+        token <- expectToken(Seq("Alice"))
       } yield {
         assert(token.actAs == Seq("Alice"))
       }
     }
     "issue a token with multiple parties" in {
       for {
-        token <- requestToken(Seq("Alice", "Bob"))
+        token <- expectToken(Seq("Alice", "Bob"))
       } yield {
         assert(token.actAs == Seq("Alice", "Bob"))
+      }
+    }
+    "deny access to unauthorized parties" in {
+      for {
+        error <- expectError(Seq("Alice", "Eve"))
+      } yield {
+        assert(error == "unauthorized")
       }
     }
   }

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
@@ -29,7 +29,8 @@ trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBindin
             port = Port.Dynamic,
             ledgerId = ledgerId,
             applicationId = Some(applicationId),
-            jwtSecret = jwtSecret))
+            jwtSecret = jwtSecret,
+            parties = None))
         client <- Resources.authClient(
           Client.Config(
             port = Port.Dynamic,

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
@@ -13,6 +13,7 @@ import com.daml.ledger.api.testing.utils.{
 }
 import com.daml.ledger.resources.ResourceContext
 import com.daml.ports.Port
+import com.daml.ledger.api.refinements.ApiTypes.Party
 import org.scalatest.Suite
 
 trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBinding, ServerBinding)] {
@@ -30,7 +31,7 @@ trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBindin
             ledgerId = ledgerId,
             applicationId = Some(applicationId),
             jwtSecret = jwtSecret,
-            parties = None))
+            parties = Some(Party.subst(Set("Alice", "Bob")))))
         client <- Resources.authClient(
           Client.Config(
             port = Port.Dynamic,

--- a/triggers/service/authentication.md
+++ b/triggers/service/authentication.md
@@ -41,7 +41,7 @@ all that much, they just need to be fixed once).
 
 2. /login If /auth returned unauthorized, the trigger service will
    redirect users to this. The parameters will include the requested
-   claims as well as a callback URL. This will start an auth flow,
+   claims as well as a callback URL (note that this is not the OAuth2 callback url but a callback URL on the trigger service). This will start an auth flow,
    e.g., an OAuth2 authorization code grant. If the flow succeeds the
    auth service will set a cookie with the access and refresh token
    and redirect to the callback URL. At this point, a request to

--- a/triggers/service/authentication.md
+++ b/triggers/service/authentication.md
@@ -41,12 +41,13 @@ all that much, they just need to be fixed once).
 
 2. /login If /auth returned unauthorized, the trigger service will
    redirect users to this. The parameters will include the requested
-   claims as well as the URL that the users tried to access originally
-   (e.g., the endpoint to start a trigger). This will start an auth
-   flow, e.g., an OAuth2 authorization code grant ending with the auth
-   service setting a cookie with the access and refresh token and
-   redirecting to the original URL. At this point, the request to
-   /auth will succeed (based on the cookie).
+   claims as well as a callback URL. This will start an auth flow,
+   e.g., an OAuth2 authorization code grant. If the flow succeeds the
+   auth service will set a cookie with the access and refresh token
+   and redirect to the callback URL. At this point, a request to
+   /auth will succeed (based on the cookie). If the flow failed the
+   auth service will not set a cookie and redirect to the callback URL
+   with an additional error and optional error_description parameter.
 
 3. /refresh This accepts a refresh token and returns a new access
    token and optionally a new refresh token (or fails).
@@ -57,24 +58,14 @@ all that much, they just need to be fixed once).
 2. /login starts an OAuth2 authorization code grant flow. After the
    redirect URI is called by the authorization server, the middleware
    makes a request to get the tokens, sets them in cookies and
-   redirects back to the original URI.
+   redirects back to the callback URI. Upon failure the middleware
+   forwards the error and error_description to the callback URI.
 3. /refresh simply proxies to the refresh endpoint on the
    authorization server adding the client id and secret.
 
 Note that the auth middleware does not need to persist any state in
 this model. The trigger service does need to persist at least the
 refresh token and potentially the access token.
-
-## Issues
-
-1. This only works if the original request was a GET
-   request. POST requests cannot be redirected in a well-supported way
-   while preserving the request body so we cannot really make this
-   work such that the final redirect to the original URL is equivalent
-   to the original one.  You could imagine a scenario where the
-   trigger service accepts both GET and POST requests so the initial
-   one is a POST request and the final redirect is a GET request but
-   at that point, only accepting GET requests is a least tempting.
 
 ## Related Projects
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -134,6 +134,8 @@ trait AuthMiddlewareFixture
     with AkkaBeforeAndAfterAll {
   self: Suite =>
 
+  protected def authParties: Option[Set[ApiTypes.Party]]
+
   protected def authService: Option[auth.AuthService] = Some(auth.AuthServiceJWT(authVerifier))
   protected def authToken(payload: AuthServiceJWTPayload): Option[String] = Some {
     val header = """{"alg": "HS256", "typ": "JWT"}"""
@@ -169,7 +171,7 @@ trait AuthMiddlewareFixture
       // TODO[AH] Choose application ID, see https://github.com/digital-asset/daml/issues/7671
       applicationId = None,
       jwtSecret = authSecret,
-      parties = None,
+      parties = authParties,
     )
     resource = new OwnedResource(new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -169,6 +169,7 @@ trait AuthMiddlewareFixture
       // TODO[AH] Choose application ID, see https://github.com/digital-asset/daml/issues/7671
       applicationId = None,
       jwtSecret = authSecret,
+      parties = None,
     )
     resource = new OwnedResource(new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =


### PR DESCRIPTION
- Make authorized parties configurable in the oauth2 test server
  If a set of parties is configured then any authorization requests for other parties will be denied.
- Extend the oauth2 test server test cases accordingly
- Handle authorization failure in the /login endpoint of the auth middleware
  The corresponding error is forwarded to the callback URI. This allows the client service to react to authorization failure, e.g. to responding with a Forbidden status code.
- Update the auth middleware specification document
  - The auth middleware accepts an arbitrary callback URI on /login
  - The auth middleware will forward OAuth2 authorization failures to the client service.
- Add a test case for authorization failure on the /start endpoint of the trigger service
  Further test cases on the other endpoints require the ability to change the set of authorized parties in the oauth2 test server. This is left for a follow up PR and tracked in #7749.

Closes #7724 
Part of #7749 

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
