### PR TITLE
daml-lf: Remove aliases that have been deprecated since v1.4.

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -4,8 +4,8 @@
 package com.daml.lf
 package transaction
 
-import com.daml.lf.data.{ImmArray, ScalazEqual}
 import com.daml.lf.data.Ref._
+import com.daml.lf.data.{ImmArray, ScalazEqual}
 import com.daml.lf.value.Value.VersionedValue
 import com.daml.lf.value.{
   CidContainer,
@@ -15,11 +15,11 @@ import com.daml.lf.value.{
   CidMapper,
   Value
 }
-
-import scala.language.higherKinds
 import scalaz.Equal
 import scalaz.std.option._
 import scalaz.syntax.equal._
+
+import scala.language.higherKinds
 
 /**
   * Generic transaction node type for both update transactions and the
@@ -367,12 +367,6 @@ object Node {
           key === key2 && result === result2
       }
     }(recorded, isReplayedBy)
-
-  @deprecated("use com.daml.lf.transaction.GlobalKey", "1.4.0")
-  type GlobalKey = transaction.GlobalKey
-
-  @deprecated("use com.daml.lf.transaction.GlobalKey", "1.4.0")
-  val GlobalKey = transaction.GlobalKey
 
   sealed trait WithTxValue2[F[+ _, + _]] {
     type WithTxValue[+Cid] = F[Cid, Transaction.Value[Cid]]

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/execution/StoreBackedCommandExecutorSpec.scala
@@ -10,8 +10,8 @@ import com.daml.lf.crypto.Hash
 import com.daml.lf.data.Ref.ParticipantId
 import com.daml.lf.data.{ImmArray, Ref, Time}
 import com.daml.lf.engine.{Engine, ResultDone}
-import com.daml.lf.transaction.Transaction
 import com.daml.lf.transaction.test.TransactionBuilder
+import com.daml.lf.transaction.{SubmittedTransaction, Transaction}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.Metrics
 import org.mockito.ArgumentMatchers._
@@ -34,7 +34,7 @@ class StoreBackedCommandExecutorSpec extends AsyncWordSpec with MockitoSugar wit
       val mockEngine = mock[Engine]
       when(mockEngine.submit(any[com.daml.lf.command.Commands], any[ParticipantId], any[Hash]))
         .thenReturn(
-          ResultDone[(Transaction.SubmittedTransaction, Transaction.Metadata)](
+          ResultDone[(SubmittedTransaction, Transaction.Metadata)](
             (TransactionBuilder.EmptySubmitted, emptyTransactionMetadata)
           )
         )


### PR DESCRIPTION
### Changelog

- [DAML-LF] Some types that were deprecated in DAML 1.4 have been removed. Please fix any deprecation warnings by using the new types before upgrading.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
