### PR TITLE
replace new Prim with Prim.valueOf

### DIFF
--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/FromValueGenerator.scala
@@ -64,7 +64,7 @@ private[inner] object FromValueGenerator extends StrictLogging {
   }
 
   private def accessors =
-    Iterator.from(0).map(i => CodeBlock.of("fields$$.get($L).getValue()", new Integer(i)))
+    Iterator.from(0).map(i => CodeBlock.of("fields$$.get($L).getValue()", Integer.valueOf(i)))
 
   def variantCheck(constructorName: String, inputVar: String, outputVar: String): CodeBlock = {
     CodeBlock

--- a/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
+++ b/language-support/java/codegen/src/main/scala/com/digitalasset/daml/lf/codegen/backend/java/inner/ToValueGenerator.scala
@@ -50,7 +50,7 @@ object ToValueGenerator {
         "$T fields = new $T($L)",
         arrayOfFields,
         arrayOfFields,
-        new Integer(fields.length))
+        Integer.valueOf(fields.length))
 
     for (FieldInfo(damlName, damlType, javaName, _) <- fields) {
       toValueMethod.addStatement(

--- a/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/SignalDispatcherTest.scala
+++ b/ledger/ledger-api-common/src/test/suite/scala/com/digitalasset/platform/akkastreams/dispatcher/SignalDispatcherTest.scala
@@ -58,7 +58,7 @@ class SignalDispatcherTest
       s.cancel()
       await("Cancellation handling")
         .atMost(Duration.TEN_SECONDS)
-        .until(() => new lang.Boolean(sut.getRunningState.isEmpty))
+        .until(() => lang.Boolean.valueOf(sut.getRunningState.isEmpty))
       sut.getRunningState shouldBe empty
     }
 


### PR DESCRIPTION
Creating new primitives has always been a bad idea.

Stolen from #8267 which stole it from #975.

CHANGELOG_BEGIN
CHANGELOG_END