### PR TITLE
Add a warning for GHC.Types.Symbol

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -325,9 +325,17 @@ checkKinds (GHC.L _ m) = do
 
     checkRdrName :: GHC.Located GHC.RdrName -> [(GHC.SrcSpan, String)]
     checkRdrName (GHC.L loc name) = case name of
+        GHC.Unqual (GHC.occNameString -> "Symbol") ->
+            [(loc, symbolKindMsg)]
         GHC.Qual (GHC.moduleNameString -> "GHC.Types") (GHC.occNameString -> "Symbol") ->
             [(loc, ghcTypesSymbolMsg)]
         _ -> []
+
+    symbolKindMsg :: String
+    symbolKindMsg = unlines
+        [ "Reference to Symbol kind will not be preserved during DAML compilation."
+        , "This will cause problems when importing this module via data-dependencies."
+        ]
 
     ghcTypesSymbolMsg :: String
     ghcTypesSymbolMsg = unlines

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -70,6 +70,7 @@ damlPreprocessor dataDependableExtensions mbUnitId dflags x
             , checkVariantUnitConstructors x
             , checkLanguageExtensions dataDependableExtensions dflags x
             , checkImportsWrtDataDependencies x
+            , checkKinds x
             ]
         , preprocErrors = checkImports x ++ checkDataTypes x ++ checkModuleDefinition x ++ checkRecordConstructor x ++ checkModuleName x
         , preprocSource = recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbUnitId $ enumTypePreprocessor "GHC.Types" x
@@ -291,3 +292,45 @@ universeConDecl m = concat
     [ dd_cons
     | GHC.TyClD _ GHC.DataDecl{tcdDataDefn=GHC.HsDataDefn{dd_cons}} <- map GHC.unLoc $ GHC.hsmodDecls $ GHC.unLoc m
     ]
+
+-- | Emit a warning if GHC.Types.Symbol was used in a top-level kind signature.
+checkKinds :: GHC.ParsedSource -> [(GHC.SrcSpan, String)]
+checkKinds (GHC.L _ m) = do
+    GHC.L _ decl <- GHC.hsmodDecls m
+    checkDeclKinds decl
+  where
+    checkDeclKinds :: GHC.HsDecl GHC.GhcPs -> [(GHC.SrcSpan, String)]
+    checkDeclKinds = \case
+        GHC.TyClD _ (GHC.SynDecl {..}) -> checkQTyVars tcdTyVars
+        GHC.TyClD _ (GHC.DataDecl {..}) -> checkQTyVars tcdTyVars
+        GHC.TyClD _ (GHC.ClassDecl {..}) -> checkQTyVars tcdTyVars
+        _ -> []
+
+    checkQTyVars :: GHC.LHsQTyVars GHC.GhcPs -> [(GHC.SrcSpan, String)]
+    checkQTyVars = \case
+        GHC.HsQTvs{..} -> concatMap checkTyVarBndr hsq_explicit
+        _ -> []
+
+    checkTyVarBndr :: GHC.LHsTyVarBndr GHC.GhcPs -> [(GHC.SrcSpan, String)]
+    checkTyVarBndr (GHC.L _ var) = case var of
+        GHC.KindedTyVar _ _ kind -> checkKind kind
+        _ -> []
+
+    checkKind :: GHC.LHsKind GHC.GhcPs -> [(GHC.SrcSpan, String)]
+    checkKind (GHC.L _ kind) = case kind of
+        GHC.HsTyVar _ _ v -> checkRdrName v
+        GHC.HsFunTy _ k1 k2 -> checkKind k1 ++ checkKind k2
+        GHC.HsParTy _ k -> checkKind k
+        _ -> []
+
+    checkRdrName :: GHC.Located GHC.RdrName -> [(GHC.SrcSpan, String)]
+    checkRdrName (GHC.L loc name) = case name of
+        GHC.Qual (GHC.moduleNameString -> "GHC.Types") (GHC.occNameString -> "Symbol") ->
+            [(loc, ghcTypesSymbolMsg)]
+        _ -> []
+
+    ghcTypesSymbolMsg :: String
+    ghcTypesSymbolMsg = unlines
+        [ "Reference to GHC.Types.Symbol will not be preserved during DAML compilation."
+        , "This will cause problems when importing this module via data-dependencies."
+        ]

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -301,9 +301,9 @@ checkKinds (GHC.L _ m) = do
   where
     checkDeclKinds :: GHC.HsDecl GHC.GhcPs -> [(GHC.SrcSpan, String)]
     checkDeclKinds = \case
-        GHC.TyClD _ (GHC.SynDecl {..}) -> checkQTyVars tcdTyVars
-        GHC.TyClD _ (GHC.DataDecl {..}) -> checkQTyVars tcdTyVars
-        GHC.TyClD _ (GHC.ClassDecl {..}) -> checkQTyVars tcdTyVars
+        GHC.TyClD _ GHC.SynDecl{..} -> checkQTyVars tcdTyVars
+        GHC.TyClD _ GHC.DataDecl{..} -> checkQTyVars tcdTyVars
+        GHC.TyClD _ GHC.ClassDecl{..} -> checkQTyVars tcdTyVars
         _ -> []
 
     checkQTyVars :: GHC.LHsQTyVars GHC.GhcPs -> [(GHC.SrcSpan, String)]

--- a/compiler/damlc/tests/daml-test-files/LFNameCollisions.daml
+++ b/compiler/damlc/tests/daml-test-files/LFNameCollisions.daml
@@ -15,6 +15,8 @@ submit x _ _ = x
 submitMustFail : a -> Int -> Int -> a
 submitMustFail x _ _ = x
 
+-- @WARN Reference to Symbol kind
+-- @WARN Reference to Symbol kind
 data Phantom (a : Symbol) (b : Symbol) = Phantom {}
 
 unpackPair : forall a b c d. Phantom a b -> (c,d) -> (c,d)

--- a/compiler/damlc/tests/daml-test-files/LFNameCollisions.daml
+++ b/compiler/damlc/tests/daml-test-files/LFNameCollisions.daml
@@ -15,12 +15,8 @@ submit x _ _ = x
 submitMustFail : a -> Int -> Int -> a
 submitMustFail x _ _ = x
 
--- @WARN Reference to Symbol kind
--- @WARN Reference to Symbol kind
-data Phantom (a : Symbol) (b : Symbol) = Phantom {}
-
-unpackPair : forall a b c d. Phantom a b -> (c,d) -> (c,d)
-unpackPair _ c = c
+unpackPair : forall (a: Symbol) (b: Symbol) c d. (c,d) -> (c,d)
+unpackPair c = c
 
 a : ()
 a = submit () 0 0
@@ -29,4 +25,4 @@ b : ()
 b = submitMustFail () 0 0
 
 c : (Int, Int)
-c = unpackPair @"abc" @"def" Phantom (42, 42)
+c = unpackPair @"abc" @"def" (42, 42)

--- a/compiler/damlc/tests/daml-test-files/SymbolKindWarnings.daml
+++ b/compiler/damlc/tests/daml-test-files/SymbolKindWarnings.daml
@@ -1,0 +1,26 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- Check that top-level signatures containing references to GHC.Types.Symbol
+-- result in a warning.
+module SymbolKindWarnings where
+
+-- @WARN range=9:13-9:29; Reference to GHC.Types.Symbol
+type T1 (x: GHC.Types.Symbol) = Int
+
+-- @WARN range=12:16-12:32; Reference to GHC.Types.Symbol
+newtype T2 (x: GHC.Types.Symbol) = T2 Int
+
+-- @WARN range=15:14-15:30; Reference to GHC.Types.Symbol
+class C1 (x: GHC.Types.Symbol) where
+
+-- @WARN range=18:14-18:30; Reference to GHC.Types.Symbol
+class C2 (x: GHC.Types.Symbol -> *) where
+
+-- @WARN range=21:19-21:35; Reference to GHC.Types.Symbol
+class C3 (x: * -> GHC.Types.Symbol) where
+
+-- @WARN range=24:15-24:31; Reference to GHC.Types.Symbol
+class C4 (x: (GHC.Types.Symbol)) where
+    -- Not a duplicate of C1, because a parenthesized kind
+    -- is not the same as a non-parenthesized kind in GHC-land.

--- a/compiler/damlc/tests/daml-test-files/SymbolKindWarnings.daml
+++ b/compiler/damlc/tests/daml-test-files/SymbolKindWarnings.daml
@@ -4,7 +4,7 @@
 -- Check that top-level signatures containing references to GHC.Types.Symbol
 -- result in a warning.
 module SymbolKindWarnings where
-
+import DA.Record
 -- @WARN range=9:13-9:29; Reference to GHC.Types.Symbol
 type T1 (x: GHC.Types.Symbol) = Int
 
@@ -24,3 +24,29 @@ class C3 (x: * -> GHC.Types.Symbol) where
 class C4 (x: (GHC.Types.Symbol)) where
     -- Not a duplicate of C1, because a parenthesized kind
     -- is not the same as a non-parenthesized kind in GHC-land.
+
+-- @WARN range=29:14-29:20; Reference to Symbol kind
+class C5 (x: Symbol) where
+
+----------------
+-- Make sure warning doesn't trigger with uses
+-- of HasField class.
+
+data R = R with
+    foo : Int
+    bar : Int
+
+data T = T Int
+
+instance HasField "foo" T Int where
+    getField (T n) = n
+    setField n (T _) = T n
+
+getFoo : HasField "foo" a b => a -> b
+getFoo = getField @"foo"
+
+getRFoo : R -> Int
+getRFoo = getFoo
+
+getTFoo : T -> Int
+getTFoo = getFoo


### PR DESCRIPTION
The warning is on top-level kind signatures for type & typeclass definitions, where the symbol kind is most likely to appear and to cause trouble.

CHANGELOG_BEGIN

- [DAML Compiler] Added a warning for references to
  the GHC.Types.Symbol kind since these cannot be
  preserved across data-dependencies.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
