### PR TITLE
Avoid compiling damlc twice

### DIFF
--- a/bazel_tools/runfiles/defs.bzl
+++ b/bazel_tools/runfiles/defs.bzl
@@ -1,0 +1,42 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@os_info//:os_info.bzl", "is_windows")
+
+def _add_data_impl(ctx):
+    executable = ctx.actions.declare_file(
+        ctx.label.name + (".exe" if is_windows else ""),
+    )
+    ctx.actions.symlink(
+        output = executable,
+        target_file = ctx.executable.executable,
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(files = [ctx.executable.executable] + ctx.files.data)
+    runfiles = runfiles.merge(ctx.attr.executable[DefaultInfo].default_runfiles)
+    for data_dep in ctx.attr.data:
+        runfiles = runfiles.merge(data_dep[DefaultInfo].default_runfiles)
+
+    return [DefaultInfo(
+        executable = executable,
+        files = depset(direct = [executable]),
+        runfiles = runfiles,
+    )]
+
+add_data = rule(
+    _add_data_impl,
+    attrs = {
+        "executable": attr.label(
+            executable = True,
+            cfg = "target",
+            doc = "Create a symlink to this executable",
+        ),
+        "data": attr.label_list(
+            allow_files = True,
+            doc = "Add these data files to the executable's runfiles",
+        ),
+    },
+    executable = True,
+    doc = "Creates a new target for the given executable with additional runfiles.",
+)

--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -1,42 +1,39 @@
 # Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_library", "da_haskell_test")
+load("//bazel_tools:haskell.bzl", "da_haskell_binary", "da_haskell_library", "da_haskell_repl", "da_haskell_test")
 load("//rules_daml:daml.bzl", "daml_doc_test")
 load("@os_info//:os_info.bzl", "is_windows")
 load("//bazel_tools/packaging:packaging.bzl", "package_app")
+load("//bazel_tools/runfiles:defs.bzl", "add_data")
 load(":util.bzl", "ghc_pkg")
 
-da_haskell_binary(
-    name = "damlc",
-    srcs = ["exe/Main.hs"],
+damlc_data = [
+    "//compiler/damlc/daml-ide-core:dlint.yaml",
+    "@static_asset_d3plus//:js/d3.min.js",
+    "@static_asset_d3plus//:js/d3plus.min.js",
+    ghc_pkg,
+    "//compiler/damlc:ghcversion",
+    "//compiler/damlc:hpp",
+    "//compiler/damlc/pkg-db",
+    "//compiler/damlc/stable-packages",
+    "//compiler/repl-service/server:repl_service_jar",
+    "//compiler/scenario-service/server:scenario_service_jar",
+]
 
-    # We need to tell the linker to statically link pthread on Windows
-    # otherwise the library is not found at runtime.
-    compiler_flags = [
-        "-optl-static",
-        "-optl-pthread",
-    ] if is_windows else [],
-    data = [
-        "//compiler/damlc/daml-ide-core:dlint.yaml",
-        "@static_asset_d3plus//:js/d3.min.js",
-        "@static_asset_d3plus//:js/d3plus.min.js",
-        ghc_pkg,
-        "//compiler/damlc:ghcversion",
-        "//compiler/damlc:hpp",
-        "//compiler/damlc/pkg-db",
-        "//compiler/damlc/stable-packages",
-        "//compiler/repl-service/server:repl_service_jar",
-        "//compiler/scenario-service/server:scenario_service_jar",
-    ],
-    hackage_deps = [
-        "base",
-    ],
-    src_strip_prefix = "exe",
+add_data(
+    name = "damlc",
+    data = damlc_data,
+    executable = ":damlc-bootstrap",
     visibility = ["//visibility:public"],
-    deps = [
-        ":damlc-lib",
-    ],
+)
+
+da_haskell_repl(
+    name = "damlc@ghci",
+    data = damlc_data,
+    repl_ghci_commands = [":m Main"],
+    visibility = ["//visibility:public"],
+    deps = [":damlc-bootstrap"],
 )
 
 genrule(


### PR DESCRIPTION
This only compiles `damlc-bootstrap` as a Haskell binary and `damlc` is a simple symlink with additional runfiles.

To that end this PR adds a small Bazel rule `add_data` that symlinks a binary (copy on Windows) and extends its runfiles. Ideally, we could achieve the same using `sh_binary`, however due to https://github.com/bazelbuild/bazel/issues/11820 this would break some targets using `damlc`.

We now need to define `damlc@ghci` manually since it is no longer defined automatically. The manual definition was tested with

```
$ bazel run //:damlc@ghci --define ghci_data=True
> :main ide -d
```

The release tarball is not affected since `package_app` bundles the full binary.

To be sure I have tested the resulting HEAD SDK on Windows and Linux by following the quickstart-java/quickstart test steps defined in [the relase test guide](https://github.com/digital-asset/daml/blob/cd858d53d5f9cc6274eae8572c38354d42c6868e/release/RELEASE.md).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
