### PR TITLE
LF: Simplify Language Version representation

### DIFF
--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -209,9 +209,7 @@ class ReplService(
   override def runScript(
       req: RunScriptRequest,
       respObs: StreamObserver[RunScriptResponse]): Unit = {
-    val lfVer = LanguageVersion(
-      LanguageVersion.Major.V1,
-      LanguageVersion.Minor fromProtoIdentifier req.getMinor)
+    val lfVer = LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor(req.getMinor))
     val dop: Decode.OfPackage[_] = Decode.decoders
       .lift(lfVer)
       .getOrElse(throw new RuntimeException(s"No decode support for LF ${lfVer.pretty}"))

--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/ScenarioServiceMain.scala
@@ -226,7 +226,7 @@ class ScenarioService(
   ): Unit = {
     val lfVersion = LanguageVersion(
       LanguageVersion.Major.V1,
-      LanguageVersion.Minor.fromProtoIdentifier(req.getLfMinor)
+      LanguageVersion.Minor(req.getLfMinor)
     )
     val ctx = Context.newContext(lfVersion)
     contexts += (ctx.contextId -> ctx)

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
@@ -79,7 +79,11 @@ abstract class Reader[+Pkg] {
     val version =
       LanguageVersion(majorVersion, LanguageVersion.Minor(minorVersion))
     if (!(majorVersion supportsMinorVersion minorVersion)) {
-      throw ParseError(s"LF file $majorVersion.$minorVersion unsupported}")
+      val supportedVersions =
+        majorVersion.acceptedVersions.map(v => s"$majorVersion.${v.identifier}")
+      throw ParseError(
+        s"LF $majorVersion.$minorVersion unsupported. Supported LF versions are ${supportedVersions
+          .mkString(",")}")
     }
     (readArchivePayloadOfVersion(hash, lf, version), majorVersion)
   }

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/Reader.scala
@@ -77,10 +77,9 @@ abstract class Reader[+Pkg] {
     val majorVersion = readArchiveVersion(lf)
     val minorVersion = lf.getMinor
     val version =
-      LanguageVersion(majorVersion, LanguageVersion.Minor fromProtoIdentifier minorVersion)
+      LanguageVersion(majorVersion, LanguageVersion.Minor(minorVersion))
     if (!(majorVersion supportsMinorVersion minorVersion)) {
-      throw ParseError(
-        s"LF file $majorVersion.$minorVersion unsupported; maximum supported $majorVersion.x is $majorVersion.${majorVersion.maxSupportedStableMinorVersion.toProtoIdentifier: String}")
+      throw ParseError(s"LF file $majorVersion.$minorVersion unsupported}")
     }
     (readArchivePayloadOfVersion(hash, lf, version), majorVersion)
   }

--- a/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/DamlLfEncoder.scala
+++ b/daml-lf/encoder/src/main/scala/com/digitalasset/daml/lf/archive/testing/DamlLfEncoder.scala
@@ -135,7 +135,7 @@ private[daml] object DamlLfEncoder extends App {
     version.split("""\.""").toSeq match {
       case Seq("1", minor)
           if LanguageMajorVersion.V1.supportsMinorVersion(minor) || minor == "dev" =>
-        LanguageVersion(LanguageMajorVersion.V1, minor)
+        LanguageVersion(LanguageMajorVersion.V1, LanguageVersion.Minor(minor))
       case _ =>
         error(s"version '$version' not supported")
     }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -6,8 +6,6 @@ package engine
 
 import java.nio.file.Path
 
-import com.daml.lf.language.LanguageVersion
-
 /**
   * The Engine configurations describes the versions of language and
   * transaction the engine is allowed to read and write together with
@@ -65,10 +63,7 @@ object EngineConfig {
   )
 
   private[this] def toDev(config: EngineConfig): EngineConfig =
-    config.copy(
-      allowedLanguageVersions = config.allowedLanguageVersions.copy(
-        max = LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor.Dev)),
-    )
+    config.copy(allowedLanguageVersions = transaction.VersionTimeline.devLanguageVersions)
 
   /**
     * Recommended production configuration.

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1955,17 +1955,17 @@ class EngineTest
     "reject disallow packages" in {
       val negativeTestCases = Table(
         ("pkg version", "minVersion", "maxVertion"),
-        (LV.Minor.Stable("6"), LV.Minor.Stable("6"), LV.Minor.Stable("8")),
-        (LV.Minor.Stable("7"), LV.Minor.Stable("6"), LV.Minor.Stable("8")),
-        (LV.Minor.Stable("8"), LV.Minor.Stable("6"), LV.Minor.Stable("8")),
-        (LV.Minor.Dev, LV.Minor.Stable("6"), LV.Minor.Dev),
+        (LV.Minor("6"), LV.Minor("6"), LV.Minor("8")),
+        (LV.Minor("7"), LV.Minor("6"), LV.Minor("8")),
+        (LV.Minor("8"), LV.Minor("6"), LV.Minor("8")),
+        (LV.Minor("dev"), LV.Minor("6"), LV.Minor("dev")),
       )
       val positiveTestCases = Table(
         ("pkg version", "minVersion", "maxVertion"),
-        (LV.Minor.Stable("6"), LV.Minor.Stable("7"), LV.Minor.Dev),
-        (LV.Minor.Stable("7"), LV.Minor.Stable("8"), LV.Minor.Stable("8")),
-        (LV.Minor.Stable("8"), LV.Minor.Stable("6"), LV.Minor.Stable("7")),
-        (LV.Minor.Dev, LV.Minor.Stable("6"), LV.Minor.Stable("8")),
+        (LV.Minor("6"), LV.Minor("7"), LV.Minor("dev")),
+        (LV.Minor("7"), LV.Minor("8"), LV.Minor("8")),
+        (LV.Minor("8"), LV.Minor("6"), LV.Minor("7")),
+        (LV.Minor("dev"), LV.Minor("6"), LV.Minor("8")),
       )
 
       forEvery(negativeTestCases)((v, min, max) =>

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
@@ -8,10 +8,8 @@ import com.daml.lf.LfVersions
 import scalaz.NonEmptyList
 
 // an ADT version of the DAML-LF version
-sealed abstract class LanguageMajorVersion(
-    val pretty: String,
-    stableAscending: NonEmptyList[String])
-    extends LfVersions(stableAscending.map[LanguageMinorVersion](LanguageMinorVersion))(
+sealed abstract class LanguageMajorVersion(val pretty: String, minorAscending: NonEmptyList[String])
+    extends LfVersions(minorAscending.map[LanguageMinorVersion](LanguageMinorVersion))(
       _.toProtoIdentifier)
     with Product
     with Serializable {
@@ -33,7 +31,7 @@ object LanguageMajorVersion {
   case object V1
       extends LanguageMajorVersion(
         pretty = "1",
-        stableAscending = NonEmptyList("6", "7", "8", "dev"))
+        minorAscending = NonEmptyList("6", "7", "8", "dev"))
 
   val All: List[LanguageMajorVersion] = List(V1)
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMajorVersion.scala
@@ -11,14 +11,10 @@ import scalaz.NonEmptyList
 sealed abstract class LanguageMajorVersion(
     val pretty: String,
     stableAscending: NonEmptyList[String])
-    extends LfVersions(
-      stableAscending.map[LanguageMinorVersion](LanguageMinorVersion.Stable) append NonEmptyList(
-        LanguageMinorVersion.Dev))(_.toProtoIdentifier)
+    extends LfVersions(stableAscending.map[LanguageMinorVersion](LanguageMinorVersion))(
+      _.toProtoIdentifier)
     with Product
     with Serializable {
-
-  final val maxSupportedStableMinorVersion: LanguageMinorVersion.Stable =
-    LanguageMinorVersion.Stable(stableAscending.last)
 
   // do *not* use implicitly unless type `LanguageMinorVersion` becomes
   // indexed by the enclosing major version's singleton type --SC
@@ -35,7 +31,9 @@ sealed abstract class LanguageMajorVersion(
 object LanguageMajorVersion {
 
   case object V1
-      extends LanguageMajorVersion(pretty = "1", stableAscending = NonEmptyList("6", "7", "8"))
+      extends LanguageMajorVersion(
+        pretty = "1",
+        stableAscending = NonEmptyList("6", "7", "8", "dev"))
 
   val All: List[LanguageMajorVersion] = List(V1)
 

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMinorVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageMinorVersion.scala
@@ -3,27 +3,6 @@
 
 package com.daml.lf.language
 
-sealed abstract class LanguageMinorVersion extends Product with Serializable {
-  import LanguageMinorVersion._
-  def toProtoIdentifier: String = this match {
-    case Stable(id) => id
-    case Dev => "dev"
-  }
-}
-
-object LanguageMinorVersion {
-  final case class Stable(identifier: String) extends LanguageMinorVersion
-  case object Dev extends LanguageMinorVersion
-
-  def fromProtoIdentifier(identifier: String): LanguageMinorVersion = identifier match {
-    case "dev" => Dev
-    case _ => Stable(identifier)
-  }
-
-  object Implicits {
-    import scala.language.implicitConversions
-
-    implicit def `LMV from proto identifier`(identifier: String): LanguageMinorVersion =
-      fromProtoIdentifier(identifier)
-  }
+final case class LanguageMinorVersion(identifier: String) {
+  def toProtoIdentifier: String = identifier
 }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -15,14 +15,9 @@ object LanguageVersion {
   type Minor = LanguageMinorVersion
   val Minor = LanguageMinorVersion
 
-  val defaultV1: LanguageVersion =
-    LanguageVersion(Major.V1, Major.V1.maxSupportedStableMinorVersion)
+  val defaultV1: LanguageVersion = LanguageVersion(Major.V1, Minor("8"))
 
-  private[lf] def apply(major: LanguageMajorVersion, minor: String): LanguageVersion =
-    apply(major, Minor fromProtoIdentifier minor)
-
-  val default: LanguageVersion =
-    defaultV1
+  val default: LanguageVersion = defaultV1
 
   final val ordering: Ordering[LanguageVersion] =
     (left, right) =>

--- a/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/LanguageVersionSpec.scala
+++ b/daml-lf/language/src/test/scala/com/digitalasset/daml/lf/language/LanguageVersionSpec.scala
@@ -3,7 +3,7 @@
 
 package com.daml.lf.language
 
-import com.daml.lf.language.{LanguageMajorVersion => LVM, LanguageVersion => LV}
+import com.daml.lf.language.{LanguageVersion => LV}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -13,9 +13,9 @@ class LanguageVersionSpec extends AnyWordSpec with Matchers with TableDrivenProp
   "LanguageVersion.ordering order as expected" in {
 
     val versionInOrder = List(
-      LV(LVM.V1, "6"),
-      LV(LVM.V1, "7"),
-      LV(LVM.V1, "8"),
+      LV(LV.Major.V1, LV.Minor("6")),
+      LV(LV.Major.V1, LV.Minor("7")),
+      LV(LV.Major.V1, LV.Minor("8")),
     )
 
     val versionRank = versionInOrder.zipWithIndex.toMap

--- a/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
+++ b/daml-lf/repl/src/main/scala/com/digitalasset/daml/lf/repl/testing/Main.scala
@@ -196,7 +196,7 @@ object Repl {
     private val seed = nextSeed()
 
     val (inputValueVersion, outputTransactionVersions) =
-      if (compilerConfig.allowedLanguageVersions.contains(LV(LV.Major.V1, LV.Minor.Dev)))
+      if (compilerConfig.allowedLanguageVersions.contains(LV(LV.Major.V1, LV.Minor("dev"))))
         (
           value.ValueVersions.DevOutputVersions,
           transaction.TransactionVersions.DevOutputVersions,

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/VersionTimeline.scala
@@ -4,7 +4,7 @@
 package com.daml.lf
 package transaction
 
-import com.daml.lf.language.{LanguageVersion, LanguageMajorVersion => LMV}
+import com.daml.lf.language.LanguageVersion
 import com.daml.lf.value.ValueVersion
 import scalaz.std.map._
 import scalaz.syntax.foldable1._
@@ -31,7 +31,7 @@ import scala.language.higherKinds
   * that same timeline.
   */
 object VersionTimeline {
-  import LanguageVersion.Minor.Dev
+  import LanguageVersion.{Major, Minor}
   import \&/.{Both, That, This}
 
   type AllVersions[:&:[_, _]] = (ValueVersion :&: TransactionVersion) :&: LanguageVersion
@@ -43,12 +43,14 @@ object VersionTimeline {
     */
   private[lf] val inAscendingOrder: NonEmptyList[Release] =
     NonEmptyList(
-      That(LanguageVersion(LMV.V1, "6")),
-      Both(This(ValueVersion("6")), LanguageVersion(LMV.V1, "7")),
-      That(LanguageVersion(LMV.V1, "8")),
+      That(LanguageVersion(Major.V1, Minor("6"))),
+      Both(This(ValueVersion("6")), LanguageVersion(Major.V1, Minor("7"))),
+      That(LanguageVersion(Major.V1, Minor("8"))),
       This(That(TransactionVersion("10"))),
       // add new versions above this line (but see more notes below)
-      Both(Both(ValueVersion("dev"), TransactionVersion("dev")), LanguageVersion(LMV.V1, Dev)),
+      Both(
+        Both(ValueVersion("dev"), TransactionVersion("dev")),
+        LanguageVersion(Major.V1, Minor("dev"))),
       //
       // "dev" versions float through the timeline with little rationale
       // due to their ephemeral contents; don't worry too much about their exact
@@ -167,11 +169,11 @@ object VersionTimeline {
 
   private[lf] val stableLanguageVersions =
     VersionRange(
-      min = LanguageVersion(LMV.V1, "6"),
-      max = LanguageVersion(LMV.V1, "8"),
+      min = LanguageVersion(Major.V1, Minor("6")),
+      max = LanguageVersion(Major.V1, Minor("8")),
     )
 
   private[lf] val devLanguageVersions =
-    stableLanguageVersions.copy(max = LanguageVersion(LMV.V1, Dev))
+    stableLanguageVersions.copy(max = LanguageVersion(Major.V1, Minor("dev")))
 
 }

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionVersionSpec.scala
@@ -14,11 +14,8 @@ class TransactionVersionSpec extends AnyWordSpec with Matchers with TableDrivenP
 
   "TransactionVersions.assignNodeVersion" should {
 
-    val Seq(v1_6, v1_7, v1_8) = Seq("6", "7", "8").map(minor =>
-      LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor.Stable(minor)))
-
-    val v1_dev =
-      LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor.Dev)
+    val Seq(v1_6, v1_7, v1_8, v1_dev) = Seq("6", "7", "8", "dev").map(minor =>
+      LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor(minor)))
 
     val testCases = Table(
       "language version" -> "transaction version",

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/VersionTimelineSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/VersionTimelineSpec.scala
@@ -4,7 +4,6 @@
 package com.daml.lf
 package transaction
 
-import com.daml.lf.language.LanguageMinorVersion.Dev
 import com.daml.lf.language._
 import value.{ValueVersion, ValueVersions}
 
@@ -74,7 +73,7 @@ class VersionTimelineSpec
       inside(inAscendingOrder.last) {
         case Both(
             Both(ValueVersion("dev"), TransactionVersion("dev")),
-            LanguageVersion(LanguageVersion.Major.V1, Dev)) =>
+            LanguageVersion(LanguageVersion.Major.V1, LanguageVersion.Minor("dev"))) =>
       }
     }
 
@@ -90,7 +89,7 @@ class VersionTimelineSpec
 
     "given a dev version" should {
       "never precede another version of same major" in forAll(genDefinedLanguageVersion) { lv =>
-        compareReleaseTime(lv, lv copy (minor = LanguageVersion.Minor.Dev)) should contain oneOf (LT, EQ)
+        compareReleaseTime(lv, lv copy (minor = LanguageVersion.Minor("dev"))) should contain oneOf (LT, EQ)
       }
     }
   }

--- a/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/DependencyVersionSpec.scala
+++ b/daml-lf/validation/src/test/scala/com/digitalasset/daml/lf/validation/DependencyVersionSpec.scala
@@ -13,9 +13,9 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class DependencyVersionSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
 
-  private[this] val v1_6 = LV(LV.Major.V1, LV.Minor.Stable("6"))
-  private[this] val v1_7 = LV(LV.Major.V1, LV.Minor.Stable("7"))
-  private[this] val v1_8 = LV(LV.Major.V1, LV.Minor.Stable("8"))
+  private[this] val v1_6 = LV(LV.Major.V1, LV.Minor("6"))
+  private[this] val v1_7 = LV(LV.Major.V1, LV.Minor("7"))
+  private[this] val v1_8 = LV(LV.Major.V1, LV.Minor("8"))
   private[this] val A = (PackageId.assertFromString("-pkg1-"), DottedName.assertFromString("A"))
   private[this] val B = (PackageId.assertFromString("-pkg2-"), DottedName.assertFromString("B"))
   private[this] val E = (PackageId.assertFromString("-pkg3-"), DottedName.assertFromString("E"))


### PR DESCRIPTION
We drop the distinction (at the type level) between "dev" and "stable" language version.

The two main reasons that motivate this choice are: 
* we never really use this distinction. 
* we want to add the concept of "preview" version


CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
