### PR TITLE
release: Remove "plain" JARs from the release application.

### DIFF
--- a/release/src/Util.hs
+++ b/release/src/Util.hs
@@ -70,23 +70,19 @@ data ReleaseType
     deriving (Eq, Show)
 
 data JarType
-    = Plain
-      -- ^ Plain java or scala library, without source jar.
-    | Lib
+    = Lib
       -- ^ A java library jar, with source and javadoc jars.
     | Deploy
       -- ^ Deploy jar, e.g. a fat jar containing transitive deps.
     | Proto
       -- ^ A java protobuf library (*-speed.jar).
     | Scala
-      -- ^ A scala library jar, with source and scaladoc jars. Use when
-      -- source or scaladoc is desired, otherwise use 'Plain'.
+      -- ^ A scala library jar, with source and scaladoc jars.
     deriving (Eq, Show)
 
 instance FromJSON ReleaseType where
     parseJSON = withText "ReleaseType" $ \t ->
         case t of
-            "jar" -> pure $ Jar Plain
             "jar-lib" -> pure $ Jar Lib
             "jar-deploy" -> pure $ Jar Deploy
             "jar-proto" -> pure $ Jar Proto
@@ -210,7 +206,6 @@ mainExt Jar{} = "jar"
 
 mainFileName :: ReleaseType -> Text -> Text
 mainFileName (Jar jarTy) name = case jarTy of
-    Plain -> name <> ".jar"
     Lib -> "lib" <> name <> ".jar"
     Deploy -> name <> "_deploy.jar"
     Proto -> "lib" <> T.replace "_java" "" name <> "-speed.jar"


### PR DESCRIPTION
We don't use them, and they are broken anyway, because Maven demands Javadoc JARs and our "plain" jars don't provide them.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
