### PR TITLE
[KV] Fill DamlTransactionEntry#bindingInfo during TransactionCommitter#blind [KVL-736]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -245,7 +245,7 @@ private[state] object Conversions {
       .map(encodeDisclosureEntry)
 
   private def encodeDivulgenceEntry(divulgenceEntry: (ContractId, Set[Party])): DivulgenceEntry =
-    DamlTransactionBlindingInfo.DivulgenceEntry.newBuilder
+    DivulgenceEntry.newBuilder
       .setContractId(divulgenceEntry._1.coid)
       .addAllDivulgedToLocalParties(encodeParties(divulgenceEntry._2).asJava)
       .build

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -15,6 +15,8 @@ import com.daml.lf.value.{Value, ValueCoder, ValueOuterClass}
 import com.daml.lf.{crypto, data}
 import com.google.protobuf.Empty
 
+import scala.collection.JavaConverters._
+
 /** Utilities for converting between protobuf messages and our scala
   * data structures.
   */
@@ -215,4 +217,20 @@ private[state] object Conversions {
       )
     )
 
+  def encodeBlindingInfo(blindingInfo: BlindingInfo): DamlTransactionBlindingInfo = {
+    val protoBlindingInfoBuilder = DamlTransactionBlindingInfo.newBuilder
+    blindingInfo.disclosure.foreach { disclosureEntry =>
+      val protoDisclosureEntryBuilder = DamlTransactionBlindingInfo.DisclosureEntry.newBuilder
+      protoDisclosureEntryBuilder.setNodeId(disclosureEntry._1.toString)
+      protoDisclosureEntryBuilder.addAllDisclosedTo(
+        disclosureEntry._2.asInstanceOf[Set[String]].asJava)
+    }
+    blindingInfo.divulgence.foreach { divulgenceEntry =>
+      val protoDivulgenceEntryBuilder = DamlTransactionBlindingInfo.DivulgenceEntry.newBuilder
+      protoDivulgenceEntryBuilder.setContractId(divulgenceEntry._1.coid)
+      protoDivulgenceEntryBuilder.addAllDivulgedTo(
+        divulgenceEntry._2.asInstanceOf[Set[String]].asJava)
+    }
+    protoBlindingInfoBuilder.build()
+  }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -217,20 +217,19 @@ private[state] object Conversions {
       )
     )
 
-  def encodeBlindingInfo(blindingInfo: BlindingInfo): DamlTransactionBlindingInfo = {
-    val protoBlindingInfoBuilder = DamlTransactionBlindingInfo.newBuilder
-    blindingInfo.disclosure.foreach { disclosureEntry =>
-      val protoDisclosureEntryBuilder = DamlTransactionBlindingInfo.DisclosureEntry.newBuilder
-      protoDisclosureEntryBuilder.setNodeId(disclosureEntry._1.toString)
-      protoDisclosureEntryBuilder.addAllDisclosedTo(
-        disclosureEntry._2.asInstanceOf[Set[String]].asJava)
-    }
-    blindingInfo.divulgence.foreach { divulgenceEntry =>
-      val protoDivulgenceEntryBuilder = DamlTransactionBlindingInfo.DivulgenceEntry.newBuilder
-      protoDivulgenceEntryBuilder.setContractId(divulgenceEntry._1.coid)
-      protoDivulgenceEntryBuilder.addAllDivulgedTo(
-        divulgenceEntry._2.asInstanceOf[Set[String]].asJava)
-    }
-    protoBlindingInfoBuilder.build()
-  }
+  def encodeBlindingInfo(blindingInfo: BlindingInfo): DamlTransactionBlindingInfo =
+    DamlTransactionBlindingInfo.newBuilder
+      .addAllDisclosure(blindingInfo.disclosure.map { disclosureEntry =>
+        DamlTransactionBlindingInfo.DisclosureEntry.newBuilder
+          .setNodeId(disclosureEntry._1.index.toString)
+          .addAllDisclosedTo(disclosureEntry._2.asInstanceOf[Set[String]].asJava)
+          .build
+      }.asJava)
+      .addAllDivulgence(blindingInfo.divulgence.map { divulgenceEntry =>
+        DamlTransactionBlindingInfo.DivulgenceEntry.newBuilder
+          .setContractId(divulgenceEntry._1.coid)
+          .addAllDivulgedTo(divulgenceEntry._2.asInstanceOf[Set[String]].asJava)
+          .build
+      }.asJava)
+      .build
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -228,31 +228,29 @@ private[state] object Conversions {
       .addAllDivulgences(encodeDivulgence(blindingInfo.divulgence).asJava)
       .build
 
-  private[kvutils] def encodeParties(parties: Iterable[Party]): List[String] =
+  private def encodeParties(parties: Iterable[Party]): List[String] =
     parties.asInstanceOf[Set[String]].toList.sorted // Deterministic
 
-  private[kvutils] def encodeDisclosureEntry(
-      disclosureEntry: (NodeId, Set[Party])): DisclosureEntry =
+  private def encodeDisclosureEntry(disclosureEntry: (NodeId, Set[Party])): DisclosureEntry =
     DisclosureEntry.newBuilder
       .setNodeId(disclosureEntry._1.index.toString)
       .addAllDisclosedToLocalParties(encodeParties(disclosureEntry._2).asJava)
       .build
 
-  private[kvutils] def encodeDisclosure(
+  private def encodeDisclosure(
       disclosure: Relation[NodeId, Party],
   ): List[DisclosureEntry] =
     disclosure.toList
       .sortBy(_._1.index) // Deterministic
       .map(encodeDisclosureEntry)
 
-  private[kvutils] def encodeDivulgenceEntry(
-      divulgenceEntry: (ContractId, Set[Party])): DivulgenceEntry =
+  private def encodeDivulgenceEntry(divulgenceEntry: (ContractId, Set[Party])): DivulgenceEntry =
     DamlTransactionBlindingInfo.DivulgenceEntry.newBuilder
       .setContractId(divulgenceEntry._1.coid)
       .addAllDivulgedToLocalParties(encodeParties(divulgenceEntry._2).asJava)
       .build
 
-  private[kvutils] def encodeDivulgence(
+  private def encodeDivulgence(
       divulgence: Relation[ContractId, Party],
   ): List[DivulgenceEntry] =
     divulgence.toList

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -219,16 +219,16 @@ private[state] object Conversions {
 
   def encodeBlindingInfo(blindingInfo: BlindingInfo): DamlTransactionBlindingInfo =
     DamlTransactionBlindingInfo.newBuilder
-      .addAllDisclosure(blindingInfo.disclosure.map { disclosureEntry =>
+      .addAllDisclosures(blindingInfo.disclosure.map { disclosureEntry =>
         DamlTransactionBlindingInfo.DisclosureEntry.newBuilder
           .setNodeId(disclosureEntry._1.index.toString)
-          .addAllDisclosedTo(disclosureEntry._2.asInstanceOf[Set[String]].asJava)
+          .addAllDisclosedToLocalParties(disclosureEntry._2.asInstanceOf[Set[String]].asJava)
           .build
       }.asJava)
-      .addAllDivulgence(blindingInfo.divulgence.map { divulgenceEntry =>
+      .addAllDivulgences(blindingInfo.divulgence.map { divulgenceEntry =>
         DamlTransactionBlindingInfo.DivulgenceEntry.newBuilder
           .setContractId(divulgenceEntry._1.coid)
-          .addAllDivulgedTo(divulgenceEntry._2.asInstanceOf[Set[String]].asJava)
+          .addAllDivulgedToLocalParties(divulgenceEntry._2.asInstanceOf[Set[String]].asJava)
           .build
       }.asJava)
       .build

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -244,10 +244,17 @@ private[kvutils] class TransactionCommitter(
       })
 
   /** Validate the submission's conformance to the DAML model */
-  private def blind: Step =
+  private[committer] def blind: Step =
     (commitContext, transactionEntry) => {
       val blindingInfo = Blinding.blind(transactionEntry.transaction)
-      buildFinalResult(commitContext, transactionEntry, blindingInfo)
+      buildFinalResult(
+        commitContext,
+        transactionEntry.copy(
+          submission = transactionEntry.submission.toBuilder
+            .setBlindingInfo(Conversions.encodeBlindingInfo(blindingInfo))
+            .build),
+        blindingInfo,
+      )
     }
 
   private def validateContractKeys: Step = (commitContext, transactionEntry) => {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils
+
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlTransactionBlindingInfo
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlTransactionBlindingInfo.{
+  DisclosureEntry,
+  DivulgenceEntry
+}
+import com.daml.lf.crypto
+import com.daml.lf.data.Ref
+import com.daml.lf.data.Ref.IdString
+import com.daml.lf.transaction.{BlindingInfo, NodeId}
+import com.daml.lf.value.Value.ContractId
+import org.scalatest.{Matchers, WordSpec}
+
+class ConversionsSpec extends WordSpec with Matchers {
+  "Conversions" should {
+    "correctly encode Blindinginfo" in {
+      val encoded = Conversions.encodeBlindingInfo(aBlindingInfo)
+      encoded shouldBe anEncodedBlindingInfo
+    }
+  }
+
+  private lazy val aParty: IdString.Party = Ref.Party.assertFromString("aParty")
+  private lazy val aPartySet = Set(aParty)
+  private lazy val aCid = ContractId.V1(crypto.Hash.hashPrivateKey("aCid"))
+  private lazy val aNode: NodeId = NodeId(0)
+  private lazy val aBlindingInfo = BlindingInfo(
+    disclosure = Map(aNode -> aPartySet),
+    divulgence = Map(aCid -> aPartySet)
+  )
+
+  private lazy val anEncodedBlindingInfo =
+    DamlTransactionBlindingInfo.newBuilder
+      .addDisclosure(
+        DisclosureEntry.newBuilder.addDisclosedTo(aParty).setNodeId(aNode.index.toString)
+      )
+      .addDivulgence(
+        DivulgenceEntry.newBuilder.addDivulgedTo(aParty).setContractId(aCid.coid)
+      )
+      .build
+}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -9,40 +9,70 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlTransactionBlin
   DivulgenceEntry
 }
 import com.daml.lf.crypto
+import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.IdString
+import com.daml.lf.data.Relation.Relation
 import com.daml.lf.transaction.{BlindingInfo, NodeId}
 import com.daml.lf.value.Value.ContractId
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.collection.JavaConverters._
+import scala.collection.immutable.ListSet
+
 class ConversionsSpec extends WordSpec with Matchers {
   "Conversions" should {
-    "correctly encode Blindinginfo" in {
-      val encoded = Conversions.encodeBlindingInfo(aBlindingInfo)
-      encoded shouldBe anEncodedBlindingInfo
+    "correctly and deterministically encode Blindinginfo" in {
+      val encoded = Conversions.encodeBlindingInfo(blindingInfoNotInOrder)
+      encoded shouldBe orderedEncodedBlindingInfo
     }
   }
 
-  private lazy val aParty: IdString.Party = Ref.Party.assertFromString("aParty")
-  private lazy val aPartySet = Set(aParty)
-  private lazy val aCid = ContractId.V1(crypto.Hash.hashPrivateKey("aCid"))
-  private lazy val aNode: NodeId = NodeId(0)
-  private lazy val aBlindingInfo = BlindingInfo(
-    disclosure = Map(aNode -> aPartySet),
-    divulgence = Map(aCid -> aPartySet)
+  private lazy val party0: IdString.Party = Ref.Party.assertFromString("party0")
+  private lazy val party1: IdString.Party = Ref.Party.assertFromString("party1")
+  private lazy val partySetNotInOrder = ListSet(party1, party0)
+  private lazy val hashesNotInOrder: List[Hash] =
+    List(crypto.Hash.hashPrivateKey("hash0"), crypto.Hash.hashPrivateKey("hash1")).sorted.reverse
+  private lazy val contractId0 = ContractId.V1(hashesNotInOrder.tail.head)
+  private lazy val contractId1 = ContractId.V1(hashesNotInOrder.head)
+  private lazy val node0: NodeId = NodeId(0)
+  private lazy val node1: NodeId = NodeId(1)
+  private lazy val disclosureNotInOrder: Relation[NodeId, Ref.Party] =
+    Map(node1 -> partySetNotInOrder, node0 -> partySetNotInOrder)
+  private lazy val divulgenceNotInOrder: Relation[ContractId, Ref.Party] =
+    Map(contractId1 -> partySetNotInOrder, contractId0 -> partySetNotInOrder)
+  private lazy val blindingInfoNotInOrder = BlindingInfo(
+    disclosure = disclosureNotInOrder,
+    divulgence = divulgenceNotInOrder,
   )
 
-  private lazy val anEncodedBlindingInfo =
+  private lazy val partiesInOrder = List(party0, party1)
+
+  private lazy val orderedEncodedBlindingInfo =
     DamlTransactionBlindingInfo.newBuilder
-      .addDisclosures(
-        DisclosureEntry.newBuilder
-          .addDisclosedToLocalParties(aParty)
-          .setNodeId(aNode.index.toString)
+      .addAllDisclosures(
+        List(
+          DisclosureEntry.newBuilder
+            .setNodeId(node0.index.toString)
+            .addAllDisclosedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
+            .build,
+          DisclosureEntry.newBuilder
+            .setNodeId(node1.index.toString)
+            .addAllDisclosedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
+            .build,
+        ).asJava
       )
-      .addDivulgences(
-        DivulgenceEntry.newBuilder
-          .addDivulgedToLocalParties(aParty)
-          .setContractId(aCid.coid)
+      .addAllDivulgences(
+        List(
+          DivulgenceEntry.newBuilder
+            .setContractId(contractId0.coid)
+            .addAllDivulgedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
+            .build,
+          DivulgenceEntry.newBuilder
+            .setContractId(contractId1.coid)
+            .addAllDivulgedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
+            .build,
+        ).asJava
       )
       .build
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -34,11 +34,15 @@ class ConversionsSpec extends WordSpec with Matchers {
 
   private lazy val anEncodedBlindingInfo =
     DamlTransactionBlindingInfo.newBuilder
-      .addDisclosure(
-        DisclosureEntry.newBuilder.addDisclosedTo(aParty).setNodeId(aNode.index.toString)
+      .addDisclosures(
+        DisclosureEntry.newBuilder
+          .addDisclosedToLocalParties(aParty)
+          .setNodeId(aNode.index.toString)
       )
-      .addDivulgence(
-        DivulgenceEntry.newBuilder.addDivulgedTo(aParty).setContractId(aCid.coid)
+      .addDivulgences(
+        DivulgenceEntry.newBuilder
+          .addDivulgedToLocalParties(aParty)
+          .setContractId(aCid.coid)
       )
       .build
 }


### PR DESCRIPTION
This is the third of a series of changes (after #8005) that will shift back blinding information computation from the read path to the write path and will remove `Fetch` and `LookupByKey` transaction nodes, reducing storage usage (KV only).

The next step will be retrieving and filling blinding info into index updates through `KeyValueConsumption` (KV only).

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
