### PR TITLE
Wait for live event in build-and-lint JS tests

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts
@@ -338,10 +338,12 @@ test("createAndExercise", async () => {
 test("multi-{key,query} stream", async () => {
   const ledger = new Ledger({token: ALICE_TOKEN, httpBaseUrl: httpBaseUrl()});
 
-  function collect<T extends object, K, I extends string, State>(stream: Stream<T, K, I, State>): [State, readonly Event<T, K, I>[]][] {
+  function collect<T extends object, K, I extends string, State>(stream: Stream<T, K, I, State>): Promise<[State, readonly Event<T, K, I>[]][]> {
     const res = [] as [State, readonly Event<T, K, I>[]][];
     stream.on('change', (state, events) => res.push([state, events]));
-    return res;
+    // wait until we’re live so that we get ordered transaction events
+    // rather than unordered acs events.
+    return new Promise(resolve => stream.on('live', () => resolve(res)));
   }
   async function create(t: string): Promise<void> {
     await ledger.create(buildAndLint.Main.Counter, {p: ALICE_PARTY, t, c: "0"});
@@ -364,13 +366,13 @@ test("multi-{key,query} stream", async () => {
     buildAndLint.Main.Counter,
     [{p: ALICE_PARTY, t: "included"},
      {c: {"%gt": 5}}]);
-  const queryResult = collect(q);
+  const queryResult = await collect(q);
   const ks = ledger.streamFetchByKeys(
     buildAndLint.Main.Counter,
     [{_1: ALICE_PARTY, _2: "included"},
      {_1: ALICE_PARTY, _2: "byKey"},
      {_1: ALICE_PARTY, _2: "included"}]);
-  const byKeysResult = collect(ks);
+  const byKeysResult = await collect(ks);
 
   await create("included");
   await create("byKey");


### PR DESCRIPTION
The stream from the JSON API is split into two sections:

1. The unordered section of ACS events.
2. The ordered transaction stream after the live event.

Our assertions assume that we only get 2 but currently we don’t wait
before sending commands so depending on timing, some of the events can
be delivered as part of the ACS section in a different order causing
very confusing assertion failures.

This test fixes this by waiting for the live event indicating the end
of section 1 and thereby forcing everything to come via the ordered
transaction stream.

Verified that this fixes the flakiness with --runs_per_test=50 which
reproduced it fairly reliable before (on CI, never managed to hit it
locally).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
