### PR TITLE
ts: generated code includes Template.QueryResult

### DIFF
--- a/language-support/ts/codegen/src/TsCodeGenMain.hs
+++ b/language-support/ts/codegen/src/TsCodeGenMain.hs
@@ -325,6 +325,7 @@ renderTemplateNamespace TemplateNamespace{..} = T.unlines $ concat
     , [ "  export type CreateEvent = damlLedger.CreateEvent" <> tParams [tnsName, tK, tI]
       , "  export type ArchiveEvent = damlLedger.ArchiveEvent" <> tParams [tnsName, tI]
       , "  export type Event = damlLedger.Event" <> tParams [tnsName, tK, tI]
+      , "  export type QueryResult = damlLedger.QueryResult" <> tParams [tnsName, tK, tI]
       , "}"
       ]
     ]

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -8,6 +8,22 @@ import WebSocket from 'isomorphic-ws';
 import _ from 'lodash';
 
 /**
+ * The result of a ``query`` against the ledger.
+ *
+ * Note: this is meant to be used by @daml/react.
+ *
+ * @typeparam T The contract template type of the query.
+ * @typeparam K The contract key type of the query.
+ * @typeparam I The template id type.
+ */
+export type QueryResult<T extends object, K, I extends string> = {
+  /** Contracts matching the query. */
+  contracts: readonly CreateEvent<T, K, I>[];
+  /** Indicator for whether the query is executing. */
+  loading: boolean;
+}
+
+/**
  * Full information about a Party.
  *
  */

--- a/language-support/ts/daml-react/createLedgerContext.ts
+++ b/language-support/ts/daml-react/createLedgerContext.ts
@@ -3,7 +3,9 @@
 
 import React, {useContext, useEffect, useMemo, useState } from 'react';
 import { ContractId,Party, Template } from '@daml/types';
-import Ledger, { CreateEvent, Query, Stream, StreamCloseEvent } from '@daml/ledger';
+import Ledger, { CreateEvent, Query, Stream, StreamCloseEvent, QueryResult } from '@daml/ledger';
+
+export { QueryResult } from '@daml/ledger';
 
 /**
  * @internal
@@ -24,20 +26,6 @@ export type LedgerProps = {
   wsBaseUrl?: string;
   party: Party;
   reconnectThreshold?: number;
-}
-
-/**
- * The result of a ``query`` against the ledger.
- *
- * @typeparam T The contract template type of the query.
- * @typeparam K The contract key type of the query.
- * @typeparam I The template id type.
- */
-export type QueryResult<T extends object, K, I extends string> = {
-  /** Contracts matching the query. */
-  contracts: readonly CreateEvent<T, K, I>[];
-  /** Indicator for whether the query is executing. */
-  loading: boolean;
 }
 
 /**


### PR DESCRIPTION
See [discourse].

[discourse]: https://discuss.daml.com/t/best-practice-for-getting-ledger-state-in-multiple-nested-react-components/1814/3

CHANGELOG_BEGIN

* [JavaScript Client Libraries] When using our React wrapper from TypeScript, users could end up having to manually reconstruct a `QueryResult` type for a specific template, leading to code looking like (assuming a `User` template):
  ```
  const allUser: QueryResult<User.User, User.User.Key, typeof User.User.templateId> = useStreamQueries(User.User);
  ```
  Our codegen will now generate an additional type definition per template such that the above can be rewritten as
  ```
  const allUser: User.User.QueryResult = useStreamQueries(User.User);
  ```
  Developers using our JavaScript bindings directly (i.e. without taking advantage of the TS type definitions) are not affected. Existing (long-form) type declaractions will also keep working.

  Note: In order to make this change, we had to move the definition of the `QueryResult` type from the `@daml/react` package to the `@daml/ledger` package. However, the `@daml/react` package is still exporting it as before, so this is a backwards-compatible change.

CHANGELOG_END