### PR TITLE
Bundle ghcversion.h and hpp with damlc.

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -23,6 +23,7 @@ da_haskell_binary(
         "@static_asset_d3plus//:js/d3plus.min.js",
         ghc_pkg,
         "//compiler/damlc:ghcversion",
+        "//compiler/damlc:hpp",
         "//compiler/damlc/pkg-db",
         "//compiler/damlc/stable-packages",
         "//compiler/repl-service/server:repl_service_jar",
@@ -46,7 +47,18 @@ genrule(
         echo > $(OUTS)
     """,
     tools = [],
-    visibility = ["__pkg__"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "hpp",
+    srcs = ["@stackage-exe//hpp"],
+    outs = ["hpp"],
+    cmd = """
+        cp $(location @stackage-exe//hpp) $(OUTS)
+    """,
+    tools = [],
+    visibility = ["//visibility:public"],
 )
 
 # damlc without runfiles. We use that to build the daml-prim and daml-stdlib
@@ -63,6 +75,7 @@ da_haskell_binary(
     ] if is_windows else [],
     data = [
         "//compiler/damlc:ghcversion",
+        "//compiler/damlc:hpp",
         "//compiler/damlc/stable-packages",
     ],
     hackage_deps = [
@@ -81,6 +94,8 @@ package_app(
     resources = [
         ":daml-base-anchors.json",
         ":ghc-pkg-dist",
+        "//compiler/damlc:ghcversion",
+        "//compiler/damlc:hpp",
         "//compiler/damlc/daml-ide-core:dlint.yaml",
         "//compiler/damlc/pkg-db",
         "//compiler/damlc/stable-packages",
@@ -220,12 +235,10 @@ genrule(
             --output=$(OUTS) \
             --package-name=daml-prim \
             --format=Json \
-            --cpp $(location @stackage-exe//hpp) \
             $(locations //compiler/damlc/daml-prim-src)
     """,
     tools = [
         "//compiler/damlc",
-        "@stackage-exe//hpp",
     ],
     visibility = ["//visibility:public"],
 )
@@ -239,12 +252,10 @@ genrule(
             --output=$(OUTS) \
             --package-name=daml-stdlib \
             --format=Json \
-            --cpp $(location @stackage-exe//hpp) \
             $(locations //compiler/damlc/daml-stdlib-src)
     """,
     tools = [
         "//compiler/damlc",
-        "@stackage-exe//hpp",
     ],
     visibility = ["//visibility:public"],
 )

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -23,6 +23,7 @@ module DA.Daml.Options
     , dataDependableExtensions
     ) where
 
+import Control.Applicative ((<|>))
 import Control.Exception
 import Control.Exception.Safe (handleIO)
 import Control.Concurrent.Extra
@@ -353,8 +354,8 @@ wOptsUnset =
 
 newtype GhcVersionHeader = GhcVersionHeader FilePath
 
-adjustDynFlags :: Options -> GhcVersionHeader -> FilePath -> DynFlags -> DynFlags
-adjustDynFlags options@Options{..} (GhcVersionHeader versionHeader) tmpDir dflags
+adjustDynFlags :: Options -> GhcVersionHeader -> FilePath -> Maybe FilePath -> DynFlags -> DynFlags
+adjustDynFlags options@Options{..} (GhcVersionHeader versionHeader) tmpDir defaultCppPath dflags
   =
   -- Generally, the lexer's "haddock mode" is disabled (`Haddock
   -- False` is the default option. In this case, we run the lexer in
@@ -387,7 +388,7 @@ adjustDynFlags options@Options{..} (GhcVersionHeader versionHeader) tmpDir dflag
   where
     apply f xs d = foldl' f d xs
     alterSettings f d = d { settings = f (settings d) }
-    addCppFlags = case optCppPath of
+    addCppFlags = case optCppPath <|> defaultCppPath of
         Nothing -> id
         Just cppPath -> alterSettings $ \s -> s
             { sPgm_P = (cppPath, [])
@@ -430,7 +431,21 @@ setImports :: [FilePath] -> DynFlags -> DynFlags
 setImports paths dflags = dflags { importPaths = paths }
 
 locateGhcVersionHeader :: IO GhcVersionHeader
-locateGhcVersionHeader = GhcVersionHeader <$> locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h")
+locateGhcVersionHeader = GhcVersionHeader <$> do
+    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h")
+    isDirectory <- doesDirectoryExist resourcesDir
+    let path | isDirectory = resourcesDir </> "ghcversion.h"
+             | otherwise = resourcesDir
+    pure path
+
+locateCppPath :: IO (Maybe FilePath)
+locateCppPath = do
+    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "hpp")
+    isDirectory <- doesDirectoryExist resourcesDir
+    let path | isDirectory = resourcesDir </> "hpp"
+             | otherwise = resourcesDir
+    exists <- doesFileExist path
+    pure (guard exists >> Just path)
 
 -- | Configures the @DynFlags@ for this session to DAML-1.2
 --  compilation:
@@ -443,7 +458,8 @@ setupDamlGHC :: GhcMonad m => Maybe NormalizedFilePath -> Options -> m ()
 setupDamlGHC mbProjectRoot options@Options{..} = do
   tmpDir <- liftIO getTemporaryDirectory
   versionHeader <- liftIO locateGhcVersionHeader
-  modifyDynFlags $ adjustDynFlags options versionHeader tmpDir
+  defaultCppPath <- liftIO locateCppPath
+  modifyDynFlags $ adjustDynFlags options versionHeader tmpDir defaultCppPath
 
   unless (null optGhcCustomOpts) $ do
     damlDFlags <- getSessionDynFlags

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -432,13 +432,18 @@ setImports paths dflags = dflags { importPaths = paths }
 
 locateGhcVersionHeader :: IO GhcVersionHeader
 locateGhcVersionHeader = GhcVersionHeader <$> do
-    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc")
-    pure (resourcesDir </> "ghcversion.h")
+    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h")
+    isDirectory <- doesDirectoryExist resourcesDir
+    let path | isDirectory = resourcesDir </> "ghcversion.h"
+             | otherwise = resourcesDir
+    pure path
 
 locateCppPath :: IO (Maybe FilePath)
 locateCppPath = do
-    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc")
-    let path = resourcesDir </> "hpp"
+    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "hpp")
+    isDirectory <- doesDirectoryExist resourcesDir
+    let path | isDirectory = resourcesDir </> "hpp"
+             | otherwise = resourcesDir
     exists <- doesFileExist path
     pure (guard exists >> Just path)
 

--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -432,18 +432,13 @@ setImports paths dflags = dflags { importPaths = paths }
 
 locateGhcVersionHeader :: IO GhcVersionHeader
 locateGhcVersionHeader = GhcVersionHeader <$> do
-    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "ghcversion.h")
-    isDirectory <- doesDirectoryExist resourcesDir
-    let path | isDirectory = resourcesDir </> "ghcversion.h"
-             | otherwise = resourcesDir
-    pure path
+    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc")
+    pure (resourcesDir </> "ghcversion.h")
 
 locateCppPath :: IO (Maybe FilePath)
 locateCppPath = do
-    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> "hpp")
-    isDirectory <- doesDirectoryExist resourcesDir
-    let path | isDirectory = resourcesDir </> "hpp"
-             | otherwise = resourcesDir
+    resourcesDir <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc")
+    let path = resourcesDir </> "hpp"
     exists <- doesFileExist path
     pure (guard exists >> Just path)
 

--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -40,7 +40,6 @@ dependencies:
 build-options: {build_options}
 EOF
           $(location //compiler/damlc) build --project-root $$TMP_DIR \
-              --cpp $$PWD/$(location @stackage-exe//hpp) \
               -o $$PWD/$@
           rm -rf $$TMP_DIR
         """.format(
@@ -54,7 +53,6 @@ EOF
         ),
         tools = [
             "//compiler/damlc",
-            "@stackage-exe//hpp",
         ],
         visibility = ["//visibility:public"],
     )
@@ -96,7 +94,6 @@ dependencies:
   - daml-script.dar
 EOF
         DAMLC=$$PWD/$(location //compiler/damlc)
-        TOOLCPP=$$PWD/$(location @stackage-exe//hpp)
         JSON=$$PWD/$(location :daml-trigger.json)
         cd $$TMP_DIR
         $$DAMLC init
@@ -104,7 +101,6 @@ EOF
             --combine \
             --output=$$JSON \
             --format=Json \
-            --cpp $$TOOLCPP \
             --package-name=daml-trigger \
             $$TMP_DIR/daml/Daml/Trigger.daml \
             $$TMP_DIR/daml/Daml/Trigger/Assert.daml \
@@ -116,7 +112,6 @@ EOF
     ),
     tools = [
         "//compiler/damlc",
-        "@stackage-exe//hpp",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This PR eliminates the red squiggly lines you get when opening up the
standard library in daml studio (e.g. after a Go To Definitien), that were
caused by CPP being poorly configured for users.

(When CPP is used, Go To Definition is still pointing to the wrong place,
because the line numbers are messed up. But it's better than having a
million error messages.)

We could also remove --cpp flag in a separate PR, though that may be
considered a breaking change.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
