### PR TITLE
Asynchronous commits for transaction inserts in index DB

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.daml.platform.store.dao
 
-import java.sql.Connection
+import java.sql.{Connection, PreparedStatement}
 import java.time.Instant
 import java.util.concurrent.Executors
 import java.util.{Date, UUID}
@@ -209,58 +209,60 @@ private class JdbcLedgerDao(
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     dbDispatcher.executeSql(
       metrics.daml.index.db.storeConfigurationEntryDbMetrics,
-    ) { implicit conn =>
-      val optCurrentConfig = ParametersTable.getLedgerEndAndConfiguration(conn)
-      val optExpectedGeneration: Option[Long] =
-        optCurrentConfig.map { case (_, c) => c.generation + 1 }
-      val finalRejectionReason: Option[String] =
-        optExpectedGeneration match {
-          case Some(expGeneration)
-              if rejectionReason.isEmpty && expGeneration != configuration.generation =>
-            // If we're not storing a rejection and the new generation is not succ of current configuration, then
-            // we store a rejection. This code path is only expected to be taken in sandbox. This follows the same
-            // pattern as with transactions.
-            Some(
-              s"Generation mismatch: expected=$expGeneration, actual=${configuration.generation}")
+    ) {
+      queries.withAsyncCommit { implicit conn =>
+        val optCurrentConfig = ParametersTable.getLedgerEndAndConfiguration(conn)
+        val optExpectedGeneration: Option[Long] =
+          optCurrentConfig.map { case (_, c) => c.generation + 1 }
+        val finalRejectionReason: Option[String] =
+          optExpectedGeneration match {
+            case Some(expGeneration)
+                if rejectionReason.isEmpty && expGeneration != configuration.generation =>
+              // If we're not storing a rejection and the new generation is not succ of current configuration, then
+              // we store a rejection. This code path is only expected to be taken in sandbox. This follows the same
+              // pattern as with transactions.
+              Some(
+                s"Generation mismatch: expected=$expGeneration, actual=${configuration.generation}")
 
-          case _ =>
-            // Rejection reason was set, or we have no previous configuration generation, in which case we accept any
-            // generation.
-            rejectionReason
+            case _ =>
+              // Rejection reason was set, or we have no previous configuration generation, in which case we accept any
+              // generation.
+              rejectionReason
+          }
+
+        ParametersTable.updateLedgerEnd(offset)
+        val configurationBytes = Configuration.encode(configuration).toByteArray
+        val typ = if (finalRejectionReason.isEmpty) {
+          acceptType
+        } else {
+          rejectType
         }
 
-      ParametersTable.updateLedgerEnd(offset)
-      val configurationBytes = Configuration.encode(configuration).toByteArray
-      val typ = if (finalRejectionReason.isEmpty) {
-        acceptType
-      } else {
-        rejectType
+        Try({
+          SQL_INSERT_CONFIGURATION_ENTRY
+            .on(
+              "ledger_offset" -> offset,
+              "recorded_at" -> recordedAt,
+              "submission_id" -> submissionId,
+              "typ" -> typ,
+              "rejection_reason" -> finalRejectionReason.orNull,
+              "configuration" -> configurationBytes
+            )
+            .execute()
+
+          if (typ == acceptType) {
+            ParametersTable.updateConfiguration(configurationBytes)
+          }
+
+          PersistenceResponse.Ok
+        }).recover {
+          case NonFatal(e) if e.getMessage.contains(queries.DUPLICATE_KEY_ERROR) =>
+            logger.warn(s"Ignoring duplicate configuration submission, submissionId=$submissionId")
+            conn.rollback()
+            PersistenceResponse.Duplicate
+        }.get
+
       }
-
-      Try({
-        SQL_INSERT_CONFIGURATION_ENTRY
-          .on(
-            "ledger_offset" -> offset,
-            "recorded_at" -> recordedAt,
-            "submission_id" -> submissionId,
-            "typ" -> typ,
-            "rejection_reason" -> finalRejectionReason.orNull,
-            "configuration" -> configurationBytes
-          )
-          .execute()
-
-        if (typ == acceptType) {
-          ParametersTable.updateConfiguration(configurationBytes)
-        }
-
-        PersistenceResponse.Ok
-      }).recover {
-        case NonFatal(e) if e.getMessage.contains(queries.DUPLICATE_KEY_ERROR) =>
-          logger.warn(s"Ignoring duplicate configuration submission, submissionId=$submissionId")
-          conn.rollback()
-          PersistenceResponse.Duplicate
-      }.get
-
     }
 
   private val SQL_INSERT_PARTY_ENTRY_ACCEPT =
@@ -279,48 +281,50 @@ private class JdbcLedgerDao(
       offset: Offset,
       partyEntry: PartyLedgerEntry,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] = {
-    dbDispatcher.executeSql(metrics.daml.index.db.storePartyEntryDbMetrics) { implicit conn =>
-      ParametersTable.updateLedgerEnd(offset)
+    dbDispatcher.executeSql(metrics.daml.index.db.storePartyEntryDbMetrics) {
+      queries.withAsyncCommit { implicit conn =>
+        ParametersTable.updateLedgerEnd(offset)
 
-      partyEntry match {
-        case PartyLedgerEntry.AllocationAccepted(submissionIdOpt, recordTime, partyDetails) =>
-          Try({
-            SQL_INSERT_PARTY_ENTRY_ACCEPT
+        partyEntry match {
+          case PartyLedgerEntry.AllocationAccepted(submissionIdOpt, recordTime, partyDetails) =>
+            Try({
+              SQL_INSERT_PARTY_ENTRY_ACCEPT
+                .on(
+                  "ledger_offset" -> offset,
+                  "recorded_at" -> recordTime,
+                  "submission_id" -> submissionIdOpt,
+                  "party" -> partyDetails.party,
+                  "display_name" -> partyDetails.displayName,
+                  "is_local" -> partyDetails.isLocal,
+                )
+                .execute()
+              SQL_INSERT_PARTY
+                .on(
+                  "party" -> partyDetails.party,
+                  "display_name" -> partyDetails.displayName,
+                  "ledger_offset" -> offset,
+                  "is_local" -> partyDetails.isLocal
+                )
+                .execute()
+              PersistenceResponse.Ok
+            }).recover {
+              case NonFatal(e) if e.getMessage.contains(queries.DUPLICATE_KEY_ERROR) =>
+                logger.warn(
+                  s"Ignoring duplicate party submission with ID ${partyDetails.party} for submissionId $submissionIdOpt")
+                conn.rollback()
+                PersistenceResponse.Duplicate
+            }.get
+          case PartyLedgerEntry.AllocationRejected(submissionId, recordTime, reason) =>
+            SQL_INSERT_PARTY_ENTRY_REJECT
               .on(
                 "ledger_offset" -> offset,
                 "recorded_at" -> recordTime,
-                "submission_id" -> submissionIdOpt,
-                "party" -> partyDetails.party,
-                "display_name" -> partyDetails.displayName,
-                "is_local" -> partyDetails.isLocal,
-              )
-              .execute()
-            SQL_INSERT_PARTY
-              .on(
-                "party" -> partyDetails.party,
-                "display_name" -> partyDetails.displayName,
-                "ledger_offset" -> offset,
-                "is_local" -> partyDetails.isLocal
+                "submission_id" -> submissionId,
+                "rejection_reason" -> reason
               )
               .execute()
             PersistenceResponse.Ok
-          }).recover {
-            case NonFatal(e) if e.getMessage.contains(queries.DUPLICATE_KEY_ERROR) =>
-              logger.warn(
-                s"Ignoring duplicate party submission with ID ${partyDetails.party} for submissionId $submissionIdOpt")
-              conn.rollback()
-              PersistenceResponse.Duplicate
-          }.get
-        case PartyLedgerEntry.AllocationRejected(submissionId, recordTime, reason) =>
-          SQL_INSERT_PARTY_ENTRY_REJECT
-            .on(
-              "ledger_offset" -> offset,
-              "recorded_at" -> recordTime,
-              "submission_id" -> submissionId,
-              "rejection_reason" -> reason
-            )
-            .execute()
-          PersistenceResponse.Ok
+        }
       }
     }
 
@@ -425,39 +429,42 @@ private class JdbcLedgerDao(
       offset: Offset,
       transaction: CommittedTransaction,
       divulged: Iterable[DivulgedContract],
-  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] = {
+  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     dbDispatcher
-      .executeSql(metrics.daml.index.db.storeTransactionDbMetrics) { implicit conn =>
-        val error =
-          Timed.value(
-            metrics.daml.index.db.storeTransactionDbMetrics.commitValidation,
-            postCommitValidation.validate(
-              transaction = transaction,
-              transactionLedgerEffectiveTime = ledgerEffectiveTime,
-              divulged = divulged.iterator.map(_.contractId).toSet,
+      .executeSql(metrics.daml.index.db.storeTransactionDbMetrics) {
+        queries.withAsyncCommit { implicit conn =>
+          val error =
+            Timed.value(
+              metrics.daml.index.db.storeTransactionDbMetrics.commitValidation,
+              postCommitValidation.validate(
+                transaction = transaction,
+                transactionLedgerEffectiveTime = ledgerEffectiveTime,
+                divulged = divulged.iterator.map(_.contractId).toSet,
+              )
             )
-          )
-        if (error.isEmpty) {
-          preparedInsert.write(metrics)
-          Timed.value(
-            metrics.daml.index.db.storeTransactionDbMetrics.insertCompletion,
-            submitterInfo
-              .map(prepareCompletionInsert(_, offset, transactionId, recordTime))
-              .foreach(_.execute())
-          )
-        } else {
-          for (info @ SubmitterInfo(actAs, _, commandId, _) <- submitterInfo) {
-            stopDeduplicatingCommandSync(domain.CommandId(commandId), info.singleSubmitterOrThrow())
-            prepareRejectionInsert(info, offset, recordTime, error.get).execute()
+          if (error.isEmpty) {
+            preparedInsert.write(metrics)
+            Timed.value(
+              metrics.daml.index.db.storeTransactionDbMetrics.insertCompletion,
+              submitterInfo
+                .map(prepareCompletionInsert(_, offset, transactionId, recordTime))
+                .foreach(_.execute())
+            )
+          } else {
+            for (info @ SubmitterInfo(_, _, commandId, _) <- submitterInfo) {
+              stopDeduplicatingCommandSync(
+                domain.CommandId(commandId),
+                info.singleSubmitterOrThrow())
+              prepareRejectionInsert(info, offset, recordTime, error.get).execute()
+            }
           }
+          Timed.value(
+            metrics.daml.index.db.storeTransactionDbMetrics.updateLedgerEnd,
+            ParametersTable.updateLedgerEnd(offset)
+          )
+          Ok
         }
-        Timed.value(
-          metrics.daml.index.db.storeTransactionDbMetrics.updateLedgerEnd,
-          ParametersTable.updateLedgerEnd(offset)
-        )
-        Ok
       }
-  }
 
   override def storeRejection(
       submitterInfo: Option[SubmitterInfo],
@@ -465,13 +472,15 @@ private class JdbcLedgerDao(
       offset: Offset,
       reason: RejectionReason,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
-    dbDispatcher.executeSql(metrics.daml.index.db.storeRejectionDbMetrics) { implicit conn =>
-      for (info @ SubmitterInfo(actAs, _, commandId, _) <- submitterInfo) {
-        stopDeduplicatingCommandSync(domain.CommandId(commandId), info.singleSubmitterOrThrow())
-        prepareRejectionInsert(info, offset, recordTime, reason).execute()
+    dbDispatcher.executeSql(metrics.daml.index.db.storeRejectionDbMetrics) {
+      queries.withAsyncCommit { implicit conn =>
+        for (info @ SubmitterInfo(_, _, commandId, _) <- submitterInfo) {
+          stopDeduplicatingCommandSync(domain.CommandId(commandId), info.singleSubmitterOrThrow())
+          prepareRejectionInsert(info, offset, recordTime, reason).execute()
+        }
+        ParametersTable.updateLedgerEnd(offset)
+        Ok
       }
-      ParametersTable.updateLedgerEnd(offset)
-      Ok
     }
 
   override def storeInitialState(
@@ -640,7 +649,7 @@ private class JdbcLedgerDao(
       optEntry: Option[PackageLedgerEntry]
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     dbDispatcher.executeSql(metrics.daml.index.db.storePackageEntryDbMetrics) {
-      implicit connection =>
+      queries.withAsyncCommit { implicit connection =>
         ParametersTable.updateLedgerEnd(offset)
 
         if (packages.nonEmpty) {
@@ -668,6 +677,7 @@ private class JdbcLedgerDao(
               .execute()
         }
         PersistenceResponse.Ok
+      }
     }
 
   private def uploadLfPackages(uploadId: String, packages: List[(Archive, PackageDetails)])(
@@ -964,6 +974,13 @@ private[platform] object JdbcLedgerDao {
 
   sealed trait Queries {
 
+    /**
+      * Performance optimization for transactions that don't
+      * require strong durability guarantees.
+      */
+    protected[JdbcLedgerDao] def withAsyncCommit(block: Connection => PersistenceResponse)(
+        provided: Connection): PersistenceResponse
+
     protected[JdbcLedgerDao] def SQL_INSERT_PACKAGE: String
 
     protected[JdbcLedgerDao] def SQL_INSERT_COMMAND: String
@@ -1005,10 +1022,20 @@ private[platform] object JdbcLedgerDao {
         |truncate table party_entries cascade;
       """.stripMargin
 
+    override protected[JdbcLedgerDao] def withAsyncCommit(block: Connection => PersistenceResponse)(
+        provided: Connection): PersistenceResponse = {
+      var statement: PreparedStatement = null
+      try {
+        statement = provided.prepareStatement("SET LOCAL synchronous_commit = 'off'")
+        statement.execute()
+        block(provided)
+      } finally {
+        if (statement != null) statement.close()
+      }
+    }
   }
 
   object H2DatabaseQueries extends Queries {
-
     override protected[JdbcLedgerDao] val SQL_INSERT_PACKAGE: String =
       """merge into packages using dual on package_id = {package_id}
         |when not matched then insert (package_id, upload_id, source_description, size, known_since, ledger_offset, package)
@@ -1042,6 +1069,9 @@ private[platform] object JdbcLedgerDao {
         |set referential_integrity true;
       """.stripMargin
 
+    /** Async commit not supported for H2 */
+    override protected[JdbcLedgerDao] def withAsyncCommit(block: Connection => PersistenceResponse)(
+        provided: Connection): PersistenceResponse =
+      block(provided)
   }
-
 }


### PR DESCRIPTION
Implementation PR as a follow-up of [DPP-50](https://digitalasset.atlassian.net/browse/DPP-50).

This optimization targets all indexer JDBC insertions performed in `JdbcLedgerDao` (except ledger initialization queries). Due to the lax durability guarantee requirements for these inserts, executing the PostgreSQL transactions in async mode allows for a throughput increase of up to 30%.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
