### PR TITLE
Make auth callback state bounded

### DIFF
--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -168,10 +168,13 @@ da_scala_test(
         "//libs-scala/resources",
         "@maven//:com_auth0_java_jwt",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
+        "@maven//:com_typesafe_akka_akka_http_2_12",
         "@maven//:com_typesafe_akka_akka_http_core_2_12",
+        "@maven//:com_typesafe_akka_akka_http_spray_json_2_12",
         "@maven//:com_typesafe_akka_akka_parsing_2_12",
         "@maven//:com_typesafe_akka_akka_stream_2_12",
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
+        "@maven//:io_spray_spray_json_2_12",
         "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -59,6 +59,7 @@ da_scala_library(
         "//ledger/cli-opts",
         "//ledger/ledger-api-auth",
         "//libs-scala/ports",
+        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_http_2_12",

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -33,7 +33,6 @@ da_scala_library(
     deps = [
         "//daml-lf/data",
         "//language-support/scala/bindings",
-        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_http_2_12",
         "@maven//:com_typesafe_akka_akka_http_core_2_12",
@@ -59,7 +58,6 @@ da_scala_library(
         "//ledger/cli-opts",
         "//ledger/ledger-api-auth",
         "//libs-scala/ports",
-        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_github_scopt_scopt_2_12",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_http_2_12",

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -33,6 +33,7 @@ da_scala_library(
     deps = [
         "//daml-lf/data",
         "//language-support/scala/bindings",
+        "@maven//:com_github_ben_manes_caffeine_caffeine",
         "@maven//:com_typesafe_akka_akka_actor_2_12",
         "@maven//:com_typesafe_akka_akka_http_2_12",
         "@maven//:com_typesafe_akka_akka_http_core_2_12",

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Client.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Client.scala
@@ -28,7 +28,7 @@ import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 
 class Client(config: Client.Config) {
   private val callbacks: Cache[UUID, Response.Login => Route] = Caffeine
@@ -208,7 +208,7 @@ object Client {
       authMiddlewareUri: Uri,
       callbackUri: Uri,
       maxAuthCallbacks: Long,
-      authCallbackTimeout: Duration,
+      authCallbackTimeout: FiniteDuration,
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
   )

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/RequestStore.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/RequestStore.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.auth.middleware.api
+
+import scala.collection.mutable.LinkedHashMap
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * A key-value store with a maximum capacity and maximum storage duration.
+  * @param maxCapacity Maximum number of requests that can be stored.
+  * @param timeout Duration after which requests will be evicted.
+  * @param monotonicClock Determines the current timestamp. The underlying clock must be monotonic.
+  *   The JVM will use a monotonic clock for [[System.nanoTime]], if available, according to
+  *   [[https://bugs.openjdk.java.net/browse/JDK-6458294?focusedCommentId=13823604&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13823604 JDK bug 6458294]]
+  * @tparam K The key type
+  * @tparam V The value type
+  */
+private[middleware] class RequestStore[K, V](
+    maxCapacity: Int,
+    timeout: FiniteDuration,
+    monotonicClock: () => Long = System.nanoTime) {
+
+  /**
+    * Mapping from key to insertion timestamp and value.
+    * The timestamp of later inserted elements must be greater or equal to the timestamp of earlier inserted elements.
+    */
+  private val store: LinkedHashMap[K, (Long, V)] = LinkedHashMap.empty
+
+  /**
+    * Check whether the given [[timestamp]] timed out relative to the current time [[now]].
+    */
+  private def timedOut(now: Long, timestamp: Long): Boolean = {
+    now - timestamp >= timeout.toNanos
+  }
+
+  private def evictTimedOut(now: Long): Unit = {
+    // Remove items until their timestamp is more recent than the configured timeout.
+    store.iterator
+      .takeWhile {
+        case (_, (t, _)) => timedOut(now, t)
+      }
+      .foreach {
+        case (k, _) => store.remove(k)
+      }
+  }
+
+  /**
+    * Insert a new key-value pair unless the maximum capacity is reached.
+    * Evicts timed out elements before attempting insertion.
+    * @return whether the key-value pair was inserted.
+    */
+  def put(key: K, value: => V): Boolean = {
+    synchronized {
+      val now = monotonicClock()
+      evictTimedOut(now)
+      if (store.size >= maxCapacity) {
+        false
+      } else {
+        store.put(key, (now, value))
+        true
+      }
+    }
+  }
+
+  /**
+    * Remove and return the value under the given key, if present and not timed out.
+    */
+  def pop(key: K): Option[V] = {
+    synchronized {
+      store.remove(key).flatMap {
+        case (t, _) if timedOut(monotonicClock(), t) => None
+        case (_, v) => Some(v)
+      }
+    }
+  }
+}

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -29,7 +29,7 @@ case class Config(
 )
 
 object Config {
-  val DefaultMaxLoginRequests: Int = 10000
+  val DefaultMaxLoginRequests: Int = 100
   val DefaultLoginTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
 
   private val Empty =

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -16,7 +16,7 @@ case class Config(
     // The URI to which the OAuth2 server will redirect after a completed login flow.
     // Must map to the `/cb` endpoint of the auth middleware.
     callbackUri: Option[Uri],
-    maxLoginRequests: Long,
+    maxLoginRequests: Int,
     loginTimeout: FiniteDuration,
     // OAuth2 server endpoints
     oauthAuth: Uri,
@@ -29,7 +29,7 @@ case class Config(
 )
 
 object Config {
-  val DefaultMaxLoginRequests: Long = 10000
+  val DefaultMaxLoginRequests: Int = 10000
   val DefaultLoginTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
 
   private val Empty =
@@ -62,10 +62,10 @@ object Config {
         .action((x, c) => c.copy(callbackUri = Some(Uri(x))))
         .text("URI to the auth middleware's callback endpoint `/cb`. By default constructed from the incoming login request.")
 
-      opt[Long]("max-pending-login-requests")
+      opt[Int]("max-pending-login-requests")
         .action((x, c) => c.copy(maxLoginRequests = x))
         .text(
-          "Maximum number of simultaneously pending login requests. Earlier requests will be evicted first when exceeded.")
+          "Maximum number of simultaneously pending login requests. Requests will be denied when exceeded until earlier requests have been completed or timed out.")
 
       opt[Long]("login-request-timeout")
         .action((x, c) => c.copy(loginTimeout = FiniteDuration(x, duration.SECONDS)))

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -7,12 +7,17 @@ import akka.http.scaladsl.model.Uri
 import com.daml.jwt.{JwtVerifierBase, JwtVerifierConfigurationCli}
 import com.daml.ports.Port
 
+import scala.concurrent.duration
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
 case class Config(
     // Port the middleware listens on
     port: Port,
     // The URI to which the OAuth2 server will redirect after a completed login flow.
     // Must map to the `/cb` endpoint of the auth middleware.
     callbackUri: Option[Uri],
+    maxLoginRequests: Long,
+    loginTimeout: Duration,
     // OAuth2 server endpoints
     oauthAuth: Uri,
     oauthToken: Uri,
@@ -24,15 +29,21 @@ case class Config(
 )
 
 object Config {
+  val DefaultMaxLoginRequests: Long = 10000
+  val DefaultLoginTimeout: Duration = FiniteDuration(1, duration.MINUTES)
+
   private val Empty =
     Config(
       port = Port.Dynamic,
       callbackUri = None,
+      maxLoginRequests = DefaultMaxLoginRequests,
+      loginTimeout = DefaultLoginTimeout,
       oauthAuth = null,
       oauthToken = null,
       clientId = null,
       clientSecret = null,
-      tokenVerifier = null)
+      tokenVerifier = null
+    )
 
   def parseConfig(args: Seq[String]): Option[Config] =
     configParser.parse(args, Empty)

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -62,6 +62,15 @@ object Config {
         .action((x, c) => c.copy(callbackUri = Some(Uri(x))))
         .text("URI to the auth middleware's callback endpoint `/cb`. By default constructed from the incoming login request.")
 
+      opt[Long]("max-pending-login-requests")
+        .action((x, c) => c.copy(maxLoginRequests = x))
+        .text(
+          "Maximum number of simultaneously pending login requests. Earlier requests will be evicted first when exceeded.")
+
+      opt[Long]("login-request-timeout")
+        .action((x, c) => c.copy(loginTimeout = FiniteDuration(x, duration.SECONDS)))
+        .text("Login request timeout. Requests will be evicted if the callback endpoint receives no corresponding request in time.")
+
       opt[String]("oauth-auth")
         .action((x, c) => c.copy(oauthAuth = Uri(x)))
         .required()

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -8,7 +8,7 @@ import com.daml.jwt.{JwtVerifierBase, JwtVerifierConfigurationCli}
 import com.daml.ports.Port
 
 import scala.concurrent.duration
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 
 case class Config(
     // Port the middleware listens on
@@ -17,7 +17,7 @@ case class Config(
     // Must map to the `/cb` endpoint of the auth middleware.
     callbackUri: Option[Uri],
     maxLoginRequests: Long,
-    loginTimeout: Duration,
+    loginTimeout: FiniteDuration,
     // OAuth2 server endpoints
     oauthAuth: Uri,
     oauthToken: Uri,
@@ -30,7 +30,7 @@ case class Config(
 
 object Config {
   val DefaultMaxLoginRequests: Long = 10000
-  val DefaultLoginTimeout: Duration = FiniteDuration(1, duration.MINUTES)
+  val DefaultLoginTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
 
   private val Empty =
     Config(

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
@@ -19,12 +19,11 @@ import com.daml.auth.oauth2.api.{Request => OAuthRequest, Response => OAuthRespo
 import com.typesafe.scalalogging.StrictLogging
 import java.util.UUID
 
-import com.daml.auth.middleware.api.{Request, Response}
+import com.daml.auth.middleware.api.{Request, RequestStore, Response}
 import com.daml.jwt.{JwtDecoder, JwtVerifierBase}
 import com.daml.jwt.domain.Jwt
 import com.daml.ledger.api.auth.AuthServiceJWTCodec
 import com.daml.auth.middleware.api.Tagged.{AccessToken, RefreshToken}
-import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
@@ -47,11 +46,8 @@ object Server extends StrictLogging {
 
   def start(
       config: Config)(implicit system: ActorSystem, ec: ExecutionContext): Future[ServerBinding] = {
-    val requests: Cache[UUID, Uri] = Caffeine
-      .newBuilder()
-      .maximumSize(config.maxLoginRequests)
-      .expireAfterWrite(config.loginTimeout.toNanos, java.util.concurrent.TimeUnit.NANOSECONDS)
-      .build()
+    val requests: RequestStore[UUID, Uri] =
+      new RequestStore(config.maxLoginRequests, config.loginTimeout)
     val route = concat(
       path("auth") {
         get {
@@ -129,39 +125,42 @@ object Server extends StrictLogging {
         }
       }
 
-  private def login(config: Config, requests: Cache[UUID, Uri]) =
+  private def login(config: Config, requests: RequestStore[UUID, Uri]) =
     parameters('redirect_uri.as[Uri], 'claims.as[Request.Claims], 'state ?)
       .as[Request.Login](Request.Login) { login =>
         extractRequest { request =>
           val requestId = UUID.randomUUID
-          requests.put(requestId, {
+          val stored = requests.put(requestId, {
             var query = login.redirectUri.query().to[Seq]
             login.state.foreach(x => query ++= Seq("state" -> x))
             login.redirectUri.withQuery(Uri.Query(query: _*))
           })
-          val authorize = OAuthRequest.Authorize(
-            responseType = "code",
-            clientId = config.clientId,
-            redirectUri = toRedirectUri(config, request.uri),
-            // Auth0 will only issue a refresh token if the offline_access claim is present.
-            // TODO[AH] Make the request configurable, see https://github.com/digital-asset/daml/issues/7957
-            scope = Some("offline_access " + login.claims.toQueryString),
-            state = Some(requestId.toString),
-            audience = Some("https://daml.com/ledger-api")
-          )
-          redirect(config.oauthAuth.withQuery(authorize.toQuery), StatusCodes.Found)
+          if (stored) {
+            val authorize = OAuthRequest.Authorize(
+              responseType = "code",
+              clientId = config.clientId,
+              redirectUri = toRedirectUri(config, request.uri),
+              // Auth0 will only issue a refresh token if the offline_access claim is present.
+              // TODO[AH] Make the request configurable, see https://github.com/digital-asset/daml/issues/7957
+              scope = Some("offline_access " + login.claims.toQueryString),
+              state = Some(requestId.toString),
+              audience = Some("https://daml.com/ledger-api")
+            )
+            redirect(config.oauthAuth.withQuery(authorize.toQuery), StatusCodes.Found)
+          } else {
+            complete(StatusCodes.ServiceUnavailable)
+          }
         }
       }
 
-  private def loginCallback(config: Config, requests: Cache[UUID, Uri])(
+  private def loginCallback(config: Config, requests: RequestStore[UUID, Uri])(
       implicit system: ActorSystem,
       ec: ExecutionContext) = {
     def popRequest(optState: Option[String]): Directive1[Uri] = {
       val redirectUri = for {
         state <- optState
         requestId <- Try(UUID.fromString(state)).toOption
-        redirectUri <- Option(requests.getIfPresent(requestId))
-        _ = requests.invalidate(requestId)
+        redirectUri <- requests.pop(requestId)
       } yield redirectUri
       redirectUri match {
         case Some(redirectUri) => provide(redirectUri)

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Test.scala
@@ -136,9 +136,9 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
           Http().singleRequest(req)
         }
       } yield {
-        // Redirect to CALLBACK
+        // Redirect to client callback
         assert(resp.status == StatusCodes.Found)
-        assert(resp.header[Location].get.uri == Uri("http://localhost/CALLBACK"))
+        assert(resp.header[Location].get.uri == middlewareClientCallbackUri)
         // Store token in cookie
         val cookie = resp.header[`Set-Cookie`].get.cookie
         assert(cookie.name == "daml-ledger-token")
@@ -165,10 +165,9 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
           Http().singleRequest(req)
         }
       } yield {
-        // Redirect to CALLBACK
+        // Redirect to client callback
         assert(resp.status == StatusCodes.Found)
-        assert(
-          resp.header[Location].get.uri.withQuery(Uri.Query()) == Uri("http://localhost/CALLBACK"))
+        assert(resp.header[Location].get.uri.withQuery(Uri.Query()) == middlewareClientCallbackUri)
         // with error parameter set
         assert(resp.header[Location].get.uri.query().toMap.get("error") == Some("access_denied"))
         // Without token in cookie
@@ -195,10 +194,9 @@ class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAr
           Http().singleRequest(req)
         }
       } yield {
-        // Redirect to CALLBACK
+        // Redirect to client callback
         assert(resp.status == StatusCodes.Found)
-        assert(
-          resp.header[Location].get.uri.withQuery(Uri.Query()) == Uri("http://localhost/CALLBACK"))
+        assert(resp.header[Location].get.uri.withQuery(Uri.Query()) == middlewareClientCallbackUri)
         // with error parameter set
         assert(resp.header[Location].get.uri.query().toMap.get("error") == Some("access_denied"))
         // Without token in cookie

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Test.scala
@@ -8,7 +8,7 @@ import java.time.Duration
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Cookie, Location, `Set-Cookie`}
-import com.daml.auth.middleware.api.{Client, Request}
+import com.daml.auth.middleware.api.{Client, Request, RequestStore}
 import com.daml.auth.middleware.api.Tagged.{AccessToken, RefreshToken}
 import com.daml.jwt.JwtSigner
 import com.daml.jwt.domain.DecodedJwt
@@ -20,6 +20,7 @@ import com.daml.auth.oauth2.api.{Response => OAuthResponse}
 import org.scalatest.wordspec.AsyncWordSpec
 
 import scala.util.{Failure, Success}
+import scala.concurrent.duration._
 
 class Test extends AsyncWordSpec with TestFixture with SuiteResourceManagementAroundAll {
   private def makeToken(
@@ -380,5 +381,63 @@ class TestLimitedClientCallbackStore
         assert(resultCarol.status == StatusCodes.OK)
       }
     }
+  }
+}
+
+class TestRequestStore extends AsyncWordSpec {
+  "return None on missing element" in {
+    val store = new RequestStore[Int, String](1, 1.day)
+    assert(store.pop(0) == None)
+  }
+
+  "return previously put element" in {
+    val store = new RequestStore[Int, String](1, 1.day)
+    store.put(0, "zero")
+    assert(store.pop(0) == Some("zero"))
+  }
+
+  "return None on previously popped element" in {
+    val store = new RequestStore[Int, String](1, 1.day)
+    store.put(0, "zero")
+    store.pop(0)
+    assert(store.pop(0) == None)
+  }
+
+  "store multiple elements" in {
+    val store = new RequestStore[Int, String](3, 1.day)
+    store.put(0, "zero")
+    store.put(1, "one")
+    store.put(2, "two")
+    assert(store.pop(0) == Some("zero"))
+    assert(store.pop(1) == Some("one"))
+    assert(store.pop(2) == Some("two"))
+  }
+
+  "store no more than max capacity" in {
+    val store = new RequestStore[Int, String](2, 1.day)
+    assert(store.put(0, "zero"))
+    assert(store.put(1, "one"))
+    assert(!store.put(2, "two"))
+    assert(store.pop(0) == Some("zero"))
+    assert(store.pop(1) == Some("one"))
+    assert(store.pop(2) == None)
+  }
+
+  "return None on timed out element" in {
+    var time: Long = 0
+    val store = new RequestStore[Int, String](1, 1.day, () => time)
+    store.put(0, "zero")
+    time += 1.day.toNanos
+    assert(store.pop(0) == None)
+  }
+
+  "free capacity for timed out elements" in {
+    var time: Long = 0
+    val store = new RequestStore[Int, String](1, 1.day, () => time)
+    assert(store.put(0, "zero"))
+    assert(!store.put(1, "one"))
+    time += 1.day.toNanos
+    assert(store.put(2, "two"))
+    assert(store.pop(2) == Some("two"))
   }
 }

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Test.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Test.scala
@@ -280,7 +280,7 @@ class TestCallbackUriOverride
 }
 
 class TestLimitedMiddlewareCallbackStore
-  extends AsyncWordSpec
+    extends AsyncWordSpec
     with TestFixture
     with SuiteResourceManagementAroundAll {
   override protected val maxMiddlewareLogins = 2

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -45,6 +45,7 @@ trait TestFixture
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
   protected val jwtSecret: String = "secret"
+  protected val maxMiddlewareLogins: Long = Config.DefaultMaxLoginRequests
   protected val maxClientAuthCallbacks: Long = 1000
   protected val middlewareCallbackUri: Option[Uri] = None
   lazy protected val clock: AdjustableClock = suiteResource.value.clock
@@ -84,7 +85,7 @@ trait TestFixture
           Config(
             port = Port.Dynamic,
             callbackUri = middlewareCallbackUri,
-            maxLoginRequests = Config.DefaultMaxLoginRequests,
+            maxLoginRequests = maxMiddlewareLogins,
             loginTimeout = Config.DefaultLoginTimeout,
             oauthAuth = serverUri.withPath(Uri.Path./("authorize")),
             oauthToken = serverUri.withPath(Uri.Path./("token")),

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -44,8 +44,8 @@ trait TestFixture
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
   protected val jwtSecret: String = "secret"
-  protected val maxMiddlewareLogins: Long = Config.DefaultMaxLoginRequests
-  protected val maxClientAuthCallbacks: Long = 1000
+  protected val maxMiddlewareLogins: Int = Config.DefaultMaxLoginRequests
+  protected val maxClientAuthCallbacks: Int = 1000
   protected val middlewareCallbackUri: Option[Uri] = None
   lazy protected val clock: AdjustableClock = suiteResource.value.clock
   lazy protected val server: OAuthServer = suiteResource.value.authServer

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -36,6 +36,7 @@ trait TestFixture
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
   protected val jwtSecret: String = "secret"
+  protected val maxAuthCallbacks: Long = 1000
   protected val middlewareCallbackUri: Option[Uri] = None
   lazy protected val clock: AdjustableClock = suiteResource.value._1
   lazy protected val server: OAuthServer = suiteResource.value._2
@@ -49,6 +50,8 @@ trait TestFixture
           middlewareBinding.localAddress.getHostName,
           middlewareBinding.localAddress.getPort),
       callbackUri = Uri("http://localhost/CALLBACK"),
+      maxAuthCallbacks = 1000,
+      authCallbackTimeout = FiniteDuration(1, duration.MINUTES),
       maxHttpEntityUploadSize = 4194304,
       httpEntityUploadTimeout = FiniteDuration(1, duration.MINUTES)
     ))

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -3,6 +3,7 @@
 
 package com.daml.auth.middleware.oauth2
 
+import java.net.InetAddress
 import java.time.{Instant, ZoneId}
 import java.util.Date
 
@@ -29,38 +30,33 @@ import org.scalatest.{BeforeAndAfterEach, Suite}
 import scala.concurrent.duration
 import scala.concurrent.duration.FiniteDuration
 
+case class TestResources(
+    clock: AdjustableClock,
+    authServer: OAuthServer,
+    authServerBinding: ServerBinding,
+    authMiddlewareBinding: ServerBinding,
+    authMiddlewareClient: Client,
+    authMiddlewareClientBinding: ServerBinding)
+
 trait TestFixture
     extends AkkaBeforeAndAfterAll
     with BeforeAndAfterEach
-    with SuiteResource[(AdjustableClock, OAuthServer, ServerBinding, ServerBinding)] {
+    with SuiteResource[TestResources] {
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
   protected val jwtSecret: String = "secret"
   protected val maxAuthCallbacks: Long = 1000
   protected val middlewareCallbackUri: Option[Uri] = None
-  lazy protected val clock: AdjustableClock = suiteResource.value._1
-  lazy protected val server: OAuthServer = suiteResource.value._2
-  lazy protected val serverBinding: ServerBinding = suiteResource.value._3
-  lazy protected val middlewareBinding: ServerBinding = suiteResource.value._4
-  lazy protected val middlewareClient: Client = Client(
-    Client.Config(
-      authMiddlewareUri = Uri()
-        .withScheme("http")
-        .withAuthority(
-          middlewareBinding.localAddress.getHostName,
-          middlewareBinding.localAddress.getPort),
-      callbackUri = Uri("http://localhost/CALLBACK"),
-      maxAuthCallbacks = 1000,
-      authCallbackTimeout = FiniteDuration(1, duration.MINUTES),
-      maxHttpEntityUploadSize = 4194304,
-      httpEntityUploadTimeout = FiniteDuration(1, duration.MINUTES)
-    ))
-  override protected lazy val suiteResource
-    : Resource[(AdjustableClock, OAuthServer, ServerBinding, ServerBinding)] = {
+  lazy protected val clock: AdjustableClock = suiteResource.value.clock
+  lazy protected val server: OAuthServer = suiteResource.value.authServer
+  lazy protected val serverBinding: ServerBinding = suiteResource.value.authServerBinding
+  lazy protected val middlewareBinding: ServerBinding = suiteResource.value.authMiddlewareBinding
+  lazy protected val middlewareClient: Client = suiteResource.value.authMiddlewareClient
+  lazy protected val middlewareClientBinding: ServerBinding =
+    suiteResource.value.authMiddlewareClientBinding
+  override protected lazy val suiteResource: Resource[TestResources] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
-    new OwnedResource[
-      ResourceContext,
-      (AdjustableClock, OAuthServer, ServerBinding, ServerBinding)](
+    new OwnedResource[ResourceContext, TestResources](
       for {
         clock <- Resources.clock(Instant.now(), ZoneId.systemDefault())
         server = OAuthServer(
@@ -93,7 +89,34 @@ trait TestFixture
                 })
             )
           ))
-      } yield { (clock, server, serverBinding, middlewareBinding) }
+        middlewareClientPort <- Resources.port()
+        middlewareClientConfig = Client.Config(
+          authMiddlewareUri = Uri()
+            .withScheme("http")
+            .withAuthority(
+              middlewareBinding.localAddress.getHostName,
+              middlewareBinding.localAddress.getPort),
+          callbackUri = Uri()
+            .withScheme("http")
+            .withAuthority(InetAddress.getLoopbackAddress.getHostName, middlewareClientPort.value)
+            .withPath(Uri.Path./("cb")),
+          maxAuthCallbacks = maxAuthCallbacks,
+          authCallbackTimeout = FiniteDuration(1, duration.MINUTES),
+          maxHttpEntityUploadSize = 4194304,
+          httpEntityUploadTimeout = FiniteDuration(1, duration.MINUTES)
+        )
+        middlewareClient = Client(middlewareClientConfig)
+        middlewareClientBinding <- Resources
+          .authMiddlewareClientBinding(middlewareClientConfig, middlewareClient)
+      } yield
+        TestResources(
+          clock = clock,
+          authServer = server,
+          authServerBinding = serverBinding,
+          authMiddlewareBinding = middlewareBinding,
+          authMiddlewareClient = middlewareClient,
+          authMiddlewareClientBinding = middlewareClientBinding,
+        )
     )
   }
 

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -52,8 +52,16 @@ trait TestFixture
   lazy protected val serverBinding: ServerBinding = suiteResource.value.authServerBinding
   lazy protected val middlewareBinding: ServerBinding = suiteResource.value.authMiddlewareBinding
   lazy protected val middlewareClient: Client = suiteResource.value.authMiddlewareClient
-  lazy protected val middlewareClientBinding: ServerBinding =
+  lazy protected val middlewareClientBinding: ServerBinding = {
     suiteResource.value.authMiddlewareClientBinding
+  }
+  lazy protected val middlewareClientCallbackUri: Uri = {
+    val host = middlewareClientBinding.localAddress
+    Uri()
+      .withScheme("http")
+      .withAuthority(host.getHostName, host.getPort)
+      .withPath(Uri.Path./("cb"))
+  }
   override protected lazy val suiteResource: Resource[TestResources] = {
     implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
     new OwnedResource[ResourceContext, TestResources](
@@ -76,6 +84,8 @@ trait TestFixture
           Config(
             port = Port.Dynamic,
             callbackUri = middlewareCallbackUri,
+            maxLoginRequests = Config.DefaultMaxLoginRequests,
+            loginTimeout = Config.DefaultLoginTimeout,
             oauthAuth = serverUri.withPath(Uri.Path./("authorize")),
             oauthToken = serverUri.withPath(Uri.Path./("token")),
             clientId = "middleware",

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -45,7 +45,7 @@ trait TestFixture
   self: Suite =>
   protected val ledgerId: String = "test-ledger"
   protected val jwtSecret: String = "secret"
-  protected val maxAuthCallbacks: Long = 1000
+  protected val maxClientAuthCallbacks: Long = 1000
   protected val middlewareCallbackUri: Option[Uri] = None
   lazy protected val clock: AdjustableClock = suiteResource.value.clock
   lazy protected val server: OAuthServer = suiteResource.value.authServer
@@ -100,7 +100,7 @@ trait TestFixture
             .withScheme("http")
             .withAuthority(InetAddress.getLoopbackAddress.getHostName, middlewareClientPort.value)
             .withPath(Uri.Path./("cb")),
-          maxAuthCallbacks = maxAuthCallbacks,
+          maxAuthCallbacks = maxClientAuthCallbacks,
           authCallbackTimeout = FiniteDuration(1, duration.MINUTES),
           maxHttpEntityUploadSize = 4194304,
           httpEntityUploadTimeout = FiniteDuration(1, duration.MINUTES)

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -3,7 +3,6 @@
 
 package com.daml.auth.middleware.oauth2
 
-import java.net.InetAddress
 import java.time.{Instant, ZoneId}
 import java.util.Date
 
@@ -60,7 +59,7 @@ trait TestFixture
     val host = middlewareClientBinding.localAddress
     Uri()
       .withScheme("http")
-      .withAuthority(host.getHostName, host.getPort)
+      .withAuthority("localhost", host.getPort)
       .withPath(Uri.Path./("cb"))
   }
   override protected lazy val suiteResource: Resource[TestResources] = {
@@ -109,7 +108,7 @@ trait TestFixture
               middlewareBinding.localAddress.getPort),
           callbackUri = Uri()
             .withScheme("http")
-            .withAuthority(InetAddress.getLoopbackAddress.getHostName, middlewareClientPort.value)
+            .withAuthority("localhost", middlewareClientPort.value)
             .withPath(Uri.Path./("cb")),
           maxAuthCallbacks = maxClientAuthCallbacks,
           authCallbackTimeout = FiniteDuration(1, duration.MINUTES),

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -498,7 +498,7 @@ object Server {
   def apply(
       host: String,
       port: Int,
-      maxAuthCallbacks: Long,
+      maxAuthCallbacks: Int,
       authCallbackTimeout: FiniteDuration,
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -499,7 +499,7 @@ object Server {
       host: String,
       port: Int,
       maxAuthCallbacks: Long,
-      authCallbackTimeout: Duration,
+      authCallbackTimeout: FiniteDuration,
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
       authConfig: AuthConfig,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -498,6 +498,8 @@ object Server {
   def apply(
       host: String,
       port: Int,
+      maxAuthCallbacks: Long,
+      authCallbackTimeout: Duration,
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
       authConfig: AuthConfig,
@@ -527,8 +529,8 @@ object Server {
             callbackUri = authCallback.getOrElse {
               Uri().withScheme("http").withAuthority(host, port).withPath(Path./("cb"))
             },
-            maxAuthCallbacks = 1000,
-            authCallbackTimeout = 1.minute,
+            maxAuthCallbacks = maxAuthCallbacks,
+            authCallbackTimeout = authCallbackTimeout,
             maxHttpEntityUploadSize = maxHttpEntityUploadSize,
             httpEntityUploadTimeout = httpEntityUploadTimeout,
           )))

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -527,6 +527,8 @@ object Server {
             callbackUri = authCallback.getOrElse {
               Uri().withScheme("http").withAuthority(host, port).withPath(Path./("cb"))
             },
+            maxAuthCallbacks = 1000,
+            authCallbackTimeout = 1.minute,
             maxHttpEntityUploadSize = maxHttpEntityUploadSize,
             httpEntityUploadTimeout = httpEntityUploadTimeout,
           )))

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -129,7 +129,6 @@ private[trigger] object ServiceConfig {
     opt[String]("auth-callback")
       .optional()
       .action((t, c) => c.copy(authCallbackUri = Some(Uri(t))))
-      .text("Auth middleware URI.")
       .text("URI to the auth login flow callback endpoint `/cb`. By default constructed from the incoming login request.")
       // TODO[AH] Expose once the auth feature is fully implemented.
       .hidden()

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -12,7 +12,7 @@ import com.daml.platform.services.time.TimeProviderType
 import scalaz.Show
 
 import scala.concurrent.duration
-import scala.concurrent.duration.{Duration => ScalaDuration, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 
 private[trigger] final case class ServiceConfig(
     // For convenience, we allow passing DARs on startup
@@ -28,7 +28,7 @@ private[trigger] final case class ServiceConfig(
     minRestartInterval: FiniteDuration,
     maxRestartInterval: FiniteDuration,
     maxAuthCallbacks: Long,
-    authCallbackTimeout: ScalaDuration,
+    authCallbackTimeout: FiniteDuration,
     maxHttpEntityUploadSize: Long,
     httpEntityUploadTimeout: FiniteDuration,
     timeProviderType: TimeProviderType,
@@ -88,7 +88,7 @@ private[trigger] object ServiceConfig {
   val DefaultMaxRestartInterval: FiniteDuration = FiniteDuration(60, duration.SECONDS)
   // Adds up to ~1GB with DefaultMaxInboundMessagesSize
   val DefaultMaxAuthCallbacks: Long = 250
-  val DefaultAuthCallbackTimeout: ScalaDuration = FiniteDuration(1, duration.MINUTES)
+  val DefaultAuthCallbackTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
   val DefaultMaxHttpEntityUploadSize: Long = RunnerConfig.DefaultMaxInboundMessageSize.toLong
   val DefaultHttpEntityUploadTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
 

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -27,7 +27,7 @@ private[trigger] final case class ServiceConfig(
     maxInboundMessageSize: Int,
     minRestartInterval: FiniteDuration,
     maxRestartInterval: FiniteDuration,
-    maxAuthCallbacks: Long,
+    maxAuthCallbacks: Int,
     authCallbackTimeout: FiniteDuration,
     maxHttpEntityUploadSize: Long,
     httpEntityUploadTimeout: FiniteDuration,
@@ -87,7 +87,7 @@ private[trigger] object ServiceConfig {
   private val DefaultMinRestartInterval: FiniteDuration = FiniteDuration(5, duration.SECONDS)
   val DefaultMaxRestartInterval: FiniteDuration = FiniteDuration(60, duration.SECONDS)
   // Adds up to ~1GB with DefaultMaxInboundMessagesSize
-  val DefaultMaxAuthCallbacks: Long = 250
+  val DefaultMaxAuthCallbacks: Int = 250
   val DefaultAuthCallbackTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
   val DefaultMaxHttpEntityUploadSize: Long = RunnerConfig.DefaultMaxInboundMessageSize.toLong
   val DefaultHttpEntityUploadTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
@@ -151,7 +151,7 @@ private[trigger] object ServiceConfig {
       .text(
         s"Maximum time interval between restarting a failed trigger. Defaults to ${DefaultMaxRestartInterval.toSeconds} seconds.")
 
-    opt[Long]("max-pending-authorizations")
+    opt[Int]("max-pending-authorizations")
       .action((x, c) => c.copy(maxAuthCallbacks = x))
       .optional()
       .text(

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -36,6 +36,8 @@ object ServiceMain {
   def startServer(
       host: String,
       port: Int,
+      maxAuthCallbacks: Long,
+      authCallbackTimeout: Duration,
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
       authConfig: AuthConfig,
@@ -52,6 +54,8 @@ object ServiceMain {
         Server(
           host,
           port,
+          maxAuthCallbacks,
+          authCallbackTimeout,
           maxHttpEntityUploadSize,
           httpEntityUploadTimeout,
           authConfig,
@@ -126,6 +130,8 @@ object ServiceMain {
             Server(
               config.address,
               config.httpPort,
+              config.maxAuthCallbacks,
+              config.authCallbackTimeout,
               config.maxHttpEntityUploadSize,
               config.httpEntityUploadTimeout,
               authConfig,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -36,7 +36,7 @@ object ServiceMain {
   def startServer(
       host: String,
       port: Int,
-      maxAuthCallbacks: Long,
+      maxAuthCallbacks: Int,
       authCallbackTimeout: FiniteDuration,
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -37,7 +37,7 @@ object ServiceMain {
       host: String,
       port: Int,
       maxAuthCallbacks: Long,
-      authCallbackTimeout: Duration,
+      authCallbackTimeout: FiniteDuration,
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
       authConfig: AuthConfig,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -213,6 +213,8 @@ trait AuthMiddlewareFixture
           middlewareConfig = MiddlewareConfig(
             port = Port.Dynamic,
             callbackUri = None,
+            maxLoginRequests = MiddlewareConfig.DefaultMaxLoginRequests,
+            loginTimeout = MiddlewareConfig.DefaultLoginTimeout,
             oauthAuth = uri.withPath(Path./("authorize")),
             oauthToken = uri.withPath(Path./("token")),
             clientId = "oauth-middleware-id",
@@ -460,6 +462,8 @@ trait TriggerServiceFixture
               r <- ServiceMain.startServer(
                 host.getHostName,
                 lock.port.value,
+                ServiceConfig.DefaultMaxAuthCallbacks,
+                ServiceConfig.DefaultAuthCallbackTimeout,
                 ServiceConfig.DefaultMaxHttpEntityUploadSize,
                 ServiceConfig.DefaultHttpEntityUploadTimeout,
                 authConfig,


### PR DESCRIPTION
Closes #7721 

- Uses a caffeine LRU cache as bounded storage rather than an unbounded `TrieMap` for pending login requests on the middleware and pending authorized requests on the trigger service.
- Adds tests that earlier requests are dropped when the bound is exceeded on both the auth middleware itself and the middleware client (i.e. trigger service).
- Makes these bounds configurable via CLI options on the auth middleware and trigger service.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/master/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
