### PR TITLE
Support multiple submitters in kvutils protobuf [KVL-704]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -133,7 +133,7 @@ message DamlLogEntryId {
 }
 
 message DamlSubmitterInfo {
-  string submitter = 1;
+  repeated string submitters = 1;
   string command_id = 2;
   string application_id = 3;
   reserved 4; // was maximum_record_time
@@ -393,7 +393,7 @@ message DamlStateValue {
 }
 
 message DamlCommandDedupKey {
-  string submitter = 1;
+  repeated string submitters = 1;
   reserved 2; // was application_id
   string command_id = 3;
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -74,7 +74,7 @@ private[state] object Conversions {
       .setCommandDedup(
         DamlCommandDedupKey.newBuilder
           .setCommandId(subInfo.getCommandId)
-          .setSubmitter(subInfo.getSubmitter)
+          .addAllSubmitters(subInfo.getSubmittersList)
           .build
       )
       .build
@@ -118,7 +118,7 @@ private[state] object Conversions {
 
   def buildSubmitterInfo(subInfo: SubmitterInfo): DamlSubmitterInfo =
     DamlSubmitterInfo.newBuilder
-      .setSubmitter(subInfo.singleSubmitterOrThrow())
+      .addAllSubmitters(subInfo.actAs.asInstanceOf[List[String]].asJava)
       .setApplicationId(subInfo.applicationId)
       .setCommandId(subInfo.commandId)
       .setDeduplicateUntil(
@@ -126,8 +126,8 @@ private[state] object Conversions {
       .build
 
   def parseSubmitterInfo(subInfo: DamlSubmitterInfo): SubmitterInfo =
-    SubmitterInfo.withSingleSubmitter(
-      submitter = Party.assertFromString(subInfo.getSubmitter),
+    SubmitterInfo(
+      actAs = subInfo.getSubmittersList.asScala.toList.map(Party.assertFromString),
       applicationId = LedgerString.assertFromString(subInfo.getApplicationId),
       commandId = LedgerString.assertFromString(subInfo.getCommandId),
       deduplicateUntil = parseTimestamp(subInfo.getDeduplicateUntil).toInstant,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -70,11 +70,14 @@ private[state] object Conversions {
   }
 
   def commandDedupKey(subInfo: DamlSubmitterInfo): DamlStateKey = {
+    val sortedUniqueSubmitters =
+      if (subInfo.getSubmittersCount == 1) subInfo.getSubmittersList
+      else subInfo.getSubmittersList.asScala.distinct.sorted.asJava
     DamlStateKey.newBuilder
       .setCommandDedup(
         DamlCommandDedupKey.newBuilder
           .setCommandId(subInfo.getCommandId)
-          .addAllSubmitters(subInfo.getSubmittersList)
+          .addAllSubmitters(sortedUniqueSubmitters)
           .build
       )
       .build

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Conversions.scala
@@ -71,8 +71,10 @@ private[state] object Conversions {
 
   def commandDedupKey(subInfo: DamlSubmitterInfo): DamlStateKey = {
     val sortedUniqueSubmitters =
-      if (subInfo.getSubmittersCount == 1) subInfo.getSubmittersList
-      else subInfo.getSubmittersList.asScala.distinct.sorted.asJava
+      if (subInfo.getSubmittersCount == 1)
+        subInfo.getSubmittersList
+      else
+        subInfo.getSubmittersList.asScala.distinct.sorted.asJava
     DamlStateKey.newBuilder
       .setCommandDedup(
         DamlCommandDedupKey.newBuilder

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -640,7 +640,8 @@ private[kvutils] object TransactionCommitter {
     val submitter: Party =
       if (submitterInfo.getSubmittersCount == 1)
         Party.assertFromString(submitterInfo.getSubmitters(0))
-      else throw Err.InternalError("Multi-party submissions are not supported")
+      else
+        throw Err.InternalError("Multi-party submissions are not supported")
     lazy val transaction: Tx.Transaction = Conversions.decodeTransaction(submission.getTransaction)
     val submissionTime: Timestamp = Conversions.parseTimestamp(submission.getSubmissionTime)
     val submissionSeed: crypto.Hash = Conversions.parseHash(submission.getSubmissionSeed)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -637,7 +637,10 @@ private[kvutils] object TransactionCommitter {
     val ledgerEffectiveTime: Timestamp = parseTimestamp(submission.getLedgerEffectiveTime)
     val submitterInfo: DamlSubmitterInfo = submission.getSubmitterInfo
     val commandId: String = submitterInfo.getCommandId
-    val submitter: Party = Party.assertFromString(submitterInfo.getSubmitter)
+    val submitter: Party =
+      if (submitterInfo.getSubmittersCount == 1)
+        Party.assertFromString(submitterInfo.getSubmitters(0))
+      else throw Err.InternalError("Multi-party submissions are not supported")
     lazy val transaction: Tx.Transaction = Conversions.decodeTransaction(submission.getTransaction)
     val submissionTime: Timestamp = Conversions.parseTimestamp(submission.getSubmissionTime)
     val submissionSeed: crypto.Hash = Conversions.parseHash(submission.getSubmissionSeed)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KeyValueConsumptionSpec.scala
@@ -266,7 +266,7 @@ class KeyValueConsumptionSpec extends WordSpec with Matchers {
 
   private def someSubmitterInfo: DamlSubmitterInfo =
     DamlSubmitterInfo.newBuilder
-      .setSubmitter("a submitter")
+      .addSubmitters("a submitter")
       .setApplicationId("test")
       .setCommandId("a command ID")
       .setDeduplicateUntil(com.google.protobuf.Timestamp.getDefaultInstance)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
@@ -27,7 +27,7 @@ class TransactionCommitterSpec extends WordSpec with Matchers with MockitoSugar 
     .setSubmitterInfo(
       DamlSubmitterInfo.newBuilder
         .setCommandId("commandId")
-        .setSubmitter("aSubmitter"))
+        .addSubmitters("aSubmitter"))
     .setSubmissionSeed(ByteString.copyFromUtf8("a" * 32))
     .build
   private val aTransactionEntrySummary = DamlTransactionEntrySummary(aDamlTransactionEntry)

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
@@ -42,9 +42,13 @@ final case class TxEntry(
     submissionTime: Time.Timestamp,
     submissionSeed: crypto.Hash,
 ) {
-  def singleSubmitterOrThrow() =
-    if (submitters.length == 1) submitters.head
-    else sys.error("Multi-party submissions are not supported")
+  // Note: this method will be removed when the entire kvutils code base
+  // supports multi-party submissions
+  def singleSubmitterOrThrow(): Ref.Party =
+    if (submitters.length == 1)
+      submitters.head
+    else
+      sys.error("Multi-party submissions are not supported")
 }
 
 final case class BenchmarkState(

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
@@ -37,11 +37,15 @@ import scala.collection.JavaConverters._
 final case class TxEntry(
     tx: SubmittedTransaction,
     participantId: ParticipantId,
-    submitter: Ref.Party,
+    submitters: List[Ref.Party],
     ledgerTime: Time.Timestamp,
     submissionTime: Time.Timestamp,
     submissionSeed: crypto.Hash,
-)
+) {
+  def singleSubmitterOrThrow() =
+    if (submitters.length == 1) submitters.head
+    else sys.error("Multi-party submissions are not supported")
+}
 
 final case class BenchmarkState(
     name: String,
@@ -87,7 +91,7 @@ class Replay {
   def bench(): Unit = {
     val result = engine
       .replay(
-        benchmark.transaction.submitter,
+        benchmark.transaction.singleSubmitterOrThrow(),
         benchmark.transaction.tx,
         benchmark.transaction.ledgerTime,
         benchmark.transaction.participantId,
@@ -122,7 +126,7 @@ class Replay {
     // before running the bench, we validate the transaction first to be sure everything is fine.
     val result = engine
       .validate(
-        benchmark.transaction.submitter,
+        benchmark.transaction.singleSubmitterOrThrow(),
         benchmark.transaction.tx,
         benchmark.transaction.ledgerTime,
         benchmark.transaction.participantId,
@@ -180,7 +184,8 @@ object Replay {
           TxEntry(
             tx = tx,
             participantId = participantId,
-            submitter = Ref.Party.assertFromString(entry.getSubmitterInfo.getSubmitter),
+            submitters = entry.getSubmitterInfo.getSubmittersList.asScala.toList
+              .map(Ref.Party.assertFromString),
             ledgerTime = parseTimestamp(entry.getLedgerEffectiveTime),
             submissionTime = parseTimestamp(entry.getSubmissionTime),
             submissionSeed = parseHash(entry.getSubmissionSeed)


### PR DESCRIPTION
This is a minimal PR that changes the kvutils storage format such that it supports multiple submitters.

Note that adding `repeated` to a primitive field is a backwards-compatible change for the serialized data.