### PR TITLE
Cleanup trigger service endpoints

### DIFF
--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -725,7 +725,7 @@ quickstartTests quickstartDir mvnDir = testGroup "quickstart"
               triggerServicePort :: Int <- fromIntegral <$> getFreePort
               let triggerServiceProc = (shell $ unwords ["daml", "trigger-service", "--ledger-host", "localhost", "--ledger-port", show sandboxPort, "--http-port", show triggerServicePort, "--wall-clock-time"]) { std_out = UseHandle devNull2, std_err = UseHandle devNull3, std_in = CreatePipe }
               withCreateProcess triggerServiceProc $ \_ _ _ triggerServicePh -> race_ (waitForProcess' triggerServiceProc triggerServicePh) $ do
-                let endpoint = "http://localhost:" <> show triggerServicePort <> "/v1/health"
+                let endpoint = "http://localhost:" <> show triggerServicePort <> "/livez"
                 waitForHttpServer (threadDelay 100000) endpoint []
                 req <- parseRequest endpoint
                 manager <- newManager defaultManagerSettings

--- a/docs/source/tools/trigger-service.rst
+++ b/docs/source/tools/trigger-service.rst
@@ -29,75 +29,173 @@ Although as we'll see, the Trigger Service exposes an endpoint for end-users to 
 
    daml trigger-service --ledger-host localhost --ledger-port 6865 --wall-clock-time
 
-End-user interaction with the Trigger Service
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Endpoints
+~~~~~~~~~
 
-``start``
-*********
+Start a trigger
+***************
 
 Start a trigger. In this example, Alice starts the trigger called ``trigger`` in a module called ``TestTrigger`` of a package with ID ``312094804c1468e2166bae3c9ba8b5cc0d285e31356304a2e9b0ac549df59d14``. The response contains an identifier for the running trigger that Alice can use in subsequent commands involving the trigger.
 
-.. code-block:: bash
+HTTP Request
+============
 
-   $curl \
-      -X POST localhost:8088/v1/start \
-      -H "Content-type: application/json" -H "Accept: application/json" \
-      -d '{"triggerName":"312094804c1468e2166bae3c9ba8b5cc0d285e31356304a2e9b0ac549df59d14:TestTrigger:trigger", "party": "alice"}'
-   {"result":{"triggerId":"4d539e9c-b962-4762-be71-40a5c97a47a6"},"status":200}
+- URL: ``/v1/triggers``
+- Method: ``POST``
+- Content-Type: ``application/json``
+- Content:
 
-``stop``
-********
+.. code-block:: json
+
+    {
+      "triggerName": "312094804c1468e2166bae3c9ba8b5cc0d285e31356304a2e9b0ac549df59d14:TestTrigger:trigger",
+      "party": "alice"
+    }
+
+HTTP Response
+=============
+
+.. code-block:: json
+
+    {
+      "result":{"triggerId":"4d539e9c-b962-4762-be71-40a5c97a47a6"},
+      "status":200
+    }
+
+
+Stop a trigger
+**************
 
 Stop a running trigger. Alice stops her running trigger like so.
 
-.. code-block:: bash
+HTTP Request
+============
 
-   $curl \
-      -X DELETE localhost:8088/v1/stop/4d539e9c-b962-4762-be71-40a5c97a47a6 \
-      -H "Content-type: application/json" -H "Accept: application/json"
-   {"result":{"triggerId":"4d539e9c-b962-4762-be71-40a5c97a47a6"},"status":200}
+- URL: ``/v1/triggers/:id``
+- Method: ``DELETE``
+- Content-Type: ``application/json``
+- Content:
 
-``upload_dar``
-**************
+HTTP Response
+=============
 
-Upload an automation DAR. If successful, the DAR's "main package ID" will be in the response (the main package ID for a DAR can also be obtained using ``daml damlc inspect-dar path/to/dar``).
+- Content-Type: ``application/json``
+- Content:
 
-.. code-block:: bash
+.. code-block:: json
 
-   $ curl -F 'dar=@/home/alice/test-model.dar' localhost:8088/v1/upload_dar
-   {"result":{"mainPackageId":"312094804c1468e2166bae3c9ba8b5cc0d285e31356304a2e9b0ac549df59d14"},"status":200}
+   {
+     "result": {"triggerId":"4d539e9c-b962-4762-be71-40a5c97a47a6"},
+     "status":200
+   }
 
-``list``
-********
+List running triggers
+*********************
 
-List the DARS running on behalf of a given party. Alice can check on her running triggers as follows.
+List the Triggers running on behalf of a given party.
 
-.. code-block:: bash
+HTTP Request
+============
 
-   $curl \
-       -X GET localhost:8088/v1/list \
-       -H "Content-type: application/json" -H "Accept: application/json"
-       -d '{"party": "alice"}'
-   {"result":{"triggerIds":["4d539e9c-b962-4762-be71-40a5c97a47a6"],"status":200}
+- URL: ``/v1/triggers``
+- Method: ``GET``
+- Content-Type: ``application/json``
+- Content:
 
-``status``
-**********
+.. code-block:: json
+
+    {"party": "alice"}
+
+HTTP Response
+=============
+
+- Content-Type: ``application/json``
+- Content:
+
+.. code-block:: json
+
+    {
+      "result": {"triggerIds":["4d539e9c-b962-4762-be71-40a5c97a47a6"]},
+      "status":200
+    }
+
+Status of a trigger
+*******************
 
 It's sometimes useful to get information about the history of a specific trigger. This can be done with the "status" endpoint.
 
-.. code-block:: bash
+HTTP Request
+============
 
-   $curl \
-      -X GET localhost:8088/v1/status/4d539e9c-b962-4762-be71-40a5c97a47a6 \
-      -H "Content-type: application/json" -H "Accept: application/json"
-  {"result":{"logs":[["2020-06-12T12:35:49.863","starting"],["2020-06-12T12:35:50.89","running"],["2020-06-12T12:51:57.557","stopped: by user request"]]},"status":200}
+- URL: ``/v1/triggers/:id``
+- Method: ``GET``
+- Content-Type: ``application/json``
+- Content:
 
-``health``
-**********
+HTTP Response
+=============
 
-Test connectivity.
+- Content-Type: ``application/json``
+- Content:
 
-.. code-block:: bash
+.. code-block:: json
 
-   $curl -X GET localhost:8088/v1/health
+    {
+      "result": {"logs":[["2020-06-12T12:35:49.863","starting"],["2020-06-12T12:35:50.89","running"],["2020-06-12T12:51:57.557","stopped: by user request"]]},
+      "status": 200
+    }
+
+Upload a new DAR
+****************
+
+Upload a DAR containing one or more triggers. If successful, the DAR's "main package ID" will be in the response (the main package ID for a DAR can also be obtained using ``daml damlc inspect-dar path/to/dar``).
+
+HTTP Request
+============
+
+- URL: ``/v1/packages``
+- Method: ``POST``
+- Content-Type: ``multipart/form-data``
+- Content:
+
+  ``dar=$dar_content``
+
+HTTP Response
+=============
+
+- Content-Type: ``application/json``
+- Content:
+
+.. code-block:: json
+
+    {
+      "result": {"mainPackageId":"312094804c1468e2166bae3c9ba8b5cc0d285e31356304a2e9b0ac549df59d14"},
+      "status": 200
+    }
+
+Liveness check
+**************
+
+This can be used as a liveness probe, e.g., in Kubernetes.
+
+HTTP Request
+============
+
+- URL: ``/livez``
+- Method: ``GET``
+- Content-Type: ``application/json``
+- Content:
+
+.. code-block:: json
+
    {"status":"pass"}
+
+HTTP Response
+=============
+
+- Content-Type: ``application/json``
+- Content:
+
+.. code-block:: json
+
+    { "status": "pass" }

--- a/docs/source/tools/trigger-service.rst
+++ b/docs/source/tools/trigger-service.rst
@@ -97,14 +97,8 @@ List the Triggers running on behalf of a given party.
 HTTP Request
 ============
 
-- URL: ``/v1/triggers``
+- URL: ``/v1/triggers?party=:party``
 - Method: ``GET``
-- Content-Type: ``application/json``
-- Content:
-
-.. code-block:: json
-
-    {"party": "alice"}
 
 HTTP Response
 =============
@@ -129,8 +123,6 @@ HTTP Request
 
 - URL: ``/v1/triggers/:id``
 - Method: ``GET``
-- Content-Type: ``application/json``
-- Content:
 
 HTTP Response
 =============
@@ -183,8 +175,6 @@ HTTP Request
 
 - URL: ``/livez``
 - Method: ``GET``
-- Content-Type: ``application/json``
-- Content:
 
 .. code-block:: json
 

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -4,59 +4,51 @@
 package com.daml.lf
 package engine.trigger
 
+import java.io.ByteArrayInputStream
+import java.time.LocalDateTime
+import java.util.UUID
+import java.util.zip.ZipInputStream
+
 import akka.actor.ActorSystem
-import akka.actor.typed.{ActorRef, Behavior}
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.actor.typed.scaladsl.adapter._
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.typed.{ActorRef, Behavior}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.server.{Directive, Directive1}
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.server.{Directive, Directive1, Route}
+import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import akka.stream.Materializer
 import akka.util.ByteString
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
+import com.daml.ledger.api.refinements.ApiTypes.Party
+import com.daml.lf.archive.Reader.ParseError
+import com.daml.lf.archive.{Dar, DarReader, Decode}
+import com.daml.lf.data.Ref.{Identifier, PackageId}
+import com.daml.lf.engine.trigger.Request.StartParams
+import com.daml.lf.engine.trigger.Response._
+import com.daml.lf.engine.trigger.Tagged.AccessToken
+import com.daml.lf.engine.trigger.dao._
+import com.daml.lf.engine._
+import com.daml.oauth.middleware.Request.Claims
 import com.daml.oauth.middleware.{
   JsonProtocol => AuthJsonProtocol,
   Request => AuthRequest,
   Response => AuthResponse
 }
-import com.daml.ledger.api.refinements.ApiTypes.Party
-import com.daml.lf.archive.{Dar, DarReader, Decode}
-import com.daml.lf.archive.Reader.ParseError
-import com.daml.lf.data.Ref.{Identifier, PackageId}
-import com.daml.lf.engine.{
-  ConcurrentCompiledPackages,
-  MutableCompiledPackages,
-  Result,
-  ResultDone,
-  ResultNeedPackage
-}
-import com.daml.lf.engine.trigger.dao._
-import com.daml.lf.engine.trigger.Request.{ListParams, StartParams}
-import com.daml.lf.engine.trigger.Response._
-import com.daml.daml_lf_dev.DamlLf
-import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.scalautil.Statement.discard
 import com.typesafe.scalalogging.StrictLogging
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 
+import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
-import java.io.ByteArrayInputStream
-import java.util.UUID
-import java.util.zip.ZipInputStream
-import java.time.LocalDateTime
-
-import com.daml.lf.engine.trigger.Tagged.AccessToken
-import com.daml.oauth.middleware.Request.Claims
-
-import scala.collection.concurrent.TrieMap
 
 class Server(
     authConfig: AuthConfig,
@@ -306,6 +298,8 @@ class Server(
       }
     }
 
+  private implicit val unmarshalParty: Unmarshaller[String, Party] = Unmarshaller.strict(Party(_))
+
   private def route(implicit ec: ExecutionContext, system: ActorSystem) = concat(
     pathPrefix("v1" / "triggers") {
       concat(
@@ -332,10 +326,10 @@ class Server(
             },
             // List triggers currently running for the given party.
             get {
-              entity(as[ListParams]) { params =>
-                val claims = Claims(readAs = List(params.party))
+              parameters('party.as[Party]) { party =>
+                val claims = Claims(readAs = List(party))
                 authorize(claims)(ec, system) { _ =>
-                  listTriggers(params.party) match {
+                  listTriggers(party) match {
                     case Left(err) =>
                       complete(errorResponse(StatusCodes.InternalServerError, err))
                     case Right(triggerInstances) => complete(successResponse(triggerInstances))

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -12,6 +12,7 @@ import akka.stream.scaladsl.{FileIO, Sink, Source}
 import java.io.File
 import java.util.UUID
 
+import akka.http.scaladsl.model.Uri.Query
 import org.scalatest._
 
 import scala.concurrent.Future
@@ -82,11 +83,7 @@ trait AbstractTriggerServiceTest
   def listTriggers(uri: Uri, party: Party): Future[HttpResponse] = {
     val req = HttpRequest(
       method = HttpMethods.GET,
-      uri = uri.withPath(Uri.Path(s"/v1/triggers")),
-      entity = HttpEntity(
-        ContentTypes.`application/json`,
-        s"""{"party": "$party"}"""
-      )
+      uri = uri.withPath(Uri.Path(s"/v1/triggers")).withQuery(Query(("party", party.toString))),
     )
     httpRequestFollow(req)
   }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -70,7 +70,7 @@ trait AbstractTriggerServiceTest
   def startTrigger(uri: Uri, triggerName: String, party: Party): Future[HttpResponse] = {
     val req = HttpRequest(
       method = HttpMethods.POST,
-      uri = uri.withPath(Uri.Path("/v1/start")),
+      uri = uri.withPath(Uri.Path("/v1/triggers")),
       entity = HttpEntity(
         ContentTypes.`application/json`,
         s"""{"triggerName": "$triggerName", "party": "$party"}"""
@@ -82,7 +82,7 @@ trait AbstractTriggerServiceTest
   def listTriggers(uri: Uri, party: Party): Future[HttpResponse] = {
     val req = HttpRequest(
       method = HttpMethods.GET,
-      uri = uri.withPath(Uri.Path(s"/v1/list")),
+      uri = uri.withPath(Uri.Path(s"/v1/triggers")),
       entity = HttpEntity(
         ContentTypes.`application/json`,
         s"""{"party": "$party"}"""
@@ -95,7 +95,7 @@ trait AbstractTriggerServiceTest
     val id = triggerInstance.toString
     val req = HttpRequest(
       method = HttpMethods.GET,
-      uri = uri.withPath(Uri.Path(s"/v1/status/$id")),
+      uri = uri.withPath(Uri.Path(s"/v1/triggers/$id")),
     )
     httpRequestFollow(req)
   }
@@ -107,7 +107,7 @@ trait AbstractTriggerServiceTest
     val id = triggerInstance.toString
     val req = HttpRequest(
       method = HttpMethods.DELETE,
-      uri = uri.withPath(Uri.Path(s"/v1/stop/$id")),
+      uri = uri.withPath(Uri.Path(s"/v1/triggers/$id")),
     )
     httpRequestFollow(req)
   }
@@ -121,7 +121,7 @@ trait AbstractTriggerServiceTest
         Map("filename" -> file.toString)))
     val req = HttpRequest(
       method = HttpMethods.POST,
-      uri = uri.withPath(Uri.Path(s"/v1/upload_dar")),
+      uri = uri.withPath(Uri.Path(s"/v1/packages")),
       entity = multipartForm.toEntity
     )
     Http().singleRequest(req)
@@ -134,8 +134,8 @@ trait AbstractTriggerServiceTest
   // Check the response was successful and extract the "result" field.
   def parseResult(resp: HttpResponse): Future[JsValue] = {
     for {
-      _ <- assert(resp.status.isSuccess)
       body <- responseBodyToString(resp)
+      _ <- assert(resp.status.isSuccess)
       JsObject(fields) = body.parseJson
       Some(result) = fields.get("result")
     } yield result
@@ -379,7 +379,7 @@ trait AbstractTriggerServiceTest
     val uuid: String = "No More Mr Nice Guy"
     val req = HttpRequest(
       method = HttpMethods.DELETE,
-      uri = uri.withPath(Uri.Path(s"/v1/stop/$uuid")),
+      uri = uri.withPath(Uri.Path(s"/v1/triggers/$uuid")),
     )
     for {
       resp <- Http().singleRequest(req)


### PR DESCRIPTION
fixes #6333

changelog_begin

- [Trigger Service]

  Endpoints have been rearranged to be more consistent:

  | New endpoint              | Old endpoint       | Functionality                |
  |---------------------------|--------------------|------------------------------|
  | GET `/v1/triggers`        | `/v1/list`         | List triggers                |
  | POST `/v1/triggers`       | `/v1/start`        | Start trigger                |
  | GET `/v1/triggers/:id`    | `/v1/status/:id`   | Trigger status               |
  | DELETE `/v1/triggers/:id` | `/v1/triggers/:id` | Stop/delete trigger          |
  | POST `/v1/packages`       | `/v1/upload_dar`   | Upload DAR                   |
  | GET `/livez`              | `/v1/health`       | liveness check               |

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
