### PR TITLE
Throw exceptions directly.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -196,13 +196,20 @@ alphaExpr' env = \case
     ETypeRep t1 -> \case
         ETypeRep t2 -> alphaType' env t1 t2
         _ -> False
-    EMakeAnyException t1 e1a e1b -> \case
-        EMakeAnyException t2 e2a e2b -> alphaType' env t1 t2
-            && alphaExpr' env e1a e2a
-            && alphaExpr' env e1b e2b
+    EMakeAnyException t1 e1 -> \case
+        EMakeAnyException t2 e2
+            -> alphaType' env t1 t2
+            && alphaExpr' env e1 e2
         _ -> False
     EFromAnyException t1 e1 -> \case
-        EFromAnyException t2 e2 -> alphaType' env t1 t2
+        EFromAnyException t2 e2
+            -> alphaType' env t1 t2
+            && alphaExpr' env e1 e2
+        _ -> False
+    EThrow t1a t1b e1 -> \case
+        EThrow t2a t2b e2
+            -> alphaType' env t1a t2a
+            && alphaType' env t1b t2b
             && alphaExpr' env e1 e2
         _ -> False
     EUpdate u1 -> \case

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Alpha.hs
@@ -196,8 +196,8 @@ alphaExpr' env = \case
     ETypeRep t1 -> \case
         ETypeRep t2 -> alphaType' env t1 t2
         _ -> False
-    EMakeAnyException t1 e1 -> \case
-        EMakeAnyException t2 e2
+    EToAnyException t1 e1 -> \case
+        EToAnyException t2 e2
             -> alphaType' env t1 t2
             && alphaExpr' env e1 e2
         _ -> False

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -516,8 +516,8 @@ data Expr
   | ETypeRep !Type
   -- | Construct an 'AnyException' value from a value of an exception type.
   | EToAnyException
-    { makeAnyExceptionType :: !Type
-    , makeAnyExceptionValue :: !Expr
+    { toAnyExceptionType :: !Type
+    , toAnyExceptionValue :: !Expr
     }
   -- | Convert 'AnyException' back to its underlying value, if possible.
   | EFromAnyException

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -236,7 +236,6 @@ data BuiltinExpr
 
   -- Exceptions
   | BEError                      -- :: ∀a. Text -> a
-  | BEThrow                      -- :: ∀a. AnyException -> a
   | BEAnyExceptionMessage        -- :: AnyException -> Text
   | BEGeneralErrorMessage        -- :: GeneralError -> Text
   | BEArithmeticErrorMessage     -- :: ArithmeticError -> Text
@@ -518,13 +517,18 @@ data Expr
   -- | Construct an 'AnyException' value from a value of an exception type.
   | EMakeAnyException
     { makeAnyExceptionType :: !Type
-    , makeAnyExceptionMessage :: !Expr
     , makeAnyExceptionValue :: !Expr
     }
   -- | Convert 'AnyException' back to its underlying value, if possible.
   | EFromAnyException
     { fromAnyExceptionType :: !Type
     , fromAnyExceptionValue :: !Expr
+    }
+  -- | Throw an exception.
+  | EThrow
+    { throwReturnType :: !Type
+    , throwExceptionType :: !Type
+    , throwExceptionValue :: !Expr
     }
   -- | Update expression.
   | EUpdate !Update
@@ -831,6 +835,7 @@ data Template = Template
 data DefException = DefException
   { exnLocation :: !(Maybe SourceLoc)
   , exnName :: !TypeConName
+  , exnMessage :: !Expr
   }
   deriving (Eq, Data, Generic, NFData, Show)
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -515,7 +515,7 @@ data Expr
     }
   | ETypeRep !Type
   -- | Construct an 'AnyException' value from a value of an exception type.
-  | EMakeAnyException
+  | EToAnyException
     { makeAnyExceptionType :: !Type
     , makeAnyExceptionValue :: !Expr
     }

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
@@ -101,8 +101,9 @@ freeVarsStep = \case
     EToAnyF t e -> freeVarsInType t <> e
     EFromAnyF t e -> freeVarsInType t <> e
     ETypeRepF t -> freeVarsInType t
-    EMakeAnyExceptionF t e1 e2 -> freeVarsInType t <> e1 <> e2
+    EMakeAnyExceptionF t e -> freeVarsInType t <> e
     EFromAnyExceptionF t e -> freeVarsInType t <> e
+    EThrowF t1 t2 e -> freeVarsInType t1 <> freeVarsInType t2 <> e
 
   where
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/FreeVars.hs
@@ -101,7 +101,7 @@ freeVarsStep = \case
     EToAnyF t e -> freeVarsInType t <> e
     EFromAnyF t e -> freeVarsInType t <> e
     ETypeRepF t -> freeVarsInType t
-    EMakeAnyExceptionF t e -> freeVarsInType t <> e
+    EToAnyExceptionF t e -> freeVarsInType t <> e
     EFromAnyExceptionF t e -> freeVarsInType t <> e
     EThrowF t1 t2 e -> freeVarsInType t1 <> freeVarsInType t2 <> e
 

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -211,7 +211,6 @@ instance Pretty BuiltinExpr where
     BEUnit -> keyword_ "unit"
     BEBool b -> keyword_ $ case b of { False -> "false"; True -> "true" }
     BEError -> "ERROR"
-    BEThrow -> "THROW"
     BEAnyExceptionMessage -> "ANY_EXCEPTION_MESSAGE"
     BEGeneralErrorMessage -> "GENERAL_ERROR_MESSAGE"
     BEArithmeticErrorMessage -> "ARITHMETIC_ERROR_MESSAGE"
@@ -509,10 +508,12 @@ instance Pretty Expr where
     EToAny ty body -> pPrintAppKeyword lvl prec "to_any" [TyArg ty, TmArg body]
     EFromAny ty body -> pPrintAppKeyword lvl prec "from_any" [TyArg ty, TmArg body]
     ETypeRep ty -> pPrintAppKeyword lvl prec "type_rep" [TyArg ty]
-    EMakeAnyException ty msg val -> pPrintAppKeyword lvl prec "make_any_exception"
-        [TyArg ty, TmArg msg, TmArg val]
+    EMakeAnyException ty val -> pPrintAppKeyword lvl prec "make_any_exception"
+        [TyArg ty, TmArg val]
     EFromAnyException ty val -> pPrintAppKeyword lvl prec "from_any_exception"
         [TyArg ty, TmArg val]
+    EThrow ty1 ty2 val -> pPrintAppKeyword lvl prec "throw"
+        [TyArg ty1, TyArg ty2, TmArg val]
 
 instance Pretty DefTypeSyn where
   pPrintPrec lvl _prec (DefTypeSyn mbLoc syn params typ) =
@@ -521,8 +522,10 @@ instance Pretty DefTypeSyn where
       lhsDoc = pPrint syn <-> hsep (map (pPrintAndKind lvl precParam) params) <-> "="
 
 instance Pretty DefException where
-  pPrintPrec lvl _prec (DefException mbLoc tycon) =
-    withSourceLoc lvl mbLoc (keyword_ "exception" <-> pPrint tycon)
+  pPrintPrec lvl _prec (DefException mbLoc tycon msg) =
+    withSourceLoc lvl mbLoc
+      $ (keyword_ "exception" <-> pPrint tycon <-> "where")
+      $$ nest 2 ("message =" <-> pPrintPrec lvl 0 msg)
 
 instance Pretty DefDataType where
   pPrintPrec lvl _prec (DefDataType mbLoc tcon (IsSerializable serializable) params dataCons) =

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -508,7 +508,7 @@ instance Pretty Expr where
     EToAny ty body -> pPrintAppKeyword lvl prec "to_any" [TyArg ty, TmArg body]
     EFromAny ty body -> pPrintAppKeyword lvl prec "from_any" [TyArg ty, TmArg body]
     ETypeRep ty -> pPrintAppKeyword lvl prec "type_rep" [TyArg ty]
-    EMakeAnyException ty val -> pPrintAppKeyword lvl prec "make_any_exception"
+    EToAnyException ty val -> pPrintAppKeyword lvl prec "to_any_exception"
         [TyArg ty, TmArg val]
     EFromAnyException ty val -> pPrintAppKeyword lvl prec "from_any_exception"
         [TyArg ty, TmArg val]

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Pretty.hs
@@ -525,7 +525,7 @@ instance Pretty DefException where
   pPrintPrec lvl _prec (DefException mbLoc tycon msg) =
     withSourceLoc lvl mbLoc
       $ (keyword_ "exception" <-> pPrint tycon <-> "where")
-      $$ nest 2 ("message =" <-> pPrintPrec lvl 0 msg)
+      $$ nest 2 ("message" <-> pPrintPrec lvl 0 msg)
 
 instance Pretty DefDataType where
   pPrintPrec lvl _prec (DefDataType mbLoc tcon (IsSerializable serializable) params dataCons) =

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -46,7 +46,7 @@ data ExprF expr
   | EToAnyF !Type !expr
   | EFromAnyF !Type !expr
   | ETypeRepF !Type
-  | EMakeAnyExceptionF !Type !expr
+  | EToAnyExceptionF !Type !expr
   | EFromAnyExceptionF !Type !expr
   | EThrowF !Type !Type !expr
   deriving (Foldable, Functor, Traversable)
@@ -187,7 +187,7 @@ instance Recursive Expr where
     EToAny a b  -> EToAnyF a b
     EFromAny a b -> EFromAnyF a b
     ETypeRep a -> ETypeRepF a
-    EMakeAnyException a b -> EMakeAnyExceptionF a b
+    EToAnyException a b -> EToAnyExceptionF a b
     EFromAnyException a b -> EFromAnyExceptionF a b
 
 instance Corecursive Expr where
@@ -219,6 +219,6 @@ instance Corecursive Expr where
     EToAnyF a b  -> EToAny a b
     EFromAnyF a b -> EFromAny a b
     ETypeRepF a -> ETypeRep a
-    EMakeAnyExceptionF a b -> EMakeAnyException a b
+    EToAnyExceptionF a b -> EToAnyException a b
     EFromAnyExceptionF a b -> EFromAnyException a b
     EThrowF a b c -> EThrow a b c

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -189,6 +189,7 @@ instance Recursive Expr where
     ETypeRep a -> ETypeRepF a
     EToAnyException a b -> EToAnyExceptionF a b
     EFromAnyException a b -> EFromAnyExceptionF a b
+    EThrow a b c -> EThrowF a b c
 
 instance Corecursive Expr where
   embed = \case

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Recursive.hs
@@ -46,8 +46,9 @@ data ExprF expr
   | EToAnyF !Type !expr
   | EFromAnyF !Type !expr
   | ETypeRepF !Type
-  | EMakeAnyExceptionF !Type !expr !expr
+  | EMakeAnyExceptionF !Type !expr
   | EFromAnyExceptionF !Type !expr
+  | EThrowF !Type !Type !expr
   deriving (Foldable, Functor, Traversable)
 
 data BindingF expr = BindingF !(ExprVarName, Type) !expr
@@ -186,7 +187,7 @@ instance Recursive Expr where
     EToAny a b  -> EToAnyF a b
     EFromAny a b -> EFromAnyF a b
     ETypeRep a -> ETypeRepF a
-    EMakeAnyException a b c -> EMakeAnyExceptionF a b c
+    EMakeAnyException a b -> EMakeAnyExceptionF a b
     EFromAnyException a b -> EFromAnyExceptionF a b
 
 instance Corecursive Expr where
@@ -218,5 +219,6 @@ instance Corecursive Expr where
     EToAnyF a b  -> EToAny a b
     EFromAnyF a b -> EFromAny a b
     ETypeRepF a -> ETypeRep a
-    EMakeAnyExceptionF a b c -> EMakeAnyException a b c
+    EMakeAnyExceptionF a b -> EMakeAnyException a b
     EFromAnyExceptionF a b -> EFromAnyException a b
+    EThrowF a b c -> EThrow a b c

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
@@ -182,7 +182,7 @@ applySubstInExpr subst@Subst{..} = \case
         (applySubstInExpr subst e)
     ETypeRep t -> ETypeRep
         (applySubstInType subst t)
-    EMakeAnyException t e -> EMakeAnyException
+    EToAnyException t e -> EToAnyException
         (applySubstInType subst t)
         (applySubstInExpr subst e)
     EFromAnyException t e -> EFromAnyException

--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Subst.hs
@@ -182,12 +182,15 @@ applySubstInExpr subst@Subst{..} = \case
         (applySubstInExpr subst e)
     ETypeRep t -> ETypeRep
         (applySubstInType subst t)
-    EMakeAnyException t e1 e2 -> EMakeAnyException
+    EMakeAnyException t e -> EMakeAnyException
         (applySubstInType subst t)
-        (applySubstInExpr subst e1)
-        (applySubstInExpr subst e2)
+        (applySubstInExpr subst e)
     EFromAnyException t e -> EFromAnyException
         (applySubstInType subst t)
+        (applySubstInExpr subst e)
+    EThrow t1 t2 e -> EThrow
+        (applySubstInType subst t1)
+        (applySubstInType subst t2)
         (applySubstInExpr subst e)
     EUpdate u -> EUpdate
         (applySubstInUpdate subst u)

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -604,9 +604,9 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
     return (EFromAny type' expr)
   LF1.ExprSumTypeRep typ ->
     ETypeRep <$> decodeType typ
-  LF1.ExprSumMakeAnyException LF1.Expr_MakeAnyException {..} -> EMakeAnyException
-    <$> mayDecode "expr_MakeAnyExceptionType" expr_MakeAnyExceptionType decodeType
-    <*> mayDecode "expr_MakeAnyExceptionExpr" expr_MakeAnyExceptionExpr decodeExpr
+  LF1.ExprSumToAnyException LF1.Expr_ToAnyException {..} -> EToAnyException
+    <$> mayDecode "expr_ToAnyExceptionType" expr_ToAnyExceptionType decodeType
+    <*> mayDecode "expr_ToAnyExceptionExpr" expr_ToAnyExceptionExpr decodeExpr
   LF1.ExprSumFromAnyException LF1.Expr_FromAnyException {..} -> EFromAnyException
     <$> mayDecode "expr_FromAnyExceptionType" expr_FromAnyExceptionType decodeType
     <*> mayDecode "expr_FromAnyExceptionExpr" expr_FromAnyExceptionExpr decodeExpr

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/DecodeV1.hs
@@ -249,6 +249,7 @@ decodeDefException LF1.DefException{..} =
   DefException
     <$> traverse decodeLocation defExceptionLocation
     <*> decodeDottedNameId TypeConName defExceptionNameInternedDname
+    <*> mayDecode "exceptionMessage" defExceptionMessage decodeExpr
 
 decodeDefDataType :: LF1.DefDataType -> Decode DefDataType
 decodeDefDataType LF1.DefDataType{..} =
@@ -441,7 +442,6 @@ decodeBuiltinFunction = pure . \case
   LF1.BuiltinFunctionAPPEND_TEXT    -> BEAppendText
 
   LF1.BuiltinFunctionERROR          -> BEError
-  LF1.BuiltinFunctionTHROW -> BEThrow
   LF1.BuiltinFunctionANY_EXCEPTION_MESSAGE -> BEAnyExceptionMessage
   LF1.BuiltinFunctionGENERAL_ERROR_MESSAGE -> BEGeneralErrorMessage
   LF1.BuiltinFunctionARITHMETIC_ERROR_MESSAGE -> BEArithmeticErrorMessage
@@ -606,11 +606,14 @@ decodeExprSum exprSum = mayDecode "exprSum" exprSum $ \case
     ETypeRep <$> decodeType typ
   LF1.ExprSumMakeAnyException LF1.Expr_MakeAnyException {..} -> EMakeAnyException
     <$> mayDecode "expr_MakeAnyExceptionType" expr_MakeAnyExceptionType decodeType
-    <*> mayDecode "expr_MakeAnyExceptionMessage" expr_MakeAnyExceptionMessage decodeExpr
     <*> mayDecode "expr_MakeAnyExceptionExpr" expr_MakeAnyExceptionExpr decodeExpr
   LF1.ExprSumFromAnyException LF1.Expr_FromAnyException {..} -> EFromAnyException
     <$> mayDecode "expr_FromAnyExceptionType" expr_FromAnyExceptionType decodeType
     <*> mayDecode "expr_FromAnyExceptionExpr" expr_FromAnyExceptionExpr decodeExpr
+  LF1.ExprSumThrow LF1.Expr_Throw {..} -> EThrow
+    <$> mayDecode "expr_ThrowReturnType" expr_ThrowReturnType decodeType
+    <*> mayDecode "expr_ThrowExceptionType" expr_ThrowExceptionType decodeType
+    <*> mayDecode "expr_ThrowExceptionExpr" expr_ThrowExceptionExpr decodeExpr
 
 decodeUpdate :: LF1.Update -> Decode Expr
 decodeUpdate LF1.Update{..} = mayDecode "updateSum" updateSum $ \case

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -672,10 +672,10 @@ encodeExpr' = \case
         pureExpr $ P.ExprSumFromAny P.Expr_FromAny{..}
     ETypeRep ty -> do
         expr . P.ExprSumTypeRep <$> encodeType' ty
-    EMakeAnyException ty val -> do
-        expr_MakeAnyExceptionType <- encodeType ty
-        expr_MakeAnyExceptionExpr <- encodeExpr val
-        pureExpr $ P.ExprSumMakeAnyException P.Expr_MakeAnyException{..}
+    EToAnyException ty val -> do
+        expr_ToAnyExceptionType <- encodeType ty
+        expr_ToAnyExceptionExpr <- encodeExpr val
+        pureExpr $ P.ExprSumToAnyException P.Expr_ToAnyException{..}
     EFromAnyException ty val -> do
         expr_FromAnyExceptionType <- encodeType ty
         expr_FromAnyExceptionExpr <- encodeExpr val

--- a/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
+++ b/compiler/daml-lf-proto/src/DA/Daml/LF/Proto3/EncodeV1.hs
@@ -517,7 +517,6 @@ encodeBuiltinExpr = \case
     BESha256Text -> builtin P.BuiltinFunctionSHA256_TEXT
 
     BEError -> builtin P.BuiltinFunctionERROR
-    BEThrow -> builtin P.BuiltinFunctionTHROW
     BEAnyExceptionMessage -> builtin P.BuiltinFunctionANY_EXCEPTION_MESSAGE
     BEGeneralErrorMessage -> builtin P.BuiltinFunctionGENERAL_ERROR_MESSAGE
     BEArithmeticErrorMessage -> builtin P.BuiltinFunctionARITHMETIC_ERROR_MESSAGE
@@ -673,15 +672,19 @@ encodeExpr' = \case
         pureExpr $ P.ExprSumFromAny P.Expr_FromAny{..}
     ETypeRep ty -> do
         expr . P.ExprSumTypeRep <$> encodeType' ty
-    EMakeAnyException ty msg val -> do
+    EMakeAnyException ty val -> do
         expr_MakeAnyExceptionType <- encodeType ty
-        expr_MakeAnyExceptionMessage <- encodeExpr msg
         expr_MakeAnyExceptionExpr <- encodeExpr val
         pureExpr $ P.ExprSumMakeAnyException P.Expr_MakeAnyException{..}
     EFromAnyException ty val -> do
         expr_FromAnyExceptionType <- encodeType ty
         expr_FromAnyExceptionExpr <- encodeExpr val
         pureExpr $ P.ExprSumFromAnyException P.Expr_FromAnyException{..}
+    EThrow ty1 ty2 val -> do
+        expr_ThrowReturnType <- encodeType ty1
+        expr_ThrowExceptionType <- encodeType ty2
+        expr_ThrowExceptionExpr <- encodeExpr val
+        pureExpr $ P.ExprSumThrow P.Expr_Throw{..}
   where
     expr = P.Expr Nothing . Just
     pureExpr = pure . expr
@@ -856,6 +859,7 @@ encodeDefException :: DefException -> Encode P.DefException
 encodeDefException DefException{..} = do
     defExceptionNameInternedDname <- encodeDottedNameId unTypeConName exnName
     defExceptionLocation <- traverse encodeSourceLoc exnLocation
+    defExceptionMessage <- encodeExpr exnMessage
     pure P.DefException{..}
 
 encodeTemplate :: Template -> Encode P.DefTemplate

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -83,7 +83,6 @@ safetyStep = \case
       BEUnit              -> Safe 0
       BEBool _            -> Safe 0
       BEError             -> Safe 0
-      BEThrow -> Safe 0
       BEAnyExceptionMessage -> Safe 1
       BEGeneralErrorMessage -> Safe 1
       BEArithmeticErrorMessage -> Safe 1
@@ -216,12 +215,13 @@ safetyStep = \case
     | Safe _ <- s -> Safe 0
     | otherwise -> Unsafe
   ETypeRepF _ -> Safe 0
-  EMakeAnyExceptionF _ s1 s2
-    | Safe _ <- min s1 s2 -> Safe 0
+  EMakeAnyExceptionF _ s
+    | Safe _ <- s -> Safe 0
     | otherwise -> Unsafe
   EFromAnyExceptionF _ s
     | Safe _ <- s -> Safe 0
     | otherwise -> Unsafe
+  EThrowF _ _ _ -> Unsafe
 
 isTypeClassDictionary :: DefValue -> Bool
 isTypeClassDictionary DefValue{..}

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -215,7 +215,7 @@ safetyStep = \case
     | Safe _ <- s -> Safe 0
     | otherwise -> Unsafe
   ETypeRepF _ -> Safe 0
-  EMakeAnyExceptionF _ s
+  EToAnyExceptionF _ s
     | Safe _ <- s -> Safe 0
     | otherwise -> Unsafe
   EFromAnyExceptionF _ s

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -214,7 +214,6 @@ typeOfBuiltin = \case
   BEUnit             -> pure TUnit
   BEBool _           -> pure TBool
   BEError            -> pure $ TForall (alpha, KStar) (TText :-> tAlpha)
-  BEThrow            -> pure $ TForall (alpha, KStar) (TAnyException :-> tAlpha)
   BEAnyExceptionMessage -> pure $ TAnyException :-> TText
   BEGeneralErrorMessage -> pure $ TGeneralError :-> TText
   BEArithmeticErrorMessage -> pure $ TArithmeticError :-> TText
@@ -699,15 +698,19 @@ typeOf' = \case
   ETypeRep ty -> do
     checkGroundType ty
     pure $ TBuiltin BTTypeRep
-  EMakeAnyException ty msg val -> do
+  EMakeAnyException ty val -> do
     checkExceptionType ty
-    checkExpr msg TText
     checkExpr val ty
     pure TAnyException
   EFromAnyException ty val -> do
     checkExceptionType ty
     checkExpr val TAnyException
     pure (TOptional ty)
+  EThrow ty1 ty2 val -> do
+    checkType ty1 KStar
+    checkExceptionType ty2
+    checkExpr val ty2
+    pure ty1
   EUpdate upd -> typeOfUpdate upd
   EScenario scen -> typeOfScenario scen
   ELocation _ expr -> typeOf' expr
@@ -837,6 +840,7 @@ checkDefException m DefException{..} = do
         tcon = Qualified PRSelf modName exnName
     DefDataType _loc _name _serializable tyParams dataCons <- inWorld (lookupDataType tcon)
     unless (null tyParams) $ throwWithContext (EExpectedExceptionTypeHasNoParams modName exnName)
+    checkExpr exnMessage (TCon tcon :-> TText)
     _ <- match _DataRecord (EExpectedExceptionTypeIsRecord modName exnName) dataCons
     case NM.lookup exnName (moduleTemplates m) of
         Nothing -> pure ()

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Check.hs
@@ -698,7 +698,7 @@ typeOf' = \case
   ETypeRep ty -> do
     checkGroundType ty
     pure $ TBuiltin BTTypeRep
-  EMakeAnyException ty val -> do
+  EToAnyException ty val -> do
     checkExceptionType ty
     checkExpr val ty
     pure TAnyException

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Error.hs
@@ -69,6 +69,7 @@ data UnserializabilityReason
   | URNumericOutOfRange !Natural
   | URTypeLevelNat
   | URAny -- ^ It contains a value of type Any.
+  | URAnyException -- ^ It contains a value of type AnyException.
   | URTypeRep -- ^ It contains a value of type TypeRep.
   | URTypeSyn  -- ^ It contains a type synonym.
 
@@ -195,6 +196,7 @@ instance Pretty UnserializabilityReason where
     URNumericOutOfRange n -> "Numeric scale " <> integer (fromIntegral n) <> " is out of range (needs to be between 0 and 38)"
     URTypeLevelNat -> "type-level nat"
     URAny -> "Any"
+    URAnyException -> "AnyException"
     URTypeRep -> "TypeRep"
     URTypeSyn -> "type synonym"
 

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -101,8 +101,8 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
         BTArrow -> Left URFunction
         BTNumeric -> Left URNumeric -- 'Numeric' is used as a higher-kinded type constructor.
         BTAny -> Left URAny
-        BTTypeRep -> Left URTypeRep
         BTAnyException -> Left URAnyException
+        BTTypeRep -> Left URTypeRep
         BTGeneralError -> noConditions
         BTArithmeticError -> noConditions
         BTContractError -> noConditions

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/TypeChecker/Serializability.hs
@@ -102,7 +102,7 @@ serializabilityConditionsType world0 _version mbModNameTpls vars = go
         BTNumeric -> Left URNumeric -- 'Numeric' is used as a higher-kinded type constructor.
         BTAny -> Left URAny
         BTTypeRep -> Left URTypeRep
-        BTAnyException -> noConditions
+        BTAnyException -> Left URAnyException
         BTGeneralError -> noConditions
         BTArithmeticError -> noConditions
         BTContractError -> noConditions

--- a/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
+++ b/compiler/scenario-service/client/src/DA/Daml/LF/PrettyScenario.hs
@@ -653,7 +653,6 @@ prettyNode Node{..}
     meta p       = text "│  " <-> p
     archivedSC = annotateSC PredicateSC -- Magenta
 
-
 prettyPartialTransaction :: PartialTransaction -> M (Doc SyntaxClass)
 prettyPartialTransaction PartialTransaction{..} = do
   world <- askWorld

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -1006,7 +1006,7 @@ message Expr {
 
     // Wrap an arbitrary exception into an AnyException ('ExpToAnyException').
     // *Available in versions >= 1.dev*
-    ToAnyException make_any_exception = 33;
+    ToAnyException to_any_exception = 33;
 
     // Extract an arbitrary exception from an AnyException ('ExpFromAnyException').
     // *Available in versions >= 1.dev*

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -485,7 +485,6 @@ enum BuiltinFunction {
   APPEND_TEXT = 24;
 
   ERROR = 25;
-  THROW = 137;                      // *Available in versions >= 1.dev*
   ANY_EXCEPTION_MESSAGE = 138;      // *Available in versions >= 1.dev*
   MAKE_GENERAL_ERROR = 139;         // *Available in versions >= 1.dev*
   GENERAL_ERROR_MESSAGE = 140;      // *Available in versions >= 1.dev*
@@ -885,12 +884,10 @@ message Expr {
     Type type = 1;
     // argument
     Expr expr = 2;
-    // error message
-    Expr message = 3;
   }
 
   // Extract the given exception type from AnyException or return None on type-mismatch
-  // *Available in versions >= 1.7*
+  // *Available in versions >= 1.dev*
   message FromAnyException {
     // type that should be extracted. Must be an exception type.
     Type type = 1;
@@ -898,6 +895,16 @@ message Expr {
     Expr expr = 2;
   }
 
+  // Throw an exception.
+  // *Available in versions >= 1.dev*
+  message Throw {
+    // Overall type of the "throw" expression.
+    Type return_type = 1;
+    // Type of exception to throw. Must be an exception type.
+    Type exception_type = 2;
+    // Value of type "exception_type".
+    Expr exception_expr = 3;
+  }
 
   // Location of the expression in the DAML code source.
   // Optional
@@ -1004,6 +1011,10 @@ message Expr {
     // Extract an arbitrary exception from an AnyException ('ExpFromAnyException').
     // *Available in versions >= 1.dev*
     FromAnyException from_any_exception = 34;
+
+    // Throw an exception ('ExpThrow').
+    // *Available in versions >= 1.dev*
+    Throw throw = 35;
   }
 
   reserved 19; // This was equals. Removed in favour of BuiltinFunction.EQUAL_*
@@ -1418,6 +1429,7 @@ message DefException {
   // *Must be a valid interned dotted name*
   int32 name_interned_dname = 1;
   Location location = 2;
+  Expr message = 3;
 }
 
 // Data type definition

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -485,13 +485,13 @@ enum BuiltinFunction {
   APPEND_TEXT = 24;
 
   ERROR = 25;
-  ANY_EXCEPTION_MESSAGE = 138;      // *Available in versions >= 1.dev*
-  MAKE_GENERAL_ERROR = 139;         // *Available in versions >= 1.dev*
-  GENERAL_ERROR_MESSAGE = 140;      // *Available in versions >= 1.dev*
-  MAKE_ARITHMETIC_ERROR = 141;      // *Available in versions >= 1.dev*
-  ARITHMETIC_ERROR_MESSAGE = 142;   // *Available in versions >= 1.dev*
-  MAKE_CONTRACT_ERROR = 143;        // *Available in versions >= 1.dev*
-  CONTRACT_ERROR_MESSAGE = 144;     // *Available in versions >= 1.dev*
+  ANY_EXCEPTION_MESSAGE = 137;      // *Available in versions >= 1.dev*
+  MAKE_GENERAL_ERROR = 138;         // *Available in versions >= 1.dev*
+  GENERAL_ERROR_MESSAGE = 139;      // *Available in versions >= 1.dev*
+  MAKE_ARITHMETIC_ERROR = 140;      // *Available in versions >= 1.dev*
+  ARITHMETIC_ERROR_MESSAGE = 141;   // *Available in versions >= 1.dev*
+  MAKE_CONTRACT_ERROR = 142;        // *Available in versions >= 1.dev*
+  CONTRACT_ERROR_MESSAGE = 143;     // *Available in versions >= 1.dev*
 
   LEQ_INT64 = 33;         // *Available in versions < 1.dev*
   LEQ_DECIMAL = 34;       // *Available in versions < 1.7*
@@ -579,7 +579,7 @@ enum BuiltinFunction {
   TEXT_FROM_CODE_POINTS = 105;  // *Available in versions >= 1.6*
   TEXT_TO_CODE_POINTS = 106; // *Available in versions >= 1.6*
 
-  // Next id is 145. 144 is CONTRACT_ERROR_MESSAGE.
+  // Next id is 144. 143 is CONTRACT_ERROR_MESSAGE.
 
   // EXPERIMENTAL TEXT PRIMITIVES -- these do not yet have stable numbers.
   TEXT_TO_UPPER = 9901; // *Available in versions >= 1.dev*

--- a/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
+++ b/daml-lf/archive/src/main/protobuf/com/daml/daml_lf_dev/daml_lf_1.proto
@@ -879,7 +879,7 @@ message Expr {
 
   // Wrap an exception value in AnyException
   // *Available in versions >= 1.dev*
-  message MakeAnyException {
+  message ToAnyException {
     // type of argument. Must be an exception type.
     Type type = 1;
     // argument
@@ -1004,9 +1004,9 @@ message Expr {
     // *Available in versions >= 1.7*
     Type type_rep = 32;
 
-    // Wrap an arbitrary exception into an AnyException ('ExpMakeAnyException').
+    // Wrap an arbitrary exception into an AnyException ('ExpToAnyException').
     // *Available in versions >= 1.dev*
-    MakeAnyException make_any_exception = 33;
+    ToAnyException make_any_exception = 33;
 
     // Extract an arbitrary exception from an AnyException ('ExpFromAnyException').
     // *Available in versions >= 1.dev*

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -988,10 +988,13 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           ETypeRep(decodeType(lfExpr.getTypeRep))
 
         case PLF.Expr.SumCase.MAKE_ANY_EXCEPTION =>
-          throw ParseError("Expr.MAKE_ANY_EXCEPTION") // TODO #8020
+          throw ParseError("Expr.MAKE_ANY_EXCEPTION") // TODO https://github.com/digital-asset/daml/issues/8020
 
         case PLF.Expr.SumCase.FROM_ANY_EXCEPTION =>
-          throw ParseError("Expr.FROM_ANY_EXCEPTION") // TODO #8020
+          throw ParseError("Expr.FROM_ANY_EXCEPTION") // TODO https://github.com/digital-asset/daml/issues/8020
+
+        case PLF.Expr.SumCase.THROW =>
+          throw ParseError("Expr.THROW") // TODO https://github.com/digital-asset/daml/issues/8020
 
         case PLF.Expr.SumCase.SUM_NOT_SET =>
           throw ParseError("Expr.SUM_NOT_SET")
@@ -1698,7 +1701,6 @@ private[lf] object DecodeV1 {
       BuiltinFunctionInfo(EQUAL_CONTRACT_ID, BEqualContractId, maxVersion = Some(genMap)),
       BuiltinFunctionInfo(TRACE, BTrace),
       BuiltinFunctionInfo(COERCE_CONTRACT_ID, BCoerceContractId),
-      BuiltinFunctionInfo(THROW, BTextToUpper, minVersion = exceptions), // TODO #8020
       BuiltinFunctionInfo(MAKE_GENERAL_ERROR, BTextToUpper, minVersion = exceptions), // TODO #8020
       BuiltinFunctionInfo(MAKE_ARITHMETIC_ERROR, BTextToUpper, minVersion = exceptions), // TODO #8020
       BuiltinFunctionInfo(MAKE_CONTRACT_ERROR, BTextToUpper, minVersion = exceptions), // TODO #8020

--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -987,8 +987,8 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
           assertSince(LV.Features.typeRep, "Expr.type_rep")
           ETypeRep(decodeType(lfExpr.getTypeRep))
 
-        case PLF.Expr.SumCase.MAKE_ANY_EXCEPTION =>
-          throw ParseError("Expr.MAKE_ANY_EXCEPTION") // TODO https://github.com/digital-asset/daml/issues/8020
+        case PLF.Expr.SumCase.TO_ANY_EXCEPTION =>
+          throw ParseError("Expr.TO_ANY_EXCEPTION") // TODO https://github.com/digital-asset/daml/issues/8020
 
         case PLF.Expr.SumCase.FROM_ANY_EXCEPTION =>
           throw ParseError("Expr.FROM_ANY_EXCEPTION") // TODO https://github.com/digital-asset/daml/issues/8020


### PR DESCRIPTION
Part of #8020.

This PR changes the exception protobuf and related AST (Haskell
side) to throw exceptions directly via a primitive expression (`EThrow`),
instead of throwing wrapping them up via `AnyException`.  Part of this is
adding a "message" field in `DefException`.

Furthermore, we don't need the `message` argument in `MakeAnyException`
anymore, because the exception message is calculated from the exception payload with
the function given by `DefException`. I renamed it to `ToAnyException` to match
the `fromAny/toAny` and `fromAnyTemplate/toAnyTemplate` and
`fromAnyChoice/toAnyChoice` convention.

I leave the specification changes to a separate PR.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
