### PR TITLE
participant-integration-api: Reuse the services execution context for data munging.

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/StandaloneApiServer.scala
@@ -25,12 +25,11 @@ import com.daml.platform.configuration.{
   PartyConfiguration,
   ServerRole,
 }
-import com.daml.ports.{PortFiles}
 import com.daml.platform.index.JdbcIndex
 import com.daml.platform.packages.InMemoryPackageStore
 import com.daml.platform.services.time.TimeProviderType
 import com.daml.platform.store.dao.events.LfValueTranslation
-import com.daml.ports.Port
+import com.daml.ports.{Port, PortFiles}
 import io.grpc.{BindableService, ServerInterceptor}
 
 import scala.collection.immutable
@@ -69,13 +68,14 @@ final class StandaloneApiServer(
     val owner = for {
       indexService <- JdbcIndex
         .owner(
-          ServerRole.ApiServer,
-          domain.LedgerId(ledgerId),
-          participantId,
-          config.jdbcUrl,
-          config.eventsPageSize,
-          metrics,
-          lfValueTranslationCache,
+          serverRole = ServerRole.ApiServer,
+          ledgerId = domain.LedgerId(ledgerId),
+          participantId = participantId,
+          jdbcUrl = config.jdbcUrl,
+          eventsPageSize = config.eventsPageSize,
+          servicesExecutionContext = servicesExecutionContext,
+          metrics = metrics,
+          lfValueTranslationCache = lfValueTranslationCache,
         )
         .map(index => new SpannedIndexService(new TimedIndexService(index, metrics)))
       authorizer = new Authorizer(Clock.systemUTC.instant _, ledgerId, participantId)

--- a/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/JdbcIndex.scala
@@ -13,6 +13,8 @@ import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.store.dao.events.LfValueTranslation
 
+import scala.concurrent.ExecutionContext
+
 private[platform] object JdbcIndex {
   def owner(
       serverRole: ServerRole,
@@ -20,16 +22,18 @@ private[platform] object JdbcIndex {
       participantId: ParticipantId,
       jdbcUrl: String,
       eventsPageSize: Int,
+      servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
   )(implicit mat: Materializer, loggingContext: LoggingContext): ResourceOwner[IndexService] =
     new ReadOnlySqlLedger.Owner(
-      serverRole,
-      jdbcUrl,
-      ledgerId,
-      eventsPageSize,
-      metrics,
-      lfValueTranslationCache,
+      serverRole = serverRole,
+      jdbcUrl = jdbcUrl,
+      initialLedgerId = ledgerId,
+      eventsPageSize = eventsPageSize,
+      servicesExecutionContext = servicesExecutionContext,
+      metrics = metrics,
+      lfValueTranslationCache = lfValueTranslationCache,
     ).map { ledger =>
       new LedgerBackedIndexService(MeteredReadOnlyLedger(ledger, metrics), participantId)
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/StandaloneIndexerServer.scala
@@ -11,9 +11,12 @@ import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.store.dao.events.LfValueTranslation
 
+import scala.concurrent.ExecutionContext
+
 final class StandaloneIndexerServer(
     readService: ReadService,
     config: IndexerConfig,
+    servicesExecutionContext: ExecutionContext,
     metrics: Metrics,
     lfValueTranslationCache: LfValueTranslation.Cache,
 )(implicit materializer: Materializer, loggingContext: LoggingContext)
@@ -26,6 +29,7 @@ final class StandaloneIndexerServer(
       ServerRole.Indexer,
       config,
       readService,
+      servicesExecutionContext,
       metrics,
       lfValueTranslationCache,
     )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/IndexMetadata.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/IndexMetadata.scala
@@ -33,11 +33,15 @@ object IndexMetadata {
       } yield metadata(ledgerId, participantId, ledgerEnd)
     }
 
-  private def ownDao(jdbcUrl: String)(implicit loggingContext: LoggingContext) =
+  private def ownDao(jdbcUrl: String)(implicit
+      executionContext: ExecutionContext,
+      loggingContext: LoggingContext,
+  ) =
     JdbcLedgerDao.readOwner(
       serverRole = ServerRole.ReadIndexMetadata,
       jdbcUrl = jdbcUrl,
       eventsPageSize = 1000,
+      servicesExecutionContext = executionContext,
       metrics = new Metrics(new MetricRegistry),
       lfValueTranslationCache = LfValueTranslation.Cache.none,
     )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -4,7 +4,6 @@ package com.daml.platform.store.dao
 
 import java.sql.Connection
 import java.time.Instant
-import java.util.concurrent.Executors
 import java.util.{Date, UUID}
 
 import akka.NotUsed
@@ -80,7 +79,7 @@ private class JdbcLedgerDao(
     override val maxConcurrentConnections: Int,
     dbDispatcher: DbDispatcher,
     dbType: DbType,
-    executionContext: ExecutionContext,
+    servicesExecutionContext: ExecutionContext,
     eventsPageSize: Int,
     performPostCommitValidation: Boolean,
     metrics: Metrics,
@@ -635,7 +634,7 @@ private class JdbcLedgerDao(
         .executeSql(metrics.daml.index.db.loadParties) { implicit conn =>
           selectParties(parties)
         }
-        .map(_.map(constructPartyDetails))(executionContext)
+        .map(_.map(constructPartyDetails))(servicesExecutionContext)
 
   override def listKnownParties()(implicit
       loggingContext: LoggingContext
@@ -645,7 +644,7 @@ private class JdbcLedgerDao(
         SQL_SELECT_ALL_PARTIES
           .as(PartyDataParser.*)
       }
-      .map(_.map(constructPartyDetails))(executionContext)
+      .map(_.map(constructPartyDetails))(servicesExecutionContext)
 
   private val SQL_INSERT_PARTY =
     SQL("""insert into parties(party, display_name, ledger_offset, explicit, is_local)
@@ -686,7 +685,7 @@ private class JdbcLedgerDao(
             d.sourceDescription,
           )
         ).toMap
-      )(executionContext)
+      )(servicesExecutionContext)
 
   override def getLfArchive(packageId: PackageId)(implicit
       loggingContext: LoggingContext
@@ -700,7 +699,7 @@ private class JdbcLedgerDao(
           .as[Option[Array[Byte]]](SqlParser.byteArray("package").singleOpt)
       }
       .map(_.map(data => Archive.parseFrom(Decode.damlLfCodedInputStreamFromBytes(data))))(
-        executionContext
+        servicesExecutionContext
       )
 
   private val SQL_INSERT_PACKAGE_ENTRY_ACCEPT =
@@ -940,14 +939,16 @@ private class JdbcLedgerDao(
 
   override val transactionsReader: TransactionsReader =
     new TransactionsReader(dbDispatcher, dbType, eventsPageSize, metrics, translation)(
-      executionContext
+      servicesExecutionContext
     )
 
   private val contractsReader: ContractsReader =
-    ContractsReader(dbDispatcher, dbType, metrics, lfValueTranslationCache)(executionContext)
+    ContractsReader(dbDispatcher, dbType, metrics, lfValueTranslationCache)(
+      servicesExecutionContext
+    )
 
   override val completions: CommandCompletionsReader =
-    new CommandCompletionsReader(dbDispatcher, dbType, metrics, executionContext)
+    new CommandCompletionsReader(dbDispatcher, dbType, metrics, servicesExecutionContext)
 
   private val postCommitValidation =
     if (performPostCommitValidation)
@@ -971,6 +972,7 @@ private[platform] object JdbcLedgerDao {
       serverRole: ServerRole,
       jdbcUrl: String,
       eventsPageSize: Int,
+      servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
   )(implicit loggingContext: LoggingContext): ResourceOwner[LedgerReadDao] = {
@@ -981,6 +983,7 @@ private[platform] object JdbcLedgerDao {
       maxConnections,
       eventsPageSize,
       validate = false,
+      servicesExecutionContext,
       metrics,
       lfValueTranslationCache,
       jdbcAsyncCommits = false,
@@ -992,6 +995,7 @@ private[platform] object JdbcLedgerDao {
       serverRole: ServerRole,
       jdbcUrl: String,
       eventsPageSize: Int,
+      servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
       jdbcAsyncCommits: Boolean,
@@ -1005,6 +1009,7 @@ private[platform] object JdbcLedgerDao {
       maxConnections,
       eventsPageSize,
       validate = false,
+      servicesExecutionContext,
       metrics,
       lfValueTranslationCache,
       jdbcAsyncCommits = jdbcAsyncCommits && dbType.supportsAsynchronousCommits,
@@ -1016,6 +1021,7 @@ private[platform] object JdbcLedgerDao {
       serverRole: ServerRole,
       jdbcUrl: String,
       eventsPageSize: Int,
+      servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
       validatePartyAllocation: Boolean = false,
@@ -1029,6 +1035,7 @@ private[platform] object JdbcLedgerDao {
       maxConnections,
       eventsPageSize,
       validate = true,
+      servicesExecutionContext,
       metrics,
       lfValueTranslationCache,
       validatePartyAllocation,
@@ -1067,6 +1074,7 @@ private[platform] object JdbcLedgerDao {
       maxConnections: Int,
       eventsPageSize: Int,
       validate: Boolean,
+      servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
       validatePartyAllocation: Boolean = false,
@@ -1082,12 +1090,11 @@ private[platform] object JdbcLedgerDao {
         metrics,
         jdbcAsyncCommits,
       )
-      executor <- ResourceOwner.forExecutorService(() => Executors.newWorkStealingPool())
     } yield new JdbcLedgerDao(
       maxConnections,
       dbDispatcher,
       DbType.jdbcType(jdbcUrl),
-      ExecutionContext.fromExecutor(executor),
+      servicesExecutionContext,
       eventsPageSize,
       validate,
       metrics,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -455,7 +455,7 @@ private class JdbcLedgerDao(
       .executeSql(metrics.daml.index.db.storeTransactionDbMetrics)(
         preparedInsert.writeState(metrics)(_)
       )
-      .map(_ => Ok)(executionContext)
+      .map(_ => Ok)(servicesExecutionContext)
 
   override def storeTransactionEvents(
       preparedInsert: PreparedInsert
@@ -464,7 +464,7 @@ private class JdbcLedgerDao(
       .executeSql(metrics.daml.index.db.storeTransactionDbMetrics)(
         preparedInsert.writeEvents(metrics)(_)
       )
-      .map(_ => Ok)(executionContext)
+      .map(_ => Ok)(servicesExecutionContext)
 
   override def completeTransaction(
       submitterInfo: Option[SubmitterInfo],

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -44,6 +44,7 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll {
       serverRole = ServerRole.Testing(getClass),
       jdbcUrl = jdbcUrl,
       eventsPageSize = eventsPageSize,
+      servicesExecutionContext = executionContext,
       metrics = new Metrics(new MetricRegistry),
       lfValueTranslationCache = LfValueTranslation.Cache.none,
       jdbcAsyncCommits = true,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPostCommitValidationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPostCommitValidationSpec.scala
@@ -27,6 +27,7 @@ private[dao] trait JdbcLedgerDaoPostCommitValidationSpec extends LoneElement {
         serverRole = ServerRole.Testing(getClass),
         jdbcUrl = jdbcUrl,
         eventsPageSize = eventsPageSize,
+        servicesExecutionContext = executionContext,
         metrics = new Metrics(new MetricRegistry),
         lfValueTranslationCache = LfValueTranslation.Cache.none,
       )

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/JdbcIndexerSpec.scala
@@ -175,6 +175,7 @@ final class JdbcIndexerSpec
       ServerRole.Indexer,
       config.jdbcUrl,
       config.eventsPageSize,
+      materializer.executionContext,
       metrics,
       LfValueTranslation.Cache.none,
       jdbcAsyncCommits = true,
@@ -182,6 +183,7 @@ final class JdbcIndexerSpec
     new indexer.JdbcIndexer.Factory(
       config = config,
       readService = mockedReadService(),
+      servicesExecutionContext = materializer.executionContext,
       metrics = metrics,
       updateFlowOwnerBuilder =
         mockedUpdateFlowOwnerBuilder(metrics, config.participantId, mockFlow),

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Runner.scala
@@ -128,6 +128,7 @@ final class Runner[T <: ReadWriteService, Extra](
                 new StandaloneIndexerServer(
                   readService = readService,
                   config = factory.indexerConfig(participantConfig, config),
+                  servicesExecutionContext = servicesExecutionContext,
                   metrics = metrics,
                   lfValueTranslationCache = lfValueTranslationCache,
                 ).acquire()

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -220,6 +220,7 @@ class RecoveringIndexerIntegrationSpec
       serverRole = ServerRole.Testing(getClass),
       jdbcUrl = jdbcUrl,
       eventsPageSize = 100,
+      servicesExecutionContext = executionContext,
       metrics = new Metrics(new MetricRegistry),
       lfValueTranslationCache = LfValueTranslation.Cache.none,
       jdbcAsyncCommits = true,

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -6,6 +6,7 @@ package com.daml.platform.indexer
 import java.time.Instant
 import java.time.temporal.ChronoUnit.SECONDS
 import java.util.UUID
+import java.util.concurrent.Executors
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
@@ -38,8 +39,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
 import scala.compat.java8.FutureConverters._
-import scala.concurrent.Future
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 class RecoveringIndexerIntegrationSpec
@@ -198,15 +199,19 @@ class RecoveringIndexerIntegrationSpec
     for {
       actorSystem <- ResourceOwner.forActorSystem(() => ActorSystem())
       materializer <- ResourceOwner.forMaterializer(() => Materializer(actorSystem))
+      servicesExecutionContext <- ResourceOwner
+        .forExecutorService(() => Executors.newWorkStealingPool())
+        .map(ExecutionContext.fromExecutorService)
       participantState <- newParticipantState(ledgerId, participantId)(materializer, loggingContext)
       _ <- new StandaloneIndexerServer(
         readService = participantState,
         config = IndexerConfig(
-          participantId,
-          jdbcUrl,
+          participantId = participantId,
+          jdbcUrl = jdbcUrl,
           startupMode = IndexerStartupMode.MigrateAndStart,
           restartDelay = restartDelay,
         ),
+        servicesExecutionContext = servicesExecutionContext,
         metrics = new Metrics(new MetricRegistry),
         lfValueTranslationCache = LfValueTranslation.Cache.none,
       )(materializer, loggingContext)

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -288,41 +288,48 @@ final class SandboxServer(
         metrics = metrics,
       )
 
-    val (ledgerType, indexAndWriteServiceResourceOwner) = config.jdbcUrl match {
-      case Some(jdbcUrl) =>
-        "postgres" -> SandboxIndexAndWriteService.postgres(
-          name = name,
-          providedLedgerId = config.ledgerIdMode,
-          participantId = config.participantId,
-          jdbcUrl = jdbcUrl,
-          timeProvider = timeProvider,
-          ledgerEntries = ledgerEntries,
-          startMode = startMode,
-          queueDepth = config.commandConfig.maxParallelSubmissions,
-          transactionCommitter = transactionCommitter,
-          templateStore = packageStore,
-          eventsPageSize = config.eventsPageSize,
-          metrics = metrics,
-          lfValueTranslationCache = lfValueTranslationCache,
-          validatePartyAllocation = !config.implicitPartyAllocation,
-        )
-
-      case None =>
-        "in-memory" -> SandboxIndexAndWriteService.inMemory(
-          name,
-          config.ledgerIdMode,
-          config.participantId,
-          timeProvider,
-          acs,
-          ledgerEntries,
-          transactionCommitter,
-          packageStore,
-          metrics,
-        )
+    val ledgerType = config.jdbcUrl match {
+      case Some(_) => "postgres"
+      case None => "in-memory"
     }
 
     for {
-      indexAndWriteService <- indexAndWriteServiceResourceOwner.acquire()
+      servicesExecutionContext <- ResourceOwner
+        .forExecutorService(() => Executors.newWorkStealingPool())
+        .map(ExecutionContext.fromExecutorService)
+        .acquire()
+      indexAndWriteService <- (config.jdbcUrl match {
+        case Some(jdbcUrl) =>
+          SandboxIndexAndWriteService.postgres(
+            name = name,
+            providedLedgerId = config.ledgerIdMode,
+            participantId = config.participantId,
+            jdbcUrl = jdbcUrl,
+            timeProvider = timeProvider,
+            ledgerEntries = ledgerEntries,
+            startMode = startMode,
+            queueDepth = config.commandConfig.maxParallelSubmissions,
+            transactionCommitter = transactionCommitter,
+            templateStore = packageStore,
+            eventsPageSize = config.eventsPageSize,
+            servicesExecutionContext = servicesExecutionContext,
+            metrics = metrics,
+            lfValueTranslationCache = lfValueTranslationCache,
+            validatePartyAllocation = !config.implicitPartyAllocation,
+          )
+        case None =>
+          SandboxIndexAndWriteService.inMemory(
+            name,
+            config.ledgerIdMode,
+            config.participantId,
+            timeProvider,
+            acs,
+            ledgerEntries,
+            transactionCommitter,
+            packageStore,
+            metrics,
+          )
+      }).acquire()
       ledgerId <- Resource.fromFuture(indexAndWriteService.indexService.getLedgerId())
       authorizer = new Authorizer(
         () => java.time.Clock.systemUTC.instant(),
@@ -341,10 +348,6 @@ final class SandboxServer(
       )
       ledgerConfiguration = config.ledgerConfig
       executionSequencerFactory <- new ExecutionSequencerFactoryOwner().acquire()
-      servicesExecutionContext <- ResourceOwner
-        .forExecutorService(() => Executors.newWorkStealingPool())
-        .map(ExecutionContext.fromExecutorService)
-        .acquire()
       apiServicesOwner = new ApiServices.Owner(
         participantId = config.participantId,
         optWriteService = Some(new TimedWriteService(indexAndWriteService.writeService, metrics)),

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/SandboxIndexAndWriteService.scala
@@ -29,8 +29,8 @@ import com.daml.platform.sandbox.stores.ledger.{Ledger, MeteredLedger}
 import com.daml.platform.store.dao.events.LfValueTranslation
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.Future
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future}
 
 private[sandbox] trait IndexAndWriteService {
   def indexService: IndexService
@@ -54,6 +54,7 @@ private[sandbox] object SandboxIndexAndWriteService {
       transactionCommitter: TransactionCommitter,
       templateStore: InMemoryPackageStore,
       eventsPageSize: Int,
+      servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
       lfValueTranslationCache: LfValueTranslation.Cache,
       validatePartyAllocation: Boolean = false,
@@ -74,9 +75,10 @@ private[sandbox] object SandboxIndexAndWriteService {
       transactionCommitter = transactionCommitter,
       startMode = startMode,
       eventsPageSize = eventsPageSize,
+      servicesExecutionContext = servicesExecutionContext,
       metrics = metrics,
-      lfValueTranslationCache,
-      validatePartyAllocation,
+      lfValueTranslationCache = lfValueTranslationCache,
+      validatePartyAllocation = validatePartyAllocation,
     ).flatMap(ledger => owner(MeteredLedger(ledger, metrics), participantId, timeProvider))
 
   def inMemory(

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -31,8 +31,8 @@ import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.platform.testing.LogCollector
 import com.daml.testing.postgresql.PostgresAroundEach
 import org.scalatest.concurrent.{AsyncTimeLimitedTests, Eventually, ScaledTimeSpans}
-import org.scalatest.time.{Minute, Seconds, Span}
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Minute, Seconds, Span}
 import org.scalatest.wordspec.AsyncWordSpec
 
 import scala.collection.mutable
@@ -300,6 +300,7 @@ final class SqlLedgerSpec
         transactionCommitter = LegacyTransactionCommitter,
         startMode = SqlStartMode.ContinueIfExists,
         eventsPageSize = 100,
+        servicesExecutionContext = executionContext,
         metrics = new Metrics(metrics),
         lfValueTranslationCache = LfValueTranslation.Cache.none,
         validatePartyAllocation = validatePartyAllocation,

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Runner.scala
@@ -180,6 +180,9 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                     )
                     .map(_ => ())
                 }
+              servicesExecutionContext <- ResourceOwner
+                .forExecutorService(() => Executors.newWorkStealingPool())
+                .map(ExecutionContext.fromExecutorService)
               _ <- new StandaloneIndexerServer(
                 readService = readService,
                 config = IndexerConfig(
@@ -191,6 +194,7 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   eventsPageSize = config.eventsPageSize,
                   allowExistingSchema = true,
                 ),
+                servicesExecutionContext = servicesExecutionContext,
                 metrics = metrics,
                 lfValueTranslationCache = lfValueTranslationCache,
               )
@@ -212,9 +216,6 @@ class Runner(config: SandboxConfig) extends ResourceOwner[Port] {
                   authorizer,
                 )
               }
-              servicesExecutionContext <- ResourceOwner
-                .forExecutorService(() => Executors.newWorkStealingPool())
-                .map(ExecutionContext.fromExecutorService)
               apiServer <- new StandaloneApiServer(
                 ledgerId = ledgerId,
                 config = ApiServerConfig(


### PR DESCRIPTION
This is the obvious follow-up to #7945. We can share the work-stealing execution pool between the indexer and the API server when they run in the same process.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
