### PR TITLE
kvutils: Remove fingerprints from the PreExecutingValidatingCommitter. [KVL-747]

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -255,7 +255,8 @@ object InMemoryLedgerReaderWriter {
         transformStateReader =
           transformStateReader(keySerializationStrategy, stateValueCacheForPreExecution),
         validator = validator,
-        postExecutionConflictDetector = new EqualityBasedPostExecutionConflictDetector,
+        postExecutionConflictDetector =
+          new EqualityBasedPostExecutionConflictDetector().contramapValues(_._2),
         postExecutionFinalizer = new RawPostExecutionFinalizer(now = timeProvider.getCurrentTime _),
       )
     locally {

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -247,11 +247,7 @@ object InMemoryLedgerReaderWriter {
     val commitStrategy = new LogAppenderPreExecutingCommitStrategy(keySerializationStrategy)
     val validator = new PreExecutingSubmissionValidator(keyValueCommitting, commitStrategy, metrics)
     val committer =
-      new PreExecutingValidatingCommitter[
-        FingerprintedReadSet,
-        RawKeyValuePairsWithLogEntry,
-        Index,
-      ](
+      new PreExecutingValidatingCommitter[FingerprintedReadSet, RawKeyValuePairsWithLogEntry](
         transformStateReader =
           transformStateReader(keySerializationStrategy, stateValueCacheForPreExecution),
         validator = validator,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -16,7 +16,7 @@ import scala.concurrent.{ExecutionContext, Future}
   *
   * @tparam LogResult type of the offset used for a log entry
   */
-trait LedgerStateAccess[LogResult] {
+trait LedgerStateAccess[+LogResult] {
 
   /**
     * Performs read and write operations on the backing store in a single atomic transaction.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PostExecutionConflictDetector.scala
@@ -12,8 +12,14 @@ import scala.concurrent.{ExecutionContext, Future}
   * pre-execution pipeline.
   */
 trait PostExecutionConflictDetector[StateKey, StateValue, -ReadSet, -WriteSet] {
+  self =>
 
   /**
+    * Re-reads the current state of the ledger and ensures that the state has not changed compared
+    * to the pre-execution read set.
+    *
+    * If there is a conflict, throws a [[ConflictDetectedException]].
+    *
     * @param preExecutionOutput The output from the pre-execution stage.
     * @param reader             The operations that can access actual ledger storage as part of a transaction.
     * @param executionContext   The execution context for ledger state operations.
@@ -23,4 +29,24 @@ trait PostExecutionConflictDetector[StateKey, StateValue, -ReadSet, -WriteSet] {
       preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet],
       reader: StateReader[StateKey, StateValue],
   )(implicit executionContext: ExecutionContext): Future[Unit]
+
+  /**
+    * Transforms the reader to widen the state value, allowing it to handle any value that can be
+    * converted to `StateValue`.
+    *
+    * This is an instance of a "contravariant functor", in which the mapping is backwards, because
+    * the values are used as input to the conflict detection.
+    *
+    * @tparam NewStateValue The new state value type.
+    * @return A new conflict detector that transforms after reading, before detecting conflicts.
+    */
+  def contramapValues[NewStateValue](transformValue: NewStateValue => StateValue)
+    : PostExecutionConflictDetector[StateKey, NewStateValue, ReadSet, WriteSet] =
+    new PostExecutionConflictDetector[StateKey, NewStateValue, ReadSet, WriteSet] {
+      override def detectConflicts(
+          preExecutionOutput: PreExecutionOutput[ReadSet, WriteSet],
+          reader: StateReader[StateKey, NewStateValue],
+      )(implicit executionContext: ExecutionContext): Future[Unit] =
+        self.detectConflicts(preExecutionOutput, reader.mapValues(transformValue))
+    }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -26,7 +26,7 @@ import scala.util.{Failure, Success}
   * @param postExecutionConflictDetector The post-execution conflict detector.
   * @param postExecutionFinalizer        The post-execution finalizer.
   */
-class PreExecutingValidatingCommitter[ReadSet, WriteSet, LogResult](
+class PreExecutingValidatingCommitter[ReadSet, WriteSet](
     transformStateReader: StateReader[Key, Option[Value]] => StateReader[
       DamlStateKey,
       (Option[DamlStateValue], Fingerprint),
@@ -54,7 +54,7 @@ class PreExecutingValidatingCommitter[ReadSet, WriteSet, LogResult](
       correlationId: String,
       submissionEnvelope: Bytes,
       submittingParticipantId: ParticipantId,
-      ledgerStateAccess: LedgerStateAccess[LogResult],
+      ledgerStateAccess: LedgerStateAccess[Any],
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
     LoggingContext.newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
       // Sequential pre-execution, implemented by enclosing the whole pre-post-exec pipeline is a single transaction.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -38,7 +38,7 @@ class PreExecutingValidatingCommitter[ReadSet, WriteSet, LogResult](
     ],
     postExecutionConflictDetector: PostExecutionConflictDetector[
       DamlStateKey,
-      Fingerprint,
+      (Option[DamlStateValue], Fingerprint),
       ReadSet,
       WriteSet,
     ],
@@ -72,11 +72,7 @@ class PreExecutingValidatingCommitter[ReadSet, WriteSet, LogResult](
               logger.error("Conflict detected during post-execution. Retrying...")
               true
           } { (_, _) =>
-            val fingerprintStateReader = stateReader.mapValues(_._2)
-            postExecutionConflictDetector.detectConflicts(
-              preExecutionOutput,
-              fingerprintStateReader,
-            )
+            postExecutionConflictDetector.detectConflicts(preExecutionOutput, stateReader)
           }.transform {
             case Failure(_: ConflictDetectedException) =>
               logger.error("Too many conflicts detected during post-execution. Giving up.")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
-import com.daml.ledger.participant.state.kvutils.{Bytes, Fingerprint}
+import com.daml.ledger.participant.state.kvutils.Bytes
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.reading.StateReader
@@ -26,19 +26,19 @@ import scala.util.{Failure, Success}
   * @param postExecutionConflictDetector The post-execution conflict detector.
   * @param postExecutionFinalizer        The post-execution finalizer.
   */
-class PreExecutingValidatingCommitter[ReadSet, WriteSet](
+class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
     transformStateReader: StateReader[Key, Option[Value]] => StateReader[
       DamlStateKey,
-      (Option[DamlStateValue], Fingerprint),
+      StateValue,
     ],
     validator: PreExecutingSubmissionValidator[
-      (Option[DamlStateValue], Fingerprint),
+      StateValue,
       ReadSet,
       WriteSet,
     ],
     postExecutionConflictDetector: PostExecutionConflictDetector[
       DamlStateKey,
-      (Option[DamlStateValue], Fingerprint),
+      StateValue,
       ReadSet,
       WriteSet,
     ],


### PR DESCRIPTION
To accomplish this, we move state reader transformations into the ledger implementation.

Instead of injecting `valueToFingerprint` into the committer, we inject a state reader transformation function that converts it to the correct type.

We also teach the post-execution conflict detector how to transform its reader (using its new `contramapValues` function), rather than expecting the committer to do it.

These two changes make the committer agnostic to the state value type, allowing it to work with anything.

I've also made `LedgerStateAccess` covariant over `LogResult`, which means we can remove it as a type parameter from the committer. This wasn't strictly necessary, but did mean we could stick to 3, rather than 4, type parameters.

This is part 6 of removing fingerprints from this code, while still maintaining the ability to pass extra ledger-specific information through.

At this point, fingerprints are only referred to in the `InMemoryLedgerReaderWriter` and some of the implementations of the traits used in kvutils. The next change will remove them entirely, but this proves that they still _can_ be used throughout the process, while keeping kvutils agnostic to their type.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
