### PR TITLE
damlc: warn on bad package names/versions.

### DIFF
--- a/compiler/damlc/daml-package-config/BUILD.bazel
+++ b/compiler/damlc/daml-package-config/BUILD.bazel
@@ -14,6 +14,7 @@ da_haskell_library(
         "base",
         "containers",
         "ghc-lib-parser",
+        "regex-tdfa",
         "safe-exceptions",
         "text",
         "yaml",

--- a/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
+++ b/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
@@ -71,11 +71,11 @@ parseProjectConfig project = do
 checkPkgConfig :: PackageConfigFields -> [String]
 checkPkgConfig PackageConfigFields {pName, pVersion} =
   [ "WARNING: Package names should have the format ^[a-zA-Z]([a-zA-Z\\-])*$. You may be able to compile packages with different formats, but you will not be able to use them as dependencies in other projects. Unsupported package names may start causing compilation errors without warning."
-  | not $ (LF.unPackageName pName) =~ ("^[a-zA-Z]([a-zA-Z\\-])*$" :: T.Text)
+  | not $ LF.unPackageName pName =~ ("^[a-zA-Z]([a-zA-Z\\-])*$" :: T.Text)
   ] ++
   [ "WARNING: Package versions should have the format ^[0-9](\\.[0-9])*$. You may be able to compile packages with different formats, but you will not be able to use them as dependencies in other projects. Unsupported package versions may start causing compilation errors without warning."
   | Just version <- [pVersion]
-  , not $ (LF.unPackageVersion version) =~ ("^[0-9](\\.[0-9])*$" :: T.Text)
+  , not $ LF.unPackageVersion version =~ ("^[0-9](\\.[0-9])*$" :: T.Text)
   ]
 
 overrideSdkVersion :: PackageConfigFields -> IO PackageConfigFields

--- a/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
+++ b/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
@@ -70,10 +70,15 @@ parseProjectConfig project = do
 
 checkPkgConfig :: PackageConfigFields -> [String]
 checkPkgConfig PackageConfigFields {pName, pVersion} =
-  [ "WARNING: Package names should have the format ^[a-zA-Z]([a-zA-Z\\-])*$. You may be able to compile packages with different formats, but you will not be able to use them as dependencies in other projects. Unsupported package names may start causing compilation errors without warning."
+  [ "WARNING: Package names should have the format ^[a-zA-Z]([a-zA-Z\\-])*$. You may be able to \
+  \ compile packages with different formats, but you will not be able to use them as dependencies \
+  \ in other projects. Unsupported package names may start causing compilation errors without warning."
   | not $ LF.unPackageName pName =~ ("^[a-zA-Z]([a-zA-Z\\-])*$" :: T.Text)
   ] ++
-  [ "WARNING: Package versions should have the format ^[0-9](\\.[0-9])*$. You may be able to compile packages with different formats, but you will not be able to use them as dependencies in other projects. Unsupported package versions may start causing compilation errors without warning."
+  [ "WARNING: Package versions should have the format ^[0-9](\\.[0-9])*$. You may be able to \
+  \ compile packages with different formats, but you will not be able to use them as dependencies \
+  \ in other projects. Unsupported package versions may start causing compilation errors without \
+  \ warning."
   | Just version <- [pVersion]
   , not $ LF.unPackageVersion version =~ ("^[0-9](\\.[0-9])*$" :: T.Text)
   ]

--- a/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
+++ b/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
@@ -75,12 +75,13 @@ checkPkgConfig PackageConfigFields {pName, pVersion} =
   \ in other projects. Unsupported package names may start causing compilation errors without warning."
   | not $ LF.unPackageName pName =~ ("^[a-zA-Z]([a-zA-Z\\-])*$" :: T.Text)
   ] ++
-  [ "WARNING: Package versions should have the format ^[0-9](\\.[0-9])*$. You may be able to \
+  [ "WARNING: Package versions should have the format \
+  \ ^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?)?. You may be able to \
   \ compile packages with different formats, but you will not be able to use them as dependencies \
   \ in other projects. Unsupported package versions may start causing compilation errors without \
   \ warning."
   | Just version <- [pVersion]
-  , not $ LF.unPackageVersion version =~ ("^[0-9](\\.[0-9])*$" :: T.Text)
+  , not $ LF.unPackageVersion version =~ ("^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?)?$" :: T.Text)
   ]
 
 overrideSdkVersion :: PackageConfigFields -> IO PackageConfigFields

--- a/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
+++ b/compiler/damlc/daml-package-config/src/DA/Daml/Package/Config.hs
@@ -70,10 +70,11 @@ parseProjectConfig project = do
 
 checkPkgConfig :: PackageConfigFields -> [String]
 checkPkgConfig PackageConfigFields {pName, pVersion} =
-  [ "WARNING: Package names should have the format ^[a-zA-Z]([a-zA-Z\\-])*$. You may be able to \
-  \ compile packages with different formats, but you will not be able to use them as dependencies \
-  \ in other projects. Unsupported package names may start causing compilation errors without warning."
-  | not $ LF.unPackageName pName =~ ("^[a-zA-Z]([a-zA-Z\\-])*$" :: T.Text)
+  [ "WARNING: Package names should have the format ^[A-Za-z][A-Za-z0-9]*(\\-[A-Za-z][A-Za-z0-9]*)*$. \
+  \ You may be able to compile packages with different formats, but you will not be able to use \
+  \ them as dependencies in other projects. Unsupported package names may start causing \
+  \ compilation errors without warning."
+  | not $ LF.unPackageName pName =~ ("^[A-Za-z][A-Za-z0-9]*(\\-[A-Za-z][A-Za-z0-9]*)*$" :: T.Text)
   ] ++
   [ "WARNING: Package versions should have the format \
   \ ^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?)?. You may be able to \
@@ -81,7 +82,9 @@ checkPkgConfig PackageConfigFields {pName, pVersion} =
   \ in other projects. Unsupported package versions may start causing compilation errors without \
   \ warning."
   | Just version <- [pVersion]
-  , not $ LF.unPackageVersion version =~ ("^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?)?$" :: T.Text)
+  , not $
+      LF.unPackageVersion version =~
+      ("^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?)?$" :: T.Text)
   ]
 
 overrideSdkVersion :: PackageConfigFields -> IO PackageConfigFields

--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -583,6 +583,8 @@ execBuild projectOpts opts mbOutFile incrementalBuild initPkgDb =
             initPackageDb opts initPkgDb
             withPackageConfig defaultProjectPath $ \pkgConfig@PackageConfigFields{..} -> do
                 putStrLn $ "Compiling " <> T.unpack (LF.unPackageName pName) <> " to a DAR."
+                let warnings = checkPkgConfig pkgConfig
+                unless (null warnings) $ putStrLn $ unlines warnings
                 loggerH <- getLogger opts "package"
                 withDamlIdeState
                     opts


### PR DESCRIPTION
This fixes #7208 and #7317. When package names or versions are
encountered in the daml.yaml that will be rejected by ghc-pkg when the
package is loaded as dependency, a big warning is printed.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
