### PR TITLE
HOTFIX bump versions for Haskell LF libraries

### DIFF
--- a/build-scripts/build_hs_lf_tooling.sh
+++ b/build-scripts/build_hs_lf_tooling.sh
@@ -15,6 +15,10 @@ cd "$(dirname ${BASH_SOURCE[0]})/.."
 
 mkdir -p $TARGET_DIR
 
+# This version needs to be adapted in all cabal files, too
+# The script below will fail on the `cp` command otherwise.
+LIB_VERSION="0.1.8.0"
+
 package_from_dir() {
     local dir=$1
     if [ ! -d $dir ]; then
@@ -23,7 +27,7 @@ package_from_dir() {
     fi
     pushd $dir
     cabal v2-sdist
-    cp dist-newstyle/sdist/*.tar.gz "$TARGET_DIR/"
+    cp dist-newstyle/sdist/*${LIB_VERSION}.tar.gz "$TARGET_DIR/"
     rm -rf cabal.tix dist-newstyle/
     popd
 }
@@ -113,7 +117,7 @@ EOF
 cat <<EOF > "$DIR/daml-lf-proto-types.cabal"
 cabal-version: 2.4
 name: daml-lf-proto-types
-version: 0.1.8.0
+version: ${LIB_VERSION}
 
 extra-source-files:
   protobuf/com/daml/daml_lf_dev/daml_lf.proto
@@ -152,11 +156,11 @@ if [ ! -f "$TARGET_DIR/cabal.project" ]; then
     cat <<EOF > "$TARGET_DIR/cabal.project"
 packages:
 --   ./. -- add this if the top project is cabalised
-  ./da-hs-base-0.1.8.0.tar.gz
-  ./daml-lf-ast-0.1.8.0.tar.gz
-  ./daml-lf-proto-0.1.8.0.tar.gz
-  ./daml-lf-proto-types-0.1.8.0.tar.gz
-  ./daml-lf-reader-0.1.8.0.tar.gz
+  ./da-hs-base-${LIB_VERSION}.tar.gz
+  ./daml-lf-ast-${LIB_VERSION}.tar.gz
+  ./daml-lf-proto-${LIB_VERSION}.tar.gz
+  ./daml-lf-proto-types-${LIB_VERSION}.tar.gz
+  ./daml-lf-reader-${LIB_VERSION}.tar.gz
 EOF
     echo "Wrote $TARGET_DIR/cabal.project"
 else
@@ -175,13 +179,32 @@ packages:
 extra-deps:
 - proto3-suite-0.4.0.0
 - proto3-wire-1.1.0
-- ./da-hs-base-0.1.8.0.tar.gz
-- ./daml-lf-ast-0.1.8.0.tar.gz
-- ./daml-lf-proto-types-0.1.8.0.tar.gz
-- ./daml-lf-proto-0.1.8.0.tar.gz
-- ./daml-lf-reader-0.1.8.0.tar.gz
+- ./da-hs-base-${LIB_VERSION}.tar.gz
+- ./daml-lf-ast-${LIB_VERSION}.tar.gz
+- ./daml-lf-proto-types-${LIB_VERSION}.tar.gz
+- ./daml-lf-proto-${LIB_VERSION}.tar.gz
+- ./daml-lf-reader-${LIB_VERSION}.tar.gz
 EOF
     echo "Wrote $TARGET_DIR/stack.yaml"
 else
     echo "not overwriting existing stack.yaml file"
 fi
+
+# add a dummy cabal file so one can compile the libraries for a test
+cat <<EOF > $TARGET_DIR/test-lib-lf.cabal
+cabal-version:    2.4
+
+name:             test-lib-lf
+description:      Dummy package to test compilation of the extracted LF libraries
+version:          ${LIB_VERSION}
+build-type:       Simple
+
+library
+  hs-source-dirs: .
+  build-depends:  da-hs-base,
+                  daml-lf-ast,
+                  daml-lf-proto,
+                  daml-lf-proto-types,
+                  daml-lf-reader
+  default-language: Haskell2010
+EOF

--- a/build-scripts/build_hs_lf_tooling.sh
+++ b/build-scripts/build_hs_lf_tooling.sh
@@ -113,7 +113,7 @@ EOF
 cat <<EOF > "$DIR/daml-lf-proto-types.cabal"
 cabal-version: 2.4
 name: daml-lf-proto-types
-version: 0.1.4.0
+version: 0.1.8.0
 
 extra-source-files:
   protobuf/com/daml/daml_lf_dev/daml_lf.proto
@@ -152,11 +152,11 @@ if [ ! -f "$TARGET_DIR/cabal.project" ]; then
     cat <<EOF > "$TARGET_DIR/cabal.project"
 packages:
 --   ./. -- add this if the top project is cabalised
-  ./da-hs-base-0.1.4.0.tar.gz
-  ./daml-lf-ast-0.1.4.0.tar.gz
-  ./daml-lf-proto-0.1.4.0.tar.gz
-  ./daml-lf-proto-types-0.1.4.0.tar.gz
-  ./daml-lf-reader-0.1.4.0.tar.gz
+  ./da-hs-base-0.1.8.0.tar.gz
+  ./daml-lf-ast-0.1.8.0.tar.gz
+  ./daml-lf-proto-0.1.8.0.tar.gz
+  ./daml-lf-proto-types-0.1.8.0.tar.gz
+  ./daml-lf-reader-0.1.8.0.tar.gz
 EOF
     echo "Wrote $TARGET_DIR/cabal.project"
 else
@@ -175,11 +175,11 @@ packages:
 extra-deps:
 - proto3-suite-0.4.0.0
 - proto3-wire-1.1.0
-- ./da-hs-base-0.1.4.0.tar.gz
-- ./daml-lf-ast-0.1.4.0.tar.gz
-- ./daml-lf-proto-types-0.1.4.0.tar.gz
-- ./daml-lf-proto-0.1.4.0.tar.gz
-- ./daml-lf-reader-0.1.4.0.tar.gz
+- ./da-hs-base-0.1.8.0.tar.gz
+- ./daml-lf-ast-0.1.8.0.tar.gz
+- ./daml-lf-proto-types-0.1.8.0.tar.gz
+- ./daml-lf-proto-0.1.8.0.tar.gz
+- ./daml-lf-reader-0.1.8.0.tar.gz
 EOF
     echo "Wrote $TARGET_DIR/stack.yaml"
 else

--- a/compiler/daml-lf-ast/daml-lf-ast.cabal
+++ b/compiler/daml-lf-ast/daml-lf-ast.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: daml-lf-ast
 build-type: Simple
-version: 0.1.4.0
+version: 0.1.8.0
 synopsis: DAML-LF AST
 license: Apache-2.0
 author: Digital Asset

--- a/compiler/daml-lf-proto/daml-lf-proto.cabal
+++ b/compiler/daml-lf-proto/daml-lf-proto.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: daml-lf-proto
 build-type: Simple
-version: 0.1.4.0
+version: 0.1.8.0
 synopsis: DAML-LF Protobuf Encoding
 license: Apache-2.0
 author: Digital Asset
@@ -55,5 +55,6 @@ library
       OverloadedStrings
       PackageImports
       RecordWildCards
+      ScopedTypeVariables
       TypeApplications
       ViewPatterns

--- a/compiler/daml-lf-reader/daml-lf-reader.cabal
+++ b/compiler/daml-lf-reader/daml-lf-reader.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: daml-lf-reader
 build-type: Simple
-version: 0.1.4.0
+version: 0.1.8.0
 synopsis: DAML-LF Archive reader
 license: Apache-2.0
 author: Digital Asset

--- a/libs-haskell/da-hs-base/da-hs-base.cabal
+++ b/libs-haskell/da-hs-base/da-hs-base.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 name: da-hs-base
 build-type: Simple
-version: 0.1.4.0
+version: 0.1.8.0
 synopsis: Kitchen sink package for common functionality shared between packages
 license: Apache-2.0
 author: Digital Asset
@@ -39,6 +39,7 @@ library
       optparse-applicative,
       pretty,
       random,
+      safe,
       safe-exceptions,
       stm,
       tar-conduit,
@@ -55,6 +56,8 @@ library
     exposed-modules:
       Control.Lens.Ast
       Control.Lens.MonoTraversal
+      DA.Directory
+      DA.PortFile
       DA.Pretty
       DA.Service.Logger
       -- DA.Service.Logger.Impl.GCP imports SdkVersion build artefact
@@ -65,11 +68,13 @@ library
       Data.NameMap
       Data.Semigroup.FixedPoint
       Data.Text.Extended
+      Data.Vector.Extended
       Options.Applicative.Extended
       Orphans.Lib_pretty
       Test.Tasty.Extended
       Text.PrettyPrint.Annotated.Extended
     default-extensions:
+      BangPatterns
       DeriveDataTypeable
       DeriveGeneric
       FlexibleContexts


### PR DESCRIPTION
Upgrade version of extracted HS LF libraries - which are probably not meant to be included in the release notes

The PR updates the versions from `0.1.4.0` to `0.1.8.0`, and also ensures that the script will fail if there are inconsistencies between cabal files and the version variable.
The new version is needed to support type interning and choice observers.
Also adding a dummy cabal file which enables compiling the extracted libraries for a quick smoke test.

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
