### PR TITLE
Speedy: Add a built to optimize cons with 1 elems

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -396,10 +396,12 @@ private[lf] final class Compiler(
       case ECons(_, front, tail) =>
         // TODO(JM): Consider emitting SEValue(SList(...)) for
         // constant lists?
-        SEApp(
-          SEBuiltin(SBConsMany(front.length)),
-          front.iterator.map(compile).toArray :+ compile(tail),
-        )
+        val args = (front.iterator.map(compile) ++ Seq(compile(tail))).toArray
+        if (front.length == 1) {
+          SEApp(SEBuiltin(SBCons), args)
+        } else {
+          SEApp(SEBuiltin(SBConsMany(front.length)), args)
+        }
       case ENone(_) =>
         SEValue.None
       case ESome(_, body) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -468,6 +468,7 @@ private[lf] object Pretty {
         case SEBuiltin(x) =>
           x match {
             case SBConsMany(n) => text(s"$$consMany[$n]")
+            case SBCons => text(s"$$cons")
             case SBRecCon(id, fields) =>
               text("$record") + char('[') + text(id.qualifiedName.toString) + char('^') + str(
                 fields.length,

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -696,6 +696,13 @@ private[lf] object SBuiltin {
     }
   }
 
+  /** $cons :: a -> List a -> List a */
+  final case object SBCons extends SBuiltinPure(2) {
+    override private[speedy] def executePure(args: util.ArrayList[SValue]): SValue = {
+      SList(args.get(0) +: args.get(1).asInstanceOf[SList].list)
+    }
+  }
+
   /** $some :: a -> Optional a */
   final case object SBSome extends SBuiltinPure(1) {
     override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {


### PR DESCRIPTION
We have a built-in `SBConsMany` that concatenate a list with a prefix
of variable size. Its appears that most of the concatenations happens
with only one element. For this reason we add a new built-in to handle
the most efficiently possible the case with 1 element.

Here are some benchmarks without optim.

```
Benchmark                          (scenario)  Mode  Cnt   Score   Error  Units
CollectAuthority.bench  CollectAuthority:test  avgt   20  83.407 ± 2.508  ms/op

Benchmark    (choiceName)  Mode  Cnt   Score   Error  Units
Replay.bench            X  avgt  200  35.419 ± 0.525  ms/op
Replay.bench            Y  avgt  200   1.651 ± 0.026  ms/op
```
Here the same benchmarks with the optim.

```
Benchmark                          (scenario)  Mode  Cnt   Score   Error  Units
CollectAuthority.bench  CollectAuthority:test  avgt   20  45.267 ± 0.533  ms/op

Benchmark     (choiceName) Mode  Cnt   Score   Error  Units
Replay.bench             X avgt  200  31.662 ± 0.393  ms/op
Replay.bench             Y avgt  200   1.639 ± 0.026  ms/op
```


CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
