### PR TITLE
ts/ledger: package management

### DIFF
--- a/language-support/ts/codegen/tests/BUILD.bazel
+++ b/language-support/ts/codegen/tests/BUILD.bazel
@@ -85,6 +85,7 @@ sh_test(
         "$(location //language-support/ts/daml-types:npm_package)",
         "$(location //language-support/ts/daml-ledger:npm_package)",
         sdk_version,
+        "$(location //ledger/test-common:model-tests.dar)",
     ],
     data = [
         "//:java",
@@ -93,6 +94,7 @@ sh_test(
         "//ledger/sandbox-classic:sandbox-classic-binary_deploy.jar",
         "//ledger-service/http-json:http-json-binary_deploy.jar",
         ":build-and-lint.dar",
+        "//ledger/test-common:model-tests.dar",
         "//language-support/ts/daml-types:npm_package",
         "//language-support/ts/daml-ledger:npm_package",
     ] + glob(

--- a/language-support/ts/codegen/tests/build-and-lint.sh
+++ b/language-support/ts/codegen/tests/build-and-lint.sh
@@ -46,6 +46,7 @@ TS_DIR=$(dirname $PACKAGE_JSON)
 DAML_TYPES=$(rlocation "$TEST_WORKSPACE/$8")
 DAML_LEDGER=$(rlocation "$TEST_WORKSPACE/$9")
 SDK_VERSION=${10}
+UPLOAD_DAR=$(rlocation "$TEST_WORKSPACE/${11}")
 
 TMP_DAML_TYPES=$TMP_DIR/daml-types
 TMP_DAML_LEDGER=$TMP_DIR/daml-ledger
@@ -69,4 +70,4 @@ $YARN run build
 $YARN run lint
 # Invoke 'yarn test'. Control is thereby passed to
 # 'language-support/ts/codegen/tests/ts/build-and-lint-test/src/__tests__/test.ts'.
-JAVA=$JAVA SANDBOX=$SANDBOX JSON_API=$JSON_API DAR=$DAR $YARN test
+JAVA=$JAVA SANDBOX=$SANDBOX JSON_API=$JSON_API DAR=$DAR UPLOAD_DAR=$UPLOAD_DAR $YARN test

--- a/language-support/ts/daml-ledger/README.md
+++ b/language-support/ts/daml-ledger/README.md
@@ -112,18 +112,34 @@ format of the JSON API. See the [JSON API docs] for details.
 `getParties`
 ------------
 
-For a given list of party identifiers, returns full information, or null if
+For a given list of party identifiers, return full information, or null if
 the party doesn't exist.
 
 `listKnownParties`
 ------------------
 
-Returns an array of PartyInfo for all parties on the ledger.
+Return an array of PartyInfo for all parties on the ledger.
 
 `allocateParty`
 ---------------
 
-Allocates a new party.
+Allocate a new party.
+
+`listPackages`
+--------------
+
+Fetch a list of all known package IDs.
+
+`getPackage`
+------------
+
+Given a package ID, fetch the binary data for the corresponding DALF.
+
+`uploadDarFile`
+---------------
+
+Upload a given byte array as a DAR to the ledger. Note that this requires a
+token with admin access.
 
 ## Source
 


### PR DESCRIPTION
This PR adds coverage for the package management endpoints of the JSON API.

```
CHANGELOG_BEGIN

- [JavaScript Client Libraries] The Ledger object (returned by
  `useLedger` through the React bindings) has three new methods covering
  the package management API: `listPackages` returns a list of all known
  packageIDs, `getPackage` returns the binary data of the corresponding
  DALF, and `uploadDarFile` takes binary data and uploads it to the
  ledger.

CHANGELOG_END
```