### PR TITLE
Rewrite multiple binding lets sequentially.

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -14,6 +14,7 @@ import           DA.Daml.Preprocessor.EnumType
 
 import Development.IDE.Types.Options
 import qualified "ghc-lib" GHC
+import qualified "ghc-lib-parser" Bag as GHC
 import qualified "ghc-lib-parser" EnumSet as ES
 import qualified "ghc-lib-parser" SrcLoc as GHC
 import qualified "ghc-lib-parser" Module as GHC
@@ -24,9 +25,12 @@ import qualified "ghc-lib-parser" GHC.LanguageExtensions.Type as GHC
 import Outputable
 
 import           Control.Monad.Extra
-import           Data.List
+import           Data.List.Extra
 import           Data.Maybe
+import qualified Data.Set as Set
 import           System.FilePath (splitDirectories)
+
+import qualified Data.Generics.Uniplate.Data as Uniplate
 
 
 isInternal :: GHC.ModuleName -> Bool
@@ -73,7 +77,7 @@ damlPreprocessor dataDependableExtensions mbUnitId dflags x
             , checkKinds x
             ]
         , preprocErrors = checkImports x ++ checkDataTypes x ++ checkModuleDefinition x ++ checkRecordConstructor x ++ checkModuleName x
-        , preprocSource = recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbUnitId $ enumTypePreprocessor "GHC.Types" x
+        , preprocSource = rewriteLets $ recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbUnitId $ enumTypePreprocessor "GHC.Types" x
         }
     where
       name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x
@@ -342,3 +346,129 @@ checkKinds (GHC.L _ m) = do
         [ "Reference to GHC.Types.Symbol will not be preserved during DAML compilation."
         , "This will cause problems when importing this module via data-dependencies."
         ]
+
+-- | Issue #6788: Rewrite multi-binding let expressions,
+--
+--      let x1 = e1
+--          x2 = e2
+--          ...
+--          xn = en
+--      in b
+--
+-- Into a chain of single-binding let expressions,
+--
+--      let x1 = e1 in
+--        let x2 = e2 in
+--          ...
+--            let xn = en in
+--              b
+--
+-- Likewise, rewrite multi-binding let statements in a "do" block,
+--
+--      do
+--          ...
+--          let x1 = e1
+--              x2 = e2
+--              ...
+--              xn = en
+--          ...
+--
+-- Into single-binding let statements,
+--
+--      do
+--          ...
+--          let x1 = e1
+--          let x2 = e2
+--          ...
+--          let xn = en
+--          ...
+--
+rewriteLets :: GHC.ParsedSource -> GHC.ParsedSource
+rewriteLets = fmap onModule
+  where
+    onModule :: GHC.HsModule GHC.GhcPs -> GHC.HsModule GHC.GhcPs
+    onModule x = x { GHC.hsmodDecls = map onDecl $ GHC.hsmodDecls x }
+
+    onDecl :: GHC.LHsDecl GHC.GhcPs -> GHC.LHsDecl GHC.GhcPs
+    onDecl = fmap (Uniplate.descendBi onExpr)
+
+    onExpr :: GHC.LHsExpr GHC.GhcPs -> GHC.LHsExpr GHC.GhcPs
+    onExpr = Uniplate.transform $ \case
+        GHC.L loc (GHC.HsLet GHC.NoExt letBinds letBody) ->
+            foldr (\bind body -> GHC.L loc (GHC.HsLet GHC.NoExt bind body))
+                letBody
+                (orderLocalBinds letBinds)
+
+        GHC.L loc1 (GHC.HsDo GHC.NoExt doContext (GHC.L loc2 doStmts)) ->
+            GHC.L loc1 (GHC.HsDo GHC.NoExt doContext
+                (GHC.L loc2 (concatMap onStmt doStmts)))
+
+        x -> x
+
+    onStmt :: GHC.ExprLStmt GHC.GhcPs -> [GHC.ExprLStmt GHC.GhcPs]
+    onStmt = \case
+        GHC.L loc (GHC.LetStmt GHC.NoExt letBinds) ->
+            map (GHC.L loc . GHC.LetStmt GHC.NoExt) (orderLocalBinds letBinds)
+        x -> [x]
+
+    orderLocalBinds :: GHC.LHsLocalBinds GHC.GhcPs -> [GHC.LHsLocalBinds GHC.GhcPs]
+    orderLocalBinds = \case
+        GHC.L loc (GHC.HsValBinds GHC.NoExt valBinds)
+            | GHC.ValBinds GHC.NoExt bindBag sigs <- valBinds
+            , binds <- GHC.bagToList bindBag
+            , length binds > 1
+            -> makeLocalValBinds loc binds sigs
+        binds -> [binds]
+
+    makeLocalValBinds :: GHC.SrcSpan
+        -> [GHC.LHsBindLR GHC.GhcPs GHC.GhcPs]
+        -> [GHC.LSig GHC.GhcPs]
+        -> [GHC.LHsLocalBinds GHC.GhcPs]
+    makeLocalValBinds _ [] _ = []
+    makeLocalValBinds loc (bind1 : bindRest) sigs =
+        let (sig1, sigRest) = peelRelevantSigs bind1 sigs
+        in GHC.L loc (GHC.HsValBinds GHC.NoExt
+            (GHC.ValBinds GHC.NoExt (GHC.unitBag bind1) sig1))
+          : makeLocalValBinds loc bindRest sigRest
+
+    -- | List of names bound in HsBindLR
+    bindNames :: GHC.HsBindLR GHC.GhcPs GHC.GhcPs -> [GHC.RdrName]
+    bindNames = \case
+        GHC.FunBind { fun_id } -> [ GHC.unLoc fun_id ]
+        GHC.PatBind { pat_lhs } -> Uniplate.universeBi pat_lhs -- safe overapproximation
+        GHC.VarBind { var_id } -> [ var_id ]
+        GHC.PatSynBind _ GHC.PSB { psb_id } -> [ GHC.unLoc psb_id ]
+        GHC.PatSynBind _ GHC.XPatSynBind { } -> unexpected "XPatSynBind"
+        GHC.AbsBinds {} -> unexpected "AbsBinds"
+        GHC.XHsBindsLR {} -> unexpected "XHsBindsLR"
+
+    peelRelevantSigs :: GHC.LHsBindLR GHC.GhcPs GHC.GhcPs
+        -> [GHC.LSig GHC.GhcPs]
+        -> ([GHC.LSig GHC.GhcPs], [GHC.LSig GHC.GhcPs])
+    peelRelevantSigs bind sigs =
+        let names = Set.fromList (bindNames (GHC.unLoc bind))
+            (sigs1, sigs2) = unzip (map (peelRelevantSig names) sigs)
+        in (concat sigs1, concat sigs2)
+
+    peelRelevantSig :: Set.Set GHC.RdrName -> GHC.LSig GHC.GhcPs -> ([GHC.LSig GHC.GhcPs], [GHC.LSig GHC.GhcPs])
+    peelRelevantSig relevantNames = \case
+        GHC.L loc (GHC.TypeSig GHC.NoExt sigNames sigType) ->
+            partitionByRelevance relevantNames sigNames
+                (\ns -> GHC.L loc (GHC.TypeSig GHC.NoExt ns sigType))
+        GHC.L loc (GHC.PatSynSig GHC.NoExt sigNames sigType) ->
+            partitionByRelevance relevantNames sigNames
+                (\ns -> GHC.L loc (GHC.PatSynSig GHC.NoExt ns sigType))
+        _ -> unexpected "local signature"
+
+    partitionByRelevance :: Set.Set GHC.RdrName
+        -> [GHC.Located GHC.RdrName]
+        -> ([GHC.Located GHC.RdrName] -> t)
+        -> ([t], [t])
+    partitionByRelevance relevantNames sigNames f =
+        let (names1, names2) = partition ((`Set.member` relevantNames) . GHC.unLoc) sigNames
+            sigs1 = [ f names1 | notNull names1 ]
+            sigs2 = [ f names2 | notNull names2 ]
+        in (sigs1, sigs2)
+
+    unexpected :: String -> t
+    unexpected x = error (unwords ["Unexpected", x, "in daml-preprocessor"])

--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -442,6 +442,7 @@ rewriteLets = fmap onModule
         GHC.AbsBinds {} -> unexpected "AbsBinds"
         GHC.XHsBindsLR {} -> unexpected "XHsBindsLR"
 
+    -- Given a binding and a set of signatures, split it into the signatures relevant to this binding and other signatures.
     peelRelevantSigs :: GHC.LHsBindLR GHC.GhcPs GHC.GhcPs
         -> [GHC.LSig GHC.GhcPs]
         -> ([GHC.LSig GHC.GhcPs], [GHC.LSig GHC.GhcPs])

--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrder.daml
@@ -15,7 +15,6 @@
 -- @ERROR Aborted: EvExpAppErr1 OK
 -- @ERROR Aborted: EvExpAppErr2 OK
 -- @ERROR Aborted: EvExpLetErr OK
--- @ERROR Aborted: ghcReordersMultiLets OK
 -- @ERROR Aborted: EvExpCaseErr OK
 -- @ERROR Aborted: EvExpCase_1 OK
 -- @ERROR Aborted: EvExpCase_2 OK
@@ -95,14 +94,12 @@ evExpLetErr = scenario do
     let _ = error "EvExpLetErr bad"
     error "EvExpLetErr failed"
 
--- | The following "multiple-binding let" behavior is caused by GHC.
--- This is tracked in issue #6788. We would love to get rid of this
--- reordering behavior, but it's very much tied with a part of GHC
--- that we don't control. So we track this behavior here.
-ghcReordersMultiLets = scenario do
-    let _ = error "ghcReordersMultiLets failed in a good way -- close the issue & update the test"
-        _ = error "ghcReordersMultiLets OK"
-    error "ghcReordersMultiLets failed in a bad way"
+-- Regression test for issue #6788
+-- @ERROR Aborted: multiLetEvalOrder OK
+multiLetEvalOrder = scenario do
+    let _ = error "multiLetEvalOrder OK"
+        _ = error "multiLetEvalOrder failed"
+    error "multiLetEvalOrder failed"
 
 evExpCaseErr = scenario do
   case error "EvExpCaseErr OK" of

--- a/compiler/damlc/tests/daml-test-files/SequentialLet.daml
+++ b/compiler/damlc/tests/daml-test-files/SequentialLet.daml
@@ -1,0 +1,37 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- | Checks that damlc enforces sequentially-ordered let bindings.
+-- Regression test for issue #6788.
+module SequentialLet where
+
+inOrder : Int
+inOrder =
+    let x = 10
+        y = x
+    in y
+
+-- @ERROR range=17:13-17:14; Variable not in scope: y
+outOfOrder : Int
+outOfOrder =
+    let x = y
+        y = 10
+    in x
+
+-- @ERROR range=24:13-24:14; Variable not in scope: y
+doBlock : Update ()
+doBlock = do
+    let x = y
+        y = 10
+    pure ()
+
+-- @ERROR range=34:29-34:30; Variable not in scope: y
+deeplyNested : Update Int
+deeplyNested = do
+    let x =
+            case () of
+                () -> do
+                    let z = y
+                        y = 10
+                    pure z
+    x

--- a/compiler/damlc/tests/daml-test-files/SequentialLetSig.daml
+++ b/compiler/damlc/tests/daml-test-files/SequentialLetSig.daml
@@ -1,0 +1,23 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- | Check that damlc preserves local type signatures
+-- in sequential let statements.
+module SequentialLetSig where
+
+preservesLocalTypeSigs : ()
+preservesLocalTypeSigs =
+    let f : Int -> Int -> Int
+        f = (*)
+
+        g : Int -> Int
+        g = negate
+    in ()
+
+multipleNames : ()
+multipleNames =
+    let x, y, z : Int
+        x = 10
+        z = 3
+        y = x + z
+    in ()

--- a/compiler/damlc/tests/daml-test-files/SequentialLetSig.daml
+++ b/compiler/damlc/tests/daml-test-files/SequentialLetSig.daml
@@ -3,6 +3,9 @@
 
 -- | Check that damlc preserves local type signatures
 -- in sequential let statements.
+--
+-- NB: The SequentialLetSig* tests cannot be combined because
+-- they test/raise errors at different GHC phases.
 module SequentialLetSig where
 
 preservesLocalTypeSigs : ()

--- a/compiler/damlc/tests/daml-test-files/SequentialLetSigUnbound.daml
+++ b/compiler/damlc/tests/daml-test-files/SequentialLetSigUnbound.daml
@@ -1,0 +1,17 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- | Check that damlc requires local type signatures
+-- in sequential let statements to be used.
+--
+-- NB: The SequentialLetSig* tests cannot be combined because
+-- they test/raise errors at different GHC phases.
+module SequentialLetSigUnbound where
+
+-- @ERROR range=14:9-14:10; The type signature for 'x' lacks an accompanying binding
+unboundSig : ()
+unboundSig =
+    let x : Int
+        y = 10
+        z = 20
+    in ()

--- a/compiler/damlc/tests/daml-test-files/SequentialLetSigWrongType.daml
+++ b/compiler/damlc/tests/daml-test-files/SequentialLetSigWrongType.daml
@@ -1,0 +1,19 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- | Check that local type signatures in a sequential let
+-- is propagated to the correct binding.
+--
+-- NB: The SequentialLetSig* tests cannot be combined because
+-- they test/raise errors at different GHC phases.
+module SequentialLetSigWrongType where
+
+-- @ERROR range=17:13-17:20; Couldn't match expected type 'Int' with actual type 'Text'
+wrongType : ()
+wrongType =
+    let x, y, z, w : Int
+        x = 10
+        z = 3
+        y = "hello"
+        w = 10
+    in ()


### PR DESCRIPTION
This PR fixes #6788 and adds a bunch of tests.

This PR enforces sequential evaluation and dependency in multiple-binding lets, by rewriting,

    let x1 = e1
        x2 = e2
        ...
        xn = en
    in b

Into a chain of single-binding let expressions,

    let x1 = e1 in
      let x2 = e2 in
        ...
          let xn = en in
            b

And likewise, rewriting multi-binding let statements in a "do" block,

    do
        ...
        let x1 = e1
            x2 = e2
            ...
            xn = en
        ...

Into single-binding let statements,

    do
        ...
        let x1 = e1
        let x2 = e2
        ...
        let xn = en
        ...

CHANGELOG_BEGIN

- [DAML Compiler] The DAML compiler now enforces sequential
  ordering for ``let`` expressions with multiple bindings.
  This fixes a bug where ``let`` expressions would be evaluated
  in the wrong order.

  This is a bugfix, but it may break existing code that relies on
out-of-order let bindings. The suggested fix is to reorder
the let bindings, placing them in order of their dependency.

CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
