### PR TITLE
[KV] Read and prefer pre-computed blinding info when decoding KV transaction log entries [KVL-736]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumption.scala
@@ -265,8 +265,11 @@ object KeyValueConsumption {
       transactionId = hexTxId,
       recordTime = recordTime,
       divulgedContracts = List.empty,
-      // Currently derived from Fetch and LookupByKey nodes, soon pre-computed
-      blindingInfo = None,
+      blindingInfo =
+        if (txEntry.hasBlindingInfo)
+          Some(Conversions.decodeBlindingInfo(txEntry.getBlindingInfo))
+        else
+          None,
     )
   }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -9,70 +9,36 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlTransactionBlin
   DivulgenceEntry
 }
 import com.daml.lf.crypto
-import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.IdString
-import com.daml.lf.data.Relation.Relation
 import com.daml.lf.transaction.{BlindingInfo, NodeId}
 import com.daml.lf.value.Value.ContractId
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.collection.JavaConverters._
-import scala.collection.immutable.ListSet
-
 class ConversionsSpec extends WordSpec with Matchers {
   "Conversions" should {
-    "correctly and deterministically encode Blindinginfo" in {
-      val encoded = Conversions.encodeBlindingInfo(blindingInfoNotInOrder)
-      encoded shouldBe orderedEncodedBlindingInfo
+    "correctly encode Blindinginfo" in {
+      val encoded = Conversions.encodeBlindingInfo(aBlindingInfo)
+      encoded shouldBe anEncodedBlindingInfo
     }
   }
 
-  private lazy val party0: IdString.Party = Ref.Party.assertFromString("party0")
-  private lazy val party1: IdString.Party = Ref.Party.assertFromString("party1")
-  private lazy val partySetNotInOrder = ListSet(party1, party0)
-  private lazy val hashesNotInOrder: List[Hash] =
-    List(crypto.Hash.hashPrivateKey("hash0"), crypto.Hash.hashPrivateKey("hash1")).sorted.reverse
-  private lazy val contractId0 = ContractId.V1(hashesNotInOrder.tail.head)
-  private lazy val contractId1 = ContractId.V1(hashesNotInOrder.head)
-  private lazy val node0: NodeId = NodeId(0)
-  private lazy val node1: NodeId = NodeId(1)
-  private lazy val disclosureNotInOrder: Relation[NodeId, Ref.Party] =
-    Map(node1 -> partySetNotInOrder, node0 -> partySetNotInOrder)
-  private lazy val divulgenceNotInOrder: Relation[ContractId, Ref.Party] =
-    Map(contractId1 -> partySetNotInOrder, contractId0 -> partySetNotInOrder)
-  private lazy val blindingInfoNotInOrder = BlindingInfo(
-    disclosure = disclosureNotInOrder,
-    divulgence = divulgenceNotInOrder,
+  private lazy val aParty: IdString.Party = Ref.Party.assertFromString("aParty")
+  private lazy val aPartySet = Set(aParty)
+  private lazy val aCid = ContractId.V1(crypto.Hash.hashPrivateKey("aCid"))
+  private lazy val aNode: NodeId = NodeId(0)
+  private lazy val aBlindingInfo = BlindingInfo(
+    disclosure = Map(aNode -> aPartySet),
+    divulgence = Map(aCid -> aPartySet)
   )
 
-  private lazy val partiesInOrder = List(party0, party1)
-
-  private lazy val orderedEncodedBlindingInfo =
+  private lazy val anEncodedBlindingInfo =
     DamlTransactionBlindingInfo.newBuilder
-      .addAllDisclosures(
-        List(
-          DisclosureEntry.newBuilder
-            .setNodeId(node0.index.toString)
-            .addAllDisclosedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
-            .build,
-          DisclosureEntry.newBuilder
-            .setNodeId(node1.index.toString)
-            .addAllDisclosedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
-            .build,
-        ).asJava
+      .addDisclosure(
+        DisclosureEntry.newBuilder.addDisclosedTo(aParty).setNodeId(aNode.index.toString)
       )
-      .addAllDivulgences(
-        List(
-          DivulgenceEntry.newBuilder
-            .setContractId(contractId0.coid)
-            .addAllDivulgedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
-            .build,
-          DivulgenceEntry.newBuilder
-            .setContractId(contractId1.coid)
-            .addAllDivulgedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
-            .build,
-        ).asJava
+      .addDivulgence(
+        DivulgenceEntry.newBuilder.addDivulgedTo(aParty).setContractId(aCid.coid)
       )
       .build
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -34,11 +34,15 @@ class ConversionsSpec extends WordSpec with Matchers {
 
   private lazy val anEncodedBlindingInfo =
     DamlTransactionBlindingInfo.newBuilder
-      .addDisclosure(
-        DisclosureEntry.newBuilder.addDisclosedTo(aParty).setNodeId(aNode.index.toString)
+      .addDisclosures(
+        DisclosureEntry.newBuilder
+          .addDisclosedToLocalParties(aParty)
+          .setNodeId(aNode.index.toString)
       )
-      .addDivulgence(
-        DivulgenceEntry.newBuilder.addDivulgedTo(aParty).setContractId(aCid.coid)
+      .addDivulgences(
+        DivulgenceEntry.newBuilder
+          .addDivulgedToLocalParties(aParty)
+          .setContractId(aCid.coid)
       )
       .build
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ConversionsSpec.scala
@@ -3,46 +3,90 @@
 
 package com.daml.ledger.participant.state.kvutils
 
+import com.daml.ledger.participant.state.kvutils.Conversions.{
+  decodeBlindingInfo,
+  encodeBlindingInfo
+}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlTransactionBlindingInfo
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlTransactionBlindingInfo.{
   DisclosureEntry,
   DivulgenceEntry
 }
 import com.daml.lf.crypto
-import com.daml.lf.data.Ref
-import com.daml.lf.data.Ref.IdString
+import com.daml.lf.crypto.Hash
+import com.daml.lf.data.Ref.Party
+import com.daml.lf.data.Relation.Relation
 import com.daml.lf.transaction.{BlindingInfo, NodeId}
 import com.daml.lf.value.Value.ContractId
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.collection.immutable.ListSet
+
+import scala.collection.JavaConverters._
+
 class ConversionsSpec extends WordSpec with Matchers {
   "Conversions" should {
-    "correctly encode Blindinginfo" in {
-      val encoded = Conversions.encodeBlindingInfo(aBlindingInfo)
-      encoded shouldBe anEncodedBlindingInfo
+    "correctly and deterministically encode Blindinginfo" in {
+      encodeBlindingInfo(blindingInfoNotInOrder) shouldBe orderedEncodedBlindingInfo
+    }
+
+    "correctly decode BlindingInfo" in {
+      decodeBlindingInfo(orderedEncodedBlindingInfo) shouldBe orderedBlindingInfo
     }
   }
 
-  private lazy val aParty: IdString.Party = Ref.Party.assertFromString("aParty")
-  private lazy val aPartySet = Set(aParty)
-  private lazy val aCid = ContractId.V1(crypto.Hash.hashPrivateKey("aCid"))
-  private lazy val aNode: NodeId = NodeId(0)
-  private lazy val aBlindingInfo = BlindingInfo(
-    disclosure = Map(aNode -> aPartySet),
-    divulgence = Map(aCid -> aPartySet)
+  private lazy val party0: Party = Party.assertFromString("party0")
+  private lazy val party1: Party = Party.assertFromString("party1")
+  private lazy val partySetNotInOrder = ListSet(party1, party0)
+  private lazy val hashesNotInOrder: List[Hash] =
+    List(crypto.Hash.hashPrivateKey("hash0"), crypto.Hash.hashPrivateKey("hash1")).sorted.reverse
+  private lazy val contractId0 = ContractId.V1(hashesNotInOrder.tail.head)
+  private lazy val contractId1 = ContractId.V1(hashesNotInOrder.head)
+  private lazy val node0: NodeId = NodeId(0)
+  private lazy val node1: NodeId = NodeId(1)
+  private lazy val disclosureNotInOrder: Relation[NodeId, Party] =
+    Map(node1 -> partySetNotInOrder, node0 -> partySetNotInOrder)
+  private lazy val divulgenceNotInOrder: Relation[ContractId, Party] =
+    Map(contractId1 -> partySetNotInOrder, contractId0 -> partySetNotInOrder)
+  private lazy val blindingInfoNotInOrder = BlindingInfo(
+    disclosure = disclosureNotInOrder,
+    divulgence = divulgenceNotInOrder,
   )
-
-  private lazy val anEncodedBlindingInfo =
+  private lazy val orderedPartySet = Set(party0, party1)
+  private lazy val orderedDisclosure: Relation[NodeId, Party] =
+    Map(node0 -> orderedPartySet, node1 -> orderedPartySet)
+  private lazy val orderedDivulgence: Relation[ContractId, Party] =
+    Map(contractId0 -> orderedPartySet, contractId1 -> orderedPartySet)
+  private lazy val orderedBlindingInfo = BlindingInfo(
+    disclosure = orderedDisclosure,
+    divulgence = orderedDivulgence,
+  )
+  private lazy val partiesInOrder = List(party0, party1)
+  private lazy val orderedEncodedBlindingInfo =
     DamlTransactionBlindingInfo.newBuilder
-      .addDisclosures(
-        DisclosureEntry.newBuilder
-          .addDisclosedToLocalParties(aParty)
-          .setNodeId(aNode.index.toString)
+      .addAllDisclosures(
+        List(
+          DisclosureEntry.newBuilder
+            .setNodeId(node0.index.toString)
+            .addAllDisclosedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
+            .build,
+          DisclosureEntry.newBuilder
+            .setNodeId(node1.index.toString)
+            .addAllDisclosedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
+            .build,
+        ).asJava
       )
-      .addDivulgences(
-        DivulgenceEntry.newBuilder
-          .addDivulgedToLocalParties(aParty)
-          .setContractId(aCid.coid)
+      .addAllDivulgences(
+        List(
+          DivulgenceEntry.newBuilder
+            .setContractId(contractId0.coid)
+            .addAllDivulgedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
+            .build,
+          DivulgenceEntry.newBuilder
+            .setContractId(contractId1.coid)
+            .addAllDivulgedToLocalParties(partiesInOrder.asInstanceOf[List[String]].asJava)
+            .build,
+        ).asJava
       )
       .build
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -368,7 +368,9 @@ private final class SqlLedger(
           ),
           _ => {
             val divulgedContracts = Nil
-            val blindingInfo = None // Currently derived from Fetch and LookupByKey nodes, soon pre-computed
+            // This indexer-ledger does not trim fetch and lookupByKey nodes in the transaction,
+            // so it doesn't need to pre-compute blinding information
+            val blindingInfo = None
 
             val preparedInsert = ledgerDao.prepareTransactionInsert(
               submitterInfo = Some(submitterInfo),

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -369,7 +369,7 @@ private final class SqlLedger(
           _ => {
             val divulgedContracts = Nil
             // This indexer-ledger does not trim fetch and lookupByKey nodes in the transaction,
-            // so it doesn't need to pre-compute blinding information
+            // so it doesn't need to pre-compute blinding information.
             val blindingInfo = None
 
             val preparedInsert = ledgerDao.prepareTransactionInsert(


### PR DESCRIPTION
This is the fourth of a series of changes (after #8009) that will shift back blinding information computation from the read path to the write path and will remove `Fetch` and `LookupByKey` transaction nodes, reducing storage usage (KV only).

The next step will be actually removing `Fetch` and `LookupByKey` nodes from transactions prior to committing them (KV only).

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
