### PR TITLE
kvutils: Avoid serializing keys and values except when necessary. [KVL-747]

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -245,7 +245,7 @@ object InMemoryLedgerReaderWriter {
         keySerializationStrategy,
         validator,
         valueToFingerprint,
-        FingerprintAwarePostExecutionConflictDetector,
+        new EqualityBasedPostExecutionConflictDetector,
         new RawPostExecutionFinalizer(now = timeProvider.getCurrentTime _),
         stateValueCache = stateValueCacheForPreExecution,
         ImmutablesOnlyCacheUpdatePolicy,

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -30,7 +30,7 @@ import com.daml.ledger.validator.batch.{
   ConflictDetection
 }
 import com.daml.ledger.validator.caching.ImmutablesOnlyCacheUpdatePolicy
-import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.FingerprintedReadSet
+import com.daml.ledger.validator.preexecution.LogAppenderPreExecutingCommitStrategy.FingerprintedReadSet
 import com.daml.ledger.validator.preexecution._
 import com.daml.ledger.validator.{StateKeySerializationStrategy, ValidateAndCommit}
 import com.daml.lf.engine.Engine

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -36,7 +36,6 @@ package object kvutils {
   type CorrelationId = String
 
   type Fingerprint = Bytes
-  type DamlStateMapWithFingerprints = Map[DamlStateKey, (Option[DamlStateValue], Fingerprint)]
   val FingerprintPlaceholder: Fingerprint = ByteString.EMPTY
 
   val MetricPrefix: MetricName = MetricName.DAML :+ "kvutils"

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
@@ -17,7 +17,7 @@ final class RawToDamlLedgerStateReaderAdapter(
   import RawToDamlLedgerStateReaderAdapter.deserializeDamlStateValue
 
   override def read(
-      keys: Seq[DamlStateKey]
+      keys: Iterable[DamlStateKey]
   )(implicit executionContext: ExecutionContext): Future[Seq[Option[DamlStateValue]]] =
     ledgerStateReader
       .read(keys.map(keySerializationStrategy.serializeStateKey))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -36,9 +36,9 @@ object BatchedSubmissionValidatorFactory {
 
   class LedgerStateReaderAdapter[LogResult](delegate: LedgerStateOperations[LogResult])
       extends LedgerStateReader {
-    override def read(keys: Seq[Key])(
-        implicit executionContext: ExecutionContext
-    ): Future[Seq[Option[Value]]] =
+    override def read(
+        keys: Iterable[Key]
+    )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]] =
       delegate.readState(keys)
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingStateReader.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/caching/CachingStateReader.scala
@@ -19,17 +19,19 @@ final class CachingStateReader[Key, Value](
     delegate: StateReader[Key, Value],
 ) extends StateReader[Key, Value] {
   override def read(
-      keys: Seq[Key]
+      keys: Iterable[Key]
   )(implicit executionContext: ExecutionContext): Future[Seq[Value]] = {
     @SuppressWarnings(Array("org.wartremover.warts.Any")) // Required to make `.view` work.
     val cachedValues = keys.view
       .map(key => key -> cache.getIfPresent(key))
       .collect { case (key, Some(value)) => key -> value }
       .toMap
-    val keysToRead = keys.toSet -- cachedValues.keySet
+    // This needs to be converted to an ordered sequence so that zipping keys with values is
+    // guaranteed to work.
+    val keysToRead = (keys.toSet -- cachedValues.keySet).toVector
     if (keysToRead.nonEmpty) {
       delegate
-        .read(keysToRead.toSeq)
+        .read(keysToRead)
         .map { readStateValues =>
           val readValues = keysToRead.zip(readStateValues).toMap
           readValues.foreach {
@@ -39,11 +41,11 @@ final class CachingStateReader[Key, Value](
               }
           }
           val all = cachedValues ++ readValues
-          keys.map(all(_))
+          keys.view.map(all(_)).toVector
         }
     } else {
       Future {
-        keys.map(cachedValues(_))
+        keys.view.map(cachedValues(_)).toVector
       }
     }
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/EqualityBasedPostExecutionConflictDetector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/EqualityBasedPostExecutionConflictDetector.scala
@@ -3,21 +3,15 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
 import com.daml.ledger.validator.reading.StateReader
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class EqualityBasedPostExecutionConflictDetector[StateValue]
-    extends PostExecutionConflictDetector[
-      DamlStateKey,
-      StateValue,
-      Map[DamlStateKey, StateValue],
-      Any,
-    ] {
+final class EqualityBasedPostExecutionConflictDetector[StateKey, StateValue]
+    extends PostExecutionConflictDetector[StateKey, StateValue, Map[StateKey, StateValue], Any] {
   override def detectConflicts(
-      preExecutionOutput: PreExecutionOutput[Map[DamlStateKey, StateValue], Any],
-      reader: StateReader[DamlStateKey, StateValue],
+      preExecutionOutput: PreExecutionOutput[Map[StateKey, StateValue], Any],
+      reader: StateReader[StateKey, StateValue],
   )(implicit executionContext: ExecutionContext): Future[Unit] = {
     val (keys, preExecutionValues) = preExecutionOutput.readSet.unzip
     reader.read(keys).map { currentValues =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/FingerprintAwarePostExecutionConflictDetector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/FingerprintAwarePostExecutionConflictDetector.scala
@@ -3,30 +3,27 @@
 
 package com.daml.ledger.validator.preexecution
 
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
 import com.daml.ledger.participant.state.kvutils.Fingerprint
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
-import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
+import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.FingerprintedReadSet
 import com.daml.ledger.validator.reading.StateReader
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object FingerprintAwarePostExecutionConflictDetector
     extends PostExecutionConflictDetector[
-      Key,
-      (Option[Value], Fingerprint),
-      ReadSet,
-      RawKeyValuePairsWithLogEntry,
+      DamlStateKey,
+      Fingerprint,
+      FingerprintedReadSet,
+      Any,
     ] {
   override def detectConflicts(
-      preExecutionOutput: PreExecutionOutput[ReadSet, RawKeyValuePairsWithLogEntry],
-      ledgerStateOperations: StateReader[Key, (Option[Value], Fingerprint)],
+      preExecutionOutput: PreExecutionOutput[FingerprintedReadSet, Any],
+      reader: StateReader[DamlStateKey, Fingerprint],
   )(implicit executionContext: ExecutionContext): Future[Unit] = {
-    val keys = preExecutionOutput.readSet.map(_._1)
-    ledgerStateOperations.read(keys).map { values =>
-      val preExecutionFingerprints = preExecutionOutput.readSet.map(_._2)
-      val currentFingerprints = values.map(_._2)
-      val hasConflict = preExecutionFingerprints != currentFingerprints
-      if (hasConflict) {
+    val (keys, preExecutionFingerprints) = preExecutionOutput.readSet.unzip
+    reader.read(keys).map { currentFingerprints =>
+      if (preExecutionFingerprints != currentFingerprints) {
         throw new ConflictDetectedException
       }
     }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
 }
 import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, Fingerprint, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.FingerprintedReadSet
+import com.daml.ledger.validator.preexecution.LogAppenderPreExecutingCommitStrategy.FingerprintedReadSet
 import com.daml.ledger.validator.{
   StateKeySerializationStrategy,
   StateSerializationStrategy,
@@ -84,4 +84,8 @@ final class LogAppenderPreExecutingCommitStrategy(
       logEntry: DamlLogEntry,
   )(implicit executionContext: ExecutionContext): Future[(Bytes, Bytes)] =
     Future(logEntryId -> Envelope.enclose(logEntry))
+}
+
+object LogAppenderPreExecutingCommitStrategy {
+  type FingerprintedReadSet = Map[DamlStateKey, Fingerprint]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategy.scala
@@ -11,7 +11,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
 }
 import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, Fingerprint, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.ReadSet
+import com.daml.ledger.validator.preexecution.PreExecutionCommitResult.FingerprintedReadSet
 import com.daml.ledger.validator.{
   StateKeySerializationStrategy,
   StateSerializationStrategy,
@@ -26,7 +26,7 @@ final class LogAppenderPreExecutingCommitStrategy(
 ) extends PreExecutingCommitStrategy[
       DamlStateKey,
       (Option[DamlStateValue], Fingerprint),
-      ReadSet,
+      FingerprintedReadSet,
       RawKeyValuePairsWithLogEntry,
     ] {
   private val stateSerializationStrategy = new StateSerializationStrategy(keySerializationStrategy)
@@ -34,19 +34,12 @@ final class LogAppenderPreExecutingCommitStrategy(
   override def generateReadSet(
       fetchedInputs: Map[DamlStateKey, (Option[DamlStateValue], Fingerprint)],
       accessedKeys: Set[DamlStateKey],
-  ): ReadSet =
-    accessedKeys
-      .map { key =>
-        val (_, fingerprint) =
-          fetchedInputs.getOrElse(key, throw new KeyNotPresentInInputException(key))
-        key -> fingerprint
-      }
-      .map {
-        case (damlKey, fingerprint) =>
-          keySerializationStrategy.serializeStateKey(damlKey) -> fingerprint
-      }
-      .toVector
-      .sortBy(_._1.asReadOnlyByteBuffer)
+  ): FingerprintedReadSet =
+    accessedKeys.view.map { key =>
+      val (_, fingerprint) =
+        fetchedInputs.getOrElse(key, throw new KeyNotPresentInInputException(key))
+      key -> fingerprint
+    }.toMap
 
   override def generateWriteSets(
       participantId: ParticipantId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
@@ -11,16 +11,16 @@ import scala.concurrent.{ExecutionContext, Future}
   * An in-transaction post-execution conflict detection to be invoked as the last stage of a
   * pre-execution pipeline.
   */
-trait PostExecutionConflictDetector[StateKey, StateValue, ReadSet, WriteSet] {
+trait PostExecutionConflictDetector[+StateKey, -StateValue, -ReadSet, -WriteSet] {
 
   /**
-    * @param preExecutionOutput    The output from the pre-execution stage.
-    * @param ledgerStateOperations The operations that can access actual ledger storage as part of a transaction.
-    * @param executionContext      The execution context for ledger state operations.
+    * @param preExecutionOutput The output from the pre-execution stage.
+    * @param reader             The operations that can access actual ledger storage as part of a transaction.
+    * @param executionContext   The execution context for ledger state operations.
     * @return The submission result (asynchronous).
     */
   def detectConflicts(
       preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet],
-      ledgerStateOperations: StateReader[StateKey, StateValue],
+      reader: StateReader[StateKey, StateValue],
   )(implicit executionContext: ExecutionContext): Future[Unit]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * An in-transaction post-execution conflict detection to be invoked as the last stage of a
   * pre-execution pipeline.
   */
-trait PostExecutionConflictDetector[+StateKey, -StateValue, -ReadSet, -WriteSet] {
+trait PostExecutionConflictDetector[StateKey, StateValue, -ReadSet, -WriteSet] {
 
   /**
     * @param preExecutionOutput The output from the pre-execution stage.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingCommitStrategy.scala
@@ -3,8 +3,7 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntryId, DamlStateKey}
-import com.daml.ledger.participant.state.kvutils.Fingerprint
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.v1.ParticipantId
 
@@ -15,10 +14,6 @@ sealed case class PreExecutionCommitResult[WriteSet](
     outOfTimeBoundsWriteSet: WriteSet,
     involvedParticipants: Set[ParticipantId]
 )
-
-object PreExecutionCommitResult {
-  type FingerprintedReadSet = Map[DamlStateKey, Fingerprint]
-}
 
 trait PreExecutingCommitStrategy[StateKey, StateValue, ReadSet, WriteSet] {
   def generateReadSet(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingCommitStrategy.scala
@@ -3,11 +3,10 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntryId, DamlStateKey}
 import com.daml.ledger.participant.state.kvutils.Fingerprint
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.LedgerStateOperations.Key
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -18,7 +17,7 @@ sealed case class PreExecutionCommitResult[WriteSet](
 )
 
 object PreExecutionCommitResult {
-  type ReadSet = Seq[(Key, Fingerprint)]
+  type FingerprintedReadSet = Map[DamlStateKey, Fingerprint]
 }
 
 trait PreExecutingCommitStrategy[StateKey, StateValue, ReadSet, WriteSet] {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
@@ -12,7 +12,7 @@ final class LedgerStateOperationsReaderAdapter[LogResult](
     operations: LedgerStateOperations[LogResult]
 ) extends StateReader[Key, Option[Value]] {
   override def read(
-      keys: Seq[Key]
+      keys: Iterable[Key]
   )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]] =
     operations.readState(keys)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/StateReader.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/StateReader.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * @tparam Key   The type of the key expected.
   * @tparam Value The type of the value returned.
   */
-trait StateReader[Key, Value] {
+trait StateReader[-Key, +Value] {
   self =>
 
   /**

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/StateReader.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/StateReader.scala
@@ -20,7 +20,7 @@ trait StateReader[Key, Value] {
     * @param keys list of keys to look up
     * @return values corresponding to the requested keys, in the same order as requested
     */
-  def read(keys: Seq[Key])(implicit executionContext: ExecutionContext): Future[Seq[Value]]
+  def read(keys: Iterable[Key])(implicit executionContext: ExecutionContext): Future[Seq[Value]]
 
   /**
     * Create a new StateReader that transforms the keys before reading.
@@ -35,7 +35,7 @@ trait StateReader[Key, Value] {
   def contramapKeys[NewKey](f: NewKey => Key): StateReader[NewKey, Value] =
     new StateReader[NewKey, Value] {
       override def read(
-          keys: Seq[NewKey]
+          keys: Iterable[NewKey]
       )(implicit executionContext: ExecutionContext): Future[Seq[Value]] =
         self.read(keys.map(f))
     }
@@ -50,7 +50,7 @@ trait StateReader[Key, Value] {
   def mapValues[NewValue](f: Value => NewValue): StateReader[Key, NewValue] =
     new StateReader[Key, NewValue] {
       override def read(
-          keys: Seq[Key]
+          keys: Iterable[Key]
       )(implicit executionContext: ExecutionContext): Future[Seq[NewValue]] =
         self.read(keys).map(_.map(f))
     }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/ArgumentMatchers.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/ArgumentMatchers.scala
@@ -13,11 +13,11 @@ trait ArgumentMatchers {
 
   def anyExecutionContext: ExecutionContext = any[ExecutionContext]
 
-  def seqOf[T](size: Int): Seq[T] =
-    argThat[Seq[T]](new ArgumentMatcher[Seq[T]] {
-      override def matches(argument: Seq[T]): Boolean = argument.size == size
+  def iterableOf[T](size: Int): Iterable[T] =
+    argThat[Iterable[T]](new ArgumentMatcher[Iterable[T]] {
+      override def matches(argument: Iterable[T]): Boolean = argument.size == size
 
-      override def toString: String = s"seq of size $size"
+      override def toString: String = s"iterable of size $size"
     })
 }
 

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
-import com.daml.ledger.participant.state.kvutils.Fingerprint
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.value.ValueOuterClass.Identifier
 import com.google.protobuf.{ByteString, Empty}
@@ -58,9 +57,6 @@ private[validator] object TestHelper {
       .setParty(party)
     builder.build
   }
-
-  def fingerprint(string: String): Fingerprint =
-    ByteString.copyFromUtf8(string)
 
   def makeContractIdStateKey(id: String): DamlStateKey =
     DamlStateKey.newBuilder.setContractId(id).build

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.participant.state.kvutils.export.{
 }
 import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.ArgumentMatchers.{anyExecutionContext, seqOf}
+import com.daml.ledger.validator.ArgumentMatchers.{anyExecutionContext, iterableOf}
 import com.daml.ledger.validator.TestHelper.{aParticipantId, anInvalidEnvelope, makePartySubmission}
 import com.daml.ledger.validator.batch.BatchedSubmissionValidatorSpec._
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
@@ -129,7 +129,7 @@ class BatchedSubmissionValidatorSpec
       val mockCommit = mock[CommitStrategy[Unit]]
       val partySubmission = makePartySubmission("foo")
       // Expect two keys, i.e., to retrieve the party and submission dedup values.
-      when(mockLedgerStateReader.read(seqOf(size = 2))(anyExecutionContext))
+      when(mockLedgerStateReader.read(iterableOf(size = 2))(anyExecutionContext))
         .thenReturn(Future.successful(Seq(None, None)))
       val logEntryCaptor = ArgumentCaptor.forClass(classOf[DamlLogEntry])
       val outputStateCaptor = ArgumentCaptor.forClass(classOf[Map[DamlStateKey, DamlStateValue]])
@@ -176,7 +176,7 @@ class BatchedSubmissionValidatorSpec
       val (submissions, _, batchSubmissionBytes) = createBatchSubmissionOf(1000)
       val mockLedgerStateReader = mock[DamlLedgerStateReader]
       // Expect two keys, i.e., to retrieve the party and submission dedup values.
-      when(mockLedgerStateReader.read(seqOf(size = 2))(anyExecutionContext))
+      when(mockLedgerStateReader.read(iterableOf(size = 2))(anyExecutionContext))
         .thenReturn(Future.successful(Seq(None, None)))
       val logEntryCaptor = ArgumentCaptor.forClass(classOf[DamlLogEntry])
       val outputStateCaptor = ArgumentCaptor.forClass(classOf[Map[DamlStateKey, DamlStateValue]])
@@ -243,7 +243,7 @@ class BatchedSubmissionValidatorSpec
         .build()
       val mockLedgerStateReader = mock[DamlLedgerStateReader]
       // Expect two keys, i.e., to retrieve the party and submission dedup values.
-      when(mockLedgerStateReader.read(seqOf(size = 2))(anyExecutionContext))
+      when(mockLedgerStateReader.read(iterableOf(size = 2))(anyExecutionContext))
         .thenReturn(Future.successful(Seq(None, None)))
       val mockCommit = mock[CommitStrategy[Unit]]
       when(
@@ -291,7 +291,7 @@ class BatchedSubmissionValidatorSpec
       val (submissions, batchSubmission, batchSubmissionBytes) = createBatchSubmissionOf(2)
       val mockLedgerStateReader = mock[DamlLedgerStateReader]
       // Expect two keys, i.e., to retrieve the party and submission dedup values.
-      when(mockLedgerStateReader.read(seqOf(size = 2))(anyExecutionContext))
+      when(mockLedgerStateReader.read(iterableOf(size = 2))(anyExecutionContext))
         .thenReturn(Future.successful(Seq(None, None)))
       val mockCommit = mock[CommitStrategy[Unit]]
       when(

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingStateReaderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/caching/CachingStateReaderSpec.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.validator.caching
 
 import com.daml.caching.Cache.Size
 import com.daml.caching.{Cache, Weight, WeightedCache}
-import com.daml.ledger.validator.ArgumentMatchers.{anyExecutionContext, seqOf}
+import com.daml.ledger.validator.ArgumentMatchers.{anyExecutionContext, iterableOf}
 import com.daml.ledger.validator.caching.CachingStateReaderSpec._
 import com.daml.ledger.validator.reading.StateReader
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
@@ -24,7 +24,7 @@ class CachingStateReaderSpec
   "read" should {
     "update cache upon read if policy allows" in {
       val mockReader = mock[TestStateReader]
-      when(mockReader.read(seqOf(size = 1))(anyExecutionContext))
+      when(mockReader.read(iterableOf(size = 1))(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(TestValue.random()))))
       val (cache, instance) = newInstance(mockReader, shouldCacheOnRead = true)
 
@@ -35,7 +35,7 @@ class CachingStateReaderSpec
 
     "do not update cache upon read if policy does not allow" in {
       val mockReader = mock[TestStateReader]
-      when(mockReader.read(seqOf(size = 1))(anyExecutionContext))
+      when(mockReader.read(iterableOf(size = 1))(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(TestValue.random()))))
       val (cache, instance) = newInstance(mockReader, shouldCacheOnRead = false)
 
@@ -46,7 +46,7 @@ class CachingStateReaderSpec
 
     "serve request from cache for seen key (if policy allows)" in {
       val mockReader = mock[TestStateReader]
-      when(mockReader.read(seqOf(size = 1))(anyExecutionContext))
+      when(mockReader.read(iterableOf(size = 1))(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(TestValue(7)))))
       val (_, instance) = newInstance(mockReader, shouldCacheOnRead = true)
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/LogAppenderPreExecutingCommitStrategySpec.scala
@@ -45,8 +45,7 @@ final class LogAppenderPreExecutingCommitStrategySpec
       instance.generateReadSet(
         fetchedInputs = Map(contractIdStateKey -> ((Some(contractIdStateValue), fingerprint))),
         accessedKeys = Set(contractIdStateKey),
-      ) should be(
-        Seq(mockStateKeySerializationStrategy.serializeStateKey(contractIdStateKey) -> fingerprint))
+      ) should be(Map(contractIdStateKey -> fingerprint))
     }
 
     "throw in case an input key is declared in the read set but not fetched as input" in {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -253,9 +253,9 @@ object PreExecutingSubmissionValidatorSpec {
     val wrappedInputState = inputState.mapValues(TestValue(_))
     new StateReader[DamlStateKey, TestValue] {
       override def read(
-          keys: Seq[DamlStateKey]
+          keys: Iterable[DamlStateKey]
       )(implicit executionContext: ExecutionContext): Future[Seq[TestValue]] =
-        Future.successful(keys.map(wrappedInputState))
+        Future.successful(keys.view.map(wrappedInputState).toVector)
     }
   }
 


### PR DESCRIPTION
This simplifies the state-reading operations considerably, and allows us to generalize over different state value types much more easily.

The biggest change is in post-execution, which now only reads the fingerprints and can therefore be generalized to do a simple equality check, and is therefore independent of fingerprints now.

This is part 5 of removing fingerprints from this code, while still maintaining the ability to pass extra ledger-specific information through.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
