### PR TITLE
Fix protobuf decoding in trigger service

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
@@ -11,7 +11,7 @@ import cats.syntax.apply._
 import cats.syntax.functor._
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.api.refinements.ApiTypes.Party
-import com.daml.lf.archive.Dar
+import com.daml.lf.archive.{Dar, Reader}
 import com.daml.lf.data.Ref.{Identifier, PackageId}
 import com.daml.lf.engine.trigger.{JdbcConfig, RunningTrigger}
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
@@ -153,7 +153,8 @@ final class DbTriggerDao private (dataSource: DataSource with Closeable, xa: Con
       pkgPayload: Array[Byte]): Either[String, (PackageId, DamlLf.ArchivePayload)] =
     for {
       pkgId <- PackageId.fromString(pkgIdString)
-      payload <- Try(DamlLf.ArchivePayload.parseFrom(pkgPayload)) match {
+      cos = Reader.damlLfCodedInputStreamFromBytes(pkgPayload)
+      payload <- Try(DamlLf.ArchivePayload.parseFrom(cos)) match {
         case Failure(err) => Left(s"Failed to parse package with id $pkgId.\n" ++ err.toString)
         case Success(pkg) => Right(pkg)
       }

--- a/triggers/service/test-model/TestTrigger.daml
+++ b/triggers/service/test-model/TestTrigger.daml
@@ -7,6 +7,7 @@ module TestTrigger where
 import DA.Action
 import DA.Foldable
 import Daml.Trigger
+import Daml.Script (script)
 
 template A
   with
@@ -38,3 +39,40 @@ triggerRule p = do
     when ((x,y) `notElem`  bs) $
     void $ emitCommands [createCmd (B x y)] [toAnyContractId aCid]
   pure ()
+
+-- This is a dummy definition to make sure
+-- that we blow the default protobuf recursion limit
+-- and thereby test that we decode using the raised limit.
+_protobufrecursionlimit y = script do
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  pure ()
+  y


### PR DESCRIPTION
We need to go via the methods in Reader to make sure that we get our
increased protobuf recursion limit. Otherwise, we fail when trying to
read from the database on anything non-trivial. I’ve verified that the
definition I’ve added is sufficient to break the default limit.

changelog_begin

- [Trigger Service] Fix a bug where complex models resulted in a fatal
  error when restoring the state from the database due to an incorrect
  protobuf recursion limit.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
