### PR TITLE
Refactor continuations for speedy machine

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -443,13 +443,7 @@ private[lf] object SBuiltin {
       val func = args.get(0)
       val init = args.get(1)
       val list = args.get(2).asInstanceOf[SList].list
-      machine.pushKont(
-        KFoldl(
-          func,
-          list,
-          machine.frame,
-          machine.actuals
-        ))
+      machine.pushKont(KFoldl(machine, func, list))
       machine.returnValue = init
     }
   }
@@ -491,29 +485,14 @@ private[lf] object SBuiltin {
       val list = args.get(2)
       if (func.arity - func.actuals.size >= 2) {
         val array = list.asInstanceOf[SList].list.toImmArray
-        machine.pushKont(
-          KFoldr(
-            func,
-            array,
-            array.length,
-            machine.frame,
-            machine.actuals,
-          ))
+        machine.pushKont(KFoldr(machine, func, array, array.length))
         machine.returnValue = init
       } else {
         val stack = list.asInstanceOf[SList].list
         stack.pop match {
           case None => machine.returnValue = init
           case Some((head, tail)) =>
-            machine.pushKont(
-              KFoldr1Map(
-                func,
-                tail,
-                FrontStack.empty,
-                init,
-                machine.frame,
-                machine.actuals
-              ))
+            machine.pushKont(KFoldr1Map(machine, func, tail, FrontStack.empty, init))
             machine.enterApplication(func, Array(SEValue(head)))
         }
       }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -335,9 +335,6 @@ object SExpr {
     */
   final case class SECatch(body: SExpr, handler: SExpr, fin: SExpr) extends SExpr {
     def execute(machine: Machine): Unit = {
-      // We call [markBase] (as standard) so the continuation may access its temporaries.
-      // In addition [env.size] is recorded for use in [tryHandleException] to allow the
-      // env-stack to be unwound correctly when an exception is thrown.
       machine.pushKont(KCatch(machine, handler, fin))
       machine.ctrl = body
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -108,7 +108,7 @@ object SExpr {
     General case: 'fun' and 'args' are any kind of expression */
   final case class SEAppGeneral(fun: SExpr, args: Array[SExpr]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KArg(machine.markBase(), args, machine.frame, machine.actuals))
+      machine.pushKont(KArg(machine, args))
       machine.ctrl = fun
     }
   }
@@ -238,7 +238,7 @@ object SExpr {
   /** Pattern match. */
   final case class SECase(scrut: SExpr, alts: Array[SCaseAlt]) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KMatch(machine.markBase(), alts, machine.frame, machine.actuals))
+      machine.pushKont(KMatch(machine, alts))
       machine.ctrl = scrut
     }
 
@@ -271,8 +271,7 @@ object SExpr {
   /** A let-expression with a single RHS */
   final case class SELet1General(rhs: SExpr, body: SExpr) extends SExpr with SomeArrayEquals {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(
-        KPushTo(machine.markBase(), machine.env, body, machine.frame, machine.actuals))
+      machine.pushKont(KPushTo(machine, machine.env, body))
       machine.ctrl = rhs
     }
   }
@@ -339,8 +338,7 @@ object SExpr {
       // We call [markBase] (as standard) so the continuation may access its temporaries.
       // In addition [env.size] is recorded for use in [tryHandleException] to allow the
       // env-stack to be unwound correctly when an exception is thrown.
-      machine.pushKont(
-        KCatch(machine.markBase(), handler, fin, machine.frame, machine.actuals, machine.env.size))
+      machine.pushKont(KCatch(machine, handler, fin))
       machine.ctrl = body
     }
   }
@@ -356,7 +354,7 @@ object SExpr {
     */
   final case class SELabelClosure(label: Profile.Label, expr: SExpr) extends SExpr {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KLabelClosure(label))
+      machine.pushKont(KLabelClosure(machine, label))
       machine.ctrl = expr
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -268,9 +268,9 @@ private[lf] object Speedy {
         // NOTE(MH): If the top of the continuation stack is the monadic token,
         // we push location information under it to account for the implicit
         // lambda binding the token.
-        case Some(KArg(_, Array(SEValue.Token), _, _)) => {
+        case Some(KArg(_, Array(SEValue.Token))) => {
           // Can't call pushKont here, because we don't push at the top of the stack.
-          kontStack.add(last_index, KLocation(loc))
+          kontStack.add(last_index, KLocation(this, loc))
           if (enableInstrumentation) {
             track.countPushesKont += 1
             if (kontDepth > track.maxDepthKont) track.maxDepthKont = kontDepth
@@ -280,9 +280,9 @@ private[lf] object Speedy {
         // stack trace it produced back on the continuation stack to get
         // complete stack trace at the use site. Thus, we store the stack traces
         // of top level values separately during their execution.
-        case Some(KCacheVal(v, defn, stack_trace)) =>
-          kontStack.set(last_index, KCacheVal(v, defn, loc :: stack_trace)); ()
-        case _ => pushKont(KLocation(loc))
+        case Some(KCacheVal(m, v, defn, stack_trace)) =>
+          kontStack.set(last_index, KCacheVal(m, v, defn, loc :: stack_trace)); ()
+        case _ => pushKont(KLocation(this, loc))
       }
     }
 
@@ -297,7 +297,7 @@ private[lf] object Speedy {
       val s = ImmArray.newBuilder[Location]
       kontStack.forEach { k =>
         k match {
-          case KLocation(location) => s += location
+          case KLocation(_, location) => s += location
           case _ => ()
         }
       }
@@ -351,11 +351,12 @@ private[lf] object Speedy {
       */
     def setExpressionToEvaluate(expr: SExpr): Unit = {
       ctrl = expr
-      kontStack = initialKontStack()
       env = emptyEnv
       envBase = 0
       steps = 0
       track = Instrumentation()
+      kontStack = emptyKontStack
+      pushKont(KFinished(this))
     }
 
     /** Run a machine until we get a result: either a final-value or a request for data, with a callback */
@@ -384,7 +385,7 @@ private[lf] object Speedy {
               val value = returnValue
               returnValue = null
               popTempStackToBase()
-              popKont.execute(value, this)
+              popKont.execute(value)
             } else {
               val expr = ctrl
               ctrl = null
@@ -438,7 +439,7 @@ private[lf] object Speedy {
                   eval.setCached(svalue, stackTrace)
                   returnValue = svalue
                 case None =>
-                  pushKont(KCacheVal(eval, defn, Nil))
+                  pushKont(KCacheVal(this, eval, defn, Nil))
                   ctrl = defn.body
               }
             case None =>
@@ -493,7 +494,7 @@ private[lf] object Speedy {
             if (othersLength > 0) {
               val others = new Array[SExprAtomic](othersLength)
               System.arraycopy(newArgs, missing, others, 0, othersLength)
-              this.pushKont(KOverApp(this.markBase(), others, this.frame, this.actuals))
+              this.pushKont(KOverApp(this, others))
             }
             // Now the correct number of arguments is ensured. What kind of prim do we have?
             prim match {
@@ -504,7 +505,7 @@ private[lf] object Speedy {
                 val label = closure.label
                 if (label != null) {
                   this.profile.addOpenEvent(label)
-                  this.pushKont(KLeaveClosure(label))
+                  this.pushKont(KLeaveClosure(this, label))
                 }
                 // Start evaluating the body of the closure.
                 popTempStackToBase()
@@ -542,23 +543,23 @@ private[lf] object Speedy {
 
           // Not enough arguments. Push a continuation to construct the PAP.
           if (othersLength < 0) {
-            this.pushKont(KPap(prim, actuals, arity))
+            this.pushKont(KPap(this, prim, actuals, arity))
           } else {
             // Too many arguments: Push a continuation to re-apply the over-applied args.
             if (othersLength > 0) {
               val others = new Array[SExpr](othersLength)
               System.arraycopy(newArgs, missing, others, 0, othersLength)
-              this.pushKont(KArg(this.markBase(), others, this.frame, this.actuals))
+              this.pushKont(KArg(this, others))
             }
             // Now the correct number of arguments is ensured. What kind of prim do we have?
             prim match {
               case closure: PClosure =>
                 // Push a continuation to execute the function body when the arguments have been evaluated
-                this.pushKont(KFun(this.markBase(), closure, actuals))
+                this.pushKont(KFun(this, closure, actuals))
 
               case PBuiltin(builtin) =>
                 // Push a continuation to execute the builtin when the arguments have been evaluated
-                this.pushKont(KBuiltin(this.markBase(), builtin, actuals))
+                this.pushKont(KBuiltin(this, builtin, actuals))
             }
           }
           this.evaluateArguments(actuals, newArgs, newArgsLimit)
@@ -582,7 +583,7 @@ private[lf] object Speedy {
       var i = 1
       while (i < n) {
         val arg = args(n - i)
-        this.pushKont(KPushTo(this.markBase(), actuals, arg, this.frame, this.actuals))
+        this.pushKont(KPushTo(this, actuals, arg))
         i = i + 1
       }
       this.ctrl = args(0)
@@ -732,33 +733,34 @@ private[lf] object Speedy {
         checkAuthorization: CheckAuthorizationMode = CheckAuthorizationMode.On,
         traceLog: TraceLog = RingBufferTraceLog(damlTraceLog, 100),
     ): Machine =
-      new Machine(
-        ctrl = expr,
-        returnValue = null,
-        frame = null,
-        actuals = null,
-        env = emptyEnv,
-        envBase = 0,
-        kontStack = initialKontStack(),
-        lastLocation = None,
-        ledgerMode = OnLedger(
-          validating = validating,
-          checkAuthorization = checkAuthorization,
-          ptx = PartialTransaction.initial(submissionTime, initialSeeding),
-          committers = committers,
-          commitLocation = None,
-          dependsOnTime = false,
-          localContracts = Map.empty,
-          globalDiscriminators = globalCids.collect {
-            case V.ContractId.V1(discriminator, _) => discriminator
-          },
-        ),
-        traceLog = traceLog,
-        compiledPackages = compiledPackages,
-        steps = 0,
-        track = Instrumentation(),
-        profile = new Profile(),
-      )
+      pushFinished(
+        new Machine(
+          ctrl = expr,
+          returnValue = null,
+          frame = null,
+          actuals = null,
+          env = emptyEnv,
+          envBase = 0,
+          kontStack = emptyKontStack,
+          lastLocation = None,
+          ledgerMode = OnLedger(
+            validating = validating,
+            checkAuthorization = checkAuthorization,
+            ptx = PartialTransaction.initial(submissionTime, initialSeeding),
+            committers = committers,
+            commitLocation = None,
+            dependsOnTime = false,
+            localContracts = Map.empty,
+            globalDiscriminators = globalCids.collect {
+              case V.ContractId.V1(discriminator, _) => discriminator
+            },
+          ),
+          traceLog = traceLog,
+          compiledPackages = compiledPackages,
+          steps = 0,
+          track = Instrumentation(),
+          profile = new Profile(),
+        ))
 
     @throws[PackageNotFound]
     @throws[CompilationError]
@@ -798,22 +800,23 @@ private[lf] object Speedy {
         expr: SExpr,
         traceLog: TraceLog = RingBufferTraceLog(damlTraceLog, 100),
     ): Machine =
-      new Machine(
-        ctrl = expr,
-        returnValue = null,
-        frame = null,
-        actuals = null,
-        env = emptyEnv,
-        envBase = 0,
-        kontStack = initialKontStack(),
-        lastLocation = None,
-        ledgerMode = OffLedger,
-        traceLog = traceLog,
-        compiledPackages = compiledPackages,
-        steps = 0,
-        track = Instrumentation(),
-        profile = new Profile(),
-      )
+      pushFinished(
+        new Machine(
+          ctrl = expr,
+          returnValue = null,
+          frame = null,
+          actuals = null,
+          env = emptyEnv,
+          envBase = 0,
+          kontStack = emptyKontStack,
+          lastLocation = None,
+          ledgerMode = OffLedger,
+          traceLog = traceLog,
+          compiledPackages = compiledPackages,
+          steps = 0,
+          track = Instrumentation(),
+          profile = new Profile(),
+        ))
 
     @throws[PackageNotFound]
     @throws[CompilationError]
@@ -840,10 +843,11 @@ private[lf] object Speedy {
   // We do this by pushing a KFinished continutaion on the initially empty stack, which
   // returns the final result (by raising it as a SpeedyHungry exception).
 
-  private[this] def initialKontStack(): util.ArrayList[Kont] = {
-    val kontStack = new util.ArrayList[Kont](128)
-    kontStack.add(KFinished)
-    kontStack
+  private[speedy] def emptyKontStack: util.ArrayList[Kont] = new util.ArrayList[Kont](128)
+
+  private[this] def pushFinished(machine: Machine): Machine = {
+    machine.pushKont(KFinished(machine))
+    machine
   }
 
   /** Kont, or continuation. Describes the next step for the machine
@@ -852,12 +856,12 @@ private[lf] object Speedy {
   private[speedy] sealed trait Kont {
 
     /** Execute the continuation. */
-    def execute(v: SValue, machine: Machine): Unit
+    def execute(v: SValue): Unit
   }
 
   /** Final continuation; machine has computed final value */
-  private[speedy] final case object KFinished extends Kont {
-    def execute(v: SValue, machine: Machine) = {
+  private[speedy] final case class KFinished(machine: Machine) extends Kont {
+    def execute(v: SValue) = {
       if (enableInstrumentation) {
         machine.track.print()
       }
@@ -865,15 +869,16 @@ private[lf] object Speedy {
     }
   }
 
-  private[speedy] final case class KOverApp(
-      savedBase: Int,
-      newArgs: Array[SExprAtomic],
-      frame: Frame,
-      actuals: Actuals)
+  private[speedy] final case class KOverApp(machine: Machine, newArgs: Array[SExprAtomic])
       extends Kont
       with SomeArrayEquals {
-    def execute(vfun: SValue, machine: Machine) = {
-      machine.restoreBase(savedBase)
+
+    private val savedBase = machine.markBase()
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(vfun: SValue) = {
+      machine.restoreBase(savedBase);
       machine.restoreFrameAndActuals(frame, actuals)
       machine.enterApplication(vfun, newArgs)
     }
@@ -881,14 +886,17 @@ private[lf] object Speedy {
 
   /** The function has been evaluated to a value. Now restore the environment and execute the application */
   private[speedy] final case class KArg(
-      savedBase: Int,
+      machine: Machine,
       newArgs: Array[SExpr],
-      frame: Frame,
-      actuals: Actuals)
-      extends Kont
+  ) extends Kont
       with SomeArrayEquals {
-    def execute(vfun: SValue, machine: Machine) = {
-      machine.restoreBase(savedBase)
+
+    private val savedBase = machine.markBase()
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(vfun: SValue) = {
+      machine.restoreBase(savedBase);
       machine.restoreFrameAndActuals(frame, actuals)
       machine.executeApplication(vfun, newArgs)
     }
@@ -896,12 +904,15 @@ private[lf] object Speedy {
 
   /** The function-closure and arguments have been evaluated. Now execute the body. */
   private[speedy] final case class KFun(
-      savedBase: Int,
+      machine: Machine,
       closure: PClosure,
       actuals: util.ArrayList[SValue])
       extends Kont
       with SomeArrayEquals {
-    def execute(v: SValue, machine: Machine) = {
+
+    private val savedBase = machine.markBase()
+
+    def execute(v: SValue) = {
       actuals.add(v)
       // Set frame/actuals to allow access to the function arguments and closure free-varables.
       machine.restoreBase(savedBase)
@@ -910,7 +921,7 @@ private[lf] object Speedy {
       val label = closure.label
       if (label != null) {
         machine.profile.addOpenEvent(label)
-        machine.pushKont(KLeaveClosure(label))
+        machine.pushKont(KLeaveClosure(machine, label))
       }
       // Start evaluating the body of the closure.
       machine.popTempStackToBase()
@@ -920,11 +931,14 @@ private[lf] object Speedy {
 
   /** The builtin arguments have been evaluated. Now execute the builtin. */
   private[speedy] final case class KBuiltin(
-      savedBase: Int,
+      machine: Machine,
       builtin: SBuiltin,
       actuals: util.ArrayList[SValue])
       extends Kont {
-    def execute(v: SValue, machine: Machine) = {
+
+    private val savedBase = machine.markBase()
+
+    def execute(v: SValue) = {
       actuals.add(v)
       // A builtin has no free-vars, so we set the frame to null.
       machine.restoreBase(savedBase)
@@ -940,9 +954,14 @@ private[lf] object Speedy {
   }
 
   /** The function's partial-arguments have been evaluated. Construct and return the PAP */
-  private[speedy] final case class KPap(prim: Prim, actuals: util.ArrayList[SValue], arity: Int)
+  private[speedy] final case class KPap(
+      machine: Machine,
+      prim: Prim,
+      actuals: util.ArrayList[SValue],
+      arity: Int)
       extends Kont {
-    def execute(v: SValue, machine: Machine) = {
+
+    def execute(v: SValue) = {
       actuals.add(v)
       machine.returnValue = SPAP(prim, actuals, arity)
     }
@@ -1025,15 +1044,16 @@ private[lf] object Speedy {
       .body
   }
 
-  private[speedy] final case class KMatch(
-      savedBase: Int,
-      alts: Array[SCaseAlt],
-      frame: Frame,
-      actuals: Actuals)
+  private[speedy] final case class KMatch(machine: Machine, alts: Array[SCaseAlt])
       extends Kont
       with SomeArrayEquals {
-    def execute(v: SValue, machine: Machine) = {
-      machine.restoreBase(savedBase)
+
+    private val savedBase = machine.markBase()
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(v: SValue) = {
+      machine.restoreBase(savedBase);
       machine.restoreFrameAndActuals(frame, actuals)
       executeMatchAlts(machine, alts, v)
     }
@@ -1046,15 +1066,18 @@ private[lf] object Speedy {
     * direy into the environment.
     */
   private[speedy] final case class KPushTo(
-      savedBase: Int,
+      machine: Machine,
       to: util.ArrayList[SValue],
       next: SExpr,
-      frame: Frame,
-      actuals: Actuals)
-      extends Kont
+  ) extends Kont
       with SomeArrayEquals {
-    def execute(v: SValue, machine: Machine) = {
-      machine.restoreBase(savedBase)
+
+    private val savedBase = machine.markBase()
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(v: SValue) = {
+      machine.restoreBase(savedBase);
       machine.restoreFrameAndActuals(frame, actuals)
       to.add(v)
       machine.ctrl = next
@@ -1062,13 +1085,16 @@ private[lf] object Speedy {
   }
 
   private[speedy] final case class KFoldl(
+      machine: Machine,
       func: SValue,
       var list: FrontStack[SValue],
-      frame: Frame,
-      actuals: Actuals
   ) extends Kont
       with SomeArrayEquals {
-    def execute(acc: SValue, machine: Machine) = {
+
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(acc: SValue) = {
       list.pop match {
         case None =>
           machine.returnValue = acc
@@ -1084,14 +1110,17 @@ private[lf] object Speedy {
   }
 
   private[speedy] final case class KFoldr(
+      machine: Machine,
       func: SValue,
       list: ImmArray[SValue],
       var lastIndex: Int,
-      frame: Frame,
-      actuals: Actuals
   ) extends Kont
       with SomeArrayEquals {
-    def execute(acc: SValue, machine: Machine) = {
+
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(acc: SValue) = {
       if (lastIndex > 0) {
         machine.restoreFrameAndActuals(frame, actuals)
         val currentIndex = lastIndex - 1
@@ -1108,19 +1137,22 @@ private[lf] object Speedy {
   // NOTE: See the explanation above the definition of `SBFoldr` on why we need
   // this continuation and what it does.
   private[speedy] final case class KFoldr1Map(
+      machine: Machine,
       func: SValue,
       var list: FrontStack[SValue],
       var revClosures: FrontStack[SValue],
       init: SValue,
-      frame: Frame,
-      actuals: Actuals
   ) extends Kont
       with SomeArrayEquals {
-    def execute(closure: SValue, machine: Machine) = {
+
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(closure: SValue) = {
       revClosures = closure +: revClosures
       list.pop match {
         case None =>
-          machine.pushKont(KFoldr1Reduce(revClosures, frame, actuals))
+          machine.pushKont(KFoldr1Reduce(machine, revClosures))
           machine.returnValue = init
         case Some((item, rest)) =>
           machine.restoreFrameAndActuals(frame, actuals)
@@ -1134,12 +1166,15 @@ private[lf] object Speedy {
   // NOTE: See the explanation above the definition of `SBFoldr` on why we need
   // this continuation and what it does.
   private[speedy] final case class KFoldr1Reduce(
+      machine: Machine,
       var revClosures: FrontStack[SValue],
-      frame: Frame,
-      actuals: Actuals
   ) extends Kont
       with SomeArrayEquals {
-    def execute(acc: SValue, machine: Machine) = {
+
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(acc: SValue) = {
       revClosures.pop match {
         case None =>
           machine.returnValue = acc
@@ -1160,11 +1195,13 @@ private[lf] object Speedy {
     * large record is updated multiple times.
     */
   private[speedy] final case class KCacheVal(
+      machine: Machine,
       v: SEVal,
       defn: SDefinition,
       stack_trace: List[Location])
       extends Kont {
-    def execute(sv: SValue, machine: Machine): Unit = {
+
+    def execute(sv: SValue): Unit = {
       machine.pushStackTrace(stack_trace)
       v.setCached(sv, stack_trace)
       defn.setCached(sv, stack_trace)
@@ -1178,24 +1215,28 @@ private[lf] object Speedy {
     * evaluated. If 'KCatch' is encountered naturally, then 'fin' is evaluated.
     */
   private[speedy] final case class KCatch(
-      savedBase: Int,
+      machine: Machine,
       handler: SExpr,
       fin: SExpr,
-      frame: Frame,
-      actuals: Actuals,
-      envSize: Int)
-      extends Kont
+  ) extends Kont
       with SomeArrayEquals {
-    def execute(v: SValue, machine: Machine) = {
-      machine.restoreBase(savedBase)
+
+    val envSize = machine.env.size
+
+    private val savedBase = machine.markBase()
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(v: SValue) = {
+      machine.restoreBase(savedBase);
       machine.restoreFrameAndActuals(frame, actuals)
       machine.ctrl = fin
     }
   }
 
   /** A location frame stores a location annotation found in the AST. */
-  final case class KLocation(location: Location) extends Kont {
-    def execute(v: SValue, machine: Machine) = {
+  final case class KLocation(machine: Machine, location: Location) extends Kont {
+    def execute(v: SValue) = {
       machine.returnValue = v
     }
   }
@@ -1204,8 +1245,9 @@ private[lf] object Speedy {
     * used during profiling. Its purpose is to attach a label to closures such
     * that entering the closure can write an "open event" with that label.
     */
-  private[speedy] final case class KLabelClosure(label: Profile.Label) extends Kont {
-    def execute(v: SValue, machine: Machine) = {
+  private[speedy] final case class KLabelClosure(machine: Machine, label: Profile.Label)
+      extends Kont {
+    def execute(v: SValue) = {
       v match {
         case SPAP(PClosure(_, expr, closure), args, arity) =>
           machine.returnValue = SPAP(PClosure(label, expr, closure), args, arity)
@@ -1218,8 +1260,9 @@ private[lf] object Speedy {
   /** Continuation marking the exit of a closure. This is only used during
     * profiling.
     */
-  private[speedy] final case class KLeaveClosure(label: Profile.Label) extends Kont {
-    def execute(v: SValue, machine: Machine) = {
+  private[speedy] final case class KLeaveClosure(machine: Machine, label: Profile.Label)
+      extends Kont {
+    def execute(v: SValue) = {
       machine.profile.addCloseEvent(label)
       machine.returnValue = v
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -280,8 +280,8 @@ private[lf] object Speedy {
         // stack trace it produced back on the continuation stack to get
         // complete stack trace at the use site. Thus, we store the stack traces
         // of top level values separately during their execution.
-        case Some(KCacheVal(m, v, defn, stack_trace)) =>
-          kontStack.set(last_index, KCacheVal(m, v, defn, loc :: stack_trace)); ()
+        case Some(KCacheVal(machine, v, defn, stack_trace)) =>
+          kontStack.set(last_index, KCacheVal(machine, v, defn, loc :: stack_trace)); ()
         case _ => pushKont(KLocation(this, loc))
       }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1221,6 +1221,10 @@ private[lf] object Speedy {
   ) extends Kont
       with SomeArrayEquals {
 
+    // We call [markBase] (as standard) so the continuation may access its temporaries.
+    // In addition [env.size] is recorded for use in [tryHandleException] to allow the
+    // env-stack to be unwound correctly when an exception is thrown.
+
     val envSize = machine.env.size
 
     private val savedBase = machine.markBase()


### PR DESCRIPTION
Cleanups following #8036

This PR improves the interface for constructing continuations.

Prior to this change, many continuations required a whole bunch of parameters to be passed on construction, and the caller was often expected/required to pass specific components on `machine` to make things work.

Now, all continuations take a `machine` parameter as standard, and then the code which implements the continuation picks out those parts of the machine which it actually requires. This means the code which selects what components are required is directly adjacent to the code which makes use of these components. For example, in `KMatch`

```
  private[speedy] final case class KMatch(machine: Machine, alts: Array[SCaseAlt])
      extends Kont
      with SomeArrayEquals {

    private val savedBase = machine.markBase()
    private val frame = machine.frame
    private val actuals = machine.actuals

    def execute(v: SValue) = {
      machine.restoreBase(savedBase);
      machine.restoreFrameAndActuals(frame, actuals)
      executeMatchAlts(machine, alts, v)
    }
  }
```

This seems much cleaner. Information is more localized in the code.

As a secondary benefit of having `machine` passed when continuations are constructed, we no longer need to pass `machine` to the `execute` method. This makes a lot of sense: It captures the notion that a continuation is created w.r.t a specific machine. -- i.e. you cant create it on one machine, and execute it on another!


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
