### PR TITLE
[KV integrity check] Fix: use the configured jdbc URL when indexing

### DIFF
--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -46,6 +46,7 @@ da_scala_test(
     srcs = glob(["src/test/scala/**/*.scala"]),
     resources = glob(["src/test/resources/**/*"]),
     deps = [
+        "//ledger/participant-integration-api",
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils/tools",
         "@maven//:com_google_protobuf_protobuf_java",

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
+import java.nio.file.Paths
+
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.daml.ledger.participant.state.kvutils.export.WriteSet
@@ -116,6 +118,20 @@ class IntegrityCheckerSpec extends AsyncWordSpec with Matchers with MockitoSugar
           verify(mockStateUpdates, times(0)).compare()
           succeed
         }, _ => fail())
+    }
+  }
+
+  "createIndexerConfig" should {
+    "use configured jdbcUrl if available" in {
+      val configuredJdbcUrl = "aJdbcUrl"
+      val config = Config.ParseInput.copy(jdbcUrl = Some(configuredJdbcUrl))
+      IntegrityChecker.createIndexerConfig(config).jdbcUrl should be(configuredJdbcUrl)
+    }
+
+    "use default jdbcUrl if none configured" in {
+      val config = Config.ParseInput.copy(exportFilePath = Paths.get("aFilePath"))
+      IntegrityChecker.createIndexerConfig(config).jdbcUrl should be(
+        IntegrityChecker.defaultJdbcUrl("aFilePath"))
     }
   }
 

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
@@ -129,9 +129,10 @@ class IntegrityCheckerSpec extends AsyncWordSpec with Matchers with MockitoSugar
     }
 
     "use the default jdbcUrl if none is configured" in {
-      val config = Config.ParseInput.copy(exportFilePath = Paths.get("aFilePath"))
+      val aFilePath = "aFilePath"
+      val config = Config.ParseInput.copy(exportFilePath = Paths.get(aFilePath))
       IntegrityChecker.createIndexerConfig(config).jdbcUrl should be(
-        IntegrityChecker.defaultJdbcUrl("aFilePath"))
+        IntegrityChecker.defaultJdbcUrl(aFilePath))
     }
   }
 

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
@@ -122,13 +122,13 @@ class IntegrityCheckerSpec extends AsyncWordSpec with Matchers with MockitoSugar
   }
 
   "createIndexerConfig" should {
-    "use configured jdbcUrl if available" in {
+    "use the configured jdbcUrl if available" in {
       val configuredJdbcUrl = "aJdbcUrl"
       val config = Config.ParseInput.copy(jdbcUrl = Some(configuredJdbcUrl))
       IntegrityChecker.createIndexerConfig(config).jdbcUrl should be(configuredJdbcUrl)
     }
 
-    "use default jdbcUrl if none configured" in {
+    "use the default jdbcUrl if none is configured" in {
       val config = Config.ParseInput.copy(exportFilePath = Paths.get("aFilePath"))
       IntegrityChecker.createIndexerConfig(config).jdbcUrl should be(
         IntegrityChecker.defaultJdbcUrl("aFilePath"))


### PR DESCRIPTION
The `jdbcUrl` configuration field was not being used.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
