### PR TITLE
Shutdown the GrpcServer and LedgerClient, even if there are active subscriptions

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/LedgerClient.scala
@@ -79,7 +79,10 @@ final class LedgerClient private (
   override def close(): Unit =
     channel match {
       case channel: ManagedChannel =>
-        val _ = channel.shutdown().awaitTermination(Long.MaxValue, TimeUnit.SECONDS)
+        // This includes closing active connections.
+        channel.shutdownNow()
+        channel.awaitTermination(Long.MaxValue, TimeUnit.SECONDS)
+        ()
       case _ => // do nothing
     }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
@@ -64,7 +64,12 @@ private[apiserver] object GrpcServer {
             throw new UnableToBind(desiredPort, e.getCause)
         }
         server
-      })(server => Future(server.shutdown().awaitTermination()))
+      })(server =>
+        Future {
+          // Do not wait until clients have disconnected.
+          server.shutdownNow()
+          server.awaitTermination()
+      })
     }
   }
 

--- a/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/IntegrationTest.scala
+++ b/navigator/backend/src/test/scala/com/digitalasset/navigator/backend/IntegrationTest.scala
@@ -61,6 +61,7 @@ class IntegrationTest
       Future
         .sequence(
           Seq[Future[Unit]](
+            clientF.map(_.close()),
             bindingF.flatMap(_.unbind()).map(_ => ()),
             sys.terminate().map(_ => ())))
         .transform(_ => ta)


### PR DESCRIPTION
Replacing `shutdown` by `shutdownNow` in `GrpcServer` so that the ledger API server can be shutdown even if there are connected applications.

Replacing `shutdown` by `shutdownNow` in `LedgerClient` so that all subscriptions can be terminated at once.

If the ledger server or client is terminated, any active subscription will receive the GRPC status unavailable or cancelled.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
