### PR TITLE
kvutils: Wrap raw key and value bytestrings in types.

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -16,7 +16,6 @@ import com.daml.ledger.participant.state.kvutils.export.LedgerDataExporter
 import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.{LedgerId, Offset, ParticipantId, SubmissionResult}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.batch.{
   BatchedSubmissionValidator,
   BatchedSubmissionValidatorFactory,
@@ -267,7 +266,7 @@ object InMemoryLedgerReaderWriter {
   private def transformStateReader(
       keySerializationStrategy: StateKeySerializationStrategy,
       cache: Cache[DamlStateKey, DamlStateValue]
-  )(stateReader: StateReader[Key, Option[Value]])
+  )(stateReader: StateReader[Raw.Key, Option[Raw.Value]])
     : StateReader[DamlStateKey, Option[DamlStateValue]] = {
     CachingStateReader(
       cache,

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.api.health.{HealthStatus, Healthy}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.api._
 import com.daml.ledger.participant.state.kvutils.export.LedgerDataExporter
-import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.participant.state.v1.{LedgerId, Offset, ParticipantId, SubmissionResult}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.ledger.validator.batch.{
@@ -25,7 +25,7 @@ import com.daml.ledger.validator.batch.{
 import com.daml.ledger.validator.caching.{CachingStateReader, ImmutablesOnlyCacheUpdatePolicy}
 import com.daml.ledger.validator.preexecution._
 import com.daml.ledger.validator.reading.{DamlLedgerStateReader, LedgerStateReader}
-import com.daml.ledger.validator.{Raw, StateKeySerializationStrategy, ValidateAndCommit}
+import com.daml.ledger.validator.{StateKeySerializationStrategy, ValidateAndCommit}
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.api.health.{HealthStatus, Healthy}
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.api._
 import com.daml.ledger.participant.state.kvutils.export.LedgerDataExporter
-import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.{LedgerId, Offset, ParticipantId, SubmissionResult}
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
@@ -26,7 +26,7 @@ import com.daml.ledger.validator.batch.{
 import com.daml.ledger.validator.caching.{CachingStateReader, ImmutablesOnlyCacheUpdatePolicy}
 import com.daml.ledger.validator.preexecution._
 import com.daml.ledger.validator.reading.StateReader
-import com.daml.ledger.validator.{StateKeySerializationStrategy, ValidateAndCommit}
+import com.daml.ledger.validator.{Raw, StateKeySerializationStrategy, ValidateAndCommit}
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
@@ -46,7 +46,7 @@ final class InMemoryLedgerReaderWriter private[memory] (
     with LedgerWriter {
   override def commit(
       correlationId: String,
-      envelope: Bytes,
+      envelope: Raw.Value,
       metadata: CommitMetadata,
   ): Future[SubmissionResult] =
     validateAndCommit(correlationId, envelope, participantId)
@@ -207,7 +207,7 @@ object InMemoryLedgerReaderWriter {
 
       def validateAndCommit(
           correlationId: String,
-          submissionEnvelope: Bytes,
+          submissionEnvelope: Raw.Value,
           submittingParticipantId: ParticipantId,
       ) =
         new InMemoryLedgerStateAccess(state, metrics).inTransaction { ledgerStateOperations =>
@@ -250,7 +250,7 @@ object InMemoryLedgerReaderWriter {
 
       def validateAndCommit(
           correlationId: String,
-          submissionEnvelope: Bytes,
+          submissionEnvelope: Raw.Value,
           submittingParticipantId: ParticipantId,
       ) =
         committer.commit(

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriter.scala
@@ -24,7 +24,7 @@ import com.daml.ledger.validator.batch.{
 }
 import com.daml.ledger.validator.caching.{CachingStateReader, ImmutablesOnlyCacheUpdatePolicy}
 import com.daml.ledger.validator.preexecution._
-import com.daml.ledger.validator.reading.StateReader
+import com.daml.ledger.validator.reading.{DamlLedgerStateReader, LedgerStateReader}
 import com.daml.ledger.validator.{Raw, StateKeySerializationStrategy, ValidateAndCommit}
 import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext.newLoggingContext
@@ -265,9 +265,8 @@ object InMemoryLedgerReaderWriter {
 
   private def transformStateReader(
       keySerializationStrategy: StateKeySerializationStrategy,
-      cache: Cache[DamlStateKey, DamlStateValue]
-  )(stateReader: StateReader[Raw.Key, Option[Raw.Value]])
-    : StateReader[DamlStateKey, Option[DamlStateValue]] = {
+      cache: Cache[DamlStateKey, DamlStateValue],
+  )(stateReader: LedgerStateReader): DamlLedgerStateReader = {
     CachingStateReader(
       cache,
       ImmutablesOnlyCacheUpdatePolicy,

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
@@ -4,10 +4,10 @@
 package com.daml.ledger.on.memory
 
 import com.daml.ledger.on.memory.InMemoryState.MutableLog
-import com.daml.ledger.participant.state.kvutils.OffsetBuilder
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
+import com.daml.ledger.participant.state.kvutils.{OffsetBuilder, Raw}
 import com.daml.ledger.participant.state.v1.Offset
-import com.daml.ledger.validator.{BatchingLedgerStateOperations, Raw}
+import com.daml.ledger.validator.BatchingLedgerStateOperations
 
 import scala.collection.{breakOut, mutable}
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
@@ -25,7 +25,7 @@ private[memory] final class InMemoryLedgerStateOperations(
     Future.successful(keys.map(state.get)(breakOut))
 
   override def writeState(
-      keyValuePairs: Iterable[Raw.Pair],
+      keyValuePairs: Iterable[Raw.KeyValuePair],
   )(implicit executionContext: ExecutionContext): Future[Unit] = {
     state ++= keyValuePairs
     Future.unit

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
@@ -7,8 +7,7 @@ import com.daml.ledger.on.memory.InMemoryState.MutableLog
 import com.daml.ledger.participant.state.kvutils.OffsetBuilder
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
 import com.daml.ledger.participant.state.v1.Offset
-import com.daml.ledger.validator.BatchingLedgerStateOperations
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.{BatchingLedgerStateOperations, Raw}
 
 import scala.collection.{breakOut, mutable}
 import scala.concurrent.{ExecutionContext, Future}
@@ -21,18 +20,18 @@ private[memory] final class InMemoryLedgerStateOperations(
   import InMemoryLedgerStateOperations.appendEntry
 
   override def readState(
-      keys: Iterable[Key],
-  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]] =
+      keys: Iterable[Raw.Key],
+  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
     Future.successful(keys.map(state.get)(breakOut))
 
   override def writeState(
-      keyValuePairs: Iterable[(Key, Value)],
+      keyValuePairs: Iterable[Raw.Pair],
   )(implicit executionContext: ExecutionContext): Future[Unit] = {
     state ++= keyValuePairs
     Future.unit
   }
 
-  override def appendToLog(key: Key, value: Value)(
+  override def appendToLog(key: Raw.Key, value: Raw.Value)(
       implicit executionContext: ExecutionContext
   ): Future[Index] =
     Future.successful(appendEntry(log, LedgerRecord(_, key, value)))
@@ -40,7 +39,7 @@ private[memory] final class InMemoryLedgerStateOperations(
 
 object InMemoryLedgerStateOperations {
   def apply(): InMemoryLedgerStateOperations = {
-    val inMemoryState = mutable.Map.empty[Key, Value]
+    val inMemoryState = mutable.Map.empty[Raw.Key, Raw.Value]
     val inMemoryLog = mutable.ArrayBuffer[LedgerRecord]()
     new InMemoryLedgerStateOperations(inMemoryLog, inMemoryState)
   }

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
@@ -6,9 +6,9 @@ package com.daml.ledger.on.memory
 import java.util.concurrent.locks.StampedLock
 
 import com.daml.ledger.on.memory.InMemoryState._
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
 import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 
 import scala.collection.mutable
@@ -43,16 +43,14 @@ private[memory] class InMemoryState private (log: MutableLog, state: MutableStat
 
 object InMemoryState {
   type ImmutableLog = IndexedSeq[LedgerRecord]
-  type ImmutableState = collection.Map[StateKey, StateValue]
+  type ImmutableState = collection.Map[Raw.Key, Raw.Value]
 
   type MutableLog = mutable.Buffer[LedgerRecord] with ImmutableLog
-  type MutableState = mutable.Map[StateKey, StateValue] with ImmutableState
-
-  type StateKey = Bytes
-  type StateValue = Bytes
+  type MutableState = mutable.Map[Raw.Key, Raw.Value] with ImmutableState
 
   // The first element will never be read because begin offsets are exclusive.
-  private val Beginning = LedgerRecord(Offset.beforeBegin, ByteString.EMPTY, ByteString.EMPTY)
+  private val Beginning =
+    LedgerRecord(Offset.beforeBegin, Raw.Key(ByteString.EMPTY), Raw.Value(ByteString.EMPTY))
 
   def empty =
     new InMemoryState(

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
@@ -6,9 +6,9 @@ package com.daml.ledger.on.memory
 import java.util.concurrent.locks.StampedLock
 
 import com.daml.ledger.on.memory.InMemoryState._
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
 import com.daml.ledger.participant.state.v1.Offset
-import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 
 import scala.collection.mutable

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterSpec.scala
@@ -5,9 +5,10 @@ package com.daml.ledger.on.memory
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.api.CommitMetadata
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.ledger.validator.{Raw, SubmissionEnvelope, ValidateAndCommit}
+import com.daml.ledger.validator.{SubmissionEnvelope, ValidateAndCommit}
 import com.daml.lf.data.Ref
 import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterSpec.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.api.CommitMetadata
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.ledger.validator.{SubmissionEnvelope, ValidateAndCommit}
+import com.daml.ledger.validator.ValidateAndCommit
 import com.daml.lf.data.Ref
 import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
@@ -29,7 +29,7 @@ class InMemoryLedgerReaderWriterSpec
     "not signal new head in case of failure" in {
       val mockDispatcher = mock[Dispatcher[Index]]
       val mockCommitter = mock[ValidateAndCommit]
-      when(mockCommitter(any[String], any[SubmissionEnvelope], any[ParticipantId]))
+      when(mockCommitter(any[String], any[Raw.Value], any[ParticipantId]))
         .thenReturn(
           Future.successful(SubmissionResult.InternalError("Validation failed with an exception")))
       val instance = new InMemoryLedgerReaderWriter(

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerReaderWriterSpec.scala
@@ -7,7 +7,7 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.api.CommitMetadata
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.ledger.validator.ValidateAndCommit
+import com.daml.ledger.validator.{Raw, SubmissionEnvelope, ValidateAndCommit}
 import com.daml.lf.data.Ref
 import com.daml.metrics.Metrics
 import com.daml.platform.akkastreams.dispatcher.Dispatcher
@@ -28,7 +28,7 @@ class InMemoryLedgerReaderWriterSpec
     "not signal new head in case of failure" in {
       val mockDispatcher = mock[Dispatcher[Index]]
       val mockCommitter = mock[ValidateAndCommit]
-      when(mockCommitter(any[String], any[ByteString], any[ParticipantId]))
+      when(mockCommitter(any[String], any[SubmissionEnvelope], any[ParticipantId]))
         .thenReturn(
           Future.successful(SubmissionResult.InternalError("Validation failed with an exception")))
       val instance = new InMemoryLedgerReaderWriter(
@@ -41,7 +41,11 @@ class InMemoryLedgerReaderWriterSpec
       )
 
       instance
-        .commit("correlation ID", ByteString.copyFromUtf8("some bytes"), CommitMetadata.Empty)
+        .commit(
+          "correlation ID",
+          Raw.Value(ByteString.copyFromUtf8("some bytes")),
+          CommitMetadata.Empty,
+        )
         .map { actual =>
           verify(mockDispatcher, times(0)).signalNewHead(any[Int])
           actual should be(a[SubmissionResult.InternalError])

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -25,7 +25,6 @@ import com.daml.ledger.participant.state.kvutils.api.{
 }
 import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator._
 import com.daml.lf.data.Ref
 import com.daml.lf.engine.Engine
@@ -199,18 +198,18 @@ object SqlLedgerReaderWriter {
   private final class SqlLedgerStateOperations(queries: Queries)
       extends BatchingLedgerStateOperations[Index] {
     override def readState(
-        keys: Iterable[Key],
-    )(implicit executionContext: sc.ExecutionContext): sc.Future[Seq[Option[Value]]] =
+        keys: Iterable[Raw.Key],
+    )(implicit executionContext: sc.ExecutionContext): sc.Future[Seq[Option[Raw.Value]]] =
       Future.fromTry(queries.selectStateValuesByKeys(keys)).removeExecutionContext
 
     override def writeState(
-        keyValuePairs: Iterable[(Key, Value)],
+        keyValuePairs: Iterable[Raw.Pair],
     )(implicit executionContext: sc.ExecutionContext): sc.Future[Unit] =
       Future.fromTry(queries.updateState(keyValuePairs)).removeExecutionContext
 
     override def appendToLog(
-        key: Key,
-        value: Value,
+        key: Raw.Key,
+        value: Raw.Value,
     )(implicit executionContext: sc.ExecutionContext): sc.Future[Index] =
       Future.fromTry(queries.insertRecordIntoLog(key, value)).removeExecutionContext
   }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -9,20 +9,20 @@ import java.util.concurrent.Executors
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.api.util.TimeProvider
-import com.daml.caching.{Cache, ConcurrentCache}
+import com.daml.caching.Cache
 import com.daml.concurrent.{ExecutionContext, Future}
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.health.{HealthStatus, Healthy}
 import com.daml.ledger.on.sql.SqlLedgerReaderWriter._
 import com.daml.ledger.on.sql.queries.Queries
-import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntryId, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
+import com.daml.ledger.participant.state.kvutils.OffsetBuilder
 import com.daml.ledger.participant.state.kvutils.api.{
   CommitMetadata,
   LedgerReader,
   LedgerRecord,
   LedgerWriter
 }
-import com.daml.ledger.participant.state.kvutils.{Bytes, OffsetBuilder}
 import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
@@ -72,7 +72,7 @@ final class SqlLedgerReaderWriter(
 
   override def commit(
       correlationId: String,
-      envelope: Bytes,
+      envelope: Raw.Value,
       metadata: CommitMetadata,
   ): sc.Future[SubmissionResult] =
     committer.commit(correlationId, envelope, participantId)(committerExecutionContext)
@@ -90,7 +90,7 @@ object SqlLedgerReaderWriter {
       engine: Engine,
       jdbcUrl: String,
       resetOnStartup: Boolean,
-      stateValueCache: ConcurrentCache[Bytes, DamlStateValue] = Cache.none,
+      stateValueCache: StateValueCache = Cache.none,
       timeProvider: TimeProvider = DefaultTimeProvider,
       seedService: SeedService,
   )(implicit loggingContext: LoggingContext)

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -203,7 +203,7 @@ object SqlLedgerReaderWriter {
       Future.fromTry(queries.selectStateValuesByKeys(keys)).removeExecutionContext
 
     override def writeState(
-        keyValuePairs: Iterable[Raw.Pair],
+        keyValuePairs: Iterable[Raw.KeyValuePair],
     )(implicit executionContext: sc.ExecutionContext): sc.Future[Unit] =
       Future.fromTry(queries.updateState(keyValuePairs)).removeExecutionContext
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -16,13 +16,13 @@ import com.daml.ledger.api.health.{HealthStatus, Healthy}
 import com.daml.ledger.on.sql.SqlLedgerReaderWriter._
 import com.daml.ledger.on.sql.queries.Queries
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlLogEntryId
-import com.daml.ledger.participant.state.kvutils.OffsetBuilder
 import com.daml.ledger.participant.state.kvutils.api.{
   CommitMetadata,
   LedgerReader,
   LedgerRecord,
   LedgerWriter
 }
+import com.daml.ledger.participant.state.kvutils.{OffsetBuilder, Raw}
 import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.ledger.validator._

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
@@ -9,9 +9,8 @@ import anorm.SqlParser._
 import anorm._
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.on.sql.queries.Queries._
-import com.daml.ledger.participant.state.kvutils.OffsetBuilder
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
-import com.daml.ledger.validator.Raw
+import com.daml.ledger.participant.state.kvutils.{OffsetBuilder, Raw}
 
 import scala.collection.{breakOut, immutable}
 import scala.util.Try

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
@@ -48,7 +48,7 @@ trait CommonQueries extends Queries {
       keys.map(results.get)(breakOut)
     }
 
-  override final def updateState(stateUpdates: Iterable[Raw.Pair]): Try[Unit] = Try {
+  override final def updateState(stateUpdates: Iterable[Raw.KeyValuePair]): Try[Unit] = Try {
     executeBatchSql(updateStateQuery, stateUpdates.map {
       case (key, value) =>
         Seq[NamedParameter]("key" -> key, "value" -> value)

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
@@ -10,7 +10,7 @@ import anorm._
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.on.sql.queries.Queries._
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.Raw
 
 import scala.util.Try
 
@@ -24,7 +24,7 @@ final class H2Queries(override protected implicit val connection: Connection)
       .as(str("ledger_id").single)
   }
 
-  override def insertRecordIntoLog(key: Key, value: Value): Try[Index] =
+  override def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index] =
     Try {
       SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value)"
         .executeInsert()
@@ -39,7 +39,7 @@ final class H2Queries(override protected implicit val connection: Connection)
       .as(long("IDENTITY()").single)
   }
 
-  override final def truncate(): Try[Unit] = Try {
+  override def truncate(): Try[Unit] = Try {
     SQL"truncate #$StateTable".executeUpdate()
     SQL"truncate #$LogTable".executeUpdate()
     SQL"truncate #$MetaTable".executeUpdate()

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
@@ -9,8 +9,8 @@ import anorm.SqlParser._
 import anorm._
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.on.sql.queries.Queries._
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.Raw
 
 import scala.util.Try
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
@@ -10,7 +10,7 @@ import anorm._
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.on.sql.queries.Queries._
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.Raw
 
 import scala.util.Try
 
@@ -24,7 +24,7 @@ final class PostgresqlQueries(override protected implicit val connection: Connec
       .as(str("ledger_id").single)
   }
 
-  override def insertRecordIntoLog(key: Key, value: Value): Try[Index] = Try {
+  override def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index] = Try {
     SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value) RETURNING sequence_no"
       .as(long("sequence_no").single)
   }
@@ -32,7 +32,7 @@ final class PostgresqlQueries(override protected implicit val connection: Connec
   override protected val updateStateQuery: String =
     s"INSERT INTO $StateTable VALUES ({key}, {value}) ON CONFLICT(key) DO UPDATE SET value = {value}"
 
-  override final def truncate(): Try[Unit] = Try {
+  override def truncate(): Try[Unit] = Try {
     SQL"truncate #$StateTable".executeUpdate()
     SQL"truncate #$LogTable".executeUpdate()
     SQL"truncate #$MetaTable".executeUpdate()

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
@@ -9,8 +9,8 @@ import anorm.SqlParser._
 import anorm._
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.on.sql.queries.Queries._
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.Raw
 
 import scala.util.Try
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
@@ -17,7 +17,7 @@ import anorm.{
   SqlRequestError,
   ToStatement
 }
-import com.daml.ledger.validator.Raw
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.google.protobuf.ByteString
 
 trait Queries extends ReadQueries with WriteQueries

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
@@ -17,6 +17,7 @@ import anorm.{
   SqlRequestError,
   ToStatement
 }
+import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 
 trait Queries extends ReadQueries with WriteQueries
@@ -43,6 +44,12 @@ object Queries {
   implicit val byteStringToStatement: ToStatement[ByteString] =
     (s: PreparedStatement, index: Int, v: ByteString) =>
       s.setBinaryStream(index, v.newInput(), v.size())
+
+  implicit val rawKeyToStatement: ToStatement[Raw.Key] =
+    byteStringToStatement.contramap(_.bytes)
+
+  implicit val rawValueToStatement: ToStatement[Raw.Value] =
+    byteStringToStatement.contramap(_.bytes)
 
   implicit val columnToByteString: Column[ByteString] =
     Column.nonNull { (value: Any, meta: MetaDataItem) =>

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.on.sql.queries
 
 import com.daml.ledger.on.sql.Index
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
-import com.daml.ledger.validator.Raw
 
 import scala.collection.immutable
 import scala.util.Try

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.on.sql.queries
 
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.Raw
 
 import scala.collection.immutable
 import scala.util.Try
@@ -15,5 +15,5 @@ trait ReadQueries {
 
   def selectFromLog(start: Index, end: Index): Try[immutable.Seq[(Index, LedgerRecord)]]
 
-  def selectStateValuesByKeys(keys: Iterable[Key]): Try[immutable.Seq[Option[Value]]]
+  def selectStateValuesByKeys(keys: Iterable[Raw.Key]): Try[immutable.Seq[Option[Raw.Value]]]
 }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
@@ -10,7 +10,7 @@ import anorm._
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.on.sql.queries.Queries._
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.Raw
 
 import scala.util.Try
 
@@ -24,7 +24,7 @@ final class SqliteQueries(override protected implicit val connection: Connection
       .as(str("ledger_id").single)
   }
 
-  override def insertRecordIntoLog(key: Key, value: Value): Try[Index] =
+  override def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index] =
     Try {
       SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value)"
         .executeInsert()

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
@@ -9,8 +9,8 @@ import anorm.SqlParser._
 import anorm._
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.on.sql.queries.Queries._
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.Raw
 
 import scala.util.Try
 
@@ -39,7 +39,7 @@ final class SqliteQueries(override protected implicit val connection: Connection
       .as(long("row_id").single)
   }
 
-  override final def truncate(): Try[Unit] = Try {
+  override def truncate(): Try[Unit] = Try {
     SQL"delete from #$StateTable".executeUpdate()
     SQL"delete from #$LogTable".executeUpdate()
     SQL"delete from #$MetaTable".executeUpdate()

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
@@ -4,9 +4,9 @@
 package com.daml.ledger.on.sql.queries
 
 import com.daml.ledger.on.sql.Index
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.Raw
 import com.daml.metrics.{Metrics, Timed}
 
 import scala.collection.immutable

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.on.sql.queries
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.Raw
 import com.daml.metrics.{Metrics, Timed}
 
 import scala.collection.immutable
@@ -24,7 +24,9 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
       metrics.daml.ledger.database.queries.selectFromLog,
       delegate.selectFromLog(start, end))
 
-  override def selectStateValuesByKeys(keys: Iterable[Key]): Try[immutable.Seq[Option[Value]]] =
+  override def selectStateValuesByKeys(
+      keys: Iterable[Raw.Key]
+  ): Try[immutable.Seq[Option[Raw.Value]]] =
     Timed.value(
       metrics.daml.ledger.database.queries.selectStateValuesByKeys,
       delegate.selectStateValuesByKeys(keys))
@@ -34,12 +36,12 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
       metrics.daml.ledger.database.queries.updateOrRetrieveLedgerId,
       delegate.updateOrRetrieveLedgerId(providedLedgerId))
 
-  override def insertRecordIntoLog(key: Key, value: Value): Try[Index] =
+  override def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index] =
     Timed.value(
       metrics.daml.ledger.database.queries.insertRecordIntoLog,
       delegate.insertRecordIntoLog(key, value))
 
-  override def updateState(stateUpdates: Iterable[(Key, Value)]): Try[Unit] =
+  override def updateState(stateUpdates: Iterable[Raw.Pair]): Try[Unit] =
     Timed.value(
       metrics.daml.ledger.database.queries.updateState,
       delegate.updateState(stateUpdates))

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
@@ -41,7 +41,7 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
       metrics.daml.ledger.database.queries.insertRecordIntoLog,
       delegate.insertRecordIntoLog(key, value))
 
-  override def updateState(stateUpdates: Iterable[Raw.Pair]): Try[Unit] =
+  override def updateState(stateUpdates: Iterable[Raw.KeyValuePair]): Try[Unit] =
     Timed.value(
       metrics.daml.ledger.database.queries.updateState,
       delegate.updateState(stateUpdates))

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
@@ -14,7 +14,7 @@ trait WriteQueries {
 
   def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index]
 
-  def updateState(stateUpdates: Iterable[Raw.Pair]): Try[Unit]
+  def updateState(stateUpdates: Iterable[Raw.KeyValuePair]): Try[Unit]
 
   def truncate(): Try[Unit]
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.on.sql.queries
 
 import com.daml.ledger.on.sql.Index
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.Raw
 
 import scala.util.Try
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
@@ -5,16 +5,16 @@ package com.daml.ledger.on.sql.queries
 
 import com.daml.ledger.on.sql.Index
 import com.daml.ledger.participant.state.v1.LedgerId
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.Raw
 
 import scala.util.Try
 
 trait WriteQueries {
   def updateOrRetrieveLedgerId(providedLedgerId: LedgerId): Try[LedgerId]
 
-  def insertRecordIntoLog(key: Key, value: Value): Try[Index]
+  def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index]
 
-  def updateState(stateUpdates: Iterable[(Key, Value)]): Try[Unit]
+  def updateState(stateUpdates: Iterable[Raw.Pair]): Try[Unit]
 
   def truncate(): Try[Unit]
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Debug.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Debug.scala
@@ -42,16 +42,16 @@ object Debug {
       outputState: Map[DamlStateKey, DamlStateValue]): Unit =
     optLedgerDumpStream.foreach { outs =>
       val dumpEntry = DamlKvutils.LedgerDumpEntry.newBuilder
-        .setSubmission(Envelope.enclose(submission))
+        .setSubmission(Envelope.enclose(submission).bytes)
         .setEntryId(entryId)
         .setParticipantId(participantId)
-        .setLogEntry(Envelope.enclose(logEntry))
+        .setLogEntry(Envelope.enclose(logEntry).bytes)
         .addAllOutputState(
           outputState.map {
             case (k, v) =>
               DamlKvutils.LedgerDumpEntry.StatePair.newBuilder
                 .setStateKey(k)
-                .setStateValue(Envelope.enclose(v))
+                .setStateValue(Envelope.enclose(v).bytes)
                 .build
           }.asJava
         )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
@@ -6,7 +6,6 @@ package com.daml.ledger.participant.state.kvutils
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils => Proto}
-import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 
 import scala.util.Try

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
@@ -5,10 +5,11 @@ package com.daml.ledger.participant.state.kvutils
 
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 
+import com.daml.ledger.participant.state.kvutils.{DamlKvutils => Proto}
+import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 
 import scala.util.Try
-import com.daml.ledger.participant.state.kvutils.{DamlKvutils => Proto}
 
 /** Envelope is a wrapping for "top-level" kvutils messages that provides
   * versioning and compression and should be used when storing or transmitting
@@ -31,40 +32,45 @@ object Envelope {
   private def enclose(
       kind: Proto.Envelope.MessageKind,
       bytes: ByteString,
-      compression: Boolean): ByteString =
-    Proto.Envelope.newBuilder
-      .setVersion(Version.version)
-      .setKind(kind)
-      .setMessage(if (compression) compress(bytes) else bytes)
-      .setCompression(
-        if (compression)
-          Proto.Envelope.CompressionSchema.GZIP
-        else
-          Proto.Envelope.CompressionSchema.NONE
-      )
-      .build
-      .toByteString
+      compression: Boolean,
+  ): Raw.Value =
+    Raw.Value(
+      Proto.Envelope.newBuilder
+        .setVersion(Version.version)
+        .setKind(kind)
+        .setMessage(if (compression) compress(bytes) else bytes)
+        .setCompression(
+          if (compression)
+            Proto.Envelope.CompressionSchema.GZIP
+          else
+            Proto.Envelope.CompressionSchema.NONE
+        )
+        .build
+        .toByteString)
 
-  def enclose(sub: Proto.DamlSubmission): ByteString =
+  def enclose(sub: Proto.DamlSubmission): Raw.Value =
     enclose(sub, compression = DefaultCompression)
-  def enclose(sub: Proto.DamlSubmission, compression: Boolean): ByteString =
+
+  def enclose(sub: Proto.DamlSubmission, compression: Boolean): Raw.Value =
     enclose(Proto.Envelope.MessageKind.SUBMISSION, sub.toByteString, compression)
 
-  def enclose(logEntry: Proto.DamlLogEntry): ByteString =
+  def enclose(logEntry: Proto.DamlLogEntry): Raw.Value =
     enclose(logEntry, compression = DefaultCompression)
-  def enclose(logEntry: Proto.DamlLogEntry, compression: Boolean): ByteString =
+
+  def enclose(logEntry: Proto.DamlLogEntry, compression: Boolean): Raw.Value =
     enclose(Proto.Envelope.MessageKind.LOG_ENTRY, logEntry.toByteString, compression)
 
-  def enclose(stateValue: Proto.DamlStateValue): ByteString =
+  def enclose(stateValue: Proto.DamlStateValue): Raw.Value =
     enclose(stateValue, compression = DefaultCompression)
-  def enclose(stateValue: Proto.DamlStateValue, compression: Boolean): ByteString =
+
+  def enclose(stateValue: Proto.DamlStateValue, compression: Boolean): Raw.Value =
     enclose(Proto.Envelope.MessageKind.STATE_VALUE, stateValue.toByteString, compression)
 
-  def enclose(batch: Proto.DamlSubmissionBatch): ByteString =
+  def enclose(batch: Proto.DamlSubmissionBatch): Raw.Value =
     enclose(Proto.Envelope.MessageKind.SUBMISSION_BATCH, batch.toByteString, compression = false)
 
-  def open(envelopeBytes: ByteString): Either[String, Message] =
-    openWithParser(() => Proto.Envelope.parseFrom(envelopeBytes))
+  def open(envelopeBytes: Raw.Value): Either[String, Message] =
+    openWithParser(() => Proto.Envelope.parseFrom(envelopeBytes.bytes))
 
   def open(envelopeBytes: Array[Byte]): Either[String, Message] =
     openWithParser(() => Proto.Envelope.parseFrom(envelopeBytes))
@@ -102,13 +108,13 @@ object Envelope {
       }
     } yield message
 
-  def openLogEntry(envelopeBytes: ByteString): Either[String, Proto.DamlLogEntry] =
+  def openLogEntry(envelopeBytes: Raw.Value): Either[String, Proto.DamlLogEntry] =
     open(envelopeBytes).flatMap {
       case LogEntryMessage(entry) => Right(entry)
       case msg => Left(s"Expected log entry, got ${msg.getClass}")
     }
 
-  def openSubmission(envelopeBytes: ByteString): Either[String, Proto.DamlSubmission] =
+  def openSubmission(envelopeBytes: Raw.Value): Either[String, Proto.DamlSubmission] =
     open(envelopeBytes).flatMap {
       case SubmissionMessage(entry) => Right(entry)
       case msg => Left(s"Expected submission, got ${msg.getClass}")
@@ -120,7 +126,7 @@ object Envelope {
       case msg => Left(s"Expected submission, got ${msg.getClass}")
     }
 
-  def openStateValue(envelopeBytes: ByteString): Either[String, Proto.DamlStateValue] =
+  def openStateValue(envelopeBytes: Raw.Value): Either[String, Proto.DamlStateValue] =
     open(envelopeBytes).flatMap {
       case StateValueMessage(entry) => Right(entry)
       case msg => Left(s"Expected state value, got ${msg.getClass}")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -17,7 +17,7 @@ object Raw {
 
   final case class Value(override val bytes: ByteString) extends Bytes
 
-  type Pair = (Key, Value)
+  type KeyValuePair = (Key, Value)
 
   implicit val `Key Ordering`: Ordering[Key] = Ordering.by(_.bytes.asReadOnlyByteBuffer)
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -5,17 +5,17 @@ package com.daml.ledger.participant.state.kvutils
 
 import com.google.protobuf.ByteString
 
-sealed trait Raw {
-  def bytes: ByteString
-
-  final def size: Long = bytes.size.toLong
-}
-
 object Raw {
 
-  final case class Key(override val bytes: ByteString) extends Raw
+  sealed trait Bytes {
+    def bytes: ByteString
 
-  final case class Value(override val bytes: ByteString) extends Raw
+    final def size: Long = bytes.size.toLong
+  }
+
+  final case class Key(override val bytes: ByteString) extends Bytes
+
+  final case class Value(override val bytes: ByteString) extends Bytes
 
   type Pair = (Key, Value)
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.ledger.validator
+package com.daml.ledger.participant.state.kvutils
 
 import com.google.protobuf.ByteString
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -5,7 +5,7 @@ package com.daml.ledger.participant.state.kvutils
 
 import com.google.protobuf.ByteString
 
-trait Raw {
+sealed trait Raw {
   def bytes: ByteString
 
   final def size: Int = bytes.size
@@ -13,9 +13,9 @@ trait Raw {
 
 object Raw {
 
-  case class Key(override val bytes: ByteString) extends Raw
+  final case class Key(override val bytes: ByteString) extends Raw
 
-  case class Value(override val bytes: ByteString) extends Raw
+  final case class Value(override val bytes: ByteString) extends Raw
 
   type Pair = (Key, Value)
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -8,7 +8,7 @@ import com.google.protobuf.ByteString
 sealed trait Raw {
   def bytes: ByteString
 
-  final def size: Int = bytes.size
+  final def size: Long = bytes.size.toLong
 }
 
 object Raw {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
@@ -9,9 +9,8 @@ import java.util.UUID
 import akka.stream.Materializer
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch
-import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.ledger.validator.Raw
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
@@ -8,10 +8,10 @@ import java.util.UUID
 
 import akka.stream.Materializer
 import com.daml.ledger.api.health.HealthStatus
-import com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch
 import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
+import com.daml.ledger.validator.Raw
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 
@@ -45,15 +45,15 @@ class BatchingLedgerWriter(val queue: BatchingQueue, val writer: LedgerWriter)(
     */
   override def commit(
       correlationId: String,
-      envelope: kvutils.Bytes,
+      envelope: Raw.Value,
       metadata: CommitMetadata,
   ): Future[SubmissionResult] =
-    queueHandle
-      .offer(
-        DamlSubmissionBatch.CorrelatedSubmission.newBuilder
-          .setCorrelationId(correlationId)
-          .setSubmission(envelope)
-          .build)
+    queueHandle.offer(
+      DamlSubmissionBatch.CorrelatedSubmission.newBuilder
+        .setCorrelationId(correlationId)
+        .setSubmission(envelope.bytes)
+        .build
+    )
 
   override def participantId: ParticipantId = writer.participantId
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/CommitMetadata.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/CommitMetadata.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
-import com.daml.ledger.participant.state.kvutils.{Bytes, KeyValueCommitting}
-import com.daml.ledger.validator.StateKeySerializationStrategy
+import com.daml.ledger.participant.state.kvutils.KeyValueCommitting
+import com.daml.ledger.validator.{Raw, StateKeySerializationStrategy}
 
 import scala.collection.JavaConverters._
 
@@ -21,9 +21,9 @@ sealed trait CommitMetadata {
     */
   def estimatedInterpretationCost: Option[Long]
 
-  def inputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Bytes]
+  def inputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Raw.Key]
 
-  def outputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Bytes]
+  def outputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Raw.Key]
 }
 
 object CommitMetadata {
@@ -32,24 +32,31 @@ object CommitMetadata {
       override def estimatedInterpretationCost: Option[Long] = None
 
       override def inputKeys(
-          serializationStrategy: StateKeySerializationStrategy): Iterable[Bytes] = Iterable.empty
+          serializationStrategy: StateKeySerializationStrategy
+      ): Iterable[Raw.Key] = Iterable.empty
 
       override def outputKeys(
-          serializationStrategy: StateKeySerializationStrategy): Iterable[Bytes] = Iterable.empty
+          serializationStrategy: StateKeySerializationStrategy
+      ): Iterable[Raw.Key] = Iterable.empty
     }
 
   def apply(
       submission: DamlSubmission,
-      inputEstimatedInterpretationCost: Option[Long]): CommitMetadata = new CommitMetadata {
+      inputEstimatedInterpretationCost: Option[Long],
+  ): CommitMetadata = new CommitMetadata {
     override def estimatedInterpretationCost: Option[Long] = inputEstimatedInterpretationCost
 
-    override def inputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Bytes] =
+    override def inputKeys(
+        serializationStrategy: StateKeySerializationStrategy
+    ): Iterable[Raw.Key] =
       submission.getInputDamlStateList.asScala
         .map(serializationStrategy.serializeStateKey)
 
     private lazy val submissionOutputs = KeyValueCommitting.submissionOutputs(submission)
 
-    override def outputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Bytes] =
+    override def outputKeys(
+        serializationStrategy: StateKeySerializationStrategy
+    ): Iterable[Raw.Key] =
       submissionOutputs.map(serializationStrategy.serializeStateKey)
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/CommitMetadata.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/CommitMetadata.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
-import com.daml.ledger.participant.state.kvutils.KeyValueCommitting
-import com.daml.ledger.validator.{Raw, StateKeySerializationStrategy}
+import com.daml.ledger.participant.state.kvutils.{KeyValueCommitting, Raw}
+import com.daml.ledger.validator.StateKeySerializationStrategy
 
 import scala.collection.JavaConverters._
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooser.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooser.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.api.health.HealthStatus
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.ledger.validator.Raw
 import com.daml.metrics.Metrics
 
 import scala.concurrent.Future

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooser.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooser.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.api.health.HealthStatus
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
+import com.daml.ledger.validator.Raw
 import com.daml.metrics.Metrics
 
 import scala.concurrent.Future
@@ -34,7 +34,7 @@ final class InterpretationCostBasedLedgerWriterChooser(
 
   override def commit(
       correlationId: String,
-      envelope: Bytes,
+      envelope: Raw.Value,
       metadata: CommitMetadata,
   ): Future[SubmissionResult] = {
     val estimatedInterpretationCost = metadata.estimatedInterpretationCost.getOrElse(0L)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReader.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReader.scala
@@ -49,7 +49,7 @@ class KeyValueParticipantStateReader private[api] (
               case Envelope.LogEntryMessage(logEntry) =>
                 Timed.value(
                   metrics.daml.kvutils.reader.parseUpdates, {
-                    val logEntryId = DamlLogEntryId.parseFrom(entryId)
+                    val logEntryId = DamlLogEntryId.parseFrom(entryId.bytes)
                     val updates =
                       logEntryToUpdate(logEntryId, logEntry, timeUpdatesProvider())
                     val updatesWithOffsets = Source(updates).zipWithIndex.map {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerRecord.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerRecord.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.api
 
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.Offset
+import com.daml.ledger.validator.Raw
 
 /**
   * A log entry read from the ledger.
@@ -13,4 +13,4 @@ import com.daml.ledger.participant.state.v1.Offset
   * @param entryId  opaque ID of log entry
   * @param envelope opaque contents of log entry
   */
-final case class LedgerRecord(offset: Offset, entryId: Bytes, envelope: Bytes)
+final case class LedgerRecord(offset: Offset, entryId: Raw.Key, envelope: Raw.Value)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerRecord.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerRecord.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.api
 
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.Offset
-import com.daml.ledger.validator.Raw
 
 /**
   * A log entry read from the ledger.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.api.health.ReportsHealth
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
+import com.daml.ledger.validator.Raw
 
 import scala.concurrent.Future
 
@@ -33,7 +33,7 @@ trait LedgerWriter extends ReportsHealth {
     */
   def commit(
       correlationId: String,
-      envelope: Bytes,
+      envelope: Raw.Value,
       metadata: CommitMetadata,
   ): Future[SubmissionResult]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.api.health.ReportsHealth
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.ledger.validator.Raw
 
 import scala.concurrent.Future
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/TimedLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/TimedLedgerWriter.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.api.health.HealthStatus
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.ledger.validator.Raw
 import com.daml.metrics.{Metrics, Timed}
 
 import scala.concurrent.Future

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/TimedLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/TimedLedgerWriter.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.api.health.HealthStatus
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
+import com.daml.ledger.validator.Raw
 import com.daml.metrics.{Metrics, Timed}
 
 import scala.concurrent.Future
@@ -17,7 +17,7 @@ class TimedLedgerWriter(delegate: LedgerWriter, metrics: Metrics) extends Ledger
 
   override def commit(
       correlationId: String,
-      envelope: Bytes,
+      envelope: Raw.Value,
       metadata: CommitMetadata,
   ): Future[SubmissionResult] =
     Timed.future(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/package.scala
@@ -7,6 +7,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.participant.state.v1.{LedgerId, Offset, ParticipantId, SubmissionResult}
+import com.daml.ledger.validator.Raw
 
 import scala.concurrent.Future
 
@@ -67,7 +68,7 @@ package object api {
 
       override def commit(
           correlationId: String,
-          envelope: Bytes,
+          envelope: Raw.Value,
           metadata: CommitMetadata,
       ): Future[SubmissionResult] =
         writer.commit(correlationId, envelope, metadata)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/package.scala
@@ -7,7 +7,6 @@ import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.participant.state.v1.{LedgerId, Offset, ParticipantId, SubmissionResult}
-import com.daml.ledger.validator.Raw
 
 import scala.concurrent.Future
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
@@ -10,14 +10,9 @@ import com.google.protobuf.MessageLite
 
 package object caching {
 
-  implicit object `Key Weight` extends Weight[Raw.Key] {
-    override def weigh(key: Raw.Key): Size =
-      key.bytes.size().toLong
-  }
-
-  implicit object `Value Weight` extends Weight[Raw.Value] {
-    override def weigh(value: Raw.Value): Size =
-      value.bytes.size().toLong
+  implicit object `Raw Weight` extends Weight[Raw] {
+    override def weigh(raw: Raw): Size =
+      raw.bytes.size().toLong
   }
 
   implicit object `Message Weight` extends Weight[MessageLite] {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state.kvutils
 
 import com.daml.caching.Cache.Size
 import com.daml.caching.{Cache, Weight}
-import com.daml.ledger.validator.Raw
 import com.google.protobuf.MessageLite
 
 package object caching {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
@@ -11,7 +11,7 @@ package object caching {
 
   implicit object `Raw Weight` extends Weight[Raw] {
     override def weigh(raw: Raw): Size =
-      raw.bytes.size().toLong
+      raw.size
   }
 
   implicit object `Message Weight` extends Weight[MessageLite] {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
@@ -10,11 +10,6 @@ import com.google.protobuf.MessageLite
 
 package object caching {
 
-  implicit object `Bytes Weight` extends Weight[Bytes] {
-    override def weigh(value: Bytes): Cache.Size =
-      value.size().toLong
-  }
-
   implicit object `Key Weight` extends Weight[Raw.Key] {
     override def weigh(key: Raw.Key): Size =
       key.bytes.size().toLong

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
@@ -9,9 +9,9 @@ import com.google.protobuf.MessageLite
 
 package object caching {
 
-  implicit object `Raw Weight` extends Weight[Raw] {
-    override def weigh(raw: Raw): Size =
-      raw.size
+  implicit object `Raw.Bytes Weight` extends Weight[Raw.Bytes] {
+    override def weigh(rawBytes: Raw.Bytes): Size =
+      rawBytes.size
   }
 
   implicit object `Message Weight` extends Weight[MessageLite] {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/caching/package.scala
@@ -3,14 +3,26 @@
 
 package com.daml.ledger.participant.state.kvutils
 
-import com.google.protobuf.MessageLite
+import com.daml.caching.Cache.Size
 import com.daml.caching.{Cache, Weight}
+import com.daml.ledger.validator.Raw
+import com.google.protobuf.MessageLite
 
 package object caching {
 
   implicit object `Bytes Weight` extends Weight[Bytes] {
     override def weigh(value: Bytes): Cache.Size =
       value.size().toLong
+  }
+
+  implicit object `Key Weight` extends Weight[Raw.Key] {
+    override def weigh(key: Raw.Key): Size =
+      key.bytes.size().toLong
+  }
+
+  implicit object `Value Weight` extends Weight[Raw.Value] {
+    override def weigh(value: Raw.Value): Size =
+      value.bytes.size().toLong
   }
 
   implicit object `Message Weight` extends Weight[MessageLite] {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregator.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.participant.state.kvutils.export
 
 import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator.WriteSetBuilder
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
 import scala.collection.mutable
 
@@ -13,7 +12,7 @@ final class InMemorySubmissionAggregator(submissionInfo: SubmissionInfo, writer:
 
   import InMemorySubmissionAggregator._
 
-  private val aggregate = mutable.Buffer.empty[(Key, Value)]
+  private val aggregate = mutable.Buffer.empty[WriteItem]
 
   override def addChild(): WriteSetBuilder = new InMemoryWriteSetBuilder(aggregate)
 
@@ -24,7 +23,7 @@ final class InMemorySubmissionAggregator(submissionInfo: SubmissionInfo, writer:
 object InMemorySubmissionAggregator {
 
   final class InMemoryWriteSetBuilder private[InMemorySubmissionAggregator] (
-      aggregate: mutable.Buffer[(Key, Value)],
+      aggregate: mutable.Buffer[WriteItem],
   ) extends WriteSetBuilder {
     override def +=(data: WriteItem): Unit = aggregate.synchronized {
       aggregate += data

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataWriter.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils.export
 
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
-
 trait LedgerDataWriter {
-  def write(submissionInfo: SubmissionInfo, writeSet: Seq[(Key, Value)]): Unit
+  def write(submissionInfo: SubmissionInfo, writeSet: WriteSet): Unit
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataExporter.scala
@@ -43,12 +43,13 @@ final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
         .build()
 
     private def buildWriteSet(writeSet: WriteSet): Iterable[LedgerExportEntry.WriteEntry] =
-      writeSet.map(
-        writeEntry =>
+      writeSet.map {
+        case (key, value) =>
           LedgerExportEntry.WriteEntry.newBuilder
-            .setKey(writeEntry._1.bytes)
-            .setValue(writeEntry._2.bytes)
-            .build())
+            .setKey(key.bytes)
+            .setValue(value.bytes)
+            .build()
+      }
   }
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataExporter.scala
@@ -39,7 +39,7 @@ final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
       LedgerExportEntry.SubmissionInfo.newBuilder
         .setParticipantId(submissionInfo.participantId: String)
         .setCorrelationId(submissionInfo.correlationId)
-        .setSubmissionEnvelope(submissionInfo.submissionEnvelope)
+        .setSubmissionEnvelope(submissionInfo.submissionEnvelope.bytes)
         .setRecordTime(Conversions.buildTimestamp(submissionInfo.recordTimeInstant))
         .build()
 
@@ -49,8 +49,8 @@ final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
       writeSet.map(
         writeEntry =>
           LedgerExportEntry.WriteEntry.newBuilder
-            .setKey(writeEntry._1)
-            .setValue(writeEntry._2)
+            .setKey(writeEntry._1.bytes)
+            .setValue(writeEntry._2.bytes)
             .build())
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataExporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataExporter.scala
@@ -8,7 +8,6 @@ import java.nio.file.{Files, Path}
 
 import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.LedgerExportEntry
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
 import scala.collection.JavaConverters._
 
@@ -22,7 +21,7 @@ final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
   override def close(): Unit = output.close()
 
   private object Writer extends LedgerDataWriter {
-    override def write(submissionInfo: SubmissionInfo, writeSet: Seq[(Key, Value)]): Unit = {
+    override def write(submissionInfo: SubmissionInfo, writeSet: WriteSet): Unit = {
       val entry = LedgerExportEntry.newBuilder
         .setSubmissionInfo(buildSubmissionInfo(submissionInfo))
         .addAllWriteSet(buildWriteSet(writeSet).asJava)
@@ -43,9 +42,7 @@ final class ProtobufBasedLedgerDataExporter private (output: OutputStream)
         .setRecordTime(Conversions.buildTimestamp(submissionInfo.recordTimeInstant))
         .build()
 
-    private def buildWriteSet(
-        writeSet: Seq[(Key, Value)],
-    ): Iterable[LedgerExportEntry.WriteEntry] =
+    private def buildWriteSet(writeSet: WriteSet): Iterable[LedgerExportEntry.WriteEntry] =
       writeSet.map(
         writeEntry =>
           LedgerExportEntry.WriteEntry.newBuilder

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
@@ -9,6 +9,7 @@ import java.nio.file.{Files, Path}
 import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.LedgerExportEntry
 import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.ledger.validator.Raw
 
 import scala.collection.JavaConverters._
 
@@ -41,14 +42,14 @@ final class ProtobufBasedLedgerDataImporter(input: InputStream)
     SubmissionInfo(
       ParticipantId.assertFromString(entrySubmissionInfo.getParticipantId),
       entrySubmissionInfo.getCorrelationId,
-      entrySubmissionInfo.getSubmissionEnvelope,
+      Raw.Value(entrySubmissionInfo.getSubmissionEnvelope),
       Conversions.parseInstant(entrySubmissionInfo.getRecordTime),
     )
   }
 
   private def parseWriteSet(entry: LedgerExportEntry): WriteSet =
     entry.getWriteSetList.asScala.view
-      .map(writeEntry => writeEntry.getKey -> writeEntry.getValue)
+      .map(writeEntry => Raw.Key(writeEntry.getKey) -> Raw.Value(writeEntry.getValue))
       .toVector
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
@@ -6,10 +6,9 @@ package com.daml.ledger.participant.state.kvutils.export
 import java.io.{BufferedInputStream, Closeable, InputStream}
 import java.nio.file.{Files, Path}
 
-import com.daml.ledger.participant.state.kvutils.Conversions
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.LedgerExportEntry
+import com.daml.ledger.participant.state.kvutils.{Conversions, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.Raw
 
 import scala.collection.JavaConverters._
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
@@ -5,9 +5,8 @@ package com.daml.ledger.participant.state.kvutils.export
 
 import java.time.Instant
 
-import com.daml.ledger.participant.state.kvutils.CorrelationId
+import com.daml.ledger.participant.state.kvutils.{CorrelationId, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.Raw
 
 case class SubmissionInfo(
     participantId: ParticipantId,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
@@ -7,11 +7,11 @@ import java.time.Instant
 
 import com.daml.ledger.participant.state.kvutils.CorrelationId
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.google.protobuf.ByteString
+import com.daml.ledger.validator.Raw
 
 case class SubmissionInfo(
     participantId: ParticipantId,
     correlationId: CorrelationId,
-    submissionEnvelope: ByteString,
+    submissionEnvelope: Raw.Value,
     recordTimeInstant: Instant,
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
@@ -7,7 +7,7 @@ package object export {
 
   val header = new Header(version = "v2")
 
-  type WriteItem = Raw.Pair
+  type WriteItem = Raw.KeyValuePair
 
   type WriteSet = Seq[WriteItem]
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
@@ -3,13 +3,13 @@
 
 package com.daml.ledger.participant.state.kvutils
 
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.Raw
 
 package object export {
 
   val header = new Header(version = "v2")
 
-  type WriteItem = (Key, Value)
+  type WriteItem = Raw.Pair
 
   type WriteSet = Seq[WriteItem]
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
@@ -3,8 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils
 
-import com.daml.ledger.validator.Raw
-
 package object export {
 
   val header = new Header(version = "v2")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -36,6 +36,4 @@ package object kvutils {
 
   val MetricPrefix: MetricName = MetricName.DAML :+ "kvutils"
 
-  implicit val `Bytes Ordering`: Ordering[Bytes] = Ordering.by(_.asReadOnlyByteBuffer)
-
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.participant.state
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.metrics.MetricName
-import com.google.protobuf.ByteString
 
 /** The participant-state key-value utilities provide methods to succinctly implement
   * [[com.daml.ledger.participant.state.v1.ReadService]] and
@@ -29,7 +28,6 @@ import com.google.protobuf.ByteString
   */
 package object kvutils {
 
-  type Bytes = ByteString
   type DamlStateMap = Map[DamlStateKey, Option[DamlStateValue]]
 
   type CorrelationId = String

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DefaultStateKeySerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DefaultStateKeySerializationStrategy.scala
@@ -3,14 +3,15 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
 
 /**
   * Default state key serialization strategy that does not prefix keys.
   */
 object DefaultStateKeySerializationStrategy extends StateKeySerializationStrategy {
-  override def serializeStateKey(key: DamlStateKey): Bytes = key.toByteString
+  override def serializeStateKey(key: DamlStateKey): Raw.Key =
+    Raw.Key(key.toByteString)
 
-  override def deserializeStateKey(input: Bytes): DamlStateKey = DamlStateKey.parseFrom(input)
+  override def deserializeStateKey(input: Raw.Key): DamlStateKey =
+    DamlStateKey.parseFrom(input.bytes)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DefaultStateKeySerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DefaultStateKeySerializationStrategy.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.Raw
 
 /**
   * Default state key serialization strategy that does not prefix keys.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.validator
 
 import com.daml.dec.DirectExecutionContext
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.validator.LedgerStateOperations._
 import com.daml.metrics.{Metrics, Timed}
 
@@ -153,7 +152,7 @@ final class TimedLedgerStateOperations[LogResult](
 
 object LedgerStateOperations {
 
-  type Key = Bytes
-  type Value = Bytes
+  type Key = Raw.Key
+  type Value = Raw.Value
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -67,7 +67,7 @@ trait LedgerStateOperations[+LogResult] {
     * Writes a list of key-value pairs to the backing store.  In case a key already exists its value is overwritten.
     */
   def writeState(
-      keyValuePairs: Iterable[Raw.Pair],
+      keyValuePairs: Iterable[Raw.KeyValuePair],
   )(implicit executionContext: ExecutionContext): Future[Unit]
 
   /**
@@ -110,7 +110,7 @@ abstract class NonBatchingLedgerStateOperations[LogResult]
     Future.sequence(keys.map(readState)).map(_.toSeq)
 
   override final def writeState(
-      keyValuePairs: Iterable[Raw.Pair],
+      keyValuePairs: Iterable[Raw.KeyValuePair],
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     Future
       .sequence(keyValuePairs.map {
@@ -141,7 +141,7 @@ final class TimedLedgerStateOperations[LogResult](
     Timed.future(metrics.daml.ledger.state.write, delegate.writeState(key, value))
 
   override def writeState(
-      keyValuePairs: Iterable[Raw.Pair],
+      keyValuePairs: Iterable[Raw.KeyValuePair],
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     Timed.future(metrics.daml.ledger.state.write, delegate.writeState(keyValuePairs))
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.validator
 
 import com.daml.dec.DirectExecutionContext
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.metrics.{Metrics, Timed}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
@@ -9,8 +9,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.participant.state.kvutils.export.SubmissionAggregator
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
@@ -30,7 +30,8 @@ class LogAppendingCommitStrategy[Index](
       inputState: Map[DamlStateKey, Option[DamlStateValue]],
       outputState: Map[DamlStateKey, DamlStateValue],
       writeSetBuilder: Option[SubmissionAggregator.WriteSetBuilder] = None,
-  ): Future[Index] =
+  ): Future[Index] = {
+    val logEntryKey = Raw.Key(entryId.toByteString)
     for {
       (serializedKeyValuePairs, envelopedLogEntry) <- inParallel(
         Future(stateSerializationStrategy.serializeStateUpdates(outputState)),
@@ -45,10 +46,11 @@ class LogAppendingCommitStrategy[Index](
         Future {
           writeSetBuilder.foreach { builder =>
             builder ++= serializedKeyValuePairs
-            builder += entryId.toByteString -> envelopedLogEntry
+            builder += logEntryKey -> envelopedLogEntry
           }
         },
-        ledgerStateOperations.appendToLog(entryId.toByteString, envelopedLogEntry),
+        ledgerStateOperations.appendToLog(logEntryKey, envelopedLogEntry),
       )
     } yield index
+  }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/Raw.scala
@@ -5,15 +5,20 @@ package com.daml.ledger.validator
 
 import com.google.protobuf.ByteString
 
+trait Raw {
+  def bytes: ByteString
+
+  final def size: Int = bytes.size
+}
+
 object Raw {
 
-  case class Key(bytes: ByteString)
+  case class Key(override val bytes: ByteString) extends Raw
 
-  case class Value(bytes: ByteString) {
-    def size: Int = bytes.size
-  }
+  case class Value(override val bytes: ByteString) extends Raw
 
   type Pair = (Key, Value)
 
   implicit val `Key Ordering`: Ordering[Key] = Ordering.by(_.bytes.asReadOnlyByteBuffer)
+
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/Raw.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.validator
+
+import com.google.protobuf.ByteString
+
+object Raw {
+
+  case class Key(bytes: ByteString)
+
+  case class Value(bytes: ByteString) {
+    def size: Int = bytes.size
+  }
+
+  type Pair = (Key, Value)
+
+  implicit val `Key Ordering`: Ordering[Key] = Ordering.by(_.bytes.asReadOnlyByteBuffer)
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
@@ -25,7 +25,7 @@ final class RawToDamlLedgerStateReaderAdapter(
 }
 
 object RawToDamlLedgerStateReaderAdapter {
-  private[validator] val deserializeDamlStateValue: LedgerStateOperations.Value => DamlStateValue =
+  private[validator] val deserializeDamlStateValue: Raw.Value => DamlStateValue =
     Envelope
       .openStateValue(_)
       .getOrElse(sys.error("Opening enveloped DamlStateValue failed"))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
-import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.validator.reading.{DamlLedgerStateReader, LedgerStateReader}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateKeySerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateKeySerializationStrategy.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.Raw
 
 /**
   * Determines how we namespace and serialize state keys.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateKeySerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateKeySerializationStrategy.scala
@@ -4,15 +4,14 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
-import com.daml.ledger.validator.LedgerStateOperations.Key
 
 /**
   * Determines how we namespace and serialize state keys.
   */
 trait StateKeySerializationStrategy {
-  def serializeStateKey(key: DamlStateKey): Key
+  def serializeStateKey(key: DamlStateKey): Raw.Key
 
-  def deserializeStateKey(input: Key): DamlStateKey
+  def deserializeStateKey(input: Raw.Key): DamlStateKey
 }
 
 object StateKeySerializationStrategy {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
-import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 
 import scala.collection.{SortedMap, breakOut}
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import scala.collection.{SortedMap, breakOut}
 
 final class StateSerializationStrategy(keyStrategy: StateKeySerializationStrategy) {
-  def serializeState(key: DamlStateKey, value: DamlStateValue): Raw.Pair =
+  def serializeState(key: DamlStateKey, value: DamlStateValue): Raw.KeyValuePair =
     (keyStrategy.serializeStateKey(key), Envelope.enclose(value))
 
   def serializeStateUpdates(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
@@ -4,16 +4,17 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
-import com.daml.ledger.participant.state.kvutils.{Envelope, `Bytes Ordering`}
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.participant.state.kvutils.Envelope
 
 import scala.collection.{SortedMap, breakOut}
 
 final class StateSerializationStrategy(keyStrategy: StateKeySerializationStrategy) {
-  def serializeState(key: DamlStateKey, value: DamlStateValue): (Key, Value) =
+  def serializeState(key: DamlStateKey, value: DamlStateValue): Raw.Pair =
     (keyStrategy.serializeStateKey(key), Envelope.enclose(value))
 
-  def serializeStateUpdates(state: Map[DamlStateKey, DamlStateValue]): SortedMap[Key, Value] =
+  def serializeStateUpdates(
+      state: Map[DamlStateKey, DamlStateValue]
+  ): SortedMap[Raw.Key, Raw.Value] =
     state.map {
       case (key, value) => serializeState(key, value)
     }(breakOut)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -296,7 +296,7 @@ class SubmissionValidator[LogResult] private[validator] (
 
 object SubmissionValidator {
 
-  type RawKeyValuePairs = Seq[Raw.Pair]
+  type RawKeyValuePairs = Seq[Raw.KeyValuePair]
 
   type StateMap = Map[DamlStateKey, DamlStateValue]
   type LogEntryAndState = (DamlLogEntry, StateMap)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -10,7 +10,7 @@ import com.codahale.metrics.Timer
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
-import com.daml.ledger.participant.state.kvutils.{DamlStateMap, Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{DamlStateMap, Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.SubmissionValidator._
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.validator
 
 import java.time.Instant
 
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}
 import com.daml.lf.data.Time.Timestamp
@@ -47,7 +46,7 @@ class ValidatingCommitter[LogResult](
 ) {
   def commit(
       correlationId: String,
-      envelope: Bytes,
+      envelope: Raw.Value,
       submittingParticipantId: ParticipantId,
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
     newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
@@ -64,7 +63,7 @@ class ValidatingCommitter[LogResult](
             SubmissionResult.Acknowledged
           case Left(MissingInputState(keys)) =>
             SubmissionResult.InternalError(
-              s"Missing input state: ${keys.map(_.asScala.map("%02x".format(_)).mkString).mkString(", ")}")
+              s"Missing input state: ${keys.map(_.bytes.asScala.map("%02x".format(_)).mkString).mkString(", ")}")
           case Left(ValidationError(reason)) =>
             SubmissionResult.InternalError(reason)
         }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.validator
 
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}
 import com.daml.lf.data.Time.Timestamp

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidationFailed.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidationFailed.scala
@@ -3,15 +3,13 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.participant.state.kvutils.Bytes
-
 import scala.util.control.NoStackTrace
 
 sealed trait ValidationFailed extends RuntimeException with NoStackTrace
 
 object ValidationFailed {
 
-  final case class MissingInputState(keys: Seq[Bytes]) extends ValidationFailed
+  final case class MissingInputState(keys: Seq[Raw.Key]) extends ValidationFailed
 
   final case class ValidationError(reason: String) extends ValidationFailed
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidationFailed.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidationFailed.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.validator
 
+import com.daml.ledger.participant.state.kvutils.Raw
+
 import scala.util.control.NoStackTrace
 
 sealed trait ValidationFailed extends RuntimeException with NoStackTrace

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -16,7 +16,7 @@ import com.daml.ledger.participant.state.kvutils.export.{
   SubmissionAggregator,
   SubmissionInfo
 }
-import com.daml.ledger.participant.state.kvutils.{CorrelationId, Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{CorrelationId, Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator
 import com.daml.ledger.validator.SubmissionValidator.LogEntryAndState

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -5,7 +5,6 @@ package com.daml.ledger.validator.batch
 
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.caching.{
   CacheUpdatePolicy,
   CachingCommitStrategy,
@@ -18,6 +17,7 @@ import com.daml.ledger.validator.{
   DefaultStateKeySerializationStrategy,
   LedgerStateOperations,
   LogAppendingCommitStrategy,
+  Raw,
   StateKeySerializationStrategy
 }
 
@@ -37,8 +37,8 @@ object BatchedSubmissionValidatorFactory {
   class LedgerStateReaderAdapter[LogResult](delegate: LedgerStateOperations[LogResult])
       extends LedgerStateReader {
     override def read(
-        keys: Iterable[Key]
-    )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]] =
+        keys: Iterable[Raw.Key]
+    )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
       delegate.readState(keys)
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -5,6 +5,7 @@ package com.daml.ledger.validator.batch
 
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.validator.caching.{
   CacheUpdatePolicy,
   CachingCommitStrategy,
@@ -17,7 +18,6 @@ import com.daml.ledger.validator.{
   DefaultStateKeySerializationStrategy,
   LedgerStateOperations,
   LogAppendingCommitStrategy,
-  Raw,
   StateKeySerializationStrategy
 }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 import akka.stream.Materializer
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator._
 import com.daml.ledger.validator.caching.{CacheUpdatePolicy, ImmutablesOnlyCacheUpdatePolicy}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
@@ -7,7 +7,6 @@ import java.time.Instant
 
 import akka.stream.Materializer
 import com.daml.caching.Cache
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator._
@@ -58,7 +57,7 @@ class BatchedValidatingCommitter[LogResult](
 
   def commit(
       correlationId: String,
-      submissionEnvelope: Bytes,
+      submissionEnvelope: Raw.Value,
       submittingParticipantId: ParticipantId,
       ledgerStateOperations: LedgerStateOperations[LogResult],
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] = {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
@@ -11,7 +11,6 @@ import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import scala.concurrent.{ExecutionContext, Future}
 
 package object validator {
-  type SubmissionEnvelope = Raw.Value
   type SubmittingParticipantId = ParticipantId
 
   /**
@@ -19,7 +18,7 @@ package object validator {
     */
   type ValidateAndCommit = (
       CorrelationId,
-      SubmissionEnvelope,
+      Raw.Value,
       SubmittingParticipantId,
   ) => Future[SubmissionResult]
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger
 
 import com.daml.caching.ConcurrentCache
-import com.daml.ledger.participant.state.kvutils.CorrelationId
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateValue
+import com.daml.ledger.participant.state.kvutils.{CorrelationId, Raw}
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
@@ -3,13 +3,15 @@
 
 package com.daml.ledger
 
-import com.daml.ledger.participant.state.kvutils.{Bytes, CorrelationId}
+import com.daml.caching.ConcurrentCache
+import com.daml.ledger.participant.state.kvutils.CorrelationId
+import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateValue
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 package object validator {
-  type SubmissionEnvelope = Bytes
+  type SubmissionEnvelope = Raw.Value
   type SubmittingParticipantId = ParticipantId
 
   /**
@@ -20,6 +22,8 @@ package object validator {
       SubmissionEnvelope,
       SubmittingParticipantId,
   ) => Future[SubmissionResult]
+
+  type StateValueCache = ConcurrentCache[Raw.Value, DamlStateValue]
 
   // At some point, someone much smarter than the author of this code will reimplement the usages of
   // `inParallel` using Cats or Scalaz.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -5,11 +5,11 @@ package com.daml.ledger.validator.preexecution
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlSubmission}
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
-import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.batch.BatchedSubmissionValidator
 import com.daml.ledger.validator.reading.StateReader
-import com.daml.ledger.validator.{HasDamlStateValue, ValidationFailed}
+import com.daml.ledger.validator.{HasDamlStateValue, Raw, ValidationFailed}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
 
@@ -40,7 +40,7 @@ class PreExecutingSubmissionValidator[StateValue, ReadSet, WriteSet](
   private val logger = ContextualizedLogger.get(getClass)
 
   def validate(
-      submissionEnvelope: Bytes,
+      submissionEnvelope: Raw.Value,
       submittingParticipantId: ParticipantId,
       ledgerStateReader: StateReader[DamlStateKey, StateValue],
   )(
@@ -60,7 +60,7 @@ class PreExecutingSubmissionValidator[StateValue, ReadSet, WriteSet](
           submittingParticipantId,
           inputState,
         )
-        logEntryId = BatchedSubmissionValidator.bytesToLogEntryId(submissionEnvelope)
+        logEntryId = BatchedSubmissionValidator.rawToLogEntryId(submissionEnvelope)
         generatedWriteSets <- Timed.future(
           metrics.daml.kvutils.submission.validator.generateWriteSets,
           commitStrategy.generateWriteSets(
@@ -82,7 +82,7 @@ class PreExecutingSubmissionValidator[StateValue, ReadSet, WriteSet](
       }
     )
 
-  private def decodeSubmission(submissionEnvelope: Bytes)(
+  private def decodeSubmission(submissionEnvelope: Raw.Value)(
       implicit executionContext: ExecutionContext,
       loggingContext: LoggingContext,
   ): Future[DamlSubmission] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -5,11 +5,11 @@ package com.daml.ledger.validator.preexecution
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlSubmission}
 import com.daml.ledger.participant.state.kvutils.api.LedgerReader
-import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.batch.BatchedSubmissionValidator
 import com.daml.ledger.validator.reading.StateReader
-import com.daml.ledger.validator.{HasDamlStateValue, Raw, ValidationFailed}
+import com.daml.ledger.validator.{HasDamlStateValue, ValidationFailed}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{Metrics, Timed}
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -3,12 +3,11 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.reading.StateReader
-import com.daml.ledger.validator.{LedgerStateAccess, LedgerStateOperationsReaderAdapter}
+import com.daml.ledger.validator.{LedgerStateAccess, LedgerStateOperationsReaderAdapter, Raw}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.timer.RetryStrategy
 
@@ -52,7 +51,7 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
     */
   def commit(
       correlationId: String,
-      submissionEnvelope: Bytes,
+      submissionEnvelope: Raw.Value,
       submittingParticipantId: ParticipantId,
       ledgerStateAccess: LedgerStateAccess[Any],
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -5,8 +5,7 @@ package com.daml.ledger.validator.preexecution
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
-import com.daml.ledger.validator.reading.StateReader
+import com.daml.ledger.validator.reading.{LedgerStateReader, StateReader}
 import com.daml.ledger.validator.{LedgerStateAccess, LedgerStateOperationsReaderAdapter, Raw}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.timer.RetryStrategy
@@ -26,15 +25,8 @@ import scala.util.{Failure, Success}
   * @param postExecutionFinalizer        The post-execution finalizer.
   */
 class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
-    transformStateReader: StateReader[Key, Option[Value]] => StateReader[
-      DamlStateKey,
-      StateValue,
-    ],
-    validator: PreExecutingSubmissionValidator[
-      StateValue,
-      ReadSet,
-      WriteSet,
-    ],
+    transformStateReader: LedgerStateReader => StateReader[DamlStateKey, StateValue],
+    validator: PreExecutingSubmissionValidator[StateValue, ReadSet, WriteSet],
     postExecutionConflictDetector: PostExecutionConflictDetector[
       DamlStateKey,
       StateValue,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -4,9 +4,10 @@
 package com.daml.ledger.validator.preexecution
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.reading.{LedgerStateReader, StateReader}
-import com.daml.ledger.validator.{LedgerStateAccess, LedgerStateOperationsReaderAdapter, Raw}
+import com.daml.ledger.validator.{LedgerStateAccess, LedgerStateOperationsReaderAdapter}
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.timer.RetryStrategy
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
@@ -3,13 +3,13 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.Bytes
+import com.daml.ledger.validator.Raw
 
 /**
   * Raw key-value pairs with a distinct log entry.
   */
 case class RawKeyValuePairsWithLogEntry(
-    state: Iterable[(Bytes, Bytes)],
-    logEntryKey: Bytes,
-    logEntryValue: Bytes,
+    state: Iterable[Raw.Pair],
+    logEntryKey: Raw.Key,
+    logEntryValue: Raw.Value,
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.validator.Raw
+import com.daml.ledger.participant.state.kvutils.Raw
 
 /**
   * Raw key-value pairs with a distinct log entry.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
@@ -9,7 +9,7 @@ import com.daml.ledger.participant.state.kvutils.Raw
   * Raw key-value pairs with a distinct log entry.
   */
 case class RawKeyValuePairsWithLogEntry(
-    state: Iterable[Raw.Pair],
+    state: Iterable[Raw.KeyValuePair],
     logEntryKey: Raw.Key,
     logEntryValue: Raw.Value,
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPostExecutionFinalizer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPostExecutionFinalizer.scala
@@ -5,8 +5,9 @@ package com.daml.ledger.validator.preexecution
 
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.SubmissionResult
-import com.daml.ledger.validator.{LedgerStateOperations, Raw}
+import com.daml.ledger.validator.LedgerStateOperations
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPostExecutionFinalizer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPostExecutionFinalizer.scala
@@ -44,7 +44,7 @@ final class RawPostExecutionFinalizer[ReadSet](now: () => Instant)
   private def retrieveLogEntry(
       preExecutionOutput: PreExecutionOutput[Any, RawKeyValuePairsWithLogEntry],
       withinTimeBounds: Boolean,
-  ): Raw.Pair = {
+  ): Raw.KeyValuePair = {
     val writeSet = if (withinTimeBounds) {
       preExecutionOutput.successWriteSet
     } else {
@@ -56,7 +56,7 @@ final class RawPostExecutionFinalizer[ReadSet](now: () => Instant)
   private def retrieveState(
       preExecutionOutput: PreExecutionOutput[Any, RawKeyValuePairsWithLogEntry],
       withinTimeBounds: Boolean,
-  ): Iterable[Raw.Pair] =
+  ): Iterable[Raw.KeyValuePair] =
     if (withinTimeBounds) {
       preExecutionOutput.successWriteSet.state
     } else {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPostExecutionFinalizer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPostExecutionFinalizer.scala
@@ -5,9 +5,8 @@ package com.daml.ledger.validator.preexecution
 
 import java.time.Instant
 
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.SubmissionResult
-import com.daml.ledger.validator.LedgerStateOperations
+import com.daml.ledger.validator.{LedgerStateOperations, Raw}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -44,7 +43,7 @@ final class RawPostExecutionFinalizer[ReadSet](now: () => Instant)
   private def retrieveLogEntry(
       preExecutionOutput: PreExecutionOutput[Any, RawKeyValuePairsWithLogEntry],
       withinTimeBounds: Boolean,
-  ): (Bytes, Bytes) = {
+  ): Raw.Pair = {
     val writeSet = if (withinTimeBounds) {
       preExecutionOutput.successWriteSet
     } else {
@@ -56,7 +55,7 @@ final class RawPostExecutionFinalizer[ReadSet](now: () => Instant)
   private def retrieveState(
       preExecutionOutput: PreExecutionOutput[Any, RawKeyValuePairsWithLogEntry],
       withinTimeBounds: Boolean,
-  ): Iterable[(Bytes, Bytes)] =
+  ): Iterable[Raw.Pair] =
     if (withinTimeBounds) {
       preExecutionOutput.successWriteSet.state
     } else {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategy.scala
@@ -9,15 +9,15 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.preexecution.RawPreExecutingCommitStrategy.{InputState, ReadSet}
 import com.daml.ledger.validator.{
+  Raw,
   StateKeySerializationStrategy,
   StateSerializationStrategy,
   inParallel
 }
-import com.google.protobuf.ByteString
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -54,7 +54,7 @@ final class RawPreExecutingCommitStrategy(
         (serializedSuccessLogEntryPair, serializedOutOfTimeBoundsLogEntryPair),
       ) <- inParallel(
         Future(stateSerializationStrategy.serializeStateUpdates(preExecutionResult.stateUpdates)),
-        Future(logEntryId.toByteString).flatMap(
+        Future(Raw.Key(logEntryId.toByteString)).flatMap(
           serializedId =>
             inParallel(
               logEntryToKeyValuePairs(serializedId, preExecutionResult.successfulLogEntry),
@@ -80,9 +80,9 @@ final class RawPreExecutingCommitStrategy(
   }
 
   private def logEntryToKeyValuePairs(
-      logEntryId: ByteString,
+      logEntryId: Raw.Key,
       logEntry: DamlLogEntry,
-  )(implicit executionContext: ExecutionContext): Future[(Bytes, Bytes)] =
+  )(implicit executionContext: ExecutionContext): Future[Raw.Pair] =
     Future(logEntryId -> Envelope.enclose(logEntry))
 }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategy.scala
@@ -81,7 +81,7 @@ final class RawPreExecutingCommitStrategy(
   private def logEntryToKeyValuePairs(
       logEntryId: Raw.Key,
       logEntry: DamlLogEntry,
-  )(implicit executionContext: ExecutionContext): Future[Raw.Pair] =
+  )(implicit executionContext: ExecutionContext): Future[Raw.KeyValuePair] =
     Future(logEntryId -> Envelope.enclose(logEntry))
 }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategy.scala
@@ -9,11 +9,10 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.preexecution.RawPreExecutingCommitStrategy.{InputState, ReadSet}
 import com.daml.ledger.validator.{
-  Raw,
   StateKeySerializationStrategy,
   StateSerializationStrategy,
   inParallel

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
@@ -3,16 +3,15 @@
 
 package com.daml.ledger.validator
 
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.reading.StateReader
 
 import scala.concurrent.{ExecutionContext, Future}
 
 final class LedgerStateOperationsReaderAdapter[LogResult](
     operations: LedgerStateOperations[LogResult]
-) extends StateReader[Key, Option[Value]] {
+) extends StateReader[Raw.Key, Option[Raw.Value]] {
   override def read(
-      keys: Iterable[Key]
-  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Value]]] =
+      keys: Iterable[Raw.Key]
+  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
     operations.readState(keys)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.validator
 
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.validator.reading.StateReader
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
+import com.daml.ledger.participant.state.kvutils.Raw
 
 package object reading {
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
@@ -4,11 +4,10 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 
 package object reading {
 
-  type LedgerStateReader = StateReader[Key, Option[Value]]
+  type LedgerStateReader = StateReader[Raw.Key, Option[Raw.Value]]
 
   type DamlLedgerStateReader = StateReader[DamlStateKey, Option[DamlStateValue]]
 

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
@@ -14,6 +14,7 @@ import java.time.Instant
 
 import com.daml.ledger.participant.state.kvutils.export.LedgerDataExportSpecBase._
 import com.daml.ledger.participant.state.v1
+import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -78,10 +79,10 @@ object LedgerDataExportSpecBase {
   private def someSubmissionInfo(): SubmissionInfo = SubmissionInfo(
     participantId = v1.ParticipantId.assertFromString("id"),
     correlationId = "parent",
-    submissionEnvelope = ByteString.copyFromUtf8("an envelope"),
+    submissionEnvelope = Raw.Value(ByteString.copyFromUtf8("an envelope")),
     recordTimeInstant = Instant.ofEpochSecond(123456, 123456789),
   )
 
-  private def keyValuePairOf(key: String, value: String): (ByteString, ByteString) =
-    ByteString.copyFromUtf8(key) -> ByteString.copyFromUtf8(value)
+  private def keyValuePairOf(key: String, value: String): Raw.Pair =
+    Raw.Key(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
@@ -12,9 +12,9 @@ import java.io.{
 }
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.export.LedgerDataExportSpecBase._
 import com.daml.ledger.participant.state.v1
-import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
@@ -83,6 +83,6 @@ object LedgerDataExportSpecBase {
     recordTimeInstant = Instant.ofEpochSecond(123456, 123456789),
   )
 
-  private def keyValuePairOf(key: String, value: String): Raw.Pair =
+  private def keyValuePairOf(key: String, value: String): Raw.KeyValuePair =
     Raw.Key(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
@@ -38,7 +38,7 @@ private[validator] object TestHelper {
       .setSubmissionDedup(DamlSubmissionDedupKey.newBuilder.setSubmissionId("a submission ID")),
   ).map(_.build)
 
-  lazy val anInvalidEnvelope: ByteString = ByteString.copyFromUtf8("invalid data")
+  lazy val anInvalidEnvelope: Raw.Value = Raw.Value(ByteString.copyFromUtf8("invalid data"))
 
   def makePartySubmission(party: String): DamlSubmission = {
     val builder = DamlSubmission.newBuilder

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
@@ -4,6 +4,7 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.lf.value.ValueOuterClass.Identifier
 import com.google.protobuf.{ByteString, Empty}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriterSpec.scala
@@ -7,9 +7,10 @@ import akka.stream.Materializer
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch
-import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, MockitoHelpers}
+import com.daml.ledger.participant.state.kvutils.{Envelope, MockitoHelpers}
+import com.daml.ledger.participant.state.v1
 import com.daml.ledger.participant.state.v1.SubmissionResult
-import com.daml.ledger.participant.state.{kvutils, v1}
+import com.daml.ledger.validator.Raw
 import com.daml.logging.LoggingContext
 import com.google.protobuf.ByteString
 import org.mockito.{ArgumentCaptor, ArgumentMatchersSugar, MockitoSugar}
@@ -50,7 +51,7 @@ class BatchingLedgerWriterSpec
     }
 
     "construct batch correctly" in {
-      val batchCaptor = MockitoHelpers.captor[kvutils.Bytes]
+      val batchCaptor = MockitoHelpers.captor[Raw.Value]
       val mockWriter = createMockWriter(captor = Some(batchCaptor))
       val batchingWriter =
         LoggingContext.newLoggingContext { implicit loggingContext =>
@@ -81,7 +82,7 @@ class BatchingLedgerWriterSpec
         result2 <- batchingWriter.commit("test2", aSubmission, someCommitMetadata)
         result3 <- batchingWriter.commit("test3", aSubmission, someCommitMetadata)
       } yield {
-        verify(mockWriter, times(3)).commit(any[String], any[Bytes], any[CommitMetadata])
+        verify(mockWriter, times(3)).commit(any[String], any[Raw.Value], any[CommitMetadata])
         all(Seq(result1, result2, result3)) should be(SubmissionResult.Acknowledged)
         batchingWriter.currentHealth should be(HealthStatus.healthy)
       }
@@ -93,7 +94,7 @@ class BatchingLedgerWriterSpec
 
 object BatchingLedgerWriterSpec extends MockitoSugar with ArgumentMatchersSugar {
   private val aCorrelationId = "aCorrelationId"
-  private val aSubmission = ByteString.copyFromUtf8("a submission")
+  private val aSubmission = Raw.Value(ByteString.copyFromUtf8("a submission"))
 
   def immediateBatchingQueue()(implicit executionContext: ExecutionContext): BatchingQueue =
     new BatchingQueue {
@@ -113,7 +114,7 @@ object BatchingLedgerWriterSpec extends MockitoSugar with ArgumentMatchersSugar 
         }
     }
 
-  private def createMockWriter(captor: Option[ArgumentCaptor[kvutils.Bytes]]): LedgerWriter = {
+  private def createMockWriter(captor: Option[ArgumentCaptor[Raw.Value]]): LedgerWriter = {
     val writer = mock[LedgerWriter]
     when(writer.commit(any[String], captor.map(_.capture()).getOrElse(any), any[CommitMetadata]))
       .thenReturn(Future.successful(SubmissionResult.Acknowledged))
@@ -122,7 +123,7 @@ object BatchingLedgerWriterSpec extends MockitoSugar with ArgumentMatchersSugar 
     writer
   }
 
-  private def createExpectedBatch(correlatedSubmissions: (String, kvutils.Bytes)*): kvutils.Bytes =
+  private def createExpectedBatch(correlatedSubmissions: (String, Raw.Value)*): Raw.Value =
     Envelope
       .enclose(
         DamlSubmissionBatch.newBuilder
@@ -131,7 +132,7 @@ object BatchingLedgerWriterSpec extends MockitoSugar with ArgumentMatchersSugar 
               case (correlationId, submission) =>
                 DamlSubmissionBatch.CorrelatedSubmission.newBuilder
                   .setCorrelationId(correlationId)
-                  .setSubmission(submission)
+                  .setSubmission(submission.bytes)
                   .build
             }.asJava
           )

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriterSpec.scala
@@ -7,10 +7,9 @@ import akka.stream.Materializer
 import com.daml.ledger.api.health.HealthStatus
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch
-import com.daml.ledger.participant.state.kvutils.{Envelope, MockitoHelpers}
+import com.daml.ledger.participant.state.kvutils.{Envelope, MockitoHelpers, Raw}
 import com.daml.ledger.participant.state.v1
 import com.daml.ledger.participant.state.v1.SubmissionResult
-import com.daml.ledger.validator.Raw
 import com.daml.logging.LoggingContext
 import com.google.protobuf.ByteString
 import org.mockito.{ArgumentCaptor, ArgumentMatchersSugar, MockitoSugar}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooserSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooserSpec.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.api.health.{Healthy, Unhealthy}
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.SubmissionResult.Acknowledged
-import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooserSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooserSpec.scala
@@ -4,8 +4,8 @@
 package com.daml.ledger.participant.state.kvutils.api
 
 import com.daml.ledger.api.health.{Healthy, Unhealthy}
-import com.daml.ledger.participant.state.kvutils.Bytes
 import com.daml.ledger.participant.state.v1.SubmissionResult.Acknowledged
+import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
@@ -22,13 +22,13 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     "delegate to cheap writer in case of no estimated interpretation cost" in {
       val commitMetadata = simpleCommitMetadata(estimatedInterpretationCost = None)
       val mockWriterCheap = mock[LedgerWriter]
-      when(mockWriterCheap.commit(any[String], any[Bytes], any[CommitMetadata]))
+      when(mockWriterCheap.commit(any[String], any[Raw.Value], any[CommitMetadata]))
         .thenReturn(Future.successful(Acknowledged))
       val instance =
         new InterpretationCostBasedLedgerWriterChooser(1L, mockWriterCheap, mock[LedgerWriter])
 
       instance.commit(aCorrelationId, anEnvelope, commitMetadata).map { _ =>
-        verify(mockWriterCheap, times(1)).commit(any[String], any[Bytes], any[CommitMetadata])
+        verify(mockWriterCheap, times(1)).commit(any[String], any[Raw.Value], any[CommitMetadata])
         succeed
       }
     }
@@ -36,13 +36,13 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     "delegate to cheap writer in case estimated interpretation cost is below threshold" in {
       val commitMetadata = simpleCommitMetadata(estimatedInterpretationCost = Some(1))
       val mockWriterCheap = mock[LedgerWriter]
-      when(mockWriterCheap.commit(any[String], any[Bytes], any[CommitMetadata]))
+      when(mockWriterCheap.commit(any[String], any[Raw.Value], any[CommitMetadata]))
         .thenReturn(Future.successful(Acknowledged))
       val instance =
         new InterpretationCostBasedLedgerWriterChooser(2L, mockWriterCheap, mock[LedgerWriter])
 
       instance.commit(aCorrelationId, anEnvelope, commitMetadata).map { _ =>
-        verify(mockWriterCheap, times(1)).commit(any[String], any[Bytes], any[CommitMetadata])
+        verify(mockWriterCheap, times(1)).commit(any[String], any[Raw.Value], any[CommitMetadata])
         succeed
       }
     }
@@ -50,13 +50,14 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     "delegate to expensive writer in case estimated interpretation cost reaches the threshold" in {
       val commitMetadata = simpleCommitMetadata(estimatedInterpretationCost = Some(1))
       val mockWriterExpensive = mock[LedgerWriter]
-      when(mockWriterExpensive.commit(any[String], any[Bytes], any[CommitMetadata]))
+      when(mockWriterExpensive.commit(any[String], any[Raw.Value], any[CommitMetadata]))
         .thenReturn(Future.successful(Acknowledged))
       val instance =
         new InterpretationCostBasedLedgerWriterChooser(1L, mock[LedgerWriter], mockWriterExpensive)
 
       instance.commit(aCorrelationId, anEnvelope, commitMetadata).map { _ =>
-        verify(mockWriterExpensive, times(1)).commit(any[String], any[Bytes], any[CommitMetadata])
+        verify(mockWriterExpensive, times(1))
+          .commit(any[String], any[Raw.Value], any[CommitMetadata])
         succeed
       }
     }
@@ -64,13 +65,14 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     "delegate to expensive writer in case threshold is 0" in {
       val commitMetadata = simpleCommitMetadata(estimatedInterpretationCost = None)
       val mockWriterExpensive = mock[LedgerWriter]
-      when(mockWriterExpensive.commit(any[String], any[Bytes], any[CommitMetadata]))
+      when(mockWriterExpensive.commit(any[String], any[Raw.Value], any[CommitMetadata]))
         .thenReturn(Future.successful(Acknowledged))
       val instance =
         new InterpretationCostBasedLedgerWriterChooser(0L, mock[LedgerWriter], mockWriterExpensive)
 
       instance.commit(aCorrelationId, anEnvelope, commitMetadata).map { _ =>
-        verify(mockWriterExpensive, times(1)).commit(any[String], any[Bytes], any[CommitMetadata])
+        verify(mockWriterExpensive, times(1))
+          .commit(any[String], any[Raw.Value], any[CommitMetadata])
         succeed
       }
     }
@@ -93,8 +95,10 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     }
   }
 
-  private def aCorrelationId: String = ""
-  private def anEnvelope: Bytes = ByteString.EMPTY
+  private def aCorrelationId = ""
+
+  private def anEnvelope = Raw.Value(ByteString.EMPTY)
+
   private def simpleCommitMetadata(estimatedInterpretationCost: Option[Long]): CommitMetadata = {
     val mockCommitMetadata = mock[CommitMetadata]
     when(mockCommitMetadata.estimatedInterpretationCost).thenReturn(estimatedInterpretationCost)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
@@ -10,9 +10,8 @@ import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateReader.offsetForUpdate
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateReaderSpec._
-import com.daml.ledger.participant.state.kvutils.{Envelope, OffsetBuilder}
+import com.daml.ledger.participant.state.kvutils.{Envelope, OffsetBuilder, Raw}
 import com.daml.ledger.participant.state.v1.{Offset, ParticipantId, Update}
-import com.daml.ledger.validator.Raw
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.metrics.Metrics

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
@@ -10,8 +10,9 @@ import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateReader.offsetForUpdate
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateReaderSpec._
-import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, OffsetBuilder}
+import com.daml.ledger.participant.state.kvutils.{Envelope, OffsetBuilder}
 import com.daml.ledger.participant.state.v1.{Offset, ParticipantId, Update}
+import com.daml.ledger.validator.Raw
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.metrics.Metrics
@@ -156,7 +157,7 @@ class KeyValueParticipantStateReaderSpec
     }
 
     "throw in case of an invalid log entry received" in {
-      val anInvalidEnvelope = ByteString.copyFrom(Array[Byte](0, 1, 2))
+      val anInvalidEnvelope = Raw.Value(ByteString.copyFrom(Array[Byte](0, 1, 2)))
       val reader = readerStreamingFrom(
         offset = None,
         LedgerRecord(toOffset(0), aLogEntryId(0), anInvalidEnvelope))
@@ -251,11 +252,12 @@ object KeyValueParticipantStateReaderSpec {
         entry,
         recordTime)
 
-  private def aLogEntryId(index: Int): Bytes =
-    DamlLogEntryId.newBuilder
-      .setEntryId(ByteString.copyFrom(s"id-$index".getBytes))
-      .build
-      .toByteString
+  private def aLogEntryId(index: Int): Raw.Key =
+    Raw.Key(
+      DamlLogEntryId.newBuilder
+        .setEntryId(ByteString.copyFrom(s"id-$index".getBytes))
+        .build
+        .toByteString)
 
   private def readerStreamingFrom(offset: Option[Offset], items: LedgerRecord*): LedgerReader = {
     val reader = mock[LedgerReader]

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateWriterSpec.scala
@@ -8,14 +8,13 @@ import java.util.UUID
 
 import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
-import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.participant.state.kvutils.MockitoHelpers.captor
 import com.daml.ledger.participant.state.kvutils.api.KeyValueParticipantStateWriterSpec._
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.participant.state.v1
 import com.daml.ledger.participant.state.v1._
 import com.daml.ledger.validator.{
   DefaultStateKeySerializationStrategy,
-  Raw,
   StateKeySerializationStrategy
 }
 import com.daml.lf.crypto

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -43,6 +43,6 @@ final class InMemorySubmissionAggregatorSpec extends AnyWordSpec with Matchers w
     }
   }
 
-  private def keyValuePairOf(key: String, value: String): Raw.Pair =
+  private def keyValuePairOf(key: String, value: String): Raw.KeyValuePair =
     Raw.Key(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -5,8 +5,8 @@ package com.daml.ledger.participant.state.kvutils.export
 
 import java.time.Instant
 
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 import org.mockito.{Mockito, MockitoSugar}
 import org.scalatest.matchers.should.Matchers

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -6,9 +6,9 @@ package com.daml.ledger.participant.state.kvutils.export
 import java.time.Instant
 
 import com.daml.ledger.participant.state.v1.ParticipantId
+import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
-import org.mockito.Mockito
-import org.mockito.MockitoSugar
+import org.mockito.{Mockito, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -18,7 +18,7 @@ final class InMemorySubmissionAggregatorSpec extends AnyWordSpec with Matchers w
       val submissionInfo = SubmissionInfo(
         ParticipantId.assertFromString("participant-id"),
         "correlation ID",
-        ByteString.copyFromUtf8("the envelope"),
+        Raw.Value(ByteString.copyFromUtf8("the envelope")),
         Instant.now(),
       )
       val writer = mock[LedgerDataWriter]
@@ -43,6 +43,6 @@ final class InMemorySubmissionAggregatorSpec extends AnyWordSpec with Matchers w
     }
   }
 
-  private def keyValuePairOf(key: String, value: String): (ByteString, ByteString) =
-    ByteString.copyFromUtf8(key) -> ByteString.copyFromUtf8(value)
+  private def keyValuePairOf(key: String, value: String): Raw.Pair =
+    Raw.Key(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
@@ -37,14 +37,15 @@ final class LogAppendingCommitStrategySpec
           verify(mockLedgerStateOperations, times(1)).appendToLog(any[Raw.Key], any[Raw.Value])(
             anyExecutionContext)
           verify(mockLedgerStateOperations, times(0))
-            .writeState(any[Iterable[Raw.Pair]])(anyExecutionContext)
+            .writeState(any[Iterable[Raw.KeyValuePair]])(anyExecutionContext)
           actualIndex should be(expectedIndex)
         }
     }
 
     "write keys serialized according to strategy" in {
       val mockLedgerStateOperations = mock[LedgerStateOperations[Long]]
-      when(mockLedgerStateOperations.writeState(any[Iterable[Raw.Pair]])(anyExecutionContext))
+      when(
+        mockLedgerStateOperations.writeState(any[Iterable[Raw.KeyValuePair]])(anyExecutionContext))
         .thenReturn(Future.unit)
       when(mockLedgerStateOperations.appendToLog(any[Raw.Key], any[Raw.Value])(anyExecutionContext))
         .thenReturn(Future.successful(0L))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.validator
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
-import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.validator.ArgumentMatchers.anyExecutionContext
 import com.daml.ledger.validator.LogAppendingCommitStrategySpec._
 import com.daml.ledger.validator.TestHelper._

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
@@ -50,7 +50,7 @@ final class LogAppendingCommitStrategySpec
       when(mockLedgerStateOperations.appendToLog(any[Key], any[Value])(anyExecutionContext))
         .thenReturn(Future.successful(0L))
       val mockStateKeySerializationStrategy = mock[StateKeySerializationStrategy]
-      val expectedStateKey = ByteString.copyFromUtf8("some key")
+      val expectedStateKey = Raw.Key(ByteString.copyFromUtf8("some key"))
       when(mockStateKeySerializationStrategy.serializeStateKey(aStateKey))
         .thenReturn(expectedStateKey)
       val expectedOutputStateBytes = Map(expectedStateKey -> Envelope.enclose(aStateValue))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
@@ -6,7 +6,6 @@ package com.daml.ledger.validator
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.validator.ArgumentMatchers.anyExecutionContext
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.LogAppendingCommitStrategySpec._
 import com.daml.ledger.validator.TestHelper._
 import com.google.protobuf.ByteString
@@ -25,7 +24,7 @@ final class LogAppendingCommitStrategySpec
     "return index from appendToLog" in {
       val mockLedgerStateOperations = mock[LedgerStateOperations[Long]]
       val expectedIndex = 1234L
-      when(mockLedgerStateOperations.appendToLog(any[Key], any[Value])(anyExecutionContext))
+      when(mockLedgerStateOperations.appendToLog(any[Raw.Key], any[Raw.Value])(anyExecutionContext))
         .thenReturn(Future.successful(expectedIndex))
       val instance =
         new LogAppendingCommitStrategy[Long](
@@ -35,19 +34,19 @@ final class LogAppendingCommitStrategySpec
       instance
         .commit(aParticipantId, "a correlation ID", aLogEntryId(), aLogEntry, Map.empty, Map.empty)
         .map { actualIndex =>
-          verify(mockLedgerStateOperations, times(1)).appendToLog(any[Key], any[Value])(
+          verify(mockLedgerStateOperations, times(1)).appendToLog(any[Raw.Key], any[Raw.Value])(
             anyExecutionContext)
           verify(mockLedgerStateOperations, times(0))
-            .writeState(any[Iterable[(Key, Value)]])(anyExecutionContext)
+            .writeState(any[Iterable[Raw.Pair]])(anyExecutionContext)
           actualIndex should be(expectedIndex)
         }
     }
 
     "write keys serialized according to strategy" in {
       val mockLedgerStateOperations = mock[LedgerStateOperations[Long]]
-      when(mockLedgerStateOperations.writeState(any[Iterable[(Key, Value)]])(anyExecutionContext))
+      when(mockLedgerStateOperations.writeState(any[Iterable[Raw.Pair]])(anyExecutionContext))
         .thenReturn(Future.unit)
-      when(mockLedgerStateOperations.appendToLog(any[Key], any[Value])(anyExecutionContext))
+      when(mockLedgerStateOperations.appendToLog(any[Raw.Key], any[Raw.Value])(anyExecutionContext))
         .thenReturn(Future.successful(0L))
       val mockStateKeySerializationStrategy = mock[StateKeySerializationStrategy]
       val expectedStateKey = Raw.Key(ByteString.copyFromUtf8("some key"))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapterSpec.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.validator.ArgumentMatchers.anyExecutionContext
 import com.daml.ledger.validator.RawToDamlLedgerStateReaderAdapterSpec._
 import com.daml.ledger.validator.TestHelper.{anInvalidEnvelope, makePartySubmission}

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapterSpec.scala
@@ -10,7 +10,6 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
 }
 import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.validator.ArgumentMatchers.anyExecutionContext
-import com.daml.ledger.validator.LedgerStateOperations.Key
 import com.daml.ledger.validator.RawToDamlLedgerStateReaderAdapterSpec._
 import com.daml.ledger.validator.TestHelper.{anInvalidEnvelope, makePartySubmission}
 import com.daml.ledger.validator.reading.LedgerStateReader
@@ -32,7 +31,7 @@ class RawToDamlLedgerStateReaderAdapterSpec
         .setParty(DamlPartyAllocation.newBuilder.setDisplayName("aParty"))
         .build
       val mockReader = mock[LedgerStateReader]
-      when(mockReader.read(any[Seq[Key]])(anyExecutionContext))
+      when(mockReader.read(any[Seq[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(Envelope.enclose(expectedValue)))))
       val instance =
         new RawToDamlLedgerStateReaderAdapter(mockReader, DefaultStateKeySerializationStrategy)
@@ -45,7 +44,7 @@ class RawToDamlLedgerStateReaderAdapterSpec
 
     "throw in case of an invalid envelope returned from underlying reader" in {
       val mockReader = mock[LedgerStateReader]
-      when(mockReader.read(any[Seq[Key]])(anyExecutionContext))
+      when(mockReader.read(any[Seq[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(anInvalidEnvelope))))
       val instance =
         new RawToDamlLedgerStateReaderAdapter(mockReader, DefaultStateKeySerializationStrategy)
@@ -59,7 +58,7 @@ class RawToDamlLedgerStateReaderAdapterSpec
     "throw in case an enveloped value other than a DamlStateValue is returned from underlying reader" in {
       val notADamlStateValue = makePartySubmission("aParty")
       val mockReader = mock[LedgerStateReader]
-      when(mockReader.read(any[Seq[Key]])(anyExecutionContext))
+      when(mockReader.read(any[Seq[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(Envelope.enclose(notADamlStateValue)))))
       val instance =
         new RawToDamlLedgerStateReaderAdapter(mockReader, DefaultStateKeySerializationStrategy)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -145,7 +145,7 @@ class SubmissionValidatorSpec
               actualLogResult should be(expectedLogResult)
               verify(mockLogEntryIdGenerator, times(1)).apply()
               verify(mockStateOperations, times(0))
-                .writeState(any[Iterable[Raw.Pair]])(anyExecutionContext)
+                .writeState(any[Iterable[Raw.KeyValuePair]])(anyExecutionContext)
               logEntryValueCaptor.getAllValues should have size 1
               logEntryIdCaptor.getAllValues should have size 1
               logEntryIdCaptor.getValue should be(Raw.Key(expectedLogEntryId.toByteString))
@@ -268,7 +268,7 @@ class SubmissionValidatorSpec
 
     "return invalid submission if state cannot be written" in {
       val mockStateOperations = mock[LedgerStateOperations[Int]]
-      when(mockStateOperations.writeState(any[Iterable[Raw.Pair]])(anyExecutionContext))
+      when(mockStateOperations.writeState(any[Iterable[Raw.KeyValuePair]])(anyExecutionContext))
         .thenThrow(new IllegalArgumentException("Write error"))
       when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -9,7 +9,7 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.MockitoHelpers.captor
-import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.ArgumentMatchers.anyExecutionContext
 import com.daml.ledger.validator.SubmissionValidator.RawKeyValuePairs

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -9,10 +9,9 @@ import com.codahale.metrics.MetricRegistry
 import com.daml.caching.Cache
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.MockitoHelpers.captor
-import com.daml.ledger.participant.state.kvutils.{Bytes, Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.ArgumentMatchers.anyExecutionContext
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.SubmissionValidator.RawKeyValuePairs
 import com.daml.ledger.validator.SubmissionValidatorSpec._
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}
@@ -37,7 +36,7 @@ class SubmissionValidatorSpec
   "validate" should {
     "return success in case of no errors during processing of submission" in {
       val mockStateOperations = mock[LedgerStateOperations[Unit]]
-      when(mockStateOperations.readState(any[Iterable[Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val instance = SubmissionValidator.create(
         new FakeStateAccess(mockStateOperations),
@@ -54,7 +53,7 @@ class SubmissionValidatorSpec
 
     "signal missing input in case state cannot be retrieved" in {
       val mockStateOperations = mock[LedgerStateOperations[Unit]]
-      when(mockStateOperations.readState(any[Iterable[Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(None)))
       val instance = SubmissionValidator.create(
         ledgerStateAccess = new FakeStateAccess(mockStateOperations),
@@ -78,10 +77,11 @@ class SubmissionValidatorSpec
       )
       instance
         .validate(
-          ByteString.copyFrom(Array[Byte](1, 2, 3)),
+          Raw.Value(ByteString.copyFrom(Array[Byte](1, 2, 3))),
           "aCorrelationId",
           newRecordTime(),
-          aParticipantId())
+          aParticipantId(),
+        )
         .map {
           inside(_) {
             case Left(ValidationError(reason)) => reason should include("Failed to parse")
@@ -91,7 +91,7 @@ class SubmissionValidatorSpec
 
     "return invalid submission in case exception is thrown during processing of submission" in {
       val mockStateOperations = mock[BatchingLedgerStateOperations[Unit]]
-      when(mockStateOperations.readState(any[Iterable[Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
 
       val failingProcessSubmission: SubmissionValidator.ProcessSubmission =
@@ -117,10 +117,10 @@ class SubmissionValidatorSpec
     "write marshalled log entry to ledger" in {
       val mockStateOperations = mock[LedgerStateOperations[Int]]
       val expectedLogResult: Int = 3
-      when(mockStateOperations.readState(any[Iterable[Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
-      val logEntryValueCaptor = captor[Bytes]
-      val logEntryIdCaptor = captor[Bytes]
+      val logEntryIdCaptor = captor[Raw.Key]
+      val logEntryValueCaptor = captor[Raw.Value]
       when(
         mockStateOperations.appendToLog(logEntryIdCaptor.capture(), logEntryValueCaptor.capture())(
           anyExecutionContext))
@@ -145,11 +145,10 @@ class SubmissionValidatorSpec
               actualLogResult should be(expectedLogResult)
               verify(mockLogEntryIdGenerator, times(1)).apply()
               verify(mockStateOperations, times(0))
-                .writeState(any[Iterable[(Key, Value)]])(anyExecutionContext)
+                .writeState(any[Iterable[Raw.Pair]])(anyExecutionContext)
               logEntryValueCaptor.getAllValues should have size 1
               logEntryIdCaptor.getAllValues should have size 1
-              logEntryIdCaptor.getValue should be(expectedLogEntryId.toByteString)
-              logEntryValueCaptor.getValue should not be logEntryIdCaptor.getValue
+              logEntryIdCaptor.getValue should be(Raw.Key(expectedLogEntryId.toByteString))
           }
         }
     }
@@ -157,13 +156,15 @@ class SubmissionValidatorSpec
     "write marshalled key-value pairs to ledger" in {
       val mockStateOperations = mock[LedgerStateOperations[Int]]
       val expectedLogResult: Int = 7
-      when(mockStateOperations.readState(any[Iterable[Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val writtenKeyValuesCaptor = captor[RawKeyValuePairs]
       when(mockStateOperations.writeState(writtenKeyValuesCaptor.capture())(anyExecutionContext))
         .thenReturn(Future.unit)
-      val logEntryCaptor = captor[Bytes]
-      when(mockStateOperations.appendToLog(any[Key], logEntryCaptor.capture())(anyExecutionContext))
+      val logEntryCaptor = captor[Raw.Value]
+      when(
+        mockStateOperations.appendToLog(any[Raw.Key], logEntryCaptor.capture())(
+          anyExecutionContext))
         .thenReturn(Future.successful(expectedLogResult))
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates)
       val instance = new SubmissionValidator(
@@ -183,7 +184,7 @@ class SubmissionValidatorSpec
               writtenKeyValuesCaptor.getAllValues should have size 1
               val writtenKeyValues = writtenKeyValuesCaptor.getValue
               writtenKeyValues should have size 1
-              Try(SubmissionValidator.bytesToStateValue(writtenKeyValues.head._2)).isSuccess shouldBe true
+              Try(SubmissionValidator.stateValueFromRaw(writtenKeyValues.head._2)).isSuccess shouldBe true
               logEntryCaptor.getAllValues should have size 1
           }
         }
@@ -192,13 +193,15 @@ class SubmissionValidatorSpec
     "support batch with single submission" in {
       val mockStateOperations = mock[LedgerStateOperations[Int]]
       val expectedLogResult: Int = 7
-      when(mockStateOperations.readState(any[Iterable[Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val writtenKeyValuesCaptor = captor[RawKeyValuePairs]
       when(mockStateOperations.writeState(writtenKeyValuesCaptor.capture())(anyExecutionContext))
         .thenReturn(Future.unit)
-      val logEntryCaptor = captor[Bytes]
-      when(mockStateOperations.appendToLog(any[Key], logEntryCaptor.capture())(anyExecutionContext))
+      val logEntryCaptor = captor[Raw.Value]
+      when(
+        mockStateOperations.appendToLog(any[Raw.Key], logEntryCaptor.capture())(
+          anyExecutionContext))
         .thenReturn(Future.successful(expectedLogResult))
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates)
       val instance = new SubmissionValidator(
@@ -215,7 +218,7 @@ class SubmissionValidatorSpec
             .addSubmissions(
               DamlSubmissionBatch.CorrelatedSubmission.newBuilder
                 .setCorrelationId("aCorrelationId")
-                .setSubmission(anEnvelope()))
+                .setSubmission(anEnvelope().bytes))
             .build)
       instance
         .validateAndCommit(batchEnvelope, "aBatchCorrelationId", newRecordTime(), aParticipantId())
@@ -226,7 +229,7 @@ class SubmissionValidatorSpec
               writtenKeyValuesCaptor.getAllValues should have size 1
               val writtenKeyValues = writtenKeyValuesCaptor.getValue
               writtenKeyValues should have size 1
-              Try(SubmissionValidator.bytesToStateValue(writtenKeyValues.head._2)).isSuccess shouldBe true
+              Try(SubmissionValidator.stateValueFromRaw(writtenKeyValues.head._2)).isSuccess shouldBe true
               logEntryCaptor.getAllValues should have size 1
           }
         }
@@ -248,10 +251,10 @@ class SubmissionValidatorSpec
           DamlSubmissionBatch.newBuilder
             .addSubmissions(DamlSubmissionBatch.CorrelatedSubmission.newBuilder
               .setCorrelationId("aCorrelationId")
-              .setSubmission(anEnvelope()))
+              .setSubmission(anEnvelope().bytes))
             .addSubmissions(DamlSubmissionBatch.CorrelatedSubmission.newBuilder
               .setCorrelationId("aCorrelationId2")
-              .setSubmission(anEnvelope()))
+              .setSubmission(anEnvelope().bytes))
             .build)
       instance
         .validateAndCommit(batchEnvelope, "aBatchCorrelationId", newRecordTime(), aParticipantId())
@@ -265,11 +268,11 @@ class SubmissionValidatorSpec
 
     "return invalid submission if state cannot be written" in {
       val mockStateOperations = mock[LedgerStateOperations[Int]]
-      when(mockStateOperations.writeState(any[Iterable[(Key, Value)]])(anyExecutionContext))
+      when(mockStateOperations.writeState(any[Iterable[Raw.Pair]])(anyExecutionContext))
         .thenThrow(new IllegalArgumentException("Write error"))
-      when(mockStateOperations.readState(any[Iterable[Bytes]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
-      when(mockStateOperations.appendToLog(any[Key], any[Value])(anyExecutionContext))
+      when(mockStateOperations.appendToLog(any[Raw.Key], any[Raw.Value])(anyExecutionContext))
         .thenReturn(Future.successful(99))
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates)
       val instance = new SubmissionValidator(
@@ -312,10 +315,10 @@ object SubmissionValidatorSpec {
     Map(key -> value)
   }
 
-  private def aStateValue(): Bytes =
-    SubmissionValidator.valueToBytes(DamlStateValue.getDefaultInstance)
+  private def aStateValue(): Raw.Value =
+    SubmissionValidator.rawValue(DamlStateValue.getDefaultInstance)
 
-  private def anEnvelope(): Bytes = {
+  private def anEnvelope(): Raw.Value = {
     val submission = DamlSubmission
       .newBuilder()
       .setConfigurationSubmission(DamlConfigurationSubmission.getDefaultInstance)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -13,13 +13,13 @@ import com.daml.ledger.participant.state.kvutils.export.{
   NoOpLedgerDataExporter,
   SubmissionAggregator
 }
-import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting}
+import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.ArgumentMatchers.{anyExecutionContext, iterableOf}
 import com.daml.ledger.validator.TestHelper.{aParticipantId, anInvalidEnvelope, makePartySubmission}
 import com.daml.ledger.validator.batch.BatchedSubmissionValidatorSpec._
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
-import com.daml.ledger.validator.{CommitStrategy, Raw, ValidationFailed}
+import com.daml.ledger.validator.{CommitStrategy, ValidationFailed}
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.Engine
 import com.daml.metrics.Metrics

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitterSpec.scala
@@ -7,10 +7,11 @@ import java.time.Instant
 
 import akka.stream.Materializer
 import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.TestHelper.aParticipantId
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
-import com.daml.ledger.validator.{CommitStrategy, LedgerStateOperations, Raw}
+import com.daml.ledger.validator.{CommitStrategy, LedgerStateOperations}
 import com.google.protobuf.ByteString
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.MockitoSugar

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitterSpec.scala
@@ -10,7 +10,7 @@ import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.TestHelper.aParticipantId
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
-import com.daml.ledger.validator.{CommitStrategy, LedgerStateOperations}
+import com.daml.ledger.validator.{CommitStrategy, LedgerStateOperations, Raw}
 import com.google.protobuf.ByteString
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.MockitoSugar
@@ -36,9 +36,10 @@ class BatchedValidatingCommitterSpec
       instance
         .commit(
           correlationId = "",
-          submissionEnvelope = ByteString.EMPTY,
+          submissionEnvelope = Raw.Value(ByteString.EMPTY),
           submittingParticipantId = aParticipantId,
-          ledgerStateOperations = mock[LedgerStateOperations[Unit]])
+          ledgerStateOperations = mock[LedgerStateOperations[Unit]]
+        )
         .map { actual =>
           actual shouldBe SubmissionResult.Acknowledged
         }
@@ -53,9 +54,10 @@ class BatchedValidatingCommitterSpec
       instance
         .commit(
           correlationId = "",
-          submissionEnvelope = ByteString.EMPTY,
+          submissionEnvelope = Raw.Value(ByteString.EMPTY),
           submittingParticipantId = aParticipantId,
-          ledgerStateOperations = mock[LedgerStateOperations[Unit]])
+          ledgerStateOperations = mock[LedgerStateOperations[Unit]]
+        )
         .map { actual =>
           actual shouldBe SubmissionResult.InternalError("Validation failure")
         }
@@ -66,7 +68,7 @@ class BatchedValidatingCommitterSpec
       mockValidator: BatchedSubmissionValidator[Unit]): ScalaFirstStubbing[Future[Unit]] =
     when(
       mockValidator.validateAndCommit(
-        any[ByteString](),
+        any[Raw.Value](),
         anyString(),
         any[Instant](),
         any[ParticipantId](),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -13,14 +13,15 @@ import com.daml.ledger.participant.state.kvutils.{
   DamlStateMap,
   Envelope,
   KeyValueCommitting,
+  Raw,
   TestHelpers
 }
 import com.daml.ledger.participant.state.v1.Configuration
+import com.daml.ledger.validator.HasDamlStateValue
 import com.daml.ledger.validator.TestHelper._
 import com.daml.ledger.validator.ValidationFailed.ValidationError
 import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidatorSpec._
 import com.daml.ledger.validator.reading.StateReader
-import com.daml.ledger.validator.{HasDamlStateValue, Raw}
 import com.daml.lf.data.Ref.ParticipantId
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -10,18 +10,17 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmissionBatch
 import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
 import com.daml.ledger.participant.state.kvutils.{
-  Bytes,
   DamlStateMap,
   Envelope,
   KeyValueCommitting,
   TestHelpers
 }
 import com.daml.ledger.participant.state.v1.Configuration
-import com.daml.ledger.validator.HasDamlStateValue
 import com.daml.ledger.validator.TestHelper._
 import com.daml.ledger.validator.ValidationFailed.ValidationError
 import com.daml.ledger.validator.preexecution.PreExecutingSubmissionValidatorSpec._
 import com.daml.ledger.validator.reading.StateReader
+import com.daml.ledger.validator.{HasDamlStateValue, Raw}
 import com.daml.lf.data.Ref.ParticipantId
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext
@@ -88,7 +87,7 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
         .addSubmissions(
           CorrelatedSubmission.newBuilder
             .setCorrelationId("correlated submission")
-            .setSubmission(anEnvelope()))
+            .setSubmission(anEnvelope().bytes))
         .build()
 
       instance
@@ -156,7 +155,7 @@ object PreExecutingSubmissionValidatorSpec {
 
   private final case class TestWriteSet(value: String)
 
-  private def anEnvelope(expectedReadSet: Set[DamlStateKey] = Set.empty): Bytes = {
+  private def anEnvelope(expectedReadSet: Set[DamlStateKey] = Set.empty): Raw.Value = {
     val submission = DamlSubmission
       .newBuilder()
       .setConfigurationSubmission(DamlConfigurationSubmission.getDefaultInstance)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategySpec.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.validator.preexecution
 
+import com.daml.ledger.participant.state.kvutils.DamlKvutils
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlContractState,
   DamlLogEntry,
@@ -11,8 +12,6 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateValue
 }
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
-import com.daml.ledger.participant.state.kvutils.{DamlKvutils, `Bytes Ordering`}
-import com.daml.ledger.validator.StateKeySerializationStrategy
 import com.daml.ledger.validator.TestHelper.{
   aLogEntry,
   aLogEntryId,
@@ -20,6 +19,7 @@ import com.daml.ledger.validator.TestHelper.{
   allDamlStateKeyTypes
 }
 import com.daml.ledger.validator.preexecution.RawPreExecutingCommitStrategySpec._
+import com.daml.ledger.validator.{Raw, StateKeySerializationStrategy}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar
 import org.mockito.invocation.InvocationOnMock
@@ -63,7 +63,7 @@ final class RawPreExecutingCommitStrategySpec
   "generateWriteSets" should {
     "serialize keys according to strategy" in {
       val logEntryId = aLogEntryId()
-      val expectedLogEntryKey = logEntryId.toByteString
+      val expectedLogEntryKey = Raw.Key(logEntryId.toByteString)
       val preExecutionResult = PreExecutionResult(
         readSet = Set.empty,
         successfulLogEntry = aLogEntry,
@@ -96,7 +96,7 @@ final class RawPreExecutingCommitStrategySpec
     val mockStateKeySerializationStrategy = mock[StateKeySerializationStrategy]
     when(mockStateKeySerializationStrategy.serializeStateKey(any[DamlStateKey]()))
       .thenAnswer((invocation: InvocationOnMock) =>
-        invocation.getArgument[DamlStateKey](0).getContractIdBytes)
+        Raw.Key(invocation.getArgument[DamlStateKey](0).getContractIdBytes))
     mockStateKeySerializationStrategy
   }
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategySpec.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.validator.preexecution
 
-import com.daml.ledger.participant.state.kvutils.DamlKvutils
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlContractState,
   DamlLogEntry,
@@ -12,6 +11,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateValue
 }
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
+import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Raw}
+import com.daml.ledger.validator.StateKeySerializationStrategy
 import com.daml.ledger.validator.TestHelper.{
   aLogEntry,
   aLogEntryId,
@@ -19,7 +20,6 @@ import com.daml.ledger.validator.TestHelper.{
   allDamlStateKeyTypes
 }
 import com.daml.ledger.validator.preexecution.RawPreExecutingCommitStrategySpec._
-import com.daml.ledger.validator.{Raw, StateKeySerializationStrategy}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar
 import org.mockito.invocation.InvocationOnMock

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/BenchmarkWithLedgerExport.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/BenchmarkWithLedgerExport.scala
@@ -9,8 +9,8 @@ import com.daml.bazeltools.BazelRunfiles
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
 import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.participant.state.kvutils.`export`.ProtobufBasedLedgerDataImporter
+import com.daml.ledger.validator.Raw
 import com.daml.lf.archive.Decode
-import com.google.protobuf.ByteString
 import org.openjdk.jmh.annotations.{Param, Scope, Setup, State}
 
 import scala.collection.JavaConverters.iterableAsScalaIterableConverter
@@ -38,7 +38,7 @@ abstract class BenchmarkWithLedgerExport {
 
     val builder = Submissions.newBuilder()
 
-    def decodeEnvelope(envelope: ByteString): Unit =
+    def decodeEnvelope(envelope: Raw.Value): Unit =
       Envelope.open(envelope).fold(sys.error, identity) match {
         case Envelope.SubmissionMessage(submission)
             if submission.getPayloadCase == DamlSubmission.PayloadCase.PACKAGE_UPLOAD_ENTRY =>
@@ -50,7 +50,7 @@ abstract class BenchmarkWithLedgerExport {
           builder += submission.getTransactionEntry.getTransaction
         case Envelope.SubmissionBatchMessage(batch) =>
           for (submission <- batch.getSubmissionsList.asScala) {
-            decodeEnvelope(submission.getSubmission)
+            decodeEnvelope(Raw.Value(submission.getSubmission))
           }
         case _ =>
           ()

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/BenchmarkWithLedgerExport.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/BenchmarkWithLedgerExport.scala
@@ -7,9 +7,8 @@ import java.nio.file.{Files, Paths}
 
 import com.daml.bazeltools.BazelRunfiles
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlSubmission
-import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.participant.state.kvutils.`export`.ProtobufBasedLedgerDataImporter
-import com.daml.ledger.validator.Raw
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.lf.archive.Decode
 import org.openjdk.jmh.annotations.{Param, Scope, Setup, State}
 

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
@@ -199,7 +199,8 @@ object Replay {
       case Envelope.SubmissionBatchMessage(batch) =>
         batch.getSubmissionsList.asScala.toStream
           .map(_.getSubmission)
-          .flatMap(envelope => decodeEnvelope(participantId, Raw.Value(envelope)))
+          .flatMap(submissionEnvelope =>
+            decodeEnvelope(participantId, Raw.Value(submissionEnvelope)))
       case Envelope.LogEntryMessage(_) | Envelope.StateValueMessage(_) =>
         Stream.empty
     }

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
@@ -12,9 +12,8 @@ import com.daml.ledger.participant.state.kvutils.export.{
   ProtobufBasedLedgerDataImporter,
   SubmissionInfo
 }
-import com.daml.ledger.participant.state.kvutils.{Envelope, DamlKvutils => Proto}
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw, DamlKvutils => Proto}
 import com.daml.ledger.participant.state.v1.ParticipantId
-import com.daml.ledger.validator.Raw
 import com.daml.lf.archive.{Decode, UniversalArchiveReader}
 import com.daml.lf.crypto
 import com.daml.lf.data._

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
@@ -12,11 +12,11 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue
 }
-import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.IntegrityChecker.rawHexString
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.validator.batch.BatchedSubmissionValidatorFactory
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
-import com.daml.ledger.validator.{CommitStrategy, Raw, StateKeySerializationStrategy}
+import com.daml.ledger.validator.{CommitStrategy, StateKeySerializationStrategy}
 import com.daml.metrics.Metrics
 
 import scala.concurrent.ExecutionContext

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
@@ -13,7 +13,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateValue
 }
 import com.daml.ledger.participant.state.kvutils.Envelope
-import com.daml.ledger.participant.state.kvutils.tools.integritycheck.IntegrityChecker.bytesAsHexString
+import com.daml.ledger.participant.state.kvutils.tools.integritycheck.IntegrityChecker.rawHexString
 import com.daml.ledger.validator.batch.BatchedSubmissionValidatorFactory
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
 import com.daml.ledger.validator.{CommitStrategy, Raw, StateKeySerializationStrategy}
@@ -60,7 +60,7 @@ final class LogAppendingCommitStrategySupport(implicit executionContext: Executi
     val expectedLogEntry = kvutils.Envelope.openLogEntry(expectedValue)
     val actualLogEntry = kvutils.Envelope.openLogEntry(actualValue)
     Some(
-      s"Log entry ID: ${bytesAsHexString(logEntryId.bytes)}${System.lineSeparator()}" +
+      s"Log entry ID: ${rawHexString(logEntryId)}${System.lineSeparator()}" +
         s"Expected: $expectedLogEntry${System.lineSeparator()}Actual: $actualLogEntry"
     )
   }

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
@@ -14,10 +14,9 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
 }
 import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.IntegrityChecker.bytesAsHexString
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.batch.BatchedSubmissionValidatorFactory
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
-import com.daml.ledger.validator.{CommitStrategy, StateKeySerializationStrategy}
+import com.daml.ledger.validator.{CommitStrategy, Raw, StateKeySerializationStrategy}
 import com.daml.metrics.Metrics
 
 import scala.concurrent.ExecutionContext
@@ -54,9 +53,10 @@ final class LogAppendingCommitStrategySupport(implicit executionContext: Executi
     new LogAppendingReadServiceFactory(metrics)
 
   override def explainMismatchingValue(
-      logEntryId: Key,
-      expectedValue: Value,
-      actualValue: Value): Option[String] = {
+      logEntryId: Raw.Key,
+      expectedValue: Raw.Value,
+      actualValue: Raw.Value,
+  ): Option[String] = {
     val expectedLogEntry = kvutils.Envelope.openLogEntry(expectedValue)
     val actualLogEntry = kvutils.Envelope.openLogEntry(actualValue)
     Some(
@@ -65,7 +65,7 @@ final class LogAppendingCommitStrategySupport(implicit executionContext: Executi
     )
   }
 
-  override def checkEntryIsReadable(rawKey: Key, rawValue: Value): Either[String, Unit] =
+  override def checkEntryIsReadable(rawKey: Raw.Key, rawValue: Raw.Value): Either[String, Unit] =
     Envelope.open(rawValue) match {
       case Left(errorMessage) =>
         Left(s"Invalid value envelope: $errorMessage")

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateOperations.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateOperations.scala
@@ -3,9 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
-import com.daml.ledger.participant.state.kvutils.export.WriteSet
-import com.daml.ledger.validator.LedgerStateOperations
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.participant.state.kvutils.export.{WriteItem, WriteSet}
+import com.daml.ledger.validator.{LedgerStateOperations, Raw}
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}
@@ -13,34 +12,37 @@ import scala.concurrent.{ExecutionContext, Future}
 class WriteRecordingLedgerStateOperations[LogResult](delegate: LedgerStateOperations[LogResult])
     extends LedgerStateOperations[LogResult]
     with QueryableWriteSet {
-  private val recordedWriteSet = ListBuffer.empty[(Key, Value)]
+  private val recordedWriteSet = ListBuffer.empty[WriteItem]
 
-  override def readState(key: Key)(
-      implicit executionContext: ExecutionContext
-  ): Future[Option[Value]] = delegate.readState(key)
+  override def readState(
+      key: Raw.Key
+  )(implicit executionContext: ExecutionContext): Future[Option[Raw.Value]] =
+    delegate.readState(key)
 
-  override def readState(keys: Iterable[Key])(
-      implicit executionContext: ExecutionContext
-  ): Future[Seq[Option[Value]]] =
+  override def readState(
+      keys: Iterable[Raw.Key]
+  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
     delegate.readState(keys)
 
-  override def writeState(key: Key, value: Value)(
-      implicit executionContext: ExecutionContext
-  ): Future[Unit] = {
+  override def writeState(
+      key: Raw.Key,
+      value: Raw.Value,
+  )(implicit executionContext: ExecutionContext): Future[Unit] = {
     this.synchronized(recordedWriteSet.append((key, value)))
     delegate.writeState(key, value)
   }
 
-  override def writeState(keyValuePairs: Iterable[(Key, Value)])(
-      implicit executionContext: ExecutionContext
-  ): Future[Unit] = {
+  override def writeState(
+      keyValuePairs: Iterable[Raw.Pair]
+  )(implicit executionContext: ExecutionContext): Future[Unit] = {
     this.synchronized(recordedWriteSet.appendAll(keyValuePairs))
     delegate.writeState(keyValuePairs)
   }
 
-  override def appendToLog(key: Key, value: Value)(
-      implicit executionContext: ExecutionContext
-  ): Future[LogResult] = {
+  override def appendToLog(
+      key: Raw.Key,
+      value: Raw.Value,
+  )(implicit executionContext: ExecutionContext): Future[LogResult] = {
     this.synchronized(recordedWriteSet.append((key, value)))
     delegate.appendToLog(key, value)
   }

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateOperations.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateOperations.scala
@@ -3,8 +3,9 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.export.{WriteItem, WriteSet}
-import com.daml.ledger.validator.{LedgerStateOperations, Raw}
+import com.daml.ledger.validator.LedgerStateOperations
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateOperations.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateOperations.scala
@@ -34,7 +34,7 @@ class WriteRecordingLedgerStateOperations[LogResult](delegate: LedgerStateOperat
   }
 
   override def writeState(
-      keyValuePairs: Iterable[Raw.Pair]
+      keyValuePairs: Iterable[Raw.KeyValuePair]
   )(implicit executionContext: ExecutionContext): Future[Unit] = {
     this.synchronized(recordedWriteSet.appendAll(keyValuePairs))
     delegate.writeState(keyValuePairs)

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupportSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupportSpec.scala
@@ -12,9 +12,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateValue
 }
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.LogAppendingCommitStrategySupportSpec._
-import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Envelope, Version}
+import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Envelope, Raw, Version}
 import com.daml.ledger.participant.state.protobuf.LedgerConfiguration
-import com.daml.ledger.validator.Raw
 import com.google.protobuf.{ByteString, Empty}
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupportSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupportSpec.scala
@@ -14,6 +14,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.LogAppendingCommitStrategySupportSpec._
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Envelope, Version}
 import com.daml.ledger.participant.state.protobuf.LedgerConfiguration
+import com.daml.ledger.validator.Raw
 import com.google.protobuf.{ByteString, Empty}
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
@@ -42,39 +43,42 @@ final class LogAppendingCommitStrategySupportSpec extends AnyWordSpec with Match
     }
 
     "fail on an invalid envelope" in {
-      val value = ByteString.copyFromUtf8("invalid envelope")
+      val value = Raw.Value(ByteString.copyFromUtf8("invalid envelope"))
       inside(support.checkEntryIsReadable(noKey, value)) {
         case Left(message) => message should startWith("Invalid value envelope:")
       }
     }
 
     "fail on an unknown entry" in {
-      val value = DamlKvutils.Envelope.newBuilder
-        .setVersion(Version.version)
-        .build()
-        .toByteString
+      val value = Raw.Value(
+        DamlKvutils.Envelope.newBuilder
+          .setVersion(Version.version)
+          .build()
+          .toByteString)
       inside(support.checkEntryIsReadable(noKey, value)) {
         case Left(_) => succeed
       }
     }
 
     "fail on a submission entry" in {
-      val value = DamlKvutils.Envelope.newBuilder
-        .setVersion(Version.version)
-        .setKind(DamlKvutils.Envelope.MessageKind.SUBMISSION)
-        .build()
-        .toByteString
+      val value = Raw.Value(
+        DamlKvutils.Envelope.newBuilder
+          .setVersion(Version.version)
+          .setKind(DamlKvutils.Envelope.MessageKind.SUBMISSION)
+          .build()
+          .toByteString)
       inside(support.checkEntryIsReadable(noKey, value)) {
         case Left(message) => message should startWith("Unexpected submission message:")
       }
     }
 
     "fail on a submission batch entry" in {
-      val value = DamlKvutils.Envelope.newBuilder
-        .setVersion(Version.version)
-        .setKind(DamlKvutils.Envelope.MessageKind.SUBMISSION_BATCH)
-        .build()
-        .toByteString
+      val value = Raw.Value(
+        DamlKvutils.Envelope.newBuilder
+          .setVersion(Version.version)
+          .setKind(DamlKvutils.Envelope.MessageKind.SUBMISSION_BATCH)
+          .build()
+          .toByteString)
       inside(support.checkEntryIsReadable(noKey, value)) {
         case Left(message) => message should startWith("Unexpected submission batch message:")
       }
@@ -89,7 +93,7 @@ final class LogAppendingCommitStrategySupportSpec extends AnyWordSpec with Match
     }
 
     "fail on a state entry with an invalid key" in {
-      val key = DamlStateKey.newBuilder.build().toByteString
+      val key = Raw.Key(DamlStateKey.newBuilder.build().toByteString)
       val value = aValidStateValue
       inside(support.checkEntryIsReadable(key, value)) {
         case Left(message) => message should be("State key not set.")
@@ -127,21 +131,26 @@ final class LogAppendingCommitStrategySupportSpec extends AnyWordSpec with Match
 }
 
 object LogAppendingCommitStrategySupportSpec {
-  private val noKey: ByteString = ByteString.EMPTY
+  private val noKey: Raw.Key =
+    Raw.Key(ByteString.EMPTY)
 
-  private val aValidLogEntryId: ByteString =
-    DamlLogEntryId.newBuilder.setEntryId(ByteString.copyFromUtf8("entry-id")).build().toByteString
+  private val aValidLogEntryId: Raw.Key =
+    Raw.Key(
+      DamlLogEntryId.newBuilder
+        .setEntryId(ByteString.copyFromUtf8("entry-id"))
+        .build()
+        .toByteString)
 
-  private val aValidLogEntry: ByteString =
+  private val aValidLogEntry: Raw.Value =
     Envelope.enclose(
       DamlLogEntry.newBuilder
         .setPartyAllocationEntry(DamlPartyAllocationEntry.newBuilder.setParty("Alice"))
         .build())
 
-  private val aValidStateKey: ByteString =
-    DamlStateKey.newBuilder.setConfiguration(Empty.getDefaultInstance).build().toByteString
+  private val aValidStateKey: Raw.Key =
+    Raw.Key(DamlStateKey.newBuilder.setConfiguration(Empty.getDefaultInstance).build().toByteString)
 
-  private val aValidStateValue: ByteString =
+  private val aValidStateValue: Raw.Value =
     Envelope.enclose(
       DamlStateValue.newBuilder
         .setConfigurationEntry(

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactorySpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactorySpec.scala
@@ -16,6 +16,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
 }
 import com.daml.ledger.participant.state.kvutils.Envelope
 import com.daml.ledger.participant.state.v1
+import com.daml.ledger.validator.Raw
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.metrics.Metrics
@@ -76,7 +77,6 @@ final class LogAppendingReadServiceFactorySpec extends AsyncWordSpec with Matche
   private val AnEntryId = "AnEntryId"
   private lazy val aLogEntryId =
     DamlLogEntryId.newBuilder().setEntryId(ByteString.copyFromUtf8(AnEntryId)).build()
-  private lazy val aSerializedLogEntryId = aLogEntryId.toByteString
 
   private lazy val APartyName = "aParty"
   private lazy val AParticipantId = "aParticipant"
@@ -96,5 +96,6 @@ final class LogAppendingReadServiceFactorySpec extends AsyncWordSpec with Matche
     None,
   )
 
+  private lazy val aSerializedLogEntryId = Raw.Key(aLogEntryId.toByteString)
   private lazy val aWrappedLogEntry = Envelope.enclose(aLogEntry)
 }

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactorySpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactorySpec.scala
@@ -14,9 +14,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlLogEntryId,
   DamlPartyAllocationEntry
 }
-import com.daml.ledger.participant.state.kvutils.Envelope
+import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 import com.daml.ledger.participant.state.v1
-import com.daml.ledger.validator.Raw
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Time.Timestamp
 import com.daml.metrics.Metrics

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/CommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/CommitStrategySupport.scala
@@ -6,9 +6,8 @@ package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 import akka.stream.Materializer
 import com.daml.ledger.participant.state.kvutils.export.WriteSet
 import com.daml.ledger.participant.state.v1.ReadService
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
-import com.daml.ledger.validator.{CommitStrategy, StateKeySerializationStrategy}
+import com.daml.ledger.validator.{CommitStrategy, Raw, StateKeySerializationStrategy}
 
 trait QueryableWriteSet {
   def getAndClearRecordedWriteSet(): WriteSet
@@ -41,14 +40,18 @@ trait CommitStrategySupport[LogResult] {
     * Determines if there's an actual difference and tries to explain it in case there is.
     * A None return value signals that no difference should be signaled to the user.
     */
-  def explainMismatchingValue(key: Key, expectedValue: Value, actualValue: Value): Option[String]
+  def explainMismatchingValue(
+      key: Raw.Key,
+      expectedValue: Raw.Value,
+      actualValue: Raw.Value,
+  ): Option[String]
 
   /**
     * Validates that a single write set entry is readable.
     *
-    * @param keyBytes   The serialized key.
-    * @param valueBytes The serialized value.
+    * @param rawKey   The serialized key.
+    * @param rawValue The serialized value.
     * @return `Right(())` if the entry is valid, or `Left(message)` with an explanation otherwise.
     */
-  def checkEntryIsReadable(keyBytes: Key, valueBytes: Value): Either[String, Unit]
+  def checkEntryIsReadable(rawKey: Raw.Key, rawValue: Raw.Value): Either[String, Unit]
 }

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/CommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/CommitStrategySupport.scala
@@ -4,10 +4,11 @@
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
 import akka.stream.Materializer
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.export.WriteSet
 import com.daml.ledger.participant.state.v1.ReadService
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
-import com.daml.ledger.validator.{CommitStrategy, Raw, StateKeySerializationStrategy}
+import com.daml.ledger.validator.{CommitStrategy, StateKeySerializationStrategy}
 
 trait QueryableWriteSet {
   def getAndClearRecordedWriteSet(): WriteSet

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -204,7 +204,7 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
           println(
             "Read submission"
               + s" correlationId=${submissionInfo.correlationId}"
-              + s" submissionEnvelopeSize=${submissionInfo.submissionEnvelope.size()}"
+              + s" submissionEnvelopeSize=${submissionInfo.submissionEnvelope.size}"
               + s" writeSetSize=${expectedWriteSet.size}"
           )
           expectedWriteSet.foreach {
@@ -227,7 +227,7 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
               val actualWriteSet = commitStrategySupport.writeSet.getAndClearRecordedWriteSet()
               val orderedActualWriteSet =
                 if (config.sortWriteSet)
-                  actualWriteSet.sortBy(_._1.asReadOnlyByteBuffer())
+                  actualWriteSet.sortBy(_._1)
                 else
                   actualWriteSet
               actualReadServiceFactory.appendBlock(orderedActualWriteSet)
@@ -273,16 +273,16 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
           if (expectedKey == actualKey && expectedValue != actualValue) {
             explainDifference(expectedKey, expectedValue, actualValue).map { explainedDifference =>
               Seq(
-                s"expected value:    ${bytesAsHexString(expectedValue)}",
-                s" vs. actual value: ${bytesAsHexString(actualValue)}",
+                s"expected value:    ${bytesAsHexString(expectedValue.bytes)}",
+                s" vs. actual value: ${bytesAsHexString(actualValue.bytes)}",
                 explainedDifference,
               )
             }
           } else if (expectedKey != actualKey) {
             Some(
               Seq(
-                s"expected key:    ${bytesAsHexString(expectedKey)}",
-                s" vs. actual key: ${bytesAsHexString(actualKey)}",
+                s"expected key:    ${bytesAsHexString(expectedKey.bytes)}",
+                s" vs. actual key: ${bytesAsHexString(actualKey.bytes)}",
               ))
           } else {
             None

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -20,7 +20,7 @@ import com.daml.ledger.participant.state.kvutils.export.{
 }
 import com.daml.ledger.participant.state.v1.{ParticipantId, ReadService}
 import com.daml.ledger.resources.{ResourceContext, ResourceOwner}
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.Raw
 import com.daml.ledger.validator.batch.{
   BatchedSubmissionValidator,
   BatchedSubmissionValidatorParameters,
@@ -299,9 +299,10 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
   }
 
   private def explainDifference(
-      key: Key,
-      expectedValue: Value,
-      actualValue: Value): Option[String] =
+      key: Raw.Key,
+      expectedValue: Raw.Value,
+      actualValue: Raw.Value,
+  ): Option[String] =
     kvutils.Envelope
       .openStateValue(expectedValue)
       .toOption

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -344,7 +344,7 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
 }
 
 object IntegrityChecker {
-  def rawHexString(raw: Raw): String =
+  def rawHexString(raw: Raw.Bytes): String =
     raw.bytes.toByteArray.map(byte => "%02x".format(byte)).mkString
 
   abstract class CheckFailedException(message: String) extends RuntimeException(message)

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -11,16 +11,15 @@ import akka.stream.scaladsl.{Sink, Source}
 import com.codahale.metrics.{ConsoleReporter, MetricRegistry}
 import com.daml.dec.DirectExecutionContext
 import com.daml.ledger.participant.state.kvutils
-import com.daml.ledger.participant.state.kvutils.KeyValueCommitting
 import com.daml.ledger.participant.state.kvutils.export.{
   LedgerDataImporter,
   NoOpLedgerDataExporter,
   ProtobufBasedLedgerDataImporter,
   WriteSet
 }
+import com.daml.ledger.participant.state.kvutils.{KeyValueCommitting, Raw}
 import com.daml.ledger.participant.state.v1.{ParticipantId, ReadService}
 import com.daml.ledger.resources.{ResourceContext, ResourceOwner}
-import com.daml.ledger.validator.Raw
 import com.daml.ledger.validator.batch.{
   BatchedSubmissionValidator,
   BatchedSubmissionValidatorParameters,

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -33,7 +33,6 @@ import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.indexer.{IndexerConfig, IndexerStartupMode, JdbcIndexer}
 import com.daml.platform.store.dao.events.LfValueTranslation
-import com.google.protobuf.ByteString
 
 import scala.PartialFunction.condOpt
 import scala.concurrent.duration.Duration
@@ -273,16 +272,16 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
           if (expectedKey == actualKey && expectedValue != actualValue) {
             explainDifference(expectedKey, expectedValue, actualValue).map { explainedDifference =>
               Seq(
-                s"expected value:    ${bytesAsHexString(expectedValue.bytes)}",
-                s" vs. actual value: ${bytesAsHexString(actualValue.bytes)}",
+                s"expected value:    ${rawHexString(expectedValue)}",
+                s" vs. actual value: ${rawHexString(actualValue)}",
                 explainedDifference,
               )
             }
           } else if (expectedKey != actualKey) {
             Some(
               Seq(
-                s"expected key:    ${bytesAsHexString(expectedKey.bytes)}",
-                s" vs. actual key: ${bytesAsHexString(actualKey.bytes)}",
+                s"expected key:    ${rawHexString(expectedKey)}",
+                s" vs. actual key: ${rawHexString(actualKey)}",
               ))
           } else {
             None
@@ -346,8 +345,8 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
 }
 
 object IntegrityChecker {
-  def bytesAsHexString(bytes: ByteString): String =
-    bytes.toByteArray.map(byte => "%02x".format(byte)).mkString
+  def rawHexString(raw: Raw): String =
+    raw.bytes.toByteArray.map(byte => "%02x".format(byte)).mkString
 
   abstract class CheckFailedException(message: String) extends RuntimeException(message)
 

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/Builders.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/Builders.scala
@@ -3,8 +3,8 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.`export`.WriteSet
-import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 
 object Builders {

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/Builders.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/Builders.scala
@@ -4,14 +4,14 @@
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
 import com.daml.ledger.participant.state.kvutils.`export`.WriteSet
+import com.daml.ledger.validator.Raw
 import com.google.protobuf.ByteString
 
 object Builders {
-  def bytes(text: String): ByteString =
-    ByteString.copyFromUtf8(text)
 
   def writeSet(values: (String, String)*): WriteSet =
     values.map {
-      case (key, value) => bytes(key) -> bytes(value)
+      case (key, value) =>
+        Raw.Key(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
     }
 }

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 import java.nio.file.Paths
 
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.Builders._
-import com.daml.ledger.validator.LedgerStateOperations.{Key, Value}
+import com.daml.ledger.validator.Raw
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
@@ -21,7 +21,9 @@ final class IntegrityCheckerSpec
   "compareSameSizeWriteSets" should {
     "return None in case strategy cannot explain difference" in {
       val mockCommitStrategySupport = mock[CommitStrategySupport[Unit]]
-      when(mockCommitStrategySupport.explainMismatchingValue(any[Key], any[Value], any[Value]))
+      when(
+        mockCommitStrategySupport
+          .explainMismatchingValue(any[Raw.Key], any[Raw.Value], any[Raw.Value]))
         .thenReturn(None)
       val instance = new IntegrityChecker[Unit](mockCommitStrategySupport)
 
@@ -37,7 +39,9 @@ final class IntegrityCheckerSpec
 
     "return explanation from strategy in case it can explain the difference" in {
       val mockCommitStrategySupport = mock[CommitStrategySupport[Unit]]
-      when(mockCommitStrategySupport.explainMismatchingValue(any[Key], any[Value], any[Value]))
+      when(
+        mockCommitStrategySupport
+          .explainMismatchingValue(any[Raw.Key], any[Raw.Value], any[Raw.Value]))
         .thenReturn(Some("expected explanation"))
       val instance = new IntegrityChecker[Unit](mockCommitStrategySupport)
 
@@ -52,7 +56,9 @@ final class IntegrityCheckerSpec
 
     "return all explanations in case of multiple differences" in {
       val mockCommitStrategySupport = mock[CommitStrategySupport[Unit]]
-      when(mockCommitStrategySupport.explainMismatchingValue(any[Key], any[Value], any[Value]))
+      when(
+        mockCommitStrategySupport
+          .explainMismatchingValue(any[Raw.Key], any[Raw.Value], any[Raw.Value]))
         .thenReturn(Some("first explanation"), Some("second explanation"))
       val instance = new IntegrityChecker[Unit](mockCommitStrategySupport)
 

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
@@ -5,8 +5,8 @@ package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
 import java.nio.file.Paths
 
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.Builders._
-import com.daml.ledger.validator.Raw
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec


### PR DESCRIPTION
When I was working in this area last month, the type aliases got very confusing; it was too easy to conflate a key for a value, or vice versa.

In the future, I would like to try and split the keys further, into log entry IDs and state keys.

And probably rename `Raw.Value` to `Raw.Envelope`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
