### PR TITLE
Disable create-daml-app-tests with default project name

### DIFF
--- a/daml-assistant/integration-tests/BUILD.bazel
+++ b/daml-assistant/integration-tests/BUILD.bazel
@@ -198,25 +198,6 @@ da_haskell_library(
 )
 
 da_haskell_test(
-    name = "create-daml-app-tests",
-    timeout = "long",
-    srcs = ["src/DA/Daml/Assistant/CreateDamlAppTestsMain.hs"],
-    args = [
-        "$(location @nodejs//:npm_bin)",
-        "$(location @nodejs//:node_bin)",
-    ],
-    data = [
-        "@nodejs//:node_bin",
-        "@nodejs//:npm_bin",
-    ],
-    hackage_deps = ["base"],
-    main_function = "DA.Daml.Assistant.CreateDamlAppTestsMain.main",
-    # Exclusive until we stop hardcoding port numbers in index.test.ts
-    tags = ["exclusive"],
-    deps = [":create-daml-app-tests-lib"],
-)
-
-da_haskell_test(
     name = "create-daml-app-tests-proj-name",
     timeout = "long",
     srcs = ["src/DA/Daml/Assistant/CreateDamlAppTestsMain.hs"],


### PR DESCRIPTION
These are basically identical to create-daml-app-tests-proj-name
except for the fact that they use the default project name and they
are super slow so we don’t want to run them twice.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
