### PR TITLE
ci: pin down Ubuntu versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -276,7 +276,7 @@ jobs:
 - job: compat_versions_pr_trigger_daily
   dependsOn: compat_versions_pr
   pool:
-    vmImage: "ubuntu-latest"
+    vmImage: "ubuntu-18.04"
   variables:
     branch: $[ dependencies.compat_versions_pr.outputs['out.branch'] ]
   steps:

--- a/ci/cron/tuesday.yml
+++ b/ci/cron/tuesday.yml
@@ -16,7 +16,7 @@ jobs:
 - job: announce_rotation
   timeoutInMinutes: 60
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-18.04
   steps:
   - checkout: self
     persistCredentials: true

--- a/ci/cron/wednesday.yml
+++ b/ci/cron/wednesday.yml
@@ -16,7 +16,7 @@ jobs:
 - job: open_release_pr
   timeoutInMinutes: 60
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-18.04
   steps:
   - checkout: self
     persistCredentials: true


### PR DESCRIPTION
For a couple weeks now there has been a warning on the Azure Pipelines web UI that says `ubuntu-latest` is in the process of switching from 18.04 to 20.04. I am not aware of any specific issue this would cause for our particular workflows, but I don't like my dependencies changing from under me.

CHANGELOG_BEGIN
CHANGELOG_END