### PR TITLE
Fix prettyprinting in DAML REPL

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -338,6 +338,13 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , input "y"
           , matchOutput "NameCollision {field = 42}"
           ]
+    , testInteraction' "long type"
+      -- Test types which will result in line breaks when prettyprinted
+          [ input "let y = ReplTest.NameCollision \"eau\""
+          , input "let x = \\f g h -> f (g (h (ReplTest.NameCollision \"a\"))) (g (ReplTest.NameCollision \"b\")) : Script ()"
+          , input "1"
+          , matchOutput "1"
+          ]
     ]
   where
     testInteraction' testName steps =


### PR DESCRIPTION
We used a weird mix of prettyprinting and string concatenation. This
breaks as soon as you have a line break somewhere because indentation
is messed up at that point. This PR fixes that by consistently (at
least more consistently than before) using the prettyprinting lib.

fixes #8213

changelog_begin

- [DAML REPL] Fix a bug where bindings with very long types sometimes
  resulted in parse errors on following lines. See #8213

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
