### PR TITLE
[not trunk] kvutils: Revert fixes to the read set to ensure that all input state is captured. [KVL-773]

### DIFF
--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -165,7 +165,6 @@ conformance_test(
 
 conformance_test(
     name = "conformance-test-pre-execution",
-    flaky = True,
     ports = [6865],
     server = ":app",
     server_args = [

--- a/ledger/ledger-on-memory/BUILD.bazel
+++ b/ledger/ledger-on-memory/BUILD.bazel
@@ -165,6 +165,7 @@ conformance_test(
 
 conformance_test(
     name = "conformance-test-pre-execution",
+    flaky = True,
     ports = [6865],
     server = ":app",
     server_args = [

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -46,8 +46,7 @@ private[kvutils] case class CommitContext(
 
   def preExecute: Boolean = recordTime.isEmpty
 
-  /** Retrieve value from output state, or if not found, from input state.
-    * Throws an exception if the key is not found in either. */
+  /** Retrieve value from output state, or if not found, from input state. */
   def get(key: DamlStateKey): Option[DamlStateValue] =
     outputs.get(key).orElse {
       val value = inputs.getOrElse(key, throw Err.MissingInputState(key))
@@ -55,12 +54,10 @@ private[kvutils] case class CommitContext(
       value
     }
 
-  /** Reads key from input state.
-    * Throws an exception if the key is not specified in the input state. */
+  /** Reads key from input state.  Records the key as being accessed even if it's not available. */
   def read(key: DamlStateKey): Option[DamlStateValue] = {
-    val value = inputs.getOrElse(key, throw Err.MissingInputState(key))
     accessedInputKeys += key
-    value
+    inputs.get(key).flatten
   }
 
   /** Generates a collection from the inputs as determined by a partial function.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -21,12 +21,10 @@ import scala.collection.mutable
 /** Commit context provides access to state inputs, commit parameters (e.g. record time) and
   * allows committer to set state outputs.
   */
-private[kvutils] case class CommitContext(
-    private val inputs: DamlStateMap,
-    recordTime: Option[Timestamp],
-    participantId: ParticipantId,
-) {
+private[kvutils] trait CommitContext {
   private[this] val logger = LoggerFactory.getLogger(this.getClass)
+
+  protected def inputs: DamlStateMap
 
   // NOTE(JM): The outputs must be iterable in deterministic order, hence we
   // keep track of insertion order.
@@ -44,7 +42,11 @@ private[kvutils] case class CommitContext(
   // pre-execution.
   var outOfTimeBoundsLogEntry: Option[DamlLogEntry] = None
 
-  def preExecute: Boolean = recordTime.isEmpty
+  def getRecordTime: Option[Timestamp]
+
+  def getParticipantId: ParticipantId
+
+  def preExecute: Boolean = getRecordTime.isEmpty
 
   /** Retrieve value from output state, or if not found, from input state. */
   def get(key: DamlStateKey): Option[DamlStateValue] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -84,7 +84,13 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
       inputState: DamlStateMap,
   ): (DamlLogEntry, Map[DamlStateKey, DamlStateValue]) =
     runTimer.time { () =>
-      val commitContext = CommitContext(inputState, recordTime, participantId)
+      val commitContext: CommitContext = new CommitContext {
+        override def getRecordTime: Option[Time.Timestamp] = recordTime
+
+        override def getParticipantId: ParticipantId = participantId
+
+        override val inputs: DamlStateMap = inputState
+      }
       val logEntry = runSteps(commitContext, submission)
       logEntry -> commitContext.getOutputs.toMap
     }
@@ -95,7 +101,13 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
       inputState: DamlStateMap,
   ): PreExecutionResult =
     preExecutionRunTimer.time { () =>
-      val commitContext = CommitContext(inputState, recordTime = None, participantId)
+      val commitContext: CommitContext = new CommitContext {
+        override def getRecordTime: Option[Time.Timestamp] = None
+
+        override def getParticipantId: ParticipantId = participantId
+
+        override val inputs: DamlStateMap = inputState
+      }
       preExecute(submission, commitContext)
     }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -91,14 +91,14 @@ final private[kvutils] class PackageCommitter(
 
   private[this] def authorizeSubmission: Step = {
     case (ctx, partialResult @ (uploadEntry, _)) =>
-      if (ctx.participantId == uploadEntry.getParticipantId) {
+      if (ctx.getParticipantId == uploadEntry.getParticipantId) {
         StepContinue(partialResult)
       } else {
         val msg =
-          s"Participant ID '${uploadEntry.getParticipantId}' did not match authorized participant ID '${ctx.participantId}'"
+          s"Participant ID '${uploadEntry.getParticipantId}' did not match authorized participant ID '${ctx.getParticipantId}'"
         rejectionTraceLog(msg, uploadEntry)
         reject(
-          ctx.recordTime,
+          ctx.getRecordTime,
           uploadEntry.getSubmissionId,
           uploadEntry.getParticipantId,
           _.setParticipantNotAuthorized(ParticipantNotAuthorized.newBuilder.setDetails(msg))
@@ -108,14 +108,14 @@ final private[kvutils] class PackageCommitter(
 
   private[this] def deduplicateSubmission: Step = {
     case (ctx, partialResult @ (uploadEntry, _)) =>
-      val submissionKey = packageUploadDedupKey(ctx.participantId, uploadEntry.getSubmissionId)
+      val submissionKey = packageUploadDedupKey(ctx.getParticipantId, uploadEntry.getSubmissionId)
       if (ctx.get(submissionKey).isEmpty) {
         StepContinue(partialResult)
       } else {
         val msg = s"duplicate submission='${uploadEntry.getSubmissionId}'"
         rejectionTraceLog(msg, uploadEntry)
         reject(
-          ctx.recordTime,
+          ctx.getRecordTime,
           uploadEntry.getSubmissionId,
           uploadEntry.getParticipantId,
           _.setDuplicateSubmission(Duplicate.newBuilder.setDetails(msg))
@@ -148,7 +148,7 @@ final private[kvutils] class PackageCommitter(
               .mkString(", ")
         rejectionTraceLog(validationError, uploadEntry)
         reject(
-          ctx.recordTime,
+          ctx.getRecordTime,
           uploadEntry.getSubmissionId,
           uploadEntry.getParticipantId,
           _.setInvalidPackage(DamlKvutils.Invalid.newBuilder.setDetails(validationError))
@@ -221,7 +221,7 @@ final private[kvutils] class PackageCommitter(
         case Left(msg) =>
           rejectionTraceLog(msg, uploadEntry)
           reject(
-            ctx.recordTime,
+            ctx.getRecordTime,
             uploadEntry.getSubmissionId,
             uploadEntry.getParticipantId,
             _.setInvalidPackage(DamlKvutils.Invalid.newBuilder.setDetails(msg))
@@ -250,7 +250,7 @@ final private[kvutils] class PackageCommitter(
         val msg = errors.mkString(", ")
         rejectionTraceLog(msg, uploadEntry)
         reject(
-          ctx.recordTime,
+          ctx.getRecordTime,
           uploadEntry.getSubmissionId,
           uploadEntry.getParticipantId,
           _.setInvalidPackage(Invalid.newBuilder.setDetails(msg))
@@ -289,7 +289,7 @@ final private[kvutils] class PackageCommitter(
         case Left(msg) =>
           rejectionTraceLog(msg, uploadEntry)
           reject(
-            ctx.recordTime,
+            ctx.getRecordTime,
             uploadEntry.getSubmissionId,
             uploadEntry.getParticipantId,
             _.setInvalidPackage(DamlKvutils.Invalid.newBuilder.setDetails(msg))
@@ -358,13 +358,13 @@ final private[kvutils] class PackageCommitter(
         )
       }
       ctx.set(
-        packageUploadDedupKey(ctx.participantId, uploadEntry.getSubmissionId),
+        packageUploadDedupKey(ctx.getParticipantId, uploadEntry.getSubmissionId),
         DamlStateValue.newBuilder
           .setSubmissionDedup(DamlSubmissionDedupValue.newBuilder)
           .build
       )
       val successLogEntry =
-        buildLogEntryWithOptionalRecordTime(ctx.recordTime, _.setPackageUploadEntry(uploadEntry))
+        buildLogEntryWithOptionalRecordTime(ctx.getRecordTime, _.setPackageUploadEntry(uploadEntry))
       if (ctx.preExecute) {
         setOutOfTimeBoundsLogEntry(uploadEntry, ctx)
       }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitter.scala
@@ -27,14 +27,14 @@ private[kvutils] class PartyAllocationCommitter(
       s"Party allocation rejected, $msg, correlationId=${partyAllocationEntry.getSubmissionId}")
 
   private val authorizeSubmission: Step = (ctx, partyAllocationEntry) => {
-    if (ctx.participantId == partyAllocationEntry.getParticipantId) {
+    if (ctx.getParticipantId == partyAllocationEntry.getParticipantId) {
       StepContinue(partyAllocationEntry)
     } else {
       val msg =
-        s"participant id ${partyAllocationEntry.getParticipantId} did not match authenticated participant id ${ctx.participantId}"
+        s"participant id ${partyAllocationEntry.getParticipantId} did not match authenticated participant id ${ctx.getParticipantId}"
       rejectionTraceLog(msg, partyAllocationEntry)
       reject(
-        ctx.recordTime,
+        ctx.getRecordTime,
         partyAllocationEntry,
         _.setParticipantNotAuthorized(
           ParticipantNotAuthorized.newBuilder
@@ -52,7 +52,7 @@ private[kvutils] class PartyAllocationCommitter(
       val msg = s"party string '$party' invalid"
       rejectionTraceLog(msg, partyAllocationEntry)
       reject(
-        ctx.recordTime,
+        ctx.getRecordTime,
         partyAllocationEntry,
         _.setInvalidName(
           Invalid.newBuilder
@@ -71,7 +71,7 @@ private[kvutils] class PartyAllocationCommitter(
       val msg = s"party already exists party='$party'"
       rejectionTraceLog(msg, partyAllocationEntry)
       reject(
-        ctx.recordTime,
+        ctx.getRecordTime,
         partyAllocationEntry,
         _.setAlreadyExists(AlreadyExists.newBuilder.setDetails(msg))
       )
@@ -80,14 +80,14 @@ private[kvutils] class PartyAllocationCommitter(
 
   private val deduplicateSubmission: Step = (ctx, partyAllocationEntry) => {
     val submissionKey =
-      partyAllocationDedupKey(ctx.participantId, partyAllocationEntry.getSubmissionId)
+      partyAllocationDedupKey(ctx.getParticipantId, partyAllocationEntry.getSubmissionId)
     if (ctx.get(submissionKey).isEmpty) {
       StepContinue(partyAllocationEntry)
     } else {
       val msg = s"duplicate submission='${partyAllocationEntry.getSubmissionId}'"
       rejectionTraceLog(msg, partyAllocationEntry)
       reject(
-        ctx.recordTime,
+        ctx.getRecordTime,
         partyAllocationEntry,
         _.setDuplicateSubmission(Duplicate.newBuilder.setDetails(msg))
       )
@@ -107,20 +107,20 @@ private[kvutils] class PartyAllocationCommitter(
       DamlStateValue.newBuilder
         .setParty(
           DamlPartyAllocation.newBuilder
-            .setParticipantId(ctx.participantId)
+            .setParticipantId(ctx.getParticipantId)
         )
         .build
     )
 
     ctx.set(
-      partyAllocationDedupKey(ctx.participantId, partyAllocationEntry.getSubmissionId),
+      partyAllocationDedupKey(ctx.getParticipantId, partyAllocationEntry.getSubmissionId),
       DamlStateValue.newBuilder
         .setSubmissionDedup(DamlSubmissionDedupValue.newBuilder)
         .build
     )
 
     val successLogEntry = buildLogEntryWithOptionalRecordTime(
-      ctx.recordTime,
+      ctx.getRecordTime,
       _.setPartyAllocationEntry(partyAllocationEntry))
     if (ctx.preExecute) {
       setOutOfTimeBoundsLogEntry(partyAllocationEntry, ctx)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -215,35 +215,27 @@ private[kvutils] class TransactionCommitter(
               value.getContractState.getContractKey -> Conversions.stateKeyToContractId(key)
           }
 
-        try {
-          engine
-            .validate(
-              Set(transactionEntry.submitter),
-              SubmittedTransaction(transactionEntry.transaction),
-              transactionEntry.ledgerEffectiveTime,
-              commitContext.participantId,
-              transactionEntry.submissionTime,
-              transactionEntry.submissionSeed,
-            )
-            .consume(
-              lookupContract(transactionEntry, commitContext),
-              lookupPackage(transactionEntry, commitContext),
-              lookupKey(commitContext, knownKeys),
-            )
-            .fold(
-              err =>
-                reject[DamlTransactionEntrySummary](
-                  commitContext.recordTime,
-                  buildRejectionLogEntry(transactionEntry, rejectionReasonForValidationError(err))),
-              _ => StepContinue[DamlTransactionEntrySummary](transactionEntry)
-            )
-        } catch {
-          case err: Err.MissingInputState =>
-            logger.warn("Exception during model conformance validation.", err)
-            reject(
-              commitContext.recordTime,
-              buildRejectionLogEntry(transactionEntry, RejectionReason.Disputed(err.getMessage)))
-        }
+        engine
+          .validate(
+            Set(transactionEntry.submitter),
+            SubmittedTransaction(transactionEntry.transaction),
+            transactionEntry.ledgerEffectiveTime,
+            commitContext.participantId,
+            transactionEntry.submissionTime,
+            transactionEntry.submissionSeed,
+          )
+          .consume(
+            lookupContract(transactionEntry, commitContext),
+            lookupPackage(transactionEntry, commitContext),
+            lookupKey(commitContext, knownKeys),
+          )
+          .fold(
+            err =>
+              reject[DamlTransactionEntrySummary](
+                commitContext.recordTime,
+                buildRejectionLogEntry(transactionEntry, rejectionReasonForValidationError(err))),
+            _ => StepContinue[DamlTransactionEntrySummary](transactionEntry)
+          )
       })
 
   private[committer] def rejectionReasonForValidationError(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -14,9 +14,9 @@ import com.daml.ledger.participant.state.kvutils.{
 }
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.batch.BatchedSubmissionValidator
-import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidator._
 import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 import com.daml.ledger.validator.{StateKeySerializationStrategy, ValidationFailed}
+import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
 
@@ -35,40 +35,43 @@ class PreExecutingSubmissionValidator[WriteSet](
 
   def validate(
       submissionEnvelope: Bytes,
+      correlationId: String,
       submittingParticipantId: ParticipantId,
       ledgerStateReader: DamlLedgerStateReaderWithFingerprints,
-  )(
-      implicit executionContext: ExecutionContext,
-      loggingContext: LoggingContext,
-  ): Future[PreExecutionOutput[WriteSet]] =
-    Timed.timedAndTrackedFuture(
-      metrics.daml.kvutils.submission.validator.validatePreExecute,
-      metrics.daml.kvutils.submission.validator.validatePreExecuteRunning,
-      for {
-        decodedSubmission <- decodeSubmission(submissionEnvelope)
-        fetchedInputs <- fetchSubmissionInputs(decodedSubmission, ledgerStateReader)
-        preExecutionResult <- preExecuteSubmission(
-          decodedSubmission,
-          submittingParticipantId,
-          fetchedInputs)
-        logEntryId = BatchedSubmissionValidator.bytesToLogEntryId(submissionEnvelope)
-        inputState = fetchedInputs.map { case (key, (value, _)) => key -> value }
-        generatedWriteSets <- Timed.future(
-          metrics.daml.kvutils.submission.validator.generateWriteSets,
-          commitStrategy
-            .generateWriteSets(submittingParticipantId, logEntryId, inputState, preExecutionResult)
-        )
-      } yield {
-        PreExecutionOutput(
-          minRecordTime = preExecutionResult.minimumRecordTime.map(_.toInstant),
-          maxRecordTime = preExecutionResult.maximumRecordTime.map(_.toInstant),
-          successWriteSet = generatedWriteSets.successWriteSet,
-          outOfTimeBoundsWriteSet = generatedWriteSets.outOfTimeBoundsWriteSet,
-          readSet = generateReadSet(fetchedInputs, preExecutionResult.readSet),
-          involvedParticipants = generatedWriteSets.involvedParticipants
-        )
-      }
-    )
+  )(implicit executionContext: ExecutionContext): Future[PreExecutionOutput[WriteSet]] =
+    newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
+      Timed.timedAndTrackedFuture(
+        metrics.daml.kvutils.submission.validator.validatePreExecute,
+        metrics.daml.kvutils.submission.validator.validatePreExecuteRunning,
+        for {
+          decodedSubmission <- decodeSubmission(submissionEnvelope)
+          fetchedInputs <- fetchSubmissionInputs(decodedSubmission, ledgerStateReader)
+          preExecutionResult <- preExecuteSubmission(
+            decodedSubmission,
+            submittingParticipantId,
+            fetchedInputs)
+          logEntryId = BatchedSubmissionValidator.bytesToLogEntryId(submissionEnvelope)
+          inputState = fetchedInputs.map { case (key, (value, _)) => key -> value }
+          generatedWriteSets <- Timed.future(
+            metrics.daml.kvutils.submission.validator.generateWriteSets,
+            commitStrategy.generateWriteSets(
+              submittingParticipantId,
+              logEntryId,
+              inputState,
+              preExecutionResult)
+          )
+        } yield {
+          PreExecutionOutput(
+            minRecordTime = preExecutionResult.minimumRecordTime.map(_.toInstant),
+            maxRecordTime = preExecutionResult.maximumRecordTime.map(_.toInstant),
+            successWriteSet = generatedWriteSets.successWriteSet,
+            outOfTimeBoundsWriteSet = generatedWriteSets.outOfTimeBoundsWriteSet,
+            readSet = generateReadSet(fetchedInputs, preExecutionResult.readSet),
+            involvedParticipants = generatedWriteSets.involvedParticipants
+          )
+        }
+      )
+    }
 
   private def decodeSubmission(submissionEnvelope: Bytes)(
       implicit executionContext: ExecutionContext,
@@ -107,22 +110,12 @@ class PreExecutingSubmissionValidator[WriteSet](
     Timed.timedAndTrackedFuture(
       metrics.daml.kvutils.submission.validator.fetchInputs,
       metrics.daml.kvutils.submission.validator.fetchInputsRunning,
-      for {
-        inputValues <- ledgerStateReader.read(inputKeys)
-
-        nestedInputKeys = inputValues.collect {
-          case (Some(value), _) if value.hasContractKeyState =>
-            val contractId = value.getContractKeyState.getContractId
-            DamlStateKey.newBuilder.setContractId(contractId).build
+      ledgerStateReader
+        .read(inputKeys)
+        .map { values =>
+          assert(inputKeys.size == values.size)
+          inputKeys.zip(values).toMap
         }
-        nestedInputValues <- ledgerStateReader.read(nestedInputKeys)
-      } yield {
-        assert(inputKeys.size == inputValues.size)
-        assert(nestedInputKeys.size == nestedInputValues.size)
-        val inputPairs = inputKeys.toIterator zip inputValues.toIterator
-        val nestedInputPairs = nestedInputKeys.toIterator zip nestedInputValues.toIterator
-        (inputPairs ++ nestedInputPairs).toMap
-      }
     )
   }
 
@@ -140,12 +133,13 @@ class PreExecutingSubmissionValidator[WriteSet](
 
   private[preexecution] def generateReadSet(
       fetchedInputs: DamlStateMapWithFingerprints,
-      accessedKeys: Set[DamlStateKey],
-  ): ReadSet =
+      accessedKeys: Set[DamlStateKey]): ReadSet =
     accessedKeys
       .map { key =>
-        val (_, fingerprint) =
-          fetchedInputs.getOrElse(key, throw new KeyNotPresentInInputException(key))
+        val (_, fingerprint) = fetchedInputs.getOrElse(
+          key,
+          throw new IllegalStateException(
+            "Committer accessed key that was not present in the input"))
         key -> fingerprint
       }
       .map {
@@ -154,12 +148,4 @@ class PreExecutingSubmissionValidator[WriteSet](
       }
       .toVector
       .sortBy(_._1.asReadOnlyByteBuffer)
-}
-
-object PreExecutingSubmissionValidator {
-
-  final class KeyNotPresentInInputException(key: DamlStateKey)
-      extends IllegalStateException(
-        s"The committer accessed a key that was not present in the input.\nKey: $key")
-
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -15,7 +15,6 @@ import com.daml.ledger.validator.caching.{
   CachingDamlLedgerStateReaderWithFingerprints
 }
 import com.daml.ledger.validator.{LedgerStateAccess, StateKeySerializationStrategy}
-import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.timer.RetryStrategy
 
 import scala.concurrent.duration._
@@ -46,8 +45,6 @@ class PreExecutingValidatingCommitter[LogResult](
     cacheUpdatePolicy: CacheUpdatePolicy,
 ) {
 
-  private val logger = ContextualizedLogger.get(getClass)
-
   /**
     * Pre-executes and then commits a submission.
     */
@@ -57,40 +54,36 @@ class PreExecutingValidatingCommitter[LogResult](
       submittingParticipantId: ParticipantId,
       ledgerStateAccess: LedgerStateAccess[LogResult],
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
-    LoggingContext.newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
-      // Sequential pre-execution, implemented by enclosing the whole pre-post-exec pipeline is a single transaction.
-      ledgerStateAccess.inTransaction { ledgerStateOperations =>
-        for {
-          preExecutionOutput <- validator
-            .validate(
-              submissionEnvelope,
-              submittingParticipantId,
-              CachingDamlLedgerStateReaderWithFingerprints(
-                stateValueCache,
-                cacheUpdatePolicy,
-                new LedgerStateReaderWithFingerprintsFromValues(
-                  ledgerStateOperations,
-                  valueToFingerprint),
-                keySerializationStrategy,
-              )
+    // Sequential pre-execution, implemented by enclosing the whole pre-post-exec pipeline is a single transaction.
+    ledgerStateAccess.inTransaction { ledgerStateOperations =>
+      for {
+        preExecutionOutput <- validator
+          .validate(
+            submissionEnvelope,
+            correlationId,
+            submittingParticipantId,
+            CachingDamlLedgerStateReaderWithFingerprints(
+              stateValueCache,
+              cacheUpdatePolicy,
+              new LedgerStateReaderWithFingerprintsFromValues(
+                ledgerStateOperations,
+                valueToFingerprint),
+              keySerializationStrategy,
             )
-          submissionResult <- retry {
-            case PostExecutionFinalizer.ConflictDetectedException =>
-              logger.error("Conflict detected during post-execution. Retrying...")
-              true
-          } { (_, _) =>
-            postExecutionFinalizer.conflictDetectAndFinalize(
-              now,
-              preExecutionOutput,
-              ledgerStateOperations)
-          }.transform {
-            case Failure(PostExecutionFinalizer.ConflictDetectedException) =>
-              logger.error("Too many conflicts detected during post-execution. Giving up.")
-              Success(SubmissionResult.Acknowledged) // But it will simply be dropped.
-            case result => result
-          }
-        } yield submissionResult
-      }
+          )
+        submissionResult <- retry {
+          case PostExecutionFinalizer.ConflictDetectedException => true
+        } { (_, _) =>
+          postExecutionFinalizer.conflictDetectAndFinalize(
+            now,
+            preExecutionOutput,
+            ledgerStateOperations)
+        }.transform {
+          case Failure(PostExecutionFinalizer.ConflictDetectedException) =>
+            Success(SubmissionResult.Acknowledged) // But it will simply be dropped.
+          case result => result
+        }
+      } yield submissionResult
     }
 
   private[this] def retry: PartialFunction[Throwable, Boolean] => RetryStrategy =

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -185,16 +185,10 @@ object KVTest {
       deduplicationTime: Duration = Duration.ofDays(1)): KVTest[(DamlLogEntryId, DamlLogEntry)] =
     for {
       testState <- get[KVTestState]
-      submissionInfo = createSubmitterInfo(submitter, commandId, deduplicationTime, testState)
+      submInfo = createSubmitterInfo(submitter, commandId, deduplicationTime, testState)
       (tx, txMetaData) = transaction
-      submission = transactionToSubmission(
-        submissionSeed,
-        letDelta,
-        testState,
-        submissionInfo,
-        tx,
-        txMetaData)
-      result <- submit(submission)
+      subm = transactionToSubmission(submissionSeed, letDelta, testState, submInfo, tx, txMetaData)
+      result <- submit(subm)
     } yield result
 
   def preExecuteTransaction(
@@ -207,16 +201,10 @@ object KVTest {
     : KVTest[(DamlLogEntryId, PreExecutionResult)] =
     for {
       testState <- get[KVTestState]
-      submitterInfo = createSubmitterInfo(submitter, commandId, deduplicationTime, testState)
+      submInfo = createSubmitterInfo(submitter, commandId, deduplicationTime, testState)
       (tx, txMetaData) = transaction
-      submission = transactionToSubmission(
-        submissionSeed,
-        letDelta,
-        testState,
-        submitterInfo,
-        tx,
-        txMetaData)
-      result <- preExecute(submission)
+      subm = transactionToSubmission(submissionSeed, letDelta, testState, submInfo, tx, txMetaData)
+      result <- preExecute(subm)
     } yield result
 
   def submitConfig(

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -8,7 +8,6 @@ import java.util.UUID
 
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
-import com.daml.ledger.participant.state.kvutils.committer.CommitContext
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId, TimeModel}
 import com.daml.lf.archive.Decode
 import com.daml.lf.archive.testing.Encode
@@ -125,10 +124,4 @@ object TestHelpers {
   def randomLedgerString: Ref.LedgerString =
     Ref.LedgerString.assertFromString(UUID.randomUUID().toString)
 
-  def createCommitContext(
-      recordTime: Option[Timestamp],
-      inputs: DamlStateMap = Map.empty,
-      participantId: Int = 0,
-  ): CommitContext =
-    CommitContext(inputs, recordTime, mkParticipantId(participantId))
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/committer/FakeCommitContext.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/committer/FakeCommitContext.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.committer
+
+import com.daml.ledger.participant.state.kvutils.DamlStateMap
+import com.daml.ledger.participant.state.kvutils.TestHelpers.mkParticipantId
+import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.lf.data.Time.Timestamp
+
+class FakeCommitContext(
+    recordTime: Option[Timestamp],
+    override val inputs: DamlStateMap = Map.empty,
+    participantId: Int = 0)
+    extends CommitContext {
+  override def getRecordTime: Option[Timestamp] = recordTime
+
+  override def getParticipantId: ParticipantId = mkParticipantId(participantId)
+}

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
@@ -3,11 +3,19 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils._
-import com.daml.ledger.participant.state.kvutils.Fingerprint
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
+  DamlCommandDedupKey,
+  DamlContractKey,
+  DamlLogEntry,
+  DamlLogEntryId,
+  DamlPartyAllocationEntry,
+  DamlStateKey,
+  DamlSubmission,
+  DamlSubmissionDedupKey
+}
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.lf.value.ValueOuterClass.Identifier
-import com.google.protobuf.{ByteString, Empty}
+import com.daml.lf.value.ValueOuterClass
+import com.google.protobuf.ByteString
 
 private[validator] object TestHelper {
 
@@ -31,12 +39,11 @@ private[validator] object TestHelper {
       .setParty("a party"),
     DamlStateKey.newBuilder
       .setContractKey(
-        DamlContractKey.newBuilder
-          .setTemplateId(Identifier.newBuilder.addName("a name"))),
-    DamlStateKey.newBuilder
-      .setConfiguration(Empty.getDefaultInstance),
-    DamlStateKey.newBuilder
-      .setSubmissionDedup(DamlSubmissionDedupKey.newBuilder.setSubmissionId("a submission ID")),
+        DamlContractKey.newBuilder.setTemplateId(
+          ValueOuterClass.Identifier.newBuilder.addName("a name"))),
+    DamlStateKey.newBuilder.setConfiguration(com.google.protobuf.Empty.getDefaultInstance),
+    DamlStateKey.newBuilder.setSubmissionDedup(
+      DamlSubmissionDedupKey.newBuilder.setSubmissionId("a submission ID"))
   ).map(_.build)
 
   lazy val anInvalidEnvelope: ByteString = ByteString.copyFromUtf8("invalid data")
@@ -58,26 +65,6 @@ private[validator] object TestHelper {
       .setParty(party)
     builder.build
   }
-
-  def fingerprint(string: String): Fingerprint =
-    ByteString.copyFromUtf8(string)
-
-  def makeContractIdStateKey(id: String): DamlStateKey =
-    DamlStateKey.newBuilder.setContractId(id).build
-
-  def makeContractIdStateValue(): DamlStateValue =
-    DamlStateValue.newBuilder.setContractState(DamlContractState.newBuilder).build
-
-  def makeContractKeyStateKey(templateId: String): DamlStateKey =
-    DamlStateKey.newBuilder
-      .setContractKey(
-        DamlContractKey.newBuilder.setTemplateId(Identifier.newBuilder.addName(templateId)))
-      .build
-
-  def makeContractKeyStateValue(contractId: String): DamlStateValue =
-    DamlStateValue.newBuilder
-      .setContractKeyState(DamlContractKeyState.newBuilder.setContractId(contractId))
-      .build
 
   def aLogEntryId(): DamlLogEntryId = SubmissionValidator.allocateRandomLogEntryId()
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -51,49 +51,6 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  "read" should {
-    "return input key and record its access" in {
-      val context =
-        newInstance(inputs = newDamlStateMap(aKey -> aValue, anotherKey -> anotherValue))
-
-      context.read(aKey) shouldBe Some(aValue)
-      context.getAccessedInputKeys shouldBe Set(aKey)
-    }
-
-    "record key as accessed even if it is not available in the input" in {
-      val context = newInstance()
-
-      context.read(aKey) shouldBe None
-      context.getAccessedInputKeys shouldBe Set(aKey)
-    }
-  }
-
-  "collectInputs" should {
-    "return keys matching the predicate and mark all inputs as accessed" in {
-      val expectedKey1 = aKeyWithContractId("a1")
-      val expectedKey2 = aKeyWithContractId("a2")
-      val expected = Map(
-        expectedKey1 -> Some(aValue),
-        expectedKey2 -> None
-      )
-      val inputs = expected ++ Map(aKeyWithContractId("b") -> Some(aValue))
-      val context = newInstance(inputs = inputs)
-
-      context.collectInputs {
-        case (key, _) if key.getContractId.startsWith("a") => key
-      }.toSet shouldBe expected.keys
-      context.getAccessedInputKeys shouldBe inputs.keys
-    }
-
-    "return no keys and mark all inputs as accessed for a predicate producing empty output" in {
-      val context =
-        newInstance(inputs = newDamlStateMap(aKey -> aValue, anotherKey -> anotherValue))
-
-      context.collectInputs { case _ if false => () } shouldBe empty
-      context.getAccessedInputKeys shouldBe Set(aKey, anotherKey)
-    }
-  }
-
   "set" should {
     "maintain order of keys based on when they were seen first" in {
       val context = newInstance()
@@ -148,11 +105,9 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  private def aKeyWithContractId(id: String): DamlStateKey =
-    DamlStateKey.newBuilder.setContractId(id).build
-
-  private val aKey: DamlStateKey = aKeyWithContractId("contract ID 1")
-  private val anotherKey: DamlStateKey = aKeyWithContractId("contract ID 2")
+  private val aKey: DamlStateKey = DamlStateKey.newBuilder.setContractId("contract ID 1").build
+  private val anotherKey: DamlStateKey =
+    DamlStateKey.newBuilder.setContractId("contract ID 2").build
   private val aValue: DamlStateValue = DamlStateValue.newBuilder
     .setParty(DamlPartyAllocation.newBuilder.setDisplayName("a party name"))
     .build

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -10,6 +10,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
 }
 import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
 import com.daml.ledger.participant.state.kvutils.{DamlStateMap, TestHelpers}
+import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.data.Time
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -159,10 +160,17 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
     .setParty(DamlPartyAllocation.newBuilder.setDisplayName("another party name"))
     .build
 
+  private class TestCommitContext(
+      override val getRecordTime: Option[Time.Timestamp],
+      override val inputs: DamlStateMap)
+      extends CommitContext {
+    override def getParticipantId: ParticipantId = TestHelpers.mkParticipantId(1)
+  }
+
   private def newInstance(
       recordTime: Option[Time.Timestamp] = Some(Time.Timestamp.now()),
       inputs: DamlStateMap = Map.empty) =
-    CommitContext(inputs, recordTime, TestHelpers.mkParticipantId(1))
+    new TestCommitContext(recordTime, inputs)
 
   private def newDamlStateMap(keyAndValues: (DamlStateKey, DamlStateValue)*): DamlStateMap =
     (for ((key, value) <- keyAndValues)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -8,8 +8,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.committer.CommitContextSpec._
-import com.daml.ledger.participant.state.kvutils.{DamlStateMap, Err, TestHelpers}
+import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
+import com.daml.ledger.participant.state.kvutils.{DamlStateMap, TestHelpers}
 import com.daml.lf.data.Time
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -46,8 +46,7 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
 
     "throw in case key cannot be found" in {
       val context = newInstance()
-      assertThrows[Err.MissingInputState](context.get(aKey))
-      context.getAccessedInputKeys shouldBe Set.empty
+      assertThrows[MissingInputState](context.get(aKey))
     }
   }
 
@@ -61,16 +60,10 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
     }
 
     "record key as accessed even if it is not available in the input" in {
-      val context = newInstance(inputs = Map(aKey -> None))
+      val context = newInstance()
 
       context.read(aKey) shouldBe None
       context.getAccessedInputKeys shouldBe Set(aKey)
-    }
-
-    "throw in case key cannot be found" in {
-      val context = newInstance()
-      assertThrows[Err.MissingInputState](context.read(aKey))
-      context.getAccessedInputKeys shouldBe Set.empty
     }
   }
 
@@ -153,9 +146,7 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
       context.preExecute shouldBe true
     }
   }
-}
 
-object CommitContextSpec {
   private def aKeyWithContractId(id: String): DamlStateKey =
     DamlStateKey.newBuilder.setContractId(id).build
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitterSpec.scala
@@ -6,11 +6,12 @@ package com.daml.ledger.participant.state.kvutils.committer
 import java.time.{Duration, Instant}
 
 import com.codahale.metrics.MetricRegistry
-import com.daml.ledger.participant.state.kvutils.Conversions.{buildTimestamp, configurationStateKey}
-import com.daml.ledger.participant.state.kvutils.DamlKvutils._
-import com.daml.ledger.participant.state.kvutils.TestHelpers.{createCommitContext, theDefaultConfig}
-import com.daml.ledger.participant.state.kvutils.committer.Committer.StepInfo
+import com.daml.ledger.participant.state.kvutils.Conversions.configurationStateKey
+import com.daml.ledger.participant.state.kvutils.Conversions.buildTimestamp
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Err}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.TestHelpers.theDefaultConfig
+import com.daml.ledger.participant.state.kvutils.committer.Committer.StepInfo
 import com.daml.ledger.participant.state.protobuf.LedgerConfiguration
 import com.daml.ledger.participant.state.v1.{Configuration, TimeModel}
 import com.daml.lf.data.Time.Timestamp
@@ -191,7 +192,7 @@ class CommitterSpec
   "getCurrentConfiguration" should {
     "return configuration in case there is one available on the ledger" in {
       val inputState = Map(configurationStateKey -> Some(aConfigurationStateValue))
-      val commitContext = createCommitContext(recordTime = None, inputState)
+      val commitContext = new FakeCommitContext(recordTime = None, inputState)
 
       val (Some(actualConfigurationEntry), actualConfiguration) =
         Committer.getCurrentConfiguration(theDefaultConfig, commitContext, createLogger())
@@ -202,7 +203,7 @@ class CommitterSpec
 
     "return default configuration in case there is no configuration on the ledger" in {
       val inputState = Map(configurationStateKey -> None)
-      val commitContext = createCommitContext(recordTime = None, inputState)
+      val commitContext = new FakeCommitContext(recordTime = None, inputState)
 
       val (actualConfigurationEntry, actualConfiguration) =
         Committer.getCurrentConfiguration(theDefaultConfig, commitContext, createLogger())
@@ -212,7 +213,7 @@ class CommitterSpec
     }
 
     "throw in case configuration key is not declared in the input" in {
-      val commitContext = createCommitContext(recordTime = None, Map.empty)
+      val commitContext = new FakeCommitContext(recordTime = None, Map.empty)
 
       assertThrows[Err.MissingInputState] {
         Committer.getCurrentConfiguration(theDefaultConfig, commitContext, createLogger())
@@ -227,7 +228,7 @@ class CommitterSpec
             .setConfiguration(LedgerConfiguration.newBuilder.setGeneration(123456))
         )
         .build
-      val commitContext = createCommitContext(
+      val commitContext = new FakeCommitContext(
         recordTime = None,
         Map(configurationStateKey -> Some(invalidConfigurationEntry)))
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/ConfigCommitterSpec.scala
@@ -28,7 +28,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
   "checkTtl" should {
     "produce rejection log entry if maximum record time is before record time" in {
       val instance = createConfigCommitter(aRecordTime)
-      val context = createCommitContext(recordTime = Some(aRecordTime.addMicros(1)))
+      val context = new FakeCommitContext(recordTime = Some(aRecordTime.addMicros(1)))
 
       val actual = instance.checkTtl(context, anEmptyResult)
 
@@ -45,7 +45,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
     "continue if maximum record time is on or after record time" in {
       for (maximumRecordTime <- Iterable(aRecordTime, aRecordTime.addMicros(1))) {
         val instance = createConfigCommitter(maximumRecordTime)
-        val context = createCommitContext(recordTime = Some(aRecordTime))
+        val context = new FakeCommitContext(recordTime = Some(aRecordTime))
 
         val actual = instance.checkTtl(context, anEmptyResult)
 
@@ -58,7 +58,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
 
     "skip checking against maximum record time if record time is not available" in {
       val instance = createConfigCommitter(aRecordTime)
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       instance.checkTtl(context, anEmptyResult) match {
         case StepContinue(_) => succeed
@@ -68,7 +68,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
 
     "set the maximum record time and out-of-time-bounds log entry in the context if record time is not available" in {
       val instance = createConfigCommitter(aRecordTime)
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       instance.checkTtl(context, anEmptyResult)
 
@@ -86,7 +86,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
 
     "not set an out-of-time-bounds rejection log entry in case pre-execution is disabled" in {
       val instance = createConfigCommitter(theRecordTime)
-      val context = createCommitContext(recordTime = Some(aRecordTime))
+      val context = new FakeCommitContext(recordTime = Some(aRecordTime))
 
       instance.checkTtl(context, anEmptyResult)
 
@@ -98,7 +98,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
   "buildLogEntry" should {
     "set record time in log entry when it is available" in {
       val instance = createConfigCommitter(theRecordTime.addMicros(1000))
-      val context = createCommitContext(recordTime = Some(theRecordTime))
+      val context = new FakeCommitContext(recordTime = Some(theRecordTime))
 
       val actual = instance.buildLogEntry(context, anEmptyResult)
 
@@ -112,7 +112,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
 
     "skip setting record time in log entry when it is not available" in {
       val instance = createConfigCommitter(theRecordTime)
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       val actual = instance.buildLogEntry(context, anEmptyResult)
 
@@ -126,7 +126,7 @@ class ConfigCommitterSpec extends AnyWordSpec with Matchers {
     "produce a log entry (pre-execution disabled or enabled)" in {
       for (recordTimeMaybe <- Iterable(Some(aRecordTime), None)) {
         val instance = createConfigCommitter(theRecordTime)
-        val context = createCommitContext(recordTime = recordTimeMaybe)
+        val context = new FakeCommitContext(recordTime = recordTimeMaybe)
 
         val actual = instance.buildLogEntry(context, anEmptyResult)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
@@ -502,7 +502,7 @@ class PackageCommitterSpec extends AnyWordSpec with Matchers with ParallelTestEx
     def newCommitter = new CommitterWrapper(PackageValidationMode.No, PackagePreloadingMode.No)
 
     "produce an out-of-time-bounds rejection log entry in case pre-execution is enabled" in {
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       newCommitter.packageCommitter.buildLogEntry(context, anEmptyResult)
 
@@ -517,7 +517,7 @@ class PackageCommitterSpec extends AnyWordSpec with Matchers with ParallelTestEx
     }
 
     "not set an out-of-time-bounds rejection log entry in case pre-execution is disabled" in {
-      val context = createCommitContext(recordTime = Some(theRecordTime))
+      val context = new FakeCommitContext(recordTime = Some(theRecordTime))
 
       newCommitter.packageCommitter.buildLogEntry(context, anEmptyResult)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PartyAllocationCommitterSpec.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.participant.state.kvutils.committer
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlPartyAllocationEntry
-import com.daml.ledger.participant.state.kvutils.TestHelpers.{createCommitContext, theRecordTime}
+import com.daml.ledger.participant.state.kvutils.TestHelpers.theRecordTime
 import com.daml.metrics.Metrics
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -19,7 +19,7 @@ class PartyAllocationCommitterSpec extends AnyWordSpec with Matchers {
   "buildLogEntry" should {
     "produce an out-of-time-bounds rejection log entry in case pre-execution is enabled" in {
       val instance = new PartyAllocationCommitter(metrics)
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       instance.buildLogEntry(context, aPartyAllocationEntry)
 
@@ -35,7 +35,7 @@ class PartyAllocationCommitterSpec extends AnyWordSpec with Matchers {
 
     "not set an out-of-time-bounds rejection log entry in case pre-execution is disabled" in {
       val instance = new PartyAllocationCommitter(metrics)
-      val context = createCommitContext(recordTime = Some(theRecordTime))
+      val context = new FakeCommitContext(recordTime = Some(theRecordTime))
 
       instance.buildLogEntry(context, aPartyAllocationEntry)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
@@ -116,7 +116,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
 
   "trimUnnecessaryNodes" should {
     "remove `Fetch` and `LookupByKey` nodes from transaction tree" in {
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       instance.trimUnnecessaryNodes(context, aRichTransactionTreeSummary) match {
         case StepContinue(logEntry) =>
@@ -143,7 +143,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
 
   "deduplicateCommand" should {
     "continue if record time is not available" in {
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       val actual = instance.deduplicateCommand(context, aTransactionEntrySummary)
 
@@ -156,7 +156,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     "continue if record time is available but no deduplication entry could be found" in {
       val inputs = Map(dedupKey -> None)
       val context =
-        createCommitContext(recordTime = Some(aRecordTime), inputs = inputs)
+        new FakeCommitContext(recordTime = Some(aRecordTime), inputs = inputs)
 
       val actual = instance.deduplicateCommand(context, aTransactionEntrySummary)
 
@@ -170,7 +170,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       val dedupValue = newDedupValue(aRecordTime)
       val inputs = Map(dedupKey -> Some(dedupValue))
       val context =
-        createCommitContext(recordTime = Some(aRecordTime.addMicros(1)), inputs = inputs)
+        new FakeCommitContext(recordTime = Some(aRecordTime.addMicros(1)), inputs = inputs)
 
       val actual = instance.deduplicateCommand(context, aTransactionEntrySummary)
 
@@ -187,7 +187,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         val dedupValue = newDedupValue(deduplicationTime)
         val inputs = Map(dedupKey -> Some(dedupValue))
         val context =
-          createCommitContext(recordTime = Some(recordTime), inputs = inputs)
+          new FakeCommitContext(recordTime = Some(recordTime), inputs = inputs)
 
         val actual = instance.deduplicateCommand(context, aTransactionEntrySummary)
 
@@ -259,7 +259,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
 
       for (ledgerEffectiveTime <- Iterable(lowerBound, upperBound)) {
         val context =
-          createCommitContext(recordTime = Some(recordTime), inputs = inputWithDeclaredConfig)
+          new FakeCommitContext(recordTime = Some(recordTime), inputs = inputWithDeclaredConfig)
         val transactionEntrySummary = DamlTransactionEntrySummary(
           aDamlTransactionEntry.toBuilder
             .setLedgerEffectiveTime(
@@ -279,7 +279,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
 
     "mark config key as accessed in context" in {
       val commitContext =
-        createCommitContext(recordTime = None, inputWithTimeModelAndCommandDeduplication)
+        new FakeCommitContext(recordTime = None, inputWithTimeModelAndCommandDeduplication)
 
       val _ = instance.validateLedgerTime(commitContext, aTransactionEntrySummary)
 
@@ -289,7 +289,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
 
   "buildLogEntry" should {
     "set record time in log entry when it is available" in {
-      val context = createCommitContext(recordTime = Some(theRecordTime))
+      val context = new FakeCommitContext(recordTime = Some(theRecordTime))
 
       val actual = instance.buildLogEntry(aTransactionEntrySummary, context)
 
@@ -300,7 +300,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     }
 
     "skip setting record time in log entry when it is not available" in {
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       val actual = instance.buildLogEntry(aTransactionEntrySummary, context)
 
@@ -310,7 +310,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     }
 
     "produce an out-of-time-bounds rejection log entry in case pre-execution is enabled" in {
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       val _ = instance.buildLogEntry(aTransactionEntrySummary, context)
 
@@ -324,7 +324,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     }
 
     "not set an out-of-time-bounds rejection log entry in case pre-execution is disabled" in {
-      val context = createCommitContext(recordTime = Some(aRecordTime))
+      val context = new FakeCommitContext(recordTime = Some(aRecordTime))
 
       val _ = instance.buildLogEntry(aTransactionEntrySummary, context)
 
@@ -335,7 +335,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
 
   "blind" should {
     "always set blindingInfo" in {
-      val context = createCommitContext(recordTime = None)
+      val context = new FakeCommitContext(recordTime = None)
 
       val actual = instance.blind(context, aTransactionEntrySummary)
 
@@ -473,10 +473,12 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
     new TransactionCommitter(theDefaultConfig, mock[Engine], metrics, inStaticTimeMode = false)
 
   private def contextWithTimeModelAndEmptyCommandDeduplication() =
-    createCommitContext(recordTime = None, inputs = inputWithTimeModelAndEmptyCommandDeduplication)
+    new FakeCommitContext(
+      recordTime = None,
+      inputs = inputWithTimeModelAndEmptyCommandDeduplication)
 
   private def contextWithTimeModelAndCommandDeduplication() =
-    createCommitContext(recordTime = None, inputs = inputWithTimeModelAndCommandDeduplication)
+    new FakeCommitContext(recordTime = None, inputs = inputWithTimeModelAndCommandDeduplication)
 
   private def newDedupValue(deduplicationTime: Timestamp): DamlStateValue =
     DamlStateValue.newBuilder


### PR DESCRIPTION
This reverts the following PRs, in reverse order:

- #8082
- #8146
- #8153
- #8180
- #8194

### Changelog

- **[Integration Kit]** Reverted a fix to the kvutils input state that caused performance degradation on some ledgers. This is a temporary measure that we do not expect to be used outside of very specific circumstances, as it can trade correctness for performance if the semantics are not completely understood.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
