### PR TITLE
Cut down data-dependencies test.

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -11,6 +11,7 @@ import qualified DA.Daml.LF.Proto3.Archive as LFArchive
 import DA.Test.Process
 import DA.Test.Util
 import qualified Data.ByteString.Lazy as BSL
+import Data.List (sort)
 import qualified Data.NameMap as NM
 import Module (unitIdString)
 import System.Directory.Extra

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -59,6 +59,12 @@ numStablePackages ver
   | ver == LF.versionDev = 16
   | otherwise = error $ "Unsupported LF version: " <> show ver
 
+-- | Sequential LF version pairs, with an additional (1.dev, 1.dev) pair at the end.
+sequentialVersionPairs :: [(LF.Version, LF.Version)]
+sequentialVersionPairs =
+    let versions = sort LF.supportedOutputVersions ++ [LF.versionDev]
+    in zip versions (tail versions)
+
 tests :: Tools -> TestTree
 tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependencies" $
     [ testCaseSteps ("Cross DAML-LF version: " <> LF.renderVersion depLfVer <> " -> " <> LF.renderVersion targetLfVer)  $ \step -> withTempDir $ \tmpDir -> do
@@ -136,9 +142,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
               (numStablePackages targetLfVer - numStablePackages depLfVer) + -- new stable packages
               1 + -- projb
               (if targetLfVer /= depLfVer then 2 else 0) -- different daml-stdlib/daml-prim
-    | depLfVer <- LF.supportedOutputVersions
-    , targetLfVer <- LF.supportedOutputVersions
-    , targetLfVer >= depLfVer
+    | (depLfVer, targetLfVer) <- sequentialVersionPairs
     ] <>
     [ testCaseSteps "Cross-SDK dependency on DAVL" $ \step -> withTempDir $ \tmpDir -> do
           step "Building DAR"
@@ -609,9 +613,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
             ]
           validate $ projb </> "projb.dar"
 
-    | depLfVer <- LF.supportedOutputVersions
-    , targetLfVer <- LF.supportedOutputVersions
-    , targetLfVer >= depLfVer
+    | (depLfVer, targetLfVer) <- sequentialVersionPairs
     , LF.supports depLfVer LF.featureTypeSynonyms -- only test for new-style typeclasses
     ] <>
     [ testCase "Cross-SDK typeclasses" $ withTempDir $ \tmpDir -> do


### PR DESCRIPTION
This PR reduces the data-dependencies test from quadratic to linear in the number of LF versions. It does so by only testing sequential version pairs, e.g. 1.6 to 1.7, 1.7 to 1.8, 1.8 to 1.11, 1.11 to 1.dev, and 1.dev to 1.dev, instead of all possible combinations. These pairs covers almost all potential problems.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
