### PR TITLE
Make featureCppFlag field optional.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -49,7 +49,7 @@ supportedInputVersions = supportedOutputVersions
 data Feature = Feature
     { featureName :: !T.Text
     , featureMinVersion :: !Version
-    , featureCppFlag :: !T.Text
+    , featureCppFlag :: Maybe T.Text
         -- ^ CPP flag to test for availability of the feature.
     } deriving Show
 
@@ -57,56 +57,56 @@ featureNumeric :: Feature
 featureNumeric = Feature
     { featureName = "Numeric type"
     , featureMinVersion = version1_7
-    , featureCppFlag = "DAML_NUMERIC"
+    , featureCppFlag = Just "DAML_NUMERIC"
     }
 
 featureAnyType :: Feature
 featureAnyType = Feature
    { featureName = "Any type"
    , featureMinVersion = version1_7
-   , featureCppFlag = "DAML_ANY_TYPE"
+   , featureCppFlag = Just "DAML_ANY_TYPE"
    }
 
 featureTypeRep :: Feature
 featureTypeRep = Feature
     { featureName = "TypeRep type"
     , featureMinVersion = version1_7
-    , featureCppFlag = "DAML_TYPE_REP"
+    , featureCppFlag = Just "DAML_TYPE_REP"
     }
 
 featureStringInterning :: Feature
 featureStringInterning = Feature
     { featureName = "String interning"
     , featureMinVersion = version1_7
-    , featureCppFlag = "DAML_STRING_INTERNING"
+    , featureCppFlag = Nothing
     }
 
 featureGenericComparison :: Feature
 featureGenericComparison = Feature
     { featureName = "Generic order relation"
     , featureMinVersion = versionDev
-    , featureCppFlag = "DAML_GENERIC_COMPARISON"
+    , featureCppFlag = Just "DAML_GENERIC_COMPARISON"
     }
 
 featureGenMap :: Feature
 featureGenMap = Feature
     { featureName = "Generic map"
     , featureMinVersion = versionDev
-    , featureCppFlag = "DAML_GENMAP"
+    , featureCppFlag = Just "DAML_GENMAP"
     }
 
 featureTypeSynonyms :: Feature
 featureTypeSynonyms = Feature
     { featureName = "LF type synonyms"
     , featureMinVersion = version1_8
-    , featureCppFlag = "DAML_TYPE_SYNONYMS"
+    , featureCppFlag = Nothing
     }
 
 featurePackageMetadata :: Feature
 featurePackageMetadata = Feature
     { featureName = "Package metadata"
     , featureMinVersion = version1_8
-    , featureCppFlag = "DAML_PACKAGE_METADATA"
+    , featureCppFlag = Nothing
     }
 
 -- Unstable, experimental features. This should stay in 1.dev forever.
@@ -116,7 +116,7 @@ featureUnstable :: Feature
 featureUnstable = Feature
     { featureName = "Unstable, experimental features"
     , featureMinVersion = versionDev
-    , featureCppFlag = "DAML_UNSTABLE"
+    , featureCppFlag = Just "DAML_UNSTABLE"
     }
 
 featureToTextContractId :: Feature
@@ -124,7 +124,7 @@ featureToTextContractId = Feature
     { featureName = "TO_TEXT_CONTRACT_ID primitive"
     -- TODO Change as part of #7139
     , featureMinVersion = versionDev
-    , featureCppFlag = "DAML_TO_TEXT_CONTRACT_ID"
+    , featureCppFlag = Just "DAML_TO_TEXT_CONTRACT_ID"
     }
 
 featureChoiceObservers :: Feature  -- issue #7709
@@ -132,7 +132,7 @@ featureChoiceObservers = Feature
     { featureName = "Choice observers"
     -- TODO Change as part of #7139
     , featureMinVersion = versionDev
-    , featureCppFlag = "DAML_CHOICE_OBSERVERS"
+    , featureCppFlag = Just "DAML_CHOICE_OBSERVERS"
     }
 
 featureTypeInterning :: Feature
@@ -140,7 +140,7 @@ featureTypeInterning = Feature
     { featureName = "Type interning"
     -- TODO Change as part of #7139
     , featureMinVersion = versionDev
-    , featureCppFlag = "DAML_TYPE_INTERNING"
+    , featureCppFlag = Nothing
     }
 
 allFeatures :: [Feature]
@@ -156,6 +156,7 @@ allFeatures =
     , featureUnstable
     , featureToTextContractId
     , featureChoiceObservers
+    , featureTypeInterning
     ]
 
 allFeaturesForVersion :: Version -> [Feature]

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -30,7 +30,7 @@ import Control.Monad.Extra
 import qualified CmdLineParser as Cmd (warnMsg)
 import Data.IORef
 import Data.List.Extra
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import DynFlags (parseDynamicFilePragma)
 import qualified EnumSet as ES
 import qualified Data.Map.Strict as Map
@@ -404,7 +404,7 @@ adjustDynFlags options@Options{..} (GhcVersionHeader versionHeader) tmpDir dflag
                 -- sometimes this is required by CPP?
             }
 
-    cppFlags = map LF.featureCppFlag (LF.allFeaturesForVersion optDamlLfVersion)
+    cppFlags = mapMaybe LF.featureCppFlag (LF.allFeaturesForVersion optDamlLfVersion)
 
     -- We need to add platform info in order to run CPP. To prevent
     -- .hi file incompatibilities, we set the platform the same way


### PR DESCRIPTION
Some features, in particular daml-lf encoding features, don't make any sense to have an associated CPP flag. I made the CPP flag optional and removed these unnecessary feature flags (based mostly on whether the flags were used in the standard library).

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
