### PR TITLE
[DAML on SQL] Support passing the JDBC URL through an environment variable via --sql-backend-jdbcurl-env

### DIFF
--- a/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
+++ b/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
@@ -9,8 +9,10 @@ import com.daml.platform.sandbox.cli.{CommonCli, SandboxCli}
 import com.daml.platform.sandbox.config.SandboxConfig
 import scopt.OptionParser
 
-private[sql] final class Cli(override val defaultConfig: SandboxConfig = DefaultConfig)
-    extends SandboxCli {
+private[sql] final class Cli(
+    override val defaultConfig: SandboxConfig = DefaultConfig,
+    getEnv: String => Option[String] = sys.env.get,
+) extends SandboxCli {
 
   override protected val parser: OptionParser[SandboxConfig] = {
     val parser =
@@ -24,6 +26,13 @@ private[sql] final class Cli(override val defaultConfig: SandboxConfig = Default
       .action((_, config) => config.copy(devMode = true))
       .text("Allows development versions of DAML-LF language and transaction format.")
       .hidden()
+
+    parser
+      .opt[String]("sql-backend-jdbcurl-env")
+      .optional()
+      .text(
+        s"The environment variable containing JDBC connection URL to a Postgres database, including username and password. If present, $Name will use the database to persist its data.")
+      .action((env, config) => config.copy(jdbcUrl = getEnv(env).orElse(config.jdbcUrl)))
 
     // Ideally we would set the relevant options to `required()`, but it doesn't seem to work.
     // Even when the value is provided, it still reports that it's missing. Instead, we check the

--- a/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
+++ b/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
@@ -30,9 +30,11 @@ private[sql] final class Cli(
     parser
       .opt[String]("sql-backend-jdbcurl-env")
       .optional()
-      .text(
-        s"The environment variable containing JDBC connection URL to a Postgres database, including username and password. If present, $Name will use the database to persist its data.")
-      .action((env, config) => config.copy(jdbcUrl = getEnv(env).orElse(config.jdbcUrl)))
+      .text("The environment variable containing JDBC connection URL to a Postgres database, " +
+        s"including username and password. If present, $Name will use the database to persist its data.")
+      .action((env, config) =>
+        config.copy(jdbcUrl = getEnv(env).orElse(
+          throw new IllegalArgumentException(s"The '$env' environment variable is undefined."))))
 
     // Ideally we would set the relevant options to `required()`, but it doesn't seem to work.
     // Even when the value is provided, it still reports that it's missing. Instead, we check the

--- a/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
+++ b/ledger/daml-on-sql/src/main/scala/on/sql/Cli.scala
@@ -46,7 +46,8 @@ private[sql] final class Cli(
     parser.checkConfig(
       config =>
         if (config.jdbcUrl.isEmpty)
-          Left("The JDBC URL is required. Please set it with `--sql-backend-jdbcurl`.")
+          Left(
+            "The JDBC URL is required. Please set it with `--sql-backend-jdbcurl` or `--sql-backend-jdbcurl-env`.")
         else
           Right(()))
     parser.checkConfig(

--- a/ledger/daml-on-sql/src/test/suite/scala/on/sql/CliSpec.scala
+++ b/ledger/daml-on-sql/src/test/suite/scala/on/sql/CliSpec.scala
@@ -11,6 +11,7 @@ import com.daml.platform.sandbox.cli.CommonCliSpecBase._
 
 import scala.collection.mutable
 import CliSpec._
+import org.scalatest.BeforeAndAfterEach
 
 class CliSpec
     extends CommonCliSpecBase(
@@ -26,7 +27,8 @@ class CliSpec
           ledgerIdMode = LedgerIdMode.Static(LedgerId("test-ledger")),
           jdbcUrl = Some(exampleJdbcUrl),
         )),
-    ) {
+    )
+    with BeforeAndAfterEach {
 
   "Cli" should {
     "reject when the ledgerid is not provided" in {
@@ -49,7 +51,6 @@ class CliSpec
       fakeEnv += "JDBC_URL" -> "jdbc:h2:mem"
       val config =
         cli.parse(Array("--ledgerid", "test-ledger", "--sql-backend-jdbcurl-env", "JDBC_URL"))
-      fakeEnv -= "JDBC_URL"
       config shouldEqual None
     }
 
@@ -58,7 +59,6 @@ class CliSpec
       fakeEnv += "JDBC_URL" -> jdbcUrl
       val config =
         cli.parse(Array("--ledgerid", "test-ledger", "--sql-backend-jdbcurl-env", "JDBC_URL"))
-      fakeEnv -= "JDBC_URL"
       config
         .getOrElse(fail("The configuration was not parsed correctly"))
         .jdbcUrl
@@ -78,6 +78,9 @@ class CliSpec
     }
   }
 
+  override def beforeEach(): Unit = {
+    fakeEnv.clear()
+  }
 }
 
 object CliSpec {

--- a/ledger/daml-on-sql/src/test/suite/scala/on/sql/CliSpec.scala
+++ b/ledger/daml-on-sql/src/test/suite/scala/on/sql/CliSpec.scala
@@ -47,6 +47,12 @@ class CliSpec
       config shouldEqual None
     }
 
+    "reject when sql-backend-jdbcurl-env points to a non-existing environment variable" in {
+      val config =
+        cli.parse(Array("--ledgerid", "test-ledger", "--sql-backend-jdbcurl-env", "JDBC_URL"))
+      config shouldEqual None
+    }
+
     "reject when sql-backend-jdbcurl-env is not a PostgreSQL URL" in {
       fakeEnv += "JDBC_URL" -> "jdbc:h2:mem"
       val config =


### PR DESCRIPTION
CHANGELOG_BEGIN
- [DAML on SQL] Support passing the PostgreSQL JDBC URL through an environment variable via `--sql-backend-jdbcurl-env`
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
