### PR TITLE
Allow for lets before letrec transformation.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -763,12 +763,12 @@ convertBind env (name, x)
     --  >    let { x_1 = e_1 ; ... ; x_m = e_m } in
     --  >    \v -> let f = name @a_1 ... @a_n in y
     --
-    | let (args, body1) = collectBinders x
+    | let (params, body1) = collectBinders x
     , let (lets, body2) = collectNonRecLets body1
     , Let (Rec [(f, Lam v y)]) (Var f') <- body2
     , f == f'
-    = convertBind env $ (,) name $ mkLams args $ makeNonRecLets lets $
-        Lam v $ Let (NonRec f $ mkVarApps (Var name) args) y
+    = convertBind env $ (,) name $ mkLams params $ makeNonRecLets lets $
+        Lam v $ Let (NonRec f $ mkVarApps (Var name) params) y
 
     -- Constraint tuple projections are turned into LF struct projections at use site.
     | ConstraintTupleProjectionName _ _ <- name

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -759,7 +759,7 @@ convertBind env (name, x)
     --
     -- is rewritten to
     --
-    --  > name \@a_1 ... @a_n ->
+    --  > name = \@a_1 ... @a_n ->
     --  >    let { x_1 = e_1 ; ... ; x_m = e_m } in
     --  >    \v -> let f = name @a_1 ... @a_n in y
     --

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -748,8 +748,27 @@ convertBind env (name, x)
     -- lifting where the lifted version of `f` happens to be `name`.)
     -- This workaround should be removed once we either have a proper lambda
     -- lifter or DAML-LF supports local recursion.
-    | (as, Let (Rec [(f, Lam v y)]) (Var f')) <- collectBinders x, f == f'
-    = convertBind env $ (,) name $ mkLams as $ Lam v $ Let (NonRec f $ mkVarApps (Var name) as) y
+    --
+    -- NOTE(SF): Due to issue #7953, this has been modified to allow for
+    -- additional (nonrecursive) let bindings between the top-level
+    -- arguments and the letrec. In particular,
+    --
+    --  > name = \@a_1 ... @a_n ->
+    --  >    let { x_1 = e_1 ; ... ; x_m = e_m } in
+    --  >    letrec f = \v -> y in f
+    --
+    -- is rewritten to
+    --
+    --  > name \@a_1 ... @a_n ->
+    --  >    let { x_1 = e_1 ; ... ; x_m = e_m } in
+    --  >    \v -> let f = name @a_1 ... @a_n in y
+    --
+    | let (args, body1) = collectBinders x
+    , let (lets, body2) = collectNonRecLets body1
+    , Let (Rec [(f, Lam v y)]) (Var f') <- body2
+    , f == f'
+    = convertBind env $ (,) name $ mkLams args $ makeNonRecLets lets $
+        Lam v $ Let (NonRec f $ mkVarApps (Var name) args) y
 
     -- Constraint tuple projections are turned into LF struct projections at use site.
     | ConstraintTupleProjectionName _ _ <- name

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
@@ -265,3 +265,19 @@ unpackCStringUtf8 :: BS.ByteString -> T.Text
 unpackCStringUtf8 bs = unsafePerformIO $
     BS.useAsCString bs $ \(Ptr a) -> do
         evaluate $ T.unpackCString# a
+
+collectNonRecLets :: GHC.Expr Var -> ([(GHC.Var, GHC.Expr Var)], GHC.Expr Var)
+collectNonRecLets = \case
+    Let (NonRec x y) rest ->
+        let (lets, body) = collectNonRecLets rest
+        in ((x,y):lets, body)
+    expr ->
+        ([], expr)
+
+makeNonRecLets :: [(GHC.Var, GHC.Expr Var)] -> GHC.Expr Var -> GHC.Expr Var
+makeNonRecLets lets body =
+    case lets of
+        (x,y):lets ->
+            Let (NonRec x y) (makeNonRecLets lets body)
+        [] ->
+            body

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
@@ -276,8 +276,4 @@ collectNonRecLets = \case
 
 makeNonRecLets :: [(GHC.Var, GHC.Expr Var)] -> GHC.Expr Var -> GHC.Expr Var
 makeNonRecLets lets body =
-    case lets of
-        (x,y):lets ->
-            Let (NonRec x y) (makeNonRecLets lets body)
-        [] ->
-            body
+    foldr (\(x,y) b -> Let (NonRec x y) b) body lets

--- a/compiler/damlc/tests/daml-test-files/IndirectLetRec.daml
+++ b/compiler/damlc/tests/daml-test-files/IndirectLetRec.daml
@@ -1,0 +1,44 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- Regression test for issue #7953 : local letrec introduced by
+-- GHC isn't lifted out because it happens under a lambda.
+module IndirectLetRec where
+
+class C a where
+class D a where
+type S a = (C a, D a)
+
+f : S a => a -> a
+f = identity
+
+-- type signature omitted on purpose (otherwise the problem goes away!)
+y a = y (f a)
+
+-- Core representation introduces a letrec inside a let:
+--
+-- y : forall t1 t2. (C t1, D t1) => t1 -> t2
+-- [GblId, Arity=2]
+-- y = \ (@ t_a10Q)
+--       (@ t1_a10S)
+--       ($dC_a10Z : C t_a10Q)
+--       ($dD_a110 : D t_a10Q) ->
+--       let {
+--         $d(%,%)_a10U : S t_a10Q
+--         [LclId]
+--         $d(%,%)_a10U = ($dC_a10Z, $dD_a110) } in
+--       letrec {
+--         y1_a10K [Occ=LoopBreaker] : t_a10Q -> t1_a10S
+--         [LclId, Arity=1]
+--         y1_a10K
+--           = \ (a_aiv : t_a10Q) ->
+--               src<daml/Main2.daml:14:1-13>
+--               case a_aiv of a1_XiE { __DEFAULT ->
+--               src<daml/Main2.daml:14:7-13>
+--               y1_a10K
+--                 (src<daml/Main2.daml:14:9-13>
+--                  f @ t_a10Q $d(%,%)_a10U (src<daml/Main2.daml:14:12> a1_XiE))
+--               }; } in
+--       y1_a10K
+--
+--


### PR DESCRIPTION
Fixes #7953 by adjusting the letrec transformation to handle
(optional) nonrecursive lets before the letrec binding, and adds
a regression test.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
