### PR TITLE
kvutils: Fix a flaky batching queue test.

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -32,6 +32,7 @@ da_scala_library(
         "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",
         "//libs-scala/resources",
+        "//libs-scala/resources-akka",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -106,8 +106,10 @@ object InMemoryLedgerReaderWriter {
         // We need to generate batched submissions for the validator in order to improve throughput.
         // Hence, we have a BatchingLedgerWriter collect and forward batched submissions to the
         // in-memory committer.
-        ledgerWriter = newLoggingContext { implicit loggingContext =>
-          BatchingLedgerWriter(batchingLedgerWriterConfig, readerWriter)
+        ledgerWriter <- newLoggingContext { implicit loggingContext =>
+          ResourceOwner
+            .forCloseable(() => BatchingLedgerWriter(batchingLedgerWriterConfig, readerWriter))
+            .acquire()
         }
       } yield createKeyValueLedger(readerWriter, ledgerWriter)
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
@@ -58,7 +58,7 @@ class BatchingLedgerWriter(val queue: BatchingQueue, val writer: LedgerWriter)(
   override def participantId: ParticipantId = writer.participantId
 
   override def currentHealth(): HealthStatus =
-    if (queueHandle.alive)
+    if (queueHandle.isAlive)
       writer.currentHealth()
     else
       HealthStatus.unhealthy
@@ -88,7 +88,11 @@ class BatchingLedgerWriter(val queue: BatchingQueue, val writer: LedgerWriter)(
     }
   }
 
-  override def close(): Unit = queueHandle.close()
+  override def close(): Unit = {
+    // Do not wait for the queue to complete; just fire and forget.
+    queueHandle.stop()
+    ()
+  }
 }
 
 object BatchingLedgerWriter {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueue.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueue.scala
@@ -3,11 +3,11 @@
 
 package com.daml.ledger.participant.state.kvutils.api
 
-import java.io.Closeable
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 import akka.stream.scaladsl.{Sink, Source, SourceQueueWithComplete}
 import akka.stream.{Materializer, OverflowStrategy, QueueOfferResult}
+import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch
 import com.daml.ledger.participant.state.v1.SubmissionResult
 
@@ -30,22 +30,45 @@ trait BatchingQueue {
 }
 
 /** Handle for a running batching queue. */
-trait RunningBatchingQueueHandle extends Closeable {
+trait RunningBatchingQueueHandle {
 
-  /** Returns true if the handle is still alive and can handle new submissions.
-    * If this returns false the queue is unrecoverable. */
-  def alive: Boolean
+  /** Returns `true` if the queue is alive, and `false` if it is in any other state. */
+  def isAlive: Boolean = state == RunningBatchingQueueState.Alive
+
+  /** Returns the current state of the queue. */
+  def state: RunningBatchingQueueState
 
   /** Enqueue a submission into a batch. */
   def offer(submission: DamlSubmissionBatch.CorrelatedSubmission): Future[SubmissionResult]
+
+  /** Stop accepting new submissions. The future will complete when all submissions are handled. */
+  def stop(): Future[Unit]
+}
+
+sealed trait RunningBatchingQueueState
+
+object RunningBatchingQueueState {
+
+  /** The queue is alive and can handle new submissions. */
+  object Alive extends RunningBatchingQueueState
+
+  /** The queue has been closed, but is still handling submissions. */
+  object Closing extends RunningBatchingQueueState
+
+  /** The queue has finished handling submissions. */
+  object Complete extends RunningBatchingQueueState
+
+  /** The queue encountered an exception when handling a submission. */
+  object Failed extends RunningBatchingQueueState
+
 }
 
 /** A default batching queue implementation for the batching ledger writer backed by an
   * akka-streams [[Source.queue]].
   *
-  * @param maxQueueSize The maximum number of submissions to queue for batching. On overflow new submissions are dropped.
-  * @param maxBatchSizeBytes Maximum size for the batch. A batch is emitted if adding a submission would exceed this limit.
-  * @param maxWaitDuration The maximum time to wait before a batch is forcefully emitted.
+  * @param maxQueueSize         The maximum number of submissions to queue for batching. On overflow new submissions are dropped.
+  * @param maxBatchSizeBytes    Maximum size for the batch. A batch is emitted if adding a submission would exceed this limit.
+  * @param maxWaitDuration      The maximum time to wait before a batch is forcefully emitted.
   * @param maxConcurrentCommits The maximum number of concurrent calls to make to [[LedgerWriter.commit]].
   */
 case class DefaultBatchingQueue(
@@ -69,13 +92,15 @@ case class DefaultBatchingQueue(
       .to(Sink.ignore)
       .run()
 
-    val queueAlive = new AtomicBoolean(true)
-    materializedQueue.watchCompletion.foreach { _ =>
-      queueAlive.set(false)
-    }(materializer.executionContext)
+    val queueState = new AtomicReference[RunningBatchingQueueState](RunningBatchingQueueState.Alive)
+    materializedQueue
+      .watchCompletion()
+      .onComplete { _ =>
+        queueState.compareAndSet(RunningBatchingQueueState.Alive, RunningBatchingQueueState.Failed)
+      }(materializer.executionContext)
 
     new RunningBatchingQueueHandle {
-      override def alive: Boolean = queueAlive.get()
+      override def state: RunningBatchingQueueState = queueState.get()
 
       override def offer(
           submission: DamlSubmissionBatch.CorrelatedSubmission): Future[SubmissionResult] = {
@@ -90,8 +115,20 @@ case class DefaultBatchingQueue(
           }(materializer.executionContext)
       }
 
-      override def close(): Unit = {
-        materializedQueue.complete()
+      override def stop(): Future[Unit] = {
+        if (queueState.compareAndSet(
+            RunningBatchingQueueState.Alive,
+            RunningBatchingQueueState.Closing)) {
+          materializedQueue.complete()
+        }
+        materializedQueue
+          .watchCompletion()
+          .map { _ =>
+            queueState.compareAndSet(
+              RunningBatchingQueueState.Closing,
+              RunningBatchingQueueState.Complete)
+            ()
+          }(DirectExecutionContext)
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueueSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingQueueSpec.scala
@@ -40,13 +40,13 @@ class BatchingQueueSpec
         throw new RuntimeException("kill the queue")
       }
 
-      queue.alive should be(true)
+      queue.state should be(RunningBatchingQueueState.Alive)
       for {
         res <- queue.offer(correlatedSubmission)
       } yield {
         res should be(SubmissionResult.Acknowledged)
         eventually {
-          queue.alive should be(false)
+          queue.state should be(RunningBatchingQueueState.Failed)
         }
       }
     }
@@ -61,10 +61,10 @@ class BatchingQueueSpec
       ).run { _ =>
         Future.unit
       }
-      queue.alive should be(true)
-      queue.close()
-      eventually {
-        queue.alive should be(false)
+      queue.state should be(RunningBatchingQueueState.Alive)
+      val wait = queue.stop()
+      wait.map { _ =>
+        queue.state should be(RunningBatchingQueueState.Complete)
       }
     }
 
@@ -115,7 +115,7 @@ class BatchingQueueSpec
         res1 should be(SubmissionResult.Acknowledged)
         res2 should be(SubmissionResult.Acknowledged)
         batches should contain only (Seq(correlatedSubmission1), Seq(correlatedSubmission2))
-        queue.alive should be(true)
+        queue.state should be(RunningBatchingQueueState.Alive)
       }
     }
 
@@ -187,7 +187,7 @@ class BatchingQueueSpec
         res1 should be(SubmissionResult.Acknowledged)
         res2 should be(SubmissionResult.Acknowledged)
         batches.reverse should contain only (Seq(correlatedSubmission1), Seq(correlatedSubmission2))
-        queue.alive should be(true)
+        queue.state should be(RunningBatchingQueueState.Alive)
       }
     }
   }


### PR DESCRIPTION
This changes the API so that we can wait for the queue to finish before asserting that it is, indeed, finished.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
