### PR TITLE
Fix compare.sh in perf test

### DIFF
--- a/ci/cron/perf/compare.sh
+++ b/ci/cron/perf/compare.sh
@@ -3,7 +3,7 @@
 
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euox pipefail
 
 BASELINE=$1
 
@@ -21,7 +21,8 @@ main() {
   local baseline_perf=$(measure)
   if [ "" = "$baseline_perf" ]; then exit 1; fi
 
-  git checkout -- daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+  # undo patch
+  git reset --hard
   git checkout $current >&2
   local current_perf=$(measure)
   if [ "" = "$current_perf" ]; then exit 1; fi


### PR DESCRIPTION
We changed the patch to target more than one file which made the
checkout insufficient for restoring the state and then the following
git checkout of current fails with:

```
error: Your local changes to the following files would be overwritten by checkout:
        stack-snapshot.yaml
```

A git reset --hard should make sure everything gets reset.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
