### PR TITLE
[KV] proto: add optional DamlTransactionBlindingInfo to DamlTransactionEntry [KVL-736]

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
@@ -7,19 +7,19 @@ import com.daml.lf.data.Ref.Party
 import com.daml.lf.data.Relation.Relation
 import com.daml.lf.value.Value.ContractId
 
-/** This gives disclosure and divulgence info.
+/** A transaction's blinding information, consisting of disclosure and
+  * divulgence info.
   *
-  * "Disclosure" tells us which nodes to communicate to which parties.
-  * See also https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
+  * "Disclosure" tells us which transaction nodes to communicate to which parties.
+  * See https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
   *
-  * "Divulgence" tells us what to communicate to
-  * each participant node so that they can perform post-commit
-  * validation. Note that divulgence can also divulge
-  * contract ids -- e.g. contract ids that were created
-  * _outside_ this transaction.
+  * "Divulgence" tells us which contracts to which parties so that
+  * their participant nodes can perform post-commit validation.
+  * Note that divulgence can also divulge contract ids -- e.g. contract
+  * ids that were created _outside_ this transaction.
   * See also https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
   *
-  * @param disclosure Disclosure, specified in terms of local node IDs
+  * @param disclosure Disclosure, specified in terms of local transaction node IDs
   * @param divulgence
   *     Divulgence, specified in terms of contract IDs.
   *     Note that if this info was produced by blinding a transaction

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/BlindingInfo.scala
@@ -10,13 +10,14 @@ import com.daml.lf.value.Value.ContractId
 /** A transaction's blinding information, consisting of disclosure and
   * divulgence info.
   *
-  * "Disclosure" tells us which transaction nodes to communicate to which parties.
+  * "Disclosure" tells us which transaction nodes to communicate to which
+  * parties.
   * See https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
   *
-  * "Divulgence" tells us which contracts to which parties so that
-  * their participant nodes can perform post-commit validation.
-  * Note that divulgence can also divulge contract ids -- e.g. contract
-  * ids that were created _outside_ this transaction.
+  * "Divulgence" tells us which contracts to communicate to which parties
+  * so that their participant nodes can perform post-commit validation.
+  * Note that divulgence can also divulge e.g. contract IDs that were
+  * created _outside_ this transaction.
   * See also https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
   *
   * @param disclosure Disclosure, specified in terms of local transaction node IDs

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -172,6 +172,44 @@ message DamlTransactionEntry {
 
   // The time used to derive contract ids
   google.protobuf.Timestamp submission_time = 6;
+
+  // The pre-computed transaction blinding information. Optional.
+  DamlTransactionBlindingInfo blinding_info = 7;
+}
+
+// A transaction's blinding information, consisting of disclosure and
+// divulgence info.
+//
+// "Disclosure" tells us which transaction nodes to communicate to which parties.
+// See https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
+//
+// "Divulgence" tells us which contracts to communicate to which parties
+// so that their participant nodes can perform post-commit validation.
+// Note that divulgence can also divulge contract ids -- e.g. contract
+// ids that were created _outside_ this transaction.
+// See https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
+message DamlTransactionBlindingInfo {
+
+  // The disclosure of a transaction node to a set of local parties
+  message DisclosureEntry {
+    string node_id = 1;
+    repeated string party = 2;
+  }
+
+  // The divulgence of a contract ID to a set of local parties
+  message DivulgenceEntry {
+    com.daml.lf.value.ContractId contract_id = 1;
+    repeated string party = 2;
+  }
+
+  // Disclosure, specified in terms of local transaction node IDs
+  repeated DisclosureEntry disclosure = 1;
+
+  // Divulgence, specified in terms of contract IDs.
+  // Note that if this info was produced by blinding a transaction
+  // containing only contract ids, this map may also
+  // contain contracts produced in the same transaction.
+  repeated DivulgenceEntry divulgence = 2;
 }
 
 // A transaction rejection entry.

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -180,13 +180,14 @@ message DamlTransactionEntry {
 // A transaction's blinding information, consisting of disclosure and
 // divulgence info.
 //
-// "Disclosure" tells us which transaction nodes to communicate to which parties.
+// "Disclosure" tells us which transaction nodes to communicate to which
+// parties.
 // See https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
 //
 // "Divulgence" tells us which contracts to communicate to which parties
 // so that their participant nodes can perform post-commit validation.
-// Note that divulgence can also divulge contract ids -- e.g. contract
-// ids that were created _outside_ this transaction.
+// Note that divulgence can also divulge e.g. contract IDs that were
+// created _outside_ this transaction.
 // See https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
 message DamlTransactionBlindingInfo {
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -194,13 +194,13 @@ message DamlTransactionBlindingInfo {
   // The disclosure of a transaction node to a set of local parties
   message DisclosureEntry {
     string node_id = 1;
-    repeated string party = 2;
+    repeated string disclosed_to = 2;
   }
 
   // The divulgence of a contract to a set of local parties
   message DivulgenceEntry {
     com.daml.lf.value.ContractId contract_id = 1;
-    repeated string party = 2;
+    repeated string divulged_to = 2;
   }
 
   // Disclosure, specified in terms of local transaction node IDs

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -197,7 +197,7 @@ message DamlTransactionBlindingInfo {
     repeated string party = 2;
   }
 
-  // The divulgence of a contract ID to a set of local parties
+  // The divulgence of a contract to a set of local parties
   message DivulgenceEntry {
     com.daml.lf.value.ContractId contract_id = 1;
     repeated string party = 2;

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -199,7 +199,7 @@ message DamlTransactionBlindingInfo {
 
   // The divulgence of a contract to a set of local parties
   message DivulgenceEntry {
-    com.daml.lf.value.ContractId contract_id = 1;
+    string contract_id = 1;
     repeated string divulged_to = 2;
   }
 

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -180,37 +180,28 @@ message DamlTransactionEntry {
 // A transaction's blinding information, consisting of disclosure and
 // divulgence info.
 //
-// "Disclosure" tells us which transaction nodes to communicate to which
-// parties.
-// See https://docs.daml.com/concepts/ledger-model/ledger-privacy.html
-//
-// "Divulgence" tells us which contracts to communicate to which parties
-// so that their participant nodes can perform post-commit validation.
-// Note that divulgence can also divulge e.g. contract IDs that were
-// created _outside_ this transaction.
-// See https://docs.daml.com/concepts/ledger-model/ledger-privacy.html#divulgence-when-non-stakeholders-see-contracts
+// See com.daml.lf.transaction.BlindingInfo for more details.
 message DamlTransactionBlindingInfo {
-
-  // The disclosure of a transaction node to a set of local parties
+  // The disclosure of a transaction node to a set of local parties.
   message DisclosureEntry {
     string node_id = 1;
-    repeated string disclosed_to = 2;
+    repeated string disclosed_to_local_parties = 2;
   }
 
-  // The divulgence of a contract to a set of local parties
+  // The divulgence of a contract to a set of local parties.
   message DivulgenceEntry {
     string contract_id = 1;
-    repeated string divulged_to = 2;
+    repeated string divulged_to_local_parties = 2;
   }
 
-  // Disclosure, specified in terms of local transaction node IDs
-  repeated DisclosureEntry disclosure = 1;
+  // Disclosure, specified in terms of local transaction node IDs.
+  repeated DisclosureEntry disclosures = 1;
 
   // Divulgence, specified in terms of contract IDs.
-  // Note that if this info was produced by blinding a transaction
-  // containing only contract ids, this map may also
-  // contain contracts produced in the same transaction.
-  repeated DivulgenceEntry divulgence = 2;
+  // Note: if this info was produced by blinding a transaction
+  // containing only contract ids, it may also contain contracts
+  // produced in the same transaction.
+  repeated DivulgenceEntry divulgences = 2;
 }
 
 // A transaction rejection entry.


### PR DESCRIPTION
This is the second of a series of changes (after #7989) that will shift back blinding information computation from the read path to the write path and will remove `Fetch` and `LookupByKey` transaction nodes, reducing storage usage (KV only).

The next step will be pre-computing, storing and retrieving blinding info through the KV stack (KV only).

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
