### PR TITLE
kvutils: Reduce the surface area of fingerprints in pre-execution. [KVL-747]

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -29,7 +29,6 @@ import com.daml.ledger.validator.batch.{
   ConflictDetection
 }
 import com.daml.ledger.validator.caching.ImmutablesOnlyCacheUpdatePolicy
-import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 import com.daml.ledger.validator.preexecution._
 import com.daml.ledger.validator.{StateKeySerializationStrategy, ValidateAndCommit}
 import com.daml.lf.engine.Engine
@@ -238,11 +237,7 @@ object InMemoryLedgerReaderWriter {
     val commitStrategy = new LogAppenderPreExecutingCommitStrategy(keySerializationStrategy)
     val valueToFingerprint: Option[Value] => Fingerprint =
       _.getOrElse(FingerprintPlaceholder)
-    val validator = new PreExecutingSubmissionValidator[ReadSet, RawKeyValuePairsWithLogEntry](
-      keyValueCommitting,
-      metrics,
-      commitStrategy,
-    )
+    val validator = new PreExecutingSubmissionValidator(keyValueCommitting, metrics, commitStrategy)
     val committer = new PreExecutingValidatingCommitter(
       keySerializationStrategy,
       validator,

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -240,8 +240,8 @@ object InMemoryLedgerReaderWriter {
     val validator = new PreExecutingSubmissionValidator[RawKeyValuePairsWithLogEntry](
       keyValueCommitting,
       metrics,
-      keySerializationStrategy,
-      commitStrategy)
+      commitStrategy,
+    )
     val committer = new PreExecutingValidatingCommitter(
       () => timeProvider.getCurrentTime,
       keySerializationStrategy,
@@ -249,7 +249,7 @@ object InMemoryLedgerReaderWriter {
       valueToFingerprint,
       new PostExecutionFinalizer[Index](valueToFingerprint),
       stateValueCache = stateValueCacheForPreExecution,
-      ImmutablesOnlyCacheUpdatePolicy
+      ImmutablesOnlyCacheUpdatePolicy,
     )
     locally {
       implicit val executionContext: ExecutionContext = materializer.executionContext

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -248,7 +248,7 @@ object InMemoryLedgerReaderWriter {
       keySerializationStrategy,
       validator,
       valueToFingerprint,
-      new PostExecutionFinalizer[Index](valueToFingerprint),
+      new PostExecutionConflictDetection,
       stateValueCache = stateValueCacheForPreExecution,
       ImmutablesOnlyCacheUpdatePolicy,
     )

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -244,11 +244,11 @@ object InMemoryLedgerReaderWriter {
       commitStrategy,
     )
     val committer = new PreExecutingValidatingCommitter(
-      () => timeProvider.getCurrentTime,
       keySerializationStrategy,
       validator,
       valueToFingerprint,
       FingerprintAwarePostExecutionConflictDetector,
+      new RawPostExecutionFinalizer(now = timeProvider.getCurrentTime _),
       stateValueCache = stateValueCacheForPreExecution,
       ImmutablesOnlyCacheUpdatePolicy,
     )

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -29,6 +29,7 @@ import com.daml.ledger.validator.batch.{
   ConflictDetection
 }
 import com.daml.ledger.validator.caching.ImmutablesOnlyCacheUpdatePolicy
+import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 import com.daml.ledger.validator.preexecution._
 import com.daml.ledger.validator.{StateKeySerializationStrategy, ValidateAndCommit}
 import com.daml.lf.engine.Engine
@@ -237,7 +238,7 @@ object InMemoryLedgerReaderWriter {
     val commitStrategy = new LogAppenderPreExecutingCommitStrategy(keySerializationStrategy)
     val valueToFingerprint: Option[Value] => Fingerprint =
       _.getOrElse(FingerprintPlaceholder)
-    val validator = new PreExecutingSubmissionValidator[RawKeyValuePairsWithLogEntry](
+    val validator = new PreExecutingSubmissionValidator[ReadSet, RawKeyValuePairsWithLogEntry](
       keyValueCommitting,
       metrics,
       commitStrategy,

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -248,7 +248,7 @@ object InMemoryLedgerReaderWriter {
       keySerializationStrategy,
       validator,
       valueToFingerprint,
-      new PostExecutionConflictDetection,
+      FingerprintAwarePostExecutionConflictDetector,
       stateValueCache = stateValueCacheForPreExecution,
       ImmutablesOnlyCacheUpdatePolicy,
     )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -34,7 +34,7 @@ trait LedgerStateAccess[LogResult] {
   *
   * @tparam LogResult type of the offset used for a log entry
   */
-trait LedgerStateOperations[LogResult] {
+trait LedgerStateOperations[+LogResult] {
 
   /**
     * Reads value of a single key from the backing store.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingDamlLedgerStateReaderWithFingerprints.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingDamlLedgerStateReaderWithFingerprints.scala
@@ -6,9 +6,9 @@ package com.daml.ledger.validator.caching
 import com.daml.caching.{Cache, Weight}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.Fingerprint
+import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.RawToDamlLedgerStateReaderAdapter.deserializeDamlStateValue
 import com.daml.ledger.validator.StateKeySerializationStrategy
-import com.daml.ledger.validator.preexecution.LedgerStateReaderWithFingerprints
 import com.daml.ledger.validator.reading.StateReader
 import com.google.protobuf.MessageLite
 
@@ -19,12 +19,10 @@ object CachingDamlLedgerStateReaderWithFingerprints {
       value._1.getSerializedSize.toLong + value._2.size()
   }
 
-  type StateCacheWithFingerprints = Cache[DamlStateKey, (DamlStateValue, Fingerprint)]
-
   def apply(
-      cache: StateCacheWithFingerprints,
+      cache: Cache[DamlStateKey, (DamlStateValue, Fingerprint)],
       cachingPolicy: CacheUpdatePolicy[DamlStateKey],
-      ledgerStateReaderWithFingerprints: LedgerStateReaderWithFingerprints,
+      ledgerStateReaderWithFingerprints: StateReader[Key, (Option[Value], Fingerprint)],
       keySerializationStrategy: StateKeySerializationStrategy,
   ): StateReader[DamlStateKey, (Option[DamlStateValue], Fingerprint)] =
     new CachingStateReader[DamlStateKey, (Option[DamlStateValue], Fingerprint)](

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/ConflictDetectedException.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/ConflictDetectedException.scala
@@ -1,0 +1,8 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.preexecution
+
+final class ConflictDetectedException
+    extends RuntimeException(
+      "A conflict has been detected with other submissions during post-execution.")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/FingerprintAwarePostExecutionConflictDetector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/FingerprintAwarePostExecutionConflictDetector.scala
@@ -5,26 +5,19 @@ package com.daml.ledger.validator.preexecution
 
 import com.daml.ledger.participant.state.kvutils.Fingerprint
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
-import com.daml.ledger.validator.preexecution.PostExecutionConflictDetection._
 import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 import com.daml.ledger.validator.reading.StateReader
 
 import scala.concurrent.{ExecutionContext, Future}
 
-/**
-  * An in-transaction post-execution conflict detection to be invoked as the last stage of a
-  * pre-execution pipeline. It performs deferred time bound checks and detects pre-execution
-  * conflicts.
-  */
-class PostExecutionConflictDetection {
-
-  /**
-    * @param preExecutionOutput    The output from the pre-execution stage.
-    * @param ledgerStateOperations The operations that can access actual ledger storage as part of a transaction.
-    * @param executionContext      The execution context for ledger state operations.
-    * @return The submission result (asynchronous).
-    */
-  def detectConflicts(
+object FingerprintAwarePostExecutionConflictDetector
+    extends PostExecutionConflictDetector[
+      Key,
+      (Option[Value], Fingerprint),
+      ReadSet,
+      RawKeyValuePairsWithLogEntry,
+    ] {
+  override def detectConflicts(
       preExecutionOutput: PreExecutionOutput[ReadSet, RawKeyValuePairsWithLogEntry],
       ledgerStateOperations: StateReader[Key, (Option[Value], Fingerprint)],
   )(implicit executionContext: ExecutionContext): Future[Unit] = {
@@ -38,12 +31,4 @@ class PostExecutionConflictDetection {
       }
     }
   }
-}
-
-object PostExecutionConflictDetection {
-
-  final class ConflictDetectedException
-      extends RuntimeException(
-        "A conflict has been detected with other submissions during post-execution.")
-
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/KeyNotPresentInInputException.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/KeyNotPresentInInputException.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.preexecution
+
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+
+final class KeyNotPresentInInputException(key: DamlStateKey)
+    extends IllegalStateException(
+      s"The committer accessed a key that was not present in the input.\nKey: $key")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
@@ -6,13 +6,14 @@ package com.daml.ledger.validator.preexecution
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlLogEntry,
   DamlLogEntryId,
-  DamlStateKey
+  DamlStateKey,
+  DamlStateValue
 }
 import com.daml.ledger.participant.state.kvutils.{
   Bytes,
-  DamlKvutils,
   DamlStateMapWithFingerprints,
   Envelope,
+  Fingerprint,
   KeyValueCommitting
 }
 import com.daml.ledger.participant.state.v1.ParticipantId
@@ -29,7 +30,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 final class LogAppenderPreExecutingCommitStrategy(
     keySerializationStrategy: StateKeySerializationStrategy,
-) extends PreExecutingCommitStrategy[ReadSet, RawKeyValuePairsWithLogEntry] {
+) extends PreExecutingCommitStrategy[
+      DamlStateKey,
+      (Option[DamlStateValue], Fingerprint),
+      ReadSet,
+      RawKeyValuePairsWithLogEntry,
+    ] {
   private val stateSerializationStrategy = new StateSerializationStrategy(keySerializationStrategy)
 
   override def generateReadSet(
@@ -52,7 +58,7 @@ final class LogAppenderPreExecutingCommitStrategy(
   override def generateWriteSets(
       participantId: ParticipantId,
       logEntryId: DamlLogEntryId,
-      inputState: Map[DamlKvutils.DamlStateKey, Option[DamlKvutils.DamlStateValue]],
+      inputState: Map[DamlStateKey, (Option[DamlStateValue], Fingerprint)],
       preExecutionResult: KeyValueCommitting.PreExecutionResult,
   )(implicit executionContext: ExecutionContext)
     : Future[PreExecutionCommitResult[RawKeyValuePairsWithLogEntry]] = {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
@@ -9,15 +9,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.{
-  Bytes,
-  DamlStateMapWithFingerprints,
-  Envelope,
-  Fingerprint,
-  KeyValueCommitting
-}
+import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, Fingerprint, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidator.KeyNotPresentInInputException
 import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 import com.daml.ledger.validator.{
   StateKeySerializationStrategy,
@@ -39,7 +32,7 @@ final class LogAppenderPreExecutingCommitStrategy(
   private val stateSerializationStrategy = new StateSerializationStrategy(keySerializationStrategy)
 
   override def generateReadSet(
-      fetchedInputs: DamlStateMapWithFingerprints,
+      fetchedInputs: Map[DamlStateKey, (Option[DamlStateValue], Fingerprint)],
       accessedKeys: Set[DamlStateKey],
   ): ReadSet =
     accessedKeys

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
@@ -13,12 +13,11 @@ import com.daml.ledger.participant.state.kvutils.{
   DamlKvutils,
   DamlStateMapWithFingerprints,
   Envelope,
-  Fingerprint,
   KeyValueCommitting
 }
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.LedgerStateOperations.Key
 import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidator.KeyNotPresentInInputException
+import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 import com.daml.ledger.validator.{
   StateKeySerializationStrategy,
   StateSerializationStrategy,
@@ -30,13 +29,13 @@ import scala.concurrent.{ExecutionContext, Future}
 
 final class LogAppenderPreExecutingCommitStrategy(
     keySerializationStrategy: StateKeySerializationStrategy,
-) extends PreExecutingCommitStrategy[Seq[(Key, Fingerprint)], RawKeyValuePairsWithLogEntry] {
+) extends PreExecutingCommitStrategy[ReadSet, RawKeyValuePairsWithLogEntry] {
   private val stateSerializationStrategy = new StateSerializationStrategy(keySerializationStrategy)
 
   override def generateReadSet(
       fetchedInputs: DamlStateMapWithFingerprints,
       accessedKeys: Set[DamlStateKey],
-  ): Seq[(Key, Fingerprint)] =
+  ): ReadSet =
     accessedKeys
       .map { key =>
         val (_, fingerprint) =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetection.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetection.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.preexecution
+
+import com.daml.ledger.participant.state.kvutils.Fingerprint
+import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.preexecution.PostExecutionConflictDetection._
+import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
+import com.daml.ledger.validator.reading.StateReader
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * An in-transaction post-execution conflict detection to be invoked as the last stage of a
+  * pre-execution pipeline. It performs deferred time bound checks and detects pre-execution
+  * conflicts.
+  */
+class PostExecutionConflictDetection {
+
+  /**
+    * @param preExecutionOutput    The output from the pre-execution stage.
+    * @param ledgerStateOperations The operations that can access actual ledger storage as part of a transaction.
+    * @param executionContext      The execution context for ledger state operations.
+    * @return The submission result (asynchronous).
+    */
+  def detectConflicts(
+      preExecutionOutput: PreExecutionOutput[ReadSet, RawKeyValuePairsWithLogEntry],
+      ledgerStateOperations: StateReader[Key, (Option[Value], Fingerprint)],
+  )(implicit executionContext: ExecutionContext): Future[Unit] = {
+    val keys = preExecutionOutput.readSet.map(_._1)
+    ledgerStateOperations.read(keys).map { values =>
+      val preExecutionFingerprints = preExecutionOutput.readSet.map(_._2)
+      val currentFingerprints = values.map(_._2)
+      val hasConflict = preExecutionFingerprints != currentFingerprints
+      if (hasConflict) {
+        throw new ConflictDetectedException
+      }
+    }
+  }
+}
+
+object PostExecutionConflictDetection {
+
+  final class ConflictDetectedException
+      extends RuntimeException(
+        "A conflict has been detected with other submissions during post-execution.")
+
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.preexecution
+
+import com.daml.ledger.validator.reading.StateReader
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * An in-transaction post-execution conflict detection to be invoked as the last stage of a
+  * pre-execution pipeline. It performs bound checks and detects pre-execution conflicts.
+  */
+trait PostExecutionConflictDetector[StateKey, StateValue, ReadSet, WriteSet] {
+
+  /**
+    * @param preExecutionOutput    The output from the pre-execution stage.
+    * @param ledgerStateOperations The operations that can access actual ledger storage as part of a transaction.
+    * @param executionContext      The execution context for ledger state operations.
+    * @return The submission result (asynchronous).
+    */
+  def detectConflicts(
+      preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet],
+      ledgerStateOperations: StateReader[StateKey, StateValue],
+  )(implicit executionContext: ExecutionContext): Future[Unit]
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
@@ -9,7 +9,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * An in-transaction post-execution conflict detection to be invoked as the last stage of a
-  * pre-execution pipeline. It performs bound checks and detects pre-execution conflicts.
+  * pre-execution pipeline.
   */
 trait PostExecutionConflictDetector[StateKey, StateValue, ReadSet, WriteSet] {
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionFinalizer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionFinalizer.scala
@@ -5,61 +5,19 @@ package com.daml.ledger.validator.preexecution
 
 import java.time.Instant
 
-import com.daml.ledger.participant.state.kvutils.{Bytes, Fingerprint}
+import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.SubmissionResult
 import com.daml.ledger.validator.LedgerStateOperations
-import com.daml.ledger.validator.LedgerStateOperations.Value
 import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * An in-transaction post-execution finalizer to be invoked as the last stage of a pre-execution pipeline that
-  * performs deferred time bound checks, detects pre-execution conflicts and persists both state changes and
-  * a suitable log entry.
-  *
-  * It access the ledger state through [[LedgerStateOperations]] that doesn't provide fingerprints along values
-  * and so it is parametric in the logic that produces a fingerprint given a value.
-  *
-  * @param valueToFingerprint The logic producing a [[Fingerprint]] given a value.
-  * @tparam LogResult Type of the offset used for a log entry.
+  * An in-transasaction finalizer that persists both the ledger state and the log entry after all
+  * checks have been performed.
   */
-class PostExecutionFinalizer[LogResult](valueToFingerprint: Option[Value] => Fingerprint) {
-
-  import PostExecutionFinalizer._
-
-  /**
-    * @param now The logic that produces the current instant for record time bounds check and record time finality.
-    * @param preExecutionOutput The output from the pre-execution stage.
-    * @param ledgerStateOperations The operations that can access actual ledger storage as part of a transaction.
-    * @param executionContext The execution context for ledger state operations.
-    * @return The submission result (asynchronous).
-    */
-  def conflictDetectAndFinalize(
-      now: () => Instant,
-      preExecutionOutput: PreExecutionOutput[ReadSet, RawKeyValuePairsWithLogEntry],
-      ledgerStateOperations: LedgerStateOperations[LogResult],
-  )(implicit executionContext: ExecutionContext): Future[SubmissionResult] = {
-    val keys = preExecutionOutput.readSet.map(_._1)
-    val preExecutionFingerprints = preExecutionOutput.readSet.map(_._2)
-
-    for {
-      values <- ledgerStateOperations.readState(keys)
-      currentFingerprints = values.map(valueToFingerprint)
-      hasConflict = preExecutionFingerprints != currentFingerprints
-      result <- if (hasConflict)
-        throw ConflictDetectedException
-      else
-        finalizeSubmission(now, preExecutionOutput, ledgerStateOperations)
-    } yield result
-  }
-}
-
 object PostExecutionFinalizer {
-  val ConflictDetectedException = new RuntimeException(
-    "A conflict has been detected with other submissions during post-execution")
-
-  private def finalizeSubmission[LogResult](
+  def finalizeSubmission[LogResult](
       now: () => Instant,
       preExecutionOutput: PreExecutionOutput[ReadSet, RawKeyValuePairsWithLogEntry],
       ledgerStateOperations: LedgerStateOperations[LogResult],

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionFinalizer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionFinalizer.scala
@@ -8,6 +8,12 @@ import com.daml.ledger.validator.LedgerStateOperations
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/**
+  * An in-transasaction finalizer that persists both the ledger state and the log entry.
+  *
+  * The implementation may optionally perform checks before writing, and return a failure if the
+  * checks failed.
+  */
 trait PostExecutionFinalizer[ReadSet, WriteSet] {
   def finalizeSubmission[LogResult](
       preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet],

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionFinalizer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionFinalizer.scala
@@ -3,60 +3,14 @@
 
 package com.daml.ledger.validator.preexecution
 
-import java.time.Instant
-
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.SubmissionResult
 import com.daml.ledger.validator.LedgerStateOperations
 
 import scala.concurrent.{ExecutionContext, Future}
 
-/**
-  * An in-transasaction finalizer that persists both the ledger state and the log entry after all
-  * checks have been performed.
-  */
-object PostExecutionFinalizer {
+trait PostExecutionFinalizer[ReadSet, WriteSet] {
   def finalizeSubmission[LogResult](
-      now: () => Instant,
-      preExecutionOutput: PreExecutionOutput[Any, RawKeyValuePairsWithLogEntry],
+      preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet],
       ledgerStateOperations: LedgerStateOperations[LogResult],
-  )(implicit executionContext: ExecutionContext): Future[SubmissionResult] = {
-    val recordTime = now()
-    val withinTimeBounds = respectsTimeBounds(preExecutionOutput, recordTime)
-    val writeSet = createWriteSet(preExecutionOutput, withinTimeBounds)
-    val logEntry = createLogEntry(preExecutionOutput, withinTimeBounds)
-    for {
-      _ <- ledgerStateOperations.writeState(writeSet)
-      _ <- ledgerStateOperations.appendToLog(logEntry._1, logEntry._2)
-    } yield SubmissionResult.Acknowledged
-  }
-
-  private def respectsTimeBounds(
-      preExecutionOutput: PreExecutionOutput[Any, Any],
-      recordTime: Instant,
-  ): Boolean =
-    !recordTime.isBefore(preExecutionOutput.minRecordTime.getOrElse(Instant.MIN)) &&
-      !recordTime.isAfter(preExecutionOutput.maxRecordTime.getOrElse(Instant.MAX))
-
-  private def createLogEntry(
-      preExecutionOutput: PreExecutionOutput[Any, RawKeyValuePairsWithLogEntry],
-      withinTimeBounds: Boolean,
-  ): (Bytes, Bytes) = {
-    val writeSet = if (withinTimeBounds) {
-      preExecutionOutput.successWriteSet
-    } else {
-      preExecutionOutput.outOfTimeBoundsWriteSet
-    }
-    writeSet.logEntryKey -> writeSet.logEntryValue
-  }
-
-  private def createWriteSet(
-      preExecutionOutput: PreExecutionOutput[Any, RawKeyValuePairsWithLogEntry],
-      withinTimeBounds: Boolean,
-  ): Iterable[(Bytes, Bytes)] =
-    if (withinTimeBounds) {
-      preExecutionOutput.successWriteSet.state
-    } else {
-      Seq.empty
-    }
+  )(implicit executionContext: ExecutionContext): Future[SubmissionResult]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingCommitStrategy.scala
@@ -3,13 +3,9 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
-  DamlLogEntryId,
-  DamlStateKey,
-  DamlStateValue
-}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
+import com.daml.ledger.participant.state.kvutils.Fingerprint
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
-import com.daml.ledger.participant.state.kvutils.{DamlStateMapWithFingerprints, Fingerprint}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.LedgerStateOperations.Key
 
@@ -25,16 +21,16 @@ object PreExecutionCommitResult {
   type ReadSet = Seq[(Key, Fingerprint)]
 }
 
-trait PreExecutingCommitStrategy[ReadSet, WriteSet] {
+trait PreExecutingCommitStrategy[StateKey, StateValue, ReadSet, WriteSet] {
   def generateReadSet(
-      fetchedInputs: DamlStateMapWithFingerprints,
-      accessedKeys: Set[DamlStateKey],
+      fetchedInputs: Map[StateKey, StateValue],
+      accessedKeys: Set[StateKey],
   ): ReadSet
 
   def generateWriteSets(
       participantId: ParticipantId,
       logEntryId: DamlLogEntryId,
-      inputState: Map[DamlStateKey, Option[DamlStateValue]],
+      inputState: Map[StateKey, StateValue],
       preExecutionResult: PreExecutionResult,
   )(implicit executionContext: ExecutionContext): Future[PreExecutionCommitResult[WriteSet]]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingCommitStrategy.scala
@@ -8,8 +8,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.Fingerprint
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
+import com.daml.ledger.participant.state.kvutils.{DamlStateMapWithFingerprints, Fingerprint}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.LedgerStateOperations.Key
 
@@ -25,7 +25,12 @@ object PreExecutionCommitResult {
   type ReadSet = Seq[(Key, Fingerprint)]
 }
 
-trait PreExecutingCommitStrategy[WriteSet] {
+trait PreExecutingCommitStrategy[ReadSet, WriteSet] {
+  def generateReadSet(
+      fetchedInputs: DamlStateMapWithFingerprints,
+      accessedKeys: Set[DamlStateKey],
+  ): ReadSet
+
   def generateWriteSets(
       participantId: ParticipantId,
       logEntryId: DamlLogEntryId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -139,11 +139,3 @@ class PreExecutingSubmissionValidator[ReadSet, WriteSet](
     )
   }
 }
-
-object PreExecutingSubmissionValidator {
-
-  final class KeyNotPresentInInputException(key: DamlStateKey)
-      extends IllegalStateException(
-        s"The committer accessed a key that was not present in the input.\nKey: $key")
-
-}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -19,6 +19,8 @@ import com.daml.ledger.participant.state.kvutils.{
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.ValidationFailed
 import com.daml.ledger.validator.batch.BatchedSubmissionValidator
+import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidator._
+import com.daml.ledger.validator.reading.StateReader
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
 
@@ -138,4 +140,9 @@ class PreExecutingSubmissionValidator[ReadSet, WriteSet](
       }
     )
   }
+}
+
+object PreExecutingSubmissionValidator {
+  type DamlLedgerStateReaderWithFingerprints =
+    StateReader[DamlStateKey, (Option[DamlStateValue], Fingerprint)]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutionOutput.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutionOutput.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import com.daml.ledger.participant.state.v1.ParticipantId
 
-sealed case class PreExecutionOutput[ReadSet, WriteSet](
+sealed case class PreExecutionOutput[+ReadSet, +WriteSet](
     minRecordTime: Option[Instant],
     maxRecordTime: Option[Instant],
     successWriteSet: WriteSet,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutionOutput.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutionOutput.scala
@@ -6,9 +6,8 @@ package com.daml.ledger.validator.preexecution
 import java.time.Instant
 
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 
-sealed case class PreExecutionOutput[WriteSet](
+sealed case class PreExecutionOutput[ReadSet, WriteSet](
     minRecordTime: Option[Instant],
     maxRecordTime: Option[Instant],
     successWriteSet: WriteSet,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPostExecutionFinalizer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPostExecutionFinalizer.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator.preexecution
+
+import java.time.Instant
+
+import com.daml.ledger.participant.state.kvutils.Bytes
+import com.daml.ledger.participant.state.v1.SubmissionResult
+import com.daml.ledger.validator.LedgerStateOperations
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * An in-transasaction finalizer that persists both the ledger state and the log entry after all
+  * checks have been performed.
+  */
+final class RawPostExecutionFinalizer[ReadSet](now: () => Instant)
+    extends PostExecutionFinalizer[ReadSet, RawKeyValuePairsWithLogEntry] {
+  override def finalizeSubmission[LogResult](
+      preExecutionOutput: PreExecutionOutput[ReadSet, RawKeyValuePairsWithLogEntry],
+      ledgerStateOperations: LedgerStateOperations[LogResult],
+  )(implicit executionContext: ExecutionContext): Future[SubmissionResult] = {
+    val recordTime = now()
+    val withinTimeBounds = respectsTimeBounds(preExecutionOutput, recordTime)
+    val writeSet = createWriteSet(preExecutionOutput, withinTimeBounds)
+    val logEntry = createLogEntry(preExecutionOutput, withinTimeBounds)
+    for {
+      _ <- ledgerStateOperations.writeState(writeSet)
+      _ <- ledgerStateOperations.appendToLog(logEntry._1, logEntry._2)
+    } yield SubmissionResult.Acknowledged
+  }
+
+  private def respectsTimeBounds(
+      preExecutionOutput: PreExecutionOutput[Any, Any],
+      recordTime: Instant,
+  ): Boolean =
+    !recordTime.isBefore(preExecutionOutput.minRecordTime.getOrElse(Instant.MIN)) &&
+      !recordTime.isAfter(preExecutionOutput.maxRecordTime.getOrElse(Instant.MAX))
+
+  private def createLogEntry(
+      preExecutionOutput: PreExecutionOutput[Any, RawKeyValuePairsWithLogEntry],
+      withinTimeBounds: Boolean,
+  ): (Bytes, Bytes) = {
+    val writeSet = if (withinTimeBounds) {
+      preExecutionOutput.successWriteSet
+    } else {
+      preExecutionOutput.outOfTimeBoundsWriteSet
+    }
+    writeSet.logEntryKey -> writeSet.logEntryValue
+  }
+
+  private def createWriteSet(
+      preExecutionOutput: PreExecutionOutput[Any, RawKeyValuePairsWithLogEntry],
+      withinTimeBounds: Boolean,
+  ): Iterable[(Bytes, Bytes)] =
+    if (withinTimeBounds) {
+      preExecutionOutput.successWriteSet.state
+    } else {
+      Seq.empty
+    }
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/package.scala
@@ -3,10 +3,6 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
-import com.daml.ledger.participant.state.kvutils.Fingerprint
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
-import com.daml.ledger.validator.reading.StateReader
 import com.daml.lf.data.Time.Timestamp
 
 package object preexecution {
@@ -16,10 +12,4 @@ package object preexecution {
     */
   type TimeUpdatesProvider =
     () => Option[Timestamp]
-
-  type LedgerStateReaderWithFingerprints =
-    StateReader[Key, (Option[Value], Fingerprint)]
-
-  type DamlLedgerStateReaderWithFingerprints =
-    StateReader[DamlStateKey, (Option[DamlStateValue], Fingerprint)]
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -219,7 +219,12 @@ object PreExecutingSubmissionValidatorSpec {
       ))
       .thenReturn(result)
 
-    val mockCommitStrategy = mock[PreExecutingCommitStrategy[ReadSet, Bytes]]
+    val mockCommitStrategy = mock[PreExecutingCommitStrategy[
+      DamlStateKey,
+      (Option[DamlStateValue], Fingerprint),
+      ReadSet,
+      Bytes,
+    ]]
     when(
       mockCommitStrategy.generateReadSet(any[DamlStateMapWithFingerprints], any[Set[DamlStateKey]]))
       .thenAnswer[DamlStateMapWithFingerprints, Set[DamlStateKey]] {
@@ -233,7 +238,7 @@ object PreExecutingSubmissionValidatorSpec {
       mockCommitStrategy.generateWriteSets(
         eqTo(aParticipantId),
         any[DamlLogEntryId],
-        any[DamlStateMap],
+        any[Map[DamlStateKey, (Option[DamlStateValue], Fingerprint)]],
         same(result),
       )(any[ExecutionContext]))
       .thenReturn(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -200,7 +200,7 @@ object PreExecutingSubmissionValidatorSpec {
       expectedSuccessWriteSet: Bytes = ByteString.EMPTY,
       expectedOutOfTimeBoundsWriteSet: Bytes = ByteString.EMPTY,
       expectedInvolvedParticipants: Set[ParticipantId] = Set.empty,
-  ): PreExecutingSubmissionValidator[Bytes] = {
+  ): PreExecutingSubmissionValidator[ReadSet, Bytes] = {
     val mockCommitter = mock[KeyValueCommitting]
     val result = PreExecutionResult(
       expectedReadSet.keySet,
@@ -243,7 +243,7 @@ object PreExecutingSubmissionValidatorSpec {
             expectedOutOfTimeBoundsWriteSet,
             expectedInvolvedParticipants)))
 
-    new PreExecutingSubmissionValidator[Bytes](mockCommitter, metrics, mockCommitStrategy)
+    new PreExecutingSubmissionValidator[ReadSet, Bytes](mockCommitter, metrics, mockCommitStrategy)
   }
 
   private def createLedgerStateReader(
@@ -256,7 +256,7 @@ object PreExecutingSubmissionValidatorSpec {
     }
 
   private def verifyReadSet(
-      output: PreExecutionOutput[Bytes],
+      output: PreExecutionOutput[ReadSet, Bytes],
       expectedReadSet: Map[DamlStateKey, Fingerprint],
   ): Assertion = {
     import org.scalatest.matchers.should.Matchers._

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -22,6 +22,7 @@ import com.daml.ledger.participant.state.kvutils.{
 import com.daml.ledger.participant.state.v1.Configuration
 import com.daml.ledger.validator.TestHelper._
 import com.daml.ledger.validator.ValidationFailed.ValidationError
+import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidator.DamlLedgerStateReaderWithFingerprints
 import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidatorSpec._
 import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 import com.daml.lf.data.Ref.ParticipantId

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -12,6 +12,7 @@ import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecution
 import com.daml.ledger.participant.state.kvutils.{
   Bytes,
   DamlStateMap,
+  DamlStateMapWithFingerprints,
   Envelope,
   Fingerprint,
   FingerprintPlaceholder,
@@ -19,10 +20,10 @@ import com.daml.ledger.participant.state.kvutils.{
   TestHelpers
 }
 import com.daml.ledger.participant.state.v1.Configuration
-import com.daml.ledger.validator.StateKeySerializationStrategy
 import com.daml.ledger.validator.TestHelper._
 import com.daml.ledger.validator.ValidationFailed.ValidationError
 import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidatorSpec._
+import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
 import com.daml.lf.data.Ref.ParticipantId
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
@@ -45,10 +46,8 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
         allDamlStateKeyTypes.head -> FingerprintPlaceholder
       )
       val actualInputState = Map(
-        allDamlStateKeyTypes.head -> (
-          (
-            Some(DamlStateValue.getDefaultInstance),
-            FingerprintPlaceholder))
+        allDamlStateKeyTypes.head ->
+          (Some(DamlStateValue.getDefaultInstance) -> FingerprintPlaceholder)
       )
       val expectedMinRecordTime = Some(recordTime.toInstant.minusSeconds(123))
       val expectedMaxRecordTime = Some(recordTime.toInstant)
@@ -61,7 +60,7 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
         expectedMaxRecordTime = expectedMaxRecordTime,
         expectedSuccessWriteSet = expectedSuccessWriteSet,
         expectedOutOfTimeBoundsWriteSet = expectedOutOfTimeBoundsWriteSet,
-        expectedInvolvedParticipants = expectedInvolvedParticipants
+        expectedInvolvedParticipants = expectedInvolvedParticipants,
       )
       val ledgerStateReader = createLedgerStateReader(actualInputState)
 
@@ -174,33 +173,6 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
         }
     }
   }
-
-  "generateReadSet" should {
-    "generate a read set" in {
-      val contractIdStateKey = DamlStateKey.newBuilder.setContractId("a contract ID").build
-      val contractIdStateValue =
-        DamlStateValue.newBuilder.setContractState(DamlContractState.newBuilder).build
-      val fingerprint = ByteString.copyFromUtf8("fingerprint")
-      val instance = createInstance()
-
-      instance.generateReadSet(
-        fetchedInputs = Map(contractIdStateKey -> ((Some(contractIdStateValue), fingerprint))),
-        accessedKeys = Set(contractIdStateKey),
-      ) should be(Seq(contractIdStateKey.toByteString -> fingerprint))
-    }
-
-    "throw in case an input key is declared in the read set but not fetched as input" in {
-      val instance = createInstance()
-
-      assertThrows[IllegalStateException](
-        instance
-          .generateReadSet(
-            fetchedInputs = Map.empty,
-            accessedKeys = allDamlStateKeyTypes.toSet
-          )
-      )
-    }
-  }
 }
 
 object PreExecutingSubmissionValidatorSpec {
@@ -211,8 +183,6 @@ object PreExecutingSubmissionValidatorSpec {
   private val recordTime = Timestamp.now()
 
   private val metrics = new Metrics(new MetricRegistry)
-
-  private val keySerializationStrategy = StateKeySerializationStrategy.createDefault()
 
   private def anEnvelope(expectedReadSet: Set[DamlStateKey] = Set.empty): Bytes = {
     val submission = DamlSubmission
@@ -232,6 +202,14 @@ object PreExecutingSubmissionValidatorSpec {
       expectedInvolvedParticipants: Set[ParticipantId] = Set.empty,
   ): PreExecutingSubmissionValidator[Bytes] = {
     val mockCommitter = mock[KeyValueCommitting]
+    val result = PreExecutionResult(
+      expectedReadSet.keySet,
+      aLogEntry,
+      Map.empty,
+      aLogEntry,
+      expectedMinRecordTime.map(Timestamp.assertFromInstant),
+      expectedMaxRecordTime.map(Timestamp.assertFromInstant)
+    )
     when(
       mockCommitter.preExecuteSubmission(
         any[Configuration],
@@ -239,22 +217,24 @@ object PreExecutingSubmissionValidatorSpec {
         any[ParticipantId],
         any[DamlStateMap],
       ))
-      .thenReturn(
-        PreExecutionResult(
-          expectedReadSet.keySet,
-          aLogEntry,
-          Map.empty,
-          aLogEntry,
-          expectedMinRecordTime.map(Timestamp.assertFromInstant),
-          expectedMaxRecordTime.map(Timestamp.assertFromInstant)
-        ))
-    val mockCommitStrategy = mock[PreExecutingCommitStrategy[Bytes]]
+      .thenReturn(result)
+
+    val mockCommitStrategy = mock[PreExecutingCommitStrategy[ReadSet, Bytes]]
+    when(
+      mockCommitStrategy.generateReadSet(any[DamlStateMapWithFingerprints], any[Set[DamlStateKey]]))
+      .thenAnswer[DamlStateMapWithFingerprints, Set[DamlStateKey]] {
+        (fetchedInputs, accessedKeys) =>
+          accessedKeys.map { key =>
+            val (_, fingerprint) = fetchedInputs(key)
+            key.toByteString -> fingerprint
+          }.toSeq
+      }
     when(
       mockCommitStrategy.generateWriteSets(
-        any[ParticipantId],
+        eqTo(aParticipantId),
         any[DamlLogEntryId],
         any[DamlStateMap],
-        any[PreExecutionResult],
+        same(result),
       )(any[ExecutionContext]))
       .thenReturn(
         Future.successful(
@@ -262,11 +242,8 @@ object PreExecutingSubmissionValidatorSpec {
             expectedSuccessWriteSet,
             expectedOutOfTimeBoundsWriteSet,
             expectedInvolvedParticipants)))
-    new PreExecutingSubmissionValidator[Bytes](
-      mockCommitter,
-      metrics,
-      keySerializationStrategy,
-      mockCommitStrategy)
+
+    new PreExecutingSubmissionValidator[Bytes](mockCommitter, metrics, mockCommitStrategy)
   }
 
   private def createLedgerStateReader(
@@ -283,13 +260,10 @@ object PreExecutingSubmissionValidatorSpec {
       expectedReadSet: Map[DamlStateKey, Fingerprint],
   ): Assertion = {
     import org.scalatest.matchers.should.Matchers._
-    val expectedSortedReadSet = expectedReadSet
-      .map {
-        case (key, fingerprint) =>
-          keySerializationStrategy.serializeStateKey(key) -> fingerprint
-      }
-      .toSeq
-      .sortBy(_._1.asReadOnlyByteBuffer())
-    output.readSet shouldBe expectedSortedReadSet
+    val actualReadSet = output.readSet.map {
+      case (key, value) =>
+        DamlStateKey.parseFrom(key) -> value
+    }.toMap
+    actualReadSet should be(expectedReadSet)
   }
 }


### PR DESCRIPTION
This changeset reduces the surface area of fingerprints from the kvutils pre-execution code.

It introduces two new traits, `PostExecutionConflictDetector` and `PostExecutionFinalizer`, which are generic over the state types, pushing the state value type of `(Option[DamlStateValue], Fingerprint)` up to the specific ledger implementation.

`generateReadSets` has been made part of the `PreExecutingCommitStrategy` trait, to allow for different read set types that do not contain a fingerprint, or that contain more information.

The classes that are still aware of fingerprints are the implementations of the above traits, `PreExecutingSubmissionValidator`, `PreExecutingValidatingCommitter`, and the ledger implementation itself. The next step will be pushing it further outwards until only the ledger is aware of extra information provided alongside the value.

This is part 3 of removing fingerprints from this code, while still maintaining the ability to pass extra ledger-specific information through.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
