### PR TITLE
Require authorization on DAR upload endpoint

### DIFF
--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -59,7 +59,7 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
 class Server(
-    maxHttpEntityUploadSize: Int,
+    maxHttpEntityUploadSize: Long,
     httpEntityUploadTimeout: FiniteDuration,
     authConfig: AuthConfig,
     triggerDao: RunningTriggerDao,
@@ -276,7 +276,7 @@ class Server(
           // Authorization failed - login and retry on callback request.
           case None =>
             // Ensure that the request is fully uploaded.
-            toStrictEntity(httpEntityUploadTimeout, maxHttpEntityUploadSize.toLong).tflatMap { _ =>
+            toStrictEntity(httpEntityUploadTimeout, maxHttpEntityUploadSize).tflatMap { _ =>
               Directive { inner => ctx =>
                 val requestId = UUID.randomUUID()
                 authCallbacks.update(
@@ -538,7 +538,7 @@ object Server {
   def apply(
       host: String,
       port: Int,
-      maxHttpEntityUploadSize: Int,
+      maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
       authConfig: AuthConfig,
       ledgerConfig: LedgerConfig,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -141,8 +141,7 @@ private[trigger] object ServiceConfig {
     opt[Int]("max-http-entity-upload-size")
       .action((x, c) => c.copy(maxHttpEntityUploadSize = x))
       .optional()
-      .text(
-        s"Optional max HTTP entity upload size. Defaults to ${DefaultMaxHttpEntityUploadSize}. HTTP uploads cannot be streamed but must be fully uploaded when a request is deferred until after a login flow with the auth middleware completed.")
+      .text(s"Optional max HTTP entity upload size. Defaults to ${DefaultMaxHttpEntityUploadSize}.")
       // TODO[AH] Expose once the auth feature is fully implemented.
       .hidden()
 
@@ -150,7 +149,7 @@ private[trigger] object ServiceConfig {
       .action((x, c) => c.copy(httpEntityUploadTimeout = FiniteDuration(x, duration.MINUTES)))
       .optional()
       .text(
-        s"Optional HTTP entity upload timeout. Defaults to ${DefaultHttpEntityUploadTimeout.toSeconds} seconds. HTTP uploads cannot be streamed but must be fully uploaded when a request is deferred until after a login flow with the auth middleware completed.")
+        s"Optional HTTP entity upload timeout. Defaults to ${DefaultHttpEntityUploadTimeout.toSeconds} seconds.")
       // TODO[AH] Expose once the auth feature is fully implemented.
       .hidden()
 

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -26,6 +26,8 @@ private[trigger] final case class ServiceConfig(
     maxInboundMessageSize: Int,
     minRestartInterval: FiniteDuration,
     maxRestartInterval: FiniteDuration,
+    maxHttpEntityUploadSize: Int,
+    httpEntityUploadTimeout: FiniteDuration,
     timeProviderType: TimeProviderType,
     commandTtl: Duration,
     init: Boolean,
@@ -81,6 +83,8 @@ private[trigger] object ServiceConfig {
   val DefaultMaxInboundMessageSize: Int = RunnerConfig.DefaultMaxInboundMessageSize
   private val DefaultMinRestartInterval: FiniteDuration = FiniteDuration(5, duration.SECONDS)
   val DefaultMaxRestartInterval: FiniteDuration = FiniteDuration(60, duration.SECONDS)
+  val DefaultMaxHttpEntityUploadSize: Int = 10485760
+  val DefaultHttpEntityUploadTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // scopt builders
   private val parser = new scopt.OptionParser[ServiceConfig]("trigger-service") {
@@ -113,7 +117,7 @@ private[trigger] object ServiceConfig {
       .optional()
       .action((t, c) => c.copy(authUri = Some(Uri(t))))
       .text("Auth middleware URI.")
-      // TODO[AH] Expose once the feature is fully implemented.
+      // TODO[AH] Expose once the auth feature is fully implemented.
       .hidden()
 
     opt[Int]("max-inbound-message-size")
@@ -133,6 +137,22 @@ private[trigger] object ServiceConfig {
       .optional()
       .text(
         s"Maximum time interval between restarting a failed trigger. Defaults to ${DefaultMaxRestartInterval.toSeconds} seconds.")
+
+    opt[Int]("max-http-entity-upload-size")
+      .action((x, c) => c.copy(maxHttpEntityUploadSize = x))
+      .optional()
+      .text(
+        s"Optional max HTTP entity upload size. Defaults to ${DefaultMaxHttpEntityUploadSize}. HTTP uploads cannot be streamed but must be fully uploaded when a request is deferred until after a login flow with the auth middleware completed.")
+      // TODO[AH] Expose once the auth feature is fully implemented.
+      .hidden()
+
+    opt[Long]("http-entity-upload-timeout")
+      .action((x, c) => c.copy(httpEntityUploadTimeout = FiniteDuration(x, duration.MINUTES)))
+      .optional()
+      .text(
+        s"Optional HTTP entity upload timeout. Defaults to ${DefaultHttpEntityUploadTimeout.toSeconds} seconds. HTTP uploads cannot be streamed but must be fully uploaded when a request is deferred until after a login flow with the auth middleware completed.")
+      // TODO[AH] Expose once the auth feature is fully implemented.
+      .hidden()
 
     opt[Unit]('w', "wall-clock-time")
       .action { (_, c) =>
@@ -172,6 +192,8 @@ private[trigger] object ServiceConfig {
         maxInboundMessageSize = DefaultMaxInboundMessageSize,
         minRestartInterval = DefaultMinRestartInterval,
         maxRestartInterval = DefaultMaxRestartInterval,
+        maxHttpEntityUploadSize = DefaultMaxHttpEntityUploadSize,
+        httpEntityUploadTimeout = DefaultHttpEntityUploadTimeout,
         timeProviderType = TimeProviderType.Static,
         commandTtl = Duration.ofSeconds(30L),
         init = false,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -26,7 +26,7 @@ private[trigger] final case class ServiceConfig(
     maxInboundMessageSize: Int,
     minRestartInterval: FiniteDuration,
     maxRestartInterval: FiniteDuration,
-    maxHttpEntityUploadSize: Int,
+    maxHttpEntityUploadSize: Long,
     httpEntityUploadTimeout: FiniteDuration,
     timeProviderType: TimeProviderType,
     commandTtl: Duration,
@@ -138,7 +138,7 @@ private[trigger] object ServiceConfig {
       .text(
         s"Maximum time interval between restarting a failed trigger. Defaults to ${DefaultMaxRestartInterval.toSeconds} seconds.")
 
-    opt[Int]("max-http-entity-upload-size")
+    opt[Long]("max-http-entity-upload-size")
       .action((x, c) => c.copy(maxHttpEntityUploadSize = x))
       .optional()
       .text(s"Optional max HTTP entity upload size. Defaults to ${DefaultMaxHttpEntityUploadSize}.")

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -83,7 +83,7 @@ private[trigger] object ServiceConfig {
   val DefaultMaxInboundMessageSize: Int = RunnerConfig.DefaultMaxInboundMessageSize
   private val DefaultMinRestartInterval: FiniteDuration = FiniteDuration(5, duration.SECONDS)
   val DefaultMaxRestartInterval: FiniteDuration = FiniteDuration(60, duration.SECONDS)
-  val DefaultMaxHttpEntityUploadSize: Int = 10485760
+  val DefaultMaxHttpEntityUploadSize: Long = RunnerConfig.DefaultMaxInboundMessageSize.toLong
   val DefaultHttpEntityUploadTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // scopt builders

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -35,7 +35,7 @@ object ServiceMain {
   def startServer(
       host: String,
       port: Int,
-      maxHttpEntityUploadSize: Int,
+      maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
       authConfig: AuthConfig,
       ledgerConfig: LedgerConfig,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -35,6 +35,8 @@ object ServiceMain {
   def startServer(
       host: String,
       port: Int,
+      maxHttpEntityUploadSize: Int,
+      httpEntityUploadTimeout: FiniteDuration,
       authConfig: AuthConfig,
       ledgerConfig: LedgerConfig,
       restartConfig: TriggerRestartConfig,
@@ -48,6 +50,8 @@ object ServiceMain {
         Server(
           host,
           port,
+          maxHttpEntityUploadSize,
+          httpEntityUploadTimeout,
           authConfig,
           ledgerConfig,
           restartConfig,
@@ -119,6 +123,8 @@ object ServiceMain {
             Server(
               config.address,
               config.httpPort,
+              config.maxHttpEntityUploadSize,
+              config.httpEntityUploadTimeout,
               authConfig,
               ledgerConfig,
               restartConfig,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -458,6 +458,8 @@ trait TriggerServiceFixture
               r <- ServiceMain.startServer(
                 host.getHostName,
                 lock.port.value,
+                ServiceConfig.DefaultMaxHttpEntityUploadSize,
+                ServiceConfig.DefaultHttpEntityUploadTimeout,
                 authConfig,
                 ledgerConfig,
                 restartConfig,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceTest.scala
@@ -142,7 +142,7 @@ trait AbstractTriggerServiceTest
       uri = uri.withPath(Uri.Path(s"/v1/packages")),
       entity = multipartForm.toEntity
     )
-    Http().singleRequest(req)
+    httpRequestFollow(req)
   }
 
   def responseBodyToString(resp: HttpResponse): Future[String] = {
@@ -562,6 +562,14 @@ trait AbstractTriggerServiceTestAuthMiddleware
         resp <- stopTrigger(uri, triggerId, alice)
         _ <- resp.status shouldBe StatusCodes.Forbidden
       } yield succeed
+  }
+
+  it should "forbid a non-authorized user to upload a DAR" in withTriggerService(Nil) { uri: Uri =>
+    authServer.revokeAdmin()
+    for {
+      resp <- uploadDar(uri, darPath) // same dar as in initialization
+      _ <- resp.status shouldBe StatusCodes.Forbidden
+    } yield succeed
   }
 
   it should "request a fresh token after expiry on user request" in withTriggerService(Nil) {


### PR DESCRIPTION
Requires authorization for `admin` claims for the upload DAR endpoint of the trigger service.

The existing `*Auth` test-suites test that uploading a DAR succeeds when permission is granted. This PR adds a test-case for the case where uploading a DAR is forbidden.

An upload DAR request contains a DAR in the HTTP entity. By default this upload is streamed. However, when a redirect for a login flow is required we need to make sure that the entity is fully uploaded before we reply with a redirection. Otherwise, the continuation will be left with a truncated entity. To that end we use the `toStrictEntity` directive. This PR adds corresponding CLI flags for the max upload size and upload timeout.

Part of #7723

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
