### PR TITLE
daml-sdk-head: don't install to path

### DIFF
--- a/dev-env/bin/daml-sdk-head
+++ b/dev-env/bin/daml-sdk-head
@@ -149,10 +149,10 @@ tar xzf "$TARBALL" -C "$SDK_DIR" --strip-components 1
 readonly DAML_CMD="$(command -v daml)"
 if [[ -x "$DAML_CMD" && "$DAML_CMD" == "$DAML_HOME/bin/daml" ]]; then
   # A daml installation already exists, so just install SDK version $DAML_SDK_RELEASE_VERSION.
-  "${DAML_HOME}/bin/daml" install "$SDK_DIR" --force
+  "${DAML_HOME}/bin/daml" install "$SDK_DIR" --force --set-path=no
 else
   # No daml installation detected, so install the tarball normally but disable auto-install.
-  "${SDK_DIR}/install.sh" --force
+  "${SDK_DIR}/install.sh" --force --set-path=no
   echo "auto-install: false" > "${DAML_HOME}/daml-config.yaml"
 fi
 


### PR DESCRIPTION
When running daml-sdk-head from circleci without set-path=no, the
installation fails because the assistant tries to get a Yes/No answer
from stdin (which is not available).

When running locally, the `~/.daml/bin` directory is likely already included
in `PATH`.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
