### PR TITLE
Exclude tests relying on 1.dev

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -28,6 +28,15 @@ first_granular_test_tool = "1.3.0-snapshot.20200623.4546.0.4f68cfc4"
 excluded_test_tool_tests = [
     {
         "start": "1.0.0",
+        "end": "1.0.1",
+        "platform_ranges": [
+            {
+                "exclusions": ["ContractKeysSubmitterIsMaintainerIT"],
+            },
+        ],
+    },
+    {
+        "start": "1.0.0",
         "end": "1.0.0",
         "platform_ranges": [
             {
@@ -37,7 +46,7 @@ excluded_test_tool_tests = [
             },
             {
                 "start": "1.1.0-snapshot.20200430.4057.0.681c862d",
-                "exclusions": ["ContractKeysIT", "ContractKeysSubmitterIsMaintainerIT"],
+                "exclusions": ["ContractKeysIT"],
             },
         ],
     },
@@ -48,10 +57,6 @@ excluded_test_tool_tests = [
             {
                 "end": "1.0.1-snapshot.20200417.3908.1.722bac90",
                 "exclusions": ["ContractKeysIT"],
-            },
-            {
-                "start": "1.1.0-snapshot.20200430.4057.0.681c862d",
-                "exclusions": ["ContractKeysSubmitterIsMaintainerIT"],
             },
         ],
     },


### PR DESCRIPTION
follow-up to #8099. If we don’t load the 1.dev dar in sandbox which is
totally sensible, we obviously also cannot run tests against it. In
newer test tool versions that’s not an issue but for older versions we
still need to exclude that one test.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
