### PR TITLE
Fix slack escaping

### DIFF
--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -9,6 +9,14 @@ steps:
     set -euo pipefail
     TMP=$(mktemp)
     cat > $TMP <<'END'
+    escape_slack() {
+      local r
+      r="$1"
+      r="${r//&/&amp;}"
+      r="${r//>/&gt;}"
+      r="${r//</&lt;}"
+      echo "$r"
+    }
     get_gh_auth_header() {
         # Credentials are persisted in a different way on GCP and Azure nodes.
         if header=$(git config 'http.https://github.com/digital-asset/daml.extraheader'); then

--- a/ci/daily_tell_slack.yml
+++ b/ci/daily_tell_slack.yml
@@ -5,11 +5,15 @@ parameters:
   success-message: '\"$(Agent.JobName) passed: $COMMIT_LINK\"'
 
 steps:
+- template: bash-lib.yml
+  parameters:
+    var_name: bash_lib
 - bash: |
     set -euo pipefail
     eval "$(dev-env/bin/dade assist)"
-    COMMIT_TITLE=$(git log --pretty=format:%s -n1)
-    COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|${${${COMMIT_TITLE//&/&amp;}//>/&gt;}//</&lt;}>"
+    source $(bash_lib)
+    COMMIT_TITLE="$(escape_slack $(git log --pretty=format:%s -n1 ${{ parameters.trigger_sha }}))"
+    COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|${COMMIT_TITLE}>"
     if [ "$(Agent.JobStatus)" != "Succeeded" ]; then
         MESSAGE="\":fire: :fire: <!here> :fire: :fire:\n$(Agent.JobName) *FAILED*: $COMMIT_LINK\n:fire: :fire:\""
     else

--- a/ci/tell-slack-failed.yml
+++ b/ci/tell-slack-failed.yml
@@ -5,10 +5,14 @@ parameters:
   trigger_sha: ''
 
 steps:
+  - template: bash-lib.yml
+    parameters:
+      var_name: bash_lib
   - bash: |
       set -euo pipefail
-      COMMIT_TITLE=$(git log --pretty=format:%s -n1 ${{ parameters.trigger_sha }})
-      COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|${${${COMMIT_TITLE//&/&amp;}//>/&gt;}//</&lt;}>"
+      source $(bash_lib)
+      COMMIT_TITLE="$(escape_slack $(git log --pretty=format:%s -n1 ${{ parameters.trigger_sha }}))"
+      COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|${COMMIT_TITLE}>"
       if [ -z "${{ parameters.trigger_sha }}" ]; then
           WARNING="<!here> *FAILED* $(Build.SourceBranchName)/$(Agent.JobName): $COMMIT_LINK"
       else


### PR DESCRIPTION
The previous escaping syntax doesn’t seem to work (after the first
layer you no longer have a variable) and has broken our build
reporting completely.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
