### PR TITLE
Add grpc-server-reflection-client

### DIFF
--- a/libs-scala/grpc-server-reflection-client/BUILD.bazel
+++ b/libs-scala/grpc-server-reflection-client/BUILD.bazel
@@ -1,0 +1,36 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+)
+
+da_scala_library(
+    name = "grpc-server-reflection-client",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    tags = ["maven_coordinates=com.daml:grpc-server-reflection-client:__VERSION__"],
+    visibility = [
+        "//:__subpackages__",
+    ],
+    deps = [
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_services",
+        "@maven//:io_grpc_grpc_stub",
+    ],
+)
+
+da_scala_test_suite(
+    name = "test",
+    srcs = glob(["src/test/scala/**/*.scala"]),
+    deps = [
+        ":grpc-server-reflection-client",
+        "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_grpc_grpc_core",
+        "@maven//:io_grpc_grpc_services",
+        "@maven//:io_grpc_grpc_stub",
+    ],
+)

--- a/libs-scala/grpc-server-reflection-client/BUILD.bazel
+++ b/libs-scala/grpc-server-reflection-client/BUILD.bazel
@@ -11,6 +11,9 @@ da_scala_library(
     name = "grpc-server-reflection-client",
     srcs = glob(["src/main/scala/**/*.scala"]),
     tags = ["maven_coordinates=com.daml:grpc-server-reflection-client:__VERSION__"],
+    versioned_scala_deps = {
+        "2.12": ["@maven//:org_scala_lang_modules_scala_collection_compat"],
+    },
     visibility = [
         "//:__subpackages__",
     ],

--- a/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/MethodDescriptorInfo.scala
+++ b/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/MethodDescriptorInfo.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.grpc.reflection
+
+import com.google.protobuf.DescriptorProtos.MethodDescriptorProto
+import io.grpc.MethodDescriptor
+import io.grpc.MethodDescriptor.{MethodType, generateFullMethodName}
+
+final case class MethodDescriptorInfo(
+    fullMethodName: String,
+    methodType: MethodType,
+) {
+
+  def toMethodDescriptor[ReqT, RespT](
+      requestMarshaller: MethodDescriptor.Marshaller[ReqT],
+      responseMarshaller: MethodDescriptor.Marshaller[RespT],
+  ): MethodDescriptor[ReqT, RespT] =
+    MethodDescriptor
+      .newBuilder(requestMarshaller, responseMarshaller)
+      .setType(methodType)
+      .setFullMethodName(fullMethodName)
+      .build()
+
+}
+
+object MethodDescriptorInfo {
+
+  def apply(fullServiceName: String, method: MethodDescriptorProto): MethodDescriptorInfo =
+    MethodDescriptorInfo(
+      methodName = generateFullMethodName(fullServiceName, method.getName),
+      clientStreaming = method.getClientStreaming,
+      serverStreaming = method.getServerStreaming,
+    )
+
+  def apply(method: MethodDescriptor[_, _]): MethodDescriptorInfo =
+    MethodDescriptorInfo(
+      fullMethodName = method.getFullMethodName,
+      methodType = method.getType,
+    )
+
+  def apply(
+      methodName: String,
+      clientStreaming: Boolean,
+      serverStreaming: Boolean,
+  ): MethodDescriptorInfo =
+    MethodDescriptorInfo(
+      fullMethodName = methodName,
+      methodType = methodType(clientStreaming, serverStreaming),
+    )
+
+  private def methodType(clientStreaming: Boolean, serverStreaming: Boolean): MethodType =
+    if (clientStreaming && serverStreaming) {
+      MethodType.BIDI_STREAMING
+    } else if (clientStreaming) {
+      MethodType.CLIENT_STREAMING
+    } else if (serverStreaming) {
+      MethodType.SERVER_STREAMING
+    } else {
+      MethodType.UNARY
+    }
+
+}

--- a/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServerReflectionClient.scala
+++ b/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServerReflectionClient.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.grpc.reflection
+
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc.ServerReflectionStub
+import io.grpc.reflection.v1alpha.ServerReflectionRequest
+import io.grpc.stub.StreamObserver
+
+import scala.concurrent.Future
+
+final class ServerReflectionClient(stub: ServerReflectionStub) {
+
+  def getAllServices(): Future[Set[ServiceDescriptorInfo]] = {
+
+    lazy val serviceDescriptorInfo: ServiceDescriptorInfoObserver =
+      new ServiceDescriptorInfoObserver(serverReflectionStream)
+
+    lazy val serverReflectionStream: StreamObserver[ServerReflectionRequest] =
+      stub.serverReflectionInfo(serviceDescriptorInfo)
+
+    serviceDescriptorInfo.result
+
+  }
+
+}

--- a/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServerReflectionRequests.scala
+++ b/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServerReflectionRequests.scala
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.grpc.reflection
+
+import io.grpc.reflection.v1alpha.ServerReflectionRequest
+
+private[reflection] object ServerReflectionRequests {
+
+  val ListServices: ServerReflectionRequest =
+    ServerReflectionRequest.newBuilder().setListServices("").build()
+
+  def fileContaining(symbol: String): ServerReflectionRequest =
+    ServerReflectionRequest.newBuilder().setFileContainingSymbol(symbol).build()
+
+}

--- a/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServiceDescriptorInfo.scala
+++ b/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServiceDescriptorInfo.scala
@@ -20,7 +20,7 @@ object ServiceDescriptorInfo {
     val fullServiceName: String = s"$packageName.$serviceName"
     ServiceDescriptorInfo(
       fullServiceName = fullServiceName,
-      methods = methods.iterator.map(MethodDescriptorInfo(fullServiceName, _)).toSet,
+      methods = methods.view.map(MethodDescriptorInfo(fullServiceName, _)).toSet,
     )
   }
 

--- a/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServiceDescriptorInfo.scala
+++ b/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServiceDescriptorInfo.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.grpc.reflection
+
+import com.google.protobuf.DescriptorProtos.MethodDescriptorProto
+
+final case class ServiceDescriptorInfo(
+    fullServiceName: String,
+    methods: Set[MethodDescriptorInfo],
+)
+
+object ServiceDescriptorInfo {
+
+  def apply(
+      packageName: String,
+      serviceName: String,
+      methods: Iterable[MethodDescriptorProto],
+  ): ServiceDescriptorInfo = {
+    val fullServiceName: String = s"$packageName.$serviceName"
+    ServiceDescriptorInfo(
+      fullServiceName = fullServiceName,
+      methods = methods.iterator.map(MethodDescriptorInfo(fullServiceName, _)).toSet,
+    )
+  }
+
+}

--- a/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServiceDescriptorInfoObserver.scala
+++ b/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServiceDescriptorInfoObserver.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.grpc.reflection
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import io.grpc.Status
+import io.grpc.reflection.v1alpha.{ServerReflectionRequest, ServerReflectionResponse}
+import io.grpc.stub.StreamObserver
+
+import scala.collection.JavaConverters.iterableAsScalaIterableConverter
+import scala.concurrent.{Future, Promise}
+import scala.util.Success
+
+private[reflection] final class ServiceDescriptorInfoObserver(
+    serverReflectionStream: => StreamObserver[ServerReflectionRequest],
+) extends StreamObserver[ServerReflectionResponse] {
+
+  private val builder = Set.newBuilder[ServiceDescriptorInfo]
+  private val promise = Promise[Set[ServiceDescriptorInfo]]
+  private val servicesLeft = new AtomicInteger(0)
+
+  lazy val result: Future[Set[ServiceDescriptorInfo]] = {
+    serverReflectionStream.onNext(ServerReflectionRequests.ListServices)
+    promise.future
+  }
+
+  override def onNext(response: ServerReflectionResponse): Unit = {
+    if (response.hasListServicesResponse) {
+      servicesLeft.set(response.getListServicesResponse.getServiceCount)
+      for (service <- response.getListServicesResponse.getServiceList.asScala) {
+        serverReflectionStream.onNext(ServerReflectionRequests.fileContaining(service.getName))
+      }
+    } else if (response.hasFileDescriptorResponse) {
+      for (bytes <- response.getFileDescriptorResponse.getFileDescriptorProtoList.asScala) {
+        val fileDescriptorProto = FileDescriptorProto.parseFrom(bytes)
+        for (service <- fileDescriptorProto.getServiceList.asScala) {
+          builder +=
+            ServiceDescriptorInfo(
+              packageName = fileDescriptorProto.getPackage,
+              serviceName = service.getName,
+              methods = service.getMethodList.asScala,
+            )
+        }
+      }
+      if (servicesLeft.decrementAndGet() < 1) {
+        serverReflectionStream.onCompleted()
+      }
+    } else if (response.hasErrorResponse) {
+      val error = response.getErrorResponse
+      val throwable = Status
+        .fromCodeValue(error.getErrorCode)
+        .withDescription(error.getErrorMessage)
+        .asRuntimeException()
+      serverReflectionStream.onError(throwable)
+    }
+  }
+
+  override def onError(throwable: Throwable): Unit = {
+    val _ = promise.tryFailure(throwable)
+  }
+
+  override def onCompleted(): Unit = {
+    val _ = promise.tryComplete(Success(builder.result()))
+  }
+}

--- a/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServiceDescriptorInfoObserver.scala
+++ b/libs-scala/grpc-server-reflection-client/src/main/scala/com/daml/grpc/reflection/ServiceDescriptorInfoObserver.scala
@@ -10,7 +10,7 @@ import io.grpc.Status
 import io.grpc.reflection.v1alpha.{ServerReflectionRequest, ServerReflectionResponse}
 import io.grpc.stub.StreamObserver
 
-import scala.collection.JavaConverters.iterableAsScalaIterableConverter
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{Future, Promise}
 import scala.util.Success
 
@@ -19,7 +19,7 @@ private[reflection] final class ServiceDescriptorInfoObserver(
 ) extends StreamObserver[ServerReflectionResponse] {
 
   private val builder = Set.newBuilder[ServiceDescriptorInfo]
-  private val promise = Promise[Set[ServiceDescriptorInfo]]
+  private val promise = Promise[Set[ServiceDescriptorInfo]]()
   private val servicesLeft = new AtomicInteger(0)
 
   lazy val result: Future[Set[ServiceDescriptorInfo]] = {

--- a/libs-scala/grpc-server-reflection-client/src/test/scala/com/daml/grpc/reflection/ServerReflectionClientSpec.scala
+++ b/libs-scala/grpc-server-reflection-client/src/test/scala/com/daml/grpc/reflection/ServerReflectionClientSpec.scala
@@ -10,14 +10,15 @@ import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
 import io.grpc.protobuf.services.ProtoReflectionService
 import io.grpc.reflection.v1alpha.ServerReflectionGrpc
 import io.grpc.services.HealthStatusManager
-import io.grpc.{BindableService, Channel}
+import io.grpc.{BindableService, Channel, StatusRuntimeException}
 import org.scalatest.Assertion
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Future
 
-final class ServerReflectionClientSpec extends AsyncFlatSpec with Matchers {
+final class ServerReflectionClientSpec extends AsyncFlatSpec with Matchers with ScalaFutures {
 
   import ServerReflectionClientSpec._
 
@@ -26,7 +27,7 @@ final class ServerReflectionClientSpec extends AsyncFlatSpec with Matchers {
   it should "fail if reflection is not supported" in withServices(health) { channel =>
     val stub = ServerReflectionGrpc.newStub(channel)
     val client = new ServerReflectionClient(stub)
-    client.getAllServices().failed.map(_ => succeed)
+    client.getAllServices().failed.futureValue shouldBe a[StatusRuntimeException]
   }
 
   it should "show all if reflection is supported" in withServices(health, reflection) { channel =>

--- a/libs-scala/grpc-server-reflection-client/src/test/scala/com/daml/grpc/reflection/ServerReflectionClientSpec.scala
+++ b/libs-scala/grpc-server-reflection-client/src/test/scala/com/daml/grpc/reflection/ServerReflectionClientSpec.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.grpc.reflection
+
+import java.util.concurrent.TimeUnit
+
+import io.grpc.health.v1.HealthGrpc
+import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
+import io.grpc.protobuf.services.ProtoReflectionService
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc
+import io.grpc.services.HealthStatusManager
+import io.grpc.{BindableService, Channel}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.Future
+
+final class ServerReflectionClientSpec extends AsyncFlatSpec with Matchers {
+
+  import ServerReflectionClientSpec._
+
+  behavior of "getAllServices"
+
+  it should "fail if reflection is not supported" in withServices(health) { channel =>
+    val stub = ServerReflectionGrpc.newStub(channel)
+    val client = new ServerReflectionClient(stub)
+    client.getAllServices().failed.map(_ => succeed)
+  }
+
+  it should "show all if reflection is supported" in withServices(health, reflection) { channel =>
+    val expected = Vector(healthDescriptor, reflectionDescriptor)
+    val stub = ServerReflectionGrpc.newStub(channel)
+    val client = new ServerReflectionClient(stub)
+    client.getAllServices().map(_ should contain theSameElementsAs expected)
+  }
+
+}
+
+object ServerReflectionClientSpec {
+
+  private def health: BindableService = new HealthStatusManager().getHealthService
+  private val healthDescriptor =
+    ServiceDescriptorInfo(
+      fullServiceName = HealthGrpc.SERVICE_NAME,
+      methods = Set(
+        MethodDescriptorInfo(HealthGrpc.getCheckMethod),
+        MethodDescriptorInfo(HealthGrpc.getWatchMethod),
+      )
+    )
+
+  private def reflection: BindableService = ProtoReflectionService.newInstance()
+  private val reflectionDescriptor =
+    ServiceDescriptorInfo(
+      fullServiceName = ServerReflectionGrpc.SERVICE_NAME,
+      methods = Set(
+        MethodDescriptorInfo(ServerReflectionGrpc.getServerReflectionInfoMethod)
+      )
+    )
+
+  private def withServices(service: BindableService, services: BindableService*)(
+      f: Channel => Future[Assertion]): Future[Assertion] = {
+    val serverName = InProcessServerBuilder.generateName()
+    val serverBuilder = InProcessServerBuilder.forName(serverName).addService(service)
+    for (additionalService <- services) {
+      serverBuilder.addService(additionalService)
+    }
+    val server = serverBuilder.build()
+    val channel = InProcessChannelBuilder.forName(serverName).build()
+    try {
+      server.start()
+      f(channel)
+    } finally {
+      server.shutdown()
+      val _ = server.awaitTermination(5, TimeUnit.SECONDS)
+    }
+  }
+
+}


### PR DESCRIPTION
Adds a small library designed to return in a simple package (a Future[Set[...]])
a full description of all services available on a gRPC server (if it exposes the
standard reflection endpoint), which is enough to easily generate a full reverse
proxy.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
