### PR TITLE
Exclude dev-dar in sandbox compatiblity tests

### DIFF
--- a/compatibility/bazel_tools/daml_sdk.bzl
+++ b/compatibility/bazel_tools/daml_sdk.bzl
@@ -162,7 +162,7 @@ cc_binary(
 # are used by the ledger API test tool.
 filegroup(
     name = "dar-files",
-    srcs = glob(["extracted-test-tool/ledger/test-common/**"]),
+    srcs = glob(["extracted-test-tool/ledger/test-common/**"], exclude = ["**/*-dev.dar"]),
 )
 exports_files(["daml-types.tgz", "daml-ledger.tgz", "daml-react.tgz", "create_daml_app.patch"])
 """.format(version = ctx.attr.version),


### PR DESCRIPTION
By definition, dev doesn’t guarantee any kind of compatibility so
trying to load it into Sandbox can fail. somewhat surprisingly it only
started failing now which I guess shows that we haven’t changed LF too
much recently.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
