### PR TITLE
Remove password option from Navigator

### DIFF
--- a/navigator/backend/README.md
+++ b/navigator/backend/README.md
@@ -29,7 +29,6 @@ cat << EOF > navigator.conf
 users {
   OPERATOR: {
     party=OPERATOR
-    password=operator_password
   }
 }
 EOF
@@ -166,11 +165,11 @@ right corner and also that you have to be logged in order to run queries. You
 can either use the frontend in the same browser to login or you can login
 manually via command line as follows:
 
-- Send a JSON POST request with the `userId` and the `password` and make note of
+- Send a JSON POST request with the `userId` and make note of
   the cookie:
 
   ```bash
-  > curl -H "Content-Type: application/json" -d'{ "userId":"PARTY", "password":"password" }' localhost:4000/api/session/ -i
+  > curl -H "Content-Type: application/json" -d'{ "userId":"PARTY" }' localhost:4000/api/session/ -i
   HTTP/1.1 200 OK
   Set-Cookie: session-id=8b4601d4-7113-407b-9b81-7fd5b213a96b; Path=/
   Server: akka-http/10.0.4
@@ -194,10 +193,8 @@ Session API
 
 In addition to the GraphQL endpoint exposing data, the user needs to act as
 some party. This is to know which party's "view" on the ledger to expose. The
-backend supplies the frontend with a list of available users. Alternatively, if
-the backend is started with the `--require-password` flag, it will not supply a
-list of users and instead ask the frontend to present the user with a standard
-username/password form. The chosen user is set in a cookie and therefore
+backend supplies the frontend with a list of available users.
+The chosen user is set in a cookie and therefore
 persists across reloads.
 
 ```typescript
@@ -219,8 +216,7 @@ type SignIn = {
   error?: 'invalid-credentials';
 }
 
-type SignInMethod = SignInPassword | SignInSelect
-type SignInPassword = { type: 'password' }
+type SignInMethod = SignInSelect
 type SignInSelect = { type: 'select', users: UserId[] }
 ```
 
@@ -229,7 +225,7 @@ type SignInSelect = { type: 'select', users: UserId[] }
 GET /session/ => Status
 
 # Sign in
-POST /session/ -d'{ userId: UserId, password?: String }' => Status
+POST /session/ -d'{ userId: UserId }' => Status
 
 # Sign out
 DELETE /session/ => SignIn

--- a/navigator/backend/scenarios/rental/ui-backend.conf
+++ b/navigator/backend/scenarios/rental/ui-backend.conf
@@ -1,14 +1,11 @@
 users {
     Betina_Beakley {
         party=Betina_Beakley
-        password=password
     }
     Scrooge_McDuck {
         party=Scrooge_McDuck
-        password=password
     }
     OPERATOR {
         party=OPERATOR
-        password=password
     }
 }

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
@@ -168,11 +168,7 @@ class PlatformStore(
         }
         self ! Subscribe(
           displayName,
-          UserConfig(
-            password = None,
-            party = ApiTypes.Party(partyDetails.party),
-            role = None,
-            useDatabase = false))
+          UserConfig(party = ApiTypes.Party(partyDetails.party), role = None, useDatabase = false))
       }
 
     case Subscribe(displayName, config) =>

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/SessionJsonProtocolTest.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/SessionJsonProtocolTest.scala
@@ -18,10 +18,8 @@ class SessionJsonProtocolTest extends FlatSpec with Matchers {
   behavior of s"JsonCodec[$userClassName]"
 
   it should s"encode $userClassName without role" in {
-    val user = User(
-      id = "id",
-      party = new PartyState(UserConfig(None, party, None, false)),
-      canAdvanceTime = true)
+    val user =
+      User(id = "id", party = new PartyState(UserConfig(party, None, false)), canAdvanceTime = true)
     val userJson = JsObject(
       "id" -> JsString("id"),
       "party" -> JsString("party"),
@@ -32,7 +30,7 @@ class SessionJsonProtocolTest extends FlatSpec with Matchers {
   it should s"encode $userClassName with role" in {
     val user = User(
       id = "id",
-      party = new PartyState(UserConfig(None, party, Some("role"), false)),
+      party = new PartyState(UserConfig(party, Some("role"), false)),
       role = Some("role"),
       canAdvanceTime = false)
     val userJson = JsObject(

--- a/navigator/backend/ui-backend.conf
+++ b/navigator/backend/ui-backend.conf
@@ -1,17 +1,14 @@
 users {
     OPERATOR {
         party=OPERATOR
-        password=password
         role=operator
     }
     BANK1 {
         party=BANK1
-        password=password
         role=bank
     }
     BANK2 {
         party=BANK2
-        password=password
         role=bank
     }
 }

--- a/navigator/frontend/src/ui-core/src/session/UI.tsx
+++ b/navigator/frontend/src/ui-core/src/session/UI.tsx
@@ -4,15 +4,9 @@
 import * as React from 'react';
 import { Action } from 'redux';
 import styled from 'styled-components';
-import Button from '../Button';
 import { Dispatch } from '../types';
 import { sessionError, signIn } from './actions';
 import * as Session from './index';
-
-const SignInButton = styled(Button)`
-  width: 100%;
-  margin-top: 1rem;
-`;
 
 const SignInForm = styled.form`
   display: flex;
@@ -72,7 +66,6 @@ export type Props<A extends Action> = OwnProps<A> & ReduxProps<A>;
 
 export interface State {
   userId: string;
-  password: string;
 }
 
 export default class Component<A extends Action>
@@ -83,21 +76,20 @@ export default class Component<A extends Action>
     if (props.dispatch === undefined) {
       throw new Error('No dispatch function available to SignIn component');
     }
-    this.state = { userId: '', password: '' };
+    this.state = { userId: '' };
     this.signIn = this.signIn.bind(this);
   }
 
-  signIn(userId: Session.UserId, password?: string) {
+  signIn(userId: Session.UserId) {
     const { dispatch, toSelf } = this.props;
     if (!dispatch) { throw new Error('dispatch not available'); }
     if (userId) {
-      dispatch(signIn(toSelf, userId, password));
+      dispatch(signIn(toSelf, userId));
     }
   }
 
   render() {
     const { isAuthenticating, method, failure } = this.props;
-    const { userId, password } = this.state;
     let loginEl = null;
     let errorEl = null;
     if (failure === 'invalid-credentials') {
@@ -131,43 +123,6 @@ export default class Component<A extends Action>
     }
 
     switch (method.type) {
-
-      case 'password':
-        loginEl = (
-          <SignInForm>
-            {errorEl}
-            <input
-              type="text"
-              disabled={isAuthenticating}
-              placeholder="Username"
-              value={userId}
-              onChange={(e: React.FormEvent<HTMLInputElement>) => {
-                this.setState({ userId: e.currentTarget.value });
-              }}
-            />
-            <input
-              type="password"
-              disabled={isAuthenticating}
-              placeholder="Password"
-              value={password}
-              onChange={(e: React.FormEvent<HTMLInputElement>) => {
-                this.setState({ password: e.currentTarget.value });
-              }}
-            />
-            <SignInButton
-              type="main"
-              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                e.preventDefault();
-                e.stopPropagation();
-                this.signIn(userId, password);
-              }}
-            >
-              Sign in
-            </SignInButton>
-          </SignInForm>
-        );
-        break;
-
       case 'select':
         loginEl = (
           <SignInForm>

--- a/navigator/frontend/src/ui-core/src/session/actions.ts
+++ b/navigator/frontend/src/ui-core/src/session/actions.ts
@@ -60,7 +60,6 @@ function init<A extends Redux.Action>(to: To<A>): ThunkAction<void> {
 function signIn<A extends Redux.Action>(
   to: To<A>,
   userId: UserId,
-  password?: string,
 ): ThunkAction<void> {
   return (dispatch) => {
     dispatch(to({ type: 'AUTHENTICATING' }));
@@ -68,7 +67,7 @@ function signIn<A extends Redux.Action>(
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId, password }),
+      body: JSON.stringify({ userId }),
     })
       .then((res: Response) => (res.json() as Promise<ServerResponse>))
       .then(handleSessionResponse(to, dispatch));

--- a/navigator/frontend/src/ui-core/src/session/types.ts
+++ b/navigator/frontend/src/ui-core/src/session/types.ts
@@ -29,8 +29,7 @@ export type State
   }
   | { type: 'authenticated', user: User }
 
-export type AuthMethod = AuthMethodPassword | AuthMethodSelect
-export type AuthMethodPassword = { type: 'password' }
+export type AuthMethod = AuthMethodSelect
 export type AuthMethodSelect = { type: 'select', users: UserId[] }
 export type AuthFailure = 'invalid-credentials';
 

--- a/navigator/integration-test/src/main/resources/ui-backend.conf
+++ b/navigator/integration-test/src/main/resources/ui-backend.conf
@@ -1,17 +1,14 @@
 users {
   Operator {
     party=Operator
-    password=password
     role=operator
   }
   Scrooge_McDuck {
     party=Scrooge_McDuck
-    password=password
     role=bank
   }
   Betina_Beakley {
     party=Betina_Beakley
-    password=password
     role=bank
   }
 }


### PR DESCRIPTION
This was leftover from ancient times. You couldn’t actually use this
in any way since we always defaulted to the select method and provided
no way to change this. We still support it in the config but emit a
warning now if you use it.

changelog_begin

- [Navigator] The `password` option in the Navigator config file is
  now deprecated. Note that it was already unused before.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
