### PR TITLE
ts/daml-ledger: createAndExercise

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -320,9 +320,8 @@ test("createAndExercise", async () => {
   const ledger = new Ledger({token: ALICE_TOKEN, httpBaseUrl: httpBaseUrl()});
 
   const [result, events] = await ledger.createAndExercise(
-    buildAndLint.Main.Person,
-    {name: 'Alice', party: ALICE_PARTY, age: '5', friends: []},
     buildAndLint.Main.Person.Birthday,
+    {name: 'Alice', party: ALICE_PARTY, age: '5', friends: []},
     {});
   expect(events).toMatchObject(
     [{created: {templateId: buildAndLint.Main.Person.templateId,

--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -316,6 +316,26 @@ test('create + fetch & exercise', async () => {
   expect(nonTopLevelContracts).toEqual([nonTopLevelContract]);
 });
 
+test("createAndExercise", async () => {
+  const ledger = new Ledger({token: ALICE_TOKEN, httpBaseUrl: httpBaseUrl()});
+
+  const [result, events] = await ledger.createAndExercise(
+    buildAndLint.Main.Person,
+    {name: 'Alice', party: ALICE_PARTY, age: '5', friends: []},
+    buildAndLint.Main.Person.Birthday,
+    {});
+  expect(events).toMatchObject(
+    [{created: {templateId: buildAndLint.Main.Person.templateId,
+                signatories: [ALICE_PARTY],
+                payload: {name: 'Alice', age: '5'}}},
+     {archived: {templateId: buildAndLint.Main.Person.templateId}},
+     {created: {templateId: buildAndLint.Main.Person.templateId,
+                signatories: [ALICE_PARTY],
+                payload: {name: 'Alice', age: '6'}}}]);
+  expect((events[0] as {created: {contractId: string}}).created.contractId).toEqual((events[1] as {archived: {contractId: string}}).archived.contractId);
+  expect(result).toEqual((events[2] as {created: {contractId: string}}).created.contractId);
+});
+
 test("multi-{key,query} stream", async () => {
   const ledger = new Ledger({token: ALICE_TOKEN, httpBaseUrl: httpBaseUrl()});
 

--- a/language-support/ts/daml-ledger/README.md
+++ b/language-support/ts/daml-ledger/README.md
@@ -47,6 +47,13 @@ Exercise a choice on a contract identified by its contract id.
 ---------------
 Exercise a choice on a contract identified by its contract key.
 
+`createAndExercise`
+-------------------
+
+Create a new contract and, within the same transaction, immediately exercise a
+choice on it. Primarily meant for consuming choices, but that's not a
+requirement.
+
 `query`
 -------
 Retrieve contracts for a given template matching a given query. If no query is given, all contracts

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -428,17 +428,13 @@ class Ledger {
   }
 
   /**
-   * Create a contract for a given template, then immediately exercise a choice
-   * on the created contract.
+   * Exercse a choice on a newly-created contract, in a single transaction.
    *
-   * @param template The template of the contract to be created.
-   * @param payload The template arguments for the contract to be created.
    * @param choice The choice to exercise.
+   * @param init The template arguments for the newly-created contract.
    * @param argument The choice arguments.
    *
    * @typeparam T The contract template type.
-   * @typeparam K The contract key type.
-   * @typeparam I The contract id type.
    * @typeparam C The type of the contract choice.
    * @typeparam R The return type of the choice.
    *
@@ -449,10 +445,10 @@ class Ledger {
    * is consuming (or otherwise archives it as part of its execution).
    *
    */
-  async createAndExercise<T extends object, K, I extends string, C, R>(template: Template<T, K, I>, payload: T, choice: Choice<T, C, R>, argument: C): Promise<[R, Event<object>[]]> {
+  async createAndExercise<T extends object, C, R>(choice: Choice<T, C, R>, payload: T, argument: C): Promise<[R, Event<object>[]]> {
     const command = {
-      templateId: template.templateId,
-      payload: template.encode(payload),
+      templateId: choice.template().templateId,
+      payload: choice.template().encode(payload),
       choice: choice.choiceName,
       argument: choice.argumentEncode(argument),
     };


### PR DESCRIPTION
Fixes #7966.

CHANGELOG_BEGIN

JavaScript Client Libraries: The Ledger object (defined in daml-ledger, returned by useLedger in daml-react) now sports an additional method `createAndExercise`, which lets JS users create a contract and exercise a choice on it in the same transaction.

CHANGELOG_END