### PR TITLE
kvutils: Publish the Protobuf definition. [KVL-714]

### DIFF
--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -103,6 +103,8 @@
   type: jar-scala
 - target: //ledger/participant-state:participant-state
   type: jar-scala
+- target: //ledger/participant-state/kvutils:daml_kvutils_proto_jar
+  type: jar-lib
 - target: //ledger/participant-state/kvutils:daml_kvutils_proto_java
   type: jar-proto
 - target: //ledger/participant-state/kvutils:kvutils


### PR DESCRIPTION
This publishes a JAR to Maven Central with the kvutils protobuf definitions.

It does not include them in _protobufs.zip_ for GitHub Releases, as they're only intended for integrators (such as yours truly), not users.

### Changelog

- **[Integration Kit]** The kvutils Protobuf definition is now published to Maven Central in a JAR, under the group "com.daml", with the artifact name "participant-state-kvutils-proto".

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
