### PR TITLE
Pass application_id through auth middleware

### DIFF
--- a/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/middleware/Request.scala
@@ -6,7 +6,7 @@ package com.daml.oauth.middleware
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.unmarshalling.Unmarshaller
-import com.daml.ledger.api.refinements.ApiTypes.Party
+import com.daml.ledger.api.refinements.ApiTypes.{ApplicationId, Party}
 import spray.json.{
   DefaultJsonProtocol,
   JsString,
@@ -22,20 +22,30 @@ import scala.util.Try
 
 object Request {
 
-  case class Claims(admin: Boolean, actAs: List[Party], readAs: List[Party]) {
+  // applicationId = None makes no guarantees about the application ID. You can use this
+  // if you don’t use the token for requests that use the application ID.
+  // applicationId = Some(appId) will return a token that is valid for
+  // appId, i.e., either a wildcard token or a token with applicationId set to appId.
+  case class Claims(
+      admin: Boolean,
+      actAs: List[Party],
+      readAs: List[Party],
+      applicationId: Option[ApplicationId]) {
     def toQueryString() = {
       val adminS = if (admin) Stream("admin") else Stream()
       val actAsS = actAs.toStream.map(party => s"actAs:$party")
       val readAsS = readAs.toStream.map(party => s"readAs:$party")
-      (adminS ++ actAsS ++ readAsS).mkString(" ")
+      val applicationIdS = applicationId.toList.toStream.map(appId => s"applicationId:$appId")
+      (adminS ++ actAsS ++ readAsS ++ applicationIdS).mkString(" ")
     }
   }
   object Claims {
     def apply(
         admin: Boolean = false,
         actAs: List[Party] = List(),
-        readAs: List[Party] = List()): Claims =
-      new Claims(admin, actAs, readAs)
+        readAs: List[Party] = List(),
+        applicationId: Option[ApplicationId] = None): Claims =
+      new Claims(admin, actAs, readAs, applicationId)
     implicit val marshalRequestEntity: Marshaller[Claims, String] =
       Marshaller.opaque(_.toQueryString)
     implicit val unmarshalHttpEntity: Unmarshaller[String, Claims] =
@@ -43,19 +53,29 @@ object Request {
         var admin = false
         val actAs = ArrayBuffer[Party]()
         val readAs = ArrayBuffer[Party]()
+        var applicationId: Option[ApplicationId] = None
         Future.fromTry(Try {
-          s.split(' ').foreach { w =>
-            if (w == "admin") {
-              admin = true
-            } else if (w.startsWith("actAs:")) {
-              actAs.append(Party(w.stripPrefix("actAs:")))
-            } else if (w.startsWith("readAs:")) {
-              readAs.append(Party(w.stripPrefix("readAs:")))
-            } else {
-              throw new IllegalArgumentException(s"Expected claim but got $w")
-            }
+          s.split(' ').foreach {
+            w =>
+              if (w == "admin") {
+                admin = true
+              } else if (w.startsWith("actAs:")) {
+                actAs.append(Party(w.stripPrefix("actAs:")))
+              } else if (w.startsWith("readAs:")) {
+                readAs.append(Party(w.stripPrefix("readAs:")))
+              } else if (w.startsWith("applicationId:")) {
+                applicationId match {
+                  case None =>
+                    applicationId = Some(ApplicationId(w.stripPrefix("applicationId:")))
+                  case Some(_) =>
+                    throw new IllegalArgumentException(
+                      "applicationId claim can only be specified once")
+                }
+              } else {
+                throw new IllegalArgumentException(s"Expected claim but got $w")
+              }
           }
-          Claims(admin, actAs.toList, readAs.toList)
+          Claims(admin, actAs.toList, readAs.toList, applicationId)
         })
       }
   }

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Config.scala
@@ -13,8 +13,6 @@ case class Config(
     port: Port,
     // Ledger ID of issued tokens
     ledgerId: String,
-    // Application ID of issued tokens
-    applicationId: Option[String],
     // Secret used to sign JWTs
     jwtSecret: String,
     // Only authorize requests for these parties, if set.
@@ -25,13 +23,7 @@ case class Config(
 
 object Config {
   private val Empty =
-    Config(
-      port = Port.Dynamic,
-      ledgerId = null,
-      applicationId = None,
-      jwtSecret = null,
-      parties = None,
-      clock = None)
+    Config(port = Port.Dynamic, ledgerId = null, jwtSecret = null, parties = None, clock = None)
 
   def parseConfig(args: Seq[String]): Option[Config] =
     configParser.parse(args, Empty)
@@ -48,9 +40,6 @@ object Config {
 
       opt[String]("ledger-id")
         .action((x, c) => c.copy(ledgerId = x))
-
-      opt[String]("application-id")
-        .action((x, c) => c.copy(applicationId = Some(x)))
 
       opt[String]("secret")
         .action((x, c) => c.copy(jwtSecret = x))

--- a/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/oauth/server/Server.scala
@@ -69,14 +69,19 @@ class Server(config: Config) {
   private def toPayload(req: Request.Authorize): AuthServiceJWTPayload = {
     var actAs: Seq[String] = Seq()
     var readAs: Seq[String] = Seq()
+    var applicationId: Option[String] = None
     req.scope.foreach(_.split(" ").foreach {
       case s if s.startsWith("actAs:") => actAs ++= Seq(s.stripPrefix("actAs:"))
       case s if s.startsWith("readAs:") => readAs ++= Seq(s.stripPrefix("readAs:"))
+      // Given that this is only for testing,
+      // we don’t guard against multiple application id claims.
+      case s if s.startsWith("applicationId:") =>
+        applicationId = Some(s.stripPrefix("applicationId:"))
       case _ => ()
     })
     AuthServiceJWTPayload(
       ledgerId = Some(config.ledgerId),
-      applicationId = config.applicationId,
+      applicationId = applicationId,
       // Not required by the default auth service
       participantId = None,
       // Expiry is set when the token is retrieved

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/middleware/TestFixture.scala
@@ -31,7 +31,6 @@ trait TestFixture
     with SuiteResource[(AdjustableClock, ServerBinding, ServerBinding)] {
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
-  protected val applicationId: String = "test-application"
   protected val jwtSecret: String = "secret"
   override protected lazy val suiteResource
     : Resource[(AdjustableClock, ServerBinding, ServerBinding)] = {
@@ -43,7 +42,6 @@ trait TestFixture
           OAuthConfig(
             port = Port.Dynamic,
             ledgerId = ledgerId,
-            applicationId = Some(applicationId),
             jwtSecret = jwtSecret,
             parties = Some(ApiTypes.Party.subst(Set("Alice", "Bob"))),
             clock = Some(clock),

--- a/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/oauth/server/TestFixture.scala
@@ -36,7 +36,6 @@ trait TestFixture
           Config(
             port = Port.Dynamic,
             ledgerId = ledgerId,
-            applicationId = Some(applicationId),
             jwtSecret = jwtSecret,
             parties = Some(Party.subst(Set("Alice", "Bob"))),
             clock = Some(clock)

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -181,8 +181,6 @@ trait AuthMiddlewareFixture
     val oauthConfig = OAuthConfig(
       port = Port.Dynamic,
       ledgerId = this.getClass.getSimpleName,
-      // TODO[AH] Choose application ID, see https://github.com/digital-asset/daml/issues/7671
-      applicationId = None,
       jwtSecret = authSecret,
       parties = authParties,
       clock = None,


### PR DESCRIPTION
fixes #7978

There is no new test in the trigger service since the existing test
for the custom application id already hits this. The difference is
that now the test authorization server will produce a token with the
application id set to what we request rather than the wildcard token
we used before.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
