### PR TITLE
speeding and cleaning up the assistant integration tests

### DIFF
--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -137,6 +137,8 @@ da_haskell_test(
         "http-client",
         "http-types",
         "jwt",
+        "lens",
+        "lens-aeson",
         "network",
         "process",
         "safe",

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -6,8 +6,10 @@ import Conduit hiding (connect)
 import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Exception.Extra
+import Control.Lens
 import Control.Monad
 import qualified Data.Aeson as Aeson
+import Data.Aeson.Lens
 import qualified Data.Conduit.Tar.Extra as Tar.Conduit.Extra
 import qualified Data.HashMap.Strict as HashMap
 import Data.List.Extra
@@ -35,10 +37,11 @@ import DA.Bazel.Runfiles
 import DA.Daml.Assistant.FreePort (getFreePort, socketHints)
 import DA.Daml.Assistant.IntegrationTestUtils
 import DA.Daml.Helper.Util (waitForConnectionOnPort, waitForHttpServer)
-import DA.PortFile
+-- import DA.PortFile
 import DA.Test.Daml2jsUtils
 import DA.Test.Process (callCommandSilent)
 import DA.Test.Util
+import DA.PortFile
 import SdkVersion
 
 main :: IO ()
@@ -60,726 +63,608 @@ main = do
         , ("TASTY_NUM_THREADS", Just "1")
         ] $ defaultMain (tests tmpDir))
 
+hardcodedToken :: T.Text
+hardcodedToken =
+    JWT.encodeSigned
+        (JWT.HMACSecret "secret")
+        mempty
+        mempty
+            { JWT.unregisteredClaims =
+                  JWT.ClaimsMap $
+                  Map.fromList
+                      [ ( "https://daml.com/ledger-api"
+                        , Aeson.Object $
+                          HashMap.fromList
+                              [ ("actAs", Aeson.toJSON ["Alice" :: T.Text])
+                              , ("ledgerId", "MyLedger")
+                              , ("applicationId", "foobar")
+                              ])
+                      ]
+            }
+
+authorizationHeaders :: RequestHeaders
+authorizationHeaders = [("Authorization", "Bearer " <> T.encodeUtf8 hardcodedToken)]
+
+data DamlStartResource = DamlStartResource
+    { projDir :: FilePath
+    , tmpDir :: FilePath
+    , startStdin :: Maybe Handle
+    , startPh :: ProcessHandle
+    , sandboxPort :: PortNumber
+    , jsonApiPort :: PortNumber
+    }
+
+data StartCwd
+    = ProjDir
+    | EnvRelativeDir
+    | EnvAbsoluteDir
+
+damlStart :: StartCwd -> FilePath -> IO DamlStartResource
+damlStart startCwd tmpDir = do
+    let projDir = tmpDir </> "assistant-integration-tests"
+    createDirectoryIfMissing True (projDir </> "daml")
+    writeFileUTF8 (projDir </> "daml.yaml") $
+        unlines
+            [ "sdk-version: " <> sdkVersion
+            , "name: assistant-integration-tests"
+            , "version: \"1.0\""
+            , "source: daml"
+            , "dependencies:"
+            , "  - daml-prim"
+            , "  - daml-stdlib"
+            , "  - daml-script"
+            , "parties:"
+            , "- Alice"
+            , "init-script: Main:init"
+            , "sandbox-options:"
+            , "  - --ledgerid=MyLedger"
+            , "  - --wall-clock-time"
+            , "codegen:"
+            , "  js:"
+            , "    output-directory: ui/daml.js"
+            , "    npm-scope: daml.js"
+            , "  java:"
+            , "    output-directory: ui/java"
+            , "  scala:"
+            , "    output-directory: ui/scala"
+      -- this configuration option shouldn't be mandatory according to docs, but it is.
+      -- See https://github.com/digital-asset/daml/issues/7547.
+            , "    package-prefix: com.digitalasset"
+            ]
+    writeFileUTF8 (projDir </> "daml/Main.daml") $
+        unlines
+            [ "module Main where"
+            , "import Daml.Script"
+            , "template T with p : Party where signatory p"
+            , "init : Script ()"
+            , "init = do"
+            , "  alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"Alice\")"
+            , "  alice `submit` createCmd (T alice)"
+            , "  pure ()"
+            , "test : Int -> Script (Int, Int)"
+            , "test x = pure (x, x + 1)"
+            ]
+    sandboxPort <- getFreePort
+    jsonApiPort <- getFreePort
+    let cwd
+          | ProjDir <- startCwd = projDir
+          | otherwise = tmpDir
+    let env
+          | ProjDir <- startCwd = []
+          | EnvRelativeDir <- startCwd = [("DAML_PROJECT", Just "assistant-integration-tests")]
+          | EnvAbsoluteDir <- startCwd = [("DAML_PROJECT", Just projDir)]
+    let startProc =
+            (shell $
+             unwords
+                 [ "daml"
+                 , "start"
+                 , "--start-navigator"
+                 , "no"
+                 , "--sandbox-port"
+                 , show sandboxPort
+                 , "--json-api-port"
+                 , show jsonApiPort
+                 ])
+                {std_in = CreatePipe, cwd = Just cwd}
+    withEnv env $ do
+      (startStdin, _, _, startPh) <- createProcess startProc
+      waitForHttpServer
+          (threadDelay 100000)
+          ("http://localhost:" <> show jsonApiPort <> "/v1/query")
+          authorizationHeaders
+      pure $
+          DamlStartResource
+              { projDir = projDir
+              , tmpDir = tmpDir
+              , sandboxPort = sandboxPort
+              , jsonApiPort = jsonApiPort
+              , startStdin = startStdin
+              , startPh = startPh
+              }
+
+data QuickSandboxResource = QuickSandboxResource
+    { quickSandboxPort :: PortNumber
+    , quickProjDir :: FilePath
+    , quickDar :: FilePath
+    , quickSandboxPh :: ProcessHandle
+    }
+
+quickSandbox :: FilePath -> IO QuickSandboxResource
+quickSandbox projDir = do
+    withDevNull $ \devNull -> do
+        callCommandSilent $ unwords ["daml", "new", projDir, "--template=quickstart-java"]
+        withCurrentDirectory projDir $ do
+            callCommandSilent "daml build"
+            sandboxPort <- getFreePort
+            let sandboxProc =
+                    (shell $
+                     unwords
+                         [ "daml"
+                         , "sandbox"
+                         , "--"
+                         , "--port"
+                         , show sandboxPort
+                         , "--"
+                         , "--static-time"
+                         , ".daml/dist/quickstart-0.0.1.dar"
+                         ])
+                        {std_out = UseHandle devNull}
+            (_, _, _, sandboxPh) <- createProcess sandboxProc
+            waitForConnectionOnPort (threadDelay 500000) $ fromIntegral sandboxPort
+            pure $
+                QuickSandboxResource
+                    { quickProjDir = projDir
+                    , quickSandboxPort = sandboxPort
+                    , quickSandboxPh = sandboxPh
+                    , quickDar = projDir </> ".daml" </> "dist" </> "quickstart-0.0.1.dar"
+                    }
+
 tests :: FilePath -> TestTree
-tests tmpDir = withSdkResource $ \_ -> testGroup "Integration tests"
-    [ testCase "daml version" $ callCommandSilent "daml version"
-    , testCase "daml --help" $ callCommandSilent "daml --help"
-    , testCase "daml new --list" $ callCommandSilent "daml new --list"
-    , packagingTests
-    , quickstartTests quickstartDir mvnDir
-    , cleanTests cleanDir
-    , templateTests
-    , codegenTests codegenDir
-    ]
-    where quickstartDir = tmpDir </> "q-u-i-c-k-s-t-a-r-t"
-          cleanDir = tmpDir </> "clean"
-          mvnDir = tmpDir </> "m2"
-          codegenDir = tmpDir </> "codegen"
+tests tmpDir =
+    withSdkResource $ \_ ->
+        testGroup
+            "Integration tests"
+            [ testCase "daml version" $
+              withCurrentDirectory tmpDir $ callCommandSilent "daml version"
+            , testCase "daml --help" $ withCurrentDirectory tmpDir $ callCommandSilent "daml --help"
+            , testCase "daml new --list" $
+              withCurrentDirectory tmpDir $ callCommandSilent "daml new --list"
+            , packagingTests tmpDir
+            , withResource (damlStart ProjDir tmpDir) (terminateProcess . startPh) damlStartTests
+            , withResource (quickSandbox quickstartDir) (terminateProcess . quickSandboxPh) $
+              quickstartTests quickstartDir mvnDir
+            , cleanTests cleanDir
+            , templateTests
+            , codegenTests codegenDir
+            ]
+  where
+    quickstartDir = tmpDir </> "q-u-i-c-k-s-t-a-r-t"
+    cleanDir = tmpDir </> "clean"
+    mvnDir = tmpDir </> "m2"
+    codegenDir = tmpDir </> "codegen"
 
 -- Most of the packaging tests are in the a separate test suite in
 -- //compiler/damlc/tests:packaging. This only has a couple of
 -- integration tests.
-packagingTests :: TestTree
-packagingTests = testGroup "packaging"
-     [ testCase "Build copy trigger" $ withTempDir $ \tmpDir -> do
-        let projDir = tmpDir </> "copy-trigger"
-        callCommandSilent $ unwords ["daml", "new", projDir, "--template=copy-trigger"]
-        withCurrentDirectory projDir $ callCommandSilent "daml build"
-        let dar = projDir </> ".daml" </> "dist" </> "copy-trigger-0.0.1.dar"
-        assertFileExists dar
-     , testCase "Build copy trigger with LF version 1.dev" $ withTempDir $ \tmpDir -> do
-        let projDir = tmpDir </> "copy-trigger"
-        callCommandSilent $ unwords ["daml", "new", projDir, "--template=copy-trigger"]
-        withCurrentDirectory projDir $ callCommandSilent "daml build --target 1.dev"
-        let dar = projDir </> ".daml" </> "dist" </> "copy-trigger-0.0.1.dar"
-        assertFileExists dar
-     , testCase "Build trigger with extra dependency" $ withTempDir $ \tmpDir -> do
-        let myDepDir = tmpDir </> "mydep"
-        createDirectoryIfMissing True (myDepDir </> "daml")
-        writeFileUTF8 (myDepDir </> "daml.yaml") $ unlines
-            [ "sdk-version: " <> sdkVersion
-            , "name: mydep"
-            , "version: \"1.0\""
-            , "source: daml"
-            , "dependencies:"
-            , "  - daml-prim"
-            , "  - daml-stdlib"
-            ]
-        writeFileUTF8 (myDepDir </> "daml" </> "MyDep.daml") $ unlines
-          [ "module MyDep where"
-          ]
-        withCurrentDirectory myDepDir $ callCommandSilent "daml build -o mydep.dar"
-        let myTriggerDir = tmpDir </> "mytrigger"
-        createDirectoryIfMissing True (myTriggerDir </> "daml")
-        writeFileUTF8 (myTriggerDir </> "daml.yaml") $ unlines
-            [ "sdk-version: " <> sdkVersion
-            , "name: mytrigger"
-            , "version: \"1.0\""
-            , "source: daml"
-            , "dependencies:"
-            , "  - daml-prim"
-            , "  - daml-stdlib"
-            , "  - daml-trigger"
-            , "  - " <> myDepDir </> "mydep.dar"
-            ]
-        writeFileUTF8 (myTriggerDir </> "daml/Main.daml") $ unlines
-            [ "module Main where"
-            , "import MyDep ()"
-            , "import Daml.Trigger ()"
-            ]
-        withCurrentDirectory myTriggerDir $ callCommandSilent "daml build -o mytrigger.dar"
-        let dar = myTriggerDir </> "mytrigger.dar"
-        assertFileExists dar
-     , testCase "Build DAML script example" $ withTempDir $ \tmpDir -> do
-        let projDir = tmpDir </> "script-example"
-        callCommandSilent $ unwords ["daml", "new", projDir, "--template=script-example"]
-        withCurrentDirectory projDir $ callCommandSilent "daml build"
-        let dar = projDir </> ".daml/dist/script-example-0.0.1.dar"
-        assertFileExists dar
-     , testCase "Build DAML script example with LF version 1.dev" $ withTempDir $ \tmpDir -> do
-        let projDir = tmpDir </> "script-example"
-        callCommandSilent $ unwords ["daml", "new", projDir, "--template=script-example"]
-        withCurrentDirectory projDir $ callCommandSilent "daml build --target 1.dev"
-        let dar = projDir </> ".daml/dist/script-example-0.0.1.dar"
-        assertFileExists dar
-     , testCase "Package depending on daml-script and daml-trigger can use data-dependencies" $ withTempDir $ \tmpDir -> do
-        callCommandSilent $ unwords ["daml", "new", tmpDir </> "data-dependency"]
-        withCurrentDirectory (tmpDir </> "data-dependency") $ callCommandSilent "daml build -o data-dependency.dar"
-        createDirectoryIfMissing True (tmpDir </> "proj")
-        writeFileUTF8 (tmpDir </> "proj" </> "daml.yaml") $ unlines
-          [ "sdk-version: " <> sdkVersion
-          , "name: proj"
-          , "version: 0.0.1"
-          , "source: ."
-          , "dependencies: [daml-prim, daml-stdlib, daml-script, daml-trigger]"
-          , "data-dependencies: [" <> show (tmpDir </> "data-dependency" </> "data-dependency.dar") <> "]"
-          ]
-        writeFileUTF8 (tmpDir </> "proj" </> "A.daml") $ unlines
-          [ "module A where"
-          , "import Daml.Script"
-          , "import Main"
-          , "f = setup >> allocateParty \"foobar\""
+packagingTests :: FilePath -> TestTree
+packagingTests tmpDir =
+    testGroup
+        "packaging"
+        [ testCase "Build copy trigger" $ do
+              let projDir = tmpDir </> "copy-trigger1"
+              callCommandSilent $ unwords ["daml", "new", projDir, "--template=copy-trigger"]
+              withCurrentDirectory projDir $ callCommandSilent "daml build"
+              let dar = projDir </> ".daml" </> "dist" </> "copy-trigger-0.0.1.dar"
+              assertFileExists dar
+        , testCase "Build copy trigger with LF version 1.dev" $ do
+              let projDir = tmpDir </> "copy-trigger2"
+              callCommandSilent $ unwords ["daml", "new", projDir, "--template=copy-trigger"]
+              withCurrentDirectory projDir $ callCommandSilent "daml build --target 1.dev"
+              let dar = projDir </> ".daml" </> "dist" </> "copy-trigger-0.0.1.dar"
+              assertFileExists dar
+        , testCase "Build trigger with extra dependency" $ do
+              let myDepDir = tmpDir </> "mydep"
+              createDirectoryIfMissing True (myDepDir </> "daml")
+              writeFileUTF8 (myDepDir </> "daml.yaml") $
+                  unlines
+                      [ "sdk-version: " <> sdkVersion
+                      , "name: mydep"
+                      , "version: \"1.0\""
+                      , "source: daml"
+                      , "dependencies:"
+                      , "  - daml-prim"
+                      , "  - daml-stdlib"
+                      ]
+              writeFileUTF8 (myDepDir </> "daml" </> "MyDep.daml") $ unlines ["module MyDep where"]
+              withCurrentDirectory myDepDir $ callCommandSilent "daml build -o mydep.dar"
+              let myTriggerDir = tmpDir </> "mytrigger"
+              createDirectoryIfMissing True (myTriggerDir </> "daml")
+              writeFileUTF8 (myTriggerDir </> "daml.yaml") $
+                  unlines
+                      [ "sdk-version: " <> sdkVersion
+                      , "name: mytrigger"
+                      , "version: \"1.0\""
+                      , "source: daml"
+                      , "dependencies:"
+                      , "  - daml-prim"
+                      , "  - daml-stdlib"
+                      , "  - daml-trigger"
+                      , "  - " <> myDepDir </> "mydep.dar"
+                      ]
+              writeFileUTF8 (myTriggerDir </> "daml/Main.daml") $
+                  unlines ["module Main where", "import MyDep ()", "import Daml.Trigger ()"]
+              withCurrentDirectory myTriggerDir $ callCommandSilent "daml build -o mytrigger.dar"
+              let dar = myTriggerDir </> "mytrigger.dar"
+              assertFileExists dar
+        , testCase "Build DAML script example" $ do
+              let projDir = tmpDir </> "script-example"
+              callCommandSilent $ unwords ["daml", "new", projDir, "--template=script-example"]
+              withCurrentDirectory projDir $ callCommandSilent "daml build"
+              let dar = projDir </> ".daml/dist/script-example-0.0.1.dar"
+              assertFileExists dar
+        , testCase "Build DAML script example with LF version 1.dev" $ do
+              let projDir = tmpDir </> "script-example1"
+              callCommandSilent $ unwords ["daml", "new", projDir, "--template=script-example"]
+              withCurrentDirectory projDir $ callCommandSilent "daml build --target 1.dev"
+              let dar = projDir </> ".daml/dist/script-example-0.0.1.dar"
+              assertFileExists dar
+        , testCase "Package depending on daml-script and daml-trigger can use data-dependencies" $ do
+              callCommandSilent $ unwords ["daml", "new", tmpDir </> "data-dependency"]
+              withCurrentDirectory (tmpDir </> "data-dependency") $
+                  callCommandSilent "daml build -o data-dependency.dar"
+              createDirectoryIfMissing True (tmpDir </> "proj")
+              writeFileUTF8 (tmpDir </> "proj" </> "daml.yaml") $
+                  unlines
+                      [ "sdk-version: " <> sdkVersion
+                      , "name: proj"
+                      , "version: 0.0.1"
+                      , "source: ."
+                      , "dependencies: [daml-prim, daml-stdlib, daml-script, daml-trigger]"
+                      , "data-dependencies: [" <>
+                        show (tmpDir </> "data-dependency" </> "data-dependency.dar") <>
+                        "]"
+                      ]
+              writeFileUTF8 (tmpDir </> "proj" </> "A.daml") $
+                  unlines
+                      [ "module A where"
+                      , "import Daml.Script"
+                      , "import Main"
+                      , "f = setup >> allocateParty \"foobar\""
           -- This also checks that we get the same Script type within an SDK version.
-          ]
-        withCurrentDirectory (tmpDir </> "proj") $ callCommandSilent "daml build"
-     , testCase "DAML Script --input-file and --output-file" $ withTempDir $ \projDir -> do
-           writeFileUTF8 (projDir </> "daml.yaml") $ unlines
-               [ "sdk-version: " <> sdkVersion
-               , "name: proj"
-               , "version: 0.0.1"
-               , "source: ."
-               , "dependencies: [daml-prim, daml-stdlib, daml-script]"
-               ]
-           writeFileUTF8 (projDir </> "Main.daml") $ unlines
-               [ "module Main where"
-               , "import Daml.Script"
-               , "test : Int -> Script (Int, Int)"
-               , "test x = pure (x, x + 1)"
-               ]
-           withCurrentDirectory projDir $ do
-               callCommandSilent "daml build -o script.dar"
-               writeFileUTF8 (projDir </> "input.json") "0"
-               p :: Int <- fromIntegral <$> getFreePort
-               withDevNull $ \devNull ->
-                   withCreateProcess (shell $ unwords ["daml sandbox --port " <> show p]) { std_out = UseHandle devNull } $ \_ _ _ _ -> do
-                       waitForConnectionOnPort (threadDelay 100000) p
-                       callCommand $ unwords
-                           [ "daml script"
-                           , "--dar script.dar --script-name Main:test"
-                           , "--input-file input.json --output-file output.json"
-                           , "--ledger-host localhost --ledger-port " <> show p
-                           ]
-           contents <- readFileUTF8 (projDir </> "output.json")
-           lines contents @?=
-               [ "{"
-               , "  \"_1\": 0,"
-               , "  \"_2\": 1"
-               , "}"
-               ]
-     , testCase "Run init-script" $ withTempDir $ \tmpDir -> do
-        let projDir = tmpDir </> "init-script-example"
-        createDirectoryIfMissing True (projDir </> "daml")
-        writeFileUTF8 (projDir </> "daml.yaml") $ unlines
-          [ "sdk-version: " <> sdkVersion
-          , "name: init-script-example"
-          , "version: \"1.0\""
-          , "source: daml"
-          , "dependencies:"
-          , "  - daml-prim"
-          , "  - daml-stdlib"
-          , "  - daml-script"
-          , "parties:"
-          , "- Alice"
-          , "init-script: Main:init"
-          , "sandbox-options:"
-          , "  - --wall-clock-time"
-          ]
-        writeFileUTF8 (projDir </> "daml/Main.daml") $ unlines
-          [ "module Main where"
-          , "import Daml.Script"
-          , "template T with p : Party where signatory p"
-          , "init : Script ()"
-          , "init = do"
-          , "  alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"Alice\")"
-          , "  alice `submit` createCmd (T alice)"
-          , "  pure ()"
-          ]
-        sandboxPort :: Int <- fromIntegral <$> getFreePort
-        jsonApiPort :: Int <- fromIntegral <$> getFreePort
-        let startProc = shell $ unwords
-              [ "daml"
-              , "start"
-              , "--start-navigator"
-              , "no"
-              , "--sandbox-port"
-              , show sandboxPort
-              , "--json-api-port"
-              , show jsonApiPort
-              ]
-        withCurrentDirectory projDir $
-          withCreateProcess startProc $ \_ _ _ startPh ->
-            race_ (waitForProcess' startProc startPh) $ do
-              -- The hard-coded secret for testing is "secret".
-              let token = JWT.encodeSigned (JWT.HMACSecret "secret") mempty mempty
-                    { JWT.unregisteredClaims = JWT.ClaimsMap $
-                          Map.fromList [("https://daml.com/ledger-api", Aeson.Object $ HashMap.fromList [("actAs", Aeson.toJSON ["Alice" :: T.Text]), ("ledgerId", "MyLedger"), ("applicationId", "foobar")])]
-                    }
-              let headers =
-                    [ ("Authorization", "Bearer " <> T.encodeUtf8 token)
-                    ] :: RequestHeaders
-              waitForHttpServer (threadDelay 100000) ("http://localhost:" <> show jsonApiPort <> "/v1/query") headers
-              initialRequest <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
-              let queryRequest = initialRequest
-                    { method = "POST"
-                    , requestHeaders = headers
-                    , requestBody = RequestBodyLBS $ Aeson.encode $ Aeson.object
-                        ["templateIds" Aeson..= [Aeson.String "Main:T"]]
-                    }
-              manager <- newManager defaultManagerSettings
-              queryResponse <- httpLbs queryRequest manager
-              statusCode (responseStatus queryResponse) @?= 200
-              case Aeson.decode (responseBody queryResponse) of
-                Just (Aeson.Object body)
-                  | Just (Aeson.Array result) <- HashMap.lookup "result" body
-                  -> length result @?= 1
-                _ -> assertFailure "Expected JSON object in response body"
-              -- waitForProcess' will block on Windows so we explicitly kill the process.
-              terminateProcess startPh
-     , testCase "hot-reload" $ withTempDir $ \tmpDir -> do
-        let projDir = tmpDir </> "hotreload"
-        createDirectoryIfMissing True (projDir </> "daml")
-        writeFileUTF8 (projDir </> "daml.yaml") $ unlines
-          [ "sdk-version: " <> sdkVersion
-          , "name: hotreload"
-          , "version: \"1.0\""
-          , "source: daml"
-          , "dependencies:"
-          , "  - daml-prim"
-          , "  - daml-stdlib"
-          , "  - daml-script"
-          , "parties:"
-          , "- Alice"
-          , "init-script: Main:init"
-          , "sandbox-options:"
-          , "  - --wall-clock-time"
-          ]
-        writeFileUTF8 (projDir </> "daml/Main.daml") $ unlines
-          [ "module Main where"
-          , "import Daml.Script"
-          , "template T with p : Party where signatory p"
-          , "init : Script ()"
-          , "init = do"
-          , "  alice <- allocatePartyWithHint \"Alice\" (PartyIdHint \"Alice\")"
-          , "  alice `submit` createCmd (T alice)"
-          , "  pure ()"
-          ]
-        sandboxPort :: Int <- fromIntegral <$> getFreePort
-        jsonApiPort :: Int <- fromIntegral <$> getFreePort
-        let startProc = (shell $ unwords
-              [ "daml"
-              , "start"
-              , "--start-navigator"
-              , "no"
-              , "--sandbox-port"
-              , show sandboxPort
-              , "--json-api-port"
-              , show jsonApiPort
-              ]) {std_in = CreatePipe, cwd = Just projDir}
-        withCurrentDirectory projDir $
-          withCreateProcess startProc $ \startStdIn _ _ startPh ->
-            race_ (waitForProcess' startProc startPh) $
-             do
-              -- The hard-coded secret for testing is "secret".
-              let token =
-                    JWT.encodeSigned
-                      (JWT.HMACSecret "secret")
-                      mempty
-                      mempty
-                        { JWT.unregisteredClaims =
-                            JWT.ClaimsMap $
-                            Map.fromList
-                              [ ( "https://daml.com/ledger-api"
-                                , Aeson.Object $
-                                  HashMap.fromList
-                                    [ ("actAs", Aeson.toJSON ["Alice" :: T.Text])
-                                    , ("ledgerId", "MyLedger")
-                                    , ("applicationId", "foobar")
-                                    ])
-                              ]
-                        }
-              let headers = [("Authorization", "Bearer " <> T.encodeUtf8 token)] :: RequestHeaders
-              waitForHttpServer
-                (threadDelay 100000)
-                ("http://localhost:" <> show jsonApiPort <> "/v1/query")
-                headers
-              writeFileUTF8 (projDir </> "daml/Main.daml") $
-                unlines
-                  [ "module Main where"
-                  , "import Daml.Script"
-                  , "template S with newFieldName : Party where signatory newFieldName"
-                  , "init : Script ()"
-                  , "init = do"
-                  , "  [aliceDetails] <- listKnownParties"
-                  , "  let alice = party aliceDetails"
-                  , "  alice `submit` createCmd (S alice)"
-                  , "  pure ()"
-                  ]
-              maybe (fail "No start process stdin handle") (\h -> hPutChar h 'r' >> hFlush h) startStdIn
-              threadDelay 25000000
-              initialRequest <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
-              let queryRequest =
-                    initialRequest
-                      { method = "POST"
-                      , requestHeaders = headers
-                      , requestBody =
-                          RequestBodyLBS $
-                          Aeson.encode $ Aeson.object ["templateIds" Aeson..= [Aeson.String "Main:S"]]
-                      }
-              manager <- newManager defaultManagerSettings
-              queryResponse <- httpLbs queryRequest manager
-              statusCode (responseStatus queryResponse) @?= 200
-              case Aeson.decode (responseBody queryResponse) of
-                Just (Aeson.Object body)
-                  | Just (Aeson.Array result) <- HashMap.lookup "result" body ->
-                    case Vector.toList result of
-                      [Aeson.Object r]
-                        | Just (Aeson.Object payload) <- HashMap.lookup "payload" r ->
-                          HashMap.lookup "newFieldName" payload @?= Just "Alice"
-                      other -> assertFailure $ "Bad result in response: " <> show other
-                other -> assertFailure $ "Expected JSON object in response body: " <> show other
+                      ]
+              withCurrentDirectory (tmpDir </> "proj") $ callCommandSilent "daml build"
+        ]
 
-              -- waitForProcess' will block on Windows so we explicitly kill the process.
-              terminateProcess startPh
-     , testCase "sandbox-options is picked up" $ withTempDir $ \tmpDir -> do
-        let projDir = tmpDir </> "sandbox-options"
-        createDirectoryIfMissing True (projDir </> "daml")
-        writeFileUTF8 (projDir </> "daml.yaml") $ unlines
-          [ "sdk-version: " <> sdkVersion
-          , "name: sandbox-options"
-          , "version: \"1.0\""
-          , "source: daml"
-          , "sandbox-options:"
-          , "  - --wall-clock-time"
-          , "  - --ledgerid=MyLedger"
-          , "dependencies:"
-          , "  - daml-prim"
-          , "  - daml-stdlib"
-          ]
-        writeFileUTF8 (projDir </> "daml/Main.daml") $ unlines
-          [ "module Main where"
-          , "template T with p : Party where signatory p"
-          ]
-        sandboxPort :: Int <- fromIntegral <$> getFreePort
-        jsonApiPort :: Int <- fromIntegral <$> getFreePort
-        let startProc = shell $ unwords
-              [ "daml"
-              , "start"
-              , "--start-navigator=no"
-              , "--sandbox-port=" <> show sandboxPort
-              , "--json-api-port=" <> show jsonApiPort
-              ]
-        withCurrentDirectory projDir $
-          withCreateProcess startProc $ \_ _ _ startPh ->
-            race_ (waitForProcess' startProc startPh) $ do
-              let token = JWT.encodeSigned (JWT.HMACSecret "secret") mempty mempty
-                    { JWT.unregisteredClaims = JWT.ClaimsMap $
-                          Map.fromList [("https://daml.com/ledger-api", Aeson.Object $ HashMap.fromList [("actAs", Aeson.toJSON ["Alice" :: T.Text]), ("ledgerId", "MyLedger"), ("applicationId", "foobar")])]
-                    }
-              let headers =
-                    [ ("Authorization", "Bearer " <> T.encodeUtf8 token)
-                    ] :: RequestHeaders
-              waitForHttpServer (threadDelay 100000) ("http://localhost:" <> show jsonApiPort <> "/v1/query") headers
-
+-- We are trying to run as many tests with the same `daml start` process as possible to safe time.
+damlStartTests :: IO DamlStartResource -> TestTree
+damlStartTests getDamlStart =
+    testGroup
+        "daml start"
+          -- If the ledger id or wall clock time is not picked or project dir was not found, this
+          -- would fail.
+        [ testCase "sandbox and json-api come up" $ do
+              DamlStartResource {jsonApiPort} <- getDamlStart
               manager <- newManager defaultManagerSettings
-              initialRequest <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/create"
-              let createRequest = initialRequest
-                    { method = "POST"
-                    , requestHeaders = headers
-                    , requestBody = RequestBodyLBS $ Aeson.encode $ Aeson.object
-                        ["templateId" Aeson..= Aeson.String "Main:T"
-                        ,"payload" Aeson..= [Aeson.String "Alice"]
-                        ]
-                    }
-              createResponse <- httpLbs createRequest manager
-              -- If the ledger id or wall clock time is not picked up this would fail.
-              statusCode (responseStatus createResponse) @?= 200
-              -- waitForProcess' will block on Windows so we explicitly kill the process.
-              terminateProcess startPh
-    , testCase "daml start --sandbox-port=0" $ withTempDir $ \tmpDir -> do
-          writeFileUTF8 (tmpDir </> "daml.yaml") $ unlines
-              [ "sdk-version: " <> sdkVersion
-              , "name: sandbox-options"
-              , "version: \"1.0\""
-              , "source: ."
-              , "dependencies:"
-              , "  - daml-prim"
-              , "  - daml-stdlib"
-              , "start-navigator: false"
-              ]
-          let startProc = shell $ unwords
-                  [ "daml"
-                  , "start"
-                  , "--sandbox-port=0"
-                  , "--sandbox-option=--ledgerid=MyLedger"
-                  , "--json-api-port=0"
-                  , "--json-api-option=--port-file=jsonapi.port"
-                  ]
-          withCurrentDirectory tmpDir $
-              withCreateProcess startProc $ \_ _ _ ph -> do
-              jsonApiPort <- readPortFile maxRetries "jsonapi.port"
-              let token = JWT.encodeSigned (JWT.HMACSecret "secret") mempty mempty
-                    { JWT.unregisteredClaims = JWT.ClaimsMap $
-                          Map.fromList [("https://daml.com/ledger-api", Aeson.Object $ HashMap.fromList [("actAs", Aeson.toJSON ["Alice" :: T.Text]), ("ledgerId", "MyLedger"), ("applicationId", "foobar")])]
-                    }
-              let headers =
-                    [ ("Authorization", "Bearer " <> T.encodeUtf8 token)
-                    ] :: RequestHeaders
-              initialRequest <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/parties/allocate"
-              let queryRequest = initialRequest
-                    { method = "POST"
-                    , requestHeaders = headers
-                    , requestBody = RequestBodyLBS $ Aeson.encode $ Aeson.object
-                        [ "identifierHint" Aeson..= ("Alice" :: String)
-                        ]
-                    }
-              manager <- newManager defaultManagerSettings
-              queryResponse <- httpLbs queryRequest manager
-              responseBody queryResponse @?= "{\"result\":{\"identifier\":\"Alice\",\"isLocal\":true},\"status\":200}"
-              -- waitForProcess' will block on Windows so we explicitly kill the process.
-              terminateProcess ph
-    , testCase "run a daml ledger command" $ withTempDir $ \tmpDir -> do
-          writeFileUTF8 (tmpDir </> "daml.yaml") $ unlines
-              [ "sdk-version: " <> sdkVersion
-              , "name: ledger-json-api"
-              , "version: \"1.0\""
-              , "source: ."
-              , "dependencies:"
-              , "  - daml-prim"
-              , "  - daml-stdlib"
-              ]
-          sandboxPort :: Int <- fromIntegral <$> getFreePort
-          jsonApiPort :: Int <- fromIntegral <$> getFreePort
-          let startProc = shell $ unwords
-                [ "daml"
-                , "start"
-                , "--start-navigator no"
-                , "--sandbox-port " <> show sandboxPort
-                , "--json-api-port " <> show jsonApiPort
-                ]
-          withCurrentDirectory tmpDir $
-            withCreateProcess startProc $ \_ _ _ startPh ->
-              race_ (waitForProcess' startProc startPh) $ do
-                let token =
-                      JWT.encodeSigned
-                        (JWT.HMACSecret "secret")
-                        mempty
-                        mempty
-                          { JWT.unregisteredClaims =
-                              JWT.ClaimsMap $
-                              Map.fromList
-                                [ ( "https://daml.com/ledger-api"
-                                  , Aeson.Object $
-                                    HashMap.fromList
-                                      [ ("actAs", Aeson.toJSON ["Alice" :: T.Text])
-                                      , ("ledgerId", "MyLedger")
-                                      , ("applicationId", "foobar")
-                                      ])
-                                ]
+              initialRequest <-
+                  parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/create"
+              let createRequest =
+                      initialRequest
+                          { method = "POST"
+                          , requestHeaders = authorizationHeaders
+                          , requestBody =
+                                RequestBodyLBS $
+                                Aeson.encode $
+                                Aeson.object
+                                    [ "templateId" Aeson..= Aeson.String "Main:T"
+                                    , "payload" Aeson..= [Aeson.String "Alice"]
+                                    ]
                           }
-                writeFileUTF8 (tmpDir </> "token.txt") $ T.unpack token
-                let headers =
-                      [("Authorization", "Bearer " <> T.encodeUtf8 token)] :: RequestHeaders
-                waitForHttpServer
-                  (threadDelay 100000)
-                  ("http://localhost:" <> show jsonApiPort <> "/v1/query")
-                  headers
-                callCommand $
-                  unwords
-                    [ "daml"
-                    , "ledger"
-                    , "allocate-party"
-                    , "--port"
-                    , show sandboxPort
-                    , "alice"
-                    ]
-                -- waitForProcess' will block on Windows so we explicitly kill the process.
-                terminateProcess startPh
-      , testCase "daml start invokes codegen" $ withTempDir $ \tmpDir -> do
-            writeFileUTF8 (tmpDir </> "daml.yaml") $ unlines
-                [ "sdk-version: " <> sdkVersion
-                , "name: codegen"
-                , "version: \"1.0\""
-                , "source: ."
-                , "dependencies:"
-                , "- daml-prim"
-                , "- daml-stdlib"
-                , "start-navigator: false"
-                , "codegen:"
-                , "  js:"
-                , "    output-directory: ui/daml.js"
-                , "    npm-scope: daml.js"
-                , "  java:"
-                , "    output-directory: ui/java"
-                , "  scala:"
-                , "    output-directory: ui/scala"
-                -- this configuration option shouldn't be mandatory according to docs, but it is.
-                -- See https://github.com/digital-asset/daml/issues/7547.
-                , "    package-prefix: com.digitalasset"
-                ]
-            let startProc = shell $ unwords
-                    [ "daml"
-                    , "start"
-                    ]
-            withCurrentDirectory tmpDir $
-              withCreateProcess startProc $ \_ _ _ startPh -> do
-              race_ (waitForProcess' startProc startPh) $ do
-                -- 15 secs for all the codegens to complete
-                threadDelay 15000000
-                didGenerateJsCode <-
-                  doesFileExist ("ui" </> "daml.js" </> "codegen-1.0" </> "package.json")
-                didGenerateJavaCode <-
-                  doesFileExist
-                    ("ui" </> "java" </> "da" </> "internal" </> "template" </> "Archive.java")
-                didGenerateScalaCode <- doesFileExist ("ui" </> "scala" </> "com" </> "digitalasset" </> "PackageIDs.scala" )
-                didGenerateJsCode @?= True
-                didGenerateJavaCode @?= True
-                didGenerateScalaCode @?= True
-                terminateProcess startPh
-     , testCase "daml start with relative DAML_PROJECT path" $ withTempDir $ \tmpDir -> do
-        let projDir = tmpDir </> "project"
-        createDirectoryIfMissing True (projDir </> "daml")
-        writeFileUTF8 (projDir </> "daml.yaml") $ unlines
-          [ "sdk-version: " <> sdkVersion
-          , "name: sandbox-options"
-          , "version: \"1.0\""
-          , "source: daml"
-          , "sandbox-options:"
-          , "  - --wall-clock-time"
-          , "  - --ledgerid=MyLedger"
-          , "dependencies:"
-          , "  - daml-prim"
-          , "  - daml-stdlib"
-          ]
-        writeFileUTF8 (projDir </> "daml/Main.daml") $ unlines
-          [ "module Main where"
-          , "template T with p : Party where signatory p"
-          ]
-        sandboxPort :: Int <- fromIntegral <$> getFreePort
-        jsonApiPort :: Int <- fromIntegral <$> getFreePort
-        let startProc = shell $ unwords
-              [ "daml"
-              , "start"
-              , "--start-navigator=no"
-              , "--sandbox-port=" <> show sandboxPort
-              , "--json-api-port=" <> show jsonApiPort
-              ]
-        withCurrentDirectory tmpDir $ withEnv [("DAML_PROJECT", Just "project")] $
-          withCreateProcess startProc $ \_ _ _ startPh ->
-            race_ (waitForProcess' startProc startPh) $ do
-              let token = JWT.encodeSigned (JWT.HMACSecret "secret") mempty mempty
-                    { JWT.unregisteredClaims = JWT.ClaimsMap $
-                          Map.fromList [("https://daml.com/ledger-api", Aeson.Object $ HashMap.fromList [("actAs", Aeson.toJSON ["Alice" :: T.Text]), ("ledgerId", "MyLedger"), ("applicationId", "foobar")])]
-                    }
-              let headers =
-                    [ ("Authorization", "Bearer " <> T.encodeUtf8 token)
-                    ] :: RequestHeaders
-              waitForHttpServer (threadDelay 100000) ("http://localhost:" <> show jsonApiPort <> "/v1/query") headers
-
-              manager <- newManager defaultManagerSettings
-              initialRequest <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/create"
-              let createRequest = initialRequest
-                    { method = "POST"
-                    , requestHeaders = headers
-                    , requestBody = RequestBodyLBS $ Aeson.encode $ Aeson.object
-                        ["templateId" Aeson..= Aeson.String "Main:T"
-                        ,"payload" Aeson..= [Aeson.String "Alice"]
-                        ]
-                    }
               createResponse <- httpLbs createRequest manager
-              -- If the ledger id or wall clock time is not picked up this would fail.
               statusCode (responseStatus createResponse) @?= 200
-              -- waitForProcess' will block on Windows so we explicitly kill the process.
-              terminateProcess startPh
-    ]
+        , testCase "daml start invokes codegen" $ do
+              DamlStartResource {projDir} <- getDamlStart
+              withCurrentDirectory projDir $ do
+                  didGenerateJsCode <-
+                      doesFileExist
+                          ("ui" </> "daml.js" </> "assistant-integration-tests-1.0" </>
+                           "package.json")
+                  didGenerateJavaCode <-
+                      doesFileExist
+                          ("ui" </> "java" </> "da" </> "internal" </> "template" </> "Archive.java")
+                  didGenerateScalaCode <-
+                      doesFileExist
+                          ("ui" </> "scala" </> "com" </> "digitalasset" </> "PackageIDs.scala")
+                  didGenerateJsCode @?= True
+                  didGenerateJavaCode @?= True
+                  didGenerateScalaCode @?= True
+        , testCase "run a daml ledger command" $ do
+              DamlStartResource {projDir, sandboxPort} <- getDamlStart
+              withCurrentDirectory projDir $
+                  callCommand $
+                  unwords ["daml", "ledger", "allocate-party", "--port", show sandboxPort, "Bob"]
+        , testCase "Run init-script" $ do
+              DamlStartResource {projDir, jsonApiPort} <- getDamlStart
+              withCurrentDirectory projDir $ do
+                  initialRequest <-
+                      parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
+                  let queryRequest =
+                          initialRequest
+                              { method = "POST"
+                              , requestHeaders = authorizationHeaders
+                              , requestBody =
+                                    RequestBodyLBS $
+                                    Aeson.encode $
+                                    Aeson.object ["templateIds" Aeson..= [Aeson.String "Main:T"]]
+                              }
+                  manager <- newManager defaultManagerSettings
+                  queryResponse <- httpLbs queryRequest manager
+                  statusCode (responseStatus queryResponse) @?= 200
+                  preview (key "result" . _Array . to Vector.length) (responseBody queryResponse) @?=
+                      Just 2
+        , testCase "DAML Script --input-file and --output-file" $ do
+              DamlStartResource {projDir, sandboxPort} <- getDamlStart
+              withCurrentDirectory projDir $ do
+                  let dar = projDir </> ".daml" </> "dist" </> "assistant-integration-tests-1.0.dar"
+                  writeFileUTF8 (projDir </> "input.json") "0"
+                  callCommand $
+                      unwords
+                          [ "daml script"
+                          , "--dar " <> dar <> " --script-name Main:test"
+                          , "--input-file input.json --output-file output.json"
+                          , "--ledger-host localhost --ledger-port " <> show sandboxPort
+                          ]
+                  contents <- readFileUTF8 (projDir </> "output.json")
+                  lines contents @?= ["{", "  \"_1\": 0,", "  \"_2\": 1", "}"]
+        , testCase "trigger service startup" $ do
+              DamlStartResource {sandboxPort} <- getDamlStart
+              withDevNull $ \devNull1 -> do
+                  withDevNull $ \devNull2 -> do
+                      triggerServicePort <- getFreePort
+                      let triggerServiceProc =
+                              (shell $
+                               unwords
+                                   [ "daml"
+                                   , "trigger-service"
+                                   , "--ledger-host"
+                                   , "localhost"
+                                   , "--ledger-port"
+                                   , show sandboxPort
+                                   , "--http-port"
+                                   , show triggerServicePort
+                                   , "--wall-clock-time"
+                                   ])
+                                  { std_out = UseHandle devNull1
+                                  , std_err = UseHandle devNull2
+                                  , std_in = CreatePipe
+                                  }
+                      withCreateProcess triggerServiceProc $ \_ _ _ triggerServicePh ->
+                          race_ (waitForProcess' triggerServiceProc triggerServicePh) $ do
+                              let endpoint =
+                                      "http://localhost:" <> show triggerServicePort <> "/livez"
+                              waitForHttpServer (threadDelay 100000) endpoint []
+                              req <- parseRequest endpoint
+                              manager <- newManager defaultManagerSettings
+                              resp <- httpLbs req manager
+                              responseBody resp @?= "{\"status\":\"pass\"}"
+                              -- waitForProcess' will block on Windows so we explicitly kill the
+                              -- process.
+                              terminateProcess triggerServicePh
+        , testCase "Navigator startup" $ do
+              DamlStartResource {projDir, sandboxPort} <- getDamlStart
+              withCurrentDirectory projDir $
+              -- This test just checks that navigator starts up and returns a 200 response.
+              -- Nevertheless this would have caught a few issues on rules_nodejs upgrades
+              -- where we got a 404 instead.
+               do
+                  withDevNull $ \devNull -> do
+                      navigatorPort :: Int <- fromIntegral <$> getFreePort
+                      let navigatorProc =
+                              (shell $
+                               unwords
+                                   [ "daml"
+                                   , "navigator"
+                                   , "server"
+                                   , "localhost"
+                                   , show sandboxPort
+                                   , "--port"
+                                   , show navigatorPort
+                                   ])
+                                  {std_out = UseHandle devNull, std_in = CreatePipe}
+                      withCreateProcess navigatorProc $ \_ _ _ navigatorPh ->
+                          race_ (waitForProcess' navigatorProc navigatorPh) $
+                          -- waitForHttpServer will only return once we get a 200 response so we
+                          -- don’t need to do anything else.
+                           do
+                              waitForHttpServer
+                                  (threadDelay 100000)
+                                  ("http://localhost:" <> show navigatorPort)
+                                  []
+                              -- waitForProcess' will block on Windows so we explicitly kill the
+                              -- process.
+                              terminateProcess navigatorPh
+        , testCase "hot-reload" $ do
+              DamlStartResource {projDir, jsonApiPort, startStdin} <- getDamlStart
+              withCurrentDirectory projDir $ do
+                  writeFileUTF8 (projDir </> "daml/Main.daml") $
+                      unlines
+                          [ "module Main where"
+                          , "import Daml.Script"
+                          , "template S with newFieldName : Party where signatory newFieldName"
+                          , "init : Script ()"
+                          , "init = do"
+                          , "  [aliceDetails,_bob] <- listKnownParties"
+                          , "  let alice = party aliceDetails"
+                          , "  alice `submit` createCmd (S alice)"
+                          , "  pure ()"
+                          ]
+                  maybe
+                      (fail "No start process stdin handle")
+                      (\h -> hPutChar h 'r' >> hFlush h)
+                      startStdin
+                  threadDelay 20000000
+                  initialRequest <-
+                      parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
+                  let queryRequest =
+                          initialRequest
+                              { method = "POST"
+                              , requestHeaders = authorizationHeaders
+                              , requestBody =
+                                    RequestBodyLBS $
+                                    Aeson.encode $
+                                    Aeson.object ["templateIds" Aeson..= [Aeson.String "Main:S"]]
+                              }
+                  manager <- newManager defaultManagerSettings
+                  queryResponse <- httpLbs queryRequest manager
+                  statusCode (responseStatus queryResponse) @?= 200
+                  preview
+                      (key "result" . nth 0 . key "payload" . key "newFieldName")
+                      (responseBody queryResponse) @?=
+                      Just "Alice"
+        , testCase "daml start --sandbox-port=0" $
+          withTempDir $ \tmpDir -> do
+              writeFileUTF8 (tmpDir </> "daml.yaml") $
+                  unlines
+                      [ "sdk-version: " <> sdkVersion
+                      , "name: sandbox-options"
+                      , "version: \"1.0\""
+                      , "source: ."
+                      , "dependencies:"
+                      , "  - daml-prim"
+                      , "  - daml-stdlib"
+                      , "start-navigator: false"
+                      ]
+              let startProc =
+                      shell $
+                      unwords
+                          [ "daml"
+                          , "start"
+                          , "--sandbox-port=0"
+                          , "--sandbox-option=--ledgerid=MyLedger"
+                          , "--json-api-port=0"
+                          , "--json-api-option=--port-file=jsonapi.port"
+                          ]
+              withCurrentDirectory tmpDir $
+                  withCreateProcess startProc $ \_ _ _ ph -> do
+                      jsonApiPort <- readPortFile maxRetries "jsonapi.port"
+                      initialRequest <-
+                          parseRequest $
+                          "http://localhost:" <> show jsonApiPort <> "/v1/parties/allocate"
+                      let queryRequest =
+                              initialRequest
+                                  { method = "POST"
+                                  , requestHeaders = authorizationHeaders
+                                  , requestBody =
+                                        RequestBodyLBS $
+                                        Aeson.encode $
+                                        Aeson.object ["identifierHint" Aeson..= ("Alice" :: String)]
+                                  }
+                      manager <- newManager defaultManagerSettings
+                      queryResponse <- httpLbs queryRequest manager
+                      responseBody queryResponse @?=
+                          "{\"result\":{\"identifier\":\"Alice\",\"isLocal\":true},\"status\":200}"
+                      -- waitForProcess' will block on Windows so we explicitly kill the process.
+                      terminateProcess ph
+        , testCase "daml start with relative project dir" $
+          withTempDir $ \tmpDir -> do
+            DamlStartResource{startPh} <- damlStart EnvRelativeDir tmpDir
+            terminateProcess startPh
+        , testCase "daml start absolut path" $
+          withTempDir $ \tmpDir -> do
+            DamlStartResource{startPh} <- damlStart EnvAbsoluteDir tmpDir
+            terminateProcess startPh
+        ]
 
-quickstartTests :: FilePath -> FilePath -> TestTree
-quickstartTests quickstartDir mvnDir = testGroup "quickstart"
-    [ testCase "daml new" $
-          callCommandSilent $ unwords ["daml", "new", quickstartDir, "--template=quickstart-java"]
-    , testCase "daml build" $ withCurrentDirectory quickstartDir $
-          callCommandSilent "daml build"
-    , testCase "daml test" $ withCurrentDirectory quickstartDir $
-          callCommandSilent "daml test"
-    , testCase "daml damlc test --files" $ withCurrentDirectory quickstartDir $
+quickstartTests :: FilePath -> FilePath -> IO QuickSandboxResource -> TestTree
+quickstartTests quickstartDir mvnDir getSandbox =
+    testGroup
+        "quickstart"
+        [ testCase "daml test" $ withCurrentDirectory quickstartDir $ callCommandSilent "daml test"
+        -- Testing `daml new` and `daml build` is done when the QuickSandboxResource is build.
+        , testCase "daml damlc test --files" $
+          withCurrentDirectory quickstartDir $
           callCommandSilent "daml damlc test --files daml/Main.daml"
-    , testCase "daml damlc visual-web" $ withCurrentDirectory quickstartDir $
-          callCommandSilent $ unwords ["daml damlc visual-web .daml/dist/quickstart-0.0.1.dar -o visual.html -b"]
-    , testCase "Sandbox startup" $
-      withCurrentDirectory quickstartDir $
-      withDevNull $ \devNull -> do
-          p :: Int <- fromIntegral <$> getFreePort
-          let sandboxProc = (shell $ unwords ["daml", "sandbox", "--wall-clock-time", "--port", show p, ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull, std_in = CreatePipe }
-          withCreateProcess sandboxProc  $
-              \_ _ _ ph -> race_ (waitForProcess' sandboxProc ph) $ do
-              waitForConnectionOnPort (threadDelay 100000) p
-              addr : _ <- getAddrInfo
-                  (Just socketHints)
-                  (Just "127.0.0.1")
-                  (Just $ show p)
-              bracket
-                  (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
-                  close
-                  (\s -> connect s (addrAddress addr))
+        , testCase "daml damlc visual-web" $
+          withCurrentDirectory quickstartDir $
+          callCommandSilent $
+          unwords ["daml damlc visual-web .daml/dist/quickstart-0.0.1.dar -o visual.html -b"]
+        , testCase "mvn compile" $
+          withCurrentDirectory quickstartDir $ do
+              mvnDbTarball <-
+                  locateRunfiles
+                      (mainWorkspace </> "daml-assistant" </> "integration-tests" </>
+                       "integration-tests-mvn.tar")
+              runConduitRes $
+                  sourceFileBS mvnDbTarball .|
+                  Tar.Conduit.Extra.untar (Tar.Conduit.Extra.restoreFile throwError mvnDir)
+              callCommand "daml codegen java"
+              callCommand $ unwords ["mvn", mvnRepoFlag, "-q", "compile"]
+        , testCase "Sandbox Classic startup" $
+          withCurrentDirectory quickstartDir $
+          withDevNull $ \devNull -> do
+              p :: Int <- fromIntegral <$> getFreePort
+              let sandboxProc =
+                      (shell $
+                       unwords
+                           [ "daml"
+                           , "sandbox-classic"
+                           , "--wall-clock-time"
+                           , "--port"
+                           , show p
+                           , ".daml/dist/quickstart-0.0.1.dar"
+                           ])
+                          {std_out = UseHandle devNull, std_in = CreatePipe}
+              withCreateProcess sandboxProc $ \_ _ _ ph ->
+                  race_ (waitForProcess' sandboxProc ph) $ do
+                      waitForConnectionOnPort (threadDelay 100000) p
+                      addr:_ <- getAddrInfo (Just socketHints) (Just "127.0.0.1") (Just $ show p)
+                      bracket
+                          (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+                          close
+                          (\s -> connect s (addrAddress addr))
               -- waitForProcess' will block on Windows so we explicitly kill the process.
-              terminateProcess ph
-    , testCase "Sandbox Classic startup" $
-      withCurrentDirectory quickstartDir $
-      withDevNull $ \devNull -> do
-          p :: Int <- fromIntegral <$> getFreePort
-          let sandboxProc = (shell $ unwords ["daml", "sandbox-classic", "--wall-clock-time", "--port", show p, ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull, std_in = CreatePipe }
-          withCreateProcess sandboxProc  $
-              \_ _ _ ph -> race_ (waitForProcess' sandboxProc ph) $ do
-              waitForConnectionOnPort (threadDelay 100000) p
-              addr : _ <- getAddrInfo
-                  (Just socketHints)
-                  (Just "127.0.0.1")
-                  (Just $ show p)
-              bracket
-                  (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
-                  close
-                  (\s -> connect s (addrAddress addr))
-              -- waitForProcess' will block on Windows so we explicitly kill the process.
-              terminateProcess ph
-    , testCase "Navigator startup" $
-    -- This test just checks that navigator starts up and returns a 200 response.
-    -- Nevertheless this would have caught a few issues on rules_nodejs upgrades
-    -- where we got a 404 instead.
-      withCurrentDirectory quickstartDir $
-      withDevNull $ \devNull1 -> do
-      withDevNull $ \devNull2 -> do
-          sandboxPort :: Int <- fromIntegral <$> getFreePort
-          let sandboxProc = (shell $ unwords ["daml", "sandbox", "--wall-clock-time", "--port", show sandboxPort, ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull1, std_in = CreatePipe }
-          withCreateProcess sandboxProc  $ \_ _ _ sandboxPh -> race_ (waitForProcess' sandboxProc sandboxPh) $ do
-              waitForConnectionOnPort (threadDelay 100000) sandboxPort
-              navigatorPort :: Int <- fromIntegral <$> getFreePort
-              let navigatorProc = (shell $ unwords ["daml", "navigator", "server", "localhost", show sandboxPort, "--port", show navigatorPort]) { std_out = UseHandle devNull2, std_in = CreatePipe }
-              withCreateProcess navigatorProc $ \_ _ _ navigatorPh -> race_ (waitForProcess' navigatorProc navigatorPh) $ do
-                  -- waitForHttpServer will only return once we get a 200 response so we don’t need to do anything else.
-                  waitForHttpServer (threadDelay 100000) ("http://localhost:" <> show navigatorPort) []
+                      terminateProcess ph
+        , testCase "mvn exec:java@run-quickstart" $ do
+              QuickSandboxResource {quickProjDir, quickSandboxPort, quickDar} <- getSandbox
+              withCurrentDirectory quickProjDir $
+                  withDevNull $ \devNull -> do
+                      callCommandSilent $
+                          unwords
+                              [ "daml script"
+                              , "--dar " <> quickDar
+                              , "--script-name Main:initialize"
+                              , "--static-time"
+                              , "--ledger-host localhost"
+                              , "--ledger-port"
+                              , show quickSandboxPort
+                              ]
+                      restPort :: Int <- fromIntegral <$> getFreePort
+                      let mavenProc =
+                              (shell $
+                               unwords
+                                   [ "mvn"
+                                   , mvnRepoFlag
+                                   , "-Dledgerport=" <> show quickSandboxPort
+                                   , "-Drestport=" <> show restPort
+                                   , "exec:java@run-quickstart"
+                                   ])
+                                  {std_out = UseHandle devNull}
+                      withCreateProcess mavenProc $ \_ _ _ mavenPh ->
+                          race_ (waitForProcess' mavenProc mavenPh) $ do
+                              let url = "http://localhost:" <> show restPort <> "/iou"
+                              waitForHttpServer (threadDelay 1000000) url []
+                              threadDelay 5000000
+                              manager <- newManager defaultManagerSettings
+                              req <- parseRequest url
+                              req <-
+                                  pure req {requestHeaders = [(hContentType, "application/json")]}
+                              resp <- httpLbs req manager
+                              responseBody resp @?=
+                                  "{\"0\":{\"issuer\":\"EUR_Bank\",\"owner\":\"Alice\",\"currency\":\"EUR\",\"amount\":100.0000000000,\"observers\":[]}}"
                   -- waitForProcess' will block on Windows so we explicitly kill the process.
-                  terminateProcess navigatorPh
-              terminateProcess sandboxPh
-    , testCase "JSON API startup" $
-      withCurrentDirectory quickstartDir $
-      withDevNull $ \devNull1 -> do
-      withDevNull $ \devNull2 -> do
-          sandboxPort :: Int <- fromIntegral <$> getFreePort
-          let sandboxProc = (shell $ unwords ["daml", "sandbox", "--wall-clock-time", "--port", show sandboxPort, ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull1, std_in = CreatePipe }
-          withCreateProcess sandboxProc  $ \_ _ _ sandboxPh -> race_ (waitForProcess' sandboxProc sandboxPh) $ do
-              waitForConnectionOnPort (threadDelay 100000) sandboxPort
-              jsonApiPort :: Int <- fromIntegral <$> getFreePort
-              let jsonApiProc = (shell $ unwords ["daml", "json-api", "--ledger-host", "localhost", "--ledger-port", show sandboxPort, "--http-port", show jsonApiPort, "--allow-insecure-tokens"]) { std_out = UseHandle devNull2, std_in = CreatePipe }
-              withCreateProcess jsonApiProc $ \_ _ _ jsonApiPh -> race_ (waitForProcess' jsonApiProc jsonApiPh) $ do
-                  let headers =
-                          [ ("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsZWRnZXJJZCI6Ik15TGVkZ2VyIiwiYXBwbGljYXRpb25JZCI6ImZvb2JhciIsInBhcnR5IjoiQWxpY2UifQ.4HYfzjlYr1ApUDot0a6a4zB49zS_jrwRUOCkAiPMqo0")
-                          ] :: RequestHeaders
-                  waitForHttpServer (threadDelay 100000) ("http://localhost:" <> show jsonApiPort <> "/v1/query") headers
-                  req <- parseRequest $ "http://localhost:" <> show jsonApiPort <> "/v1/query"
-                  req <- pure req { requestHeaders = headers }
-                  manager <- newManager defaultManagerSettings
-                  resp <- httpLbs req manager
-                  responseBody resp @?=
-                      "{\"result\":[],\"status\":200}"
-                  -- waitForProcess' will block on Windows so we explicitly kill the process.
-                  terminateProcess jsonApiPh
-              terminateProcess sandboxPh
-    , testCase "trigger service startup" $
-      withCurrentDirectory quickstartDir $
-      withDevNull $ \devNull1 -> do
-      withDevNull $ \devNull2 -> do
-      withDevNull $ \devNull3 -> do
-          sandboxPort :: Int <- fromIntegral <$> getFreePort
-          let sandboxProc = (shell $ unwords ["daml", "sandbox", "--wall-clock-time", "--port", show sandboxPort, ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull1, std_in = CreatePipe }
-          withCreateProcess sandboxProc  $ \_ _ _ sandboxPh -> race_ (waitForProcess' sandboxProc sandboxPh) $ do
-              waitForConnectionOnPort (threadDelay 100000) sandboxPort
-              triggerServicePort :: Int <- fromIntegral <$> getFreePort
-              let triggerServiceProc = (shell $ unwords ["daml", "trigger-service", "--ledger-host", "localhost", "--ledger-port", show sandboxPort, "--http-port", show triggerServicePort, "--wall-clock-time"]) { std_out = UseHandle devNull2, std_err = UseHandle devNull3, std_in = CreatePipe }
-              withCreateProcess triggerServiceProc $ \_ _ _ triggerServicePh -> race_ (waitForProcess' triggerServiceProc triggerServicePh) $ do
-                let endpoint = "http://localhost:" <> show triggerServicePort <> "/livez"
-                waitForHttpServer (threadDelay 100000) endpoint []
-                req <- parseRequest endpoint
-                manager <- newManager defaultManagerSettings
-                resp <- httpLbs req manager
-                responseBody resp @?= "{\"status\":\"pass\"}"
-                -- waitForProcess' will block on Windows so we
-                -- explicitly kill the process.
-                terminateProcess triggerServicePh
-              terminateProcess sandboxPh
-    , testCase "mvn compile" $
-      withCurrentDirectory quickstartDir $ do
-          mvnDbTarball <- locateRunfiles (mainWorkspace </> "daml-assistant" </> "integration-tests" </> "integration-tests-mvn.tar")
-          runConduitRes
-            $ sourceFileBS mvnDbTarball
-            .| Tar.Conduit.Extra.untar (Tar.Conduit.Extra.restoreFile throwError mvnDir)
-          callCommand "daml codegen java"
-          callCommand $ unwords ["mvn", mvnRepoFlag, "-q", "compile"]
-    , testCase "mvn exec:java@run-quickstart" $
-      withCurrentDirectory quickstartDir $
-      withDevNull $ \devNull1 ->
-      withDevNull $ \devNull2 -> do
-          sandboxPort :: Int <- fromIntegral <$> getFreePort
-          let sandboxProc = (shell $ unwords ["daml", "sandbox", "--", "--port", show sandboxPort, "--", "--static-time", ".daml/dist/quickstart-0.0.1.dar"]) { std_out = UseHandle devNull1, std_in = CreatePipe }
-          withCreateProcess sandboxProc $
-              \_ _ _ ph -> race_ (waitForProcess' sandboxProc ph) $ do
-              waitForConnectionOnPort (threadDelay 500000) sandboxPort
-              callCommandSilent $ unwords
-                    [ "daml script"
-                    , "--dar .daml/dist/quickstart-0.0.1.dar"
-                    , "--script-name Main:initialize"
-                    , "--static-time"
-                    , "--ledger-host localhost"
-                    , "--ledger-port", show sandboxPort
-                    ]
-              restPort :: Int <- fromIntegral <$> getFreePort
-              let mavenProc = (shell $ unwords ["mvn", mvnRepoFlag, "-Dledgerport=" <> show sandboxPort, "-Drestport=" <> show restPort, "exec:java@run-quickstart"]) { std_out = UseHandle devNull2 }
-              withCreateProcess mavenProc $
-                  \_ _ _ ph -> race_ (waitForProcess' mavenProc ph) $ do
-                  let url = "http://localhost:" <> show restPort <> "/iou"
-                  waitForHttpServer (threadDelay 1000000) url []
-                  threadDelay 5000000
-                  manager <- newManager defaultManagerSettings
-                  req <- parseRequest url
-                  req <- pure req { requestHeaders = [(hContentType, "application/json")] }
-                  resp <- httpLbs req manager
-                  responseBody resp @?=
-                      "{\"0\":{\"issuer\":\"EUR_Bank\",\"owner\":\"Alice\",\"currency\":\"EUR\",\"amount\":100.0000000000,\"observers\":[]}}"
-                  -- waitForProcess' will block on Windows so we explicitly kill the process.
-                  terminateProcess ph
-              -- waitForProcess' will block on Windows so we explicitly kill the process.
-              terminateProcess ph
-    ]
-    where
-        mvnRepoFlag = "-Dmaven.repo.local=" <> mvnDir
+                              terminateProcess mavenPh
+        ]
+  where
+    mvnRepoFlag = "-Dmaven.repo.local=" <> mvnDir
 
 -- | Ensure that daml clean removes precisely the files created by daml build.
 cleanTests :: FilePath -> TestTree
@@ -814,21 +699,20 @@ cleanTests baseDir = testGroup "daml clean"
 templateTests :: TestTree
 templateTests = testGroup "templates" $
     [ testCase name $ do
-          withTempDir $ \dir -> withCurrentDirectory dir $ do
-              callCommandSilent $ unwords ["daml", "new", "foobar", "--template", name]
-              withCurrentDirectory (dir </> "foobar") $ callCommandSilent "daml build"
+          withTempDir $ \tmpDir -> do
+          let dir = tmpDir </> "foobar"
+          callCommandSilent $ unwords ["daml", "new", dir, "--template", name]
+          withCurrentDirectory dir $ callCommandSilent "daml build"
     | name <- templateNames
     ] <>
     [ testCase "quickstart-java, positional template" $ do
+          withTempDir $ \tmpDir -> do
+          let dir = tmpDir </> "foobar"
           -- Verify that the old syntax for `daml new` still works.
-          withTempDir $ \dir -> withCurrentDirectory dir $ do
-              callCommandSilent "daml new foobar quickstart-java"
-              contents <- readFileUTF8 "foobar/daml.yaml"
-              assertInfixOf "name: quickstart" contents
+          callCommandSilent $ unwords ["daml","new", dir, "quickstart-java"]
+          contents <- readFileUTF8 $ dir </> "daml.yaml"
+          assertInfixOf "name: quickstart" contents
     ]
-
-
-
   -- NOTE (MK) We might want to autogenerate this list at some point but for now
   -- this should be good enough.
   where templateNames =
@@ -885,3 +769,4 @@ data ProcessExitFailure = ProcessExitFailure !ExitCode !CreateProcess
     deriving (Show, Typeable)
 
 instance Exception ProcessExitFailure
+


### PR DESCRIPTION
This cleans up the daml assistant integration tests. The time is cut down to
about 3min from previously 15. This is done by minimizing the number of `daml
start` invocations.

Sadly the diff is quite a mess, you'll have to look at the whole file. Sorry
for that!

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
