### PR TITLE
Upgrade ledger-api-test-tool-on-canton to the canton 0.19.0 release

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -961,10 +961,10 @@ package(default_visibility = ["//visibility:public"])
 
 java_import(
     name = "lib",
-    jars = glob(["lib/**"]),
+    jars = glob(["lib/**/*.jar"]),
 )
 """,
-    sha256 = "dff85a80e893f1d4e99c3eb3cd62ed0fbb8a91d4b76aa2cc3394a635da968aed",
-    strip_prefix = "canton-0.18.2",
-    urls = ["https://www.canton.io/releases/canton-0.18.2.tar.gz"],
+    sha256 = "3c6ff12b65d9e6e85686383b811094d8b04d3f4033e725951fba95cc35bd804c",
+    strip_prefix = "canton-community-0.19.0",
+    urls = ["https://www.canton.io/releases/canton-community-0.19.0.tar.gz"],
 )

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -6,7 +6,7 @@ load("@os_info//:os_info.bzl", "is_windows")
 
 java_binary(
     name = "canton",
-    main_class = "com.digitalasset.canton.CantonApp",
+    main_class = "com.digitalasset.canton.CantonCommunityApp",
     runtime_deps = ["@canton//:lib"],
 )
 
@@ -71,9 +71,39 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--concurrent-test-runs=4",  # lowered from default #procs to reduce flakes - details in https://github.com/digital-asset/daml/issues/7316
-        "--exclude=ContractKeysIT" +  # 3 of the more specialized tests currently fail on Canton
+        # The following three contract key tests require uniqueness and are tested in conformance-test-contract-keys below
+        "--exclude=ContractKeysIT,ContractKeysIT:CKFetchOrLookup,ContractKeysIT:CKNoFetchUndisclosed,ContractKeysIT:CKMaintainerScoped" +
         ",ConfigManagementServiceIT,LedgerConfigurationServiceIT" +  # dynamic config management not supported by Canton
         ",TransactionScaleIT,LotsOfPartiesIT" +  # scale tests need timeout-scale-factor 1.5 and 2.0 respectively on Canton
         ",ClosedWorldIT",  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
+    ],
+) if not is_windows else None
+
+conformance_test(
+    name = "conformance-test-contract-keys",
+    # Ideally these would be part of the script definition above, but that doesn't seem to work.
+    extra_data = [
+        ":bootstrap.canton",
+        ":canton",
+        ":canton.conf",
+        ":unique-contract-keys.conf", # needed to pass all contract keys conformance tests
+        ":logback-debug.xml",
+        "@coreutils_nix//:bin/base64",
+        "@curl_nix//:bin/curl",
+        "@grpcurl_nix//:bin/grpcurl",
+        "@jq_dev_env//:jq",
+    ],
+    ports = [
+        5011,
+        5021,
+        5031,
+        5041,
+    ],
+    runner = "@//bazel_tools/client_server/runner:runner",
+    server = ":canton-test-runner-with-dependencies",
+    test_tool_args = [
+        "--verbose",
+        "--concurrent-test-runs=4",  # lowered from default #procs to reduce flakes - details in https://github.com/digital-asset/daml/issues/7316
+        "--include=ContractKeysIT"
     ],
 ) if not is_windows else None

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -74,7 +74,6 @@ conformance_test(
         # The following three contract key tests require uniqueness and are tested in conformance-test-contract-keys below
         "--exclude=ContractKeysIT,ContractKeysIT:CKFetchOrLookup,ContractKeysIT:CKNoFetchUndisclosed,ContractKeysIT:CKMaintainerScoped" +
         ",ConfigManagementServiceIT,LedgerConfigurationServiceIT" +  # dynamic config management not supported by Canton
-        ",TransactionScaleIT,LotsOfPartiesIT" +  # scale tests need timeout-scale-factor 1.5 and 2.0 respectively on Canton
         ",ClosedWorldIT",  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
     ],
 ) if not is_windows else None

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -86,7 +86,7 @@ conformance_test(
         ":bootstrap.canton",
         ":canton",
         ":canton.conf",
-        ":unique-contract-keys.conf", # needed to pass all contract keys conformance tests
+        ":unique-contract-keys.conf",  # needed to pass all contract keys conformance tests
         ":logback-debug.xml",
         "@coreutils_nix//:bin/base64",
         "@curl_nix//:bin/curl",
@@ -104,6 +104,6 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--concurrent-test-runs=4",  # lowered from default #procs to reduce flakes - details in https://github.com/digital-asset/daml/issues/7316
-        "--include=ContractKeysIT"
+        "--include=ContractKeysIT",
     ],
 ) if not is_windows else None

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -57,6 +57,10 @@ if [[ -z "$port_file" ]]; then
   exit 2
 fi
 
+if [[ -f $(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf) ]]; then
+  command+=("--config=$(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf)")
+fi
+
 # Change HOME since Canton uses ammonite in the default configuration, which tries to write to
 # ~/.ammonite/cache, which is read-only when sandboxing is enabled.
 HOME="$(mktemp -d)"

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -57,8 +57,9 @@ if [[ -z "$port_file" ]]; then
   exit 2
 fi
 
-if [[ -f $(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf) ]]; then
-  command+=("--config=$(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf)")
+UNIQUE_CONTRACT_KEYS="$(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf)"
+if [[ -f ${UNIQUE_CONTRACT_KEYS} ]]; then
+  command+=("--config=${UNIQUE_CONTRACT_KEYS}")
 fi
 
 # Change HOME since Canton uses ammonite in the default configuration, which tries to write to

--- a/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
+++ b/ledger/ledger-api-test-tool-on-canton/canton-test-runner.sh
@@ -57,7 +57,7 @@ if [[ -z "$port_file" ]]; then
   exit 2
 fi
 
-UNIQUE_CONTRACT_KEYS="$(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf)"
+export UNIQUE_CONTRACT_KEYS="$(rlocation com_github_digital_asset_daml/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf)"
 if [[ -f ${UNIQUE_CONTRACT_KEYS} ]]; then
   command+=("--config=${UNIQUE_CONTRACT_KEYS}")
 fi

--- a/ledger/ledger-api-test-tool-on-canton/canton.conf
+++ b/ledger/ledger-api-test-tool-on-canton/canton.conf
@@ -3,8 +3,10 @@
 
 canton {
   parameters {
-    party-change-notification {
-      type = via-domain
+    participant {
+      party-change-notification {
+        type = via-domain
+      }
     }
   }
 

--- a/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf
+++ b/ledger/ledger-api-test-tool-on-canton/unique-contract-keys.conf
@@ -1,0 +1,1 @@
+canton.domains.test_domain.domain-parameters.unique-contract-keys = true


### PR DESCRIPTION
- Reflecting changes related to the Community edition of canton
- Testing full ContractKeysIT in a separate canton environment with
  unique contract keys. The ability to run multiple canton environments
  will come in handy when we introduce the participant pruning test suite.
- Slight canton configuration changes
- Changed bazel `java_import` to filter for `*.jar` files so the new `canton.ico`
  does not mess up building.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
