### PR TITLE
damlc: Don't warn on ExplicitNamespaces extension

### DIFF
--- a/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
+++ b/compiler/damlc/daml-opts/daml-opts/DA/Daml/Options.hs
@@ -291,6 +291,9 @@ dataDependableExtensions = ES.fromList $ xExtensionsSet ++
     -- data-dependencies to work, except for putting them into the files used
     -- for reconstructing the interfaces, which we already do
   , TypeOperators, UndecidableInstances
+    -- TypeOperators implies ExplicitNamespaces, hence warning on the latter
+    -- would be silly
+  , ExplicitNamespaces
     -- there's no way for our users to actually use this and listing it here
     -- removes a lot of warning from out stdlib, script and trigger builds
     -- NOTE: This should not appear on any list of extensions that are

--- a/compiler/damlc/tests/daml-test-files/TypeFamily.daml
+++ b/compiler/damlc/tests/daml-test-files/TypeFamily.daml
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeFamilies #-}
 -- @ERROR range=11:1-11:16; Data definition, of type type family.
 -- @WARN Modules compiled with the TypeFamilies language extension might not work properly with data-dependencies.
--- @WARN Modules compiled with the ExplicitNamespaces language extension might not work properly with data-dependencies.
+
 
 module TypeFamily where
 

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -884,13 +884,13 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
     , simpleImportTest "Using TypeOperators extension"
         -- This test checks that we reconstruct type operators properly.
         [ "{-# LANGUAGE TypeOperators #-}"
-        , "module Lib where"
+        , "module Lib (type (:+:) (..), type (+)) where"
         , "data a :+: b = (:+:){left: a, right:  b}"
         , "type a + b = a :+: b"
         ]
         [ "{-# LANGUAGE TypeOperators #-}"
         , "module Main where"
-        , "import Lib"
+        , "import Lib (type (:+:) (..), type (+))"
         , "colonPlus: Bool :+: Int"
         , "colonPlus = True :+: 1"
         , "onlyPlus: Int + Bool"


### PR DESCRIPTION
Since we allow the `TypeOperators` extension, which implies
`ExplicitNamespaces`, there is no point in warning in warning about
the latter.

There's not much to test for this wrt to `data-dependencies` since we
don't reconstruct export lists.

CHANGELOG_BEGIN
damlc: Don't warn on ExplicitNamespaces extensions anymore.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/8285)
<!-- Reviewable:end -->
