### PR TITLE
kvutils: Throw if CommitContext#read encounters missing input state. [KVL-757]

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -164,7 +164,6 @@ conformance_test(
 
 conformance_test(
     name = "conformance-test-pre-execution",
-    flaky = True,
     ports = [6865],
     server = ":app",
     server_args = [

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -46,7 +46,8 @@ private[kvutils] case class CommitContext(
 
   def preExecute: Boolean = recordTime.isEmpty
 
-  /** Retrieve value from output state, or if not found, from input state. */
+  /** Retrieve value from output state, or if not found, from input state.
+    * Throws an exception if the key is not found in either. */
   def get(key: DamlStateKey): Option[DamlStateValue] =
     outputs.get(key).orElse {
       val value = inputs.getOrElse(key, throw Err.MissingInputState(key))
@@ -54,7 +55,8 @@ private[kvutils] case class CommitContext(
       value
     }
 
-  /** Reads key from input state.  Records the key as being accessed even if it's not available. */
+  /** Reads key from input state.
+    * Throws an exception if the key is not specified in the input state. */
   def read(key: DamlStateKey): Option[DamlStateValue] = {
     val value = inputs.getOrElse(key, throw Err.MissingInputState(key))
     accessedInputKeys += key

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -47,17 +47,17 @@ private[kvutils] case class CommitContext(
   def preExecute: Boolean = recordTime.isEmpty
 
   /** Retrieve value from output state, or if not found, from input state. */
-  def get(key: DamlStateKey): Option[DamlStateValue] =
-    outputs.get(key).orElse {
-      val value = inputs.getOrElse(key, throw Err.MissingInputState(key))
-      accessedInputKeys += key
-      value
-    }
+  def get(key: DamlStateKey): Option[DamlStateValue] = {
+    val value = outputs.get(key).orElse(inputs.getOrElse(key, throw Err.MissingInputState(key)))
+    accessedInputKeys += key
+    value
+  }
 
   /** Reads key from input state.  Records the key as being accessed even if it's not available. */
   def read(key: DamlStateKey): Option[DamlStateValue] = {
+    val value = inputs.getOrElse(key, throw Err.MissingInputState(key))
     accessedInputKeys += key
-    inputs.get(key).flatten
+    value
   }
 
   /** Generates a collection from the inputs as determined by a partial function.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -47,11 +47,12 @@ private[kvutils] case class CommitContext(
   def preExecute: Boolean = recordTime.isEmpty
 
   /** Retrieve value from output state, or if not found, from input state. */
-  def get(key: DamlStateKey): Option[DamlStateValue] = {
-    val value = outputs.get(key).orElse(inputs.getOrElse(key, throw Err.MissingInputState(key)))
-    accessedInputKeys += key
-    value
-  }
+  def get(key: DamlStateKey): Option[DamlStateValue] =
+    outputs.get(key).orElse {
+      val value = inputs.getOrElse(key, throw Err.MissingInputState(key))
+      accessedInputKeys += key
+      value
+    }
 
   /** Reads key from input state.  Records the key as being accessed even if it's not available. */
   def read(key: DamlStateKey): Option[DamlStateValue] = {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -47,6 +47,7 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
     "throw in case key cannot be found" in {
       val context = newInstance()
       assertThrows[Err.MissingInputState](context.get(aKey))
+      context.getAccessedInputKeys shouldBe Set.empty
     }
   }
 
@@ -69,6 +70,7 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
     "throw in case key cannot be found" in {
       val context = newInstance()
       assertThrows[Err.MissingInputState](context.read(aKey))
+      context.getAccessedInputKeys shouldBe Set.empty
     }
   }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -8,8 +8,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
-import com.daml.ledger.participant.state.kvutils.{DamlStateMap, TestHelpers}
+import com.daml.ledger.participant.state.kvutils.committer.CommitContextSpec._
+import com.daml.ledger.participant.state.kvutils.{DamlStateMap, Err, TestHelpers}
 import com.daml.lf.data.Time
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -46,7 +46,7 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
 
     "throw in case key cannot be found" in {
       val context = newInstance()
-      assertThrows[MissingInputState](context.get(aKey))
+      assertThrows[Err.MissingInputState](context.get(aKey))
     }
   }
 
@@ -60,10 +60,15 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
     }
 
     "record key as accessed even if it is not available in the input" in {
-      val context = newInstance()
+      val context = newInstance(inputs = Map(aKey -> None))
 
       context.read(aKey) shouldBe None
       context.getAccessedInputKeys shouldBe Set(aKey)
+    }
+
+    "throw in case key cannot be found" in {
+      val context = newInstance()
+      assertThrows[Err.MissingInputState](context.read(aKey))
     }
   }
 
@@ -146,7 +151,9 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
       context.preExecute shouldBe true
     }
   }
+}
 
+object CommitContextSpec {
   private def aKeyWithContractId(id: String): DamlStateKey =
     DamlStateKey.newBuilder.setContractId(id).build
 


### PR DESCRIPTION
This was not possible before #8180.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
