### PR TITLE
sandbox-common: Use a single sandbox for all the reset service tests.

### DIFF
--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/services/reset/ResetServiceITBase.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/services/reset/ResetServiceITBase.scala
@@ -12,7 +12,7 @@ import com.daml.bazeltools.BazelRunfiles.rlocation
 import com.daml.ledger.api.domain.LedgerId
 import com.daml.ledger.api.testing.utils.{
   IsStatusException,
-  SuiteResourceManagementAroundEach,
+  SuiteResourceManagementAroundAll,
   MockMessages => M
 }
 import com.daml.ledger.api.v1.active_contracts_service.{
@@ -74,7 +74,7 @@ abstract class ResetServiceITBase
     with ScalaFutures
     with TestResourceContext
     with AbstractSandboxFixture
-    with SuiteResourceManagementAroundEach
+    with SuiteResourceManagementAroundAll
     with TestCommands {
 
   override def timeLimit: Span = scaled(30.seconds)


### PR DESCRIPTION
This makes the test a lot faster, not just because we don't restart the Sandbox, but because we don't restart PostgreSQL either.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
