### PR TITLE
fail on failed perf check

### DIFF
--- a/ci/cron/perf/CollectAuthority.scala.patch
+++ b/ci/cron/perf/CollectAuthority.scala.patch
@@ -114,3 +114,22 @@ index 76689ce45..c723418a8 100644
      state.run()
    }
  }
+diff --git a/stack-snapshot.yaml b/stack-snapshot.yaml
+index 01ab7e789..c2e09093d 100644
+--- a/stack-snapshot.yaml
++++ b/stack-snapshot.yaml
+@@ -3,10 +3,10 @@
+
+ resolver: lts-14.1
+ packages:
+-  - archive: http://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-parser-8.8.1.20200225.tar.gz
+-    sha256: "31b6f1fc15d257e66d3264e62e229203087a2e799a9638f6d5ff6cc43ec0b4a4"
+-  - archive: http://digitalassetsdk.bintray.com/ghc-lib/ghc-lib-8.8.1.20200225.tar.gz
+-    sha256: "2cd22db09fdcb9bb121bd6f85024aba437ca2796ebe16453d15cbf2cb192023c"
++  - archive: https://daml-binaries.da-ext.net/da-ghc-lib/ghc-lib-48295232a0bebf0bf80b90447d0f5890.tar.gz
++    sha256: "32ef1e2aebdd473681e38fbbf4747b88a1e03d00ea90adb9917b613659acad9f"
++  - archive: https://daml-binaries.da-ext.net/da-ghc-lib/ghc-lib-parser-48295232a0bebf0bf80b90447d0f5890.tar.gz
++    sha256: "dbaaca05c677794261e102f1a7d6a4409d368a47feb214b6378fa1169d269ec3"
+   - github: digital-asset/hlint
+     commit: "3e78bce69749b22a80fec1e8eb853cc0c100c18e"
+     sha256: "cf39f2b378485afc77ffdad4dbb057d5d9b4dfc5a38c76ddc44e920e537fb0fa"

--- a/ci/cron/perf/compare.sh
+++ b/ci/cron/perf/compare.sh
@@ -19,10 +19,12 @@ main() {
   git checkout $BASELINE >&2
   git show ${current}:ci/cron/perf/CollectAuthority.scala.patch | git apply
   local baseline_perf=$(measure)
+  if [ "" = "$baseline_perf" ]; then exit 1; fi
 
   git checkout -- daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
   git checkout $current >&2
   local current_perf=$(measure)
+  if [ "" = "$current_perf" ]; then exit 1; fi
 
   local speedup=$(printf "%.2f" $(echo "$baseline_perf / $current_perf" | bc -l))
   local progress_5x=$(printf "%05.2f%%" $(echo "100 * l($speedup) / l(5)" | bc -l))


### PR DESCRIPTION
Today the [perf check failed], but we got no notification of it. I'm not sure what's happening as I can't reproduce any of it locally: not only does the `bazel run` command work for me (despite the ghc-lib URL returning a 404 when I try it manually), I also can't reproduce the fact that Bash, on CI, doesn't seem to fail on either the `bazel run` error or the fact that on the next line `cat` tries to access a file that doesn't exist (for which CI does print the error message).

This PR does two things:

- Add an explicit check that _should_ get Bash to actually fail should this happen again in the future. It is not a great fix but at least we'll know if it happens again (to the best of my knowledge today was the first time we hit this).
- Amend the existing patch we apply on the baseline commit to use the GCS-hosted ghc-lib packages.

CHANGELOG_BEGIN
CHANGELOG_END

[perf check failed]: https://dev.azure.com/digitalasset/daml/_build/results?buildId=64395&view=results