### PR TITLE
fix: Create missing directories for script output

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/RunnerMain.scala
@@ -106,6 +106,10 @@ object RunnerMain {
           _ <- Future {
             config.outputFile.foreach { outputFile =>
               val jsVal = LfValueCodec.apiValueToJsValue(result.toValue)
+              val outDir = outputFile.getParentFile()
+              if (outDir != null) {
+                val _ = Files.createDirectories(outDir.toPath())
+              }
               Files.write(outputFile.toPath, Seq(jsVal.prettyPrint).asJava)
             }
           }


### PR DESCRIPTION
This fixes #8142. We create all missing directories of the specified output
path for the `daml script` command.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
