### PR TITLE
Disable asynchronous commits in JdbcIndexer

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -63,7 +63,10 @@ object JdbcIndexer {
           config.eventsPageSize,
           metrics,
           lfValueTranslationCache,
-          jdbcAsyncCommits = true,
+          /* There is currently a corner-case which affects durability
+           * guarantees when performing async commits. This feature
+           * will be disabled until the mitigation is merged. */
+          jdbcAsyncCommits = false,
         )
         _ <- ResourceOwner.forFuture(() => ledgerDao.reset())
         initialLedgerEnd <- initializeLedger(ledgerDao)
@@ -77,7 +80,7 @@ object JdbcIndexer {
           config.eventsPageSize,
           metrics,
           lfValueTranslationCache,
-          jdbcAsyncCommits = true,
+          jdbcAsyncCommits = false,
         )
         initialLedgerEnd <- initializeLedger(ledgerDao)
       } yield new JdbcIndexer(initialLedgerEnd, config.participantId, ledgerDao, metrics)


### PR DESCRIPTION
Currently asynchronous commits are enabled by default when the `JdbcIndexer` is performing transactional inserts in the index database. As discussed with @oliverse-da and @gerolf-da , there is a corner case not handled by the current implementation which could affect durability guarantees in case of PostgreSQL db restarts that go unnoticed by the `RecoveringIndexer`.

This PR disables async commits until the mitigation is merged.

CHANGELOG_BEGIN
[JdbcIndexer] Asynchornous commits are disabled.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
