### PR TITLE
Fix missing trace statements on failed submits

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/ScriptService.hs
+++ b/compiler/damlc/tests/src/DA/Test/ScriptService.hs
@@ -569,19 +569,25 @@ main =
                     , "    choice C : ()"
                     , "      controller p"
                     , "      do debug \"logLedger\""
+                    , "    choice Failing : ()"
+                    , "      controller p"
+                    , "      do debug \"please don't die\""
+                    , "         abort \"die\""
                     , "testTrace = do"
                     , "  debug \"logClient1\""
                     , "  p <- allocateParty \"p\""
                     , "  submit p (createAndExerciseCmd (T p) C)"
                     , "  debug \"logClient2\""
+                    , "  submit p (createAndExerciseCmd (T p) Failing)"
                     , "  pure ()"
                     ]
-                expectScriptSuccess rs (vr "testTrace") $ \r ->
+                expectScriptFailure rs (vr "testTrace") $ \r ->
                   matchRegex r $ T.concat
                     [ "Trace: \n"
                     , "  \"logClient1\"\n"
                     , "  \"logLedger\"\n"
-                    , "  \"logClient2\""
+                    , "  \"logClient2\"\n"
+                    , "  \"please don't die\""
                     ],
               testCase "multi-party query" $ do
                 rs <-

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Context.scala
@@ -221,6 +221,13 @@ class Context(val contextId: Context.ContextId, languageVersion: LanguageVersion
       case Failure(e: SError) =>
         // SError are the errors that should be handled and displayed as
         // failed partial transactions.
+
+        // We copy tracelogs after every submit but on failures we need
+        // to copy the tracelog from the partial transaction as well since we
+        // don’t reach the end of the submit.
+        for ((msg, optLoc) <- ledgerClient.tracelogIterator) {
+          clientMachine.traceLog.add(msg, optLoc)
+        }
         Success(
           Some(
             (ledgerClient.scenarioRunner.ledger, (clientMachine, ledgerClient.machine), Left(e))))


### PR DESCRIPTION
changelog_begin

- [DAML Script] Fix a bug where trace statements from a failing
  transaction where not displayed in DAML Studio.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
