### PR TITLE
Handle admin claims in OAuth2 test server

### DIFF
--- a/triggers/service/auth/src/main/scala/com/daml/auth/oauth2/test/server/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/oauth2/test/server/Config.scala
@@ -5,7 +5,6 @@ package com.daml.auth.oauth2.test.server
 
 import java.time.Clock
 
-import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ports.Port
 
 case class Config(
@@ -15,15 +14,13 @@ case class Config(
     ledgerId: String,
     // Secret used to sign JWTs
     jwtSecret: String,
-    // Only authorize requests for these parties, if set.
-    parties: Option[Set[Party]],
     // Use the provided clock instead of system time for token generation.
     clock: Option[Clock],
 )
 
 object Config {
   private val Empty =
-    Config(port = Port.Dynamic, ledgerId = null, jwtSecret = null, parties = None, clock = None)
+    Config(port = Port.Dynamic, ledgerId = null, jwtSecret = null, clock = None)
 
   def parseConfig(args: Seq[String]): Option[Config] =
     configParser.parse(args, Empty)
@@ -43,10 +40,6 @@ object Config {
 
       opt[String]("secret")
         .action((x, c) => c.copy(jwtSecret = x))
-
-      opt[Seq[String]]("parties")
-        .action((x, c) => c.copy(parties = Some(Party.subst(x).toSet)))
-        .text("Only authorize requests for these parties")
 
       help("help").text("Print this usage text")
     }

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Resources.scala
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http.ServerBinding
 import com.daml.clock.AdjustableClock
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
-import com.daml.auth.oauth2.test.server.{Config => OAuthConfig, Server => OAuthServer}
+import com.daml.auth.oauth2.test.server.{Server => OAuthServer}
 
 import scala.concurrent.Future
 
@@ -21,12 +21,14 @@ object Resources {
           Future(()))
       }
     }
-  def authServer(config: OAuthConfig)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
+  def authServerBinding(server: OAuthServer)(
+      implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
-        Resource(OAuthServer(config).start())(_.unbind().map(_ => ()))
+        Resource(server.start())(_.unbind().map(_ => ()))
     }
-  def authMiddleware(config: Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
+  def authMiddlewareBinding(config: Config)(
+      implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
         Resource(Server.start(config))(_.unbind().map(_ => ()))

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Test.scala
@@ -17,6 +17,7 @@ import com.daml.jwt.JwtSigner
 import com.daml.jwt.domain.DecodedJwt
 import com.daml.ledger.api.auth.{AuthServiceJWTCodec, AuthServiceJWTPayload}
 import com.daml.ledger.api.refinements.ApiTypes
+import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.auth.oauth2.api.{Response => OAuthResponse}
 import org.scalatest.wordspec.AsyncWordSpec
@@ -199,6 +200,7 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
       }
     }
     "not authorize unauthorized parties" in {
+      server.revokeParty(Party("Eve"))
       val claims = "actAs:Eve"
       val req = HttpRequest(
         uri = middlewareUri

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -79,6 +79,7 @@ trait TestFixture
 
   override protected def afterEach(): Unit = {
     server.resetAuthorizedParties()
+    server.resetAdmin()
 
     super.afterEach()
   }

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -22,23 +22,29 @@ import com.daml.ledger.api.testing.utils.{
   SuiteResource
 }
 import com.daml.ledger.resources.ResourceContext
-import com.daml.auth.oauth2.test.server.{Config => OAuthConfig}
+import com.daml.auth.oauth2.test.server.{Config => OAuthConfig, Server => OAuthServer}
 import com.daml.ports.Port
 import org.scalatest.Suite
 
 trait TestFixture
     extends AkkaBeforeAndAfterAll
-    with SuiteResource[(AdjustableClock, ServerBinding, ServerBinding)] {
+    with SuiteResource[(AdjustableClock, OAuthServer, ServerBinding, ServerBinding)] {
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
   protected val jwtSecret: String = "secret"
+  lazy protected val clock: AdjustableClock = suiteResource.value._1
+  lazy protected val server: OAuthServer = suiteResource.value._2
+  lazy protected val serverBinding: ServerBinding = suiteResource.value._3
+  lazy protected val middlewareBinding: ServerBinding = suiteResource.value._4
   override protected lazy val suiteResource
-    : Resource[(AdjustableClock, ServerBinding, ServerBinding)] = {
+    : Resource[(AdjustableClock, OAuthServer, ServerBinding, ServerBinding)] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
-    new OwnedResource[ResourceContext, (AdjustableClock, ServerBinding, ServerBinding)](
+    new OwnedResource[
+      ResourceContext,
+      (AdjustableClock, OAuthServer, ServerBinding, ServerBinding)](
       for {
         clock <- Resources.clock(Instant.now(), ZoneId.systemDefault())
-        server <- Resources.authServer(
+        server = OAuthServer(
           OAuthConfig(
             port = Port.Dynamic,
             ledgerId = ledgerId,
@@ -46,10 +52,13 @@ trait TestFixture
             parties = Some(ApiTypes.Party.subst(Set("Alice", "Bob"))),
             clock = Some(clock),
           ))
+        serverBinding <- Resources.authServerBinding(server)
         serverUri = Uri()
           .withScheme("http")
-          .withAuthority(server.localAddress.getHostString, server.localAddress.getPort)
-        client <- Resources.authMiddleware(
+          .withAuthority(
+            serverBinding.localAddress.getHostString,
+            serverBinding.localAddress.getPort)
+        middlewareBinding <- Resources.authMiddlewareBinding(
           Config(
             port = Port.Dynamic,
             oauthAuth = serverUri.withPath(Uri.Path./("authorize")),
@@ -65,7 +74,7 @@ trait TestFixture
                 })
             )
           ))
-      } yield { (clock, server, client) }
+      } yield { (clock, server, serverBinding, middlewareBinding) }
     )
   }
 }

--- a/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/Client.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/Client.scala
@@ -32,7 +32,7 @@ object Client {
   )
 
   object JsonProtocol extends DefaultJsonProtocol {
-    implicit val accessParamsFormat: RootJsonFormat[AccessParams] = jsonFormat2(AccessParams)
+    implicit val accessParamsFormat: RootJsonFormat[AccessParams] = jsonFormat3(AccessParams)
     implicit val refreshParamsFormat: RootJsonFormat[RefreshParams] = jsonFormat1(RefreshParams)
     implicit object ResponseJsonFormat extends RootJsonFormat[Response] {
       implicit private val accessFormat: RootJsonFormat[AccessResponse] = jsonFormat2(
@@ -52,7 +52,7 @@ object Client {
     }
   }
 
-  case class AccessParams(parties: Seq[String], applicationId: Option[String])
+  case class AccessParams(parties: Seq[String], admin: Boolean, applicationId: Option[String])
   case class RefreshParams(refreshToken: String)
   sealed trait Response
   final case class AccessResponse(token: String, refresh: String) extends Response
@@ -76,6 +76,7 @@ object Client {
                   val redirectUri = toRedirectUri(request.uri)
                   val scope =
                     (params.parties.map(p => "actAs:" + p) ++
+                      (if (params.admin) List("admin") else Nil) ++
                       params.applicationId.toList.map(id => "applicationId:" + id)).mkString(" ")
                   val authParams = Request.Authorize(
                     responseType = "code",

--- a/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/Resources.scala
@@ -20,12 +20,13 @@ object Resources {
           Future(()))
       }
     }
-  def authServer(config: Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
+  def authServerBinding(server: Server)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
-        Resource(Server(config).start())(_.unbind().map(_ => ()))
+        Resource(server.start())(_.unbind().map(_ => ()))
     }
-  def authClient(config: Client.Config)(implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
+  def authClientBinding(config: Client.Config)(
+      implicit sys: ActorSystem): ResourceOwner[ServerBinding] =
     new ResourceOwner[ServerBinding] {
       override def acquire()(implicit context: ResourceContext): Resource[ServerBinding] =
         Resource(Client.start(config))(_.unbind().map(_ => ()))

--- a/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/Test.scala
@@ -12,6 +12,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import com.daml.jwt.JwtDecoder
 import com.daml.jwt.domain.Jwt
 import com.daml.ledger.api.auth.{AuthServiceJWTCodec, AuthServiceJWTPayload}
+import com.daml.ledger.api.refinements.ApiTypes.Party
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import org.scalatest.wordspec.AsyncWordSpec
 import spray.json._
@@ -138,6 +139,7 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
       }
     }
     "deny access to unauthorized parties" in {
+      server.revokeParty(Party("Eve"))
       for {
         error <- expectError(Seq("Alice", "Eve"))
       } yield {

--- a/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/Test.scala
@@ -23,8 +23,8 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
   private def requestToken(
       parties: Seq[String],
       applicationId: Option[String]): Future[Either[String, (AuthServiceJWTPayload, String)]] = {
-    lazy val clientBinding = suiteResource.value._3.localAddress
-    lazy val clientUri = Uri().withAuthority(clientBinding.getHostString, clientBinding.getPort)
+    lazy val clientUri = Uri()
+      .withAuthority(clientBinding.localAddress.getHostString, clientBinding.localAddress.getPort)
     val req = HttpRequest(
       uri = clientUri.withPath(Path./("access")).withScheme("http"),
       method = HttpMethods.POST,
@@ -65,8 +65,8 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
 
   private def requestRefresh(
       refreshToken: String): Future[Either[String, (AuthServiceJWTPayload, String)]] = {
-    lazy val clientBinding = suiteResource.value._3.localAddress
-    lazy val clientUri = Uri().withAuthority(clientBinding.getHostString, clientBinding.getPort)
+    lazy val clientUri = Uri()
+      .withAuthority(clientBinding.localAddress.getHostString, clientBinding.localAddress.getPort)
     val req = HttpRequest(
       uri = clientUri.withPath(Path./("refresh")).withScheme("http"),
       method = HttpMethods.POST,
@@ -147,7 +147,7 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
     "refresh a token" in {
       for {
         (token1, refresh1) <- expectToken(Seq())
-        _ <- Future(suiteResource.value._1.set(token1.exp.get.plusSeconds(1)))
+        _ <- Future(clock.set(token1.exp.get.plusSeconds(1)))
         (token2, _) <- expectRefresh(refresh1)
       } yield {
         assert(token2.exp.get.isAfter(token1.exp.get))

--- a/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/TestFixture.scala
@@ -16,11 +16,11 @@ import com.daml.ledger.api.testing.utils.{
 }
 import com.daml.ledger.resources.ResourceContext
 import com.daml.ports.Port
-import com.daml.ledger.api.refinements.ApiTypes.Party
-import org.scalatest.Suite
+import org.scalatest.{BeforeAndAfterEach, Suite}
 
 trait TestFixture
     extends AkkaBeforeAndAfterAll
+    with BeforeAndAfterEach
     with SuiteResource[(AdjustableClock, Server, ServerBinding, ServerBinding)] {
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
@@ -41,7 +41,6 @@ trait TestFixture
             port = Port.Dynamic,
             ledgerId = ledgerId,
             jwtSecret = jwtSecret,
-            parties = Some(Party.subst(Set("Alice", "Bob"))),
             clock = Some(clock)
           ))
         serverBinding <- Resources.authServerBinding(server)
@@ -58,5 +57,11 @@ trait TestFixture
           ))
       } yield { (clock, server, serverBinding, clientBinding) }
     )
+  }
+
+  override protected def afterEach(): Unit = {
+    server.resetAuthorizedParties()
+
+    super.afterEach()
   }
 }

--- a/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/oauth2/test/server/TestFixture.scala
@@ -61,6 +61,7 @@ trait TestFixture
 
   override protected def afterEach(): Unit = {
     server.resetAuthorizedParties()
+    server.resetAdmin()
 
     super.afterEach()
   }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -151,8 +151,6 @@ trait AuthMiddlewareFixture
     with AkkaBeforeAndAfterAll {
   self: Suite =>
 
-  protected def authParties: Option[Set[ApiTypes.Party]]
-
   protected def authService: Option[auth.AuthService] = Some(auth.AuthServiceJWT(authVerifier))
   protected def authToken(payload: AuthServiceJWTPayload): Option[String] = Some {
     val header = """{"alg": "HS256", "typ": "JWT"}"""
@@ -205,7 +203,6 @@ trait AuthMiddlewareFixture
             port = Port.Dynamic,
             ledgerId = ledgerId,
             jwtSecret = authSecret,
-            parties = authParties,
             clock = Some(clock),
           )
           oauthServer = OAuthServer(oauthConfig)

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -233,6 +233,7 @@ trait AuthMiddlewareFixture
 
   override protected def afterEach(): Unit = {
     authServer.resetAuthorizedParties()
+    authServer.resetAdmin()
 
     super.afterEach()
   }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -516,12 +516,11 @@ trait AbstractTriggerServiceTestAuthMiddleware
     extends AbstractTriggerServiceTest
     with AuthMiddlewareFixture {
 
-  override protected val authParties = Some(Set(alice, aliceAcs, aliceExp, bob))
-
   behavior of "authenticated service"
 
   it should "forbid a non-authorized party to start a trigger" in withTriggerService(List(dar)) {
     uri: Uri =>
+      authServer.revokeParty(eve)
       for {
         resp <- startTrigger(uri, s"$testPkgId:TestTrigger:trigger", eve)
         _ <- resp.status shouldBe StatusCodes.Forbidden
@@ -530,6 +529,7 @@ trait AbstractTriggerServiceTestAuthMiddleware
 
   it should "forbid a non-authorized party to list triggers" in withTriggerService(Nil) {
     uri: Uri =>
+      authServer.revokeParty(eve)
       for {
         resp <- listTriggers(uri, eve)
         _ <- resp.status shouldBe StatusCodes.Forbidden


### PR DESCRIPTION
This is a prerequisite for testing authorization on the upload-DAR endpoint of the trigger service.

The OAuth2 test server now handles `admin` claims. By default admin claims are granted, the server can be instructed to deny requests for admin claims.

Whether admin claims are allowed or not can be controlled with methods on the test server, similar to how party authorization is controlled. Test-cases need access to the server object to do this. The test fixtures of the test server and middleware test-suites are extended to give access to the server object. Note, the trigger service test suite already had access to this object.

The mechanism to deny authorization to certain parties is simplified. Instead of switching between two different modes of either allowing blanket access or maintaining an allow list, we simply maintain a deny list which is empty by default. Test cases that expect authorization to be denied for certain parties add these parties to the deny list.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
