### PR TITLE
assistant: get the latest sdk version form docs.daml.com

### DIFF
--- a/daml-assistant/BUILD.bazel
+++ b/daml-assistant/BUILD.bazel
@@ -44,6 +44,7 @@ da_haskell_library(
         "http-client",
         "http-client-tls",
         "http-conduit",
+        "http-types",
         "lens",
         "optparse-applicative",
         "process",

--- a/daml-assistant/get-daml.sh
+++ b/daml-assistant/get-daml.sh
@@ -80,7 +80,7 @@ fi
 #
 if [ -z "${1:-}" ] ; then
   echo "Determining latest SDK version..."
-  readonly VERSION="$(curl -sS https://github.com/digital-asset/daml/releases/latest | sed 's/^.*github.com\/digital-asset\/daml\/releases\/tag\/v//' | sed 's/".*$//')"
+  readonly VERSION="$(curl -sS https://docs.daml.com/latest)"
   if [ -z "$VERSION" ] ; then
     echo "Failed to determine latest SDK version."
     exit 1

--- a/daml-assistant/src/DA/Daml/Assistant/Install.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install.hs
@@ -8,7 +8,6 @@ module DA.Daml.Assistant.Install
     , InstallURL (..)
     , InstallEnv (..)
     , versionInstall
-    , getLatestVersion
     , install
     , uninstallVersion
     , pattern RawInstallTarget_Project
@@ -20,7 +19,7 @@ import DA.Daml.Assistant.Util
 import qualified DA.Daml.Assistant.Install.Github as Github
 import DA.Daml.Assistant.Install.Path
 import DA.Daml.Assistant.Install.Completion
-import DA.Daml.Assistant.Version (getLatestSdkSnapshotVersion)
+import DA.Daml.Assistant.Version (getLatestSdkSnapshotVersion, getLatestReleaseVersion)
 import DA.Daml.Project.Consts
 import DA.Daml.Project.Config
 import Safe
@@ -372,16 +371,12 @@ versionInstall env@InstallEnv{..} version = do
 -- | Install the latest version of the SDK.
 latestInstall :: InstallEnv -> IO ()
 latestInstall env@InstallEnv{..} = do
-    version1 <- getLatestVersion
+    version1 <- getLatestReleaseVersion
     version2M <- if iSnapshots options
         then getLatestSdkSnapshotVersion
         else pure Nothing
     let version = maybe version1 (max version1) version2M
     versionInstall env version
-
--- | Get the latest stable version.
-getLatestVersion :: IO SdkVersion
-getLatestVersion = Github.getLatestVersion
 
 -- | Install the SDK version of the current project.
 projectInstall :: InstallEnv -> ProjectPath -> IO ()

--- a/daml-assistant/src/DA/Daml/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/Github.hs
@@ -5,20 +5,15 @@
 -- | Discover releases from the digital-asset/daml github.
 module DA.Daml.Assistant.Install.Github
     ( versionURL
-    , getLatestVersion
+    , tagToVersion
     ) where
 
 import DA.Daml.Assistant.Types
-import DA.Daml.Assistant.Util
 import Data.Aeson
-import Network.HTTP.Client
-import Network.HTTP.Client.TLS
 import Control.Exception.Safe
-import Control.Monad
 import Data.Either.Extra
 import qualified System.Info
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 
 -- | General git tag. We only care about the tags of the form "v<VERSION>"
 -- where <VERSION> is an SDK version. For example, "v0.11.1".
@@ -41,37 +36,6 @@ tagToVersion (Tag t) =
             mapLeft (pack . displayException) $ parseVersion (T.drop 1 t)
         else
             Left "Tag must start with v followed by semantic version."
-
--- | Get the version of the latest stable (i.e. non-prerelease) release.
--- We avoid the Github API because of very low rate limits. As such, we
--- discover the latest version by parsing an HTTP redirect. We make a
--- request to:
---
---     https://github.com/digital-asset/daml/releases/latest
---
--- Which always redirects to the latest stable release, for example:
---
---     https://github.com/digital-asset/daml/releases/tag/v0.12.3
---
--- So we take that URL to get the tag, and from there the version of
--- the latest stable release.
-getLatestVersion :: IO SdkVersion
-getLatestVersion = requiredAny "Failed to get latest SDK version from Github." $ do
-    manager <- newTlsManager
-    request <- parseRequest "HEAD https://github.com/digital-asset/daml/releases/latest"
-    finalRequest <- withResponseHistory request manager $ pure . hrFinalRequest
-
-    let pathText = T.decodeUtf8 (path finalRequest)
-        (parent, tag) = T.breakOnEnd "/" pathText
-        prefix = "/digital-asset/daml/releases/tag/"
-
-    when (parent /= prefix) $ do
-        throwIO $ assistantErrorBecause
-            "Failed to get latest SDK version from GitHub."
-            ("Unexpected final HTTP redirect location.\n    Expected: " <> prefix <> "TAG\n    Got: " <> pathText)
-
-    fromRightM throwIO (tagToVersion (Tag tag))
-
 
 -- | OS-specific part of the asset name.
 osName :: Text

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -203,7 +203,7 @@ getLatestReleaseVersion = do
         case responseStatus resp of
             s | s == ok200 -> do
                     body <- responseBody resp
-                    case (parseVersion $ decodeUtf8 body) of
+                    case parseVersion $ decodeUtf8 body of
                         Right v -> pure v
                         Left invalidVersion ->
                             throwIO $

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -14,6 +14,7 @@ module DA.Daml.Assistant.Version
     , getLatestSdkVersionCached
     , getAvailableSdkSnapshotVersions
     , getLatestSdkSnapshotVersion
+    , getLatestReleaseVersion
     ) where
 
 import DA.Daml.Assistant.Types
@@ -30,9 +31,18 @@ import Data.Maybe
 import Data.List
 import Data.Either.Extra
 import Data.Aeson (eitherDecodeStrict')
+import Data.Text.Encoding
 import Safe
 import Network.HTTP.Simple
-import Network.HTTP.Client (Request(responseTimeout), responseTimeoutMicro)
+import Network.HTTP.Client
+    ( Request(responseTimeout)
+    , responseBody
+    , responseStatus
+    , responseTimeoutMicro
+    )
+import qualified Network.HTTP.Client as Http
+import Network.HTTP.Types (ok200)
+import Network.HTTP.Client.TLS (newTlsManager)
 
 import qualified Data.HashMap.Strict as M
 
@@ -181,3 +191,28 @@ getLatestSdkSnapshotVersion = do
     pure $ do
         versions <- eitherToMaybe versionsE
         maximumMay versions
+
+latestReleaseVersionUrl :: String
+latestReleaseVersionUrl = "https://docs.daml.com/latest"
+
+getLatestReleaseVersion :: IO SdkVersion
+getLatestReleaseVersion = do
+    manager <- newTlsManager
+    request <- parseRequest latestReleaseVersionUrl
+    Http.withResponse request manager $ \resp -> do
+        case responseStatus resp of
+            s | s == ok200 -> do
+                    body <- responseBody resp
+                    case (parseVersion $ decodeUtf8 body) of
+                        Right v -> pure v
+                        Left invalidVersion ->
+                            throwIO $
+                            assistantErrorBecause
+                                (pack $
+                                 "Failed to parse SDK version from " <> latestReleaseVersionUrl)
+                                (pack $ ivMessage invalidVersion)
+            otherStatus ->
+                throwIO $
+                assistantErrorBecause
+                    (pack $ "Bad response status code when requesting " <> latestReleaseVersionUrl)
+                    (pack $ show otherStatus)


### PR DESCRIPTION
We get the latest sdk version from docs.daml.com/latest instead of
github.com. Getting the latest release from github proved to be tricky,
because github defines 'latest' by timestamps.

This fixes #8354.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
