### PR TITLE
Remove ParticipantPruningIT from compatibility exceptions

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -21,8 +21,6 @@ load("//:versions.bzl", "latest_stable_version")
 #   - https://github.com/digital-asset/daml/pull/7829
 # - ContractKeysSubmitterIsMaintainerIT:
 #   - https://github.com/digital-asset/daml/pull/5611
-# - ParticipantPruningIT:
-#   - https://github.com/digital-asset/daml/pull/7988
 
 last_nongranular_test_tool = "1.3.0-snapshot.20200617.4484.0.7e0a6848"
 first_granular_test_tool = "1.3.0-snapshot.20200623.4546.0.4f68cfc4"
@@ -149,17 +147,6 @@ excluded_test_tool_tests = [
                     "ContractKeysIT:CKFetchOrLookup",
                     "ContractKeysIT:CKNoFetchUndisclosed",
                 ],
-            },
-        ],
-    },
-    {
-        "start": "0.0.0",  #fix to first snapshot after now
-        "platform_ranges": [
-            {
-                "start": "1.0.0",
-                "end": "1.8.0-snapshot.20201117.5661.0.76fae40c",
-                # See https://github.com/digital-asset/daml/pull/7988
-                "exclusions": ["ParticipantPruningIT"],
             },
         ],
     },


### PR DESCRIPTION
Since https://github.com/digital-asset/daml/pull/8041 ParticipantPruningIT is no longer included by default on any ledger, so removing the exception from the compat tests seems like the right thing to do.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
