### PR TITLE
Disable daml assistant's update-check by default.

### DIFF
--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -35,6 +35,7 @@ import qualified Data.ByteString.UTF8 as BS.UTF8
 import System.Environment
 import System.Exit
 import System.IO
+import System.IO.Extra (writeFileUTF8)
 import System.IO.Temp
 import System.FilePath
 import System.Directory
@@ -92,8 +93,16 @@ setupDamlPath :: DamlPath -> IO ()
 setupDamlPath (DamlPath path) = do
     createDirectoryIfMissing True (path </> "bin")
     createDirectoryIfMissing True (path </> "sdk")
-    -- For now, we only ensure that the config file exists.
-    appendFile (path </> damlConfigName) ""
+    -- Ensure that the config file exists.
+    unlessM (doesFileExist (path </> damlConfigName)) $ do
+        writeFileUTF8 (path </> damlConfigName) defaultConfig
+  where
+    defaultConfig = unlines
+        [ "update-check: never"
+        , if isWindows
+            then "auto-install: false"
+            else "auto-install: true"
+        ]
 
 -- | Install (extracted) SDK directory to the correct place, after performing
 -- a version sanity check. Then run the sdk install hook if applicable.


### PR DESCRIPTION
Related to https://github.com/digital-asset/daml/issues/5654

Disable daml assistant's update-check by default.  

Also disable auto-install on Windows, since installation-related
errors range from "simple error message" to "program hangs forever",
and users can bypass "daml install" by downloading the new installer.

changelog_begin

- [DAML Assistant] The update-check is disabled by default for
  newer installations. In addition, auto-install is disabled by
  default on Windows. See here for instructions on how to
  configure these settings manually: https://docs.daml.com/tools/assistant.html#global-config-file-daml-config-yaml

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
