### PR TITLE
LF: Archive decoder reject choice observers for LF < 1.dev

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -555,7 +555,7 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
       )
     }
 
-    private[this] def decodeChoice(
+    private[archive] def decodeChoice(
         tpl: DottedName,
         lfChoice: PLF.TemplateChoice): TemplateChoice = {
       val (v, t) = decodeBinder(lfChoice.getArgBinder)
@@ -579,10 +579,13 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         name = chName,
         consuming = lfChoice.getConsuming,
         controllers = decodeExpr(lfChoice.getControllers, s"$tpl:$chName:controller"),
-        choiceObservers =
-          if (lfChoice.hasObservers)
-            Some(decodeExpr(lfChoice.getObservers, s"$tpl:$chName:observers"))
-          else None,
+        choiceObservers = if (lfChoice.hasObservers) {
+          assertSince(LV.Features.choiceObservers, "TemplateChoice.observers")
+          Some(decodeExpr(lfChoice.getObservers, s"$tpl:$chName:observers"))
+        } else {
+          assertUntil(LV.Features.choiceObservers, "non empty TemplateChoice.observers")
+          None
+        },
         selfBinder = selfBinder,
         argBinder = v -> t,
         returnType = decodeType(lfChoice.getRetType),

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -583,7 +583,6 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           assertSince(LV.Features.choiceObservers, "TemplateChoice.observers")
           Some(decodeExpr(lfChoice.getObservers, s"$tpl:$chName:observers"))
         } else {
-          assertUntil(LV.Features.choiceObservers, "non empty TemplateChoice.observers")
           None
         },
         selfBinder = selfBinder,

--- a/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
+++ b/daml-lf/archive/src/test/scala/com/digitalasset/daml/lf/archive/DecodeV1Spec.scala
@@ -883,8 +883,8 @@ class DecodeV1Spec
     val observersExpr = DamlLf1.Expr.newBuilder().setVarInternedStr(2).build()
     val bodyExp = DamlLf1.Expr.newBuilder().setVarInternedStr(5).build()
 
-    "reject choice with observers if lf version < 1.7" in {
-
+    "reject choice with observers if lf version = 1.6" in {
+      // special case for LF 1.6 that does not support string interning
       val unitTyp: DamlLf1.Type = DamlLf1.Type
         .newBuilder()
         .setPrim(DamlLf1.Type.Prim.newBuilder().setPrim(DamlLf1.PrimType.UNIT))
@@ -952,7 +952,7 @@ class DecodeV1Spec
       }
     }
 
-    "reject choice without observers if lv version >= 1.dev" in {
+    "accept choice with or without observers if lv version >= 1.dev" in {
 
       val unitTyp = DamlLf1.Type.newBuilder().setInterned(0).build()
 
@@ -976,8 +976,7 @@ class DecodeV1Spec
 
         val decoder = moduleDecoder(version, stringTable, ImmArraySeq.empty, typeTable)
 
-        a[ParseError] should be thrownBy (decoder
-          .decodeChoice(templateName, protoChoiceWithoutObservers))
+        decoder.decodeChoice(templateName, protoChoiceWithoutObservers)
         decoder.decodeChoice(templateName, protoChoiceWithObservers)
       }
     }

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -47,6 +47,7 @@ object LanguageVersion {
     val contractIdTextConversions = v1_dev
     val exerciseByKey = v1_dev
     val internedTypes = v1_dev
+    val choiceObservers = v1_dev
     val exceptions = v1_dev
 
     /** Unstable, experimental features. This should stay in 1.dev forever.


### PR DESCRIPTION
This PR fixes the archive decoder which is too lenient and accepts old archive formats (LF 1.6 to 1.8) with choice observer. 

This advances the state of #7709.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
