### PR TITLE
fix Slack messages

### DIFF
--- a/ci/daily_tell_slack.yml
+++ b/ci/daily_tell_slack.yml
@@ -9,7 +9,7 @@ steps:
     set -euo pipefail
     eval "$(dev-env/bin/dade assist)"
     COMMIT_TITLE=$(git log --pretty=format:%s -n1)
-    COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$COMMIT_TITLE>"
+    COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|${${${COMMIT_TITLE//&/&amp;}//>/&gt;}//</&lt;}>"
     if [ "$(Agent.JobStatus)" != "Succeeded" ]; then
         MESSAGE="\":fire: :fire: <!here> :fire: :fire:\n$(Agent.JobName) *FAILED*: $COMMIT_LINK\n:fire: :fire:\""
     else

--- a/ci/tell-slack-failed.yml
+++ b/ci/tell-slack-failed.yml
@@ -8,7 +8,7 @@ steps:
   - bash: |
       set -euo pipefail
       COMMIT_TITLE=$(git log --pretty=format:%s -n1 ${{ parameters.trigger_sha }})
-      COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|$COMMIT_TITLE>"
+      COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|${${${COMMIT_TITLE//&/&amp;}//>/&gt;}//</&lt;}>"
       if [ -z "${{ parameters.trigger_sha }}" ]; then
           WARNING="<!here> *FAILED* $(Build.SourceBranchName)/$(Agent.JobName): $COMMIT_LINK"
       else


### PR DESCRIPTION
When including commit titles in Slack messages, care has to be taken to
escape what Slack considers [control characters], namely `&`, `>` & `<`.

[control characters]: https://api.slack.com/reference/surfaces/formatting#escaping

CHANGELOG_BEGIN
CHANGELOG_END