### PR TITLE
Fix variance of choice key type in ledger.(createAnd)exercise

### DIFF
--- a/language-support/ts/codegen/tests/ts/build-and-lint-test/src/index.ts
+++ b/language-support/ts/codegen/tests/ts/build-and-lint-test/src/index.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import Ledger from  '@daml/ledger';
+import { ContractId, Party, Template, Choice } from '@daml/types';
+
+// Regression test for #8338, we only care that this compiles.
+
+const ledger = new Ledger({token: ""});
+
+type X = {p: Party};
+
+type Archive = {};
+
+// Note that the codegen will generate only X with the type intersected with Y.
+// However, due to what looks like a typescript bug that does not trigger the
+// error in TS 3.8. It does however, trigger the error in TS >= 3.9.
+// To make sure we hit this, we separate them here.
+const X: Template<X, undefined, 'pkg-id:M:X'> = undefined!;
+
+const Y: {
+  Archive: Choice<X, Archive, {}, undefined>;
+} = undefined!;
+
+const cid: ContractId<X> = undefined!;
+
+export const f = async () => {
+      await ledger.exercise(Y.Archive, cid, {});
+      await ledger.createAndExercise(Y.Archive, {p: "Alice"}, {});
+}
+

--- a/language-support/ts/daml-ledger/index.ts
+++ b/language-support/ts/daml-ledger/index.ts
@@ -473,7 +473,7 @@ class Ledger {
    * @returns The return value of the choice together with a list of
    * [[event]]'s that were created as a result of exercising the choice.
    */
-  async exercise<T extends object, C, R>(choice: Choice<T, C, R>, contractId: ContractId<T>, argument: C): Promise<[R , Event<object>[]]> {
+  async exercise<T extends object, C, R, K>(choice: Choice<T, C, R, K>, contractId: ContractId<T>, argument: C): Promise<[R , Event<object>[]]> {
     const payload = {
       templateId: choice.template().templateId,
       contractId: ContractId(choice.template()).encode(contractId),
@@ -508,7 +508,7 @@ class Ledger {
    * is consuming (or otherwise archives it as part of its execution).
    *
    */
-  async createAndExercise<T extends object, C, R>(choice: Choice<T, C, R>, payload: T, argument: C): Promise<[R, Event<object>[]]> {
+  async createAndExercise<T extends object, C, R, K>(choice: Choice<T, C, R, K>, payload: T, argument: C): Promise<[R, Event<object>[]]> {
     const command = {
       templateId: choice.template().templateId,
       payload: choice.template().encode(payload),


### PR DESCRIPTION
Fixes #8338

This is a bit of a weird one. The basic issue is fairly clear. We have
code which looks something like:

```
interface MyTemplate<K> {
  keyEncode: (k: K) => unknown;
  keyDecoder: () => K;
}

interface MyChoice<K = unknown> {
  template: () => MyTemplate<K>;
}

function exercise(c: MyChoice) {
  console.log(c);
}

const y = (x : MyChoice<undefined>) => {
  exercise(x);
}
```

The key type is invariant here since it occurs in both covariant and
contravariant positions. We compile in strict mode so this is a
typescript error. This fails in all typescript versions I tested
including 3.8 which we use in our tests. So why don’t the tests fail?

Afaict, this is because the template constant is defined as an
intersection of the template type and the choices available on the
template. In TypeScript 3.8, this seems to (mostly, we’ll get to a
bit) hide this error. In TypeScript 3.9 and later, you hit it. There
is something in the release notes about intersection types but only
about optional properties which don’t seem to be required
here. Nevertheless, it is definitely related to the typescript
version.

So there are two more weird things about TypeScript 3.8:

1. Sometimes you get the error in the IDE but not in `npm start` and
   `npm run build`. Afaict, this is caused by the VSCode plugin being
   based on a different TypeScript version, e.g., mine was at 4.1.2 so
   this seems to match up with the 3.9 hypothesis.

2. In some cases (not all afaict), the issue shows up in `npm start`
   but only intermittendly. As described in #8338, it goes away after
   a restart. I have no idea what is going on here. something
   something incremental builds are hard :shrug: I’ve spent way too
   much time trying to figure it out but since the underlying issue
   seems clear, I gave up at some point.

changelog_begin

- [JS Client Libraries] Fix a bug where in some cases calls to
  `exercise` and `createAndExercise` failed to typecheck with a mismatch
  in the key type.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
