### PR TITLE
Enable multiple parties in command deduplication

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -187,21 +187,21 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
 
   override def deduplicateCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
       submittedAt: Instant,
       deduplicateUntil: Instant,
   )(implicit loggingContext: LoggingContext): Future[v2.CommandDeduplicationResult] =
     Timed.future(
       metrics.daml.services.index.deduplicateCommand,
-      delegate.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil))
+      delegate.deduplicateCommand(commandId, submitters, submittedAt, deduplicateUntil))
 
   override def stopDeduplicatingCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
   )(implicit loggingContext: LoggingContext): Future[Unit] =
     Timed.future(
       metrics.daml.services.index.stopDeduplicateCommand,
-      delegate.stopDeduplicatingCommand(commandId, submitter))
+      delegate.stopDeduplicatingCommand(commandId, submitters))
 
   override def prune(pruneUpToInclusive: Offset)(
       implicit loggingContext: LoggingContext): Future[Unit] =

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -125,7 +125,7 @@ private[apiserver] final class ApiSubmissionService private (
     submissionService
       .deduplicateCommand(
         commands.commandId,
-        commands.submitter,
+        List(commands.submitter),
         commands.submittedAt,
         commands.deduplicateUntil,
       )
@@ -136,7 +136,7 @@ private[apiserver] final class ApiSubmissionService private (
             .recoverWith {
               case NonFatal(originalCause) =>
                 submissionService
-                  .stopDeduplicatingCommand(commands.commandId, commands.submitter)
+                  .stopDeduplicatingCommand(commands.commandId, List(commands.submitter))
                   .transform(_ => Failure(originalCause))
             }
         case _: CommandDeduplicationDuplicate =>

--- a/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
@@ -296,17 +296,17 @@ private[platform] final class LedgerBackedIndexService(
   /** Deduplicate commands */
   override def deduplicateCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
       submittedAt: Instant,
       deduplicateUntil: Instant,
   )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult] =
-    ledger.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil)
+    ledger.deduplicateCommand(commandId, submitters, submittedAt, deduplicateUntil)
 
   override def stopDeduplicatingCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
   )(implicit loggingContext: LoggingContext): Future[Unit] =
-    ledger.stopDeduplicatingCommand(commandId, submitter)
+    ledger.stopDeduplicatingCommand(commandId, submitters)
 
   /** Participant pruning command */
   override def prune(pruneUpToInclusive: Offset)(

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -160,13 +160,13 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
 
   override def deduplicateCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
       submittedAt: Instant,
       deduplicateUntil: Instant,
   )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult] =
     Timed.future(
       metrics.daml.index.deduplicateCommand,
-      ledger.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil))
+      ledger.deduplicateCommand(commandId, submitters, submittedAt, deduplicateUntil))
 
   override def removeExpiredDeduplicationData(currentTime: Instant)(
       implicit loggingContext: LoggingContext,
@@ -177,11 +177,11 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
 
   override def stopDeduplicatingCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
   )(implicit loggingContext: LoggingContext): Future[Unit] =
     Timed.future(
       metrics.daml.index.stopDeduplicatingCommand,
-      ledger.stopDeduplicatingCommand(commandId, submitter))
+      ledger.stopDeduplicatingCommand(commandId, submitters))
 
   override def prune(pruneUpToInclusive: Offset)(
       implicit loggingContext: LoggingContext): Future[Unit] =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -179,21 +179,21 @@ private[platform] abstract class BaseLedger(
 
   override def deduplicateCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
       submittedAt: Instant,
       deduplicateUntil: Instant,
   )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult] =
-    ledgerDao.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil)
+    ledgerDao.deduplicateCommand(commandId, submitters, submittedAt, deduplicateUntil)
 
   override def removeExpiredDeduplicationData(currentTime: Instant)(
       implicit loggingContext: LoggingContext,
   ): Future[Unit] =
     ledgerDao.removeExpiredDeduplicationData(currentTime)
 
-  override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party)(
+  override def stopDeduplicatingCommand(commandId: CommandId, submitters: List[Party])(
       implicit loggingContext: LoggingContext,
   ): Future[Unit] =
-    ledgerDao.stopDeduplicatingCommand(commandId, submitter)
+    ledgerDao.stopDeduplicatingCommand(commandId, submitters)
 
   override def prune(pruneUpToInclusive: Offset)(
       implicit loggingContext: LoggingContext): Future[Unit] =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
@@ -135,7 +135,7 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
     */
   def deduplicateCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
       submittedAt: Instant,
       deduplicateUntil: Instant,
   )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult]
@@ -148,7 +148,7 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
     */
   def stopDeduplicatingCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
   )(implicit loggingContext: LoggingContext): Future[Unit]
 
   /**

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -123,7 +123,7 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
   /** Deduplicates commands.
     *
     * @param commandId The command Id
-    * @param submitters The submitting party
+    * @param submitters The submitting parties
     * @param submittedAt The time when the command was submitted
     * @param deduplicateUntil The time until which the command should be deduplicated
     * @return whether the command is a duplicate or not

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -123,14 +123,14 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
   /** Deduplicates commands.
     *
     * @param commandId The command Id
-    * @param submitter The submitting party
+    * @param submitters The submitting party
     * @param submittedAt The time when the command was submitted
     * @param deduplicateUntil The time until which the command should be deduplicated
     * @return whether the command is a duplicate or not
     */
   def deduplicateCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
       submittedAt: Instant,
       deduplicateUntil: Instant,
   )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult]
@@ -158,12 +158,12 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
     * window before they could send a retry.
     *
     * @param commandId The command Id
-    * @param submitter The submitting party
+    * @param submitters The submitting party
     * @return
     */
   def stopDeduplicatingCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
   )(implicit loggingContext: LoggingContext): Future[Unit]
 
   /**

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -158,7 +158,7 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
     * window before they could send a retry.
     *
     * @param commandId The command Id
-    * @param submitters The submitting party
+    * @param submitters The submitting parties
     * @return
     */
   def stopDeduplicatingCommand(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -123,13 +123,13 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
 
   override def deduplicateCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
       submittedAt: Instant,
       deduplicateUntil: Instant,
   )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult] =
     Timed.future(
       metrics.daml.index.db.deduplicateCommand,
-      ledgerDao.deduplicateCommand(commandId, submitter, submittedAt, deduplicateUntil))
+      ledgerDao.deduplicateCommand(commandId, submitters, submittedAt, deduplicateUntil))
 
   override def removeExpiredDeduplicationData(currentTime: Instant)(
       implicit loggingContext: LoggingContext,
@@ -138,12 +138,12 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
       metrics.daml.index.db.removeExpiredDeduplicationData,
       ledgerDao.removeExpiredDeduplicationData(currentTime))
 
-  override def stopDeduplicatingCommand(commandId: CommandId, submitter: Party)(
+  override def stopDeduplicatingCommand(commandId: CommandId, submitters: List[Party])(
       implicit loggingContext: LoggingContext,
   ): Future[Unit] =
     Timed.future(
       metrics.daml.index.db.stopDeduplicatingCommand,
-      ledgerDao.stopDeduplicatingCommand(commandId, submitter))
+      ledgerDao.stopDeduplicatingCommand(commandId, submitters))
 
   override def prune(pruneUpToInclusive: Offset)(
       implicit loggingContext: LoggingContext): Future[Unit] =

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCommandDeduplicationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCommandDeduplicationSpec.scala
@@ -1,0 +1,101 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao
+
+import java.time.Instant
+import java.util.UUID
+
+import com.daml.ledger.api.domain.CommandId
+import com.daml.ledger.participant.state.index.v2.{
+  CommandDeduplicationDuplicate,
+  CommandDeduplicationNew
+}
+import org.scalatest.{AsyncFlatSpec, Matchers}
+
+private[dao] trait JdbcLedgerDaoCommandDeduplicationSpec {
+  this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
+
+  behavior of "JdbcLedgerDao (comman deduplication)"
+
+  it should "correctly deduplicate a command" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original <- ledgerDao.deduplicateCommand(commandId, List(alice), t(0), t(5000))
+      duplicate <- ledgerDao.deduplicateCommand(commandId, List(alice), t(500), t(5500))
+    } yield {
+      original shouldBe CommandDeduplicationNew
+      duplicate shouldBe CommandDeduplicationDuplicate(t(5000))
+    }
+  }
+
+  it should "correctly deduplicate commands with multiple submitters" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original <- ledgerDao.deduplicateCommand(commandId, List(alice, bob), t(0), t(5000))
+      duplicate1 <- ledgerDao.deduplicateCommand(commandId, List(alice, bob), t(500), t(5500))
+      duplicate2 <- ledgerDao.deduplicateCommand(commandId, List(bob, alice), t(500), t(5500))
+      duplicate3 <- ledgerDao.deduplicateCommand(
+        commandId,
+        List(alice, bob, alice),
+        t(500),
+        t(5500))
+    } yield {
+      original shouldBe CommandDeduplicationNew
+      duplicate1 shouldBe CommandDeduplicationDuplicate(t(5000))
+      duplicate2 shouldBe CommandDeduplicationDuplicate(t(5000))
+      duplicate3 shouldBe CommandDeduplicationDuplicate(t(5000))
+    }
+  }
+
+  it should "not deduplicate a command after it expired" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original1 <- ledgerDao.deduplicateCommand(commandId, List(alice), t(0), t(100))
+      original2 <- ledgerDao.deduplicateCommand(commandId, List(alice), t(101), t(200))
+    } yield {
+      original1 shouldBe CommandDeduplicationNew
+      original2 shouldBe CommandDeduplicationNew
+    }
+  }
+
+  it should "not deduplicate a command after it was cancelled" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original1 <- ledgerDao.deduplicateCommand(commandId, List(alice), t(0), t(10000))
+      _ <- ledgerDao.stopDeduplicatingCommand(commandId, List(alice))
+      original2 <- ledgerDao.deduplicateCommand(commandId, List(alice), t(1), t(10001))
+    } yield {
+      original1 shouldBe CommandDeduplicationNew
+      original2 shouldBe CommandDeduplicationNew
+    }
+  }
+
+  it should "not deduplicate commands with different command ids" in {
+    val commandId1: CommandId = CommandId(UUID.randomUUID.toString)
+    val commandId2: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original1 <- ledgerDao.deduplicateCommand(commandId1, List(alice, bob), t(0), t(1000))
+      original2 <- ledgerDao.deduplicateCommand(commandId2, List(alice, bob), t(0), t(1000))
+    } yield {
+      original1 shouldBe CommandDeduplicationNew
+      original2 shouldBe CommandDeduplicationNew
+    }
+  }
+
+  it should "not deduplicate commands with different submitters" in {
+    val commandId: CommandId = CommandId(UUID.randomUUID.toString)
+    for {
+      original1 <- ledgerDao.deduplicateCommand(commandId, List(alice, bob), t(0), t(1000))
+      original2 <- ledgerDao.deduplicateCommand(commandId, List(alice, charlie), t(0), t(1000))
+    } yield {
+      original1 shouldBe CommandDeduplicationNew
+      original2 shouldBe CommandDeduplicationNew
+    }
+  }
+
+  private[this] val t0 = Instant.now()
+  private[this] def t(ms: Long): Instant = {
+    t0.plusMillis(ms)
+  }
+}

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoCompletionsSpec.scala
@@ -86,8 +86,6 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
     }
   }
 
-  // Disabled, because it depends on multi-party command deduplication
-  /*
   it should "return the expected completion for a multi-party rejection" in {
     val expectedCmdId = UUID.randomUUID.toString
     for {
@@ -112,7 +110,6 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
       response3.completions.loneElement.commandId shouldBe expectedCmdId
     }
   }
-   */
 
   it should "not return completions if the application id is wrong" in {
     for {
@@ -144,8 +141,6 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
     }
   }
 
-  // Disabled, because it depends on multi-party command deduplication
-  /*
   it should "not return completions if the parties do not match (multi-party submission)" in {
     for {
       from <- ledgerDao.lookupLedgerEnd()
@@ -162,7 +157,6 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
       response2 shouldBe Seq.empty
     }
   }
-   */
 
   it should "return the expected status for each rejection reason" in {
     val reasons = Seq[RejectionReason](
@@ -208,11 +202,9 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
       .map(_ => offset)
   }
 
-  // Disabled, because it depends on multi-party command deduplication
-  /*
   private def storeMultiPartyRejection(
       reason: RejectionReason,
-      commandId: String,
+      commandId: String = UUID.randomUUID().toString,
   ): Future[Offset] = {
     lazy val offset = nextOffset()
     ledgerDao
@@ -225,7 +217,6 @@ private[dao] trait JdbcLedgerDaoCompletionsSpec extends OptionValues with LoneEl
       )
       .map(_ => offset)
   }
- */
 }
 
 private[dao] object JdbcLedgerDaoCompletionsSpec {

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexSubmissionService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexSubmissionService.scala
@@ -18,13 +18,13 @@ import scala.concurrent.Future
 trait IndexSubmissionService {
   def deduplicateCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
       submittedAt: Instant,
       deduplicateUntil: Instant,
   )(implicit loggingContext: LoggingContext): Future[CommandDeduplicationResult]
 
   def stopDeduplicatingCommand(
       commandId: CommandId,
-      submitter: Ref.Party,
+      submitters: List[Ref.Party],
   )(implicit loggingContext: LoggingContext): Future[Unit]
 }


### PR DESCRIPTION
This PR prepares participant-side command deduplication for multi-party submissions.


This PR is based on https://github.com/digital-asset/daml/pull/8035, and should be merged after it.