### PR TITLE
Add LFConversion support for exception primitives.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1675,6 +1675,16 @@ convertTyCon env t
                     then TTypeRep
                     else TUnit
             _ -> defaultTyCon
+    | NameIn DA_Internal_Exception n <- t =
+        case n of
+            -- TODO #8020 https://github.com/digital-asset/daml/issues/8020:
+            -- Depending on how we end up using these during desugaring, we may need
+            -- to erase these to TUnit on LF versions that don't support exceptions.
+            "AnyException" -> pure (TBuiltin BTAnyException)
+            "GeneralError" -> pure (TBuiltin BTGeneralError)
+            "ArithmeticError" -> pure (TBuiltin BTArithmeticError)
+            "ContractError" -> pure (TBuiltin BTContractError)
+            _ -> defaultTyCon
     | NameIn DA_Internal_Prelude "Optional" <- t = pure (TBuiltin BTOptional)
     | otherwise = defaultTyCon
     where

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -824,7 +824,11 @@ convertBind env (name, x)
 -- during conversion to DAML-LF together with their constructors since we
 -- deliberately remove 'GHC.Types.Opaque' as well.
 internalTypes :: UniqSet FastString
-internalTypes = mkUniqSet ["Scenario","Update","ContractId","Time","Date","Party","Pair", "TextMap", "Map", "Any", "TypeRep"]
+internalTypes = mkUniqSet
+    [ "Scenario", "Update", "ContractId", "Time", "Date", "Party"
+    , "Pair", "TextMap", "Map", "Any", "TypeRep"
+    , "AnyException", "GeneralError", "ArithmeticError", "ContractError"
+    ]
 
 consumingTypes :: UniqSet FastString
 consumingTypes = mkUniqSet ["Consuming", "PreConsuming", "PostConsuming", "NonConsuming"]
@@ -1674,12 +1678,6 @@ convertTyCon env t
                 pure $ if envLfVersion env `supports` featureTypeRep
                     then TTypeRep
                     else TUnit
-            _ -> defaultTyCon
-    | NameIn DA_Internal_Exception n <- t =
-        case n of
-            -- TODO #8020 https://github.com/digital-asset/daml/issues/8020:
-            -- Depending on how we end up using these during desugaring, we may need
-            -- to erase these to TUnit on LF versions that don't support exceptions.
             "AnyException" -> pure (TBuiltin BTAnyException)
             "GeneralError" -> pure (TBuiltin BTGeneralError)
             "ArithmeticError" -> pure (TBuiltin BTArithmeticError)

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -378,6 +378,18 @@ convertPrim version "BEAnyExceptionMessage"
     ty@(TBuiltin BTAnyException :-> TText) =
     whenRuntimeSupports version featureExceptions ty $
         EBuiltin BEAnyExceptionMessage
+convertPrim version "BEGeneralErrorMessage"
+    ty@(TBuiltin BTGeneralError :-> TText) =
+    whenRuntimeSupports version featureExceptions ty $
+        EBuiltin BEGeneralErrorMessage
+convertPrim version "BEArithmeticErrorMessage"
+    ty@(TBuiltin BTArithmeticError :-> TText) =
+    whenRuntimeSupports version featureExceptions ty $
+        EBuiltin BEArithmeticErrorMessage
+convertPrim version "BEContractErrorMessage"
+    ty@(TBuiltin BTContractError :-> TText) =
+    whenRuntimeSupports version featureExceptions ty $
+        EBuiltin BEContractErrorMessage
 
 -- Unknown primitive.
 convertPrim _ x ty = error $ "Unknown primitive " ++ show x ++ " at type " ++ renderPretty ty

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -374,22 +374,23 @@ convertPrim version "EToAnyContractKey"
         EToAny key (EVar $ mkVar "key")
 
 -- Exceptions
-convertPrim version "BEAnyExceptionMessage"
-    ty@(TBuiltin BTAnyException :-> TText) =
-    whenRuntimeSupports version featureExceptions ty $
-        EBuiltin BEAnyExceptionMessage
-convertPrim version "BEGeneralErrorMessage"
-    ty@(TBuiltin BTGeneralError :-> TText) =
-    whenRuntimeSupports version featureExceptions ty $
-        EBuiltin BEGeneralErrorMessage
-convertPrim version "BEArithmeticErrorMessage"
-    ty@(TBuiltin BTArithmeticError :-> TText) =
-    whenRuntimeSupports version featureExceptions ty $
-        EBuiltin BEArithmeticErrorMessage
-convertPrim version "BEContractErrorMessage"
-    ty@(TBuiltin BTContractError :-> TText) =
-    whenRuntimeSupports version featureExceptions ty $
-        EBuiltin BEContractErrorMessage
+convertPrim _ "BEAnyExceptionMessage" (TBuiltin BTAnyException :-> TText) =
+    EBuiltin BEAnyExceptionMessage
+convertPrim _ "BEGeneralErrorMessage" (TBuiltin BTGeneralError :-> TText) =
+    EBuiltin BEGeneralErrorMessage
+convertPrim _ "BEArithmeticErrorMessage" (TBuiltin BTArithmeticError :-> TText) =
+    EBuiltin BEArithmeticErrorMessage
+convertPrim _ "BEContractErrorMessage" (TBuiltin BTContractError :-> TText) =
+    EBuiltin BEContractErrorMessage
+
+-- TODO #8020 https://github.com/digital-asset/daml/issues/8020
+-- Handle these three in LFConversion.hs and check that ty1 is an exception type.
+convertPrim _ "EThrow" (ty1 :-> ty2) =
+    ETmLam (mkVar "x", ty1) (EThrow ty2 ty1 (EVar (mkVar "x")))
+convertPrim _ "EToAnyException" (ty :-> TBuiltin BTAnyException) =
+    ETmLam (mkVar "x", ty) (EToAnyException ty (EVar (mkVar "x")))
+convertPrim _ "EFromAnyException" (TBuiltin BTAnyException :-> TOptional ty) =
+    ETmLam (mkVar "x", TBuiltin BTAnyException) (EFromAnyException ty (EVar (mkVar "x")))
 
 -- Unknown primitive.
 convertPrim _ x ty = error $ "Unknown primitive " ++ show x ++ " at type " ++ renderPretty ty

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/Primitives.hs
@@ -373,6 +373,12 @@ convertPrim version "EToAnyContractKey"
         ETmLam (mkVar "key", key) $
         EToAny key (EVar $ mkVar "key")
 
+-- Exceptions
+convertPrim version "BEAnyExceptionMessage"
+    ty@(TBuiltin BTAnyException :-> TText) =
+    whenRuntimeSupports version featureExceptions ty $
+        EBuiltin BEAnyExceptionMessage
+
 -- Unknown primitive.
 convertPrim _ x ty = error $ "Unknown primitive " ++ show x ++ " at type " ++ renderPretty ty
 

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
@@ -93,7 +93,7 @@ pattern GHC_Tuple <- ModuleIn DamlPrim "GHC.Tuple"
 pattern GHC_Types <- ModuleIn DamlPrim "GHC.Types"
 
 -- daml-stdlib module patterns
-pattern DA_Action, DA_Generics, DA_Internal_LF, DA_Internal_Prelude, DA_Internal_Record, DA_Internal_Desugar, DA_Internal_Template_Functions :: GHC.Module
+pattern DA_Action, DA_Generics, DA_Internal_LF, DA_Internal_Prelude, DA_Internal_Record, DA_Internal_Desugar, DA_Internal_Template_Functions, DA_Internal_Exception :: GHC.Module
 pattern DA_Action <- ModuleIn DamlStdlib "DA.Action"
 pattern DA_Generics <- ModuleIn DamlStdlib "DA.Generics"
 pattern DA_Internal_LF <- ModuleIn DamlStdlib "DA.Internal.LF"
@@ -101,6 +101,7 @@ pattern DA_Internal_Prelude <- ModuleIn DamlStdlib "DA.Internal.Prelude"
 pattern DA_Internal_Record <- ModuleIn DamlStdlib "DA.Internal.Record"
 pattern DA_Internal_Desugar <- ModuleIn DamlStdlib "DA.Internal.Desugar"
 pattern DA_Internal_Template_Functions <- ModuleIn DamlStdlib "DA.Internal.Template.Functions"
+pattern DA_Internal_Exception <- ModuleIn DamlStdlib "DA.Internal.Exception"
 
 -- | Deconstruct a dictionary function (DFun) identifier into a tuple
 -- containing, in order:

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -112,4 +112,22 @@ instance HasFromAnyException ContractError where
 
 --------------------------------------------------------------
 
+-- | Action type in which `throw` is supported.
+class Action m => ActionThrow m where
+    throw : Exception e => e -> m t
+
+-- | Action type in which `try ... catch ...` is supported.
+class ActionThrow m => ActionCatch m where
+    -- | Handle an exception. Use the `try ... catch ...` syntax
+    -- instead of calling this method directly.
+    tryCatchRaw : (() -> m t) -> (AnyException -> Maybe (m t)) -> m t
+
+instance ActionThrow Update where
+    throw e = pure () >>= \_ -> throwPure e
+
+instance ActionCatch Update where
+    tryCatchRaw = undefined -- primitive @"UTryCatch"
+
+--------------------------------------------------------------
+
 #endif

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -43,6 +43,7 @@ class HasToAnyException e where
 class HasFromAnyException e where
     fromAnyException : AnyException -> Optional e
 
+{-
 instance HasMessage AnyException where
     message = primitive @"BEAnyExceptionMessage"
 instance HasMessage GeneralError where
@@ -51,6 +52,7 @@ instance HasMessage ArithmeticError where
     message = primitive @"BEArithmeticErrorMessage"
 instance HasMessage ContractError where
     message = primitive @"BEContractErrorMessage"
+-}
 
 {-
 instance HasThrow GeneralError where

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -24,66 +24,92 @@ import GHC.Types
 import DA.Internal.LF
 import DA.Internal.Prelude ( Optional (..) )
 
+--------------------------------------------------------------
+
+-- | Exception typeclass. This should not be implemented directly,
+-- instead, use the `exception` syntax.
 type Exception e =
-    ( HasMessage e
-    , HasThrow e
+    ( HasThrow e
+    , HasMessage e
     , HasToAnyException e
     , HasFromAnyException e
     )
 
-class HasMessage e where
-    message : e -> Text
-
+-- | Part of the `Exception` constraint.
 class HasThrow e where
+    -- | Throw exception in a pure context.
     throwPure : forall t. e -> t
 
+-- | Part of the `Exception` constraint.
+class HasMessage e where
+    -- | Get the error message associated with an exception.
+    message : e -> Text
+
+-- | Part of the `Exception` constraint.
 class HasToAnyException e where
+    -- | Convert an exception type to AnyException.
     toAnyException : e -> AnyException
 
+-- | Part of the `Exception` constraint.
 class HasFromAnyException e where
+    -- | Convert an AnyException back to the underlying exception type, if possible.
     fromAnyException : AnyException -> Optional e
 
-{--
-instance HasMessage AnyException where
-    message = primitive @"BEAnyExceptionMessage"
-instance HasMessage GeneralError where
-    message = primitive @"BEGeneralErrorMessage"
-instance HasMessage ArithmeticError where
-    message = primitive @"BEArithmeticErrorMessage"
-instance HasMessage ContractError where
-    message = primitive @"BEContractErrorMessage"
---}
+--------------------------------------------------------------
 
-{--
-instance HasThrow GeneralError where
-    throwPure = primitive @"EThrow"
-instance HasThrow ArithmeticError where
-    throwPure = primitive @"EThrow"
-instance HasThrow ContractError where
-    throwPure = primitive @"EThrow"
---}
+-- No throw for AnyException.
+
+instance HasMessage AnyException where
+    message = undefined -- primitive @"BEAnyExceptionMessage"
 
 instance HasToAnyException AnyException where
     toAnyException e = e
-{--
-instance HasToAnyException GeneralError where
-    toAnyException = primitive @"EToAnyException"
-instance HasToAnyException ArithmeticError where
-    toAnyException = primitive @"EToAnyException"
-instance HasToAnyException ContractError where
-    toAnyException = primitive @"EToAnyException"
---}
 
 instance HasFromAnyException AnyException where
     fromAnyException = Some
-{--
-instance HasFromAnyException GeneralError where
-    fromAnyException = primitive @"EFromAnyException"
-instance HasFromAnyException ArithmeticError where
-    fromAnyException = primitive @"EFromAnyException"
-instance HasFromAnyException ContractError where
-    fromAnyException = primitive @"EFromAnyException"
---}
 
+--------------------------------------------------------------
+
+instance HasThrow GeneralError where
+    throwPure = undefined -- primitive @"EThrow"
+
+instance HasMessage GeneralError where
+    message = undefined -- primitive @"BEGeneralErrorMessage"
+
+instance HasToAnyException GeneralError where
+    toAnyException = undefined -- primitive @"EToAnyException"
+
+instance HasFromAnyException GeneralError where
+    fromAnyException = undefined -- primitive @"EFromAnyException"
+
+--------------------------------------------------------------
+
+instance HasThrow ArithmeticError where
+    throwPure = undefined -- primitive @"EThrow"
+
+instance HasMessage ArithmeticError where
+    message = undefined -- primitive @"BEArithmeticErrorMessage"
+
+instance HasToAnyException ArithmeticError where
+    toAnyException = undefined -- primitive @"EToAnyException"
+
+instance HasFromAnyException ArithmeticError where
+    fromAnyException = undefined -- primitive @"EFromAnyException"
+
+--------------------------------------------------------------
+
+instance HasThrow ContractError where
+    throwPure = undefined -- primitive @"EThrow"
+
+instance HasMessage ContractError where
+    message = undefined -- primitive @"BEContractErrorMessage"
+
+instance HasToAnyException ContractError where
+    toAnyException = undefined -- primitive @"EToAnyException"
+
+instance HasFromAnyException ContractError where
+    fromAnyException = undefined -- primitive @"EFromAnyException"
+
+--------------------------------------------------------------
 
 #endif

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -1,0 +1,49 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+#ifndef DAML_EXCEPTIONS
+
+-- | HIDE
+module DA.Internal.Exception where
+
+#else
+
+-- | MOVE Prelude This module contains the definitions needed for exception desugaring.
+module DA.Internal.Exception
+    ( module DA.Internal.Exception
+    , AnyException
+    , GeneralError
+    , ArithmeticError
+    , ContractError
+    ) where
+
+import GHC.Types
+import DA.Internal.LF
+import DA.Internal.Prelude ( Optional )
+
+type Exception e =
+    ( HasMessage e
+    , HasThrow e
+    , HasToAnyException e
+    , HasFromAnyException e
+    )
+
+class HasMessage e where
+    message : e -> Text
+
+class HasThrow e where
+    throwPure : forall t. e -> t
+
+class HasToAnyException e where
+    toAnyException : e -> AnyException
+
+class HasFromAnyException e where
+    fromAnyException : AnyException -> Optional e
+
+instance HasMessage AnyException where
+    message = primitive @"BEAnyExceptionMessage"
+
+#endif

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -120,7 +120,7 @@ class Action m => ActionThrow m where
 class ActionThrow m => ActionCatch m where
     -- | Handle an exception. Use the `try ... catch ...` syntax
     -- instead of calling this method directly.
-    tryCatchRaw : (() -> m t) -> (AnyException -> Maybe (m t)) -> m t
+    tryCatchRaw : (() -> m t) -> (AnyException -> Optional (m t)) -> m t
 
 instance ActionThrow Update where
     throw e = pure () >>= \_ -> throwPure e

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -43,7 +43,7 @@ class HasToAnyException e where
 class HasFromAnyException e where
     fromAnyException : AnyException -> Optional e
 
-{-
+{--
 instance HasMessage AnyException where
     message = primitive @"BEAnyExceptionMessage"
 instance HasMessage GeneralError where
@@ -52,38 +52,38 @@ instance HasMessage ArithmeticError where
     message = primitive @"BEArithmeticErrorMessage"
 instance HasMessage ContractError where
     message = primitive @"BEContractErrorMessage"
--}
+--}
 
-{-
+{--
 instance HasThrow GeneralError where
-    throwPure = magic @"throw"
+    throwPure = primitive @"EThrow"
 instance HasThrow ArithmeticError where
-    throwPure = magic @"throw"
+    throwPure = primitive @"EThrow"
 instance HasThrow ContractError where
-    throwPure = magic @"throw"
--}
+    throwPure = primitive @"EThrow"
+--}
 
 instance HasToAnyException AnyException where
     toAnyException e = e
-{-
+{--
 instance HasToAnyException GeneralError where
-    toAnyException = magic @"toAnyException"
+    toAnyException = primitive @"EToAnyException"
 instance HasToAnyException ArithmeticError where
-    toAnyException = magic @"toAnyException"
+    toAnyException = primitive @"EToAnyException"
 instance HasToAnyException ContractError where
-    toAnyException = magic @"toAnyException"
--}
+    toAnyException = primitive @"EToAnyException"
+--}
 
 instance HasFromAnyException AnyException where
     fromAnyException = Some
-{-
+{--
 instance HasFromAnyException GeneralError where
-    fromAnyException = magic @"fromAnyException"
+    fromAnyException = primitive @"EFromAnyException"
 instance HasFromAnyException ArithmeticError where
-    fromAnyException = magic @"fromAnyException"
+    fromAnyException = primitive @"EFromAnyException"
 instance HasFromAnyException ContractError where
-    fromAnyException = magic @"fromAnyException"
--}
+    fromAnyException = primitive @"EFromAnyException"
+--}
 
 
 #endif

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -22,7 +22,7 @@ module DA.Internal.Exception
 
 import GHC.Types
 import DA.Internal.LF
-import DA.Internal.Prelude ( Optional (..) )
+import DA.Internal.Prelude
 
 --------------------------------------------------------------
 

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -11,7 +11,7 @@ module DA.Internal.Exception where
 
 #else
 
--- | MOVE Prelude This module contains the definitions needed for exception desugaring.
+-- | MOVE DA.Exception This module contains the definitions needed for exception desugaring.
 module DA.Internal.Exception
     ( module DA.Internal.Exception
     , AnyException
@@ -22,7 +22,7 @@ module DA.Internal.Exception
 
 import GHC.Types
 import DA.Internal.LF
-import DA.Internal.Prelude ( Optional )
+import DA.Internal.Prelude ( Optional (..) )
 
 type Exception e =
     ( HasMessage e
@@ -45,5 +45,43 @@ class HasFromAnyException e where
 
 instance HasMessage AnyException where
     message = primitive @"BEAnyExceptionMessage"
+instance HasMessage GeneralError where
+    message = primitive @"BEGeneralErrorMessage"
+instance HasMessage ArithmeticError where
+    message = primitive @"BEArithmeticErrorMessage"
+instance HasMessage ContractError where
+    message = primitive @"BEContractErrorMessage"
+
+{-
+instance HasThrow GeneralError where
+    throwPure = magic @"throw"
+instance HasThrow ArithmeticError where
+    throwPure = magic @"throw"
+instance HasThrow ContractError where
+    throwPure = magic @"throw"
+-}
+
+instance HasToAnyException AnyException where
+    toAnyException e = e
+{-
+instance HasToAnyException GeneralError where
+    toAnyException = magic @"toAnyException"
+instance HasToAnyException ArithmeticError where
+    toAnyException = magic @"toAnyException"
+instance HasToAnyException ContractError where
+    toAnyException = magic @"toAnyException"
+-}
+
+instance HasFromAnyException AnyException where
+    fromAnyException = Some
+{-
+instance HasFromAnyException GeneralError where
+    fromAnyException = magic @"fromAnyException"
+instance HasFromAnyException ArithmeticError where
+    fromAnyException = magic @"fromAnyException"
+instance HasFromAnyException ContractError where
+    fromAnyException = magic @"fromAnyException"
+-}
+
 
 #endif

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -45,6 +45,13 @@ module DA.Internal.LF
   -- If this is not supported by the target LF version, we compile it to ().
   , Any
   , TypeRep
+
+  #ifdef DAML_EXCEPTIONS
+  , AnyException
+  , GeneralError
+  , ArithmeticError
+  , ContractError
+  #endif
   ) where
 
 import GHC.Stack.Types (HasCallStack)
@@ -266,4 +273,20 @@ instance Ord TypeRep where
   (<) = primitive @"BELess"
   (>) = primitive @"BEGreater"
 #endif -- DAML_GENERIC_COMPARISON
+#endif
+
+#ifdef DAML_EXCEPTIONS
+
+-- | A wrapper for all exception types.
+data AnyException = AnyException Opaque
+
+-- | Exception raised by `error`.
+data GeneralError = GeneralError Opaque
+
+-- | Exception raised by an arithmetic operation, such as divide-by-zero or overflow.
+data ArithmeticError = ArithmeticError Opaque
+
+-- | Exception raised when a contract is invalid, i.e. fails the ensure clause.
+data ContractError = ContractError Opaque
+
 #endif

--- a/compiler/damlc/daml-stdlib-src/LibraryModules.daml
+++ b/compiler/damlc/daml-stdlib-src/LibraryModules.daml
@@ -27,6 +27,7 @@ import DA.Internal.Record
 import DA.Internal.Template
 import DA.Internal.Template.Functions
 import DA.Internal.Time
+import DA.Internal.Exception
 import DA.List.Total
 import DA.List
 import DA.Logic


### PR DESCRIPTION
This PR starts putting in place the LFConversion support for exceptions that will be needed.

It adds the built-in exception types in `DA.Internal.LF` (where most of the built-in "opaque" types are added) and it adds a `DA.Internal.Exception` module which will later be used for desugaring.

The primitives pass typechecking, but because the engine does not yet support them, they are commented out (otherwise our integration tests fail).

