### PR TITLE
sandbox: fail on already existing port-file.

### DIFF
--- a/compatibility/bazel_tools/daml_ledger/Sandbox.hs
+++ b/compatibility/bazel_tools/daml_ledger/Sandbox.hs
@@ -24,7 +24,7 @@ import System.Environment (getEnvironment)
 import System.Exit (exitFailure)
 import System.FilePath ((</>))
 import System.IO.Error (isDoesNotExistError)
-import System.IO.Extra (Handle, IOMode (..), hClose, newTempFile, openBinaryFile, stderr)
+import System.IO.Extra (Handle, IOMode (..), hClose, newTempDir, openBinaryFile, stderr)
 import System.Info.Extra (isWindows)
 import System.Process
 import Test.Tasty (TestTree, withResource)
@@ -113,9 +113,10 @@ createSandbox portFile sandboxOutput conf = do
 withSandbox :: IO SandboxConfig -> (IO Int -> TestTree) -> TestTree
 withSandbox getConf f =
     withResource (openBinaryFile nullDevice ReadWriteMode) hClose $ \getDevNull ->
-    withResource newTempFile snd $ \getPortFile ->
+    withResource newTempDir snd $ \getTempDir ->
         let createSandbox' = do
-                (portFile, _) <- getPortFile
+                (tempDir, _) <- getTempDir
+                let portFile = tempDir </> "sandbox-portfile"
                 devNull <- getDevNull
                 conf <- getConf
                 createSandbox portFile devNull conf

--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -60,7 +60,9 @@ main = do
     -- pulling apart functions like `withGrpcClient`. Therefore we just
     -- allocate the resources before handing over to tasty and accept that
     -- it will spin up sandbox and the repl client.
-    withTempFile $ \portFile ->
+    withTempDir $ \tmpDir ->
+        let portFile = tmpDir </> "sandbox-portfile"
+        in
         withBinaryFile nullDevice WriteMode $ \devNull ->
         bracket (createSandbox portFile devNull defaultSandboxConf { dars = testDars }) destroySandbox $ \SandboxResource{sandboxPort} ->
         ReplClient.withReplClient (ReplClient.Options replJar (Just ("localhost", show sandboxPort)) Nothing Nothing Nothing Nothing ReplClient.ReplWallClock CreatePipe) $ \replHandle mbServiceOut processHandle ->

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -100,7 +100,8 @@ navigatorURL :: NavigatorPort -> String
 navigatorURL (NavigatorPort p) = "http://localhost:" <> show p
 
 withSandbox :: SandboxClassic -> SandboxPortSpec -> [String] -> (Process () () () -> SandboxPort -> IO a) -> IO a
-withSandbox (SandboxClassic classic) portSpec extraArgs a = withTempFile $ \portFile -> do
+withSandbox (SandboxClassic classic) portSpec extraArgs a = withTempDir $ \tempDir -> do
+    let portFile = tempDir </> "sandbox-portfile"
     let sandbox = if classic then "sandbox-classic" else "sandbox"
     let args = [ sandbox
                , "--port", show (fromSandboxPortSpec portSpec)

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/MultiParticipantFixture.scala
@@ -26,8 +26,9 @@ trait MultiParticipantFixture
     with AkkaBeforeAndAfterAll {
   self: Suite =>
   private def darFile = Paths.get(rlocation("daml-script/test/script-test.dar"))
-  private val participant1Portfile = Files.createTempFile("participant1", "port")
-  private val participant2Portfile = Files.createTempFile("participant2", "port")
+  private val tmpDir = Files.createTempDirectory("testMultiParticipantFixture")
+  private val participant1Portfile = tmpDir.resolve("participant1-portfile")
+  private val participant2Portfile = tmpDir.resolve("participant2-portfile")
 
   override protected def afterAll(): Unit = {
     Files.delete(participant1Portfile)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -4,7 +4,6 @@
 package com.daml.platform.apiserver
 
 import java.io.File
-import java.nio.file.Files
 import java.time.{Clock, Instant}
 
 import akka.actor.ActorSystem
@@ -26,6 +25,7 @@ import com.daml.platform.configuration.{
   PartyConfiguration,
   ServerRole
 }
+import com.daml.ports.{PortFiles}
 import com.daml.platform.index.JdbcIndex
 import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.services.time.TimeProviderType
@@ -33,7 +33,6 @@ import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.ports.Port
 import io.grpc.{BindableService, ServerInterceptor}
 
-import scala.collection.JavaConverters._
 import scala.collection.immutable
 
 // Main entry point to start an index server that also hosts the ledger API.
@@ -150,6 +149,6 @@ final class StandaloneApiServer(
 
   private def writePortFile(port: Port): Unit =
     config.portFile.foreach { path =>
-      Files.write(path, Seq(port.toString).asJava)
+      PortFiles.write(path, port)
     }
 }

--- a/libs-haskell/test-utils/DA/Test/Sandbox.hs
+++ b/libs-haskell/test-utils/DA/Test/Sandbox.hs
@@ -90,9 +90,10 @@ createSandbox portFile sandboxOutput conf = do
 
 withSandbox :: SandboxConfig -> (IO Int -> TestTree) -> TestTree
 withSandbox conf f =
-    withResource newTempFile snd $ \getPortFile ->
+    withResource newTempDir snd $ \getTmpDir ->
         let createSandbox' = do
-                (portFile, _) <- getPortFile
+                (tempDir, _) <- getTmpDir
+                let portFile = tempDir </> "sandbox-portfile"
                 createSandbox portFile stdout conf
         in withResource createSandbox' destroySandbox (f . fmap sandboxPort)
 

--- a/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortFiles.scala
+++ b/libs-scala/ports/src/main/scala/com/digitalasset/ports/PortFiles.scala
@@ -36,9 +36,10 @@ object PortFiles {
     }
 
   private def writeUnsafe(path: Path, port: Port): Unit = {
-    import java.nio.file.StandardOpenOption.CREATE_NEW
     val lines: java.lang.Iterable[String] = List(port.value.toString).asJava
-    val created = Files.write(path, lines, CREATE_NEW)
+    val tmpFile = Files.createTempFile("portfile", "")
+    Files.write(tmpFile, lines)
+    val created = Files.move(tmpFile, path)
     created.toFile.deleteOnExit()
   }
 }


### PR DESCRIPTION
Fixes #7806. This aligns the port file behavior of the sandbox with the
HTTP JSON API.

CHANGELOG_BEGIN
[sandbox/json-api] Both services have the same port-file behavior now. They fail when a port-file already exists and write port-files atomically.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
