### PR TITLE
Only subscribe to local parties in Navigator

### DIFF
--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
@@ -162,13 +162,18 @@ class PlatformStore(
       ()
     case UpdatedParties(details) =>
       details.foreach { partyDetails =>
-        val displayName = partyDetails.displayName match {
-          case Some(value) => value
-          case None => partyDetails.party
+        if (partyDetails.isLocal) {
+          val displayName = partyDetails.displayName match {
+            case Some(value) => value
+            case None => partyDetails.party
+          }
+          self ! Subscribe(
+            displayName,
+            UserConfig(
+              party = ApiTypes.Party(partyDetails.party),
+              role = None,
+              useDatabase = false))
         }
-        self ! Subscribe(
-          displayName,
-          UserConfig(party = ApiTypes.Party(partyDetails.party), role = None, useDatabase = false))
       }
 
     case Subscribe(displayName, config) =>

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
@@ -173,6 +173,8 @@ class PlatformStore(
               party = ApiTypes.Party(partyDetails.party),
               role = None,
               useDatabase = false))
+        } else {
+          log.debug(s"Ignoring non-local party ${partyDetails.party}")
         }
       }
 
@@ -183,7 +185,7 @@ class PlatformStore(
         startPartyActor(state.ledgerClient, partyState)
         context.become(connected(state.copy(parties = state.parties + (displayName -> partyState))))
       } else {
-        log.info(s"Actor for $displayName is already running")
+        log.debug(s"Actor for $displayName is already running")
       }
 
     case CreateContract(party, templateId, value) =>


### PR DESCRIPTION
Subscribing to non-local parties isn’t going to work. Not quite sure
how to test this. Spinning up one of the multi-node ledgers just for
this seems a bit overkill.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
