### PR TITLE
Improve error messages on use of contract ids in contract keys

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -94,7 +94,7 @@ private[lf] final class CommandPreprocessor(compiledPackages: CompiledPackages) 
     val (arg, argCids) = valueTranslator.unsafeTranslateValue(choiceArgType, argument)
     val (key, keyCids) = valueTranslator.unsafeTranslateValue(ckTtype, contractKey)
     keyCids.foreach { coid =>
-      fail(s"Unexpected contract id in key: $coid")
+      fail(s"Contract IDs are not supported in contract keys: $coid")
     }
     speedy.Command.ExerciseByKey(templateId, key, choiceId, arg) -> argCids
   }
@@ -125,7 +125,7 @@ private[lf] final class CommandPreprocessor(compiledPackages: CompiledPackages) 
     val ckTtype = unsafeGetContractKeyType(templateId, template)
     val (key, keyCids) = valueTranslator.unsafeTranslateValue(ckTtype, contractKey)
     keyCids.foreach { coid =>
-      fail(s"Unexpected contract id in key: $coid")
+      fail(s"Contract IDs are not supported in contract keys: $coid")
     }
     speedy.Command.LookupByKey(templateId, key)
   }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/CommandPreprocessor.scala
@@ -94,7 +94,7 @@ private[lf] final class CommandPreprocessor(compiledPackages: CompiledPackages) 
     val (arg, argCids) = valueTranslator.unsafeTranslateValue(choiceArgType, argument)
     val (key, keyCids) = valueTranslator.unsafeTranslateValue(ckTtype, contractKey)
     keyCids.foreach { coid =>
-      fail(s"Contract IDs are not supported in contract keys: $coid")
+      fail(s"Contract IDs are not supported in contract key of $templateId: $coid")
     }
     speedy.Command.ExerciseByKey(templateId, key, choiceId, arg) -> argCids
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1629,7 +1629,7 @@ private[lf] object SBuiltin {
               .toValue
               .ensureNoCid
               .left
-              .map(coid => s"Unexpected contract id in key: $coid")
+              .map(coid => s"Contract IDs are not supported in contract keys: $coid")
           } yield
             Node.KeyWithMaintainers(
               key = keyVal,

--- a/daml-lf/tests/scenario/stable/no-contract-ids-in-keys/EXPECTED.ledger
+++ b/daml-lf/tests/scenario/stable/no-contract-ids-in-keys/EXPECTED.ledger
@@ -1,1 +1,1 @@
-Error: CRASH: Unexpected contract id in key: ContractId(007be5e2626fcafa36cdf73e6ad638f3026f866d665764c7bc0ece5e945d71bbfb)
+Error: CRASH: Contract IDs are not supported in contract keys: ContractId(007be5e2626fcafa36cdf73e6ad638f3026f866d665764c7bc0ece5e945d71bbfb)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -137,7 +137,7 @@ private[kvutils] object InputsAndEffects {
                           .fold(
                             _ =>
                               throw Err.InvalidSubmission(
-                                "Unexpected contract id in contract key."),
+                                "Contract IDs are not supported in contract keys."),
                             identity)),
                       Some(create.coid)
                   )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -519,7 +519,8 @@ private[kvutils] class TransactionCommitter(
                 keyWithMaintainers.key.value
               )
               .fold(
-                _ => throw Err.InvalidSubmission("Unexpected contract id in contract key."),
+                _ =>
+                  throw Err.InvalidSubmission("Contract IDs are not supported in contract keys."),
                 identity))
         )
       }


### PR DESCRIPTION
We got some feedback that "Unexpected contract id" sounds like an
internal error whereas this is really a user error.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
