### PR TITLE
KV pre-exec: don't prefetch indirect state inputs from keys

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -109,19 +109,10 @@ class PreExecutingSubmissionValidator[WriteSet](
       metrics.daml.kvutils.submission.validator.fetchInputsRunning,
       for {
         inputValues <- ledgerStateReader.read(inputKeys)
-
-        nestedInputKeys = inputValues.collect {
-          case (Some(value), _) if value.hasContractKeyState =>
-            val contractId = value.getContractKeyState.getContractId
-            DamlStateKey.newBuilder.setContractId(contractId).build
-        }
-        nestedInputValues <- ledgerStateReader.read(nestedInputKeys)
       } yield {
         assert(inputKeys.size == inputValues.size)
-        assert(nestedInputKeys.size == nestedInputValues.size)
         val inputPairs = inputKeys.toIterator zip inputValues.toIterator
-        val nestedInputPairs = nestedInputKeys.toIterator zip nestedInputValues.toIterator
-        (inputPairs ++ nestedInputPairs).toMap
+        inputPairs.toMap
       }
     )
   }


### PR DESCRIPTION
This backports #8323.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
