### PR TITLE
Participant Indexer pipelined parallelization

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -7,9 +7,8 @@ import java.time.Instant
 
 import akka.NotUsed
 import akka.stream._
-import akka.stream.scaladsl.{Keep, Sink}
+import akka.stream.scaladsl.{Flow, Keep, Sink}
 import com.daml.daml_lf_dev.DamlLf
-import com.daml.dec.{DirectExecutionContext => DEC}
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.domain.ParticipantId
 import com.daml.ledger.participant.state.index.v2
@@ -27,7 +26,7 @@ import com.daml.platform.common.MismatchException
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.store.FlywayMigrations
 import com.daml.platform.store.dao.events.LfValueTranslation
-import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao}
+import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao, PersistenceResponse}
 import com.daml.platform.store.entries.{PackageLedgerEntry, PartyLedgerEntry}
 
 import scala.concurrent.Future
@@ -235,75 +234,75 @@ private[indexer] class JdbcIndexer private[indexer] (
     new SubscriptionResourceOwner(readService)
 
   private def handleStateUpdate(
-      offset: Offset,
-      update: Update,
-  )(implicit loggingContext: LoggingContext): Future[Unit] = {
-    lastReceivedRecordTime = update.recordTime.toInstant.toEpochMilli
+      implicit loggingContext: LoggingContext): Flow[(Offset, Update), Unit, NotUsed] =
+    Flow[(Offset, Update)]
+      .wireTap(Sink.foreach[(Offset, Update)] {
+        case (offset, update) =>
+          lastReceivedRecordTime = update.recordTime.toInstant.toEpochMilli
 
-    logger.trace(update.description)
+          logger.trace(update.description)
 
-    metrics.daml.indexer.lastReceivedRecordTime.updateValue(lastReceivedRecordTime)
-    metrics.daml.indexer.lastReceivedOffset.updateValue(offset.toApiString)
+          metrics.daml.indexer.lastReceivedRecordTime.updateValue(lastReceivedRecordTime)
+          metrics.daml.indexer.lastReceivedOffset.updateValue(offset.toApiString)
+      })
+      .mapAsync(1)((prepareTransactionInsert _).tupled)
+      .mapAsync(1) {
+        case kvUpdate @ OffsetUpdate(offset, update) =>
+          withEnrichedLoggingContext(JdbcIndexer.loggingContextFor(offset, update)) {
+            implicit loggingContext =>
+              Timed.future(
+                metrics.daml.indexer.stateUpdateProcessing,
+                executeUpdate(kvUpdate),
+              )
+          }
+      }
+      .map(_ => ())
 
-    val result = update match {
-      case PartyAddedToParticipant(
-          party,
-          displayName,
-          hostingParticipantId,
-          recordTime,
-          submissionId,
-          ) =>
-        val entry = PartyLedgerEntry.AllocationAccepted(
-          submissionId,
-          recordTime.toInstant,
-          domain.PartyDetails(party, Some(displayName), participantId == hostingParticipantId)
+  private def prepareTransactionInsert(offset: Offset, update: Update): Future[OffsetUpdate] =
+    update match {
+      case update @ TransactionAccepted(
+            optSubmitterInfo,
+            transactionMeta,
+            transaction,
+            transactionId,
+            _,
+            divulgedContracts) =>
+        Timed.future(
+          metrics.daml.index.db.storeTransactionDbMetrics.prepareBatches,
+          Future {
+            OffsetUpdate.PreparedTransactionInsert(
+              offset = offset,
+              update = update,
+              preparedInsert = ledgerDao.transactionsWriter.prepare(
+                submitterInfo = optSubmitterInfo,
+                workflowId = transactionMeta.workflowId,
+                transactionId = transactionId,
+                ledgerEffectiveTime = transactionMeta.ledgerEffectiveTime.toInstant,
+                offset = offset,
+                transaction = transaction,
+                divulgedContracts = divulgedContracts,
+              )
+            )
+          }(mat.executionContext)
         )
-        ledgerDao.storePartyEntry(offset, entry)
+      case update => Future.successful(OffsetUpdate.OffsetUpdatePair(offset, update))
+    }
 
-      case PartyAllocationRejected(
-          submissionId,
-          _,
-          recordTime,
-          rejectionReason,
-          ) =>
-        val entry = PartyLedgerEntry.AllocationRejected(
-          submissionId,
-          recordTime.toInstant,
-          rejectionReason,
-        )
-        ledgerDao.storePartyEntry(offset, entry)
-
-      case PublicPackageUpload(archives, optSourceDescription, recordTime, optSubmissionId) =>
-        val recordTimeInstant = recordTime.toInstant
-        val packages: List[(DamlLf.Archive, v2.PackageDetails)] = archives.map(
-          archive =>
-            archive -> v2.PackageDetails(
-              size = archive.getPayload.size.toLong,
-              knownSince = recordTimeInstant,
-              sourceDescription = optSourceDescription,
-          ))
-        val optEntry: Option[PackageLedgerEntry] =
-          optSubmissionId.map(submissionId =>
-            PackageLedgerEntry.PackageUploadAccepted(submissionId, recordTimeInstant))
-        ledgerDao.storePackageEntry(offset, packages, optEntry)
-
-      case PublicPackageUploadRejected(submissionId, recordTime, rejectionReason) =>
-        val entry = PackageLedgerEntry.PackageUploadRejected(
-          submissionId,
-          recordTime.toInstant,
-          rejectionReason,
-        )
-        ledgerDao.storePackageEntry(offset, List.empty, Some(entry))
-
-      case TransactionAccepted(
-          optSubmitterInfo,
-          transactionMeta,
-          transaction,
-          transactionId,
-          recordTime,
-          divulgedContracts,
-          ) =>
+  private def executeUpdate(offsetUpdate: OffsetUpdate)(
+      implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
+    offsetUpdate match {
+      case OffsetUpdate.PreparedTransactionInsert(
+          offset,
+          TransactionAccepted(
+            optSubmitterInfo,
+            transactionMeta,
+            transaction,
+            transactionId,
+            recordTime,
+            divulgedContracts),
+          preparedInsert) =>
         ledgerDao.storeTransaction(
+          preparedInsert,
           submitterInfo = optSubmitterInfo,
           workflowId = transactionMeta.workflowId,
           transactionId = transactionId,
@@ -313,30 +312,103 @@ private[indexer] class JdbcIndexer private[indexer] (
           transaction = transaction,
           divulged = divulgedContracts,
         )
+      case OffsetUpdate.OffsetUpdatePair(offset, update) =>
+        update match {
+          case PartyAddedToParticipant(
+              party,
+              displayName,
+              hostingParticipantId,
+              recordTime,
+              submissionId,
+              ) =>
+            val entry = PartyLedgerEntry.AllocationAccepted(
+              submissionId,
+              recordTime.toInstant,
+              domain.PartyDetails(party, Some(displayName), participantId == hostingParticipantId)
+            )
+            ledgerDao.storePartyEntry(offset, entry)
 
-      case config: ConfigurationChanged =>
-        ledgerDao.storeConfigurationEntry(
-          offset,
-          config.recordTime.toInstant,
-          config.submissionId,
-          config.newConfiguration,
-          None,
-        )
+          case PartyAllocationRejected(
+              submissionId,
+              _,
+              recordTime,
+              rejectionReason,
+              ) =>
+            val entry = PartyLedgerEntry.AllocationRejected(
+              submissionId,
+              recordTime.toInstant,
+              rejectionReason,
+            )
+            ledgerDao.storePartyEntry(offset, entry)
 
-      case configRejection: ConfigurationChangeRejected =>
-        ledgerDao.storeConfigurationEntry(
-          offset,
-          configRejection.recordTime.toInstant,
-          configRejection.submissionId,
-          configRejection.proposedConfiguration,
-          Some(configRejection.rejectionReason),
-        )
+          case PublicPackageUpload(archives, optSourceDescription, recordTime, optSubmissionId) =>
+            val recordTimeInstant = recordTime.toInstant
+            val packages: List[(DamlLf.Archive, v2.PackageDetails)] = archives.map(
+              archive =>
+                archive -> v2.PackageDetails(
+                  size = archive.getPayload.size.toLong,
+                  knownSince = recordTimeInstant,
+                  sourceDescription = optSourceDescription,
+              ))
+            val optEntry: Option[PackageLedgerEntry] =
+              optSubmissionId.map(submissionId =>
+                PackageLedgerEntry.PackageUploadAccepted(submissionId, recordTimeInstant))
+            ledgerDao.storePackageEntry(offset, packages, optEntry)
 
-      case CommandRejected(recordTime, submitterInfo, reason) =>
-        ledgerDao.storeRejection(Some(submitterInfo), recordTime.toInstant, offset, reason)
+          case PublicPackageUploadRejected(submissionId, recordTime, rejectionReason) =>
+            val entry = PackageLedgerEntry.PackageUploadRejected(
+              submissionId,
+              recordTime.toInstant,
+              rejectionReason,
+            )
+            ledgerDao.storePackageEntry(offset, List.empty, Some(entry))
+
+          case config: ConfigurationChanged =>
+            ledgerDao.storeConfigurationEntry(
+              offset,
+              config.recordTime.toInstant,
+              config.submissionId,
+              config.newConfiguration,
+              None,
+            )
+
+          case configRejection: ConfigurationChangeRejected =>
+            ledgerDao.storeConfigurationEntry(
+              offset,
+              configRejection.recordTime.toInstant,
+              configRejection.submissionId,
+              configRejection.proposedConfiguration,
+              Some(configRejection.rejectionReason),
+            )
+
+          case CommandRejected(recordTime, submitterInfo, reason) =>
+            ledgerDao.storeRejection(Some(submitterInfo), recordTime.toInstant, offset, reason)
+          case update: TransactionAccepted =>
+            import update._
+            logger.warn(
+              """For performance considerations, TransactionAccepted should be handled in a different branch.
+                |Recomputing PreparedInsert..""".stripMargin)
+            ledgerDao.storeTransaction(
+              preparedInsert = ledgerDao.transactionsWriter.prepare(
+                submitterInfo = optSubmitterInfo,
+                workflowId = transactionMeta.workflowId,
+                transactionId = transactionId,
+                ledgerEffectiveTime = transactionMeta.ledgerEffectiveTime.toInstant,
+                offset = offset,
+                transaction = transaction,
+                divulgedContracts = divulgedContracts,
+              ),
+              submitterInfo = optSubmitterInfo,
+              workflowId = transactionMeta.workflowId,
+              transactionId = transactionId,
+              recordTime = recordTime.toInstant,
+              ledgerEffectiveTime = transactionMeta.ledgerEffectiveTime.toInstant,
+              offset = offset,
+              transaction = transaction,
+              divulged = divulgedContracts,
+            )
+        }
     }
-    result.map(_ => ())(DEC)
-  }
 
   private class SubscriptionResourceOwner(
       readService: ReadService,
@@ -347,16 +419,7 @@ private[indexer] class JdbcIndexer private[indexer] (
         val (killSwitch, completionFuture) = readService
           .stateUpdates(startExclusive)
           .viaMat(KillSwitches.single)(Keep.right[NotUsed, UniqueKillSwitch])
-          .mapAsync(1) {
-            case (offset, update) =>
-              withEnrichedLoggingContext(JdbcIndexer.loggingContextFor(offset, update)) {
-                implicit loggingContext =>
-                  Timed.future(
-                    metrics.daml.indexer.stateUpdateProcessing,
-                    handleStateUpdate(offset, update),
-                  )
-              }
-          }
+          .via(handleStateUpdate)
           .toMat(Sink.ignore)(Keep.both)
           .run()
 
@@ -374,4 +437,5 @@ private[indexer] class JdbcIndexer private[indexer] (
       val killSwitch: KillSwitch,
       override val completed: Future[Unit],
   ) extends IndexFeedHandle
+
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/OffsetUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/OffsetUpdate.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.indexer
+
+import com.daml.ledger.participant.state.v1.{Offset, Update}
+import com.daml.ledger.participant.state.v1.Update.TransactionAccepted
+import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
+
+sealed trait OffsetUpdate {
+  def offset: Offset
+
+  def update: Update
+}
+
+object OffsetUpdate {
+  def unapply(offsetUpdate: OffsetUpdate): Option[(Offset, Update)] =
+    Some((offsetUpdate.offset, offsetUpdate.update))
+
+  final case class PreparedTransactionInsert(
+      offset: Offset,
+      update: TransactionAccepted,
+      preparedInsert: PreparedInsert)
+      extends OffsetUpdate
+
+  final case class OffsetUpdatePair(offset: Offset, update: Update) extends OffsetUpdate
+}

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -168,8 +168,6 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
 }
 
 private[platform] trait LedgerWriteDao extends ReportsHealth {
-  def transactionsWriter: TransactionsWriter
-
   def maxConcurrentConnections: Int
 
   /**
@@ -182,6 +180,16 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
   def initializeParticipantId(participantId: ParticipantId)(
       implicit loggingContext: LoggingContext,
   ): Future[Unit]
+
+  def prepareTransactionInsert(
+      submitterInfo: Option[SubmitterInfo],
+      workflowId: Option[WorkflowId],
+      transactionId: TransactionId,
+      ledgerEffectiveTime: Instant,
+      offset: Offset,
+      transaction: CommittedTransaction,
+      divulgedContracts: Iterable[DivulgedContract],
+  )(implicit loggingContext: LoggingContext): TransactionsWriter.PreparedInsert
 
   def storeTransaction(
       preparedInsert: PreparedInsert,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -27,7 +27,8 @@ import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.LoggingContext
-import com.daml.platform.store.dao.events.TransactionsReader
+import com.daml.platform.store.dao.events.{TransactionsReader, TransactionsWriter}
+import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 import com.daml.platform.store.entries.{
   ConfigurationEntry,
   LedgerEntry,
@@ -167,6 +168,7 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
 }
 
 private[platform] trait LedgerWriteDao extends ReportsHealth {
+  def transactionsWriter: TransactionsWriter
 
   def maxConcurrentConnections: Int
 
@@ -182,6 +184,7 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
   ): Future[Unit]
 
   def storeTransaction(
+      preparedInsert: PreparedInsert,
       submitterInfo: Option[SubmitterInfo],
       workflowId: Option[WorkflowId],
       transactionId: TransactionId,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -20,7 +20,8 @@ import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
-import com.daml.platform.store.dao.events.TransactionsReader
+import com.daml.platform.store.dao.events.{TransactionsReader, TransactionsWriter}
+import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 import com.daml.platform.store.entries.{
   ConfigurationEntry,
   LedgerEntry,
@@ -151,7 +152,10 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
 
+  override def transactionsWriter: TransactionsWriter = ledgerDao.transactionsWriter
+
   override def storeTransaction(
+      preparedInsert: PreparedInsert,
       submitterInfo: Option[SubmitterInfo],
       workflowId: Option[WorkflowId],
       transactionId: TransactionId,
@@ -164,6 +168,7 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
     Timed.future(
       metrics.daml.index.db.storeTransaction,
       ledgerDao.storeTransaction(
+        preparedInsert,
         submitterInfo,
         workflowId,
         transactionId,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.daml_lf_dev.DamlLf.Archive
-import com.daml.ledger.WorkflowId
+import com.daml.ledger.{TransactionId, WorkflowId}
 import com.daml.ledger.api.domain.{CommandId, LedgerId, ParticipantId, PartyDetails}
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.participant.state.index.v2.{CommandDeduplicationResult, PackageDetails}
@@ -152,8 +152,6 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
 
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
 
-  override def transactionsWriter: TransactionsWriter = ledgerDao.transactionsWriter
-
   override def storeTransaction(
       preparedInsert: PreparedInsert,
       submitterInfo: Option[SubmitterInfo],
@@ -179,6 +177,24 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
         divulged,
       )
     )
+
+  def prepareTransactionInsert(
+      submitterInfo: Option[SubmitterInfo],
+      workflowId: Option[WorkflowId],
+      transactionId: TransactionId,
+      ledgerEffectiveTime: Instant,
+      offset: Offset,
+      transaction: CommittedTransaction,
+      divulgedContracts: Iterable[DivulgedContract],
+  )(implicit loggingContext: LoggingContext): TransactionsWriter.PreparedInsert =
+    ledgerDao.prepareTransactionInsert(
+      submitterInfo,
+      workflowId,
+      transactionId,
+      ledgerEffectiveTime,
+      offset,
+      transaction,
+      divulgedContracts)
 
   override def storeRejection(
       submitterInfo: Option[SubmitterInfo],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsWriter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsWriter.scala
@@ -19,7 +19,7 @@ import com.daml.lf.transaction.BlindingInfo
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.store.DbType
 
-private[dao] object TransactionsWriter {
+object TransactionsWriter {
 
   final class PreparedInsert private[TransactionsWriter] (
       eventBatches: EventsTable.PreparedBatches,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -438,16 +438,29 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
     val submitterInfo =
       for (submitter <- entry.submittingParty; app <- entry.applicationId; cmd <- entry.commandId)
         yield v1.SubmitterInfo(submitter, app, cmd, Instant.EPOCH)
+    val committedTransaction = CommittedTransaction(entry.transaction)
+    val ledgerEffectiveTime = entry.ledgerEffectiveTime
+    val divulged = divulgedContracts.keysIterator.map(c => v1.DivulgedContract(c._1, c._2)).toList
+    val preparedTransactionInsert = ledgerDao.transactionsWriter
+      .prepare(
+        submitterInfo,
+        entry.workflowId,
+        entry.transactionId,
+        ledgerEffectiveTime,
+        offset,
+        committedTransaction,
+        divulged)
     ledgerDao
       .storeTransaction(
+        preparedInsert = preparedTransactionInsert,
         submitterInfo = submitterInfo,
         workflowId = entry.workflowId,
         transactionId = entry.transactionId,
-        transaction = CommittedTransaction(entry.transaction),
+        transaction = committedTransaction,
         recordTime = entry.recordedAt,
-        ledgerEffectiveTime = entry.ledgerEffectiveTime,
+        ledgerEffectiveTime = ledgerEffectiveTime,
         offset = offset,
-        divulged = divulgedContracts.keysIterator.map(c => v1.DivulgedContract(c._1, c._2)).toList
+        divulged = divulged
       )
       .map(_ => offsetAndTx)
   }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -441,15 +441,14 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
     val committedTransaction = CommittedTransaction(entry.transaction)
     val ledgerEffectiveTime = entry.ledgerEffectiveTime
     val divulged = divulgedContracts.keysIterator.map(c => v1.DivulgedContract(c._1, c._2)).toList
-    val preparedTransactionInsert = ledgerDao.transactionsWriter
-      .prepare(
-        submitterInfo,
-        entry.workflowId,
-        entry.transactionId,
-        ledgerEffectiveTime,
-        offset,
-        committedTransaction,
-        divulged)
+    val preparedTransactionInsert = ledgerDao.prepareTransactionInsert(
+      submitterInfo,
+      entry.workflowId,
+      entry.transactionId,
+      ledgerEffectiveTime,
+      offset,
+      committedTransaction,
+      divulged)
     ledgerDao
       .storeTransaction(
         preparedInsert = preparedTransactionInsert,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -365,7 +365,7 @@ private final class SqlLedger(
               reason,
           ),
           _ => {
-            val preparedInsert = ledgerDao.transactionsWriter.prepare(
+            val preparedInsert = ledgerDao.prepareTransactionInsert(
               submitterInfo = Some(submitterInfo),
               workflowId = transactionMeta.workflowId,
               transactionId = transactionId,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -364,8 +364,18 @@ private final class SqlLedger(
               offset,
               reason,
           ),
-          _ =>
+          _ => {
+            val preparedInsert = ledgerDao.transactionsWriter.prepare(
+              submitterInfo = Some(submitterInfo),
+              workflowId = transactionMeta.workflowId,
+              transactionId = transactionId,
+              ledgerEffectiveTime = transactionMeta.ledgerEffectiveTime.toInstant,
+              offset = offset,
+              transaction = transactionCommitter.commitTransaction(transactionId, transaction),
+              divulgedContracts = Nil,
+            )
             ledgerDao.storeTransaction(
+              preparedInsert,
               Some(submitterInfo),
               transactionMeta.workflowId,
               transactionId,
@@ -374,7 +384,8 @@ private final class SqlLedger(
               offset,
               transactionCommitter.commitTransaction(transactionId, transaction),
               Nil,
-          )
+            )
+          }
         )
         .transform(
           _.map(_ => ()).recover {


### PR DESCRIPTION
As part of [DPP-61](https://digitalasset.atlassian.net/browse/DPP-61) this PR aims at improving indexer pipelining (and parallelization implicitly) by extracting the transaction insert preparation out of the SQL execution path (from `ledgerDao.storeTransaction`)

Expected improvement: ~ 15 % throughput increase for the indexer.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
