### PR TITLE
Update VC redist to 14.28.29325.2

### DIFF
--- a/.dadew
+++ b/.dadew
@@ -14,6 +14,6 @@
         "python-3.8.2",
         "stack",
         "toxiproxy",
-        "vcredist-14.27.29112"
+        "vcredist"
     ]
 }

--- a/dev-env/windows/manifests/bazel.json
+++ b/dev-env/windows/manifests/bazel.json
@@ -11,7 +11,7 @@
   },
   "depends": [
     "msys2",
-    "vcredist-14.27.29112"
+    "vcredist"
   ],
   "env_set": {
     "BAZEL_SH": "$(appdir msys2)\\current\\usr\\bin\\bash.exe"

--- a/dev-env/windows/manifests/vcredist.json
+++ b/dev-env/windows/manifests/vcredist.json
@@ -1,18 +1,18 @@
 {
     "homepage": "https://www.visualstudio.com/downloads/",
     "description": "Microsoft Visual C++ Redistributable for Visual Studio 2005/2008/2010/2012/2013/2015-2019.",
-    "version": "14.27.29112",
+    "version": "14.28.29325.2",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.microsoft.com/en-us/legal/intellectualproperty/copyright/default.aspx"
     },
     "url": [
-        "https://download.visualstudio.microsoft.com/download/pr/48431a06-59c5-4b63-a102-20b66a521863/4B5890EB1AEFDF8DFA3234B5032147EB90F050C5758A80901B201AE969780107/VC_redist.x64.exe",
-        "https://download.visualstudio.microsoft.com/download/pr/48431a06-59c5-4b63-a102-20b66a521863/CAA38FD474164A38AB47AC1755C8CCCA5CCFACFA9A874F62609E6439924E87EC/VC_redist.x86.exe"
+        "https://download.visualstudio.microsoft.com/download/pr/89a3b9df-4a09-492e-8474-8f92c115c51d/B1A32C71A6B7D5978904FB223763263EA5A7EB23B2C44A0D60E90D234AD99178/VC_redist.x64.exe",
+        "https://download.visualstudio.microsoft.com/download/pr/8ecb9800-52fd-432d-83ee-d6e037e96cc2/50A3E92ADE4C2D8F310A2812D46322459104039B9DEADBD7FDD483B5C697C0C8/VC_redist.x86.exe"
     ],
     "hash": [
-        "4b5890eb1aefdf8dfa3234b5032147eb90f050c5758a80901b201ae969780107",
-        "caa38fd474164a38ab47ac1755c8ccca5ccfacfa9a874f62609e6439924e87ec"
+        "b1a32c71a6b7d5978904fb223763263ea5a7eb23b2c44a0d60e90d234ad99178",
+        "50a3e92ade4c2d8f310a2812d46322459104039b9deadbd7fdd483b5c697c0c8"
     ],
     "post_install": [
         "Invoke-ExternalCommand -FilePath \"$dir\\VC_redist.x64.exe\" -ArgumentList \"/fo /quiet /norestart\" -RunAs | Out-Null",


### PR DESCRIPTION
I encountered another instance of Bazel no longer working on a Windows ad-hoc machine, as previously described [here](https://github.com/digital-asset/daml/pull/7843), while testing https://github.com/digital-asset/daml/pull/8428. This PR updates VC redist which resolved this issue on the ad-hoc machine where I encountered it.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
