### PR TITLE
LF: fix versioning output in LF Repl.

### DIFF
--- a/daml-lf/tests/scenario/dev/gen-map/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/dev/gen-map/EXPECTED.ledger
@@ -1,9 +1,9 @@
 transactions:
-TX #0 1970-01-01T00:00:00Z [Test:18]
-#0:0
+TX #0 1970-01-01T00:00:00Z [Test:18] version: dev
+#0:0 version: dev
 │   known to (since): Alice (#0)
 └─> create Test:MapTemplate@XXXXXXXX
-    with: { party = 'Alice', value = GenMap(1 -> "c", 2 -> "a", 5 -> "b") } value-version: dev
+    with: { party = 'Alice', value = GenMap(1 -> "c", 2 -> "a", 5 -> "b") }
 
 active contracts:
    0019f204ef6ba77f8003a1c679c3ca245028d8e82c713ebb267ea3cc3d802d6df3

--- a/daml-lf/tests/scenario/stable/contract-key-through-exercises/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/stable/contract-key-through-exercises/EXPECTED.ledger
@@ -1,66 +1,66 @@
 transactions:
-TX #0 1970-01-01T00:00:00Z [Test:48]
-#0:0
+TX #0 1970-01-01T00:00:00Z [Test:48] version: 10
+#0:0 version: 10
 │   archived by #1:0
 │   referenced by #1:0
 │   known to (since): Alice (#0), Bob (#0)
 └─> create Test:KeyOps@XXXXXXXX
-    with: { signatories = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) }, counterParty = 'Bob' } value-version: 6
+    with: { signatories = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) }, counterParty = 'Bob' }
 
-TX #1 1970-01-01T00:00:00Z [Test:49]
-#1:0
+TX #1 1970-01-01T00:00:00Z [Test:49] version: 10
+#1:0 version: 10
 │   known to (since): Alice (#1), Bob (#1)
 └─> Bob exercises Accept:Test:KeyOps@XXXXXXXX on 0066d7eab72b04d1ab3c24f2f3cb2a2d9266c2c2dc769c8b4699b6db3a4f56ec46
-    with {  } value-version: 6
+    with {  }
     children:
-    #1:1
+    #1:1 version: 10
     │   referenced by #2:0, #3:0, #5:0
     │   known to (since): Alice (#1), Bob (#1)
     └─> create Test:KeyOps@XXXXXXXX
-        with: { signatories = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>, Bob -> <unit>) }, counterParty = 'Bob' } value-version: 6
+        with: { signatories = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>, Bob -> <unit>) }, counterParty = 'Bob' }
 
-TX #2 1970-01-01T00:00:00Z [Test:51]
-#2:0
+TX #2 1970-01-01T00:00:00Z [Test:51] version: 10
+#2:0 version: 10
 │   known to (since): Alice (#2), Bob (#2)
 └─> Alice exercises LookupGivenKey:Test:KeyOps@XXXXXXXX on 00541236708d6615d0586a50793ccd77d0bc2b7c51025df96ce743c2469c8d3c95
-    with { actor = 'Alice', keyMaintainers = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) } } value-version: 6
+    with { actor = 'Alice', keyMaintainers = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) } }
     children:
-    #2:1
+    #2:1 version: 10
     │   known to (since): Alice (#2), Bob (#2)
     └─> lookup by key Test:BasicKey@XXXXXXXX
-    key { textMap = TextMap(Alice -> <unit>) } value-version: 6
+    key { textMap = TextMap(Alice -> <unit>) }
     not found
 
-TX #3 1970-01-01T00:00:00Z [Test:54]
-#3:0
+TX #3 1970-01-01T00:00:00Z [Test:54] version: 10
+#3:0 version: 10
 │   known to (since): Alice (#3), Bob (#3)
 └─> Bob exercises LookupGivenKey:Test:KeyOps@XXXXXXXX on 00541236708d6615d0586a50793ccd77d0bc2b7c51025df96ce743c2469c8d3c95
-    with { actor = 'Bob', keyMaintainers = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) } } value-version: 6
+    with { actor = 'Bob', keyMaintainers = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) } }
     children:
-    #3:1
+    #3:1 version: 10
     │   known to (since): Alice (#3), Bob (#3)
     └─> lookup by key Test:BasicKey@XXXXXXXX
-    key { textMap = TextMap(Alice -> <unit>) } value-version: 6
+    key { textMap = TextMap(Alice -> <unit>) }
     not found
 
-TX #4 1970-01-01T00:00:00Z [Test:57]
-#4:0
+TX #4 1970-01-01T00:00:00Z [Test:57] version: 10
+#4:0 version: 10
 │   referenced by #5:1
 │   known to (since): Alice (#4)
 └─> create Test:BasicKey@XXXXXXXX
-    with: { owners = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) } } value-version: 6
-key { textMap = TextMap(Alice -> <unit>) } value-version: 6
+    with: { owners = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) } }
+key { textMap = TextMap(Alice -> <unit>) }
 
-TX #5 1970-01-01T00:00:00Z [Test:59]
-#5:0
+TX #5 1970-01-01T00:00:00Z [Test:59] version: 10
+#5:0 version: 10
 │   known to (since): Alice (#5), Bob (#5)
 └─> Alice exercises LookupGivenKey:Test:KeyOps@XXXXXXXX on 00541236708d6615d0586a50793ccd77d0bc2b7c51025df96ce743c2469c8d3c95
-    with { actor = 'Alice', keyMaintainers = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) } } value-version: 6
+    with { actor = 'Alice', keyMaintainers = DA.Next.Set:Set@XXXXXXXX{ textMap = TextMap(Alice -> <unit>) } }
     children:
-    #5:1
+    #5:1 version: 10
     │   known to (since): Alice (#5), Bob (#5)
     └─> lookup by key Test:BasicKey@XXXXXXXX
-    key { textMap = TextMap(Alice -> <unit>) } value-version: 6
+    key { textMap = TextMap(Alice -> <unit>) }
     found 001562b1ff4a33485e45d6e392d6eea26e518c878dae2b8f1d2a6c7d8face9d0f7
 
 mustFailAt 'Bob' [Test:62]

--- a/daml-lf/tests/scenario/stable/contract-keys/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/stable/contract-keys/EXPECTED.ledger
@@ -1,12 +1,12 @@
 transactions:
-TX #0 1970-01-01T00:00:00Z [Test:77]
-#0:0
+TX #0 1970-01-01T00:00:00Z [Test:77] version: 10
+#0:0 version: 10
 │   archived by #8:0
 │   referenced by #4:0, #5:0, #8:0
 │   known to (since): Alice (#0), Bob (#0)
 └─> create Test:TextKey@XXXXXXXX
-    with: { p = 'Alice', k = "some-key", disclosedTo = ['Bob'] } value-version: 6
-key { _1 = 'Alice', _2 = "some-key" } value-version: 6
+    with: { p = 'Alice', k = "some-key", disclosedTo = ['Bob'] }
+key { _1 = 'Alice', _2 = "some-key" }
 
 mustFailAt 'Alice' [Test:84]
 
@@ -14,130 +14,130 @@ mustFailAt 'Bob' [Test:91]
 
 mustFailAt 'Bob' [Test:93]
 
-TX #4 1970-01-01T00:00:00Z [Test:96]
-#4:0
+TX #4 1970-01-01T00:00:00Z [Test:96] version: 10
+#4:0 version: 10
 │   known to (since): Alice (#4)
 └─> lookup by key Test:TextKey@XXXXXXXX
-key { _1 = 'Alice', _2 = "some-key" } value-version: 6
+key { _1 = 'Alice', _2 = "some-key" }
 found 0066d7eab72b04d1ab3c24f2f3cb2a2d9266c2c2dc769c8b4699b6db3a4f56ec46
 
-TX #5 1970-01-01T00:00:00Z [Test:100]
-#5:0
+TX #5 1970-01-01T00:00:00Z [Test:100] version: 10
+#5:0 version: 10
 │   known to (since): Alice (#5)
 └─> ensure active 0066d7eab72b04d1ab3c24f2f3cb2a2d9266c2c2dc769c8b4699b6db3a4f56ec46
 
-TX #6 1970-01-01T00:00:00Z [Test:104]
-#6:0
+TX #6 1970-01-01T00:00:00Z [Test:104] version: 10
+#6:0 version: 10
 │   known to (since): Alice (#6)
 └─> lookup by key Test:TextKey@XXXXXXXX
-key { _1 = 'Alice', _2 = "blah" } value-version: 6
+key { _1 = 'Alice', _2 = "blah" }
 not found
 
-TX #7 1970-01-01T00:00:00Z [Test:108]
-#7:0
+TX #7 1970-01-01T00:00:00Z [Test:108] version: 10
+#7:0 version: 10
 │   known to (since): Bob (#7)
 └─> lookup by key Test:TextKey@XXXXXXXX
-key { _1 = 'Bob', _2 = "some-key" } value-version: 6
+key { _1 = 'Bob', _2 = "some-key" }
 not found
 
-TX #8 1970-01-01T00:00:00Z [Test:112]
-#8:0
+TX #8 1970-01-01T00:00:00Z [Test:112] version: 10
+#8:0 version: 10
 │   known to (since): Alice (#8), Bob (#8)
 └─> Alice exercises TextKeyChoice:Test:TextKey@XXXXXXXX on 0066d7eab72b04d1ab3c24f2f3cb2a2d9266c2c2dc769c8b4699b6db3a4f56ec46
-    with {  } value-version: 6
+    with {  }
     
 
-TX #9 1970-01-01T00:00:00Z [Test:115]
-#9:0
+TX #9 1970-01-01T00:00:00Z [Test:115] version: 10
+#9:0 version: 10
 │   known to (since): Alice (#9)
 └─> lookup by key Test:TextKey@XXXXXXXX
-key { _1 = 'Alice', _2 = "some-key" } value-version: 6
+key { _1 = 'Alice', _2 = "some-key" }
 not found
 
-TX #10 1970-01-01T00:00:00Z [Test:121]
-#10:0
+TX #10 1970-01-01T00:00:00Z [Test:121] version: 10
+#10:0 version: 10
 │   archived by #11:0
 │   referenced by #11:0
 │   known to (since): Alice (#10), Bob (#10)
 └─> create Test:TextKey@XXXXXXXX
-    with: { p = 'Alice', k = "some-key-2", disclosedTo = ['Bob'] } value-version: 6
-key { _1 = 'Alice', _2 = "some-key-2" } value-version: 6
+    with: { p = 'Alice', k = "some-key-2", disclosedTo = ['Bob'] }
+key { _1 = 'Alice', _2 = "some-key-2" }
 
-TX #11 1970-01-01T00:00:00Z [Test:126]
-#11:0
+TX #11 1970-01-01T00:00:00Z [Test:126] version: 10
+#11:0 version: 10
 │   known to (since): Alice (#11), Bob (#11)
 └─> Alice exercises TextKeyChoice:Test:TextKey@XXXXXXXX on 004f56105c00ca4026b905ed27b104471dffcaf2de15832139b93ef46b87000232
-    with {  } value-version: 6
+    with {  }
     
 
-#11:1
+#11:1 version: 10
 │   known to (since): Alice (#11)
 └─> lookup by key Test:TextKey@XXXXXXXX
-key { _1 = 'Alice', _2 = "some-key-2" } value-version: 6
+key { _1 = 'Alice', _2 = "some-key-2" }
 not found
 
-TX #12 1970-01-01T00:00:00Z [Test:132]
-#12:0
+TX #12 1970-01-01T00:00:00Z [Test:132] version: 10
+#12:0 version: 10
 │   referenced by #12:1
 │   known to (since): Alice (#12)
 └─> create Test:TextKey@XXXXXXXX
-    with: { p = 'Alice', k = "same-submit-key", disclosedTo = [] } value-version: 6
-key { _1 = 'Alice', _2 = "same-submit-key" } value-version: 6
+    with: { p = 'Alice', k = "same-submit-key", disclosedTo = [] }
+key { _1 = 'Alice', _2 = "same-submit-key" }
 
-#12:1
+#12:1 version: 10
 │   known to (since): Alice (#12)
 └─> lookup by key Test:TextKey@XXXXXXXX
-key { _1 = 'Alice', _2 = "same-submit-key" } value-version: 6
+key { _1 = 'Alice', _2 = "same-submit-key" }
 found 00a95ea3bb21422ab003f15dc95de204110b3f7f2682b407a2ba75d36b0be9053b
 
-TX #13 1970-01-01T00:00:00Z [Test:140]
-#13:0
+TX #13 1970-01-01T00:00:00Z [Test:140] version: 10
+#13:0 version: 10
 │   referenced by #14:0
 │   known to (since): Alice (#13)
 └─> create Test:CreateAndLookup@XXXXXXXX
-    with: { p = 'Alice', k = "same-choice-key" } value-version: 6
+    with: { p = 'Alice', k = "same-choice-key" }
 
-TX #14 1970-01-01T00:00:00Z [Test:144]
-#14:0
+TX #14 1970-01-01T00:00:00Z [Test:144] version: 10
+#14:0 version: 10
 │   known to (since): Alice (#14)
 └─> Alice exercises Good:Test:CreateAndLookup@XXXXXXXX on 00528ef7ca096fcc1cfb640394394117e237d21236faef81c544770ec5962c462c
-    with {  } value-version: 6
+    with {  }
     children:
-    #14:1
+    #14:1 version: 10
     │   referenced by #14:2, #14:3
     │   known to (since): Alice (#14)
     └─> create Test:TextKey@XXXXXXXX
-        with: { p = 'Alice', k = "same-choice-key", disclosedTo = [] } value-version: 6
-    key { _1 = 'Alice', _2 = "same-choice-key" } value-version: 6
-    #14:2
+        with: { p = 'Alice', k = "same-choice-key", disclosedTo = [] }
+    key { _1 = 'Alice', _2 = "same-choice-key" }
+    #14:2 version: 10
     │   known to (since): Alice (#14)
     └─> lookup by key Test:TextKey@XXXXXXXX
-    key { _1 = 'Alice', _2 = "same-choice-key" } value-version: 6
+    key { _1 = 'Alice', _2 = "same-choice-key" }
     found 00ce68df68a7e42ecadca4ff1e4d35ffff75f009d1f01ae130d36116e1332ff773
-    #14:3
+    #14:3 version: 10
     │   known to (since): Alice (#14)
     └─> ensure active 00ce68df68a7e42ecadca4ff1e4d35ffff75f009d1f01ae130d36116e1332ff773
 
 mustFailAt 'Alice' [Test:147]
 
-TX #16 1970-01-01T00:00:00Z [Test:151]
-#16:0
+TX #16 1970-01-01T00:00:00Z [Test:151] version: 10
+#16:0 version: 10
 │   referenced by #16:1, #16:2
 │   known to (since): Alice (#16)
 └─> create Test:TextKey@XXXXXXXX
-    with: { p = 'Alice', k = "non-consuming-choice", disclosedTo = [] } value-version: 6
-key { _1 = 'Alice', _2 = "non-consuming-choice" } value-version: 6
+    with: { p = 'Alice', k = "non-consuming-choice", disclosedTo = [] }
+key { _1 = 'Alice', _2 = "non-consuming-choice" }
 
-#16:1
+#16:1 version: 10
 │   known to (since): Alice (#16)
 └─> Alice exercises TextKeyNonconsumingChoice:Test:TextKey@XXXXXXXX on 00bcf23c0f4133f226e7051a79ab289277e1a3941dcf08c545ff477593c9b22651
-    with {  } value-version: 6
+    with {  }
     
 
-#16:2
+#16:2 version: 10
 │   known to (since): Alice (#16)
 └─> lookup by key Test:TextKey@XXXXXXXX
-key { _1 = 'Alice', _2 = "non-consuming-choice" } value-version: 6
+key { _1 = 'Alice', _2 = "non-consuming-choice" }
 found 00bcf23c0f4133f226e7051a79ab289277e1a3941dcf08c545ff477593c9b22651
 
 mustFailAt 'Alice' [Test:161]

--- a/daml-lf/tests/scenario/stable/divulge-iou/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/stable/divulge-iou/EXPECTED.ledger
@@ -1,25 +1,25 @@
 transactions:
-TX #0 1970-01-01T00:00:00Z [Test:12]
-#0:0
+TX #0 1970-01-01T00:00:00Z [Test:12] version: 10
+#0:0 version: 10
 │   referenced by #2:1
 │   known to (since): Alice (#0), AlicesBank (#0), Bob (#2)
 └─> create Test:Iou@XXXXXXXX
-    with: { payer = 'AlicesBank', owner = 'Alice', amount = Test:Amount@XXXXXXXX{ value = 1.0000000000, currency = "USD" } } value-version: 6
+    with: { payer = 'AlicesBank', owner = 'Alice', amount = Test:Amount@XXXXXXXX{ value = 1.0000000000, currency = "USD" } }
 
-TX #1 1970-01-01T00:00:00Z [Test:17]
-#1:0
+TX #1 1970-01-01T00:00:00Z [Test:17] version: 10
+#1:0 version: 10
 │   referenced by #2:0
 │   known to (since): AlicesBank (#1), Bob (#1)
 └─> create Test:DivulgeIouByExercise@XXXXXXXX
-    with: { payer = 'AlicesBank', divulgee = 'Bob' } value-version: 6
+    with: { payer = 'AlicesBank', divulgee = 'Bob' }
 
-TX #2 1970-01-01T00:00:00Z [Test:20]
-#2:0
+TX #2 1970-01-01T00:00:00Z [Test:20] version: 10
+#2:0 version: 10
 │   known to (since): AlicesBank (#2), Bob (#2)
 └─> AlicesBank exercises Divulge:Test:DivulgeIouByExercise@XXXXXXXX on 00999d35e67dc49f91772eaffd08179f431661a382cd68edc7d25ee2c2508fb6a3
-    with { ref = 00a21310a64aec150c16589881ebebc4780fc8e476489ef939a1ebfbfeb1aa3835 } value-version: 6
+    with { ref = 00a21310a64aec150c16589881ebebc4780fc8e476489ef939a1ebfbfeb1aa3835 }
     children:
-    #2:1
+    #2:1 version: 10
     │   known to (since): AlicesBank (#2), Bob (#2)
     └─> ensure active 00a21310a64aec150c16589881ebebc4780fc8e476489ef939a1ebfbfeb1aa3835
 

--- a/daml-lf/tests/scenario/stable/embed-abort/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/stable/embed-abort/EXPECTED.ledger
@@ -1,8 +1,8 @@
 transactions:
-TX #0 1970-01-01T00:00:00Z [Test:20]
+TX #0 1970-01-01T00:00:00Z [Test:20] version: 10
 
 
-TX #1 1970-01-01T00:00:00Z [Test:21]
+TX #1 1970-01-01T00:00:00Z [Test:21] version: 10
 
 
 active contracts:

--- a/daml-lf/tests/scenario/stable/mustfails/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/stable/mustfails/EXPECTED.ledger
@@ -7,80 +7,80 @@ mustFailAt 'Alice' [Test:96]
 
 mustFailAt 'Alice' [Test:100]
 
-TX #4 1970-01-01T00:00:00Z [Test:108]
-#4:0
+TX #4 1970-01-01T00:00:00Z [Test:108] version: 10
+#4:0 version: 10
 │   known to (since): Alice (#4), Bob (#4)
 └─> create Test:X@XXXXXXXX
-    with: { p = 'Alice', p2 = 'Bob' } value-version: 6
+    with: { p = 'Alice', p2 = 'Bob' }
 
 pass -100000000
 
 mustFailAt 'Bob' [Test:110]
 
-TX #7 1969-12-31T23:58:20Z [Test:115]
-#7:0
+TX #7 1969-12-31T23:58:20Z [Test:115] version: 10
+#7:0 version: 10
 │   known to (since): Alice (#7)
 └─> create Test:TwoParties@XXXXXXXX
-    with: { p = 'Alice', p2 = 'Alice' } value-version: 6
+    with: { p = 'Alice', p2 = 'Alice' }
 
 mustFailAt 'Bob' [Test:116]
 
 mustFailAt 'Alice' [Test:123]
 
-TX #10 1969-12-31T23:58:20Z [Test:128]
-#10:0
+TX #10 1969-12-31T23:58:20Z [Test:128] version: 10
+#10:0 version: 10
 │   archived by #11:0
 │   referenced by #11:0
 │   known to (since): Alice (#10), Bob (#10)
 └─> create Test:ToTwoParties@XXXXXXXX
-    with: { p = 'Alice', p2 = 'Bob' } value-version: 6
+    with: { p = 'Alice', p2 = 'Bob' }
 
-TX #11 1969-12-31T23:58:20Z [Test:129]
-#11:0
+TX #11 1969-12-31T23:58:20Z [Test:129] version: 10
+#11:0 version: 10
 │   known to (since): Alice (#11), Bob (#11)
 └─> Bob exercises Convert:Test:ToTwoParties@XXXXXXXX on 00059653cdb8e866d69fac4d5bd0f62bbdaba4c36b01c438b86351fbdbf2cab8b0
-    with {  } value-version: 6
+    with {  }
     children:
-    #11:1
+    #11:1 version: 10
     │   known to (since): Alice (#11), Bob (#11)
     └─> create Test:TwoParties@XXXXXXXX
-        with: { p = 'Alice', p2 = 'Bob' } value-version: 6
+        with: { p = 'Alice', p2 = 'Bob' }
 
 mustFailAt 'Bob' [Test:130]
 
-TX #13 1969-12-31T23:58:20Z [Test:134]
-#13:0
+TX #13 1969-12-31T23:58:20Z [Test:134] version: 10
+#13:0 version: 10
 │   known to (since): Alice (#13)
 └─> create Test:NoCtrls@XXXXXXXX
-    with: { p = 'Alice', xs = [] } value-version: 6
+    with: { p = 'Alice', xs = [] }
 
 mustFailAt 'Alice' [Test:135]
 
 mustFailAt 'Alice' [Test:139]
 
-TX #16 1969-12-31T23:58:20Z [Test:144]
-#16:0
+TX #16 1969-12-31T23:58:20Z [Test:144] version: 10
+#16:0 version: 10
 │   known to (since): Alice (#16), Bob (#16)
 └─> create Test:X@XXXXXXXX
-    with: { p = 'Alice', p2 = 'Bob' } value-version: 6
+    with: { p = 'Alice', p2 = 'Bob' }
 
 mustFailAt 'Alice' [Test:145]
 
-TX #18 1969-12-31T23:58:20Z [Test:151]
-#18:0
+TX #18 1969-12-31T23:58:20Z [Test:151] version: 10
+#18:0 version: 10
 │   known to (since): Alice (#18)
 └─> create Test:Recursive@XXXXXXXX
-    with: { p = 'Alice' } value-version: 6
+    with: { p = 'Alice' }
 
 mustFailAt 'Alice' [Test:154]
 
 mustFailAt 'Alice' [Test:340]
 
-TX #21 1969-12-31T23:58:20Z [Test:345]
-#21:0
+TX #21 1969-12-31T23:58:20Z [Test:345] version: 10
+#21:0 version: 10
 │   known to (since): Alice (#21)
 └─> create Test:NestingLimitExercise@XXXXXXXX
-    with: { p = 'Alice' } value-version: 6
+    with: { p = 'Alice' }
 
 mustFailAt 'Alice' [Test:346]
 


### PR DESCRIPTION
With this PR, The Repl now:
* outputs the transaction version (not sure why it was not
there before)
* outputs the node version, because each node is now versioned
independently (See #7788)
* drops the value version, because it is dictated by the node version
(See #7788)

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
