### PR TITLE
[kvutils] Add config key to read set [KVL-746]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -176,16 +176,10 @@ object Committer {
 
   def getCurrentConfiguration(
       defaultConfig: Configuration,
-      inputState: DamlStateMap,
+      commitContext: CommitContext,
       logger: Logger): (Option[DamlConfigurationEntry], Configuration) =
-    inputState
-      .getOrElse(
-        Conversions.configurationStateKey,
-        /* If we're retrieving configuration, we require it to at least
-         * have been declared as an input by the submitter as it is used
-         * to authorize configuration changes. */
-        throw Err.MissingInputState(Conversions.configurationStateKey)
-      )
+    commitContext
+      .get(Conversions.configurationStateKey)
       .flatMap { v =>
         val entry = v.getConfigurationEntry
         Configuration

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitter.scala
@@ -209,7 +209,7 @@ private[kvutils] class ConfigCommitter(
   ): ConfigCommitter.Result =
     ConfigCommitter.Result(
       submission.getConfigurationSubmission,
-      getCurrentConfiguration(defaultConfig, ctx.inputs, logger)
+      getCurrentConfiguration(defaultConfig, ctx, logger)
     )
 
   override protected val steps: Iterable[(StepInfo, Step)] = Iterable(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -155,7 +155,7 @@ private[kvutils] class TransactionCommitter(
   /** Validate ledger effective time and the command's time-to-live. */
   private[committer] def validateLedgerTime: Step =
     (commitContext, transactionEntry) => {
-      val (_, config) = getCurrentConfiguration(defaultConfig, commitContext.inputs, logger)
+      val (_, config) = getCurrentConfiguration(defaultConfig, commitContext, logger)
       val timeModel = config.timeModel
 
       commitContext.getRecordTime match {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -3,19 +3,24 @@
 
 package com.daml.ledger.participant.state.kvutils.committer
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 
 import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.participant.state.kvutils.Conversions.configurationStateKey
 import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
-import com.daml.ledger.participant.state.kvutils.DamlKvutils
+import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Err}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.TestHelpers.theDefaultConfig
 import com.daml.ledger.participant.state.kvutils.committer.Committer.StepInfo
+import com.daml.ledger.participant.state.protobuf.LedgerConfiguration
+import com.daml.ledger.participant.state.v1.{Configuration, TimeModel}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.metrics.Metrics
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Matchers, WordSpec}
+import org.slf4j.{Logger, LoggerFactory}
 
 class CommitterSpec
     extends WordSpec
@@ -184,6 +189,57 @@ class CommitterSpec
     }
   }
 
+  "getCurrentConfiguration" should {
+    "return configuration in case there is one available on the ledger" in {
+      val inputState = Map(configurationStateKey -> Some(aConfigurationStateValue))
+      val commitContext = new FakeCommitContext(recordTime = None, inputState)
+
+      val (Some(actualConfigurationEntry), actualConfiguration) =
+        Committer.getCurrentConfiguration(theDefaultConfig, commitContext, createLogger())
+
+      actualConfigurationEntry should be(aConfigurationStateValue.getConfigurationEntry)
+      actualConfiguration should be(aConfig)
+    }
+
+    "return default configuration in case there is no configuration on the ledger" in {
+      val inputState = Map(configurationStateKey -> None)
+      val commitContext = new FakeCommitContext(recordTime = None, inputState)
+
+      val (actualConfigurationEntry, actualConfiguration) =
+        Committer.getCurrentConfiguration(theDefaultConfig, commitContext, createLogger())
+
+      actualConfigurationEntry should not be defined
+      actualConfiguration should be(theDefaultConfig)
+    }
+
+    "throw in case configuration key is not declared in the input" in {
+      val commitContext = new FakeCommitContext(recordTime = None, Map.empty)
+
+      assertThrows[Err.MissingInputState] {
+        Committer.getCurrentConfiguration(theDefaultConfig, commitContext, createLogger())
+      }
+    }
+
+    "return no configuration entry in case decoding of configuration fails" in {
+      // Create a configuration with an unsupported generation number.
+      val invalidConfigurationEntry = DamlStateValue.newBuilder
+        .setConfigurationEntry(
+          DamlConfigurationEntry.newBuilder
+            .setConfiguration(LedgerConfiguration.newBuilder.setGeneration(123456))
+        )
+        .build
+      val commitContext = new FakeCommitContext(
+        recordTime = None,
+        Map(configurationStateKey -> Some(invalidConfigurationEntry)))
+
+      val (actualConfigurationEntry, actualConfiguration) =
+        Committer.getCurrentConfiguration(theDefaultConfig, commitContext, createLogger())
+
+      actualConfigurationEntry should not be defined
+      actualConfiguration should be(theDefaultConfig)
+    }
+  }
+
   private val aRecordTime = Timestamp(100)
   private val aDamlSubmission = DamlSubmission.getDefaultInstance
   private val aLogEntry = DamlLogEntry.newBuilder
@@ -199,6 +255,11 @@ class CommitterSpec
         .setSubmissionId("an ID")
         .setParticipantId("a participant"))
     .build
+  private val aConfig: Configuration = Configuration(
+    generation = 1,
+    timeModel = TimeModel.reasonableDefault,
+    maxDeduplicationTime = Duration.ofMinutes(1),
+  )
 
   private def newMetrics() = new Metrics(new MetricRegistry)
 
@@ -212,4 +273,14 @@ class CommitterSpec
 
     override protected val metrics: Metrics = newMetrics()
   }
+
+  private def aConfigurationStateValue: DamlStateValue =
+    DamlStateValue.newBuilder
+      .setConfigurationEntry(
+        DamlConfigurationEntry.newBuilder
+          .setConfiguration(Configuration.encode(aConfig))
+      )
+      .build
+
+  private def createLogger(): Logger = LoggerFactory.getLogger(this.getClass)
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
@@ -7,6 +7,7 @@ import java.time.Instant
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.Conversions
+import com.daml.ledger.participant.state.kvutils.Conversions.configurationStateKey
 import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
@@ -190,6 +191,15 @@ class TransactionCommitterSpec extends WordSpec with Matchers with MockitoSugar 
             actualLogEntry.hasTransactionRejectionEntry shouldBe true
         }
       }
+    }
+
+    "mark config key as accessed in context" in {
+      val commitContext =
+        new FakeCommitContext(recordTime = None, inputWithTimeModelAndCommandDeduplication)
+
+      val _ = instance.validateLedgerTime(commitContext, aTransactionEntrySummary)
+
+      commitContext.getAccessedInputKeys should contain(configurationStateKey)
     }
   }
 


### PR DESCRIPTION
Summary of changes:
* Make retrieval of the current configuration go through `CommitContext` to get accessed keys properly recorded.
* Improved test coverage of `Committer.getCurrentConfiguration`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
