### PR TITLE
Avoid haskell and jvm bazel blackduck scan stomping

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -24,6 +24,7 @@ schedules:
 
 jobs:
   - job: compatibility_ts_libs
+    condition: false
     timeoutInMinutes: 60
     pool:
       name: linux-pool
@@ -34,6 +35,7 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility
+    condition: false
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     strategy:
@@ -53,6 +55,7 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility_windows
+    condition: false
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     pool:
@@ -69,6 +72,7 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: perf_speedy
+    condition: false
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -117,6 +121,7 @@ jobs:
           success-message: '$(cat $(Build.StagingDirectory)/perf-results.json | jq . | jq -sR ''"perf for ''"$COMMIT_LINK"'':```\(.)```"'')'
 
   - job: perf_http_json
+    condition: false
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -175,6 +180,7 @@ jobs:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
 
   - job: check_releases
+    condition: false
     timeoutInMinutes: 240
     pool:
       name: linux-pool
@@ -265,17 +271,17 @@ jobs:
       - template: ../bash-lib.yml
         parameters:
           var_name: bash_lib
-      - bash: |
-          set -euo pipefail
-          eval "$(./dev-env/bin/dade-assist)"
-          source $(bash_lib)
+      # - bash: |
+      #     set -euo pipefail
+      #     eval "$(./dev-env/bin/dade-assist)"
+      #     source $(bash_lib)
 
-          tr -d '\015' <*_Black_Duck_Notices_Report.txt | grep -v digital-asset_daml >NOTICES
-          if git diff --exit-code -- NOTICES; then
-              echo "NOTICES file already up-to-date."
-          else
-              git add NOTICES
-              open_pr "notices-update-$(Build.BuildId)" "update NOTICES file"
-          fi
-        displayName: notices
+      #     tr -d '\015' <*_Black_Duck_Notices_Report.txt | grep -v digital-asset_daml >NOTICES
+      #     if git diff --exit-code -- NOTICES; then
+      #         echo "NOTICES file already up-to-date."
+      #     else
+      #         git add NOTICES
+      #         open_pr "notices-update-$(Build.BuildId)" "update NOTICES file"
+      #     fi
+      #   displayName: notices
       - template: ../daily_tell_slack.yml

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -242,7 +242,7 @@ jobs:
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml $Build.SourceBranchName) \
+          ci-build digital-asset_daml $(Build.SourceBranchName) \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \
           --detect.excluded.detector.types=NUGET \

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -238,8 +238,8 @@ jobs:
           --detect.bazel.target=//... \
           --detect.bazel.dependency.type=haskell_cabal_library \
           --detect.notices.report=true \
-          --detect.report.timeout=1500 \
-          --detect.code.location.prefix=haskell_cabal_library"
+          --detect.code.location.prefix=haskell_cabal_library \
+          --detect.report.timeout=1500
         displayName: 'Blackduck Haskell Scan'
         env:
           BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)        
@@ -262,7 +262,7 @@ jobs:
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \
           --detect.cleanup.bdio.files=true \
-          --detect.code.location.prefix=maven_install" \
+          --detect.code.location.prefix=maven_install \
           --detect.report.timeout=4500
         displayName: 'Blackduck Scan'
         env:

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -231,8 +231,8 @@ jobs:
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
-          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml $(Build.SourceBranchName) \
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/3d0d81df71cb3ec809a7c2463e1fe9acc119092b/synopsys-detect) \
+          ci-build digital-asset_daml blackduck-jvm-before-haskell \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
@@ -246,8 +246,8 @@ jobs:
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
-          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml $(Build.SourceBranchName) \
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/3d0d81df71cb3ec809a7c2463e1fe9acc119092b/synopsys-detect) \
+          ci-build digital-asset_daml blackduck-jvm-before-haskell \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \
           --detect.excluded.detector.types=NUGET \
@@ -262,6 +262,7 @@ jobs:
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \
           --detect.cleanup.bdio.files=true \
+          --detect.code.location.name=digital-asset_daml_jvm" \
           --detect.report.timeout=4500
         displayName: 'Blackduck Scan'
         env:

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -239,7 +239,7 @@ jobs:
           --detect.bazel.dependency.type=haskell_cabal_library \
           --detect.notices.report=true \
           --detect.report.timeout=1500 \
-          --detect.code.location.name=digital-asset_daml_haskell"
+          --detect.code.location.prefix=haskell_cabal_library"
         displayName: 'Blackduck Haskell Scan'
         env:
           BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)        
@@ -262,7 +262,7 @@ jobs:
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \
           --detect.cleanup.bdio.files=true \
-          --detect.code.location.name=digital-asset_daml_jvm" \
+          --detect.code.location.prefix=maven_install" \
           --detect.report.timeout=4500
         displayName: 'Blackduck Scan'
         env:

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -238,7 +238,7 @@ jobs:
           --detect.bazel.target=//... \
           --detect.bazel.dependency.type=haskell_cabal_library \
           --detect.notices.report=true \
-          --detect.code.location.prefix=haskell_cabal_library \
+          --detect.code.location.name=digital-asset_daml_haskell_cabal_library \
           --detect.report.timeout=1500
         displayName: 'Blackduck Haskell Scan'
         env:
@@ -262,7 +262,7 @@ jobs:
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \
           --detect.cleanup.bdio.files=true \
-          --detect.code.location.prefix=maven_install \
+          --detect.code.location.name=digital-asset_daml_maven_install \
           --detect.report.timeout=4500
         displayName: 'Blackduck Scan'
         env:

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -24,7 +24,6 @@ schedules:
 
 jobs:
   - job: compatibility_ts_libs
-    condition: false
     timeoutInMinutes: 60
     pool:
       name: linux-pool
@@ -35,7 +34,6 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility
-    condition: false
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     strategy:
@@ -55,7 +53,6 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility_windows
-    condition: false
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     pool:
@@ -72,7 +69,6 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: perf_speedy
-    condition: false
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -121,7 +117,6 @@ jobs:
           success-message: '$(cat $(Build.StagingDirectory)/perf-results.json | jq . | jq -sR ''"perf for ''"$COMMIT_LINK"'':```\(.)```"'')'
 
   - job: perf_http_json
-    condition: false
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -180,7 +175,6 @@ jobs:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
 
   - job: check_releases
-    condition: false
     timeoutInMinutes: 240
     pool:
       name: linux-pool
@@ -231,15 +225,19 @@ jobs:
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
+
+          #needs to be specified since blackduck can not scan all bazel dependency types in one go, haskell has to be scanned separatey and code location name uniquely identified to avoid stomping
+          BAZEL_DEPENDENCY_TYPE="haskell_cabal_library"
+
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
           ci-build digital-asset_daml $(Build.SourceBranchName) \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
-          --detect.bazel.dependency.type=haskell_cabal_library \
+          --detect.bazel.dependency.type=${BAZEL_DEPENDENCY_TYPE} \
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \
-          --detect.code.location.name=digital-asset_daml_haskell_cabal_library \
+          --detect.code.location.name=digital-asset_daml_${BAZEL_DEPENDENCY_TYPE} \
           --detect.report.timeout=1500
         displayName: 'Blackduck Haskell Scan'
         env:
@@ -247,6 +245,10 @@ jobs:
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
+
+          #avoid stomping any previous bazel haskell scans for this repository by qualifying as a maven_install (aka jvm) bazel blackduck scan
+          BAZEL_DEPENDENCY_TYPE="maven_install"
+
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
           ci-build digital-asset_daml $(Build.SourceBranchName) \
           --logging.level.com.synopsys.integration=DEBUG \
@@ -257,13 +259,13 @@ jobs:
           --detect.python.python3=true \
           --detect.tools=DETECTOR,BAZEL,DOCKER \
           --detect.bazel.target=//... \
-          --detect.bazel.dependency.type=maven_install \
+          --detect.bazel.dependency.type=${BAZEL_DEPENDENCY_TYPE} \
           --detect.detector.search.exclusion.paths=.bazel-cache,language-support/ts/codegen/tests/ts,language-support/ts,language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
           --detect.cleanup=false \
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \
           --detect.cleanup.bdio.files=true \
-          --detect.code.location.name=digital-asset_daml_maven_install \
+          --detect.code.location.name=digital-asset_daml_${BAZEL_DEPENDENCY_TYPE} \
           --detect.report.timeout=4500
         displayName: 'Blackduck Scan'
         env:
@@ -271,17 +273,17 @@ jobs:
       - template: ../bash-lib.yml
         parameters:
           var_name: bash_lib
-      # - bash: |
-      #     set -euo pipefail
-      #     eval "$(./dev-env/bin/dade-assist)"
-      #     source $(bash_lib)
+      - bash: |
+          set -euo pipefail
+          eval "$(./dev-env/bin/dade-assist)"
+          source $(bash_lib)
 
-      #     tr -d '\015' <*_Black_Duck_Notices_Report.txt | grep -v digital-asset_daml >NOTICES
-      #     if git diff --exit-code -- NOTICES; then
-      #         echo "NOTICES file already up-to-date."
-      #     else
-      #         git add NOTICES
-      #         open_pr "notices-update-$(Build.BuildId)" "update NOTICES file"
-      #     fi
-      #   displayName: notices
+          tr -d '\015' <*_Black_Duck_Notices_Report.txt | grep -v digital-asset_daml >NOTICES
+          if git diff --exit-code -- NOTICES; then
+              echo "NOTICES file already up-to-date."
+          else
+              git add NOTICES
+              open_pr "notices-update-$(Build.BuildId)" "update NOTICES file"
+          fi
+        displayName: notices
       - template: ../daily_tell_slack.yml

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -237,7 +237,7 @@ jobs:
           --detect.report.timeout=1500
         displayName: 'Blackduck Haskell Scan'
         env:
-          BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)        
+          BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -231,7 +231,7 @@ jobs:
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
-          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/3d0d81df71cb3ec809a7c2463e1fe9acc119092b/synopsys-detect) \
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
           ci-build digital-asset_daml blackduck-jvm-before-haskell \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
@@ -246,7 +246,7 @@ jobs:
       - bash: |
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
-          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/3d0d81df71cb3ec809a7c2463e1fe9acc119092b/synopsys-detect) \
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
           ci-build digital-asset_daml blackduck-jvm-before-haskell \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -228,20 +228,6 @@ jobs:
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
           ci-build digital-asset_daml master \
           --logging.level.com.synopsys.integration=DEBUG \
-          --detect.tools=BAZEL \
-          --detect.bazel.target=//... \
-          --detect.bazel.dependency.type=haskell_cabal_library \
-          --detect.notices.report=true \
-          --detect.report.timeout=1500
-        displayName: 'Blackduck Haskell Scan'
-        env:
-          BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
-      - bash: |
-          set -euo pipefail
-          eval "$(./dev-env/bin/dade-assist)"
-          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml master \
-          --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \
           --detect.excluded.detector.types=NUGET \
           --detect.excluded.detector.types=GO_MOD \
@@ -253,12 +239,28 @@ jobs:
           --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
           --detect.cleanup=false \
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
-          --detect.notices.report=true \
+          --detect.notices.report=false \
           --detect.cleanup.bdio.files=true \
           --detect.report.timeout=4500
         displayName: 'Blackduck Scan'
         env:
           BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
+      - bash: |
+          set -euo pipefail
+          eval "$(./dev-env/bin/dade-assist)"
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
+          ci-build digital-asset_daml master \
+          --logging.level.com.synopsys.integration=DEBUG \
+          --detect.tools=BAZEL \
+          --detect.bazel.target=//... \
+          --detect.bazel.dependency.type=haskell_cabal_library \
+          --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
+          --detect.notices.report=true \
+          --detect.report.timeout=1500 \
+          --detect.code.location.unmap=false
+        displayName: 'Blackduck Haskell Scan'
+        env:
+          BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)          
       - template: ../bash-lib.yml
         parameters:
           var_name: bash_lib

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -226,7 +226,7 @@ jobs:
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml master \
+          ci-build digital-asset_daml $(Build.SourceBranchName) \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
@@ -242,7 +242,7 @@ jobs:
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml master \
+          ci-build digital-asset_daml $Build.SourceBranchName) \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \
           --detect.excluded.detector.types=NUGET \

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -24,7 +24,6 @@ schedules:
 
 jobs:
   - job: compatibility_ts_libs
-    condition: false
     timeoutInMinutes: 60
     pool:
       name: linux-pool
@@ -35,7 +34,6 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility
-    condition: false
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     strategy:
@@ -55,7 +53,6 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility_windows
-    condition: false
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     pool:
@@ -72,7 +69,6 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: perf_speedy
-    condition: false
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -121,7 +117,6 @@ jobs:
           success-message: '$(cat $(Build.StagingDirectory)/perf-results.json | jq . | jq -sR ''"perf for ''"$COMMIT_LINK"'':```\(.)```"'')'
 
   - job: perf_http_json
-    condition: false  
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -180,7 +175,6 @@ jobs:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
 
   - job: check_releases
-    condition: false  
     timeoutInMinutes: 240
     pool:
       name: linux-pool
@@ -232,11 +226,12 @@ jobs:
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml blackduck-jvm-before-haskell \
+          ci-build digital-asset_daml master \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
           --detect.bazel.dependency.type=haskell_cabal_library \
+          --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \
           --detect.code.location.name=digital-asset_daml_haskell_cabal_library \
           --detect.report.timeout=1500
@@ -247,7 +242,7 @@ jobs:
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml blackduck-jvm-before-haskell \
+          ci-build digital-asset_daml master \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \
           --detect.excluded.detector.types=NUGET \
@@ -257,7 +252,7 @@ jobs:
           --detect.tools=DETECTOR,BAZEL,DOCKER \
           --detect.bazel.target=//... \
           --detect.bazel.dependency.type=maven_install \
-          --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
+          --detect.detector.search.exclusion.paths=.bazel-cache,language-support/ts/codegen/tests/ts,language-support/ts,language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
           --detect.cleanup=false \
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -232,7 +232,7 @@ jobs:
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml ${Build.SourceBranchName} \
+          ci-build digital-asset_daml $(Build.SourceBranchName) \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
@@ -247,7 +247,7 @@ jobs:
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml ${Build.SourceBranchName} \
+          ci-build digital-asset_daml $(Build.SourceBranchName) \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \
           --detect.excluded.detector.types=NUGET \

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -226,7 +226,7 @@ jobs:
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml master \
+          ci-build digital-asset_daml ${Build.SourceBranchName} \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \
           --detect.excluded.detector.types=NUGET \
@@ -241,6 +241,7 @@ jobs:
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=false \
           --detect.cleanup.bdio.files=true \
+          --detect.code.location.prefix=daml \
           --detect.report.timeout=4500
         displayName: 'Blackduck Scan'
         env:
@@ -249,7 +250,7 @@ jobs:
           set -euo pipefail
           eval "$(./dev-env/bin/dade-assist)"
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml master \
+          ci-build digital-asset_daml ${Build.SourceBranchName} \
           --logging.level.com.synopsys.integration=DEBUG \
           --detect.tools=BAZEL \
           --detect.bazel.target=//... \
@@ -257,6 +258,7 @@ jobs:
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
           --detect.notices.report=true \
           --detect.report.timeout=1500 \
+          --detect.code.location.prefix=daml \
           --detect.code.location.unmap=false
         displayName: 'Blackduck Haskell Scan'
         env:

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -24,6 +24,7 @@ schedules:
 
 jobs:
   - job: compatibility_ts_libs
+    condition: false
     timeoutInMinutes: 60
     pool:
       name: linux-pool
@@ -34,6 +35,7 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility
+    condition: false
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     strategy:
@@ -53,6 +55,7 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: compatibility_windows
+    condition: false
     dependsOn: compatibility_ts_libs
     timeoutInMinutes: 720
     pool:
@@ -69,6 +72,7 @@ jobs:
       - template: ../daily_tell_slack.yml
 
   - job: perf_speedy
+    condition: false
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -117,6 +121,7 @@ jobs:
           success-message: '$(cat $(Build.StagingDirectory)/perf-results.json | jq . | jq -sR ''"perf for ''"$COMMIT_LINK"'':```\(.)```"'')'
 
   - job: perf_http_json
+    condition: false  
     timeoutInMinutes: 120
     pool:
       name: "linux-pool"
@@ -175,6 +180,7 @@ jobs:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
 
   - job: check_releases
+    condition: false  
     timeoutInMinutes: 240
     pool:
       name: linux-pool

--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -234,6 +234,21 @@ jobs:
           bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
           ci-build digital-asset_daml ${Build.SourceBranchName} \
           --logging.level.com.synopsys.integration=DEBUG \
+          --detect.tools=BAZEL \
+          --detect.bazel.target=//... \
+          --detect.bazel.dependency.type=haskell_cabal_library \
+          --detect.notices.report=true \
+          --detect.report.timeout=1500 \
+          --detect.code.location.name=digital-asset_daml_haskell"
+        displayName: 'Blackduck Haskell Scan'
+        env:
+          BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)        
+      - bash: |
+          set -euo pipefail
+          eval "$(./dev-env/bin/dade-assist)"
+          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
+          ci-build digital-asset_daml ${Build.SourceBranchName} \
+          --logging.level.com.synopsys.integration=DEBUG \
           --detect.npm.include.dev.dependencies=false \
           --detect.excluded.detector.types=NUGET \
           --detect.excluded.detector.types=GO_MOD \
@@ -245,30 +260,12 @@ jobs:
           --detect.detector.search.exclusion.paths=language-support/ts/codegen/tests/ts,language-support/ts,language-support/scala/examples/iou-no-codegen,language-support/scala/examples/quickstart-scala,docs/source/app-dev/bindings-java/code-snippets,docs/source/app-dev/bindings-java/quickstart/template-root,language-support/scala/examples/quickstart-scala,language-support/scala/examples/iou-no-codegen \
           --detect.cleanup=false \
           --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
-          --detect.notices.report=false \
+          --detect.notices.report=true \
           --detect.cleanup.bdio.files=true \
-          --detect.code.location.prefix=daml \
           --detect.report.timeout=4500
         displayName: 'Blackduck Scan'
         env:
           BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)
-      - bash: |
-          set -euo pipefail
-          eval "$(./dev-env/bin/dade-assist)"
-          bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
-          ci-build digital-asset_daml ${Build.SourceBranchName} \
-          --logging.level.com.synopsys.integration=DEBUG \
-          --detect.tools=BAZEL \
-          --detect.bazel.target=//... \
-          --detect.bazel.dependency.type=haskell_cabal_library \
-          --detect.policy.check.fail.on.severities=MAJOR,CRITICAL,BLOCKER \
-          --detect.notices.report=true \
-          --detect.report.timeout=1500 \
-          --detect.code.location.prefix=daml \
-          --detect.code.location.unmap=false
-        displayName: 'Blackduck Haskell Scan'
-        env:
-          BLACKDUCK_HUBDETECT_TOKEN: $(BLACKDUCK_HUBDETECT_TOKEN)          
       - template: ../bash-lib.yml
         parameters:
           var_name: bash_lib


### PR DESCRIPTION
While cross-checking against Gary's PRs cleaning up license cruft, I noticed that haskell libs were not in the NOTICES file.

This is because the jvm bazel scan run after the haskell scan stomps the results since the scans share a name.

This PR gives a unique code location to haskell vs jvm scan so they will not stomp on each other, and the final scan results and NOTICES file generated at the end is comprehensive.

Also makes sure the scan is run with the actual branch name, and not always with `master` regardless of where it is run from