### PR TITLE
[DAML on SQL] Avoid executor re-entry for parties validation [KVL-693]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsTable.scala
@@ -6,11 +6,13 @@ package com.daml.platform.store.dao.events
 import java.sql.Connection
 import java.time.Instant
 
-import com.daml.ledger.participant.state.v1.{CommittedTransaction, DivulgedContract}
 import anorm.SqlParser.int
 import anorm.{BatchSql, NamedParameter, SqlStringInterpolation, ~}
+import com.daml.ledger.api.domain.PartyDetails
+import com.daml.ledger.participant.state.v1.{CommittedTransaction, DivulgedContract}
 import com.daml.platform.store.Conversions._
 import com.daml.platform.store.DbType
+import com.daml.platform.store.dao.JdbcLedgerDao
 import com.daml.platform.store.dao.events.RawBatch.PartialParameters
 
 import scala.util.{Failure, Success, Try}
@@ -195,6 +197,9 @@ private[events] sealed abstract class ContractsTable extends PostCommitValidatio
             })
     }
 
+  override final def lookupParties(parties: Seq[Party])(
+      implicit connection: Connection): List[PartyDetails] =
+    JdbcLedgerDao.selectParties(parties).map(JdbcLedgerDao.constructPartyDetails)
 }
 
 private[events] object ContractsTable {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/PostCommitValidation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/PostCommitValidation.scala
@@ -6,11 +6,7 @@ package com.daml.platform.store.dao.events
 import java.sql.Connection
 import java.time.Instant
 
-import com.daml.ledger.api.domain.PartyDetails
 import com.daml.ledger.participant.state.v1.{CommittedTransaction, RejectionReason}
-
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 
 /**
   * Performs post-commit validation on transactions for Sandbox Classic.
@@ -55,10 +51,8 @@ private[dao] object PostCommitValidation {
       None
   }
 
-  final class BackedBy(
-      data: PostCommitValidationData,
-      getParties: Option[Seq[Party] => Future[List[PartyDetails]]] = None,
-  ) extends PostCommitValidation {
+  final class BackedBy(data: PostCommitValidationData, validatePartyAllocation: Boolean)
+      extends PostCommitValidation {
 
     def validate(
         transaction: CommittedTransaction,
@@ -71,7 +65,11 @@ private[dao] object PostCommitValidation {
 
       val invalidKeyUsage = validateKeyUsages(transaction)
 
-      val unallocatedParties = validatePartiesAllocation(transaction)
+      val unallocatedParties =
+        if (validatePartyAllocation)
+          validateParties(transaction)
+        else
+          None
 
       unallocatedParties.orElse(invalidKeyUsage.orElse(causalMonotonicityViolation))
     }
@@ -114,8 +112,9 @@ private[dao] object PostCommitValidation {
           }
         )
 
-    private def validatePartiesAllocation(
-        transaction: CommittedTransaction): Option[RejectionReason] = {
+    private def validateParties(
+        transaction: CommittedTransaction,
+    )(implicit connection: Connection): Option[RejectionReason] = {
       def foldInformees[T](tx: CommittedTransaction, init: T)(
           f: (T, String) => T
       ): T =
@@ -127,20 +126,12 @@ private[dao] object PostCommitValidation {
       val informees = foldInformees(transaction, Seq.empty[Party]) { (informeesSoFar, partyId) =>
         Party.assertFromString(partyId) +: informeesSoFar
       }
-      val allocatedInformees = getPartiesSync(informees).map(_.party)
+      val allocatedInformees = data.lookupParties(informees).map(_.party)
       if (allocatedInformees.toSet == informees.toSet)
         None
       else
         Some(RejectionReason.PartyNotKnownOnLedger("Some parties are unallocated"))
     }
-
-    private def getPartiesSync(parties: Seq[Party]): List[PartyDetails] =
-      Await.result(getParties.getOrElse(identityGetParties _)(parties), AwaitDuration)
-
-    private def identityGetParties(parties: Seq[Party]): Future[List[PartyDetails]] =
-      Future.successful(parties.map { party =>
-        PartyDetails(party, None, isLocal = true)
-      }.toList)
 
     private def collectReferredContracts(
         transaction: CommittedTransaction,
@@ -272,6 +263,4 @@ private[dao] object PostCommitValidation {
     RejectionReason.InvalidLedgerTime(
       s"Encountered contract with LET [$contractLedgerEffectiveTime] greater than the LET of the transaction [$transactionLedgerEffectiveTime]"
     )
-
-  private val AwaitDuration: Duration = 30.seconds
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/PostCommitValidationData.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/PostCommitValidationData.scala
@@ -6,6 +6,8 @@ package com.daml.platform.store.dao.events
 import java.sql.Connection
 import java.time.Instant
 
+import com.daml.ledger.api.domain.PartyDetails
+
 import scala.util.Try
 
 private[events] trait PostCommitValidationData {
@@ -15,4 +17,5 @@ private[events] trait PostCommitValidationData {
   def lookupMaximumLedgerTime(ids: Set[ContractId])(
       implicit connection: Connection): Try[Option[Instant]]
 
+  def lookupParties(parties: Seq[Party])(implicit connection: Connection): List[PartyDetails]
 }

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/PostCommitValidationSpec.scala
@@ -7,12 +7,12 @@ import java.sql.Connection
 import java.time.Instant
 import java.util.UUID
 
+import com.daml.ledger.api.domain.PartyDetails
 import com.daml.ledger.participant.state.v1.RejectionReason
 import com.daml.lf.transaction.GlobalKey
 import com.daml.lf.transaction.test.{TransactionBuilder => TxBuilder}
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 final class PostCommitValidationSpec extends WordSpec with Matchers {
@@ -24,7 +24,11 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
     "run without prior history" should {
 
-      val store = new PostCommitValidation.BackedBy(noCommittedContract)
+      val store =
+        new PostCommitValidation.BackedBy(
+          noCommittedContract(parties = List.empty),
+          validatePartyAllocation = false,
+        )
 
       "accept a create with a key" in {
 
@@ -212,13 +216,15 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
       val store = new PostCommitValidation.BackedBy(
         committedContracts(
-          committed(
+          parties = List.empty,
+          contractFixture = committed(
             id = committedContract.coid.coid,
             ledgerEffectiveTime = committedContractLedgerEffectiveTime,
             key = committedContract.key.map(x =>
               GlobalKey.assertBuild(committedContract.coinst.template, x.key))
-          )
-        )
+          ),
+        ),
+        validatePartyAllocation = false,
       )
 
       "reject a create that would introduce a duplicate key" in {
@@ -338,8 +344,10 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
 
       val store = new PostCommitValidation.BackedBy(
         committedContracts(
-          divulged(divulgedContract.coid.coid),
-        )
+          parties = List.empty,
+          contractFixture = divulged(divulgedContract.coid.coid),
+        ),
+        validatePartyAllocation = false,
       )
 
       "accept an exercise on the divulged contract" in {
@@ -372,8 +380,9 @@ final class PostCommitValidationSpec extends WordSpec with Matchers {
     "run with unallocated parties" should {
       val store =
         new PostCommitValidation.BackedBy(
-          noCommittedContract,
-          Some(_ => Future.successful(List.empty)))
+          noCommittedContract(List.empty),
+          validatePartyAllocation = true,
+        )
 
       "reject" in {
         val createWithKey = genTestCreate()
@@ -420,7 +429,9 @@ object PostCommitValidationSpec {
   // Very dirty hack to have a contract store fixture without persistence
   private implicit val connection: Connection = null
 
-  private final case class ContractStoreFixture private (contracts: Set[ContractFixture])
+  private final case class ContractStoreFixture private (
+      contracts: Set[ContractFixture],
+      parties: List[PartyDetails])
       extends PostCommitValidationData {
 
     override def lookupContractKeyGlobally(key: Key)(
@@ -435,6 +446,12 @@ object PostCommitValidationSpec {
       if (lookup.isEmpty) Failure(notFound(ids))
       else Success(lookup.fold[Option[Instant]](None)(pickTheGreatest))
     }
+
+    override def lookupParties(parties: Seq[Party])(
+        implicit connection: Connection): List[PartyDetails] =
+      this.parties.filter { party =>
+        parties.contains(party.party)
+      }
   }
 
   private def pickTheGreatest(l: Option[Instant], r: Option[Instant]): Option[Instant] =
@@ -445,14 +462,15 @@ object PostCommitValidationSpec {
       s"One or more of the following contract identifiers has been found: ${contractIds.map(_.coid).mkString(", ")}"
     )
 
-  private val noCommittedContract: ContractStoreFixture =
-    ContractStoreFixture(Set.empty)
+  private def noCommittedContract(parties: List[PartyDetails]): ContractStoreFixture =
+    ContractStoreFixture(Set.empty, parties)
 
   private def committedContracts(
-      c: ContractFixture,
-      cs: ContractFixture*,
+      parties: List[PartyDetails],
+      contractFixture: ContractFixture,
+      contractFixtures: ContractFixture*,
   ): ContractStoreFixture =
-    ContractStoreFixture((c +: cs).toSet)
+    ContractStoreFixture((contractFixture +: contractFixtures).toSet, parties)
 
   private def committed(
       id: String,


### PR DESCRIPTION
...by using `PostCommitValidationData`. #7941's solution based on `Await` turns out to be worse than thought: `DbDispatcher#executeSql` runs a thread-blocking block that includes another `DbDispatcher#executeSql` call, causing two executor threads (and two connections) with a dependency to be needed for a single validation, which could result in deadlocks.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
