### PR TITLE
Change actAs parties from List to Set [KVL-701]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -131,7 +131,7 @@ object JdbcIndexer {
 
   }
 
-  private def loggingContextPartiesValue(parties: List[Party]) =
+  private def loggingContextPartiesValue(parties: Set[Party]) =
     parties.mkString("[", ", ", "]")
 
   private def loggingContextFor(update: Update): Map[String, String] =

--- a/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
+++ b/ledger/participant-state/src/main/scala/com/daml/ledger/participant/state/v1/SubmitterInfo.scala
@@ -31,7 +31,7 @@ import java.time.Instant
   *   - Commands should not be deduplicated after the command was rejected.
   */
 final case class SubmitterInfo(
-    actAs: List[Party],
+    actAs: Set[Party],
     applicationId: ApplicationId,
     commandId: CommandId,
     deduplicateUntil: Instant,
@@ -39,7 +39,7 @@ final case class SubmitterInfo(
   // Note: this function is only available temporarily until the entire DAML code base
   // supports multi-party submissions. Use at your own risk.
   def singleSubmitterOrThrow(): Party = {
-    if (actAs.length == 1)
+    if (actAs.size == 1)
       actAs.head
     else
       throw new RuntimeException("SubmitterInfo contains more than one acting party")
@@ -55,7 +55,7 @@ object SubmitterInfo {
       commandId: CommandId,
       deduplicateUntil: Instant,
   ): SubmitterInfo = SubmitterInfo.apply(
-    actAs = List(submitter),
+    actAs = Set(submitter),
     applicationId = applicationId,
     commandId = commandId,
     deduplicateUntil = deduplicateUntil,


### PR DESCRIPTION
This PR changes `SubmitterInfo.actAs` from `List` to `Set`, as there is no semantic ordering of submitters.

Implementations of WriteService will have to make sure they use a stable ordering of the set elements if they use the submitters for deterministic results.