### PR TITLE
LF: Drop Speedy SBConsMany builtin

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -396,11 +396,8 @@ private[lf] final class Compiler(
       case ECons(_, front, tail) =>
         // TODO(JM): Consider emitting SEValue(SList(...)) for
         // constant lists?
-        val args = (front.iterator.map(compile) ++ Seq(compile(tail))).toArray
-        if (front.length == 1) {
-          SEApp(SEBuiltin(SBCons), args)
-        } else {
-          SEApp(SEBuiltin(SBConsMany(front.length)), args)
+        front.foldRight(compile(tail)) { (head, acc) =>
+          SEApp(SEBuiltin(SBCons), Array(compile(head), acc))
         }
       case ENone(_) =>
         SEValue.None

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -467,7 +467,6 @@ private[lf] object Pretty {
 
         case SEBuiltin(x) =>
           x match {
-            case SBConsMany(n) => text(s"$$consMany[$n]")
             case SBCons => text(s"$$cons")
             case SBRecCon(id, fields) =>
               text("$record") + char('[') + text(id.qualifiedName.toString) + char('^') + str(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -684,18 +684,6 @@ private[lf] object SBuiltin {
   final case object SBGreater extends SBCompare(_ > 0)
   final case object SBGreaterEq extends SBCompare(_ >= 0)
 
-  /** $consMany[n] :: a -> ... -> List a -> List a */
-  final case class SBConsMany(n: Int) extends SBuiltinPure(1 + n) {
-    override private[speedy] final def executePure(args: util.ArrayList[SValue]): SValue = {
-      args.get(n) match {
-        case SList(tail) =>
-          SList(ImmArray(args.subList(0, n).asScala) ++: tail)
-        case x =>
-          crash(s"Cons onto non-list: $x")
-      }
-    }
-  }
-
   /** $cons :: a -> List a -> List a */
   final case object SBCons extends SBuiltinPure(2) {
     override private[speedy] def executePure(args: util.ArrayList[SValue]): SValue = {


### PR DESCRIPTION
This PR is a follow up on #8122, where we add a special case
in speedy the concatenation of 1 elem prefix. In this PR we drop 
completely the general case.

CHANGELOG_BEGIN
CHAGNELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
