### PR TITLE
LF: check for ill-formed kinds in scala type checker.

### DIFF
--- a/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
+++ b/daml-lf/validation/src/main/scala/com/digitalasset/daml/lf/validation/ValidationError.scala
@@ -166,7 +166,9 @@ abstract class ValidationError extends java.lang.RuntimeException with Product w
   override def getMessage: String = pretty
   protected def prettyInternal: String
 }
-
+final case class ENatKindRightOfArrow(context: Context, kind: Kind) extends ValidationError {
+  protected def prettyInternal: String = s"invalid kind ${kind.pretty}"
+}
 final case class EUnknownTypeVar(context: Context, varName: TypeVarName) extends ValidationError {
   protected def prettyInternal: String = s"unknown type variable: $varName"
 }


### PR DESCRIPTION
Following what have been done in #7944, we add a check in the Scala LF
type checker that reject invalid kinds (i.e. kinds of the form `k ->Nat`).

This PR does the "Scala side" of #7917.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
