### PR TITLE
When computing blinding info, divulge to choice-observers.

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -81,7 +81,9 @@ object BlindingTransaction {
 
         case ex: NodeExercises.WithTxValue[NodeId, ContractId] =>
           val state1 =
-            state.divulgeCoidTo(parentExerciseWitnesses -- ex.stakeholders, ex.targetCoid)
+            state.divulgeCoidTo(
+              (parentExerciseWitnesses union ex.choiceObservers) -- ex.stakeholders,
+              ex.targetCoid)
 
           ex.children.foldLeft(state1) { (s, childNodeId) =>
             processNode(


### PR DESCRIPTION
When computing blinding info, we must divulge to choice-observers.
With this fix, when the choice-observer syntax lands (https://github.com/digital-asset/daml/pull/7922) they will actually work!

Tested with both scenario and daml-script.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
