### PR TITLE
Await termination of the CommandTrackerFlow when closing.

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/services/tracking/TrackerImplTest.scala
@@ -3,11 +3,11 @@
 
 package com.daml.platform.apiserver.services.tracking
 
-import akka.NotUsed
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Keep, Source, SourceQueueWithComplete}
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
+import akka.{Done, NotUsed}
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.api.testing.utils.{
   AkkaBeforeAndAfterAll,
@@ -24,6 +24,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterEach, Matchers, Succeeded, WordSpec}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 class TrackerImplTest
@@ -52,7 +53,7 @@ class TrackerImplTest
       .toMat(TestSink.probe[NotUsed])(Keep.both)
       .run()
     queue = q
-    sut = new TrackerImpl(q)
+    sut = new TrackerImpl(q, Future.successful(Done))
     consumer = sink
   }
 


### PR DESCRIPTION
This fixes the following bug:
1. The command tracker is closed as part of the command service.
2. The dispatcher is closed.
3. The command tracker accesses the dispatcher, resulting in an exception ("Dispatcher is closed").

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
