### PR TITLE
hotreload: archive active contracts

### DIFF
--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -52,6 +52,7 @@ da_haskell_library(
         "//compiler/damlc/daml-package-config",
         "//daml-assistant:daml-project-config",
         "//language-support/hs/bindings:hs-ledger",
+        "//ledger-api/grpc-definitions:ledger-api-haskellpb",
         "//libs-haskell/da-hs-base",
     ],
 )

--- a/daml-assistant/daml-helper/BUILD.bazel
+++ b/daml-assistant/daml-helper/BUILD.bazel
@@ -40,6 +40,7 @@ da_haskell_library(
         "typed-process",
         "unordered-containers",
         "utf8-string",
+        "uuid",
         "vector",
         "yaml",
     ],

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -373,7 +373,7 @@ tokenFor parties ledgerId =
 
 runLedgerReset :: LedgerFlags -> IO ()
 runLedgerReset flags = do
-  putStrLn $ "Resetting ledger."
+  putStrLn "Resetting ledger."
   args <- getDefaultArgs flags
   reset args
 
@@ -387,10 +387,11 @@ reset args =
           ledgerId <- L.getLedgerIdentity
           L.setToken (tokenFor parties ledgerId) $ do
             activeContracts <-
-              (L.getActiveContracts
-                 ledgerId
-                 (TransactionFilter $ Map.fromList [(L.unParty p, Just $ Filters Nothing) | p <- parties])
-                 (L.Verbosity False))
+              L.getActiveContracts
+                ledgerId
+                (TransactionFilter $
+                 Map.fromList [(L.unParty p, Just $ Filters Nothing) | p <- parties])
+                (L.Verbosity False)
             let cmds =
                   L.Commands
                     { coms =

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -52,7 +52,7 @@ import System.FilePath
 import System.IO.Extra
 import System.Process.Typed
 
-import Com.Daml.Ledger.Api.V1.TransactionFilter --TODO: HL mirror
+import Com.Daml.Ledger.Api.V1.TransactionFilter
 import DA.Daml.Compiler.Dar (createArchive, createDarFile)
 import DA.Daml.Helper.Util
 import qualified DA.Daml.LF.Ast as LF

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -391,7 +391,6 @@ reset args =
                     , aid = L.ApplicationId "hotreload"
                     , cid = L.CommandId "reset"
                     , actAs = parties
-                    , readAs = parties
                     , dedupTime = Nothing
                     , minLeTimeAbs = Nothing
                     , minLeTimeRel = Nothing

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -366,7 +366,8 @@ reset args =
              T.unpack $
              tokenFor
                [TL.toStrict $ L.unParty p | p <- parties]
-               (TL.toStrict $ L.unLedgerId ledgerId)) $ do
+               (TL.toStrict $ L.unLedgerId ledgerId)
+               "ledger-reset") $ do
             activeContracts <-
               L.getActiveContracts
                 ledgerId

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -22,8 +22,8 @@ module DA.Daml.Helper.Ledger (
 
 import Control.Exception (SomeException(..), catch)
 import Control.Lens (toListOf)
-import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Extra hiding (fromMaybeM)
+import Control.Monad.IO.Class (liftIO)
 import Data.Aeson ((.=))
 import qualified Data.Aeson as A
 import Data.Aeson.Text
@@ -39,6 +39,8 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.IO as TL
+import qualified Data.UUID as UUID
+import qualified Data.UUID.V4 as UUID
 import GHC.Generics
 import Network.GRPC.Unsafe.ChannelArgs (Arg(..))
 import Network.HTTP.Simple
@@ -354,7 +356,8 @@ runLedgerReset flags = do
   reset args
 
 reset :: LedgerArgs -> IO ()
-reset args =
+reset args = do
+  cmdId <- UUID.nextRandom
   case api args of
     Grpc ->
       runWithLedgerArgs args $ do
@@ -388,9 +391,10 @@ reset args =
                         ]
                     , lid = ledgerId
                     , wid = Nothing
-                    , aid = L.ApplicationId "hotreload"
-                    , cid = L.CommandId "reset"
+                    , aid = L.ApplicationId "ledger-reset"
+                    , cid = L.CommandId $ TL.fromStrict $ UUID.toText cmdId
                     , actAs = parties
+                    , readAs = []
                     , dedupTime = Nothing
                     , minLeTimeAbs = Nothing
                     , minLeTimeRel = Nothing

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Main.hs
@@ -80,6 +80,7 @@ data Command
     | LedgerAllocateParties { flags :: LedgerFlags, parties :: [String] }
     | LedgerUploadDar { flags :: LedgerFlags, darPathM :: Maybe FilePath }
     | LedgerFetchDar { flags :: LedgerFlags, pid :: String, saveAs :: FilePath }
+    | LedgerReset {flags :: LedgerFlags}
     | LedgerNavigator { flags :: LedgerFlags, remainingArguments :: [String] }
     | Codegen { lang :: Lang, remainingArguments :: [String] }
 
@@ -277,6 +278,9 @@ commandParser = subparser $ fold
             [ command "allocate-party" $ info
                 (ledgerAllocatePartyCmd <**> helper)
                 (progDesc "Allocate a single party on ledger")
+            , command "reset" $ info
+                (ledgerResetCmd <**> helper)
+                (progDesc "Archive all currently active contracts.")
             ]
         ]
 
@@ -301,6 +305,9 @@ commandParser = subparser $ fold
         <$> ledgerFlags (ShowJsonApi True)
         <*> option str (long "main-package-id" <> metavar "PKGID" <> help "Fetch DAR for this package identifier.")
         <*> option str (short 'o' <> long "output" <> metavar "PATH" <> help "Save fetched DAR into this file.")
+
+    ledgerResetCmd = LedgerReset
+        <$> ledgerFlags (ShowJsonApi True)
 
     ledgerNavigatorCmd = LedgerNavigator
         <$> ledgerFlags (ShowJsonApi False)
@@ -431,5 +438,6 @@ runCommand = \case
     LedgerAllocateParties {..} -> runLedgerAllocateParties flags parties
     LedgerUploadDar {..} -> runLedgerUploadDar flags darPathM
     LedgerFetchDar {..} -> runLedgerFetchDar flags pid saveAs
+    LedgerReset {..} -> runLedgerReset flags
     LedgerNavigator {..} -> runLedgerNavigator flags remainingArguments
     Codegen {..} -> runCodegen lang remainingArguments

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -278,6 +278,8 @@ runStart
                 projectConfig
             whenJust mbOutputPath $ \_outputPath -> do
               runCodegen lang []
+        doReset (SandboxPort sandboxPort) =
+          runLedgerReset $ (defaultLedgerFlags Grpc) {fPortM = Just sandboxPort}
         doUploadDar darPath (SandboxPort sandboxPort) =
           runLedgerUploadDar ((defaultLedgerFlags Grpc) {fPortM = Just sandboxPort}) (Just darPath)
         listenForKeyPress projectConfig darPath sandboxPort runInitScript = do
@@ -295,6 +297,7 @@ runStart
         rebuild :: ProjectConfig -> FilePath -> SandboxPort -> IO () -> IO ()
         rebuild projectConfig darPath sandboxPort doRunInitScript = do
           putStrLn "Re-building and uploading package ..."
+          doReset sandboxPort
           doBuild
           doCodegen projectConfig
           doUploadDar darPath sandboxPort

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -20,6 +20,7 @@ module DA.Daml.Helper.Util
   , getLogbackArg
   , waitForConnectionOnPort
   , waitForHttpServer
+  , tokenFor
   ) where
 
 import Control.Exception.Safe
@@ -33,15 +34,21 @@ import qualified Network.HTTP.Types as HTTP
 import Network.Socket
 import System.Directory
 import System.FilePath
+import System.IO
+import System.Info.Extra
 import System.Process (showCommandForUser, terminateProcess)
 import System.Process.Typed
-import System.Info.Extra
-import System.IO
+import qualified Web.JWT as JWT
+import qualified Data.Aeson as A
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map as Map
+import qualified Data.Text.Lazy as TL
 
 import DA.Daml.Project.Config
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Types
 import DA.Daml.Project.Util hiding (fromMaybeM)
+import qualified DA.Ledger as L
 
 findDamlProjectRoot :: FilePath -> IO (Maybe FilePath)
 findDamlProjectRoot = findAscendantWithFile projectConfigName
@@ -197,3 +204,21 @@ waitForHttpServer sleep url headers = do
     where isIOException e = isJust (fromException e :: Maybe IOException)
           isHttpException e = isJust (fromException e :: Maybe HTTP.HttpException)
 
+tokenFor :: [T.Text] -> T.Text -> T.Text
+tokenFor parties ledgerId =
+  JWT.encodeSigned
+    (JWT.HMACSecret "secret")
+    mempty
+    mempty
+      { JWT.unregisteredClaims =
+          JWT.ClaimsMap $
+          Map.fromList
+            [ ( "https://daml.com/ledger-api"
+              , A.Object $
+                HashMap.fromList
+                  [ ("actAs", A.toJSON parties)
+                  , ("readAs", A.toJSON parties)
+                  , ("ledgerId", A.String ledgerId)
+                  ])
+            ]
+      }

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -42,13 +42,11 @@ import qualified Web.JWT as JWT
 import qualified Data.Aeson as A
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map as Map
-import qualified Data.Text.Lazy as TL
 
 import DA.Daml.Project.Config
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Types
 import DA.Daml.Project.Util hiding (fromMaybeM)
-import qualified DA.Ledger as L
 
 findDamlProjectRoot :: FilePath -> IO (Maybe FilePath)
 findDamlProjectRoot = findAscendantWithFile projectConfigName

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -215,7 +215,6 @@ tokenFor parties ledgerId applicationId =
               , A.Object $
                 HashMap.fromList
                   [ ("actAs", A.toJSON parties)
-                  , ("readAs", A.toJSON parties)
                   , ("ledgerId", A.String ledgerId)
                   , ("applicationId", A.String applicationId)
                   ])

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -202,8 +202,8 @@ waitForHttpServer sleep url headers = do
     where isIOException e = isJust (fromException e :: Maybe IOException)
           isHttpException e = isJust (fromException e :: Maybe HTTP.HttpException)
 
-tokenFor :: [T.Text] -> T.Text -> T.Text
-tokenFor parties ledgerId =
+tokenFor :: [T.Text] -> T.Text -> T.Text -> T.Text
+tokenFor parties ledgerId applicationId =
   JWT.encodeSigned
     (JWT.HMACSecret "secret")
     mempty
@@ -217,6 +217,7 @@ tokenFor parties ledgerId =
                   [ ("actAs", A.toJSON parties)
                   , ("readAs", A.toJSON parties)
                   , ("ledgerId", A.String ledgerId)
+                  , ("applicationId", A.String applicationId)
                   ])
             ]
       }

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -31,12 +31,11 @@ import System.Info.Extra
 import System.Process
 import Test.Tasty
 import Test.Tasty.HUnit
-import qualified Web.JWT as JWT
 
 import DA.Bazel.Runfiles
 import DA.Daml.Assistant.FreePort (getFreePort, socketHints)
 import DA.Daml.Assistant.IntegrationTestUtils
-import DA.Daml.Helper.Util (waitForConnectionOnPort, waitForHttpServer)
+import DA.Daml.Helper.Util (waitForConnectionOnPort, waitForHttpServer, tokenFor)
 -- import DA.PortFile
 import DA.Test.Daml2jsUtils
 import DA.Test.Process (callCommandSilent)
@@ -64,23 +63,7 @@ main = do
         ] $ defaultMain (tests tmpDir))
 
 hardcodedToken :: T.Text
-hardcodedToken =
-    JWT.encodeSigned
-        (JWT.HMACSecret "secret")
-        mempty
-        mempty
-            { JWT.unregisteredClaims =
-                  JWT.ClaimsMap $
-                  Map.fromList
-                      [ ( "https://daml.com/ledger-api"
-                        , Aeson.Object $
-                          HashMap.fromList
-                              [ ("actAs", Aeson.toJSON ["Alice" :: T.Text])
-                              , ("ledgerId", "MyLedger")
-                              , ("applicationId", "foobar")
-                              ])
-                      ]
-            }
+hardcodedToken = tokenFor ["Alice"] "MyLedger"
 
 authorizationHeaders :: RequestHeaders
 authorizationHeaders = [("Authorization", "Bearer " <> T.encodeUtf8 hardcodedToken)]

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -61,7 +61,7 @@ main = do
         ] $ defaultMain (tests tmpDir))
 
 hardcodedToken :: T.Text
-hardcodedToken = tokenFor ["Alice"] "MyLedger"
+hardcodedToken = tokenFor ["Alice"] "MyLedger" "AssistantIntegrationTests"
 
 authorizationHeaders :: RequestHeaders
 authorizationHeaders = [("Authorization", "Bearer " <> T.encodeUtf8 hardcodedToken)]

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -11,9 +11,7 @@ import Control.Monad
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Lens
 import qualified Data.Conduit.Tar.Extra as Tar.Conduit.Extra
-import qualified Data.HashMap.Strict as HashMap
 import Data.List.Extra
-import qualified Data.Map as Map
 import Data.Maybe (maybeToList)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T


### PR DESCRIPTION
Fixes #8162. This archives all active contracts on the ledger when a hotreload
is performed. A hidden command `reset` is added to `daml ledger` to perform the
reset against a running sandbox. Once prunning is available we also drop
existing dars from the sandbox on hot-reload.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
