### PR TITLE
Dedup parties in JwtPayload

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -51,6 +51,9 @@ object domain {
 
   type LfValue = lf.value.Value[lf.value.Value.ContractId]
 
+  private def oneAndSet[A](p: A, sp: Set[A]) =
+    OneAnd(p, sp - p)
+
   // Until we get multi-party submissions, write endpoints require a single party in actAs but we
   // can have multiple parties in readAs.
   case class JwtWritePayload(
@@ -58,7 +61,7 @@ object domain {
       applicationId: ApplicationId,
       actAs: Party,
       readAs: List[Party]) {
-    val parties: OneAnd[Set, Party] = OneAnd(actAs, readAs.toSet - actAs)
+    val parties: OneAnd[Set, Party] = oneAndSet(actAs, readAs.toSet)
   }
 
   // JWT payload that preserves readAs and actAs and supports multiple parties. This is currently only used for
@@ -79,7 +82,7 @@ object domain {
       (readAs ++ actAs) match {
         case Nil => None
         case p :: ps =>
-          Some(new JwtPayload(ledgerId, applicationId, readAs, actAs, OneAnd(p, ps.toSet)) {})
+          Some(new JwtPayload(ledgerId, applicationId, readAs, actAs, oneAndSet(p, ps.toSet)) {})
       }
     }
   }

--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/DomainSpec.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/DomainSpec.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.http
+
+import domain._
+
+import org.scalatest._
+import scalaz.OneAnd
+
+final class DomainSpec extends FreeSpec with Matchers {
+  private val ledgerId = LedgerId("myledger")
+  private val appId = ApplicationId("myAppId")
+  private val alice = Party("Alice")
+  private val bob = Party("Bob")
+  "JwtWritePayload" - {
+    "parties deduplicates between actAs and readAs" in {
+      val payload = JwtWritePayload(ledgerId, appId, actAs = alice, readAs = List(alice, bob))
+      payload.parties shouldBe OneAnd(alice, Set(bob))
+    }
+  }
+  "JwtPayload" - {
+    "parties deduplicates between actAs and readAs" in {
+      val payload = JwtPayload(ledgerId, appId, actAs = List(alice), readAs = List(alice, bob))
+      payload.map(_.parties) shouldBe Some(OneAnd(alice, Set(bob)))
+    }
+    "returns None if readAs and actAs are empty" in {
+      val payload = JwtPayload(ledgerId, appId, actAs = List(), readAs = List())
+      payload shouldBe None
+    }
+  }
+}


### PR DESCRIPTION
Previously we didn’t build up the `OneAnd[Set, Party]` properly and
included the one party in the set as well. This was an issue if you
have the same party multiple times, most likely in readAs and
actAs (but not limited to that). This then lead to SQL queries failing
since we tried to insert twice for a given party. This PR fixes that
by properly deduplicating the parties and adding a test for this.

changelog_begin

- [JSON API] Fix a regression introduced in SDK 1.7.0, where using a
  party multiple times in the same JWT token (e.g., readAs and actAs)
  broke database queries for that party. Note that there is never a
  reason to include a party multiple times since actAs implies readAs.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
