### PR TITLE
document name mangling from DAML to DAML-LF

### DIFF
--- a/docs/source/app-dev/daml-lf-translation.rst
+++ b/docs/source/app-dev/daml-lf-translation.rst
@@ -245,3 +245,29 @@ These translate to the DAML-LF record declarations:
 
 	record DoNothing ↦ {}
 	record Transfer ↦ { newOwner: Party }
+
+Names with special characters
+*****************************
+
+All names in DAML—of types, templates, choices, fields, and variant data constructors—are translated to the more restrictive rules of DAML-LF.  ASCII letters, digits, and ``_`` underscore are unchanged in DAML-LF; all other characters must be mangled in some way, as follows:
+
+- ``$`` changes to ``$$``,
+- Unicode codepoints less than 65536 translate to ``$uABCD``, where ``ABCD`` are exactly four (zero-padded) hexadecimal digits of the codepoint in question, using only lowercase ``a-f``, and
+- Unicode codepoints greater translate to ``$UABCD1234``, where ``ABCD1234`` are exactly eight (zero-padded) hexadecimal digits of the codepoint in question, with the same ``a-f`` rule.
+
+.. list-table::
+   :widths: 10 15
+   :header-rows: 1
+
+   * - DAML name
+     - DAML-LF identifier
+   * - ``Foo_bar``
+     - ``Foo_bar``
+   * - ``baz'``
+     - ``baz$u0027``
+   * - ``:+:``
+     - ``$u003a$u002b$u003a``
+   * - ``naïveté``
+     - ``na$u00efvet$u00e9``
+   * - ``:🙂:``
+     - ``$u003a$U0001f642$u003a``


### PR DESCRIPTION
Name mangling to LF is important to users of language integrations, as referenced in #7919, but isn't mentioned as part of the LF translation documentation. So here.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
