### PR TITLE
Multi-party submissions in kvutils [KVL-707]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -159,8 +159,7 @@ private[kvutils] class TransactionCommitter(
         case None =>
           Some(
             rejection(
-              RejectionReason.PartyNotKnownOnLedger(
-                s"Submitting party '$submitter' not known")
+              RejectionReason.PartyNotKnownOnLedger(s"Submitting party '$submitter' not known")
             ))
       }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -125,7 +125,7 @@ private[kvutils] class TransactionCommitter(
   /** Authorize the submission by looking up the party allocation and verifying
     * that all of the submitting parties are indeed hosted by the submitting participant.
     */
-  private def authorizeSubmitters: Step = (commitContext, transactionEntry) => {
+  private[committer] def authorizeSubmitters: Step = (commitContext, transactionEntry) => {
     def rejection(reason: RejectionReason) =
       reject[DamlTransactionEntrySummary](
         commitContext.recordTime,

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
@@ -555,7 +555,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     def notHostedParty(party: String): DamlPartyAllocation =
       partyAllocation(party, OtherParticipantId)
     def createInputs(
-                      inputs: (String, Option[DamlPartyAllocation])*): Map[DamlStateKey, Option[DamlStateValue]] =
+        inputs: (String, Option[DamlPartyAllocation])*): Map[DamlStateKey, Option[DamlStateValue]] =
       inputs.map {
         case (party, partyAllocation) =>
           DamlStateKey.newBuilder().setParty(party).build() -> partyAllocation.map(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
@@ -39,7 +39,7 @@ import scala.collection.JavaConverters._
 class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSugar {
   private[this] val txBuilder = TransactionBuilder()
   private val metrics = new Metrics(new MetricRegistry)
-  private val aDamlTransactionEntry = createTransationEntry(List("aSubmitter"))
+  private val aDamlTransactionEntry = createTransactionEntry(List("aSubmitter"))
   private val aTransactionEntrySummary = DamlTransactionEntrySummary(aDamlTransactionEntry)
   private val aRecordTime = Timestamp(100)
   private val instance = createTransactionCommitter() // Stateless, can be shared between tests
@@ -474,7 +474,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         ),
         participantId = ParticipantId
       )
-      val tx = DamlTransactionEntrySummary(createTransationEntry(List(Alice, Bob, Emma)))
+      val tx = DamlTransactionEntrySummary(createTransactionEntry(List(Alice, Bob, Emma)))
 
       assertThrows[MissingInputState](instance.authorizeSubmitters.apply(context, tx))
     }
@@ -488,7 +488,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         ),
         participantId = ParticipantId
       )
-      val tx = DamlTransactionEntrySummary(createTransationEntry(List(Alice, Bob)))
+      val tx = DamlTransactionEntrySummary(createTransactionEntry(List(Alice, Bob)))
 
       val result = instance.authorizeSubmitters.apply(context, tx)
       result shouldBe a[StepStop]
@@ -510,7 +510,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         ),
         participantId = ParticipantId
       )
-      val tx = DamlTransactionEntrySummary(createTransationEntry(List(Alice, Bob)))
+      val tx = DamlTransactionEntrySummary(createTransactionEntry(List(Alice, Bob)))
 
       val result = instance.authorizeSubmitters.apply(context, tx)
       result shouldBe a[StepStop]
@@ -534,7 +534,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         ),
         participantId = ParticipantId
       )
-      val tx = DamlTransactionEntrySummary(createTransationEntry(List(Alice, Bob, Emma)))
+      val tx = DamlTransactionEntrySummary(createTransactionEntry(List(Alice, Bob, Emma)))
 
       instance.authorizeSubmitters.apply(context, tx) shouldBe a[StepContinue[_]]
     }
@@ -588,7 +588,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
           .setConfiguration(Configuration.encode(theDefaultConfig))
       )
 
-  private def createTransationEntry(submitters: List[String]): DamlTransactionEntry = {
+  private def createTransactionEntry(submitters: List[String]): DamlTransactionEntry = {
     DamlTransactionEntry.newBuilder
       .setTransaction(Conversions.encodeTransaction(TransactionBuilder.Empty))
       .setSubmitterInfo(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
@@ -17,7 +17,14 @@ import com.daml.ledger.participant.state.v1.{Configuration, RejectionReason}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Engine, ReplayMismatch}
 import com.daml.lf.transaction
-import com.daml.lf.transaction.{NodeId, RecordedNodeMissing, ReplayNodeMismatch, ReplayedNodeMissing, Transaction, TransactionOuterClass}
+import com.daml.lf.transaction.{
+  NodeId,
+  RecordedNodeMissing,
+  ReplayNodeMismatch,
+  ReplayedNodeMissing,
+  Transaction,
+  TransactionOuterClass
+}
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.value.Value
 import com.daml.metrics.Metrics
@@ -463,19 +470,23 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     val emma = "emma"
     val participantId = 0
     val otherParticipantId = 1
-    def partyAllocation(party: String, participantId: Int): DamlPartyAllocation = DamlPartyAllocation.newBuilder()
-      .setParticipantId(mkParticipantId(participantId))
-      .setDisplayName(party).build()
+    def partyAllocation(party: String, participantId: Int): DamlPartyAllocation =
+      DamlPartyAllocation
+        .newBuilder()
+        .setParticipantId(mkParticipantId(participantId))
+        .setDisplayName(party)
+        .build()
 
     def hostedParty(party: String): DamlPartyAllocation = partyAllocation(party, participantId)
-    def notHostedParty(party: String): DamlPartyAllocation = partyAllocation(party, otherParticipantId)
-    def createInputs(inputs: (String, Option[DamlPartyAllocation])*): Map[DamlStateKey, Option[DamlStateValue]] =
+    def notHostedParty(party: String): DamlPartyAllocation =
+      partyAllocation(party, otherParticipantId)
+    def createInputs(
+        inputs: (String, Option[DamlPartyAllocation])*): Map[DamlStateKey, Option[DamlStateValue]] =
       inputs.map {
         case (party, partyAllocation) =>
-          DamlStateKey.newBuilder().setParty(party).build() -> partyAllocation.map(DamlStateValue.newBuilder().setParty(_).build())
+          DamlStateKey.newBuilder().setParty(party).build() -> partyAllocation.map(
+            DamlStateValue.newBuilder().setParty(_).build())
       }.toMap
-
-
 
     "reject a submission when any of the submitters keys is not present in the input state" in {
       val context = createCommitContext(
@@ -504,7 +515,12 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
 
       val result = instance.authorizeSubmitters.apply(context, tx)
       result shouldBe a[StepStop]
-      val rejectionReason = result.asInstanceOf[StepStop].logEntry.getTransactionRejectionEntry.getPartyNotKnownOnLedger.getDetails
+      val rejectionReason = result
+        .asInstanceOf[StepStop]
+        .logEntry
+        .getTransactionRejectionEntry
+        .getPartyNotKnownOnLedger
+        .getDetails
       rejectionReason should fullyMatch regex """Submitting party .+ not known"""
     }
 
@@ -521,8 +537,14 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
 
       val result = instance.authorizeSubmitters.apply(context, tx)
       result shouldBe a[StepStop]
-      val rejectionReason = result.asInstanceOf[StepStop].logEntry.getTransactionRejectionEntry.getSubmitterCannotActViaParticipant.getDetails
-      rejectionReason should fullyMatch regex s"""Party .+ not hosted by participant ${mkParticipantId(participantId)}"""
+      val rejectionReason = result
+        .asInstanceOf[StepStop]
+        .logEntry
+        .getTransactionRejectionEntry
+        .getSubmitterCannotActViaParticipant
+        .getDetails
+      rejectionReason should fullyMatch regex s"""Party .+ not hosted by participant ${mkParticipantId(
+        participantId)}"""
     }
 
     "allow a submission when all of the submitters are hosted on the participant" in {


### PR DESCRIPTION
### Pull Request Checklist

This PR extends authorisation checks in `TransactionCommitter` in order to support multi-party submissions.

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
