### PR TITLE
test-common: Make FiniteStreamObserver more lenient.

### DIFF
--- a/ledger/test-common/src/main/scala/com/digitalasset/platform/testing/FiniteStreamObserver.scala
+++ b/ledger/test-common/src/main/scala/com/digitalasset/platform/testing/FiniteStreamObserver.scala
@@ -19,14 +19,16 @@ private[testing] final class FiniteStreamObserver[A] extends StreamObserver[A] {
 
   val result: Future[Vector[A]] = promise.future
 
-  override def onNext(value: A): Unit = {
-    val _ = items.synchronized(items += value)
+  override def onNext(value: A): Unit = items.synchronized {
+    val _ = items += value
   }
 
-  override def onError(t: Throwable): Unit = promise.failure(t)
+  override def onError(t: Throwable): Unit = {
+    val _ = promise.tryFailure(t)
+  }
 
-  override def onCompleted(): Unit = {
-    val _ = items.synchronized(promise.success(items.result()))
+  override def onCompleted(): Unit = items.synchronized {
+    val _ = promise.trySuccess(items.result())
   }
 
 }


### PR DESCRIPTION
We can't protect against all possible race conditions; we just have to accept that sometimes `onNext` will be called after `onCompleted`, or `onCompleted` will be called twice, or…

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
