### PR TITLE
Add spans for index DB reads [LPF-270]

### DIFF
--- a/ledger/metrics/src/main/scala/com/daml/metrics/Event.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Event.scala
@@ -14,7 +14,9 @@ final case class Event(name: String, attributeMap: Map[String, String])
 
   override lazy val getAttributes: Attributes = {
     val attributes = Attributes.newBuilder()
-    attributeMap.foreach { case (k, v) => attributes.setAttribute(k, v) }
+    attributeMap
+      .filter { case (_, v) => !v.isEmpty }
+      .foreach { case (k, v) => attributes.setAttribute(k, v) }
     attributes.build
   }
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Event.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Event.scala
@@ -14,9 +14,7 @@ final case class Event(name: String, attributeMap: Map[String, String])
 
   override lazy val getAttributes: Attributes = {
     val attributes = Attributes.newBuilder()
-    attributeMap
-      .filter { case (_, v) => !v.isEmpty }
-      .foreach { case (k, v) => attributes.setAttribute(k, v) }
+    attributeMap.foreach { case (k, v) => if (!v.isEmpty) attributes.setAttribute(k, v) }
     attributes.build
   }
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/package.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/package.scala
@@ -3,10 +3,14 @@
 
 package com.daml
 
-import com.codahale.metrics.{Gauge, MetricRegistry}
 import com.codahale.metrics.MetricRegistry.MetricSupplier
+import com.codahale.metrics.{Gauge, MetricRegistry}
+import io.opentelemetry.OpenTelemetry
+import io.opentelemetry.trace.Tracer
 
 package object metrics {
+
+  val OpenTelemetryTracer: Tracer = OpenTelemetry.getTracer("ledger")
 
   private[metrics] def registerGauge(
       name: MetricName,

--- a/ledger/metrics/src/main/scala/com/daml/metrics/package.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/package.scala
@@ -10,7 +10,7 @@ import io.opentelemetry.trace.Tracer
 
 package object metrics {
 
-  val OpenTelemetryTracer: Tracer = OpenTelemetry.getTracer("ledger")
+  val ParticipantTracer: Tracer = OpenTelemetry.getTracer("participant")
 
   private[metrics] def registerGauge(
       name: MetricName,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
@@ -72,7 +72,7 @@ private[dao] final class TransactionsReader(
       verbose: Boolean,
   )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] = {
     val span =
-      OpenTelemetryTracer
+      ParticipantTracer
         .spanBuilder("com.daml.platform.store.dao.events.TransactionsReader.getFlatTransactions")
         .setNoParent()
         .setAttribute(SpanAttribute.OffsetFrom.key, startExclusive.toHexString)
@@ -152,7 +152,7 @@ private[dao] final class TransactionsReader(
   )(implicit loggingContext: LoggingContext)
     : Source[(Offset, GetTransactionTreesResponse), NotUsed] = {
     val span =
-      OpenTelemetryTracer
+      ParticipantTracer
         .spanBuilder("com.daml.platform.store.dao.events.TransactionsReader.getTransactionTrees")
         .setNoParent()
         .setAttribute(SpanAttribute.OffsetFrom.key, startExclusive.toHexString)
@@ -232,7 +232,7 @@ private[dao] final class TransactionsReader(
       verbose: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetActiveContractsResponse, NotUsed] = {
     val span =
-      OpenTelemetryTracer
+      ParticipantTracer
         .spanBuilder("com.daml.platform.store.dao.events.TransactionsReader.getActiveContracts")
         .setNoParent()
         .setAttribute(SpanAttribute.Offset.key, activeAt.toHexString)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
@@ -5,9 +5,10 @@ package com.daml.platform.store.dao.events
 
 import java.sql.Connection
 
-import akka.NotUsed
 import akka.stream.scaladsl.Source
-import com.daml.ledger.participant.state.v1.{Offset, TransactionId}
+import akka.{Done, NotUsed}
+import com.daml
+import com.daml.ledger.api.TraceIdentifiers
 import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.daml.ledger.api.v1.event.Event
 import com.daml.ledger.api.v1.transaction.TreeEvent
@@ -17,14 +18,17 @@ import com.daml.ledger.api.v1.transaction_service.{
   GetTransactionTreesResponse,
   GetTransactionsResponse
 }
+import com.daml.ledger.participant.state.v1.{Offset, TransactionId}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
-import com.daml.metrics.{DatabaseMetrics, Metrics, Timed}
+import com.daml.metrics._
 import com.daml.platform.ApiOffset
 import com.daml.platform.store.DbType
 import com.daml.platform.store.SimpleSqlAsVectorOf.SimpleSqlAsVectorOf
 import com.daml.platform.store.dao.{DbDispatcher, PaginatingAsyncStream}
+import io.opentelemetry.trace.Span
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 /**
   * @param dispatcher Executes the queries prepared by this object
@@ -67,7 +71,13 @@ private[dao] final class TransactionsReader(
       filter: FilterRelation,
       verbose: Boolean,
   )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] = {
-
+    val span =
+      OpenTelemetryTracer
+        .spanBuilder("com.daml.platform.store.dao.events.TransactionsReader.getFlatTransactions")
+        .setNoParent()
+        .setAttribute(SpanAttribute.OffsetFrom.key, startExclusive.toHexString)
+        .setAttribute(SpanAttribute.OffsetTo.key, endInclusive.toHexString)
+        .startSpan()
     logger.debug(s"getFlatTransactions($startExclusive, $endInclusive, $filter, $verbose)")
 
     val requestedRangeF = getEventSeqIdRange(startExclusive, endInclusive)
@@ -95,7 +105,7 @@ private[dao] final class TransactionsReader(
             verbose,
             dbMetrics.getFlatTransactions,
             query,
-            nextPageRange[Event](requestedRange.endInclusive)
+            nextPageRange[Event](requestedRange.endInclusive),
           )(requestedRange)
         })
         .mapMaterializedValue(_ => NotUsed)
@@ -105,6 +115,12 @@ private[dao] final class TransactionsReader(
         val response = EventsTable.Entry.toGetTransactionsResponse(events)
         response.map(r => offsetFor(r) -> r)
       }
+      .wireTap(_ match {
+        case (_, response) =>
+          response.transactions.foreach(txn =>
+            span.addEvent(daml.metrics.Event("transaction", TraceIdentifiers.fromTransaction(txn))))
+      })
+      .watchTermination()(endSpanOnTermination(span))
   }
 
   def lookupFlatTransactionById(
@@ -135,7 +151,13 @@ private[dao] final class TransactionsReader(
       verbose: Boolean,
   )(implicit loggingContext: LoggingContext)
     : Source[(Offset, GetTransactionTreesResponse), NotUsed] = {
-
+    val span =
+      OpenTelemetryTracer
+        .spanBuilder("com.daml.platform.store.dao.events.TransactionsReader.getTransactionTrees")
+        .setNoParent()
+        .setAttribute(SpanAttribute.OffsetFrom.key, startExclusive.toHexString)
+        .setAttribute(SpanAttribute.OffsetTo.key, endInclusive.toHexString)
+        .startSpan()
     logger.debug(
       s"getTransactionTrees($startExclusive, $endInclusive, $requestingParties, $verbose)")
 
@@ -148,7 +170,7 @@ private[dao] final class TransactionsReader(
           .preparePagedGetTransactionTrees(sqlFunctions)(
             eventsRange = EventsRange(range.startExclusive._2, range.endInclusive._2),
             requestingParties = requestingParties,
-            pageSize = pageSize,
+            pageSize = pageSize
           )
           .executeSql,
         range.startExclusive._1,
@@ -164,7 +186,7 @@ private[dao] final class TransactionsReader(
             verbose,
             dbMetrics.getTransactionTrees,
             query,
-            nextPageRange[TreeEvent](requestedRange.endInclusive)
+            nextPageRange[TreeEvent](requestedRange.endInclusive),
           )(requestedRange)
         })
         .mapMaterializedValue(_ => NotUsed)
@@ -174,6 +196,13 @@ private[dao] final class TransactionsReader(
         val response = EventsTable.Entry.toGetTransactionTreesResponse(events)
         response.map(r => offsetFor(r) -> r)
       }
+      .wireTap(_ match {
+        case (_, response) =>
+          response.transactions.foreach(txn =>
+            span.addEvent(
+              daml.metrics.Event("transaction", TraceIdentifiers.fromTransactionTree(txn))))
+      })
+      .watchTermination()(endSpanOnTermination(span))
   }
 
   def lookupTransactionTreeById(
@@ -202,7 +231,12 @@ private[dao] final class TransactionsReader(
       filter: FilterRelation,
       verbose: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetActiveContractsResponse, NotUsed] = {
-
+    val span =
+      OpenTelemetryTracer
+        .spanBuilder("com.daml.platform.store.dao.events.TransactionsReader.getActiveContracts")
+        .setNoParent()
+        .setAttribute(SpanAttribute.Offset.key, activeAt.toHexString)
+        .startSpan()
     logger.debug(s"getActiveContracts($activeAt, $filter, $verbose)")
 
     val requestedRangeF: Future[EventsRange[(Offset, Long)]] = getAcsEventSeqIdRange(activeAt)
@@ -230,13 +264,18 @@ private[dao] final class TransactionsReader(
             verbose,
             dbMetrics.getActiveContracts,
             query,
-            nextPageRange[Event](requestedRange.endInclusive)
+            nextPageRange[Event](requestedRange.endInclusive),
           )(requestedRange)
         })
         .mapMaterializedValue(_ => NotUsed)
 
     groupContiguous(events)(by = _.transactionId)
       .mapConcat(EventsTable.Entry.toGetActiveContractsResponse)
+      .wireTap(response => {
+        span.addEvent(
+          com.daml.metrics.Event("contract", Map((SpanAttribute.Offset.key, response.offset))))
+      })
+      .watchTermination()(endSpanOnTermination(span))
   }
 
   private def nextPageRange[E](endEventSeqId: (Offset, Long))(
@@ -307,4 +346,15 @@ private[dao] final class TransactionsReader(
         )
       }
     }
+
+  private def endSpanOnTermination[Mat, Out](span: Span)(mat: Mat, done: Future[Done]): Mat = {
+    done.onComplete {
+      case Failure(exception) =>
+        span.recordException(exception)
+        span.end()
+      case Success(_) =>
+        span.end()
+    }
+    mat
+  }
 }


### PR DESCRIPTION
Emit OpenTelemetry spans and events for index DB reads.

![Screenshot_2020-12-10 Jaeger UI(2)](https://user-images.githubusercontent.com/67470645/101783197-40e64580-3afa-11eb-8e94-6a048225f85c.png)

![Screenshot_2020-12-10 Jaeger UI](https://user-images.githubusercontent.com/67470645/101783209-4774bd00-3afa-11eb-99d2-3199d33884a7.png)

Searching for correlated calls via a given `daml.offset`:

![Screenshot_2020-12-10 Jaeger UI(1)](https://user-images.githubusercontent.com/67470645/101750987-08317680-3ad0-11eb-859a-5ddc6769ef1f.png)

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description