### PR TITLE
kvutils/tools: Fix the integrity checker so it compares state updates.

### DIFF
--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactory.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactory.scala
@@ -17,6 +17,7 @@ import com.daml.ledger.participant.state.kvutils.export.WriteSet
 import com.daml.ledger.participant.state.v1.{LedgerId, LedgerInitialConditions, Offset, Update}
 import com.daml.metrics.Metrics
 
+import scala.collection.immutable
 import scala.collection.mutable.ListBuffer
 
 final class LogAppendingReadServiceFactory(
@@ -36,7 +37,7 @@ final class LogAppendingReadServiceFactory(
   /** Returns a new ReadService that can stream all previously recorded updates */
   override def createReadService(implicit materializer: Materializer): ReplayingReadService =
     this.synchronized {
-      val recordedBlocksSnapshot = recordedBlocks.toList
+      def recordedBlocksSnapshot: immutable.Seq[LedgerRecord] = recordedBlocks.toList
 
       val keyValueSource = new LedgerReader {
         override def events(offset: Option[Offset]): Source[LedgerRecord, NotUsed] =


### PR DESCRIPTION
Previously, it would always take the list of updates _before_ processing the import, leading to this useless check:

    Comparing expected and actual state updates.
    Successfully compared 0 state updates.

This makes the snapshotting lazy (by using a function instead of a value), ensuring we actually perform the assertion.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
