### PR TITLE
Document offset inclusivity and exclusivity in Protobuf

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
@@ -69,7 +69,7 @@ message CompletionStreamRequest {
   repeated string parties = 3;
 
   // This field indicates the minimum offset for completions. This can be used to resume an earlier completion stream.
-  // This offset is exclusive: the response will not contain any command whose offset is less than or equal to this.
+  // This offset is exclusive: the response will only contain commands whose offset is strictly greater than this.
   // Optional, if not set the ledger uses the current ledger end offset instead.
   LedgerOffset offset = 4;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/command_completion_service.proto
@@ -69,6 +69,7 @@ message CompletionStreamRequest {
   repeated string parties = 3;
 
   // This field indicates the minimum offset for completions. This can be used to resume an earlier completion stream.
+  // This offset is exclusive: the response will not contain any command whose offset is less than or equal to this.
   // Optional, if not set the ledger uses the current ledger end offset instead.
   LedgerOffset offset = 4;
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -88,12 +88,12 @@ message GetTransactionsRequest {
   string ledger_id = 1;
 
   // Beginning of the requested ledger section.
-  // This offset is exclusive: the response will not contain any transaction whose offset is less than or equal to this.
+  // This offset is exclusive: the response will only contain transactions whose offset is strictly greater than this.
   // Required
   LedgerOffset begin = 2;
 
   // End of the requested ledger section.
-  // This offset is inclusive: the response will not contain any transaction whose offset is strictly greater than this.
+  // This offset is inclusive: the response will only contain transactions whose offset is less than or equal to this.
   // Optional, if not set, the stream will not terminate.
   LedgerOffset end = 3;
 

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -88,10 +88,12 @@ message GetTransactionsRequest {
   string ledger_id = 1;
 
   // Beginning of the requested ledger section.
+  // This offset is exclusive: the response will not contain any transaction whose offset is less than or equal to this.
   // Required
   LedgerOffset begin = 2;
 
   // End of the requested ledger section.
+  // This offset is inclusive: the response will not contain any transaction whose offset is strictly greater than this.
   // Optional, if not set, the stream will not terminate.
   LedgerOffset end = 3;
 


### PR DESCRIPTION
As brought up in https://discuss.daml.com/t/using-offsets/1731, the
inclusivity and exclusivity of start and end offsets as exposed by
the Ledger API is not well documented.

This commit clearly states which offset is inclusive and which is
exclusive on all relevant endpoints (command completion and
transaction services).

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
