### PR TITLE
Enable asynchronous commit per connection level

### DIFF
--- a/ledger/participant-integration-api/BUILD.bazel
+++ b/ledger/participant-integration-api/BUILD.bazel
@@ -237,6 +237,7 @@ test_deps = [
     "@maven//:org_scalatestplus_scalacheck_1_14_2_12",
     "@maven//:org_scalaz_scalaz_core_2_12",
     "@maven//:org_slf4j_slf4j_api",
+    "@maven//:com_zaxxer_HikariCP",
 ]
 
 openssl_executable = "@openssl_dev_env//:bin/openssl" if not is_windows else "@openssl_dev_env//:usr/bin/openssl.exe"

--- a/ledger/participant-integration-api/src/main/scala/platform/store/DbType.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/DbType.scala
@@ -7,16 +7,29 @@ private[platform] sealed abstract class DbType(
     val name: String,
     val driver: String,
     val supportsParallelWrites: Boolean,
+    val supportsAsynchronousCommits: Boolean,
 )
 
 private[platform] object DbType {
-  object Postgres extends DbType("postgres", "org.postgresql.Driver", true)
+  object Postgres
+      extends DbType(
+        "postgres",
+        "org.postgresql.Driver",
+        supportsParallelWrites = true,
+        supportsAsynchronousCommits = true,
+      )
 
   // H2 does not support concurrent, conditional updates to the ledger_end at read committed isolation
   // level: "It is possible that a transaction from one connection overtakes a transaction from a different
   // connection. Depending on the operations, this might result in different results, for example when conditionally
   // incrementing a value in a row." - from http://www.h2database.com/html/advanced.html
-  object H2Database extends DbType("h2database", "org.h2.Driver", false)
+  object H2Database
+      extends DbType(
+        "h2database",
+        "org.h2.Driver",
+        supportsParallelWrites = false,
+        supportsAsynchronousCommits = false,
+      )
 
   def jdbcType(jdbcUrl: String): DbType = jdbcUrl match {
     case h2 if h2.startsWith("jdbc:h2:") => H2Database

--- a/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
@@ -65,6 +65,7 @@ private[platform] class FlywayMigrations(jdbcUrl: String)(implicit loggingContex
       maxPoolSize = 2,
       connectionTimeout = 5.seconds,
       metrics = None,
+      connectionAsyncCommit = false,
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
@@ -84,6 +84,7 @@ private[platform] object DbDispatcher {
       jdbcUrl: String,
       maxConnections: Int,
       metrics: Metrics,
+      connectionAsyncCommit: Boolean,
   )(implicit loggingContext: LoggingContext): ResourceOwner[DbDispatcher] =
     for {
       connectionProvider <- HikariJdbcConnectionProvider.owner(
@@ -91,6 +92,7 @@ private[platform] object DbDispatcher {
         jdbcUrl,
         maxConnections,
         metrics.registry,
+        connectionAsyncCommit,
       )
       executor <- ResourceOwner.forExecutorService(() =>
         Executors.newFixedThreadPool(

--- a/ledger/participant-integration-api/src/test/resources/logback-test.xml
+++ b/ledger/participant-integration-api/src/test/resources/logback-test.xml
@@ -25,6 +25,14 @@
         <appender-ref ref="MEM" />
     </logger>
 
+    <appender name="JdbcIndexerSpecAppender" class="com.daml.platform.testing.LogCollector">
+        <test>com.daml.platform.indexer.JdbcIndexerSpec</test>
+    </appender>
+
+    <logger name="com.daml.platform.store.dao.HikariConnection" level="INFO">
+        <appender-ref ref="JdbcIndexerSpecAppender" />
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ASYNC"/>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/HikariConnectionSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/HikariConnectionSpec.scala
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao
+
+import com.daml.ledger.resources.TestResourceContext
+import com.daml.logging.LoggingContext
+import com.daml.platform.configuration.ServerRole
+import com.daml.testing.postgresql.PostgresAroundAll
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+class HikariConnectionSpec
+    extends AsyncFlatSpec
+    with Matchers
+    with MockitoSugar
+    with TestResourceContext
+    with PostgresAroundAll {
+
+  it should "use asynchronous commits if enabled" in {
+    assertAsyncCommit(asyncCommitEnabled = true, expectedQueryResponse = "off")
+  }
+
+  it should "not use asynchronous commits if disabled" in {
+    assertAsyncCommit(asyncCommitEnabled = false, expectedQueryResponse = "on")
+  }
+
+  private def assertAsyncCommit(asyncCommitEnabled: Boolean, expectedQueryResponse: String) =
+    newHikariConnection(asyncCommitEnabled)
+      .use { hikariDataSource =>
+        val rs =
+          hikariDataSource.getConnection.createStatement().executeQuery("SHOW synchronous_commit")
+        rs.next()
+        rs.getString(1) shouldBe expectedQueryResponse
+      }
+
+  private def newHikariConnection(asyncCommitEnabled: Boolean) =
+    HikariConnection.owner(
+      serverRole = ServerRole.Testing(this.getClass),
+      jdbcUrl = postgresDatabase.url,
+      minimumIdle = 2,
+      maxPoolSize = 2,
+      connectionTimeout = 5.seconds,
+      metrics = None,
+      connectionAsyncCommit = asyncCommitEnabled,
+    )(LoggingContext.ForTesting)
+}

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -821,7 +821,7 @@ private[kvutils] object TransactionCommitter {
         ), // DeduplicateUntil defines a rejection window, endpoints inclusive
       Some(timeModel.minRecordTime(ledgerTime)),
       Some(timeModel.minRecordTime(submissionTime)),
-    ).flatten.max
+    ).flatten.maxledger / sandbox - classic / src / test / suite / scala / platform / sandbox / stores / ledger / sql / SqlLedgerSpec.scala
 
   private def transactionMaxRecordTime(
       submissionTime: Instant,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitter.scala
@@ -821,7 +821,7 @@ private[kvutils] object TransactionCommitter {
         ), // DeduplicateUntil defines a rejection window, endpoints inclusive
       Some(timeModel.minRecordTime(ledgerTime)),
       Some(timeModel.minRecordTime(submissionTime)),
-    ).flatten.maxledger / sandbox - classic / src / test / suite / scala / platform / sandbox / stores / ledger / sql / SqlLedgerSpec.scala
+    ).flatten.max
 
   private def transactionMaxRecordTime(
       submissionTime: Instant,

--- a/ledger/sandbox-classic/src/test/resources/logback-test.xml
+++ b/ledger/sandbox-classic/src/test/resources/logback-test.xml
@@ -13,7 +13,7 @@
         <appender-ref ref="SqlLedgerSpecAppender" />
     </logger>
 
-    <logger name="com.daml.platform.store.dao.JdbcLedgerDao" level="INFO">
+    <logger name="com.daml.platform.store.dao.HikariConnection" level="INFO">
         <appender-ref ref="SqlLedgerSpecAppender" />
     </logger>
 </configuration>

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -220,10 +220,10 @@ final class SqlLedgerSpec
       for {
         _ <- createSqlLedger(validatePartyAllocation = false)
       } yield {
-        val jdbcLedgerDaoLogs =
-          LogCollector.read[this.type]("com.daml.platform.store.dao.JdbcLedgerDao")
-        jdbcLedgerDaoLogs should contain(
-          Level.INFO -> "Starting JdbcLedgerDao with async commit disabled"
+        val hikariDataSourceLogs =
+          LogCollector.read[this.type]("com.daml.platform.store.dao.HikariConnection")
+        hikariDataSourceLogs should contain(
+          Level.INFO -> "Creating Hikari connections with asynchronous commit disabled"
         )
       }
     }


### PR DESCRIPTION
Currently, asynchronous commits are enabled at transaction level for the PostgreSQL JdbcLedgerDao. As a further optimization, this setting is moved at JDBC connection level (when Hikari spawns it).

This optimization aims at removing ~0.27 ms out of each transaction insertion for the indexer. At current performance levels, throughput improves by ~2 %.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
