### PR TITLE
Add daml.yaml in temp directory during SDK install

### DIFF
--- a/daml-assistant/get-daml.sh
+++ b/daml-assistant/get-daml.sh
@@ -101,6 +101,11 @@ if [ -d $DAML_HOME ] ; then
 fi
 
 #
+# Add daml.yaml in temp directory.
+#
+echo "sdk-version: $VERSION" > $TMPDIR/daml.yaml
+
+#
 # Extract and install SDK tarball.
 #
 echo "Extracting SDK release tarball."


### PR DESCRIPTION
By adding a daml.yaml in the temp directory, we prevent issues that
could arise from a spurious daml.yaml existing in parent directories
(e.g. in /tmp). The daml.yaml contents are not important for the
installation, but if there's an error while reading daml.yaml, the
installation would fail.

This fixes #5720 in a backward-compatible way. I tested the fix manually.
I'm not sure there's an easy way to automate the test.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
