### PR TITLE
When publishing Protobuf source JARs, publish the dependencies.

### DIFF
--- a/bazel_tools/proto.bzl
+++ b/bazel_tools/proto.bzl
@@ -220,9 +220,11 @@ def proto_jars(
         name = "%s_jar" % name,
         srcs = None,
         deps = None,
+        runtime_deps = ["%s_jar" % label for label in proto_deps],
         resources = srcs,
         resource_strip_prefix = "%s/%s/" % (native.package_name(), strip_import_prefix),
         tags = _maven_tags(maven_group, maven_artifact_prefix, maven_artifact_proto_suffix),
+        visibility = visibility,
     )
 
     # An empty Javadoc JAR for uploading the source proto JAR to Maven Central.

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -3,12 +3,20 @@
 
 - target: //daml-assistant/scala-daml-project-config:scala-daml-project-config
   type: jar-scala
+- target: //daml-lf/archive:daml_lf_1.6_archive_proto_jar
+  type: jar-lib
 - target: //daml-lf/archive:daml_lf_1.6_archive_proto_java
   type: jar-proto
+- target: //daml-lf/archive:daml_lf_1.7_archive_proto_jar
+  type: jar-lib
 - target: //daml-lf/archive:daml_lf_1.7_archive_proto_java
   type: jar-proto
+- target: //daml-lf/archive:daml_lf_1.8_archive_proto_jar
+  type: jar-lib
 - target: //daml-lf/archive:daml_lf_1.8_archive_proto_java
   type: jar-proto
+- target: //daml-lf/archive:daml_lf_dev_archive_proto_jar
+  type: jar-lib
 - target: //daml-lf/archive:daml_lf_dev_archive_proto_java
   type: jar-proto
 - target: //daml-lf/archive:daml_lf_archive_reader
@@ -29,8 +37,12 @@
   type: jar-scala
 - target: //daml-lf/transaction:transaction
   type: jar-scala
+- target: //daml-lf/transaction:transaction_proto_jar
+  type: jar-lib
 - target: //daml-lf/transaction:transaction_proto_java
   type: jar-proto
+- target: //daml-lf/transaction:value_proto_jar
+  type: jar-lib
 - target: //daml-lf/transaction:value_proto_java
   type: jar-proto
 - target: //daml-lf/transaction-test-lib:transaction-test-lib
@@ -113,6 +125,8 @@
   type: jar-scala
 - target: //ledger/participant-state/kvutils/tools:tools
   type: jar-scala
+- target: //ledger/participant-state/protobuf:ledger_configuration_proto_jar
+  type: jar-lib
 - target: //ledger/participant-state/protobuf:ledger_configuration_proto_java
   type: jar-proto
 - target: //ledger/participant-state-index:participant-state-index


### PR DESCRIPTION
Previously, each Protobuf source JAR was considered independent, and did not require dependencies. This meant that the kvutils Protobuf sources were published without the associated DAML-LF sources, making them useless.

This change adds the source JARs as runtime dependencies to ensure that when publishing a Protobuf source JAR, the release process will fail if the dependencies are not also published.

### Changelog

- **[Ledger API]** We now publish Protobuf sources in JARs for DAML-LF types to Maven Central, with the group "com.daml". The artifact names follow the format "<name>_proto_jar".

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
