### PR TITLE
daml codegen: Add deprecation warning for scala.

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -232,7 +232,7 @@ commandParser = subparser $ fold
     codegenCmd = asum
         [ subparser $ fold
             [  command "java" $ info codegenJavaCmd forwardOptions
-            ,  command "scala" $ info codegenScalaCmd forwardOptions
+            ,  command "scala" $ info codegenScalaCmd (progDesc "(deprecated)" <> forwardOptions)
             ,  command "js" $ info codegenJavaScriptCmd forwardOptions
             ]
         ]


### PR DESCRIPTION
This fixes #8022. This adds a deprecation warning for the scala codegen.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
