### PR TITLE
navigator: allocate parties from daml.yaml

### DIFF
--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
@@ -31,7 +31,8 @@ case class Arguments(
     startConsole: Boolean = false,
     startWebServer: Boolean = false,
     useDatabase: Boolean = false,
-    ledgerInboundMessageSizeMax: Int = 50 * 1024 * 1024 // 50 MiB
+    ledgerInboundMessageSizeMax: Int = 50 * 1024 * 1024, // 50 MiB
+    allocateProjectParties: Boolean = false
 )
 
 trait ArgumentsHelper { self: OptionParser[Arguments] =>
@@ -153,6 +154,11 @@ object Arguments {
             )
           }
         )
+
+      opt[Unit]("allocateProjectParties")
+        .optional()
+        .text("Allocate parties specified in the daml.yaml project configuration file.")
+        .action((_, arguments) => arguments.copy(allocateProjectParties = true))
 
       cmd("server")
         .text("serve data from platform")

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/Store.scala
@@ -34,6 +34,8 @@ object Store {
 
   case class UpdatedParties(details: List[PartyDetails])
 
+  case class AllocateParties(parties: List[String])
+
   /** Request to subscribe a party to the store (without response to sender). */
   case class Subscribe(displayName: String, config: UserConfig)
 

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/store/platform/PlatformStore.scala
@@ -178,6 +178,12 @@ class PlatformStore(
         }
       }
 
+    case AllocateParties(parties) =>
+      parties.foreach(
+        party =>
+          state.ledgerClient.partyManagementClient
+            .allocateParty(Some(party), Some(party)))
+
     case Subscribe(displayName, config) =>
       if (!state.parties.contains(displayName)) {
         log.info(s"Starting actor for $displayName")


### PR DESCRIPTION
This adds a flag '--allocateProjectParties' to navigator such that
parties specified in the `daml.yaml` file are allocated on startup.

This is part of #6099.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
