### PR TITLE
Sandbox: In tests, wait for Sandbox Classic to "properly" start.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServer.scala
@@ -9,10 +9,13 @@ import scala.concurrent.Future
 
 trait ApiServer {
 
-  /** the API port the server is listening on */
+  /** The API port that the server is listening on. */
   def port: Port
 
-  /** completes when all services have been closed during the shutdown */
-  def servicesClosed(): Future[Unit]
+  /** A future that completes when the server is up and has a valid configuration. */
+  def whenReady: Future[Unit]
+
+  /** A future that completes when all services have been closed during the shutdown. */
+  def servicesClosed: Future[Unit]
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServer.scala
@@ -13,7 +13,7 @@ trait ApiServer {
   def port: Port
 
   /** A future that completes when the server is up and has a valid configuration. */
-  def whenReady: Future[Unit]
+  def ready: Future[Unit]
 
   /** A future that completes when all services have been closed during the shutdown. */
   def servicesClosed: Future[Unit]

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/ApiServices.scala
@@ -54,7 +54,7 @@ import scala.concurrent.{ExecutionContext, Future}
 private[daml] trait ApiServices {
   val services: Iterable[BindableService]
 
-  def whenReady: Future[Unit]
+  def ready: Future[Unit]
 
   def withServices(otherServices: immutable.Seq[BindableService]): ApiServices
 }
@@ -64,7 +64,7 @@ private case class ApiServicesBundle(
     services: immutable.Seq[BindableService],
 ) extends ApiServices {
 
-  override val whenReady: Future[Unit] =
+  override val ready: Future[Unit] =
     ledgerConfigProvider.ready
 
   override def withServices(otherServices: immutable.Seq[BindableService]): ApiServices =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
@@ -60,7 +60,10 @@ private[daml] final class LedgerApiServer(
         override val port: Port =
           Port(server.getPort)
 
-        override def servicesClosed(): Future[Unit] =
+        override val whenReady: Future[Unit] =
+          apiServices.whenReady
+
+        override val servicesClosed: Future[Unit] =
           servicesClosedPromise.future
       }
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
@@ -60,8 +60,8 @@ private[daml] final class LedgerApiServer(
         override val port: Port =
           Port(server.getPort)
 
-        override val whenReady: Future[Unit] =
-          apiServices.whenReady
+        override val ready: Future[Unit] =
+          apiServices.ready
 
         override val servicesClosed: Future[Unit] =
           servicesClosedPromise.future

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -172,11 +172,18 @@ final class SandboxServer(
   def portF(implicit executionContext: ExecutionContext): Future[Port] =
     apiServer.map(_.port)
 
+  // Used for testing.
+  def whenReady(implicit executionContext: ExecutionContext): Future[Unit] =
+    for {
+      _ <- portF
+      _ <- apiServer.map(_.whenReady)
+    } yield ()
+
   def resetAndRestartServer()(
       implicit executionContext: ExecutionContext,
       loggingContext: LoggingContext,
   ): Future[Unit] = {
-    val apiServicesClosed = apiServer.flatMap(_.servicesClosed())
+    val apiServicesClosed = apiServer.flatMap(_.servicesClosed)
 
     // TODO: eliminate the state mutation somehow
     sandboxState = sandboxState.flatMap(

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -173,10 +173,10 @@ final class SandboxServer(
     apiServer.map(_.port)
 
   // Used for testing.
-  def whenReady(implicit executionContext: ExecutionContext): Future[Unit] =
+  def ready(implicit executionContext: ExecutionContext): Future[Unit] =
     for {
       _ <- portF
-      _ <- apiServer.map(_.whenReady)
+      _ <- apiServer.map(_.ready)
     } yield ()
 
   def resetAndRestartServer()(

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SandboxFixture.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/services/SandboxFixture.scala
@@ -47,7 +47,7 @@ trait SandboxFixture extends AbstractSandboxFixture with SuiteResource[(SandboxS
             Some(info.jdbcUrl)))
           .acquire()
         server <- SandboxServer.owner(config.copy(jdbcUrl = jdbcUrl)).acquire()
-        _ <- Resource.fromFuture(server.whenReady)
+        _ <- Resource.fromFuture(server.ready)
         channel <- GrpcClientResource.owner(server.port).acquire()
       } yield (server, channel)
   }

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -231,7 +231,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   otherInterceptors = List(resetService),
                   lfValueTranslationCache = lfValueTranslationCache,
                 )
-                _ = promise.completeWith(apiServer.servicesClosed())
+                _ = promise.completeWith(apiServer.servicesClosed)
               } yield {
                 Banner.show(Console.out)
                 logger.withoutContext.info(


### PR DESCRIPTION
There's a potential race condition in tests, where we could submit a request _before_ the ledger has processed its own configuration. This results in an `UNAVAILABLE` gRPC error: "The ledger configuration is not available."

This changes the `SandboxFixture` abstract class to wait for the server to intialize its config before considering it to be properly "started".

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
