### PR TITLE
Implement token refresh in auth middleware

### DIFF
--- a/libs-scala/adjustable-clock/BUILD.bazel
+++ b/libs-scala/adjustable-clock/BUILD.bazel
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+)
+
+da_scala_library(
+    name = "adjustable-clock",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    tags = ["maven_coordinates=com.daml:adjustable-clock:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/libs-scala/adjustable-clock/src/main/scala/com/digitalasset/clock/AdjustableClock.scala
+++ b/libs-scala/adjustable-clock/src/main/scala/com/digitalasset/clock/AdjustableClock.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.clock
+
+import java.time.{Clock, Duration, Instant, ZoneId}
+
+case class AdjustableClock(baseClock: Clock, var offset: Duration) extends Clock {
+  def fastForward(by: Duration): Unit =
+    offset = offset.plus(by)
+
+  def rewind(by: Duration): Unit =
+    offset = offset.minus(by)
+
+  def set(to: Instant): Unit =
+    offset = Duration.between(baseClock.instant(), to)
+
+  override def getZone: ZoneId = baseClock.getZone
+
+  override def withZone(zone: ZoneId): Clock =
+    if (zone == baseClock.getZone) this
+    else AdjustableClock(baseClock.withZone(zone), offset)
+
+  override def millis: Long = Math.addExact(baseClock.millis, offset.toMillis)
+
+  override def instant: Instant = baseClock.instant.plus(offset)
+
+  override def equals(obj: Any): Boolean =
+    if (!obj.isInstanceOf[AdjustableClock]) false
+    else {
+      val other = obj.asInstanceOf[AdjustableClock]
+      baseClock == other.baseClock && offset == other.offset
+    }
+
+  override def hashCode: Int = baseClock.hashCode ^ offset.hashCode
+}

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -124,6 +124,7 @@ da_scala_test(
         "//ledger-service/jwt",
         "//ledger/ledger-api-auth",
         "//ledger/ledger-resources",
+        "//libs-scala/adjustable-clock",
         "//libs-scala/ports",
         "//libs-scala/resources",
         "@maven//:com_auth0_java_jwt",

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -125,6 +125,7 @@ da_scala_test(
         "//ledger/ledger-resources",
         "//libs-scala/ports",
         "//libs-scala/resources",
+        "@maven//:com_auth0_java_jwt",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_http_2_12",
         "@maven//:com_typesafe_akka_akka_http_core_2_12",

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -96,6 +96,7 @@ da_scala_test(
         "//ledger-service/jwt",
         "//ledger/ledger-api-auth",
         "//ledger/ledger-resources",
+        "//libs-scala/adjustable-clock",
         "//libs-scala/ports",
         "//libs-scala/resources",
         "@maven//:com_typesafe_akka_akka_actor_2_12",

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
@@ -18,6 +18,7 @@ repository](https://github.com/digital-asset/ex-secure-daml-infra).
   - Provide a name (`ex-daml-api`).
   - Provide an Identifier (`https://daml.com/ledger-api`).
   - Select Signing Algorithm of `RS256`.
+  - Allow offline access to enable refresh token generation.
 * Create a new native application.
   - Provide a name (`ex-daml-auth-middleware`).
   - Select the authorized API (`ex-daml-api`).
@@ -31,8 +32,14 @@ repository](https://github.com/digital-asset/ex-secure-daml-infra).
   - Provide a script
     ``` javascript
     function (user, context, callback) {
+      // Only handle ledger-api audience.
+      const audience = context.request.query && context.request.query.audience || "";
+      if (audience !== "https://daml.com/ledger-api") {
+        return callback(null, user, context);
+      }
+
       // Grant all requested claims
-      const scope = (context.request.query.scope || "").split(" ");
+      const scope = (context.request.query && context.request.query.scope || "").split(" ");
       var actAs = [];
       var readAs = [];
       var admin = false;
@@ -41,7 +48,7 @@ repository](https://github.com/digital-asset/ex-secure-daml-infra).
           actAs.push(s.slice(6));
         } else if (s.startsWith("readAs:")) {
           readAs.push(s.slice(7));
-        } else if (s.startsWith("admin")) {
+        } else if (s === "admin") {
           admin = true;
         }
       });

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md
@@ -19,6 +19,7 @@ repository](https://github.com/digital-asset/ex-secure-daml-infra).
   - Provide an Identifier (`https://daml.com/ledger-api`).
   - Select Signing Algorithm of `RS256`.
   - Allow offline access to enable refresh token generation.
+    This allows the OAuth2 client, i.e. the auth middleware, to request access through a refresh token when the resource owner, i.e. the user, is offline. 
 * Create a new native application.
   - Provide a name (`ex-daml-auth-middleware`).
   - Select the authorized API (`ex-daml-api`).

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
@@ -83,6 +83,10 @@ object Request {
     }
   }
 
+  /** Refresh endpoint request entity
+    */
+  case class Refresh(refreshToken: String)
+
 }
 
 object Response {
@@ -99,6 +103,8 @@ object JsonProtocol extends DefaultJsonProtocol {
     }
     def write(uri: Uri) = JsString(uri.toString)
   }
+  implicit val requestRefreshFormat: RootJsonFormat[Request.Refresh] =
+    jsonFormat(Request.Refresh, "refresh_token")
   implicit val responseAuthorizeFormat: RootJsonFormat[Response.Authorize] =
     jsonFormat(Response.Authorize, "access_token", "refresh_token")
 }

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
@@ -212,11 +212,9 @@ object Server extends StrictLogging {
               Response.Authorize(accessToken = token.accessToken, refreshToken = token.refreshToken)
             }
             complete(authResponse)
-          // Forward unauthorized and forbidden responses.
-          case StatusCodes.Unauthorized =>
-            complete(HttpResponse.apply(status = StatusCodes.Unauthorized, entity = resp.entity))
-          case StatusCodes.Forbidden =>
-            complete(HttpResponse.apply(status = StatusCodes.Forbidden, entity = resp.entity))
+          // Forward client errors.
+          case status: StatusCodes.ClientError =>
+            complete(HttpResponse.apply(status = status, entity = resp.entity))
           // Fail on unexpected responses.
           case _ =>
             onSuccess(Unmarshal(resp).to[String]) { msg =>

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Server.scala
@@ -115,7 +115,9 @@ object Server extends StrictLogging {
             responseType = "code",
             clientId = config.clientId,
             redirectUri = toRedirectUri(request.uri),
-            scope = Some(login.claims.toQueryString),
+            // Auth0 will only issue a refresh token if the offline_access claim is present.
+            // TODO[AH] Make the request configurable, see https://github.com/digital-asset/daml/issues/7957
+            scope = Some("offline_access " + login.claims.toQueryString),
             state = Some(requestId.toString),
             audience = Some("https://daml.com/ledger-api")
           )

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
@@ -3,6 +3,8 @@
 
 package com.daml.oauth.server
 
+import java.time.Clock
+
 import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ports.Port
 
@@ -16,7 +18,9 @@ case class Config(
     // Secret used to sign JWTs
     jwtSecret: String,
     // Only authorize requests for these parties, if set.
-    parties: Option[Set[Party]]
+    parties: Option[Set[Party]],
+    // Use the provided clock instead of system time for token generation. For testing only.
+    clock: Option[Clock],
 )
 
 object Config {
@@ -26,7 +30,8 @@ object Config {
       ledgerId = null,
       applicationId = None,
       jwtSecret = null,
-      parties = None)
+      parties = None,
+      clock = None)
 
   def parseConfig(args: Seq[String]): Option[Config] =
     configParser.parse(args, Empty)

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
@@ -19,7 +19,7 @@ case class Config(
     jwtSecret: String,
     // Only authorize requests for these parties, if set.
     parties: Option[Set[Party]],
-    // Use the provided clock instead of system time for token generation. For testing only.
+    // Use the provided clock instead of system time for token generation.
     clock: Option[Clock],
 )
 

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
@@ -94,7 +94,7 @@ object Request {
       Unmarshaller.defaultUrlEncodedFormDataUnmarshaller.map { form =>
         Refresh(
           grantType = form.fields.get("grant_type").get,
-          refreshToken = form.fields.get("code").get,
+          refreshToken = form.fields.get("refresh_token").get,
           clientId = form.fields.get("client_id").get,
           clientSecret = form.fields.get("client_secret").get,
         )

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Request.scala
@@ -73,6 +73,34 @@ object Request {
       }
   }
 
+  // https://tools.ietf.org/html/rfc6749#section-6
+  case class Refresh(
+      grantType: String,
+      refreshToken: String,
+      clientId: String,
+      clientSecret: String)
+
+  object Refresh {
+    implicit val marshalRequestEntity: Marshaller[Refresh, RequestEntity] =
+      Marshaller.combined { refresh =>
+        FormData(
+          "grant_type" -> refresh.grantType,
+          "refresh_token" -> refresh.refreshToken,
+          "client_id" -> refresh.clientId,
+          "client_secret" -> refresh.clientSecret,
+        )
+      }
+    implicit val unmarshalHttpEntity: Unmarshaller[HttpEntity, Refresh] =
+      Unmarshaller.defaultUrlEncodedFormDataUnmarshaller.map { form =>
+        Refresh(
+          grantType = form.fields.get("grant_type").get,
+          refreshToken = form.fields.get("code").get,
+          clientId = form.fields.get("client_id").get,
+          clientSecret = form.fields.get("client_secret").get,
+        )
+      }
+  }
+
 }
 
 object Response {

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -58,8 +58,13 @@ class Server(config: Config) {
   // The token request then only does a lookup and signs the token.
   private val requests = TrieMap.empty[UUID, AuthServiceJWTPayload]
 
-  private def tokenExpiry(): Instant =
-    Instant.now().plusSeconds(tokenLifetimeSeconds.asInstanceOf[Long])
+  private def tokenExpiry(): Instant = {
+    val now = config.clock match {
+      case Some(clock) => Instant.now(clock)
+      case None => Instant.now()
+    }
+    now.plusSeconds(tokenLifetimeSeconds.asInstanceOf[Long])
+  }
   private def toPayload(req: Request.Authorize): AuthServiceJWTPayload = {
     var actAs: Seq[String] = Seq()
     var readAs: Seq[String] = Seq()

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -102,7 +102,7 @@ class Server(config: Config) {
                   Response
                     .Authorize(code = authorizationCode.toString, state = request.state)
                     .toQuery
-                requests += (authorizationCode -> toPayload(request))
+                requests += (authorizationCode -> payload)
                 // We skip any actual consent screen since this is only intended for testing and
                 // this is outside of the scope of the trigger service anyway.
                 redirect(request.redirectUri.withQuery(params), StatusCodes.Found)

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -3,6 +3,7 @@
 
 package com.daml.oauth.server
 
+import java.time.Instant
 import java.util.UUID
 
 import akka.Done
@@ -18,6 +19,7 @@ import com.daml.jwt.domain.DecodedJwt
 import com.daml.ledger.api.auth.{AuthServiceJWTCodec, AuthServiceJWTPayload}
 import com.daml.ledger.api.refinements.ApiTypes.Party
 
+import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 
@@ -29,6 +31,7 @@ import scala.language.postfixOps
 // request to /authorize are immediately redirected to the redirect_uri.
 class Server(config: Config) {
   private val jwtHeader = """{"alg": "HS256", "typ": "JWT"}"""
+  private val tokenLifetimeSeconds = 24 * 60 * 60
 
   // None indicates that all parties are authorized, Some that only the given set of parties is authorized.
   private var authorizedParties: Option[Set[Party]] = config.parties
@@ -50,11 +53,13 @@ class Server(config: Config) {
     authorizedParties = config.parties
   }
 
-  // To keep things as simple as possible, we use a UUID as the authorization code
+  // To keep things as simple as possible, we use a UUID as the authorization code and refresh token
   // and in the /authorize request we already pre-compute the JWT payload based on the scope.
   // The token request then only does a lookup and signs the token.
-  private var requests = Map.empty[UUID, AuthServiceJWTPayload]
+  private val requests = TrieMap.empty[UUID, AuthServiceJWTPayload]
 
+  private def tokenExpiry(): Instant =
+    Instant.now().plusSeconds(tokenLifetimeSeconds.asInstanceOf[Long])
   private def toPayload(req: Request.Authorize): AuthServiceJWTPayload = {
     var actAs: Seq[String] = Seq()
     var readAs: Seq[String] = Seq()
@@ -68,7 +73,7 @@ class Server(config: Config) {
       applicationId = config.applicationId,
       // Not required by the default auth service
       participantId = None,
-      // Only for testing, expire never.
+      // Expiry is set when the token is retrieved
       exp = None,
       // no admin claim for now.
       admin = false,
@@ -122,30 +127,41 @@ class Server(config: Config) {
     },
     path("token") {
       post {
-        entity(as[Request.Token]) {
-          request =>
-            // No validation to keep things simple
-            requests.get(UUID.fromString(request.code)) match {
-              case None => sys.exit(2)
-              case Some(payload) =>
-                import JsonProtocol._
-                complete(
-                  Response.Token(
-                    accessToken = JwtSigner.HMAC256
-                      .sign(
-                        DecodedJwt(jwtHeader, AuthServiceJWTCodec.compactPrint(payload)),
-                        config.jwtSecret)
-                      .getOrElse(
-                        throw new IllegalArgumentException("Failed to sign a token")
-                      )
-                      .value,
-                    refreshToken = None,
-                    expiresIn = None,
-                    scope = None,
-                    tokenType = "bearer"
-                  ))
-            }
+        def returnToken(uuid: UUID) = {
+          requests.remove(uuid) match {
+            case Some(payload) =>
+              // Generate refresh token
+              val refreshCode = UUID.randomUUID()
+              requests += (refreshCode -> payload)
+              // Construct access token with expiry
+              val accessToken = JwtSigner.HMAC256
+                .sign(
+                  DecodedJwt(
+                    jwtHeader,
+                    AuthServiceJWTCodec.compactPrint(payload.copy(exp = Some(tokenExpiry())))),
+                  config.jwtSecret)
+                .getOrElse(throw new IllegalArgumentException("Failed to sign a token"))
+                .value
+              import JsonProtocol._
+              complete(
+                Response.Token(
+                  accessToken = accessToken,
+                  refreshToken = Some(refreshCode.toString),
+                  expiresIn = Some(tokenLifetimeSeconds),
+                  scope = None,
+                  tokenType = "bearer"))
+            case None =>
+              complete(StatusCodes.NotFound)
+          }
         }
+        concat(
+          entity(as[Request.Token]) { request =>
+            returnToken(UUID.fromString(request.code))
+          },
+          entity(as[Request.Refresh]) { request =>
+            returnToken(UUID.fromString(request.refreshToken))
+          },
+        )
       }
     }
   )

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -83,6 +83,7 @@ class Server(config: Config) {
   }
 
   import Request.Token.unmarshalHttpEntity
+  import Request.Refresh.unmarshalHttpEntity
   implicit val unmarshal: Unmarshaller[String, Uri] = Unmarshaller.strict(Uri(_))
 
   val route = concat(

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Resources.scala
@@ -3,20 +3,22 @@
 
 package com.daml.oauth.middleware
 
-import java.time.{Clock, Instant, ZoneId}
+import java.time.{Clock, Duration, Instant, ZoneId}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
+import com.daml.clock.AdjustableClock
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.oauth.server.{Config => OAuthConfig, Server => OAuthServer}
 
 import scala.concurrent.Future
 
 object Resources {
-  def clock(start: Instant, zoneId: ZoneId): ResourceOwner[Clock] =
-    new ResourceOwner[Clock] {
-      override def acquire()(implicit context: ResourceContext): Resource[Clock] = {
-        Resource(Future(Clock.fixed(start, zoneId)))(_ => Future(()))
+  def clock(start: Instant, zoneId: ZoneId): ResourceOwner[AdjustableClock] =
+    new ResourceOwner[AdjustableClock] {
+      override def acquire()(implicit context: ResourceContext): Resource[AdjustableClock] = {
+        Resource(Future(AdjustableClock(Clock.fixed(start, zoneId), Duration.ZERO)))(_ =>
+          Future(()))
       }
     }
   def authServer(config: OAuthConfig)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Resources.scala
@@ -3,12 +3,22 @@
 
 package com.daml.oauth.middleware
 
+import java.time.{Clock, Instant, ZoneId}
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.oauth.server.{Config => OAuthConfig, Server => OAuthServer}
 
+import scala.concurrent.Future
+
 object Resources {
+  def clock(start: Instant, zoneId: ZoneId): ResourceOwner[Clock] =
+    new ResourceOwner[Clock] {
+      override def acquire()(implicit context: ResourceContext): Resource[Clock] = {
+        Resource(Future(Clock.fixed(start, zoneId)))(_ => Future(()))
+      }
+    }
   def authServer(config: OAuthConfig)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/Test.scala
@@ -20,7 +20,7 @@ import org.scalatest.AsyncWordSpec
 class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAroundAll {
   import JsonProtocol._
   lazy private val middlewareUri = {
-    lazy val middlewareBinding = suiteResource.value._2.localAddress
+    lazy val middlewareBinding = suiteResource.value._3.localAddress
     Uri()
       .withScheme("http")
       .withAuthority(middlewareBinding.getHostString, middlewareBinding.getPort)

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
@@ -33,7 +33,9 @@ trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBindin
             ledgerId = ledgerId,
             applicationId = Some(applicationId),
             jwtSecret = jwtSecret,
-            parties = Some(ApiTypes.Party.subst(Set("Alice", "Bob")))))
+            parties = Some(ApiTypes.Party.subst(Set("Alice", "Bob"))),
+            clock = None
+          ))
         serverUri = Uri()
           .withScheme("http")
           .withAuthority(server.localAddress.getHostString, server.localAddress.getPort)

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
@@ -3,7 +3,7 @@
 
 package com.daml.oauth.middleware
 
-import java.time.{Clock, Instant, ZoneId}
+import java.time.{Instant, ZoneId}
 import java.util.Date
 
 import akka.http.scaladsl.Http.ServerBinding
@@ -12,6 +12,7 @@ import com.auth0.jwt.JWTVerifier.BaseVerification
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.interfaces.{Clock => Auth0Clock}
+import com.daml.clock.AdjustableClock
 import com.daml.jwt.JwtVerifier
 import com.daml.ledger.api.refinements.ApiTypes
 import com.daml.ledger.api.testing.utils.{
@@ -27,14 +28,15 @@ import org.scalatest.Suite
 
 trait TestFixture
     extends AkkaBeforeAndAfterAll
-    with SuiteResource[(Clock, ServerBinding, ServerBinding)] {
+    with SuiteResource[(AdjustableClock, ServerBinding, ServerBinding)] {
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
   protected val applicationId: String = "test-application"
   protected val jwtSecret: String = "secret"
-  override protected lazy val suiteResource: Resource[(Clock, ServerBinding, ServerBinding)] = {
+  override protected lazy val suiteResource
+    : Resource[(AdjustableClock, ServerBinding, ServerBinding)] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
-    new OwnedResource[ResourceContext, (Clock, ServerBinding, ServerBinding)](
+    new OwnedResource[ResourceContext, (AdjustableClock, ServerBinding, ServerBinding)](
       for {
         clock <- Resources.clock(Instant.now(), ZoneId.systemDefault())
         server <- Resources.authServer(

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Resources.scala
@@ -3,19 +3,21 @@
 
 package com.daml.oauth.server
 
-import java.time.{Clock, Instant, ZoneId}
+import java.time.{Clock, Duration, Instant, ZoneId}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
+import com.daml.clock.AdjustableClock
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 
 import scala.concurrent.Future
 
 object Resources {
-  def clock(start: Instant, zoneId: ZoneId): ResourceOwner[Clock] =
-    new ResourceOwner[Clock] {
-      override def acquire()(implicit context: ResourceContext): Resource[Clock] = {
-        Resource(Future(Clock.fixed(start, zoneId)))(_ => Future(()))
+  def clock(start: Instant, zoneId: ZoneId): ResourceOwner[AdjustableClock] =
+    new ResourceOwner[AdjustableClock] {
+      override def acquire()(implicit context: ResourceContext): Resource[AdjustableClock] = {
+        Resource(Future(AdjustableClock(Clock.fixed(start, zoneId), Duration.ZERO)))(_ =>
+          Future(()))
       }
     }
   def authServer(config: Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Resources.scala
@@ -3,11 +3,21 @@
 
 package com.daml.oauth.server
 
+import java.time.{Clock, Instant, ZoneId}
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 
+import scala.concurrent.Future
+
 object Resources {
+  def clock(start: Instant, zoneId: ZoneId): ResourceOwner[Clock] =
+    new ResourceOwner[Clock] {
+      override def acquire()(implicit context: ResourceContext): Resource[Clock] = {
+        Resource(Future(Clock.fixed(start, zoneId)))(_ => Future(()))
+      }
+    }
   def authServer(config: Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
@@ -141,13 +141,11 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
     "refresh a token" in {
       for {
         (token1, refresh1) <- expectToken(Seq())
-        (token2, refresh2) <- expectRefresh(refresh1)
-        (token3, _) <- expectRefresh(refresh2)
+        _ <- Future(suiteResource.value._1.set(token1.exp.get.plusSeconds(1)))
+        (token2, _) <- expectRefresh(refresh1)
       } yield {
-        assert(!token1.exp.get.isAfter(token2.exp.get))
-        assert(!token2.exp.get.isAfter(token3.exp.get))
+        assert(token2.exp.get.isAfter(token1.exp.get))
         assert(token1.copy(exp = None) == token2.copy(exp = None))
-        assert(token2.copy(exp = None) == token3.copy(exp = None))
       }
     }
   }

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/Test.scala
@@ -22,7 +22,7 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
   import Client.JsonProtocol._
   private def requestToken(
       parties: Seq[String]): Future[Either[String, (AuthServiceJWTPayload, String)]] = {
-    lazy val clientBinding = suiteResource.value._2.localAddress
+    lazy val clientBinding = suiteResource.value._3.localAddress
     lazy val clientUri = Uri().withAuthority(clientBinding.getHostString, clientBinding.getPort)
     val req = HttpRequest(
       uri = clientUri.withPath(Path./("access")).withScheme("http"),
@@ -63,7 +63,7 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
 
   private def requestRefresh(
       refreshToken: String): Future[Either[String, (AuthServiceJWTPayload, String)]] = {
-    lazy val clientBinding = suiteResource.value._2.localAddress
+    lazy val clientBinding = suiteResource.value._3.localAddress
     lazy val clientUri = Uri().withAuthority(clientBinding.getHostString, clientBinding.getPort)
     val req = HttpRequest(
       uri = clientUri.withPath(Path./("refresh")).withScheme("http"),

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
@@ -3,10 +3,11 @@
 
 package com.daml.oauth.server
 
-import java.time.{Clock, Instant, ZoneId}
+import java.time.{Instant, ZoneId}
 
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.Uri
+import com.daml.clock.AdjustableClock
 import com.daml.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
   OwnedResource,
@@ -20,14 +21,15 @@ import org.scalatest.Suite
 
 trait TestFixture
     extends AkkaBeforeAndAfterAll
-    with SuiteResource[(Clock, ServerBinding, ServerBinding)] {
+    with SuiteResource[(AdjustableClock, ServerBinding, ServerBinding)] {
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
   protected val applicationId: String = "test-application"
   protected val jwtSecret: String = "secret"
-  override protected lazy val suiteResource: Resource[(Clock, ServerBinding, ServerBinding)] = {
+  override protected lazy val suiteResource
+    : Resource[(AdjustableClock, ServerBinding, ServerBinding)] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
-    new OwnedResource[ResourceContext, (Clock, ServerBinding, ServerBinding)](
+    new OwnedResource[ResourceContext, (AdjustableClock, ServerBinding, ServerBinding)](
       for {
         clock <- Resources.clock(Instant.now(), ZoneId.systemDefault())
         server <- Resources.authServer(

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
@@ -31,7 +31,8 @@ trait TestFixture extends AkkaBeforeAndAfterAll with SuiteResource[(ServerBindin
             ledgerId = ledgerId,
             applicationId = Some(applicationId),
             jwtSecret = jwtSecret,
-            parties = Some(Party.subst(Set("Alice", "Bob")))))
+            parties = Some(Party.subst(Set("Alice", "Bob"))),
+            clock = None))
         client <- Resources.authClient(
           Client.Config(
             port = Port.Dynamic,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -185,6 +185,7 @@ trait AuthMiddlewareFixture
       applicationId = None,
       jwtSecret = authSecret,
       parties = authParties,
+      clock = None,
     )
     resource = new OwnedResource(new ResourceOwner[(OAuthServer, ServerBinding)] {
       override def acquire()(


### PR DESCRIPTION
- Implements the `/refresh` endpoint in the auth middleware according to [the spec](https://github.com/digital-asset/daml/blob/00da07c9ea180d9cb6b4b2cbbd62c8b3a2fc754f/triggers/service/authentication.md) and following the [Auth0 documentation](https://auth0.com/docs/tokens/refresh-tokens)
- I have manually tested token refresh against auth0 and updated the [README](https://github.com/digital-asset/daml/blob/00da07c9ea180d9cb6b4b2cbbd62c8b3a2fc754f/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/README.md) accordingly. Auth0 requires the `offline_access` scope to generate a refresh token.
- Implements token expiry and refresh in the auth test server.
- Implements an adjustable clock to test token expiry. The JWT verifier can be initialized with a custom clock to determine when a token is expired. This allows us to simulate token expiry in the test suite without resorting to `sleep`.
  I did not find an adjustable clock class that met our needs and worked out of the box on maven. Given how simple this class is I decided to roll our own instead.
- Adds test cases for expiry and refresh to the auth middleware and auth server test suites.
  Handling refresh in the trigger service will follow in a separate PR

Closes https://github.com/digital-asset/daml/issues/7763

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
