### PR TITLE
Add DA.Maybe to preprocessor exceptions.

### DIFF
--- a/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
+++ b/compiler/damlc/daml-preprocessor/src/DA/Daml/Preprocessor.hs
@@ -24,7 +24,6 @@ import qualified "ghc-lib-parser" FastString as GHC
 import qualified "ghc-lib-parser" GHC.LanguageExtensions.Type as GHC
 import Outputable
 
-import           Control.Monad.Extra
 import           Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NE
 import           Data.List.Extra
@@ -47,29 +46,37 @@ isInternal (GHC.moduleNameString -> x)
       , "DA.Time.Types"
       ]
 
-mayImportInternal :: [GHC.ModuleName]
-mayImportInternal =
-    map GHC.mkModuleName
-        [ "Prelude"
-        , "DA.Time"
-        , "DA.Date"
-        , "DA.Record"
-        , "DA.TextMap"
-        , "DA.Map"
-        , "DA.Generics"
-        , "DA.Text"
-        , "DA.Numeric"
-        , "DA.Stack"
+preprocessorExceptions :: Set.Set GHC.ModuleName
+preprocessorExceptions = Set.fromList $ map GHC.mkModuleName
+    -- These modules need to import internal modules.
+    [ "Prelude"
+    , "DA.Time"
+    , "DA.Date"
+    , "DA.Record"
+    , "DA.TextMap"
+    , "DA.Map"
+    , "DA.Generics"
+    , "DA.Text"
+    , "DA.Numeric"
+    , "DA.Stack"
 
-        -- These modules are just listed to disable the record preprocessor.
-        , "DA.NonEmpty.Types"
-        , "DA.Monoid.Types"
-        ]
+    -- These modules need to have the record preprocessor disabled.
+    , "DA.NonEmpty.Types"
+    , "DA.Monoid.Types"
+
+    -- This module needs to use the PatternSynonyms extension.
+    , "DA.Maybe"
+    ]
+
+shouldSkipPreprocessor :: GHC.ModuleName -> Bool
+shouldSkipPreprocessor name =
+    isInternal name
+    || Set.member name preprocessorExceptions
 
 -- | Apply all necessary preprocessors
 damlPreprocessor :: ES.EnumSet GHC.Extension -> Maybe GHC.UnitId -> GHC.DynFlags -> GHC.ParsedSource -> IdePreprocessedSource
 damlPreprocessor dataDependableExtensions mbUnitId dflags x
-    | maybe False (isInternal ||^ (`elem` mayImportInternal)) name = noPreprocessor dflags x
+    | maybe False shouldSkipPreprocessor name = noPreprocessor dflags x
     | otherwise = IdePreprocessedSource
         { preprocWarnings = concat
             [ checkDamlHeader x
@@ -78,8 +85,19 @@ damlPreprocessor dataDependableExtensions mbUnitId dflags x
             , checkImportsWrtDataDependencies x
             , checkKinds x
             ]
-        , preprocErrors = checkImports x ++ checkDataTypes x ++ checkModuleDefinition x ++ checkRecordConstructor x ++ checkModuleName x
-        , preprocSource = rewriteLets $ recordDotPreprocessor $ importDamlPreprocessor $ genericsPreprocessor mbUnitId $ enumTypePreprocessor "GHC.Types" x
+        , preprocErrors = concat
+            [ checkImports x
+            , checkDataTypes x
+            , checkModuleDefinition x
+            , checkRecordConstructor x
+            , checkModuleName x
+            ]
+        , preprocSource =
+            rewriteLets
+            . recordDotPreprocessor
+            . importDamlPreprocessor
+            . genericsPreprocessor mbUnitId
+            $ enumTypePreprocessor "GHC.Types" x
         }
     where
       name = fmap GHC.unLoc $ GHC.hsmodName $ GHC.unLoc x


### PR DESCRIPTION
Don't run the preprocessor on DA.Maybe since it doesn't need it, and the
preprocessor was generating a bunch of warnings due to use of the
PatternSynonyms extension. We can safely ignore these warnings.

Also refactors that part of the preprocessor a little bit.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
