### PR TITLE
Add build rule for DAML Driver for PostgreSQL docs

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -7,6 +7,13 @@ load("//rules_daml:daml.bzl", "daml_build_test", "daml_compile", "daml_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@build_environment//:configuration.bzl", "mvn_version", "sdk_version")
 
+exports_files(
+    ["configs/html/conf.py",
+     "configs/static/pygments_daml_lexer.py",
+     "configs/static/typescript.py",
+     "scripts/check-closing-quotes.sh",
+     "scripts/check-closing-quotes.sh.allow",])
+
 nodejs_binary(
     name = "grunt",
     data = [
@@ -251,6 +258,7 @@ genrule(
         "//bazel_tools/sh:mktgz",
         "@sass_nix//:bin/sass",
     ],
+    visibility = ["//visibility:public"]
 ) if not is_windows else None
 
 genrule(

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -8,11 +8,14 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@build_environment//:configuration.bzl", "mvn_version", "sdk_version")
 
 exports_files(
-    ["configs/html/conf.py",
-     "configs/static/pygments_daml_lexer.py",
-     "configs/static/typescript.py",
-     "scripts/check-closing-quotes.sh",
-     "scripts/check-closing-quotes.sh.allow",])
+    [
+        "configs/html/conf.py",
+        "configs/static/pygments_daml_lexer.py",
+        "configs/static/typescript.py",
+        "scripts/check-closing-quotes.sh",
+        "scripts/check-closing-quotes.sh.allow",
+    ],
+)
 
 nodejs_binary(
     name = "grunt",
@@ -258,7 +261,7 @@ genrule(
         "//bazel_tools/sh:mktgz",
         "@sass_nix//:bin/sass",
     ],
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
 ) if not is_windows else None
 
 genrule(

--- a/docs/configs/html/conf.py
+++ b/docs/configs/html/conf.py
@@ -94,7 +94,9 @@ html_theme_path = ['../../theme']
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-  'collapse_navigation': False
+  'collapse_navigation': False,
+  'index_page_boxes': True,
+  'pdf_download': True
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/theme/da_theme_skeleton/layout.html
+++ b/docs/theme/da_theme_skeleton/layout.html
@@ -4,6 +4,7 @@
 {# TEMPLATE VAR SETTINGS #}
 {%- set url_root = pathto('', 1) %}
 {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
+{%- set is_index = theme_index_page_boxes and url_root == './' %}
 {%- if not embedded and docstitle %}
 {%- set titlesuffix = " &mdash; "|safe + docstitle|e %}
 {%- else %}
@@ -106,7 +107,7 @@
   {%- endif %}
   {%- endblock %}
   {%- block extrahead %} {% endblock %}
-  {%- if url_root == './' %}
+  {%- if is_index %}
   <style>
     .wy-nav-content {
       max-width: initial;
@@ -163,13 +164,15 @@
           <div class="local-toc">{{ toc }}</div>
           {% endif %}
           {% endblock %}
+          {% if theme_pdf_download %}
           <div class="pdf-download"><a href="{{ pathto('_downloads/DigitalAssetSDK.pdf', 1) }}" download>Download as PDF</a></div>
+          {% endif %}
         </div>
       </div>
     </nav>
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
-      {%- if url_root == './' %}
+      {%- if is_index %}
       {% set addClass = ' landing' %}
       {% endif %}
       <div class="topbar fixed">
@@ -182,7 +185,7 @@
         {% include "navbar.html" %}
 
         <div class="version {{addClass}}">
-          {%- if url_root == './' %}
+          {%- if is_index %}
           <span class="hide-tablet">Documentation&nbsp;</span><span class="hide-mobile">Version&nbsp;</span><span class="version_switcher_placeholder"></span>
           {% else %}
           <span class="hide-mobile">Version&nbsp;</span><span class="version_switcher_placeholder"></span>
@@ -192,7 +195,7 @@
 
         {% include "searchinput.html" %}
 
-        {%- if url_root != './' %}
+        {%- if not is_index %}
           {% include "onthispage.html" %}
         {% endif %}
 
@@ -207,7 +210,7 @@
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
             {%- block document %}
             <div itemprop="articleBody">
-              {%- if url_root == './' and activePage != 'search.html' %}
+              {%- if is_index and activePage != 'search.html' %}
                 {% include "boxes.html" %}
               {% else %}
                 {% block body %}
@@ -219,7 +222,7 @@
               {% block comments %}{% endblock %}
             </div>
             {% endif%}
-            {% if url_root != './' %}
+            {% if  not is_index %}
               {% include "footer.html" %}
             {% endif %}
           </div>
@@ -257,7 +260,7 @@
     {% endif %}
   {% endif %}
 
-  {%- if url_root != './' %}
+  {%- if not is_index %}
   <div id="inpageContent"></div>
   {% else %}
   <div id="inpageContent" style="display: none;"></div>

--- a/docs/theme/da_theme_skeleton/searchinput.html
+++ b/docs/theme/da_theme_skeleton/searchinput.html
@@ -1,7 +1,7 @@
 <!-- Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-{%- if url_root == './' %}
+{%- if theme_index_page_boxes and url_root == './' %}
 {% set addClass = ' landing' %}
 {% endif %}
 <div class="search-inline{{addClass}}">

--- a/docs/theme/da_theme_skeleton/theme.conf
+++ b/docs/theme/da_theme_skeleton/theme.conf
@@ -15,3 +15,5 @@ logo_only =
 display_version = False
 prev_next_buttons_location = bottom
 style_external_links = False
+index_page_boxes = True
+pdf_download = True

--- a/docs/theme/docs/conf.py
+++ b/docs/theme/docs/conf.py
@@ -97,7 +97,9 @@ html_theme_path = ['..']
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-  'collapse_navigation': False
+  'collapse_navigation': False,
+  'index_page_boxes': True,
+  'pdf_download': True
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/theme/js/switcher.js
+++ b/docs/theme/js/switcher.js
@@ -87,10 +87,36 @@
       return ''
     }
   
+    function nthIndex(str, pat, n){
+      var L= str.length, i= -1;
+      while(n-- && i++<L){
+          i= str.indexOf(pat, i);
+          if (i < 0) break;
+      }
+      return i;
+    }
+  
+    function count(str, pat){
+      var L= str.length, i= -1;
+      var n = 0;
+      while(i++<L){
+          i= str.indexOf(pat, i);
+          if (i < 0) break;
+          n++;
+      }
+      return n;
+    }
+
     function versions_root_in_url(url) {
-      var version = version_segment_in_url(url)
-      if(version == '') return get_host()
-      else return url.substring(0, url.indexOf(version))
+      var version = version_segment_in_url(url);
+      if(version == '') {
+        var depth_from_root = count(DOCUMENTATION_OPTIONS.URL_ROOT, "../");
+        var depth = count(url, "/");
+        var dir = url.substring(0, nthIndex(url, '/', depth - depth_from_root)) + "/";
+        return dir;
+      } else {
+        return url.substring(0, url.indexOf(version));
+      }
     }
   
     jQuery(document).ready(function() {

--- a/docs/theme/js/switcher.js
+++ b/docs/theme/js/switcher.js
@@ -88,23 +88,16 @@
     }
   
     function nthIndex(str, pat, n){
-      var L= str.length, i= -1;
-      while(n-- && i++<L){
-          i= str.indexOf(pat, i);
-          if (i < 0) break;
-      }
-      return i;
+      var re = new RegExp(pat, "g");
+      var m = null;
+      for(var i = 0; i < n; i++)
+        m = re.exec(str);
+      return m ? re.lastIndex : -1;
     }
   
     function count(str, pat){
-      var L= str.length, i= -1;
-      var n = 0;
-      while(i++<L){
-          i= str.indexOf(pat, i);
-          if (i < 0) break;
-          n++;
-      }
-      return n;
+      var re = new RegExp(pat, "g");
+      return (str.match(re) || []).length;
     }
 
     function versions_root_in_url(url) {
@@ -112,7 +105,7 @@
       if(version == '') {
         var depth_from_root = count(DOCUMENTATION_OPTIONS.URL_ROOT, "../");
         var depth = count(url, "/");
-        var dir = url.substring(0, nthIndex(url, '/', depth - depth_from_root)) + "/";
+        var dir = url.substring(0, nthIndex(url, '/', depth - depth_from_root));
         return dir;
       } else {
         return url.substring(0, url.indexOf(version));

--- a/ledger/daml-on-sql/BUILD.bazel
+++ b/ledger/daml-on-sql/BUILD.bazel
@@ -3,7 +3,7 @@
 
 load("//bazel_tools:scala.bzl", "da_scala_binary", "da_scala_library", "da_scala_test")
 load("//ledger/ledger-api-test-tool:conformance.bzl", "conformance_test")
-load("@os_info//:os_info.bzl", "is_windows", "is_linux")
+load("@os_info//:os_info.bzl", "is_linux", "is_windows")
 load("@build_environment//:configuration.bzl", "sdk_version")
 
 da_scala_library(
@@ -165,6 +165,6 @@ genrule(
         """.format(sdk = sdk_version),
     tools = [
         "@sphinx_nix//:bin/sphinx-build",
-        "//bazel_tools/sh:mktgz"
+        "//bazel_tools/sh:mktgz",
     ] + (["@glibc_locales//:locale-archive"] if is_linux else []),
 ) if not is_windows else None

--- a/ledger/daml-on-sql/BUILD.bazel
+++ b/ledger/daml-on-sql/BUILD.bazel
@@ -3,7 +3,8 @@
 
 load("//bazel_tools:scala.bzl", "da_scala_binary", "da_scala_library", "da_scala_test")
 load("//ledger/ledger-api-test-tool:conformance.bzl", "conformance_test")
-load("@os_info//:os_info.bzl", "is_windows")
+load("@os_info//:os_info.bzl", "is_windows", "is_linux")
+load("@build_environment//:configuration.bzl", "sdk_version")
 
 da_scala_library(
     name = "daml-on-sql",
@@ -103,3 +104,67 @@ conformance_test(
         "--eager-package-loading",
     ],
 )
+
+genrule(
+    name = "docs",
+    srcs = [
+        "README.rst",
+        "//docs:theme",
+        "//docs:configs/html/conf.py",
+        "//docs:configs/static/pygments_daml_lexer.py",
+        "//docs:configs/static/typescript.py",
+        "//docs:scripts/check-closing-quotes.sh",
+        "//docs:scripts/check-closing-quotes.sh.allow",
+    ],
+    outs = ["html.tar.gz"],
+    cmd = """
+        mkdir -p build/docs/source
+        cp $(location :README.rst) build/docs/source/index.rst
+
+        mkdir -p build/docs/configs/html
+        cp $(location //docs:configs/html/conf.py) build/docs/configs/html/conf.py
+        mkdir -p build/docs/configs/static
+        cp $(location //docs:configs/static/pygments_daml_lexer.py) build/docs/configs/static/pygments_daml_lexer.py
+        cp $(location //docs:configs/static/typescript.py) build/docs/configs/static/typescript.py
+
+        # Copy in theme
+        mkdir -p build/docs/theme
+        tar -zxf $(location //docs:theme) -C build/docs/theme
+
+        if ! $(location //docs:scripts/check-closing-quotes.sh) . $(location //docs:scripts/check-closing-quotes.sh.allow); then
+            exit 1
+        fi
+
+        # Build with Sphinx 
+        cd build
+        sed -i "s,__VERSION__,"{sdk}"," docs/configs/html/conf.py
+        sed -i "s,'index_page_boxes': True,'index_page_boxes': False," docs/configs/html/conf.py
+        sed -i "s,'pdf_download': True,'pdf_download': False," docs/configs/html/conf.py
+        export LC_ALL=en_US.UTF-8
+        export LANG=en_US.UTF-8
+        # Sphinx 1.8.3 triggers the following warning:
+        #
+        #   /nix/store/1v39mhhyn48s251przk2fwcvgm71vfqi-python3.7-sphinx-1.8.3/lib/python3.7/site-packages/sphinx/writers/html.py:462: FutureWarning:
+        #      The iterable returned by Node.traverse()
+        #      will become an iterator instead of a list in Docutils > 0.16.
+        #     target_node = image_nodes and image_nodes[0] or node.parent
+        #
+        # We are using an older Sphinx (1.8.3) with a more recent nixpkgs revision.
+        # Unfortunately, an update is not so easy because Sphinx 2.3.1 breaks
+        # the PDF documentation due to issues with the FreeSerif font in the
+        # fontspec package. So, for now we ignore `FutureWarning`.
+        WARNINGS=$$(../$(location @sphinx_nix//:bin/sphinx-build) -c docs/configs/html docs/source html 2>&1 | \\
+          grep -Pi "(?<!future)warning:" || true)
+
+        if [ "$$WARNINGS" != "" ]; then
+            echo "$$WARNINGS"
+            exit 1
+        fi
+
+        ../$(execpath //bazel_tools/sh:mktgz) ../$@ html
+        """.format(sdk = sdk_version),
+    tools = [
+        "@sphinx_nix//:bin/sphinx-build",
+        "//bazel_tools/sh:mktgz"
+    ] + (["@glibc_locales//:locale-archive"] if is_linux else []),
+) if not is_windows else None

--- a/ledger/daml-on-sql/README.rst
+++ b/ledger/daml-on-sql/README.rst
@@ -1,22 +1,29 @@
 .. Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-*DAML for PostgreSQL*
-#####################
+.. toctree::
+   :titlesonly:
+   :maxdepth: 2
+   :hidden:
 
-*DAML for PostgreSQL* is a PostgreSQL-based DAML ledger implementation.
+   self
+
+*DAML Driver for PostgreSQL*
+############################
+
+*DAML Driver for PostgreSQL* is a PostgreSQL-based DAML ledger implementation.
 
 Setup PostgreSQL and run
 ************************
 
 Before starting, you need to perform the following steps:
 
-- create an initially empty PostgreSQL database that *DAML for PostgreSQL* can
+- create an initially empty PostgreSQL database that *DAML Driver for PostgreSQL* can
   access
-- create a database user for *DAML for PostgreSQL* that has authority to execute
+- create a database user for *DAML Driver for PostgreSQL* that has authority to execute
   DDL operations
 
-This is because *DAML for PostgreSQL* manages its own database schema, applying
+This is because *DAML Driver for PostgreSQL* manages its own database schema, applying
 migrations if necessary when upgrading versions.
 
 To specify the PostgreSQL instance you wish to connect, use the
@@ -42,19 +49,19 @@ Architecture and availability
 Processes and components
 ========================
 
-The core processes necessary to run a *DAML for PostgreSQL* deployment are:
+The core processes necessary to run a *DAML Driver for PostgreSQL* deployment are:
 
-- the *DAML for PostgreSQL* server, and
+- the *DAML Driver for PostgreSQL* server, and
 - the PostgreSQL server used to persist the ledger data.
 
-*DAML for PostgreSQL* communicates with the external world via the gRPC Ledger
+*DAML Driver for PostgreSQL* communicates with the external world via the gRPC Ledger
 API and communicates with PostgreSQL via JDBC to persist transactions, keep
 track of active contracts, store compiled DAML packages, and so on.
 
 Server hardware and software requirements
 =========================================
 
-*DAML for PostgreSQL* is provided as a self-contained JAR file, containing the
+*DAML Driver for PostgreSQL* is provided as a self-contained JAR file, containing the
 application and all dependencies. The application is routinely tested with
 OpenJDK 8 on a 64-bit x86 architecture, with Ubuntu 16.04, macOS 10.15, and
 Windows Server 2016.
@@ -67,7 +74,7 @@ environment. Core requirements in such a situation include:
 - OpenSSL 1.1 or later, made available to the above JRE
 - glibc, made available to the above JRE
 
-As a Java-based application, *DAML for PostgreSQL* can work on other operating
+As a Java-based application, *DAML Driver for PostgreSQL* can work on other operating
 systems and architectures supporting a Java Runtime Environment. However, such
 an environment will not have been tested and may cause issues.
 
@@ -76,7 +83,7 @@ Core architecture considerations
 
 The backing PostgreSQL server performs a lot of work which is both CPU- and
 IO-intensive: all (valid) Ledger API requests will eventually hit the database.
-At the same time, the *DAML for PostgreSQL* server has to have available
+At the same time, the *DAML Driver for PostgreSQL* server has to have available
 resources to validate requests, evaluate commands and prepare responses. While
 the PostgreSQL schema is designed to be as efficient as possible, practical
 experience has shown that having **dedicated computation and memory resources
@@ -96,14 +103,14 @@ In order to address availability concerns, it is important to understand what
 each of the core components do and how they interact with each other, in
 particular regarding state and consistency.
 
-Having two *DAML for PostgreSQL* servers running on top of a single PostgreSQL
+Having two *DAML Driver for PostgreSQL* servers running on top of a single PostgreSQL
 server can lead to undefined (and likely broken) behavior. For this reason,
 you must maintain a strict 1:1 relationship between a running *DAML for
 PostgreSQL* server and a running PostgreSQL server. Note that using PostgreSQL
 in a high-availability configuration does not allow you to run additional *DAML
 for PostgreSQL* servers.
 
-Downtime for the *DAML for PostgreSQL* server can be minimized using a watchdog
+Downtime for the *DAML Driver for PostgreSQL* server can be minimized using a watchdog
 or orchestration system taking care of evaluating its health of the core
 components and ensuring its availability. The Ledger API exposes the standard
 gRPC health checkpoint that can be used to evaluate the health status of the
@@ -163,14 +170,14 @@ Security and privacy
 Trust assumptions
 =================
 
-In *DAML for PostgreSQL*, all data is kept centrally by the operator of the
+In *DAML Driver for PostgreSQL*, all data is kept centrally by the operator of the
 deployment. Thus, it is their responsibility to ensure that the data is treated
 with the appropriate care so to respect confidentiality and the applicable
 regulations.
 
 The ledger operator is advised to use the tools available to them to not divulge
 private user data, including those documented by PostgreSQL, to protect data at
-rest and using a secure communication channel between the *DAML for PostgreSQL*
+rest and using a secure communication channel between the *DAML Driver for PostgreSQL*
 server and the PostgreSQL server.
 
 Ledger API over TLS
@@ -194,7 +201,7 @@ Protocol (OCSP) use ``--cert-revocation-checking true``.
 Ledger API Authorization
 ========================
 
-By default, *DAML for PostgreSQL* accepts all valid Ledger API requests.
+By default, *DAML Driver for PostgreSQL* accepts all valid Ledger API requests.
 
 You can enable authorization, representing claims as defined by the
 `Ledger API authorization documentation <https://docs.daml.com/app-dev/authentication.html#authentication-claims>`__
@@ -229,7 +236,7 @@ The following command line options are available to enable authorization:
   `JWKS <https://tools.ietf.org/html/rfc7517>`__ URL.
 
 Testing-only authorization options
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------
 
 For testing purposes only, the following option may also be used. This is not
 considered safe for production.
@@ -239,7 +246,7 @@ considered safe for production.
   plaintext secret.
 
 Token payload
-^^^^^^^^^^^^^
+-------------
 
 The following is an example of a valid JWT payload:
 
@@ -269,13 +276,13 @@ The ``public`` claim is implicitly held by anyone bearing a valid JWT (even
 without being an admin or being able to act or read on behalf of any party).
 
 Generate JSON Web Tokens (JWT)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------
 
 To generate tokens for testing purposes, use the `jwt.io <https://jwt.io/>`__
 web site.
 
 Generate RSA keys
-^^^^^^^^^^^^^^^^^
+-----------------
 
 To generate RSA keys for testing purposes, use the following command::
 
@@ -288,7 +295,7 @@ which generates the following files:
   PEM/DER/X.509 Certificate format.
 
 Generate EC keys
-^^^^^^^^^^^^^^^^
+----------------
 
 To generate keys to be used with ES256 for testing purposes, use the following
 command::
@@ -319,12 +326,12 @@ Monitoring
 Configure logging
 =================
 
-*DAML for PostgreSQL* uses the industry-standard Logback for logging. You can
-read more on how to set it up in the *DAML for PostgreSQL* CLI reference and the
+*DAML Driver for PostgreSQL* uses the industry-standard Logback for logging. You can
+read more on how to set it up in the *DAML Driver for PostgreSQL* CLI reference and the
 `Logback documentation <http://logback.qos.ch/>`__.
 
 Structured logging
-^^^^^^^^^^^^^^^^^^
+------------------
 
 The logging infrastructure leverages structured logging as implemented by the
 `Logstash Logback Encoder <https://github.com/logstash/logstash-logback-encoder/blob/logstash-logback-encoder-6.3/README.md>`__.
@@ -512,7 +519,7 @@ A timer. Time to validate submitted commands before they are fed to the DAML
 interpreter.
 
 ``daml.commands.<party_name>.input_buffer_capacity``
-------------------------------------------------
+-----------------------------------------------------
 
 A counter. The capacity of the queue accepting submissions on
 the CommandService for a given party.
@@ -530,7 +537,7 @@ A timer. Measures the queuing delay for pending submissions
 on the CommandService.
 
 ``daml.commands.<party_name>.max_in_flight_capacity``
--------------------------------------------------
+-----------------------------------------------------
 
 A counter. The capacity of the queue tracking completions on
 the CommandService for a given party.
@@ -598,7 +605,7 @@ A meter. Number of commands that are currently being interpreted (includes
 executing DAML code and fetching data).
 
 ``daml.execution.engine_running``
---------------------------------
+---------------------------------
 A meter. Number of commands that are currently being executed by the DAML engine
 (excluding fetching data).
 
@@ -817,14 +824,14 @@ CPU usage, memory consumption and the current state of threads.
 DAML Ledger Model Compliance
 ****************************
 
-*DAML for PostgreSQL* is tested regularly against the DAML Ledger API Test Tool
+*DAML Driver for PostgreSQL* is tested regularly against the DAML Ledger API Test Tool
 to verify that the ledger implements correctly the DAML semantics and to check
 its performance envelope.
 
 Semantics
 =========
 
-On top of bespoke unit and integration tests, *DAML for PostgreSQL* is
+On top of bespoke unit and integration tests, *DAML Driver for PostgreSQL* is
 thoroughly tested with the Ledger API Test Tool to ensure that the
 implementation correctly implements the DAML semantics.
 
@@ -839,7 +846,7 @@ Performance envelope
 Furthermore, this implementation is regularly tested to comply with the DAML
 Ledger Implementation Performance Envelope tests.
 
-In particular, the tests are run to ensure that *DAML for PostgreSQL* can:
+In particular, the tests are run to ensure that *DAML Driver for PostgreSQL* can:
 
 - process transactions as large as 1 MB
 - have a tail latency no greater than 1 second when issuing 20 pings
@@ -858,7 +865,7 @@ The following setup has been used to run the performance envelope tests:
   MB/s of R/W disk throughput, 8 RIOPS and 15 WIOPS, no automatic failover or
   disk increase, default PostgreSQL 12 configuration.
 
-- *DAML for PostgreSQL* server: a GCP N1-Standard-1 instance, with 1 vCPU, 3.75
+- *DAML Driver for PostgreSQL* server: a GCP N1-Standard-1 instance, with 1 vCPU, 3.75
   GB of RAM, Ubuntu 20.04 LTS (64 bit), 10 GB boot disk, OpenJDK 1.8.0_242
 
 - Ledger API test tool client: a GCP F1-Micro instance, with 1 shared vCPU, 614
@@ -875,3 +882,4 @@ The tests run to evaluate the performance envelope are:
 
 Please refer to the documentation for the Ledger API Test Tool to learn how to
 run these tests.
+


### PR DESCRIPTION
CHANGELOG_BEGIN
CHANGELOG_END

This adds a build rule ``//ledger/daml-on-sql:docs`` for the docs of the DAML Driver for PostgreSQL using the DAML docs theme. This required some additional config options on the theme and fine-tuning of the version switcher to be able to have independent versions for main docs and driver docs.

The end-result can be seen on https://staging-docs.daml.com/ and https://staging-docs.daml.com/daml-driver-for-postgresql/index.html respectively.

A followup PR will be needed to release this to docs.daml.com.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
