### PR TITLE
[KV integrity checker] Remove extra stateUpdates.compare()

### DIFF
--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -44,10 +44,13 @@ da_scala_test(
     name = "tools-tests",
     size = "small",
     srcs = glob(["src/test/scala/**/*.scala"]),
+    resources = glob(["src/test/resources/**/*"]),
     deps = [
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils/tools",
         "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:com_typesafe_akka_akka_actor_2_12",
+        "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:org_mockito_mockito_core",
         "@maven//:org_scalatest_scalatest_2_12",
     ],

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/Config.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/Config.scala
@@ -20,13 +20,13 @@ case class Config(
 }
 
 object Config {
-  private implicit val `Read Path`: scopt.Read[Path] = scopt.Read.reads(Paths.get(_))
-
-  private val ParseInput: Config = Config(
+  private[integritycheck] val ParseInput: Config = Config(
     exportFilePath = null,
     performByteComparison = true,
     sortWriteSet = false,
   )
+
+  private implicit val `Read Path`: scopt.Read[Path] = scopt.Read.reads(Paths.get(_))
 
   private val Parser: OptionParser[Config] =
     new OptionParser[Config]("integrity-checker") {

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -112,7 +112,6 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
         actualReadServiceFactory,
         config,
       )
-      _ <- stateUpdates.compare()
       _ <- if (!config.indexOnly) stateUpdates.compare() else Future.unit
       _ <- indexStateUpdates(
         exportFileName = config.exportFileName,

--- a/ledger/participant-state/kvutils/tools/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/ledger/participant-state/kvutils/tools/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
An extra `stateUpdates.compare()` causes state updates to be checked even when in index-only mode.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
