### PR TITLE
Support listKnownParties in DAML Script over JSON API

### DIFF
--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -227,7 +227,12 @@ jsonExpectedFailureCreateAndExercise : Party -> Script ()
 jsonExpectedFailureCreateAndExercise p = submitMustFail p $ createAndExerciseCmd (C p 0) ShouldFail
 
 jsonAllocateParty : Text -> Script Party
-jsonAllocateParty p = allocatePartyWithHint p (PartyIdHint p)
+jsonAllocateParty p = do
+  pre <- listKnownParties
+  r <- allocatePartyWithHint p (PartyIdHint p)
+  post <- listKnownParties
+  sort (PartyDetails r (Some p) True :: pre) === sort post
+  pure r
 
 jsonMultiParty : (Party, Party) -> Script ()
 jsonMultiParty (alice, bob) = do

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -333,7 +333,7 @@ final class JsonApiIt
         assert(result == SUnit)
       }
     }
-    "allocateParty" in {
+    "party management" in {
       for {
         clients <- getClients(parties = List(), admin = true)
         result <- run(


### PR DESCRIPTION
fixes #6374

changelog_begin

- [DAML Script] listKnownParties is now also supported when running
  over the JSON API.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
