### PR TITLE
Revamp trigger status endpoint

### DIFF
--- a/docs/source/tools/trigger-service.rst
+++ b/docs/source/tools/trigger-service.rst
@@ -116,7 +116,9 @@ HTTP Response
 Status of a trigger
 *******************
 
-It's sometimes useful to get information about the history of a specific trigger. This can be done with the "status" endpoint.
+The status endoint returns you metadata about the trigger like the
+party it is running as and the trigger id as well as the state the
+trigger is in (querying the acs, running, stopped).
 
 HTTP Request
 ============
@@ -133,8 +135,13 @@ HTTP Response
 .. code-block:: json
 
     {
-      "result": {"logs":[["2020-06-12T12:35:49.863","starting"],["2020-06-12T12:35:50.89","running"],["2020-06-12T12:51:57.557","stopped: by user request"]]},
-      "status": 200
+      "result":
+        {
+          "party": "Alice",
+          "triggerId":"312094804c1468e2166bae3c9ba8b5cc0d285e31356304a2e9b0ac549df59d14:TestTrigger:trigger",
+          "status": "running"
+        },
+      "status":200
     }
 
 Upload a new DAR

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -119,6 +119,7 @@ da_scala_test(
         "//libs-scala/ports",
         "//libs-scala/postgresql-testing",
         "//libs-scala/resources",
+        "//libs-scala/scala-utils",
         "//libs-scala/timer-utils",
         "//triggers/service/auth:oauth-middleware",
         "//triggers/service/auth:oauth-test-server",

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -3,6 +3,8 @@
 
 package com.daml.lf.engine.trigger
 
+import java.util.UUID
+
 import akka.actor.typed.{ActorRef, ActorSystem, Scheduler}
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.http.scaladsl.Http.ServerBinding
@@ -35,6 +37,7 @@ object ServiceMain {
       restartConfig: TriggerRestartConfig,
       encodedDars: List[Dar[(PackageId, DamlLf.ArchivePayload)]],
       jdbcConfig: Option[JdbcConfig],
+      logTriggerStatus: (UUID, String) => Unit = (_, _) => ()
   ): Future[(ServerBinding, ActorSystem[Message])] = {
 
     val system: ActorSystem[Message] =
@@ -47,7 +50,8 @@ object ServiceMain {
           restartConfig,
           encodedDars,
           jdbcConfig,
-          initDb = false // for tests we initialize the database in beforeEach clause
+          initDb = false, // for tests we initialize the database in beforeEach clause
+          logTriggerStatus
         ),
         "TriggerService"
       )

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/TriggerRunner.scala
@@ -3,78 +3,85 @@
 
 package com.daml.lf.engine.trigger
 
-import akka.actor.typed.{ActorRef, Behavior, PostStop, Signal}
-import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.SupervisorStrategy._
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.{ActorRef, Behavior, PostStop}
 import akka.stream.Materializer
 import com.daml.grpc.adapter.ExecutionSequencerFactory
-import com.daml.logging.{ContextualizedLogger, LoggingContextOf}
-import LoggingContextOf.{label, newLoggingContext}
-import com.daml.scalautil.Statement.discard
+import com.daml.logging.LoggingContextOf.{label, newLoggingContext}
+import com.daml.logging.{ContextualizedLogger}
+import spray.json._
 
 class InitializationHalted(s: String) extends Exception(s) {}
 class InitializationException(s: String) extends Exception(s) {}
 
 object TriggerRunner {
+  private val logger = ContextualizedLogger.get(this.getClass)
+
   type Config = TriggerRunnerImpl.Config
 
   trait Message
   final case object Stop extends Message
+  final case class Status(replyTo: ActorRef[TriggerStatus]) extends Message
+
+  sealed trait TriggerStatus
+  final case object QueryingACS extends TriggerStatus
+  final case object Running extends TriggerStatus
+  final case object Stopped extends TriggerStatus
+
+  implicit val triggerStatusFormat: JsonFormat[TriggerStatus] = new JsonFormat[TriggerStatus] {
+    override def read(json: JsValue): TriggerStatus = json match {
+      case JsString("running") => Running
+      case JsString("stopped") => Stopped
+      case JsString("querying ACS") => QueryingACS
+      case _ => deserializationError(s"TriggerStatus expected")
+    }
+    override def write(obj: TriggerStatus): JsValue = obj match {
+      case QueryingACS => JsString("querying ACS")
+      case Running => JsString("running")
+      case Stopped => JsString("stopped")
+    }
+  }
 
   def apply(config: Config, name: String)(
       implicit esf: ExecutionSequencerFactory,
       mat: Materializer): Behavior[TriggerRunner.Message] =
     newLoggingContext(label[Config with Trigger], config.loggingExtension) {
       implicit loggingContext =>
-        Behaviors.setup(ctx => new TriggerRunner(ctx, config, name))
-    }
-}
-
-final class TriggerRunner private (
-    ctx: ActorContext[TriggerRunner.Message],
-    config: TriggerRunner.Config,
-    name: String)(
-    implicit esf: ExecutionSequencerFactory,
-    mat: Materializer,
-    loggingContext: LoggingContextOf[TriggerRunner.Config with Trigger])
-    extends AbstractBehavior[TriggerRunner.Message](ctx) {
-
-  import TriggerRunner.{Message, Stop}
-
-  private[this] def logger = ContextualizedLogger get getClass
-
-  // Spawn a trigger runner impl. Supervise it. Stop immediately on
-  // initialization halted exceptions, retry any initialization or
-  // execution failure exceptions.
-  discard[ActorRef[Message]] {
-    ctx.spawn(
-      Behaviors
-        .supervise(
+        Behaviors.setup { ctx =>
+          // Spawn a trigger runner impl. Supervise it. Stop immediately on
+          // initialization halted exceptions, retry any initialization or
+          // execution failure exceptions.
+          val runner =
+            ctx.spawn(
+              Behaviors
+                .supervise(
+                  Behaviors
+                    .supervise(TriggerRunnerImpl(config))
+                    .onFailure[InitializationHalted](stop)
+                )
+                .onFailure(
+                  restartWithBackoff(
+                    config.restartConfig.minRestartInterval,
+                    config.restartConfig.maxRestartInterval,
+                    config.restartConfig.restartIntervalRandomFactor)),
+              name
+            )
           Behaviors
-            .supervise(TriggerRunnerImpl(config))
-            .onFailure[InitializationHalted](stop)
-        )
-        .onFailure(
-          restartWithBackoff(
-            config.restartConfig.minRestartInterval,
-            config.restartConfig.maxRestartInterval,
-            config.restartConfig.restartIntervalRandomFactor)),
-      name
-    )
-  }
-
-  override def onMessage(msg: Message): Behavior[Message] =
-    Behaviors.receiveMessagePartial[Message] {
-      case Stop =>
-        Behaviors.stopped // Automatically stops the child actor if running.
+            .receiveMessagePartial[Message] {
+              case Status(replyTo) =>
+                // pass through
+                logger.error("PROXYING STATUS")
+                runner ! Status(replyTo)
+                Behaviors.same
+              case Stop =>
+                Behaviors.stopped // Automatically stops the child actor if running.
+            }
+            .receiveSignal {
+              case (_, PostStop) =>
+                logger.info(s"Trigger $name stopped")
+                Behaviors.same
+            }
+        }
     }
-
-  override def onSignal: PartialFunction[Signal, Behavior[Message]] = {
-    case PostStop =>
-      logger.info(s"Trigger $name stopped")
-      this
-  }
-
 }


### PR DESCRIPTION
fixes #7951

The previous endpoint was a memory leak, nothing got persisted across
restarts and it omitted useful information like the metadata of the
trigger. The information is useful for testing, so I abstracted over
it so we can do what we did before in testing.

As for the endpoint, it now queries the actor for its current status
and only returns that and includes the metadata in the response.

As mentioned in #7951, I do think there is value in some kind of
history and potentially something including trace statements but I’d
like to do that properly instead of the hacky thing we have atm.

changelog_begin

- [Trigger Service] The trigger status endpoint /v1/triggers/:id now
  includes metadata about the trigger like the party and the trigger
  id. The logs field has been replaced by a status field.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
