### PR TITLE
sandbox: When testing the reset service, wait for the ledger config.

### DIFF
--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -221,10 +221,7 @@ test_deps = [
 
 da_scala_test_suite(
     name = "sandbox-classic-tests",
-    srcs = glob(
-        ["src/test/suite/**/*.scala"],
-        exclude = ["src/test/suite/**/ResetService*IT.scala"],
-    ),
+    srcs = glob(["src/test/suite/**/*.scala"]),
     data = [
         "//daml-lf/encoder:testing-dar-dev",
         "//daml-lf/encoder:testing-dar-latest",
@@ -232,20 +229,6 @@ da_scala_test_suite(
         "//ledger/test-common/test-certificates",
     ],
     resources = glob(["src/test/resources/**/*"]) + ["//ledger/sandbox-common:src/main/resources/logback.xml"],
-    deps = test_deps,
-)
-
-da_scala_test_suite(
-    name = "sandbox-classic-resetservice-tests",
-    srcs = glob(
-        ["src/test/suite/**/ResetService*IT.scala"],
-    ),
-    data = [
-        "//ledger/test-common:model-tests.dar",
-        "//ledger/test-common/test-certificates",
-    ],
-    flaky = True,
-    resources = glob(["src/test/resources/**/*"]),
     deps = test_deps,
 )
 

--- a/ledger/sandbox-classic/src/test/resources/logback-test.xml
+++ b/ledger/sandbox-classic/src/test/resources/logback-test.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
-        </encoder>
-    </appender>
+<!-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
-    <root level="INFO">
-        <appender-ref ref="STDOUT"/>
-    </root>
+<configuration>
+    <include resource="com/daml/platform/sandbox/logback-test.base.xml"/>
 </configuration>

--- a/ledger/sandbox-classic/src/test/resources/logback-test.xml
+++ b/ledger/sandbox-classic/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/ledger/sandbox-common/BUILD.bazel
+++ b/ledger/sandbox-common/BUILD.bazel
@@ -64,6 +64,7 @@ alias(
 da_scala_library(
     name = "sandbox-common-scala-tests-lib",
     srcs = glob(["src/test/lib/**/*.scala"]),
+    resources = glob(["src/test/resources/**/*"]),
     visibility = ["//visibility:public"],
     runtime_deps = [
         "@maven//:com_h2database_h2",

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/services/reset/ResetServiceITBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/services/reset/ResetServiceITBase.scala
@@ -208,7 +208,7 @@ abstract class ResetServiceITBase
           .map(ids => ids.distinct should have size 20L)
       }
 
-      // 5 attempts with 5 transactions each seem to strike the right balance to complete before the
+      // 4 attempts with 5 transactions each seem to strike the right balance to complete before the
       // 30 seconds test timeout in normal conditions while still causing the test to fail if
       // something goes wrong.
       //
@@ -217,7 +217,7 @@ abstract class ResetServiceITBase
       val expectedResetCompletionTime = Span.convertSpanToDuration(scaled(5.seconds))
       s"consistently complete within $expectedResetCompletionTime" in {
         val numberOfCommands = 5
-        val numberOfAttempts = 5
+        val numberOfAttempts = 4
         Future
           .sequence(
             Iterator

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/services/reset/ResetServiceITBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/services/reset/ResetServiceITBase.scala
@@ -31,6 +31,11 @@ import com.daml.ledger.api.v1.command_completion_service.{
 import com.daml.ledger.api.v1.command_service.{CommandServiceGrpc, SubmitAndWaitRequest}
 import com.daml.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc
 import com.daml.ledger.api.v1.event.CreatedEvent
+import com.daml.ledger.api.v1.ledger_configuration_service.{
+  GetLedgerConfigurationRequest,
+  GetLedgerConfigurationResponse,
+  LedgerConfigurationServiceGrpc
+}
 import com.daml.ledger.api.v1.ledger_identity_service.{
   GetLedgerIdentityRequest,
   LedgerIdentityServiceGrpc
@@ -57,9 +62,10 @@ import io.grpc.Status
 import org.scalatest.concurrent.{AsyncTimeLimitedTests, ScalaFutures}
 import org.scalatest.time.Span
 import org.scalatest.{AsyncWordSpec, Matchers}
+import scalaz.syntax.tag._
 
-import scala.concurrent.Future
 import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future}
 
 abstract class ResetServiceITBase
     extends AsyncWordSpec
@@ -76,7 +82,9 @@ abstract class ResetServiceITBase
   override protected def config: SandboxConfig =
     super.config.copy(ledgerIdMode = LedgerIdMode.Dynamic)
 
-  protected val eventually: RetryStrategy = RetryStrategy.exponentialBackoff(10, scaled(10.millis))
+  protected val eventually: RetryStrategy = RetryStrategy.constant(50, 100.milliseconds)
+
+  protected implicit val ec: ExecutionContext = ExecutionContext.global
 
   override protected def darFile: File =
     new File(rlocation("ledger/test-common/model-tests.dar"))
@@ -84,22 +92,33 @@ abstract class ResetServiceITBase
   protected def timeIsStatic: Boolean =
     config.timeProviderType.getOrElse(SandboxConfig.DefaultTimeProviderType) == TimeProviderType.Static
 
-  protected def fetchLedgerId(): Future[String] =
+  protected def waitForLedgerToStart(): Future[LedgerId] =
+    for {
+      ledgerId <- eventually { (_, _) =>
+        fetchLedgerId()
+      }
+      // Completions won't work until a ledger configuration is in place, so we wait for one.
+      _ <- new StreamConsumer[GetLedgerConfigurationResponse](responseObserver =>
+        LedgerConfigurationServiceGrpc
+          .stub(channel)
+          .getLedgerConfiguration(GetLedgerConfigurationRequest(ledgerId.unwrap), responseObserver))
+        .firstWithin(Span.convertSpanToDuration(scaled(1.second)))
+    } yield ledgerId
+
+  protected def fetchLedgerId(): Future[LedgerId] =
     LedgerIdentityServiceGrpc
       .stub(channel)
       .getLedgerIdentity(GetLedgerIdentityRequest())
-      .map(_.ledgerId)
+      .map(response => LedgerId(response.ledgerId))
 
   // Resets and waits for a new ledger identity to be available
-  protected def reset(ledgerId: String): Future[String] =
-    for {
-      _ <- ResetServiceGrpc.stub(channel).reset(ResetRequest(ledgerId))
-      newLedgerId <- eventually { (_, _) =>
-        fetchLedgerId()
-      }
-    } yield newLedgerId
+  protected def reset(ledgerId: LedgerId): Future[LedgerId] =
+    ResetServiceGrpc
+      .stub(channel)
+      .reset(ResetRequest(ledgerId.unwrap))
+      .flatMap(_ => waitForLedgerToStart())
 
-  protected def timedReset(ledgerId: String): Future[(String, FiniteDuration)] = {
+  protected def timedReset(ledgerId: LedgerId): Future[(LedgerId, FiniteDuration)] = {
     val start = System.nanoTime()
     reset(ledgerId).map(_ -> (System.nanoTime() - start).nanos)
   }
@@ -113,19 +132,24 @@ abstract class ResetServiceITBase
   protected def submitAndWait(req: SubmitAndWaitRequest): Future[Empty] =
     CommandServiceGrpc.stub(channel).submitAndWait(req)
 
-  protected def activeContracts(ledgerId: String, f: TransactionFilter): Future[Set[CreatedEvent]] =
+  protected def activeContracts(
+      ledgerId: LedgerId,
+      f: TransactionFilter): Future[Set[CreatedEvent]] =
     new StreamConsumer[GetActiveContractsResponse](
       ActiveContractsServiceGrpc
         .stub(channel)
-        .getActiveContracts(GetActiveContractsRequest(ledgerId, Some(f)), _))
+        .getActiveContracts(GetActiveContractsRequest(ledgerId.unwrap, Some(f)), _))
       .all()
       .map(_.flatMap(_.activeContracts)(collection.breakOut))
 
-  protected def listPackages(ledgerId: String): Future[Seq[String]] =
-    PackageServiceGrpc.stub(channel).listPackages(ListPackagesRequest(ledgerId)).map(_.packageIds)
+  protected def listPackages(ledgerId: LedgerId): Future[Seq[String]] =
+    PackageServiceGrpc
+      .stub(channel)
+      .listPackages(ListPackagesRequest(ledgerId.unwrap))
+      .map(_.packageIds)
 
   protected def submitAndExpectCompletions(
-      ledgerId: String,
+      ledgerId: LedgerId,
       commands: Int,
       party: String,
   ): Future[Unit] =
@@ -134,13 +158,13 @@ abstract class ResetServiceITBase
         Vector.fill(commands)(
           CommandSubmissionServiceGrpc
             .stub(channel)
-            .submit(dummyCommands(LedgerId(ledgerId), UUID.randomUUID.toString, party))))
+            .submit(dummyCommands(ledgerId, UUID.randomUUID.toString, party))))
       unit <- WaitForCompletionsObserver(commands)(
         CommandCompletionServiceGrpc
           .stub(channel)
           .completionStream(
             CompletionStreamRequest(
-              ledgerId = ledgerId,
+              ledgerId = ledgerId.unwrap,
               applicationId = M.applicationId,
               parties = Seq(party),
               offset = Some(M.ledgerBegin)
@@ -148,18 +172,18 @@ abstract class ResetServiceITBase
             _))
     } yield unit
 
-  protected def getTime(ledgerId: String): Future[Instant] =
+  protected def getTime(ledgerId: LedgerId): Future[Instant] =
     new StreamConsumer[GetTimeResponse](
-      TimeServiceGrpc.stub(channel).getTime(GetTimeRequest(ledgerId), _))
+      TimeServiceGrpc.stub(channel).getTime(GetTimeRequest(ledgerId.unwrap), _))
       .first()
       .map(_.flatMap(_.currentTime).map(TimestampConversion.toInstant).get)
 
-  protected def setTime(ledgerId: String, currentTime: Instant, newTime: Instant): Future[Unit] =
+  protected def setTime(ledgerId: LedgerId, currentTime: Instant, newTime: Instant): Future[Unit] =
     TimeServiceGrpc
       .stub(channel)
       .setTime(
         SetTimeRequest(
-          ledgerId,
+          ledgerId.unwrap,
           Some(TimestampConversion.fromInstant(currentTime)),
           Some(TimestampConversion.fromInstant(newTime)),
         ))
@@ -197,7 +221,7 @@ abstract class ResetServiceITBase
         Future
           .sequence(
             Iterator
-              .iterate(fetchLedgerId()) { ledgerIdF =>
+              .iterate(waitForLedgerToStart()) { ledgerIdF =>
                 for {
                   ledgerId <- ledgerIdF
                   party <- allocateParty(M.party)
@@ -213,9 +237,9 @@ abstract class ResetServiceITBase
 
       "remove contracts from ACS after reset" in {
         for {
-          ledgerId <- fetchLedgerId()
+          ledgerId <- waitForLedgerToStart()
           party <- allocateParty(M.party)
-          request = dummyCommands(LedgerId(ledgerId), "commandId1", party)
+          request = dummyCommands(ledgerId, "commandId1", party)
           _ <- submitAndWait(SubmitAndWaitRequest(commands = request.commands))
           events <- activeContracts(ledgerId, M.transactionFilter)
           _ = events should have size 3

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/services/reset/ResetServiceITBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/services/reset/ResetServiceITBase.scala
@@ -98,12 +98,15 @@ abstract class ResetServiceITBase
         fetchLedgerId()
       }
       // Completions won't work until a ledger configuration is in place, so we wait for one.
-      _ <- new StreamConsumer[GetLedgerConfigurationResponse](responseObserver =>
+      configurations <- new StreamConsumer[GetLedgerConfigurationResponse](responseObserver =>
         LedgerConfigurationServiceGrpc
           .stub(channel)
           .getLedgerConfiguration(GetLedgerConfigurationRequest(ledgerId.unwrap), responseObserver))
         .firstWithin(Span.convertSpanToDuration(scaled(1.second)))
-    } yield ledgerId
+    } yield {
+      configurations should have size 1
+      ledgerId
+    }
 
   protected def fetchLedgerId(): Future[LedgerId] =
     LedgerIdentityServiceGrpc

--- a/ledger/sandbox-common/src/test/resources/com/daml/platform/sandbox/logback-test.base.xml
+++ b/ledger/sandbox-common/src/test/resources/com/daml/platform/sandbox/logback-test.base.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<included>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} %-5level %logger{5}@[%-4.30thread] -
+                %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</included>

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -135,10 +135,7 @@ da_scala_library(
 
 da_scala_test_suite(
     name = "sandbox-tests",
-    srcs = glob(
-        ["src/test/suite/**/*.scala"],
-        exclude = ["src/test/suite/**/ResetService*IT.scala"],
-    ),
+    srcs = glob(["src/test/suite/**/*.scala"]),
     data = [
         "//ledger/test-common:model-tests.dar",
         "//ledger/test-common/test-certificates",
@@ -203,41 +200,6 @@ da_scala_test_suite(
         "@maven//:org_mockito_mockito_scala_2_12",
         "@maven//:org_reactivestreams_reactive_streams",
         "@maven//:org_scalacheck_scalacheck_2_12",
-        "@maven//:org_scalactic_scalactic_2_12",
-        "@maven//:org_scalatest_scalatest_2_12",
-        "@maven//:org_scalaz_scalaz_core_2_12",
-        "@maven//:org_slf4j_slf4j_api",
-    ],
-)
-
-da_scala_test_suite(
-    name = "sandbox-resetservice-tests",
-    srcs = glob(
-        ["src/test/suite/**/ResetService*IT.scala"],
-    ),
-    data = [
-        "//ledger/test-common:model-tests.dar",
-        "//ledger/test-common/test-certificates",
-    ],
-    flaky = True,
-    resources = glob(["src/test/resources/**/*"]),
-    deps = [
-        ":sandbox-scala-tests-lib",
-        "//daml-lf/data",
-        "//language-support/scala/bindings",
-        "//ledger-api/rs-grpc-bridge",
-        "//ledger-api/testing-utils",
-        "//ledger/ledger-api-common",
-        "//ledger/ledger-api-domain",
-        "//ledger/ledger-resources",
-        "//ledger/ledger-resources:ledger-resources-test-lib",
-        "//ledger/sandbox-common",
-        "//ledger/sandbox-common:sandbox-common-scala-tests-lib",
-        "//ledger/test-common",
-        "//libs-scala/ports",
-        "//libs-scala/resources",
-        "@maven//:com_typesafe_akka_akka_actor_2_12",
-        "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:org_scalactic_scalactic_2_12",
         "@maven//:org_scalatest_scalatest_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",

--- a/ledger/sandbox/src/test/resources/logback-test.xml
+++ b/ledger/sandbox/src/test/resources/logback-test.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
-        </encoder>
-    </appender>
+<!-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
-    <root level="INFO">
-        <appender-ref ref="STDOUT"/>
-    </root>
+<configuration>
+    <include resource="com/daml/platform/sandbox/logback-test.base.xml"/>
 </configuration>

--- a/ledger/sandbox/src/test/resources/logback-test.xml
+++ b/ledger/sandbox/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} %-5level %logger{5}@[%-4.30thread] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/ledger/test-common/src/main/scala/com/digitalasset/platform/testing/StreamConsumer.scala
+++ b/ledger/test-common/src/main/scala/com/digitalasset/platform/testing/StreamConsumer.scala
@@ -6,8 +6,8 @@ package com.daml.platform.testing
 import com.daml.dec.DirectExecutionContext
 import io.grpc.stub.StreamObserver
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
 
 final class StreamConsumer[A](attach: StreamObserver[A] => Unit) {
 
@@ -43,6 +43,12 @@ final class StreamConsumer[A](attach: StreamObserver[A] => Unit) {
 
   def within(duration: FiniteDuration)(implicit ec: ExecutionContext): Future[Vector[A]] = {
     val observer = new TimeBoundObserver[A](duration)
+    attach(observer)
+    observer.result
+  }
+
+  def firstWithin(duration: FiniteDuration)(implicit ec: ExecutionContext): Future[Vector[A]] = {
+    val observer = new TimeBoundObserver[A](duration, maximumResults = Some(1))
     attach(observer)
     observer.result
   }


### PR DESCRIPTION
If we don't wait for the ledger configuration, we could potentially ask for completions before the server is fully ready.

This seems to be the source of the flakiness and issues in the reset service tests. I can no longer reproduce the flakes with these changes.

I don't have conclusive proof that these changes make the reset service tests less flaky, but I'm fairly confident. We can revert commit https://github.com/digital-asset/daml/commit/86cfbca7cc2bce9965b920e4d69c6a2d7123e9ef if they turn out to still need some attention.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
