### PR TITLE
TransactionCommitter: remove Fetch and LookupByKey nodes [KVL-738]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionIndexing.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionIndexing.scala
@@ -77,6 +77,15 @@ object TransactionIndexing {
     private val disclosure = Map.newBuilder[NodeId, Set[Party]]
     private val visibility = Vector.newBuilder[(ContractId, Set[Party])]
 
+    init()
+
+    private def init(): Unit = {
+      for (contractId <- blinding.divulgence.keys) {
+        addDivulgence(contractId)
+      }
+      ()
+    }
+
     private def addEventAndDisclosure(event: (NodeId, Node)): Unit = {
       events += event
       disclosure += ((event._1, blinding.disclosure(event._1)))
@@ -116,8 +125,6 @@ object TransactionIndexing {
           } else {
             addStakeholders(nodeId, Set.empty)
           }
-        case (_, fetch: Fetch) =>
-          addDivulgence(fetch.coid)
         case _ =>
           () // ignore anything else
       }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionIndexing.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionIndexing.scala
@@ -77,13 +77,8 @@ object TransactionIndexing {
     private val disclosure = Map.newBuilder[NodeId, Set[Party]]
     private val visibility = Vector.newBuilder[(ContractId, Set[Party])]
 
-    init()
-
-    private def init(): Unit = {
-      for (contractId <- blinding.divulgence.keys) {
-        addDivulgence(contractId)
-      }
-      ()
+    for (contractId <- blinding.divulgence.keys) {
+      addDivulgence(contractId)
     }
 
     private def addEventAndDisclosure(event: (NodeId, Node)): Unit = {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsWriter.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsWriter.scala
@@ -79,6 +79,9 @@ private[dao] final class TransactionsWriter(
       blindingInfo: Option[BlindingInfo],
   ): TransactionsWriter.PreparedInsert = {
 
+    // Backwards-compatibility: blinding info was previously not pre-computed and saved by the committer
+    // but rather computed on the read path from Fetch and LookupByKey nodes (now trimmed just before
+    // commit, for storage reduction).
     val blinding = blindingInfo.getOrElse(Blinding.blind(transaction))
 
     val indexing =

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionIndexingSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/events/TransactionIndexingSpec.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao.events
+
+import java.time.Instant
+
+import com.daml.ledger
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.lf.transaction.BlindingInfo
+import com.daml.lf.transaction.test.TransactionBuilder
+import org.scalatest.{Matchers, WordSpec}
+
+final class TransactionIndexingSpec extends WordSpec with Matchers {
+  "TransactionIndexing" should {
+    "apply blindingInfo divulgence upon construction" in {
+      val aContractId = ContractId.assertFromString("#c0")
+      val aDivulgedParty = Party.assertFromString("aParty")
+      val aDivulgence = Map(aContractId -> Set(aDivulgedParty))
+      val anOffset = Offset.fromByteArray(Array.emptyByteArray)
+      val aTransactionId = ledger.TransactionId.assertFromString("0")
+
+      val anInstant = Instant.EPOCH
+      val aCommittedTransaction = TransactionBuilder().buildCommitted()
+
+      TransactionIndexing
+        .from(
+          blindingInfo = BlindingInfo(Map.empty, aDivulgence),
+          submitterInfo = None,
+          workflowId = None,
+          aTransactionId,
+          anInstant,
+          anOffset,
+          aCommittedTransaction,
+          Iterable.empty,
+        )
+        .contractWitnesses should be(
+        TransactionIndexing
+          .ContractWitnessesInfo(Set.empty, aDivulgence)
+      )
+    }
+  }
+}

--- a/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
+++ b/ledger/participant-state/kvutils/src/main/protobuf/daml_kvutils.proto
@@ -173,7 +173,7 @@ message DamlTransactionEntry {
   // The time used to derive contract ids
   google.protobuf.Timestamp submission_time = 6;
 
-  // The pre-computed transaction blinding information. Optional.
+  // The pre-computed transaction blinding information.
   DamlTransactionBlindingInfo blinding_info = 7;
 }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -27,6 +27,7 @@ import com.daml.lf.transaction.{
   NodeId,
   ReplayNodeMismatch,
   SubmittedTransaction,
+  TransactionOuterClass,
   VersionedTransaction,
   Transaction => Tx
 }
@@ -69,7 +70,8 @@ private[kvutils] class TransactionCommitter(
     "validate_ledger_time" -> validateLedgerTime,
     "validate_contract_keys" -> validateContractKeys,
     "validate_model_conformance" -> validateModelConformance,
-    "blind" -> blind
+    "blind" -> blind,
+    "remove_unnecessary_nodes" -> removeUnnecessaryNodes,
   )
 
   private def contractIsActiveAndVisibleToSubmitter(
@@ -291,7 +293,7 @@ private[kvutils] class TransactionCommitter(
   private[committer] def blind: Step =
     (commitContext, transactionEntry) => {
       val blindingInfo = Blinding.blind(transactionEntry.transaction)
-      buildFinalResult(
+      buildFinalResultState(
         commitContext,
         transactionEntry.copy(
           submission = transactionEntry.submission.toBuilder
@@ -300,6 +302,51 @@ private[kvutils] class TransactionCommitter(
         blindingInfo,
       )
     }
+
+  /**
+    * Removes `Fetch` and `LookupByKey` nodes from the transactionEntry
+    */
+  private[committer] def removeUnnecessaryNodes: Step = (commitContext, transactionEntry) => {
+    val transaction = transactionEntry.submission.getTransaction
+    val nodes = transaction.getNodesList.asScala
+    val nodesToKeep = nodes.iterator.collect {
+      case node if node.hasCreate || node.hasExercise => node.getNodeId
+    }.toSet
+
+    val roots = transaction.getRootsList.asScala.filter(nodesToKeep)
+
+    def stripUnnecessaryNodes(node: TransactionOuterClass.Node) =
+      if (node.hasExercise) {
+        val exerciseNode = node.getExercise
+        val keep = exerciseNode.getChildrenList.asScala.filter(nodesToKeep)
+        val newExercise = exerciseNode.toBuilder
+          .clearChildren()
+          .addAllChildren(keep.asJavaCollection)
+          .build()
+
+        node.toBuilder
+          .setExercise(newExercise)
+          .build()
+      } else node
+
+    val newNodes = nodes
+      .collect {
+        case node if nodesToKeep(node.getNodeId) => stripUnnecessaryNodes(node)
+      }
+
+    val newTx = transaction
+      .newBuilderForType()
+      .addAllRoots(roots.asJavaCollection)
+      .addAllNodes(newNodes.asJavaCollection)
+      .setVersion(transaction.getVersion)
+      .build()
+
+    val newTxEntry = transactionEntry.submission.toBuilder
+      .setTransaction(newTx)
+      .build()
+
+    StepStop(buildLogEntry(DamlTransactionEntrySummary(newTxEntry), commitContext))
+  }
 
   private def validateContractKeys: Step = (commitContext, transactionEntry) => {
     val damlState = commitContext.inputs
@@ -411,7 +458,7 @@ private[kvutils] class TransactionCommitter(
   }
 
   /** All checks passed. Produce the log entry and contract state updates. */
-  private def buildFinalResult(
+  private def buildFinalResultState(
       commitContext: CommitContext,
       transactionEntry: DamlTransactionEntrySummary,
       blindingInfo: BlindingInfo
@@ -431,7 +478,7 @@ private[kvutils] class TransactionCommitter(
 
     metrics.daml.kvutils.committer.transaction.accepts.inc()
     logger.trace(s"Transaction accepted, correlationId=${transactionEntry.commandId}")
-    StepStop(buildLogEntry(transactionEntry, commitContext))
+    StepContinue(transactionEntry)
   }
 
   private def updateContractState(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
@@ -118,9 +118,8 @@ class TransactionCommitterSpec extends WordSpec with Matchers with MockitoSugar 
       val context = new FakeCommitContext(recordTime = None)
 
       instance.removeUnnecessaryNodes(context, aRichTransactionTreeSummary) match {
-        case StepContinue(_) => fail("should be StepStop")
-        case StepStop(logEntry) =>
-          val transaction = logEntry.getTransactionEntry.getTransaction
+        case StepContinue(logEntry) =>
+          val transaction = logEntry.submission.getTransaction
           transaction.getRootsList.asScala should contain theSameElementsInOrderAs Seq(
             "Exercise-1",
             "Create-1")
@@ -131,12 +130,12 @@ class TransactionCommitterSpec extends WordSpec with Matchers with MockitoSugar 
             "Create-3",
             "Exercise-2",
             "Exercise-1")
-          nodes.head.hasCreate shouldBe true
           nodes(3).getExercise.getChildrenList.asScala should contain theSameElementsInOrderAs Seq(
             "Create-3")
           nodes(4).getExercise.getChildrenList.asScala should contain theSameElementsInOrderAs Seq(
             "Create-2",
             "Exercise-2")
+        case StepStop(_) => fail("should be StepContinue")
       }
     }
   }


### PR DESCRIPTION
## Description

This is the fifth and last of a series of changes (after #8012) that will shift back blinding information computation from the read path to the write path for storage reduction.

This change actually removes `Fetch` and `LookupByKey` transaction nodes as the last stage of `TransactionCommitter`, reducing storage usage (KV only).

Most of this change consists of re-applying #7743.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
