### PR TITLE
Fix queryContractKey for complex keys over gRPC

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -33,7 +33,7 @@ import com.daml.lf.data.Time
 import com.daml.lf.iface.{EnvironmentInterface, InterfaceType}
 import com.daml.lf.language.Ast._
 import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
-import com.daml.lf.speedy.{ScenarioRunner, TraceLog}
+import com.daml.lf.speedy.{ScenarioRunner, TraceLog, svalue}
 import com.daml.lf.speedy.Speedy.{Machine, OffLedger, OnLedger}
 import com.daml.lf.speedy.{PartialTransaction, SValue}
 import com.daml.lf.speedy.SError._
@@ -108,7 +108,11 @@ trait ScriptLedgerClient {
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]]
 
-  def queryContractKey(parties: OneAnd[Set, Ref.Party], templateId: Identifier, key: SValue)(
+  def queryContractKey(
+      parties: OneAnd[Set, Ref.Party],
+      templateId: Identifier,
+      key: SValue,
+      translateKey: (Identifier, Value[ContractId]) => Either[String, SValue])(
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]]
 
@@ -170,15 +174,15 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
   private def queryWithKey(parties: OneAnd[Set, Ref.Party], templateId: Identifier)(
       implicit ec: ExecutionContext,
       mat: Materializer)
-    : Future[Seq[(ScriptLedgerClient.ActiveContract, Option[Value[ContractId]])]] = {
+    : Future[Vector[(ScriptLedgerClient.ActiveContract, Option[Value[ContractId]])]] = {
     val filter = transactionFilter(parties, templateId)
     val acsResponses =
       grpcClient.activeContractSetClient
         .getActiveContracts(filter, verbose = false)
         .runWith(Sink.seq)
     acsResponses.map(acsPages =>
-      acsPages.flatMap(page =>
-        page.activeContracts.map(createdEvent => {
+      acsPages.toVector.flatMap(page =>
+        page.activeContracts.toVector.map(createdEvent => {
           val argument = ValueValidator.validateRecord(createdEvent.getCreateArguments) match {
             case Left(err) => throw new ConverterException(err.toString)
             case Right(argument) => argument
@@ -217,14 +221,28 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
   override def queryContractKey(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
-      key: SValue)(
+      key: SValue,
+      translateKey: (Identifier, Value[ContractId]) => Either[String, SValue])(
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]] = {
     // We cannot do better than a linear search over query here.
+    import scalaz.syntax.traverse._
+    import scalaz.std.vector._
+    import scalaz.std.option._
+    import scalaz.std.scalaFuture._
     for {
       activeContracts <- queryWithKey(parties, templateId)
+      speedyContracts <- activeContracts.traverse {
+        case (t, kOpt) =>
+          Converter.toFuture(kOpt.traverse(translateKey(templateId, _)).map(k => (t, k)))
+      }
     } yield {
-      activeContracts.collectFirst({ case (c, Some(k)) if k === key.toValue => c })
+      // Note that the Equal instance on Value performs structural equality
+      // and also compares optional field and constructor names and is
+      // therefore not correct here.
+      // Equality.areEqual corresponds to the DAML-LF value equality
+      // which we want here.
+      speedyContracts.collectFirst({ case (c, Some(k)) if svalue.Equality.areEqual(k, key) => c })
     }
   }
 
@@ -459,7 +477,8 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
   override def queryContractKey(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
-      key: SValue)(
+      key: SValue,
+      translateKey: (Identifier, Value[ContractId]) => Either[String, SValue])(
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]] = {
     GlobalKey
@@ -788,7 +807,10 @@ class JsonLedgerClient(
   override def queryContractKey(
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
-      key: SValue)(implicit ec: ExecutionContext, mat: Materializer) = {
+      key: SValue,
+      translateKey: (Identifier, Value[ContractId]) => Either[String, SValue])(
+      implicit ec: ExecutionContext,
+      mat: Materializer) = {
     for {
       _ <- validateTokenParties(parties, "queryContractKey")
       fetchResponse <- requestSuccess[FetchKeyArgs, FetchResponse](

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -478,7 +478,8 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       parties: OneAnd[Set, Ref.Party],
       templateId: Identifier,
       key: SValue,
-      translateKey: (Identifier, Value[ContractId]) => Either[String, SValue])(
+      translateKey: (Identifier, Value[ContractId]) => Either[String, SValue],
+  )(
       implicit ec: ExecutionContext,
       mat: Materializer): Future[Option[ScriptLedgerClient.ActiveContract]] = {
     GlobalKey

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -48,6 +48,7 @@ import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.LedgerClientConfiguration
 import ParticipantsJsonProtocol.ContractIdFormat
 import com.daml.lf.language.LanguageVersion
+import com.daml.lf.value.Value
 import com.daml.script.converter.Converter.{JavaList, toContractId, unrollFree}
 import com.daml.script.converter.ConverterException
 
@@ -397,7 +398,27 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
         .toRight(s"Failed to find choice $choice in $id")
     } yield choice.returnType
 
+  private def lookupKeyTy(id: Identifier): Either[String, Type] =
+    for {
+      pkg <- compiledPackages
+        .getSignature(id.packageId)
+        .toRight(s"Failed to find package ${id.packageId}")
+      module <- pkg.modules
+        .get(id.qualifiedName.module)
+        .toRight(s"Failed to find module ${id.qualifiedName.module}")
+      tpl <- module.templates
+        .get(id.qualifiedName.name)
+        .toRight(s"Failed to find template ${id.qualifiedName.name}")
+      key <- tpl.key.toRight(s"Template ${id} does not have a contract key")
+    } yield key.typ
+
   private val valueTranslator = new preprocessing.ValueTranslator(extendedCompiledPackages)
+
+  private def translateKey(id: Identifier, v: Value[ContractId]): Either[String, SValue] =
+    for {
+      keyTy <- lookupKeyTy(id)
+      translated <- valueTranslator.translateValue(keyTy, v).left.map(_.msg)
+    } yield translated
 
   // Maps GHC unit ids to LF package ids. Used for location conversion.
   private val knownPackages: Map[String, PackageId] = (for {
@@ -688,7 +709,7 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
                       tplId <- Converter.toFuture(Converter.typeRepToIdentifier(sTplId))
                       key <- Converter.toFuture(Converter.toAnyContractKey(sKey))
                       client <- Converter.toFuture(clients.getPartiesParticipant(parties))
-                      optR <- client.queryContractKey(parties, tplId, key.key)
+                      optR <- client.queryContractKey(parties, tplId, key.key, translateKey)
                       optR <- Converter.toFuture(
                         optR.traverse(Converter.fromCreated(valueTranslator, _)))
                       v <- run(SEApp(SEValue(continue), Array(SEValue(SOptional(optR)))))

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -62,6 +62,7 @@ ScriptTest:testQueryContractKey SUCCESS
 ScriptTest:testSetTime SUCCESS
 ScriptTest:testStack SUCCESS
 ScriptTest:traceOrder SUCCESS
+ScriptTest:tupleKey SUCCESS
 EOF
 )"
 

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -70,6 +70,16 @@ template WithKey
       controller p
       do pure self
 
+template TTupleKey
+  with
+    p1 : Party
+    p2 : Party
+  where
+    signatory p1
+    observer p2
+    key (p1, p2) : (Party, Party)
+    maintainer key._1
+
 test0 : Script (Party, Party, [T], [TProposal], [C])
 test0 = do
   alice <- allocateParty "alice"
@@ -348,6 +358,15 @@ multiPartySubmission = do
   single <- submitMulti [p1] [] (createCmd (MultiPartyContract [p1]))
   submitMultiMustFail [p2] [] (exerciseCmd shared (MPFetchOther single p2))
   submitMulti [p2] [p1] (exerciseCmd shared (MPFetchOther single p2))
+  pure ()
+
+tupleKey : Script ()
+tupleKey = do
+  p1 <- allocateParty "p1"
+  p2 <- allocateParty "p2"
+  cid <- submit p1 (createCmd (TTupleKey p1 p2))
+  r <- queryContractKey @TTupleKey p1 (p1, p2)
+  r === Some (cid, TTupleKey p1 p2)
   pure ()
 
 -- Create a contract only visible to one party to test readAs

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -316,5 +316,17 @@ abstract class AbstractFuncIT
         assert(v == SUnit)
       }
     }
+    "tuple key" in {
+      for {
+        clients <- participantClients()
+        v <- run(
+          clients,
+          QualifiedName.assertFromString("ScriptTest:tupleKey"),
+          dar = stableDar
+        )
+      } yield {
+        assert(v == SUnit)
+      }
+    }
   }
 }


### PR DESCRIPTION
Unfortunately the Equal instance of Value only performs structural
equality which includes optional field names and constructor
names. While we could try to ensure that they are always present or
always absent, the more reliable solution seems to be to not rely on
this at all and instead use the equality on SValues which is
explicitly designed for this.

changelog_begin

- [DAML Script] Fix a bug where queryContractKey incorrectly returned
  None despite their being an active contract with the given key. This
  only affected DAML Script over gRPC.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
