### PR TITLE
more idempotent copyright updater

### DIFF
--- a/dev-env/bin/dade-copyright-headers
+++ b/dev-env/bin/dade-copyright-headers
@@ -142,7 +142,7 @@ def process_file(filename, check_only):
   for line in lines:
     # looking for start comment block
     if state == 'start':
-      if (line.strip(filetypes[ext]['line']).strip(filetypes[ext]['start'])[0:19] == " Copyright (c) 2020"):
+      if (line.strip(filetypes[ext]['line']).strip(filetypes[ext]['start'])[1:14] == "Copyright (c)"):
         state='notice'
 
         if line != notice_lines[0]+"\n":


### PR DESCRIPTION
At the moment, updating copyright headers requires the following dance:

1. Update the COPY file.
2. Run `./fmt.sh`
3. Update the `dev-env/bin/dade-copyright-headers` file to update the expected copyright marker.

Forgetting to do 3 results in `./fmt.sh` (really the underlying `dev-env/bin/dade-copyright-headers update`) to not be idempotent, and to add an extra 3 lines of copyright headers on each run (with `dade-copyright-headers check`, and therefore `./fmt.sh --test`, never succeeding). This small tweak makes step 3 unnecessary.

CHANGELOG_BEGIN
CHANGELOG_END