### PR TITLE
Trigger auth failure

### DIFF
--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Main.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Main.scala
@@ -24,7 +24,7 @@ object Main extends StrictLogging {
 
     def terminate() = Await.result(system.terminate(), 10.seconds)
 
-    val bindingFuture = Server.start(config)
+    val bindingFuture = Server(config).start()
 
     sys.addShutdownHook {
       Server

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -132,12 +132,14 @@ class Server(config: Config) {
       }
     }
   )
+
+  def start()(implicit system: ActorSystem): Future[ServerBinding] = {
+    Http().bindAndHandle(route, "localhost", config.port.value)
+  }
 }
 
 object Server {
-  def start(config: Config)(implicit system: ActorSystem): Future[ServerBinding] = {
-    Http().bindAndHandle(new Server(config).route, "localhost", config.port.value)
-  }
+  def apply(config: Config) = new Server(config)
   def stop(f: Future[ServerBinding])(implicit ec: ExecutionContext): Future[Done] =
     f.flatMap(_.unbind())
 }

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -30,6 +30,8 @@ import scala.language.postfixOps
 class Server(config: Config) {
   private val jwtHeader = """{"alg": "HS256", "typ": "JWT"}"""
 
+  var authorizedParties: Option[Set[Party]] = config.parties
+
   // To keep things as simple as possible, we use a UUID as the authorization code
   // and in the /authorize request we already pre-compute the JWT payload based on the scope.
   // The token request then only does a lookup and signs the token.
@@ -78,7 +80,7 @@ class Server(config: Config) {
           .as[Request.Authorize](Request.Authorize) {
             request =>
               val parties = requestParties(request)
-              val denied = config.parties.map(parties.toSet -- _).getOrElse(Nil)
+              val denied = authorizedParties.map(parties.toSet -- _).getOrElse(Nil)
               if (denied.isEmpty) {
                 val authorizationCode = UUID.randomUUID()
                 val params =

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -35,10 +35,7 @@ class Server(config: Config) {
   // Add the given party to the set of authorized parties,
   // if authorization of individual parties is enabled.
   def authorizeParty(party: Party): Unit = {
-    authorizedParties = authorizedParties match {
-      case Some(parties) => Some(parties + party)
-      case None => None
-    }
+    authorizedParties = authorizedParties.map(_ + party)
   }
 
   // Remove the given party from the set of authorized parties,

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -30,7 +30,25 @@ import scala.language.postfixOps
 class Server(config: Config) {
   private val jwtHeader = """{"alg": "HS256", "typ": "JWT"}"""
 
-  var authorizedParties: Option[Set[Party]] = config.parties
+  private var authorizedParties: Option[Set[Party]] = config.parties
+
+  def authorizeParty(party: Party): Unit = {
+    authorizedParties = authorizedParties match {
+      case Some(parties) => Some(parties + party)
+      case None => None
+    }
+  }
+
+  def revokeParty(party: Party): Unit = {
+    authorizedParties = authorizedParties match {
+      case Some(parties) => Some(parties - party)
+      case None => None
+    }
+  }
+
+  def resetAuthorizedParties(): Unit = {
+    authorizedParties = config.parties
+  }
 
   // To keep things as simple as possible, we use a UUID as the authorization code
   // and in the /authorize request we already pre-compute the JWT payload based on the scope.

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -61,6 +61,7 @@ class Server(config: Config) {
     req.scope.foreach(_.split(" ").foreach {
       case s if s.startsWith("actAs:") => actAs ++= Seq(s.stripPrefix("actAs:"))
       case s if s.startsWith("readAs:") => readAs ++= Seq(s.stripPrefix("readAs:"))
+      case _ => ()
     })
     AuthServiceJWTPayload(
       ledgerId = Some(config.ledgerId),

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -44,9 +44,7 @@ class Server(config: Config) {
   // Remove the given party from the set of authorized parties,
   // if authorization of individual parties is enabled.
   def revokeParty(party: Party): Unit = {
-    authorizedParties = authorizedParties match {
-      case Some(parties) => Some(parties - party)
-      case None => None
+    authorizedParties = authorizedParties.map(_ - party)
     }
   }
 

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -30,6 +30,7 @@ import scala.language.postfixOps
 class Server(config: Config) {
   private val jwtHeader = """{"alg": "HS256", "typ": "JWT"}"""
 
+  // None indicates that all parties are authorized, Some that only the given set of parties is authorized.
   private var authorizedParties: Option[Set[Party]] = config.parties
 
   // Add the given party to the set of authorized parties,

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -43,7 +43,6 @@ class Server(config: Config) {
   // if authorization of individual parties is enabled.
   def revokeParty(party: Party): Unit = {
     authorizedParties = authorizedParties.map(_ - party)
-    }
   }
 
   // Reset party authorization to the initially configured state.

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -32,6 +32,8 @@ class Server(config: Config) {
 
   private var authorizedParties: Option[Set[Party]] = config.parties
 
+  // Add the given party to the set of authorized parties,
+  // if authorization of individual parties is enabled.
   def authorizeParty(party: Party): Unit = {
     authorizedParties = authorizedParties match {
       case Some(parties) => Some(parties + party)
@@ -39,6 +41,8 @@ class Server(config: Config) {
     }
   }
 
+  // Remove the given party from the set of authorized parties,
+  // if authorization of individual parties is enabled.
   def revokeParty(party: Party): Unit = {
     authorizedParties = authorizedParties match {
       case Some(parties) => Some(parties - party)
@@ -46,6 +50,7 @@ class Server(config: Config) {
     }
   }
 
+  // Reset party authorization to the initially configured state.
   def resetAuthorizedParties(): Unit = {
     authorizedParties = config.parties
   }

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -27,113 +27,116 @@ import scala.language.postfixOps
 // Given scopes of the form `actAs:$party`, the authorization server will issue
 // tokens with the respective claims. Requests for authorized parties will be accepted and
 // request to /authorize are immediately redirected to the redirect_uri.
-object Server {
+class Server(config: Config) {
   private val jwtHeader = """{"alg": "HS256", "typ": "JWT"}"""
-  def start(config: Config)(implicit system: ActorSystem): Future[ServerBinding] = {
-    // To keep things as simple as possible, we use a UUID as the authorization code
-    // and in the /authorize request we already pre-compute the JWT payload based on the scope.
-    // The token request then only does a lookup and signs the token.
-    var requests = Map.empty[UUID, AuthServiceJWTPayload]
 
-    def requestParties(req: Request.Authorize): List[Party] =
-      Party.subst {
-        req.scope.fold(List.empty[String])(s => List[String](s.split(" "): _*)).collect {
-          case s if s.startsWith("actAs:") => s.stripPrefix("actAs:")
-        }
+  // To keep things as simple as possible, we use a UUID as the authorization code
+  // and in the /authorize request we already pre-compute the JWT payload based on the scope.
+  // The token request then only does a lookup and signs the token.
+  private var requests = Map.empty[UUID, AuthServiceJWTPayload]
+
+  private def requestParties(req: Request.Authorize): List[Party] =
+    Party.subst {
+      req.scope.fold(List.empty[String])(s => List[String](s.split(" "): _*)).collect {
+        case s if s.startsWith("actAs:") => s.stripPrefix("actAs:")
       }
-    def toPayload(req: Request.Authorize): AuthServiceJWTPayload = {
-      val parties: List[String] =
-        req.scope.fold(List.empty[String])(s => List[String](s.split(" "): _*)).collect {
-          case s if s.startsWith("actAs:") => s.stripPrefix("actAs:")
-        }
-      AuthServiceJWTPayload(
-        ledgerId = Some(config.ledgerId),
-        applicationId = config.applicationId,
-        // Not required by the default auth service
-        participantId = None,
-        // Only for testing, expire never.
-        exp = None,
-        // no admin claim for now.
-        admin = false,
-        actAs = parties,
-        readAs = List()
-      )
     }
 
-    import Request.Token.unmarshalHttpEntity
+  private def toPayload(req: Request.Authorize): AuthServiceJWTPayload = {
+    val parties: List[String] =
+      req.scope.fold(List.empty[String])(s => List[String](s.split(" "): _*)).collect {
+        case s if s.startsWith("actAs:") => s.stripPrefix("actAs:")
+      }
+    AuthServiceJWTPayload(
+      ledgerId = Some(config.ledgerId),
+      applicationId = config.applicationId,
+      // Not required by the default auth service
+      participantId = None,
+      // Only for testing, expire never.
+      exp = None,
+      // no admin claim for now.
+      admin = false,
+      actAs = parties,
+      readAs = List()
+    )
+  }
 
-    implicit val unmarshal: Unmarshaller[String, Uri] = Unmarshaller.strict(Uri(_))
+  import Request.Token.unmarshalHttpEntity
+  implicit val unmarshal: Unmarshaller[String, Uri] = Unmarshaller.strict(Uri(_))
 
-    val route = concat(
-      path("authorize") {
-        get {
-          parameters(
-            (
-              'response_type,
-              'client_id,
-              'redirect_uri.as[Uri],
-              'scope ?,
-              'state ?,
-              'audience.as[Uri] ?))
-            .as[Request.Authorize](Request.Authorize) {
-              request =>
-                val parties = requestParties(request)
-                val denied = config.parties.map(parties.toSet -- _).getOrElse(Nil)
-                if (denied.isEmpty) {
-                  val authorizationCode = UUID.randomUUID()
-                  val params =
-                    Response
-                      .Authorize(code = authorizationCode.toString, state = request.state)
-                      .toQuery
-                  requests += (authorizationCode -> toPayload(request))
-                  // We skip any actual consent screen since this is only intended for testing and
-                  // this is outside of the scope of the trigger service anyway.
-                  redirect(request.redirectUri.withQuery(params), StatusCodes.Found)
-                } else {
-                  val params =
-                    Response
-                      .Error(
-                        error = "access_denied",
-                        errorDescription = Some(s"Access to parties ${denied.mkString(" ")} denied"),
-                        errorUri = None,
-                        state = request.state)
-                      .toQuery
-                  redirect(request.redirectUri.withQuery(params), StatusCodes.Found)
-                }
-            }
-        }
-      },
-      path("token") {
-        post {
-          entity(as[Request.Token]) {
+  val route = concat(
+    path("authorize") {
+      get {
+        parameters(
+          (
+            'response_type,
+            'client_id,
+            'redirect_uri.as[Uri],
+            'scope ?,
+            'state ?,
+            'audience.as[Uri] ?))
+          .as[Request.Authorize](Request.Authorize) {
             request =>
-              // No validation to keep things simple
-              requests.get(UUID.fromString(request.code)) match {
-                case None => sys.exit(2)
-                case Some(payload) =>
-                  import JsonProtocol._
-                  complete(
-                    Response.Token(
-                      accessToken = JwtSigner.HMAC256
-                        .sign(
-                          DecodedJwt(jwtHeader, AuthServiceJWTCodec.compactPrint(payload)),
-                          config.jwtSecret)
-                        .getOrElse(
-                          throw new IllegalArgumentException("Failed to sign a token")
-                        )
-                        .value,
-                      refreshToken = None,
-                      expiresIn = None,
-                      scope = None,
-                      tokenType = "bearer"
-                    ))
+              val parties = requestParties(request)
+              val denied = config.parties.map(parties.toSet -- _).getOrElse(Nil)
+              if (denied.isEmpty) {
+                val authorizationCode = UUID.randomUUID()
+                val params =
+                  Response
+                    .Authorize(code = authorizationCode.toString, state = request.state)
+                    .toQuery
+                requests += (authorizationCode -> toPayload(request))
+                // We skip any actual consent screen since this is only intended for testing and
+                // this is outside of the scope of the trigger service anyway.
+                redirect(request.redirectUri.withQuery(params), StatusCodes.Found)
+              } else {
+                val params =
+                  Response
+                    .Error(
+                      error = "access_denied",
+                      errorDescription = Some(s"Access to parties ${denied.mkString(" ")} denied"),
+                      errorUri = None,
+                      state = request.state)
+                    .toQuery
+                redirect(request.redirectUri.withQuery(params), StatusCodes.Found)
               }
           }
+      }
+    },
+    path("token") {
+      post {
+        entity(as[Request.Token]) {
+          request =>
+            // No validation to keep things simple
+            requests.get(UUID.fromString(request.code)) match {
+              case None => sys.exit(2)
+              case Some(payload) =>
+                import JsonProtocol._
+                complete(
+                  Response.Token(
+                    accessToken = JwtSigner.HMAC256
+                      .sign(
+                        DecodedJwt(jwtHeader, AuthServiceJWTCodec.compactPrint(payload)),
+                        config.jwtSecret)
+                      .getOrElse(
+                        throw new IllegalArgumentException("Failed to sign a token")
+                      )
+                      .value,
+                    refreshToken = None,
+                    expiresIn = None,
+                    scope = None,
+                    tokenType = "bearer"
+                  ))
+            }
         }
       }
-    )
+    }
+  )
+}
 
-    Http().bindAndHandle(route, "localhost", config.port.value)
+object Server {
+  def start(config: Config)(implicit system: ActorSystem): Future[ServerBinding] = {
+    Http().bindAndHandle(new Server(config).route, "localhost", config.port.value)
   }
   def stop(f: Future[ServerBinding])(implicit ec: ExecutionContext): Future[Done] =
     f.flatMap(_.unbind())

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Resources.scala
@@ -12,7 +12,7 @@ object Resources {
   def authServer(config: OAuthConfig)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
-        Resource(OAuthServer.start(config))(_.unbind().map(_ => ()))
+        Resource(OAuthServer(config).start())(_.unbind().map(_ => ()))
     }
   def authMiddleware(config: Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Resources.scala
@@ -11,7 +11,7 @@ object Resources {
   def authServer(config: Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
-        Resource(Server.start(config))(_.unbind().map(_ => ()))
+        Resource(Server(config).start())(_.unbind().map(_ => ()))
     }
   def authClient(config: Client.Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -112,8 +112,8 @@ trait HttpCookies extends BeforeAndAfterEach { this: Suite =>
   }
 
   /**
-   * Remove all stored cookies.
-   */
+    * Remove all stored cookies.
+    */
   def deleteCookies(): Unit = {
     cookieJar.clear()
   }
@@ -183,7 +183,8 @@ trait AuthMiddlewareFixture
       parties = authParties,
     )
     resource = new OwnedResource(new ResourceOwner[(OAuthServer, ServerBinding)] {
-      override def acquire()(implicit context: ResourceContext): Resource[(OAuthServer, ServerBinding)] = {
+      override def acquire()(
+          implicit context: ResourceContext): Resource[(OAuthServer, ServerBinding)] = {
         val oauthServer = OAuthServer(oauthConfig)
         for {
           oauth <- Resource(oauthServer.start())(closeServerBinding)

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -110,6 +110,13 @@ trait HttpCookies extends BeforeAndAfterEach { this: Suite =>
       case resp => Future(resp)
     }
   }
+
+  /**
+   * Remove all stored cookies.
+   */
+  def deleteCookies(): Unit = {
+    cookieJar.clear()
+  }
 }
 
 trait AbstractAuthFixture extends SuiteMixin {

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -131,6 +131,7 @@ trait NoAuthFixture extends AbstractAuthFixture {
 trait AuthMiddlewareFixture
     extends AbstractAuthFixture
     with BeforeAndAfterAll
+    with BeforeAndAfterEach
     with AkkaBeforeAndAfterAll {
   self: Suite =>
 
@@ -146,16 +147,17 @@ trait AuthMiddlewareFixture
     jwt.value
   }
   protected def authConfig: AuthConfig = AuthMiddleware(authMiddlewareUri)
+  protected def authServer: OAuthServer = resource.value._1
 
   private def authVerifier: JwtVerifierBase = HMAC256Verifier(authSecret).toOption.get
-  private def authMiddleware: ServerBinding = resource.value
+  private def authMiddleware: ServerBinding = resource.value._2
   private def authMiddlewareUri: Uri =
     Uri()
       .withScheme("http")
       .withAuthority(authMiddleware.localAddress.getHostString, authMiddleware.localAddress.getPort)
 
   private val authSecret: String = "secret"
-  private var resource: OwnedResource[ResourceContext, ServerBinding] = null
+  private var resource: OwnedResource[ResourceContext, (OAuthServer, ServerBinding)] = null
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -173,10 +175,11 @@ trait AuthMiddlewareFixture
       jwtSecret = authSecret,
       parties = authParties,
     )
-    resource = new OwnedResource(new ResourceOwner[ServerBinding] {
-      override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
+    resource = new OwnedResource(new ResourceOwner[(OAuthServer, ServerBinding)] {
+      override def acquire()(implicit context: ResourceContext): Resource[(OAuthServer, ServerBinding)] = {
+        val oauthServer = OAuthServer(oauthConfig)
         for {
-          oauth <- Resource(OAuthServer(oauthConfig).start())(closeServerBinding)
+          oauth <- Resource(oauthServer.start())(closeServerBinding)
           uri = Uri()
             .withScheme("http")
             .withAuthority(oauth.localAddress.getHostString, oauth.localAddress.getPort)
@@ -189,7 +192,8 @@ trait AuthMiddlewareFixture
             tokenVerifier = authVerifier,
           )
           middleware <- Resource(MiddlewareServer.start(middlewareConfig))(closeServerBinding)
-        } yield middleware
+        } yield (oauthServer, middleware)
+      }
     })
     resource.setup()
   }
@@ -198,6 +202,12 @@ trait AuthMiddlewareFixture
     resource.close()
 
     super.afterAll()
+  }
+
+  override protected def afterEach(): Unit = {
+    authServer.resetAuthorizedParties()
+
+    super.afterEach()
   }
 }
 

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -176,7 +176,7 @@ trait AuthMiddlewareFixture
     resource = new OwnedResource(new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
         for {
-          oauth <- Resource(OAuthServer.start(oauthConfig))(closeServerBinding)
+          oauth <- Resource(OAuthServer(oauthConfig).start())(closeServerBinding)
           uri = Uri()
             .withScheme("http")
             .withAuthority(oauth.localAddress.getHostString, oauth.localAddress.getPort)

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -512,19 +512,19 @@ trait AbstractTriggerServiceTestAuthMiddleware
       } yield succeed
   }
 
-  it should "forbid a non-authorized party to check the status of a trigger" in withTriggerService(List(dar)) {
-    uri: Uri =>
-      val expectedSuccess = StatusCodes.OK
-      val expectedError = StatusCodes.Forbidden
-      for {
-        resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
-        _ <- resp.status should equal(expectedSuccess)
-        triggerId <- parseTriggerId(resp)
-        _ = authServer.revokeParty(alice)
-        _ = deleteCookies()
-        resp <- triggerStatus(uri, triggerId)
-        _ <- resp.status should equal(expectedError)
-      } yield succeed
+  it should "forbid a non-authorized party to check the status of a trigger" in withTriggerService(
+    List(dar)) { uri: Uri =>
+    val expectedSuccess = StatusCodes.OK
+    val expectedError = StatusCodes.Forbidden
+    for {
+      resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
+      _ <- resp.status should equal(expectedSuccess)
+      triggerId <- parseTriggerId(resp)
+      _ = authServer.revokeParty(alice)
+      _ = deleteCookies()
+      resp <- triggerStatus(uri, triggerId)
+      _ <- resp.status should equal(expectedError)
+    } yield succeed
   }
 
   it should "forbid a non-authorized party to stop a trigger" in withTriggerService(List(dar)) {

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -206,13 +206,13 @@ trait AbstractTriggerServiceTest
     val expectedError = StatusCodes.UnprocessableEntity
     for {
       resp <- startTrigger(uri, s"$testPkgId:TestTrigger:foobar", alice)
-      _ <- resp.status should equal(expectedError)
+      _ <- resp.status shouldBe expectedError
       // Check the "status" and "errors" fields
       body <- responseBodyToString(resp)
       JsObject(fields) = body.parseJson
-      _ <- fields.get("status") should equal(Some(JsNumber(expectedError.intValue)))
-      _ <- fields.get("errors") should equal(
-        Some(JsArray(JsString("Could not find name foobar in module TestTrigger"))))
+      _ <- fields.get("status") shouldBe Some(JsNumber(expectedError.intValue))
+      _ <- fields.get("errors") shouldBe
+        Some(JsArray(JsString("Could not find name foobar in module TestTrigger")))
     } yield succeed
   }
 
@@ -227,7 +227,7 @@ trait AbstractTriggerServiceTest
       _ <- assertTriggerIds(uri, alice, Vector(triggerId))
       resp <- stopTrigger(uri, triggerId, alice)
       stoppedTriggerId <- parseTriggerId(resp)
-      _ <- stoppedTriggerId should equal(triggerId)
+      _ <- stoppedTriggerId shouldBe triggerId
     } yield succeed
   }
 
@@ -236,7 +236,7 @@ trait AbstractTriggerServiceTest
       for {
         resp <- listTriggers(uri, alice)
         result <- parseTriggerIds(resp)
-        _ <- result should equal(Vector())
+        _ <- result shouldBe Vector()
         // Start trigger for Alice.
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
         aliceTrigger <- parseTriggerId(resp)
@@ -383,7 +383,7 @@ trait AbstractTriggerServiceTest
     )
     for {
       resp <- Http().singleRequest(req)
-      _ <- resp.status should equal(StatusCodes.NotFound)
+      _ <- resp.status shouldBe StatusCodes.NotFound
     } yield succeed
   }
 
@@ -392,12 +392,12 @@ trait AbstractTriggerServiceTest
     val uuid = UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff")
     for {
       resp <- stopTrigger(uri, uuid, alice)
-      _ <- resp.status should equal(StatusCodes.NotFound)
+      _ <- resp.status shouldBe StatusCodes.NotFound
       body <- responseBodyToString(resp)
       JsObject(fields) = body.parseJson
-      _ <- fields.get("status") should equal(Some(JsNumber(StatusCodes.NotFound.intValue)))
-      _ <- fields.get("errors") should equal(
-        Some(JsArray(JsString(s"No trigger running with id $uuid"))))
+      _ <- fields.get("status") shouldBe Some(JsNumber(StatusCodes.NotFound.intValue))
+      _ <- fields.get("errors") shouldBe
+        Some(JsArray(JsString(s"No trigger running with id $uuid")))
     } yield succeed
   }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -503,7 +503,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
       } yield succeed
   }
 
-  ignore should "forbid a non-authorized party to list triggers" in withTriggerService(Nil) {
+  it should "forbid a non-authorized party to list triggers" in withTriggerService(Nil) {
     uri: Uri =>
       val expectedError = StatusCodes.Forbidden
       for {
@@ -512,7 +512,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
       } yield succeed
   }
 
-  ignore should "forbid a non-authorized party to check the status of a trigger" in withTriggerService(List(dar)) {
+  it should "forbid a non-authorized party to check the status of a trigger" in withTriggerService(List(dar)) {
     uri: Uri =>
       val expectedSuccess = StatusCodes.OK
       val expectedError = StatusCodes.Forbidden

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -498,7 +498,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
     uri: Uri =>
       for {
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", eve)
-        _ <- resp.status should equal(StatusCodes.Forbidden)
+        _ <- resp.status shouldBe StatusCodes.Forbidden
       } yield succeed
   }
 
@@ -506,7 +506,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
     uri: Uri =>
       for {
         resp <- listTriggers(uri, eve)
-        _ <- resp.status should equal(StatusCodes.Forbidden)
+        _ <- resp.status shouldBe StatusCodes.Forbidden
       } yield succeed
   }
 
@@ -514,12 +514,12 @@ trait AbstractTriggerServiceTestAuthMiddleware
     List(dar)) { uri: Uri =>
     for {
       resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
-      _ <- resp.status should equal(StatusCodes.OK)
+      _ <- resp.status shouldBe StatusCodes.OK
       triggerId <- parseTriggerId(resp)
       _ = authServer.revokeParty(alice)
       _ = deleteCookies()
       resp <- triggerStatus(uri, triggerId)
-      _ <- resp.status should equal(StatusCodes.Forbidden)
+      _ <- resp.status shouldBe StatusCodes.Forbidden
     } yield succeed
   }
 
@@ -527,12 +527,12 @@ trait AbstractTriggerServiceTestAuthMiddleware
     uri: Uri =>
       for {
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
-        _ <- resp.status should equal(StatusCodes.OK)
+        _ <- resp.status shouldBe StatusCodes.OK
         triggerId <- parseTriggerId(resp)
         _ = authServer.revokeParty(alice)
         _ = deleteCookies()
         resp <- stopTrigger(uri, triggerId, alice)
-        _ <- resp.status should equal(StatusCodes.Forbidden)
+        _ <- resp.status shouldBe StatusCodes.Forbidden
       } yield succeed
   }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -496,49 +496,43 @@ trait AbstractTriggerServiceTestAuthMiddleware
 
   it should "forbid a non-authorized party to start a trigger" in withTriggerService(List(dar)) {
     uri: Uri =>
-      val expectedError = StatusCodes.Forbidden
       for {
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", eve)
-        _ <- resp.status should equal(expectedError)
+        _ <- resp.status should equal(StatusCodes.Forbidden)
       } yield succeed
   }
 
   it should "forbid a non-authorized party to list triggers" in withTriggerService(Nil) {
     uri: Uri =>
-      val expectedError = StatusCodes.Forbidden
       for {
         resp <- listTriggers(uri, eve)
-        _ <- resp.status should equal(expectedError)
+        _ <- resp.status should equal(StatusCodes.Forbidden)
       } yield succeed
   }
 
   it should "forbid a non-authorized party to check the status of a trigger" in withTriggerService(
     List(dar)) { uri: Uri =>
-    val expectedSuccess = StatusCodes.OK
-    val expectedError = StatusCodes.Forbidden
     for {
       resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
-      _ <- resp.status should equal(expectedSuccess)
+      _ <- resp.status should equal(StatusCodes.OK)
       triggerId <- parseTriggerId(resp)
       _ = authServer.revokeParty(alice)
       _ = deleteCookies()
       resp <- triggerStatus(uri, triggerId)
-      _ <- resp.status should equal(expectedError)
+      _ <- resp.status should equal(StatusCodes.Forbidden)
     } yield succeed
   }
 
   it should "forbid a non-authorized party to stop a trigger" in withTriggerService(List(dar)) {
     uri: Uri =>
-      val expectedSuccess = StatusCodes.OK
-      val expectedError = StatusCodes.Forbidden
       for {
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
-        _ <- resp.status should equal(expectedSuccess)
+        _ <- resp.status should equal(StatusCodes.OK)
         triggerId <- parseTriggerId(resp)
         _ = authServer.revokeParty(alice)
         _ = deleteCookies()
         resp <- stopTrigger(uri, triggerId, alice)
-        _ <- resp.status should equal(expectedError)
+        _ <- resp.status should equal(StatusCodes.Forbidden)
       } yield succeed
   }
 }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -516,6 +516,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
       resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
       _ <- resp.status shouldBe StatusCodes.OK
       triggerId <- parseTriggerId(resp)
+      // emulate access by a different user by revoking access to alice and deleting the current token cookie
       _ = authServer.revokeParty(alice)
       _ = deleteCookies()
       resp <- triggerStatus(uri, triggerId)
@@ -529,6 +530,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", alice)
         _ <- resp.status shouldBe StatusCodes.OK
         triggerId <- parseTriggerId(resp)
+        // emulate access by a different user by revoking access to alice and deleting the current token cookie
         _ = authServer.revokeParty(alice)
         _ = deleteCookies()
         resp <- stopTrigger(uri, triggerId, alice)


### PR DESCRIPTION
Closes #7749 

- Makes the set of authorized parties on the oauth2 test server mutable.
  To that end the server implementation is moved into a `class`.
  This is used during testing to first start a trigger with a party but then forbid that same party to access the trigger afterward to test the access denied case on endpoints that assume a running trigger.
  In reality such a situation would arise when a different user with a different associated party would try to access a trigger they're not authorized to access. However, the oauth2 test server does not implement identity management. The above mentioned approach seems simpler than implementing identity management in the test server.
- Enable deleting stored cookies within a test case on the http cookie fixture.
  Otherwise, a previously stored access token would still be in place and removing a party from the authorized set would have no effect.
- Add test-cases for access denied on the list, status, and stop endpoints.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
