### PR TITLE
Avoid generating ill-formed kinds in DAML compiler

### DIFF
--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -117,6 +117,7 @@ data Error
   | EUnsupportedFeature !Feature
   | EForbiddenNameCollision !T.Text ![T.Text]
   | ESynAppWrongArity       !DefTypeSyn ![Type]
+  | ENatKindRightOfArrow    !Kind
 
 contextLocation :: Context -> Maybe SourceLoc
 contextLocation = \case
@@ -330,6 +331,11 @@ instance Pretty Error where
     ESynAppWrongArity DefTypeSyn{synName,synParams} args ->
       vcat ["wrong arity in type synonym application: " <> pretty synName,
             "expected: " <> pretty (length synParams) <> ", found: " <> pretty (length args)]
+    ENatKindRightOfArrow k ->
+      vcat
+        [ "Kind is invalid: " <> pretty k
+        , "Nat kind is not allowed on the right side of kind arrow."
+        ]
 
 instance Pretty Context where
   pPrint = \case

--- a/compiler/damlc/tests/daml-test-files/KindChecking.daml
+++ b/compiler/damlc/tests/daml-test-files/KindChecking.daml
@@ -1,0 +1,9 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- Make sure that invalid kinds are reported as errors by the DAML compiler.
+module KindChecking where
+
+-- @ERROR range=9:1-9:4; Nat kind on the right-hand side of kind arrow
+foo : forall (f: * -> GHC.Types.Nat). Numeric (f ()) -> Numeric (f ()) -> Numeric (f ())
+foo = (+)

--- a/compiler/damlc/tests/daml-test-files/KindChecking.daml
+++ b/compiler/damlc/tests/daml-test-files/KindChecking.daml
@@ -5,6 +5,6 @@
 -- Make sure that invalid kinds are reported as errors by the DAML compiler.
 module KindChecking where
 
--- @ERROR range=9:1-9:4; Nat kind on the right-hand side of kind arrow
+-- @ERROR range=10:1-10:4; Nat kind on the right-hand side of kind arrow
 foo : forall (f: * -> GHC.Types.Nat). Numeric (f ()) -> Numeric (f ()) -> Numeric (f ())
 foo = (+)

--- a/compiler/damlc/tests/daml-test-files/KindChecking.daml
+++ b/compiler/damlc/tests/daml-test-files/KindChecking.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- All rights reserved.
 
+-- @SINCE-LF 1.7
 -- Make sure that invalid kinds are reported as errors by the DAML compiler.
 module KindChecking where
 


### PR DESCRIPTION
This PR avoids generating invalid kinds (i.e. kinds of the form `k ->
Nat`)
during LF conversion, and adds a small "kind checking" step
whenever a type variable is introduced in the LF typechecker (since the
only way to get invalid kinds is to introduce them in a `forall`).

Right now there's no way to test that both the typechecker & the
conversion raise an error here, and in general, we try to always push
our LF type errors into GHC type errors or LF conversion errors. This
is something we can work on (adding actual LF typechecker tests). But
also, I verified manually that the type checker raises the error, in
the absence of the changes to LF conversion.

Ok, last point: The test case here has a weird location, but I tried and
couldn't figure out how to get a better location. I think this is a
general problem with the GHC Core representation?

This PR does the "Haskell side" of #7917.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
