### PR TITLE
Do not checkout release commit in scala 2.13

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,7 +216,6 @@ jobs:
   - job: Linux_scala_2_13
     dependsOn:
       - da_ghc_lib
-      - check_for_release
     timeoutInMinutes: 360
     pool:
       name: 'linux-pool'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,11 +217,6 @@ jobs:
     dependsOn:
       - da_ghc_lib
       - check_for_release
-    variables:
-      release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
-      release_tag: $[ coalesce(dependencies.check_for_release.outputs['out.release_tag'], '0.0.0') ]
-      trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
-      is_release: $[ dependencies.check_for_release.outputs['out.is_release'] ]
     timeoutInMinutes: 360
     pool:
       name: 'linux-pool'
@@ -229,11 +224,6 @@ jobs:
     steps:
       - template: ci/report-start.yml
       - checkout: self
-      - bash: |
-          set -euo pipefail
-          git checkout $(release_sha)
-        name: checkout_release
-        condition: eq(variables.is_release, 'true')
       - bash: ci/dev-env-install.sh
         displayName: 'Build/Install the Developer Environment'
       - bash: |
@@ -259,8 +249,6 @@ jobs:
           # gatling-utils tests fail with a ClassNotFoundException for scala.collection.SeqLike
           bazel test --config scala_2_13 -- //libs-scala/... -//libs-scala/gatling-utils/...
         displayName: 'Build'
-        env:
-          DAML_SDK_RELEASE_VERSION: $(release_tag)
       - template: ci/tell-slack-failed.yml
         parameters:
           trigger_sha: '$(trigger_sha)'


### PR DESCRIPTION
At least for now, this fails because older commits don’t have the
necessary infrastructure so far. At some point we probably do want to
run this on release commits but that can wait a bit and this unblocks
release PRs for bugfix releases.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
