### PR TITLE
JdbcIndexer async commit durability issue mitigation

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/OffsetUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/OffsetUpdate.scala
@@ -7,21 +7,35 @@ import com.daml.ledger.participant.state.v1.{Offset, Update}
 import com.daml.ledger.participant.state.v1.Update.TransactionAccepted
 import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 
-sealed trait OffsetUpdate {
-  def offset: Offset
+sealed trait OffsetUpdate extends Product with Serializable {
+  def offsetStep: OffsetStep
 
   def update: Update
 }
 
 object OffsetUpdate {
-  def unapply(offsetUpdate: OffsetUpdate): Option[(Offset, Update)] =
-    Some((offsetUpdate.offset, offsetUpdate.update))
+  def unapply(offsetUpdate: OffsetUpdate): Option[(OffsetStep, Update)] =
+    Some((offsetUpdate.offsetStep, offsetUpdate.update))
 
   final case class PreparedTransactionInsert(
-      offset: Offset,
+      offsetStep: OffsetStep,
       update: TransactionAccepted,
       preparedInsert: PreparedInsert)
       extends OffsetUpdate
 
-  final case class OffsetUpdatePair(offset: Offset, update: Update) extends OffsetUpdate
+  final case class OffsetStepUpdatePair(offsetStep: OffsetStep, update: Update) extends OffsetUpdate
 }
+
+sealed trait OffsetStep extends Product with Serializable {
+  def offset: Offset
+}
+
+object OffsetStep {
+  def apply(previousOffset: Option[Offset], offset: Offset): OffsetStep = previousOffset match {
+    case Some(prevOffset) => IncrementalOffsetStep(prevOffset, offset)
+    case None => CurrentOffset(offset)
+  }
+}
+
+final case class CurrentOffset(offset: Offset) extends OffsetStep
+final case class IncrementalOffsetStep(previousOffset: Offset, offset: Offset) extends OffsetStep

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -27,6 +27,7 @@ import com.daml.lf.transaction.{BlindingInfo, GlobalKey}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.LoggingContext
+import com.daml.platform.indexer.OffsetStep
 import com.daml.platform.store.dao.events.{TransactionsReader, TransactionsWriter}
 import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 import com.daml.platform.store.entries.{
@@ -207,7 +208,7 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
       transactionId: TransactionId,
       recordTime: Instant,
       ledgerEffectiveTime: Instant,
-      offset: Offset,
+      offsetStep: OffsetStep,
       transaction: CommittedTransaction,
       divulged: Iterable[DivulgedContract],
       blindingInfo: Option[BlindingInfo],
@@ -216,7 +217,7 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
   def storeRejection(
       submitterInfo: Option[SubmitterInfo],
       recordTime: Instant,
-      offset: Offset,
+      offsetStep: OffsetStep,
       reason: RejectionReason,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
@@ -235,11 +236,11 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
   /**
     * Stores a party allocation or rejection thereof.
     *
-    * @param offset       the offset to store the party entry
+    * @param offsetStep  Pair of previous offset and the offset to store the party entry at
     * @param partyEntry  the PartyEntry to be stored
     * @return Ok when the operation was successful otherwise a Duplicate
     */
-  def storePartyEntry(offset: Offset, partyEntry: PartyLedgerEntry)(
+  def storePartyEntry(offsetStep: OffsetStep, partyEntry: PartyLedgerEntry)(
       implicit loggingContext: LoggingContext,
   ): Future[PersistenceResponse]
 
@@ -247,18 +248,18 @@ private[platform] trait LedgerWriteDao extends ReportsHealth {
     * Store a configuration change or rejection.
     */
   def storeConfigurationEntry(
-      offset: Offset,
+      offsetStep: OffsetStep,
       recordedAt: Instant,
       submissionId: String,
       configuration: Configuration,
-      rejectionReason: Option[String]
-  )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]
+      rejectionReason: Option[String])(
+      implicit loggingContext: LoggingContext): Future[PersistenceResponse]
 
   /**
     * Store a DAML-LF package upload result.
     */
   def storePackageEntry(
-      offset: Offset,
+      offsetStep: OffsetStep,
       packages: List[(Archive, PackageDetails)],
       optEntry: Option[PackageLedgerEntry]
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse]

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -20,6 +20,7 @@ import com.daml.lf.value.Value
 import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
+import com.daml.platform.indexer.OffsetStep
 import com.daml.platform.store.dao.events.{TransactionsReader, TransactionsWriter}
 import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 import com.daml.platform.store.entries.{
@@ -162,7 +163,7 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
       transactionId: TransactionId,
       recordTime: Instant,
       ledgerEffectiveTime: Instant,
-      offset: Offset,
+      offsetStep: OffsetStep,
       transaction: CommittedTransaction,
       divulged: Iterable[DivulgedContract],
       blindingInfo: Option[BlindingInfo],
@@ -175,7 +176,7 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
         transactionId,
         recordTime,
         ledgerEffectiveTime,
-        offset,
+        offsetStep,
         transaction,
         divulged,
         blindingInfo,
@@ -206,12 +207,12 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
   override def storeRejection(
       submitterInfo: Option[SubmitterInfo],
       recordTime: Instant,
-      offset: Offset,
+      offsetStep: OffsetStep,
       reason: RejectionReason,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storeRejection,
-      ledgerDao.storeRejection(submitterInfo, recordTime, offset, reason),
+      ledgerDao.storeRejection(submitterInfo, recordTime, offsetStep, reason),
     )
 
   override def storeInitialState(
@@ -235,16 +236,16 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
     ledgerDao.reset()
 
   override def storePartyEntry(
-      offset: Offset,
+      offsetStep: OffsetStep,
       partyEntry: PartyLedgerEntry,
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storePartyEntry,
-      ledgerDao.storePartyEntry(offset, partyEntry),
+      ledgerDao.storePartyEntry(offsetStep, partyEntry),
     )
 
   override def storeConfigurationEntry(
-      offset: Offset,
+      offsetStep: OffsetStep,
       recordTime: Instant,
       submissionId: String,
       configuration: Configuration,
@@ -253,7 +254,7 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
     Timed.future(
       metrics.daml.index.db.storeConfigurationEntry,
       ledgerDao.storeConfigurationEntry(
-        offset,
+        offsetStep,
         recordTime,
         submissionId,
         configuration,
@@ -262,12 +263,12 @@ private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)
     )
 
   override def storePackageEntry(
-      offset: Offset,
+      offsetStep: OffsetStep,
       packages: List[(Archive, PackageDetails)],
       entry: Option[PackageLedgerEntry],
   )(implicit loggingContext: LoggingContext): Future[PersistenceResponse] =
     Timed.future(
       metrics.daml.index.db.storePackageEntry,
-      ledgerDao.storePackageEntry(offset, packages, entry))
+      ledgerDao.storePackageEntry(offsetStep, packages, entry))
 
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
@@ -177,7 +177,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
       _ <- store(
         divulgedContracts = Map((create2, someVersionedContractInstance) -> Set(alice)),
         blindingInfo = None,
-        nextOffset() -> LedgerEntry.Transaction(
+        offsetAndTx = nextOffset() -> LedgerEntry.Transaction(
           commandId = Some(UUID.randomUUID.toString),
           transactionId = UUID.randomUUID.toString,
           applicationId = Some(appId),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPackagesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPackagesSpec.scala
@@ -5,6 +5,11 @@ package com.daml.platform.store.dao
 
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
+import com.daml.daml_lf_dev.DamlLf
+import com.daml.ledger.participant.state.index.v2.PackageDetails
+import com.daml.ledger.participant.state.v1.Offset
+import com.daml.platform.indexer.IncrementalOffsetStep
+import com.daml.platform.store.dao.ParametersTable.LedgerEndUpdateError
 
 private[dao] trait JdbcLedgerDaoPackagesSpec {
   this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
@@ -17,18 +22,14 @@ private[dao] trait JdbcLedgerDaoPackagesSpec {
     val offset1 = nextOffset()
     val offset2 = nextOffset()
     for {
-      firstUploadResult <- ledgerDao
-        .storePackageEntry(
-          offset1,
-          packages
-            .map(a => a._1 -> a._2.copy(sourceDescription = Some(firstDescription)))
-            .take(1),
-          None)
-      secondUploadResult <- ledgerDao
-        .storePackageEntry(
-          offset2,
-          packages.map(a => a._1 -> a._2.copy(sourceDescription = Some(secondDescription))),
-          None)
+      firstUploadResult <- storePackageEntry(
+        offset1,
+        packages
+          .map(a => a._1 -> a._2.copy(sourceDescription = Some(firstDescription)))
+          .take(1))
+      secondUploadResult <- storePackageEntry(
+        offset2,
+        packages.map(a => a._1 -> a._2.copy(sourceDescription = Some(secondDescription))))
       loadedPackages <- ledgerDao.listLfPackages
     } yield {
       firstUploadResult shouldBe PersistenceResponse.Ok
@@ -39,4 +40,17 @@ private[dao] trait JdbcLedgerDaoPackagesSpec {
     }
   }
 
+  it should "fail on storing package entry with non-incremental offsets" in {
+    val offset = nextOffset()
+    recoverToSucceededIf[LedgerEndUpdateError](
+      ledgerDao
+        .storePackageEntry(IncrementalOffsetStep(offset, offset), packages, None)
+    )
+  }
+
+  private def storePackageEntry(
+      offset: Offset,
+      packageList: List[(DamlLf.Archive, PackageDetails)]) =
+    ledgerDao
+      .storePackageEntry(nextOffsetStep(offset), packageList, None)
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsWriterSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsWriterSpec.scala
@@ -8,6 +8,8 @@ import com.daml.lf.transaction.{BlindingInfo, NodeId}
 import org.scalatest.LoneElement
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
+import com.daml.platform.indexer.IncrementalOffsetStep
+import com.daml.platform.store.dao.ParametersTable.LedgerEndUpdateError
 
 private[dao] trait JdbcLedgerDaoTransactionsWriterSpec extends LoneElement {
   this: AsyncFlatSpec with Matchers with JdbcLedgerDaoSuite =>
@@ -67,4 +69,14 @@ private[dao] trait JdbcLedgerDaoTransactionsWriterSpec extends LoneElement {
     }
   }
 
+  it should "fail trying to store transactions with non-incremental offsets" in {
+    val (offset, tx) = singleCreate
+    recoverToSucceededIf[LedgerEndUpdateError](
+      storeOffsetStepAndTx(
+        offsetStepAndTx = IncrementalOffsetStep(nextOffset(), offset) -> tx,
+        blindingInfo = None,
+        divulgedContracts = Map.empty,
+      )
+    )
+  }
 }


### PR DESCRIPTION
This PR provides a mitigation to an indexer durability guarantee degradation case as described in https://github.com/digital-asset/daml/pull/8195, where loss of data could be possible in case of a PostgreSQL index DB crash that goes unnoticed by the RecoveringIndexer.
 
**Hypothetical scenario**
* PostgreSQL crashes just after acknowledging an asynchronous commit from the indexer, but before being able to persist the WAL changes to persistent storage.
* The indexer does not receive new updates from the ledger, so it is unaware that the DB crashed.
* The PostgreSQL DB is restarted.
* On new incoming updates, the indexer continues from its own last known ledger end leaving a gap in persisted/durable updates.

**Resolution**
A compare-and-set mechanism is implemented when updating the parameters table with new ledger ends (at the end of each PostgreSQL transaction). In case the compare fails, an exception is thrown which causes a restart of the indexer.

Together with this mitigation, the asynchronous commits are re-enabled for the `JdbcIndexer`.

CHANGELOG_BEGIN
[Integration Kit] Re-enabled asynchronous commits in JdbcIndexer.
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
