### PR TITLE
navigator: ignore project parties flag

### DIFF
--- a/ci/cron/perf/compare.sh
+++ b/ci/cron/perf/compare.sh
@@ -22,7 +22,7 @@ main() {
   if [ "" = "$baseline_perf" ]; then exit 1; fi
 
   # undo patch
-  git reset --hard
+  git reset --hard >&2
   git checkout $current >&2
   local current_perf=$(measure)
   if [ "" = "$current_perf" ]; then exit 1; fi

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -422,9 +422,12 @@ runLedgerNavigator flags remainingArguments = do
 
         writeFileUTF8 navigatorConfPath (T.unpack $ navigatorConfig partyDetails)
         unsetEnv "DAML_PROJECT" -- necessary to prevent config contamination
-        withJar damlSdkJar [logbackArg] ("navigator" : navigatorArgs ++ ["-c", confDir </> "ui-backend.conf"]) $ \ph -> do
-            exitCode <- waitExitCode ph
-            exitWith exitCode
+        withJar
+          damlSdkJar
+          [logbackArg]
+          ("navigator" : navigatorArgs ++ ["-c", confDir </> "ui-backend.conf", "--ignoreProjectParties"]) $ \ph -> do
+          exitCode <- waitExitCode ph
+          exitWith exitCode
 
   where
     navigatorConfig :: [L.PartyDetails] -> T.Text

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -411,42 +411,19 @@ runLedgerNavigator flags remainingArguments = do
     logbackArg <- getLogbackArg (damlSdkJarFolder </> "navigator-logback.xml")
     putStrLn $ "Opening navigator at " <> showHostAndPort args
     partyDetails <- listParties args
-
-    withTempDir $ \confDir -> do
-        let navigatorConfPath = confDir </> "ui-backend.conf"
-            navigatorArgs = concat
-                [ ["server"]
-                , [host args, show (port args)]
-                , remainingArguments
-                ]
-
-        writeFileUTF8 navigatorConfPath (T.unpack $ navigatorConfig partyDetails)
-        unsetEnv "DAML_PROJECT" -- necessary to prevent config contamination
-        withJar
-          damlSdkJar
-          [logbackArg]
-          ("navigator" : navigatorArgs ++ ["-c", confDir </> "ui-backend.conf", "--ignoreProjectParties"]) $ \ph -> do
-          exitCode <- waitExitCode ph
-          exitWith exitCode
-
-  where
-    navigatorConfig :: [L.PartyDetails] -> T.Text
-    navigatorConfig partyDetails = T.unlines . concat $
-        [ ["users", "  {"]
-        , [ T.concat
-            [ "    "
-            , T.pack . show $
-                if TL.null displayName
-                    then L.unParty party
-                    else displayName
-            , " { party = "
-            , T.pack (show (L.unParty party))
-            , " }"
+    let navigatorArgs = concat
+            [ ["server"]
+            , [host args, show (port args)]
+            , ["--ignore-project-parties"]
+            , remainingArguments
             ]
-          | L.PartyDetails{..} <- partyDetails
-          ]
-        , ["  }"]
-        ]
+    unsetEnv "DAML_PROJECT" -- necessary to prevent config contamination
+    withJar
+      damlSdkJar
+      [logbackArg]
+      ("navigator" : navigatorArgs) $ \ph -> do
+      exitCode <- waitExitCode ph
+          exitWith exitCode
 
 --
 -- Interface with the Haskell bindings

--- a/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
+++ b/navigator/backend/src/main/scala/com/digitalasset/navigator/config/Arguments.scala
@@ -31,7 +31,8 @@ case class Arguments(
     startConsole: Boolean = false,
     startWebServer: Boolean = false,
     useDatabase: Boolean = false,
-    ledgerInboundMessageSizeMax: Int = 50 * 1024 * 1024 // 50 MiB
+    ledgerInboundMessageSizeMax: Int = 50 * 1024 * 1024, // 50 MiB
+    ignoreProjectParties: Boolean = false
 )
 
 trait ArgumentsHelper { self: OptionParser[Arguments] =>
@@ -153,6 +154,12 @@ object Arguments {
             )
           }
         )
+
+      opt[Unit]("ignoreProjectParties")
+        .hidden()
+        .optional()
+        .text("Ignore the parties specified in the project configuration file and query the ledger for parties instead.")
+        .action((_, arguments) => arguments.copy(ignoreProjectParties = true))
 
       cmd("server")
         .text("serve data from platform")


### PR DESCRIPTION
This adds a flag '--ignoreProjectParties' to navigator such that
parties specified in the daml.yaml file are ignored and the
`PartyManagementService` is queried for parties instead.

This fixes #6099.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
