### PR TITLE
Fix the paths of the files in protobufs.zip.

### DIFF
--- a/bazel_tools/proto.bzl
+++ b/bazel_tools/proto.bzl
@@ -180,7 +180,6 @@ def proto_jars(
         proto_deps = [],
         java_deps = [],
         scala_deps = [],
-        file_root = None,
         javadoc_root_packages = [],
         maven_group = None,
         maven_artifact_prefix = None,
@@ -191,7 +190,6 @@ def proto_jars(
         srcs = srcs,
         extension = "tar.gz",
         strip_prefix = strip_import_prefix,
-        package_dir = file_root,
         visibility = ["//visibility:public"],
     )
 

--- a/daml-lf/archive/BUILD.bazel
+++ b/daml-lf/archive/BUILD.bazel
@@ -37,10 +37,6 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
         proto_jars(
             name = "daml_lf_%s_archive_proto" % version,
             srcs = [":daml_lf_%s_archive_proto_srcs" % version],
-            file_root = "com/{package}/daml_lf_{version}".format(
-                package = lf_version_package(version),
-                version = mangle_for_java(version),
-            ),
             javadoc_root_packages = [
                 "com.{package}.daml_lf_{version}".format(
                     package = lf_version_package(version),


### PR DESCRIPTION
Turns out the `package_dir` is not what we're looking for. Omitting it fixes the path.

_Before:_

```
     1766  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_8/com/digitalasset/daml_lf_1_8/daml_lf.proto
```

_After:_

```
     1766  2010-01-01 00:00   protos-0.0.0/com/digitalasset/daml_lf_1_8/daml_lf.proto
```

I tried to write a `sh_test` for this, but Bazel, data dependencies, and `rlocation` beat me.

Fix for #8084.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
