### PR TITLE
fix backtick rendering errors in docs

### DIFF
--- a/docs/source/daml/intro/7_Composing.rst
+++ b/docs/source/daml/intro/7_Composing.rst
@@ -30,7 +30,7 @@ You can start a new project with a skeleton structure using ``daml new project_n
 .. literalinclude:: daml/daml-intro-7/daml.yaml.template
   :language: yaml
 
-You can generally set ``name`` and ``version`` freely to describe your project. ``dependencies`` does what the name suggests: It includes dependencies. You should always include ``daml-prim`` and ``daml-stdlib``. The former contains internals of compiler and DAML Runtime, the latter gives access to the DAML Standard Library.``daml-script`` contains the types and standard library for DAML Script.
+You can generally set ``name`` and ``version`` freely to describe your project. ``dependencies`` does what the name suggests: It includes dependencies. You should always include ``daml-prim`` and ``daml-stdlib``. The former contains internals of compiler and DAML Runtime, the latter gives access to the DAML Standard Library. ``daml-script`` contains the types and standard library for DAML Script.
 
 You compile a DAML project by running ``daml build`` from the project root directory. This creates a ``dar`` file in ``.daml/dist/dist/project_name-project_version.dar``. A ``dar`` file is DAML's equivalent of a ``JAR`` file in Java: it's the artifact that gets deployed to a ledger to load the package and its dependencies. ``dar`` files are fully self-contained in that they contain all dependencies of the main package. More on all of this in :doc:`8_Dependencies`.
 

--- a/docs/source/daml/intro/9_Functional101.rst
+++ b/docs/source/daml/intro/9_Functional101.rst
@@ -76,7 +76,7 @@ There are two interesting things going on here:
 Function Application
 ....................
 
-Let's start by looking at the right hand part ``a -> a -> a``. The ``->`` is right associative, meaning ``a -> a -> a`` is equivalent to ``a -> (a -> a)``. Using the "maps to" way of reading ``->`` we get "a maps to a function that maps a to a``.
+Let's start by looking at the right hand part ``a -> a -> a``. The ``->`` is right associative, meaning ``a -> a -> a`` is equivalent to ``a -> (a -> a)``. Using the "maps to" way of reading ``->`` we get "a maps to a function that maps a to a".
 
 And this is indeed what happens. We can define a different version of ``increment`` by *partially applying* ``add``:
 
@@ -469,7 +469,7 @@ The folds and ``map`` function above are pure in the sense introduced in :doc:`5
   :start-after: -- MAPA_BEGIN
   :end-before: -- MAPA_END
 
-Here we have a list of relationships (type ``[Relationship]`` and a function ``setupRelationship : Relationship -> Script (ContractId AssetHolder) ``. We want the ``AssetHolder`` contracts for those relationships, ie something of type ``[ContractId AssetHolder]``. Using the map function almost gets us there. ``map setupRelationship rels : [Update (ContractId AssetHolder)]``. This is a list of ``Update`` actions, each resulting in a ``ContractId AssetHolder``. What we need is an ``Update`` action resulting in a ``[ContractId AssetHolder]``. The list and ``Update`` are the wrong way around for our purposes.
+Here we have a list of relationships (type ``[Relationship]`` and a function ``setupRelationship : Relationship -> Script (ContractId AssetHolder)``. We want the ``AssetHolder`` contracts for those relationships, ie something of type ``[ContractId AssetHolder]``. Using the map function almost gets us there. ``map setupRelationship rels : [Update (ContractId AssetHolder)]``. This is a list of ``Update`` actions, each resulting in a ``ContractId AssetHolder``. What we need is an ``Update`` action resulting in a ``[ContractId AssetHolder]``. The list and ``Update`` are the wrong way around for our purposes.
 
 Intuitively, it's clear how to fix this: we want the compound action consisting of performing each of the actions in the list in turn. There's a function for that, of course. ``sequence : : Applicative m => [m a] -> m [a]`` implements that intuition and allows us to take the ``Update`` out of the list. So we could write ``sequence (map setupRelationship rels)``. This is so common that it's encapsulated in the ``mapA`` function, a possible implementation of which is
 

--- a/docs/source/json-api/index.rst
+++ b/docs/source/json-api/index.rst
@@ -219,7 +219,7 @@ Example:
 
 .. code-block:: none
 
-    jwt.token.eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJIVFRQLUpTT04tQVBJLUdhdGV3YXkiLCJhY3RBcyI6WyJBbGljZSJdfX0.34zzF_fbWv7p60r5s1kKzwndvGdsJDX-W4Xhm4oVdpk``
+    jwt.token.eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2RhbWwuY29tL2xlZGdlci1hcGkiOnsibGVkZ2VySWQiOiJNeUxlZGdlciIsImFwcGxpY2F0aW9uSWQiOiJIVFRQLUpTT04tQVBJLUdhdGV3YXkiLCJhY3RBcyI6WyJBbGljZSJdfX0.34zzF_fbWv7p60r5s1kKzwndvGdsJDX-W4Xhm4oVdpk
 
 HTTP Status Codes
 *****************


### PR DESCRIPTION
To see the problems, open the problematic pages:
https://docs.daml.com/daml/intro/7_Composing.html
https://docs.daml.com/daml/intro/9_Functional101.html
https://docs.daml.com/json-api/index.html

I made sure that no other mistakes left, used:
```
grep '``' -R --include \*html docs/build/html/
```

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
