### PR TITLE
accept new nix key

### DIFF
--- a/dev-env/etc/nix.conf
+++ b/dev-env/etc/nix.conf
@@ -3,7 +3,7 @@ binary-caches = https://nix-cache.da-ext.net https://cache.nixos.org
 # Note: the "hydra.da-int.net" string is now part of the name of the key for
 # legacy reasons; it bears no relation to the DNS hostname of the current
 # cache.
-binary-cache-public-keys = hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
+binary-cache-public-keys = hydra.da-int.net-2:91tXuJGf/ExbAz7IWsMsxQ5FsO6lG/EGM5QVt+xhZu0= hydra.da-int.net-1:6Oy2+KYvI7xkAOg0gJisD7Nz/6m8CmyKMbWfSKUe03g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=
 
 # Keep build-time dependencies of non-garbage outputs around
 gc-keep-outputs = true


### PR DESCRIPTION
We're rotating the nix key used by CI to sign our artifacts. This is step 1: add the new public key.

Step 2 will be to update the CI configuration to use the new (private) key, and step 3 will be the removal of the old public key from this conf file.

CHANGELOG_BEGIN
CHANGELOG_END