### PR TITLE
ts/ledger: party management API

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/package.json
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
+    "@types/lodash": "4.14.161",
     "@types/node": "^12.12.14",
     "@types/wait-on": "^3.2.0",
     "@typescript-eslint/eslint-plugin": "^2.16.0",

--- a/language-support/ts/daml-ledger/README.md
+++ b/language-support/ts/daml-ledger/README.md
@@ -109,6 +109,22 @@ format of the JSON API. See the [JSON API docs] for details.
 
 [JSON API docs]: https://docs.daml.com/json-api/lf-value-specification.html
 
+`getParties`
+------------
+
+For a given list of party identifiers, returns full information, or null if
+the party doesn't exist.
+
+`listKnownParties`
+------------------
+
+Returns an array of PartyInfo for all parties on the ledger.
+
+`allocateParty`
+---------------
+
+Allocates a new party.
+
 ## Source
 
 https://github.com/digital-asset/daml/tree/master/language-support/ts/daml-ledger


### PR DESCRIPTION
This PR adds TS bindings coverage for the party management methods of the JSON API.

```
CHANGELOG_BEGIN

- [JavaScript Client Libraries] The Ledger object (returned by
  `useLedger` through the React bindings) has three new methods covering
  the Party management API: `fetchPartiesInfo` allows users to, based on
  a party id (or party ids, as the name suggests) fetch more information
  about the party or check for its existence; `fetchAllPartiesInfo` will
  return a list of all known parties, and `allocateParty` will allocate
  a new party.

CHANGELOG_END
```