### PR TITLE
Sandbox: add early access flag to the sandboxes

### DIFF
--- a/daml-lf/encoder/BUILD.bazel
+++ b/daml-lf/encoder/BUILD.bazel
@@ -12,7 +12,7 @@ load(
     "//daml-lf/language:daml-lf.bzl",
     "lf_dev_version",
     "lf_latest_version",
-    "lf_preview_versions",
+    "lf_preview_version",
     "lf_stable_version",
 )
 
@@ -159,6 +159,6 @@ da_scala_binary(
         ("dev", lf_dev_version),
     ] + [
         ("preview", v)
-        for v in lf_preview_versions
+        for v in lf_preview_version
     ]
 ]

--- a/daml-lf/encoder/BUILD.bazel
+++ b/daml-lf/encoder/BUILD.bazel
@@ -12,6 +12,7 @@ load(
     "//daml-lf/language:daml-lf.bzl",
     "lf_dev_version",
     "lf_latest_version",
+    "lf_preview_versions",
     "lf_stable_version",
 )
 
@@ -156,5 +157,8 @@ da_scala_binary(
         ("stable", lf_stable_version),
         ("latest", lf_latest_version),
         ("dev", lf_dev_version),
+    ] + [
+        ("preview", v)
+        for v in lf_preview_versions
     ]
 ]

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -17,6 +17,7 @@ import com.daml.lf.transaction.Node._
 import com.daml.lf.value.Value
 import java.nio.file.Files
 
+import com.daml.lf.language.LanguageVersion
 import com.daml.lf.validation.Validation
 
 /** Allows for evaluating [[Commands]] and validating [[Transaction]]s.
@@ -48,7 +49,7 @@ import com.daml.lf.validation.Validation
   *
   * This class is thread safe as long `nextRandomInt` is.
   */
-class Engine(val config: EngineConfig = EngineConfig.Stable) {
+class Engine(val config: EngineConfig = new EngineConfig(LanguageVersion.StableVersions)) {
 
   config.profileDir.foreach(Files.createDirectories(_))
 
@@ -477,8 +478,8 @@ object Engine {
     }
   }
 
-  def DevEngine(): Engine = new Engine(EngineConfig.Dev)
+  def DevEngine(): Engine = new Engine(new EngineConfig(LanguageVersion.DevVersions))
 
-  def StableEngine(): Engine = new Engine(EngineConfig.Stable)
+  def StableEngine(): Engine = new Engine()
 
 }

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -59,15 +59,15 @@ object EngineConfig {
     * Recommended production configuration.
     * Allows the all stable versions of language.
     */
-  @deprecated("use LanguageVersion.StableVersions directly", since = "1.10.0")
+  @deprecated("use LanguageVersion.StableVersions directly", since = "1.9.0")
   def Stable: EngineConfig = new EngineConfig(
     allowedLanguageVersions = LanguageVersion.StableVersions
   )
 
   /**
-    * Allows languages version compatible with legacy contract ID is used.
+    * Only allows language versions compatible with the legacy contract ID scheme.
     */
-  @deprecated("use LanguageVersion.LegacyVersions directly", since = "1.10.0")
+  @deprecated("use LanguageVersion.LegacyVersions directly", since = "1.9.0")
   def Legacy: EngineConfig = new EngineConfig(
     allowedLanguageVersions = LanguageVersion.LegacyVersions
   )
@@ -76,7 +76,7 @@ object EngineConfig {
     * Development configuration, should not be used in PROD.
     * Allows all language version
     */
-  @deprecated("use LanguageVersion.DevVersions directly", since = "1.10.0")
+  @deprecated("use LanguageVersion.DevVersions directly", since = "1.9.0")
   def Dev: EngineConfig = new EngineConfig(
     allowedLanguageVersions = LanguageVersion.DevVersions
   )

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -8,7 +8,8 @@ import java.nio.file.Path
 
 import com.daml.lf.language.LanguageVersion
 
-/** The Engine configurations describes the versions of language and
+/**
+  * The Engine configurations describes the versions of language and
   * transaction the engine is allowed to read and write together with
   * engine debugging feature.
   *
@@ -54,30 +55,29 @@ final case class EngineConfig(
 
 object EngineConfig {
 
-  /** Most lenient production engine configuration. This allows the
-    * engine to load and produce all non-deprecated stable versions of
-    * language and transaction.
+  /**
+    * Recommended production configuration.
+    * Allows the all stable versions of language.
     */
-  val Lenient: EngineConfig = new EngineConfig(
+  @deprecated("use LanguageVersion.StableVersions directly", since = "1.10.0")
+  def Stable: EngineConfig = new EngineConfig(
     allowedLanguageVersions = LanguageVersion.StableVersions
   )
 
-  /** Recommended production configuration.
+  /**
+    * Allows languages version compatible with legacy contract ID is used.
     */
-  def Stable: EngineConfig = Lenient
+  @deprecated("use LanguageVersion.LegacyVersions directly", since = "1.10.0")
+  def Legacy: EngineConfig = new EngineConfig(
+    allowedLanguageVersions = LanguageVersion.LegacyVersions
+  )
 
-  /** Configuration if legacy contract ID is used.
+  /**
+    * Development configuration, should not be used in PROD.
+    * Allows all language version
     */
-  def Legacy: EngineConfig =
-    Lenient.copy(
-      allowedLanguageVersions = LanguageVersion.StableVersions.copy(max = LanguageVersion.v1_8)
-    )
-
-  /** Development configuration, should not be used in PROD.  Allowed
-    * the same input and output versions as [[Lenient]] plus the
-    * development versions.
-    */
-  val Dev: EngineConfig = new EngineConfig(
+  @deprecated("use LanguageVersion.DevVersions directly", since = "1.10.0")
+  def Dev: EngineConfig = new EngineConfig(
     allowedLanguageVersions = LanguageVersion.DevVersions
   )
 

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -8,8 +8,7 @@ import java.nio.file.Path
 
 import com.daml.lf.language.LanguageVersion
 
-/**
-  * The Engine configurations describes the versions of language and
+/** The Engine configurations describes the versions of language and
   * transaction the engine is allowed to read and write together with
   * engine debugging feature.
   *
@@ -55,8 +54,7 @@ final case class EngineConfig(
 
 object EngineConfig {
 
-  /**
-    * Recommended production configuration.
+  /** Recommended production configuration.
     * Allows the all stable versions of language.
     */
   @deprecated("use LanguageVersion.StableVersions directly", since = "1.9.0")
@@ -64,16 +62,14 @@ object EngineConfig {
     allowedLanguageVersions = LanguageVersion.StableVersions
   )
 
-  /**
-    * Only allows language versions compatible with the legacy contract ID scheme.
+  /** Only allows language versions compatible with the legacy contract ID scheme.
     */
   @deprecated("use LanguageVersion.LegacyVersions directly", since = "1.9.0")
   def Legacy: EngineConfig = new EngineConfig(
     allowedLanguageVersions = LanguageVersion.LegacyVersions
   )
 
-  /**
-    * Development configuration, should not be used in PROD.
+  /** Development configuration, should not be used in PROD.
     * Allows all language version
     */
   @deprecated("use LanguageVersion.DevVersions directly", since = "1.9.0")

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/EngineConfig.scala
@@ -70,7 +70,7 @@ object EngineConfig {
   )
 
   /** Development configuration, should not be used in PROD.
-    * Allows all language version
+    * Allows all language versions
     */
   @deprecated("use LanguageVersion.DevVersions directly", since = "1.9.0")
   def Dev: EngineConfig = new EngineConfig(

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineInfoTest.scala
@@ -3,6 +3,7 @@
 
 package com.daml.lf.engine
 
+import com.daml.lf.language.LanguageVersion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -10,8 +11,13 @@ class EngineInfoTest extends AnyWordSpec with Matchers {
 
   "EngineInfo" should {
 
-    val Seq(engineInfoLegacy, engineInfoStable, engineInfoDev) =
-      Seq(EngineConfig.Legacy, EngineConfig.Stable, EngineConfig.Dev).map(new EngineInfo(_))
+    val Seq(engineInfoLegacy, engineInfoStable, engineEarlyAccess, engineInfoDev) =
+      List(
+        LanguageVersion.LegacyVersions,
+        LanguageVersion.StableVersions,
+        LanguageVersion.EarlyAccessVersions,
+        LanguageVersion.DevVersions,
+      ).map(versions => new EngineInfo(EngineConfig(allowedLanguageVersions = versions)))
 
     "show supported LF, Transaction and Value versions" in {
 
@@ -20,6 +26,9 @@ class EngineInfoTest extends AnyWordSpec with Matchers {
 
       engineInfoStable.show shouldBe
         "DAML LF Engine supports LF versions: 1.6, 1.7, 1.8"
+
+      engineEarlyAccess.show shouldBe
+        "DAML LF Engine supports LF versions: 1.6, 1.7, 1.8, 1.11"
 
       engineInfoDev.show shouldBe
         "DAML LF Engine supports LF versions: 1.6, 1.7, 1.8, 1.11, 1.dev"

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1984,7 +1984,7 @@ class EngineTest
 
     def engine(min: LV, max: LV) =
       new Engine(
-        EngineConfig.Dev.copy(
+        EngineConfig(
           allowedLanguageVersions = VersionRange(min, max)
         )
       )

--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -9,7 +9,7 @@ lf_latest_version = "1.8"
 
 # lf_preview_version is non empty if a preview version is available
 # contains at most one version
-lf_preview_version = []
+lf_preview_version = ["1.11"]
 lf_dev_version = "1.dev"
 
 # All LF versions for which we have protobufs.

--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -6,7 +6,10 @@
 # we bump stable.
 lf_stable_version = "1.8"
 lf_latest_version = "1.8"
-lf_preview_versions = ["1.11"]
+
+# lf_preview_version is non empty if a preview version is available
+# contains at most one version
+lf_preview_version = []
 lf_dev_version = "1.dev"
 
 # All LF versions for which we have protobufs.

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -17,10 +17,6 @@ object LanguageVersion {
   type Minor = LanguageMinorVersion
   val Minor = LanguageMinorVersion
 
-  val defaultV1: LanguageVersion = LanguageVersion(Major.V1, Minor("8"))
-
-  val default: LanguageVersion = defaultV1
-
   implicit val Ordering: scala.Ordering[LanguageVersion] = {
     case (LanguageVersion(Major.V1, leftMinor), LanguageVersion(Major.V1, rightMinor)) =>
       Major.V1.minorVersionOrdering.compare(leftMinor, rightMinor)
@@ -58,10 +54,25 @@ object LanguageVersion {
 
   }
 
-  private[lf] val StableVersions: VersionRange[LanguageVersion] =
+  // All the stable versions.
+  val StableVersions: VersionRange[LanguageVersion] =
     VersionRange(min = v1_6, max = v1_8)
 
-  private[lf] val DevVersions: VersionRange[LanguageVersion] =
+  // All versions compatible with legacy contract ID scheme.
+  val LegacyVersions: VersionRange[LanguageVersion] =
+    StableVersions.copy(max = v1_8)
+
+  // All the stable and preview versions
+  // Equals `Stable` if no preview version is available
+  val EarlyAccessVersions: VersionRange[LanguageVersion] =
+    StableVersions.copy(max = v1_11)
+
+  // All the versions
+  val DevVersions: VersionRange[LanguageVersion] =
     StableVersions.copy(max = v1_dev)
+
+  val defaultV1: LanguageVersion = StableVersions.max
+
+  val default: LanguageVersion = defaultV1
 
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
@@ -14,7 +14,7 @@ import com.daml.lf.archive.Decode
 import com.daml.lf.archive.testing.Encode
 import com.daml.lf.data.Ref
 import com.daml.lf.engine.{Engine, EngineConfig}
-import com.daml.lf.language.Ast
+import com.daml.lf.language.{Ast, LanguageVersion}
 import com.daml.metrics.Metrics
 import com.google.protobuf.ByteString
 import org.scalatest.ParallelTestExecution
@@ -92,7 +92,11 @@ class PackageCommitterSpec extends AnyWordSpec with Matchers with ParallelTestEx
 
     // simulate restart of the participant node
     def restart() = this.synchronized {
-      engine = new Engine(EngineConfig.Dev.copy(packageValidation = false))
+      engine = new Engine(
+        EngineConfig(
+          allowedLanguageVersions = LanguageVersion.DevVersions,
+          packageValidation = false,
+        ))
       packageCommitter = new PackageCommitter(engine, metrics, validationMode, preloadingMode)
     }
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitterSpec.scala
@@ -96,7 +96,8 @@ class PackageCommitterSpec extends AnyWordSpec with Matchers with ParallelTestEx
         EngineConfig(
           allowedLanguageVersions = LanguageVersion.DevVersions,
           packageValidation = false,
-        ))
+        )
+      )
       packageCommitter = new PackageCommitter(engine, metrics, validationMode, preloadingMode)
     }
 

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -25,7 +25,7 @@ import com.daml.ledger.validator.batch.{
   BatchedSubmissionValidatorParameters,
   ConflictDetection,
 }
-import com.daml.lf.engine.{Engine, EngineConfig}
+import com.daml.lf.engine.Engine
 import com.daml.logging.LoggingContext
 import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
@@ -57,7 +57,7 @@ class IntegrityChecker[LogResult](commitStrategySupport: CommitStrategySupport[L
       println()
     }
 
-    val engine = new Engine(EngineConfig.Stable)
+    val engine = new Engine()
     val metricRegistry = new MetricRegistry
     val metrics = new Metrics(metricRegistry)
     val submissionValidator = BatchedSubmissionValidator[LogResult](

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -236,6 +236,7 @@ da_scala_test_suite(
     data = [
         "//daml-lf/encoder:testing-dar-dev",
         "//daml-lf/encoder:testing-dar-latest",
+        "//daml-lf/encoder:testing-dar-preview",
         "//ledger/test-common:model-tests.dar",
         "//ledger/test-common/test-certificates",
     ],

--- a/ledger/sandbox-classic/BUILD.bazel
+++ b/ledger/sandbox-classic/BUILD.bazel
@@ -5,6 +5,10 @@ load("//bazel_tools:scala.bzl", "da_scala_binary", "da_scala_library", "da_scala
 load("//ledger/ledger-api-test-tool:conformance.bzl", "server_conformance_test")
 load("@os_info//:os_info.bzl", "is_windows")
 load("@build_environment//:configuration.bzl", "mvn_version")
+load(
+    "//daml-lf/language:daml-lf.bzl",
+    "lf_preview_version",
+)
 
 da_scala_library(
     name = "sandbox-classic",
@@ -236,9 +240,11 @@ da_scala_test_suite(
     data = [
         "//daml-lf/encoder:testing-dar-dev",
         "//daml-lf/encoder:testing-dar-latest",
-        "//daml-lf/encoder:testing-dar-preview",
         "//ledger/test-common:model-tests.dar",
         "//ledger/test-common/test-certificates",
+    ] + [
+        "//daml-lf/encoder:testing-dar-preview"
+        for v in lf_preview_version
     ],
     resources = glob(["src/test/resources/**/*"]) + ["//ledger/sandbox-common:src/main/resources/logback.xml"],
     deps = test_deps,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/Cli.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/Cli.scala
@@ -13,7 +13,7 @@ private[sandbox] object Cli extends SandboxCli {
   override val defaultConfig: SandboxConfig = DefaultConfig
 
   override protected val parser: OptionParser[SandboxConfig] = {
-    val parser = new CommonCli(Name)
+    val parser = new CommonCli(Name).withEarlyAccess
       .withContractIdSeeding(
         defaultConfig,
         None,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxServer.scala
@@ -414,7 +414,7 @@ final class SandboxServer(
       }
       if (config.seeding.isEmpty) {
         // TODO https://github.com/digital-asset/daml/issues/7139
-        //  change the message once LF 1.11 is release
+        //  rephrase the message once LF 1.11 is released
         logger.withoutContext.warn(
           s"""|'${Seeding.NoSeedingModeName}' contract IDs seeding mode is not compatible with the LF 1.11 languages or later which will be released soon.
               |A ledger stared with ${Seeding.NoSeedingModeName} contract IDs seeding will refuse to load LF 1.11 language or later. 

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/EngineModeIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/EngineModeIT.scala
@@ -52,7 +52,7 @@ class EngineModeIT
       ledgerIdRequirement = ledger.client.configuration.LedgerIdRequirement.none,
       commandClient = ledger.client.configuration.CommandClientConfiguration.default,
       sslContext = None,
-      token = None
+      token = None,
     )
 
   private[this] def buildServer(mode: SandboxConfig.EngineMode) =
@@ -60,7 +60,8 @@ class EngineModeIT
       DefaultConfig.copy(
         port = Port.Dynamic,
         engineMode = mode,
-      ))
+      )
+    )
 
   private[this] def buildRequest(pkgId: String, ledgerId: LedgerId) = {
     import scalaz.syntax.tag._
@@ -74,10 +75,12 @@ class EngineModeIT
             tmplId,
             Seq(
               RecordField(value = Some(Value().withUnit(protobuf.empty.Empty()))),
-              RecordField(value = Some(Value().withParty(party)))
+              RecordField(value = Some(Value().withParty(party))),
             ),
-          ))
-      ))
+          )
+        ),
+      )
+    )
     SubmitAndWaitRequest(
       Some(
         Commands(
@@ -85,8 +88,10 @@ class EngineModeIT
           applicationId = applicationId.unwrap,
           ledgerId = ledgerId.unwrap,
           commandId = UUID.randomUUID.toString,
-          commands = Seq(cmd)
-        )))
+          commands = Seq(cmd),
+        )
+      )
+    )
   }
 
   private[this] def run(darPath: Path, server: SandboxServer) =
@@ -114,22 +119,22 @@ class EngineModeIT
 
     def load(langVersion: LanguageVersion, mode: EngineMode) =
       buildServer(mode).use(
-        run(Paths.get(rlocation(s"daml-lf/encoder/test-${langVersion.pretty}.dar")), _))
+        run(Paths.get(rlocation(s"daml-lf/encoder/test-${langVersion.pretty}.dar")), _)
+      )
 
     def accept(langVersion: LanguageVersion, mode: EngineMode) =
       s"accept LF ${langVersion.pretty} when $mode mode is used" in
         load(langVersion, mode).map {
-          inside(_) {
-            case Success(_) => succeed
+          inside(_) { case Success(_) =>
+            succeed
           }
         }
 
     def reject(langVersion: LanguageVersion, mode: EngineMode) =
       s"reject LF ${langVersion.pretty} when $mode mode is used" in
         load(langVersion, mode).map {
-          inside(_) {
-            case Failure(exception) =>
-              exception.getMessage should include("Disallowed language version")
+          inside(_) { case Failure(exception) =>
+            exception.getMessage should include("Disallowed language version")
           }
         }
 

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCli.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCli.scala
@@ -50,7 +50,9 @@ class CommonCli(name: LedgerName) {
       opt[Unit]("dev-mode-unsafe")
         .optional()
         .action((_, config) => config.copy(engineMode = SandboxConfig.EngineMode.Dev))
-        .text("Turns on development mode. Development mode allows development versions of Daml-LF language.")
+        .text(
+          "Turns on development mode. Development mode allows development versions of Daml-LF language."
+        )
         .hidden()
 
       arg[File]("<archive>...")
@@ -58,7 +60,9 @@ class CommonCli(name: LedgerName) {
         .unbounded()
         .validate(f => Either.cond(checkIfZip(f), (), s"Invalid dar file: ${f.getName}"))
         .action((f, c) => c.copy(damlPackages = f :: c.damlPackages))
-        .text("Daml archives to load in .dar format. Only Daml-LF v1 Archives are currently supported. Can be mixed in with optional arguments.")
+        .text(
+          "Daml archives to load in .dar format. Only Daml-LF v1 Archives are currently supported. Can be mixed in with optional arguments."
+        )
 
       opt[String]('a', "address")
         .optional()
@@ -74,13 +78,17 @@ class CommonCli(name: LedgerName) {
       opt[File]("port-file")
         .optional()
         .action((f, c) => c.copy(portFile = Some(f.toPath)))
-        .text("File to write the allocated port number to. Used to inform clients in CI about the allocated port.")
+        .text(
+          "File to write the allocated port number to. Used to inform clients in CI about the allocated port."
+        )
 
       opt[String]("ledgerid")
         .optional()
         .action((id, c) =>
           c.copy(
-            ledgerIdMode = LedgerIdMode.Static(LedgerId(Ref.LedgerString.assertFromString(id)))))
+            ledgerIdMode = LedgerIdMode.Static(LedgerId(Ref.LedgerString.assertFromString(id)))
+          )
+        )
         .text(s"Ledger ID. If missing, a random unique ledger ID will be used.")
 
       opt[String]("participant-id")
@@ -92,7 +100,8 @@ class CommonCli(name: LedgerName) {
       opt[Unit]("dalf")
         .optional()
         .text(
-          "This argument is present for backwards compatibility. DALF and DAR archives are now identified by their extensions.")
+          "This argument is present for backwards compatibility. DALF and DAR archives are now identified by their extensions."
+        )
 
       opt[Unit]('s', "static-time")
         .optional()
@@ -116,52 +125,74 @@ class CommonCli(name: LedgerName) {
         .optional()
         .text("TLS: The pem file to be used as the private key.")
         .action((path, config) =>
-          config.copy(tlsConfig = config.tlsConfig
-            .fold(Some(TlsConfiguration(enabled = true, None, Some(new File(path)), None)))(c =>
-              Some(c.copy(keyFile = Some(new File(path)))))))
+          config.copy(tlsConfig =
+            config.tlsConfig
+              .fold(Some(TlsConfiguration(enabled = true, None, Some(new File(path)), None)))(c =>
+                Some(c.copy(keyFile = Some(new File(path))))
+              )
+          )
+        )
 
       opt[String]("crt")
         .optional()
-        .text("TLS: The crt file to be used as the cert chain. Required if any other TLS parameters are set.")
+        .text(
+          "TLS: The crt file to be used as the cert chain. Required if any other TLS parameters are set."
+        )
         .action((path: String, config: SandboxConfig) =>
-          config.copy(tlsConfig = config.tlsConfig
-            .fold(Some(TlsConfiguration(enabled = true, Some(new File(path)), None, None)))(c =>
-              Some(c.copy(keyCertChainFile = Some(new File(path)))))))
+          config.copy(tlsConfig =
+            config.tlsConfig
+              .fold(Some(TlsConfiguration(enabled = true, Some(new File(path)), None, None)))(c =>
+                Some(c.copy(keyCertChainFile = Some(new File(path))))
+              )
+          )
+        )
 
       opt[String]("cacrt")
         .optional()
         .text("TLS: The crt file to be used as the trusted root CA.")
         .action((path, config) =>
-          config.copy(tlsConfig = config.tlsConfig
-            .fold(Some(TlsConfiguration(enabled = true, None, None, Some(new File(path)))))(c =>
-              Some(c.copy(trustCertCollectionFile = Some(new File(path)))))))
+          config.copy(tlsConfig =
+            config.tlsConfig
+              .fold(Some(TlsConfiguration(enabled = true, None, None, Some(new File(path)))))(c =>
+                Some(c.copy(trustCertCollectionFile = Some(new File(path))))
+              )
+          )
+        )
 
       opt[ClientAuth]("client-auth")
         .optional()
-        .text("TLS: The client authentication mode. Must be one of none, optional or require. Defaults to required.")
+        .text(
+          "TLS: The client authentication mode. Must be one of none, optional or require. Defaults to required."
+        )
         .action((clientAuth, config) =>
-          config.copy(tlsConfig = config.tlsConfig
-            .fold(Some(TlsConfiguration(enabled = true, None, None, None, clientAuth)))(c =>
-              Some(c.copy(clientAuth = clientAuth)))))
+          config.copy(tlsConfig =
+            config.tlsConfig
+              .fold(Some(TlsConfiguration(enabled = true, None, None, None, clientAuth)))(c =>
+                Some(c.copy(clientAuth = clientAuth))
+              )
+          )
+        )
 
       opt[Boolean]("cert-revocation-checking")
         .optional()
         .text(
-          "TLS: enable/disable certificate revocation checks with the OCSP. Disabled by default.")
-        .action(
-          (checksEnabled, config) =>
-            config.copy(
-              tlsConfig = config.tlsConfig
-                .fold(
-                  Some(TlsConfiguration.Empty.copy(enableCertRevocationChecking = checksEnabled)))(
-                  config => Some(config.copy(enableCertRevocationChecking = checksEnabled)))
-          ))
+          "TLS: enable/disable certificate revocation checks with the OCSP. Disabled by default."
+        )
+        .action((checksEnabled, config) =>
+          config.copy(
+            tlsConfig = config.tlsConfig
+              .fold(
+                Some(TlsConfiguration.Empty.copy(enableCertRevocationChecking = checksEnabled))
+              )(config => Some(config.copy(enableCertRevocationChecking = checksEnabled)))
+          )
+        )
 
       opt[Int]("max-inbound-message-size")
         .optional()
         .action((x, c) => c.copy(maxInboundMessageSize = x))
         .text(
-          s"Max inbound message size in bytes. Defaults to ${SandboxConfig.DefaultMaxInboundMessageSize}.")
+          s"Max inbound message size in bytes. Defaults to ${SandboxConfig.DefaultMaxInboundMessageSize}."
+        )
 
       opt[Int]("maxInboundMessageSize")
         .optional()
@@ -177,22 +208,29 @@ class CommonCli(name: LedgerName) {
         .optional()
         .validate(l =>
           Either
-            .cond(KnownLogLevels.contains(l.toUpperCase), (), s"Unrecognized logging level $l"))
+            .cond(KnownLogLevels.contains(l.toUpperCase), (), s"Unrecognized logging level $l")
+        )
         .action((level, c) => c.copy(logLevel = Some(Level.toLevel(level.toUpperCase))))
-        .text("Default logging level to use. Available values are INFO, TRACE, DEBUG, WARN, and ERROR. Defaults to INFO.")
+        .text(
+          "Default logging level to use. Available values are INFO, TRACE, DEBUG, WARN, and ERROR. Defaults to INFO."
+        )
 
       opt[Unit]("eager-package-loading")
         .optional()
-        .text("Whether to load all the packages in the .dar files provided eagerly, rather than when needed as the commands come.")
+        .text(
+          "Whether to load all the packages in the .dar files provided eagerly, rather than when needed as the commands come."
+        )
         .action((_, config) => config.copy(eagerPackageLoading = true))
 
       JwtVerifierConfigurationCli.parse(this)((v, c) =>
-        c.copy(authService = Some(AuthServiceJWT(v))))
+        c.copy(authService = Some(AuthServiceJWT(v)))
+      )
 
       opt[Int]("events-page-size")
         .optional()
         .text(
-          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${SandboxConfig.DefaultEventsPageSize}.")
+          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${SandboxConfig.DefaultEventsPageSize}."
+        )
         .action((eventsPageSize, config) => config.copy(eventsPageSize = eventsPageSize))
 
       opt[MetricsReporter]("metrics-reporter")
@@ -206,34 +244,43 @@ class CommonCli(name: LedgerName) {
       opt[Int]("max-commands-in-flight")
         .optional()
         .action((value, config) =>
-          config.copy(commandConfig = config.commandConfig.copy(maxCommandsInFlight = value)))
-        .text("Maximum number of submitted commands waiting for completion for each party (only applied when using the CommandService). Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 256.")
+          config.copy(commandConfig = config.commandConfig.copy(maxCommandsInFlight = value))
+        )
+        .text(
+          "Maximum number of submitted commands waiting for completion for each party (only applied when using the CommandService). Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 256."
+        )
 
       opt[Int]("max-parallel-submissions")
         .optional()
         .action((value, config) =>
-          config.copy(commandConfig = config.commandConfig.copy(maxParallelSubmissions = value)))
-        .text("Maximum number of successfully interpreted commands waiting to be sequenced (applied only when running sandbox-classic). The threshold is shared across all parties. Overflowing it will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512.")
+          config.copy(commandConfig = config.commandConfig.copy(maxParallelSubmissions = value))
+        )
+        .text(
+          "Maximum number of successfully interpreted commands waiting to be sequenced (applied only when running sandbox-classic). The threshold is shared across all parties. Overflowing it will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512."
+        )
 
       opt[Int]("input-buffer-size")
         .optional()
         .action((value, config) =>
-          config.copy(commandConfig = config.commandConfig.copy(inputBufferSize = value)))
-        .text("The maximum number of commands waiting to be submitted for each party. Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512.")
+          config.copy(commandConfig = config.commandConfig.copy(inputBufferSize = value))
+        )
+        .text(
+          "The maximum number of commands waiting to be submitted for each party. Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512."
+        )
 
       opt[Long]("max-lf-value-translation-cache-entries")
         .optional()
         .text(
-          s"The maximum size of the cache used to deserialize Daml-LF values, in number of allowed entries. By default, nothing is cached.")
-        .action(
-          (maximumLfValueTranslationCacheEntries, config) =>
-            config.copy(
-              lfValueTranslationEventCacheConfiguration =
-                config.lfValueTranslationEventCacheConfiguration
-                  .copy(maximumSize = maximumLfValueTranslationCacheEntries),
-              lfValueTranslationContractCacheConfiguration =
-                config.lfValueTranslationContractCacheConfiguration
-                  .copy(maximumSize = maximumLfValueTranslationCacheEntries)
+          s"The maximum size of the cache used to deserialize Daml-LF values, in number of allowed entries. By default, nothing is cached."
+        )
+        .action((maximumLfValueTranslationCacheEntries, config) =>
+          config.copy(
+            lfValueTranslationEventCacheConfiguration =
+              config.lfValueTranslationEventCacheConfiguration
+                .copy(maximumSize = maximumLfValueTranslationCacheEntries),
+            lfValueTranslationContractCacheConfiguration =
+              config.lfValueTranslationContractCacheConfiguration
+                .copy(maximumSize = maximumLfValueTranslationCacheEntries),
           )
         )
 
@@ -258,28 +305,31 @@ class CommonCli(name: LedgerName) {
           config.copy(ledgerConfig = config.ledgerConfig.copy(initialConfiguration = ledgerConfig))
         })
         .text(
-          s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${v1.TimeModel.reasonableDefault.minSkew.getSeconds}.")
+          s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${v1.TimeModel.reasonableDefault.minSkew.getSeconds}."
+        )
 
       opt[Duration]("management-service-timeout")
         .hidden()
         .optional()
         .action((value, config) => config.copy(managementServiceTimeout = value))
         .text(
-          s"The timeout used for requests by management services of the Ledger API. The default is set to ${SandboxConfig.DefaultManagementServiceTimeout.getSeconds} seconds.")
+          s"The timeout used for requests by management services of the Ledger API. The default is set to ${SandboxConfig.DefaultManagementServiceTimeout.getSeconds} seconds."
+        )
 
       help("help").text("Print the usage text")
 
       checkConfig(c => {
         if (c.scenario.isDefined && c.timeProviderType.contains(TimeProviderType.WallClock))
           failure(
-            "Wall-clock time mode (`-w`/`--wall-clock-time`) and scenario initialization (`--scenario`) may not be used together.")
+            "Wall-clock time mode (`-w`/`--wall-clock-time`) and scenario initialization (`--scenario`) may not be used together."
+          )
         else success
       })
     }
 
   def withContractIdSeeding(
       defaultConfig: SandboxConfig,
-      seedingModes: Option[Seeding]*,
+      seedingModes: Option[Seeding]*
   ): CommonCli = {
     val seedingModesMap =
       seedingModes.map(mode => (mode.map(_.name).getOrElse(Seeding.NoSeedingModeName), mode)).toMap
@@ -290,13 +340,15 @@ class CommonCli(name: LedgerName) {
       .opt[String]("contract-id-seeding")
       .optional()
       .text(
-        s"""Set the seeding mode of contract IDs. Possible values are $allSeedingModeNames. "$defaultSeedingModeName" mode is not compatible with development mode. Default is "$defaultSeedingModeName".""")
-      .validate(
-        v =>
-          Either.cond(
-            seedingModesMap.contains(v.toLowerCase),
-            (),
-            s"seeding mode must be one of $allSeedingModeNames"))
+        s"""Set the seeding mode of contract IDs. Possible values are $allSeedingModeNames. "$defaultSeedingModeName" mode is not compatible with development mode. Default is "$defaultSeedingModeName"."""
+      )
+      .validate(v =>
+        Either.cond(
+          seedingModesMap.contains(v.toLowerCase),
+          (),
+          s"seeding mode must be one of $allSeedingModeNames",
+        )
+      )
       .action((text, config) => config.copy(seeding = seedingModesMap(text)))
     this
   }
@@ -310,9 +362,11 @@ class CommonCli(name: LedgerName) {
           c.copy(engineMode = SandboxConfig.EngineMode.EarlyAccess)
         } else {
           c
-      })
+        }
+      )
       .text(
-        "Enable preview version of the next Daml-LF language. Should not be used in production.")
+        "Enable preview version of the next Daml-LF language. Should not be used in production."
+      )
     this
   }
 
@@ -326,7 +380,8 @@ object CommonCli {
   ): SandboxConfig = {
     if (config.timeProviderType.exists(_ != timeProviderType)) {
       throw new IllegalStateException(
-        "Static time mode (`-s`/`--static-time`) and wall-clock time mode (`-w`/`--wall-clock-time`) are mutually exclusive. The time mode must be unambiguous.")
+        "Static time mode (`-s`/`--static-time`) and wall-clock time mode (`-w`/`--wall-clock-time`) are mutually exclusive. The time mode must be unambiguous."
+      )
     }
     config.copy(timeProviderType = Some(timeProviderType))
   }
@@ -337,7 +392,7 @@ object CommonCli {
       val raf = new RandomAccessFile(f, "r")
       val n = raf.readInt
       raf.close()
-      n == 0x504B0304 //non-empty, non-spanned ZIPs are always beginning with this
+      n == 0x504b0304 //non-empty, non-spanned ZIPs are always beginning with this
     }.getOrElse(false)
   }
 

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCli.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/cli/CommonCli.scala
@@ -49,10 +49,8 @@ class CommonCli(name: LedgerName) {
 
       opt[Unit]("dev-mode-unsafe")
         .optional()
-        .action((_, config) => config.copy(devMode = true))
-        .text(
-          "Turns on development mode. Development mode allows development versions of Daml-LF language."
-        )
+        .action((_, config) => config.copy(engineMode = SandboxConfig.EngineMode.Dev))
+        .text("Turns on development mode. Development mode allows development versions of Daml-LF language.")
         .hidden()
 
       arg[File]("<archive>...")
@@ -60,9 +58,7 @@ class CommonCli(name: LedgerName) {
         .unbounded()
         .validate(f => Either.cond(checkIfZip(f), (), s"Invalid dar file: ${f.getName}"))
         .action((f, c) => c.copy(damlPackages = f :: c.damlPackages))
-        .text(
-          "Daml archives to load in .dar format. Only Daml-LF v1 Archives are currently supported. Can be mixed in with optional arguments."
-        )
+        .text("Daml archives to load in .dar format. Only Daml-LF v1 Archives are currently supported. Can be mixed in with optional arguments.")
 
       opt[String]('a', "address")
         .optional()
@@ -78,17 +74,13 @@ class CommonCli(name: LedgerName) {
       opt[File]("port-file")
         .optional()
         .action((f, c) => c.copy(portFile = Some(f.toPath)))
-        .text(
-          "File to write the allocated port number to. Used to inform clients in CI about the allocated port."
-        )
+        .text("File to write the allocated port number to. Used to inform clients in CI about the allocated port.")
 
       opt[String]("ledgerid")
         .optional()
         .action((id, c) =>
           c.copy(
-            ledgerIdMode = LedgerIdMode.Static(LedgerId(Ref.LedgerString.assertFromString(id)))
-          )
-        )
+            ledgerIdMode = LedgerIdMode.Static(LedgerId(Ref.LedgerString.assertFromString(id)))))
         .text(s"Ledger ID. If missing, a random unique ledger ID will be used.")
 
       opt[String]("participant-id")
@@ -100,8 +92,7 @@ class CommonCli(name: LedgerName) {
       opt[Unit]("dalf")
         .optional()
         .text(
-          "This argument is present for backwards compatibility. DALF and DAR archives are now identified by their extensions."
-        )
+          "This argument is present for backwards compatibility. DALF and DAR archives are now identified by their extensions.")
 
       opt[Unit]('s', "static-time")
         .optional()
@@ -125,74 +116,52 @@ class CommonCli(name: LedgerName) {
         .optional()
         .text("TLS: The pem file to be used as the private key.")
         .action((path, config) =>
-          config.copy(tlsConfig =
-            config.tlsConfig
-              .fold(Some(TlsConfiguration(enabled = true, None, Some(new File(path)), None)))(c =>
-                Some(c.copy(keyFile = Some(new File(path))))
-              )
-          )
-        )
+          config.copy(tlsConfig = config.tlsConfig
+            .fold(Some(TlsConfiguration(enabled = true, None, Some(new File(path)), None)))(c =>
+              Some(c.copy(keyFile = Some(new File(path)))))))
 
       opt[String]("crt")
         .optional()
-        .text(
-          "TLS: The crt file to be used as the cert chain. Required if any other TLS parameters are set."
-        )
+        .text("TLS: The crt file to be used as the cert chain. Required if any other TLS parameters are set.")
         .action((path: String, config: SandboxConfig) =>
-          config.copy(tlsConfig =
-            config.tlsConfig
-              .fold(Some(TlsConfiguration(enabled = true, Some(new File(path)), None, None)))(c =>
-                Some(c.copy(keyCertChainFile = Some(new File(path))))
-              )
-          )
-        )
+          config.copy(tlsConfig = config.tlsConfig
+            .fold(Some(TlsConfiguration(enabled = true, Some(new File(path)), None, None)))(c =>
+              Some(c.copy(keyCertChainFile = Some(new File(path)))))))
 
       opt[String]("cacrt")
         .optional()
         .text("TLS: The crt file to be used as the trusted root CA.")
         .action((path, config) =>
-          config.copy(tlsConfig =
-            config.tlsConfig
-              .fold(Some(TlsConfiguration(enabled = true, None, None, Some(new File(path)))))(c =>
-                Some(c.copy(trustCertCollectionFile = Some(new File(path))))
-              )
-          )
-        )
+          config.copy(tlsConfig = config.tlsConfig
+            .fold(Some(TlsConfiguration(enabled = true, None, None, Some(new File(path)))))(c =>
+              Some(c.copy(trustCertCollectionFile = Some(new File(path)))))))
 
       opt[ClientAuth]("client-auth")
         .optional()
-        .text(
-          "TLS: The client authentication mode. Must be one of none, optional or require. Defaults to required."
-        )
+        .text("TLS: The client authentication mode. Must be one of none, optional or require. Defaults to required.")
         .action((clientAuth, config) =>
-          config.copy(tlsConfig =
-            config.tlsConfig
-              .fold(Some(TlsConfiguration(enabled = true, None, None, None, clientAuth)))(c =>
-                Some(c.copy(clientAuth = clientAuth))
-              )
-          )
-        )
+          config.copy(tlsConfig = config.tlsConfig
+            .fold(Some(TlsConfiguration(enabled = true, None, None, None, clientAuth)))(c =>
+              Some(c.copy(clientAuth = clientAuth)))))
 
       opt[Boolean]("cert-revocation-checking")
         .optional()
         .text(
-          "TLS: enable/disable certificate revocation checks with the OCSP. Disabled by default."
-        )
-        .action((checksEnabled, config) =>
-          config.copy(
-            tlsConfig = config.tlsConfig
-              .fold(
-                Some(TlsConfiguration.Empty.copy(enableCertRevocationChecking = checksEnabled))
-              )(config => Some(config.copy(enableCertRevocationChecking = checksEnabled)))
-          )
-        )
+          "TLS: enable/disable certificate revocation checks with the OCSP. Disabled by default.")
+        .action(
+          (checksEnabled, config) =>
+            config.copy(
+              tlsConfig = config.tlsConfig
+                .fold(
+                  Some(TlsConfiguration.Empty.copy(enableCertRevocationChecking = checksEnabled)))(
+                  config => Some(config.copy(enableCertRevocationChecking = checksEnabled)))
+          ))
 
       opt[Int]("max-inbound-message-size")
         .optional()
         .action((x, c) => c.copy(maxInboundMessageSize = x))
         .text(
-          s"Max inbound message size in bytes. Defaults to ${SandboxConfig.DefaultMaxInboundMessageSize}."
-        )
+          s"Max inbound message size in bytes. Defaults to ${SandboxConfig.DefaultMaxInboundMessageSize}.")
 
       opt[Int]("maxInboundMessageSize")
         .optional()
@@ -208,29 +177,22 @@ class CommonCli(name: LedgerName) {
         .optional()
         .validate(l =>
           Either
-            .cond(KnownLogLevels.contains(l.toUpperCase), (), s"Unrecognized logging level $l")
-        )
+            .cond(KnownLogLevels.contains(l.toUpperCase), (), s"Unrecognized logging level $l"))
         .action((level, c) => c.copy(logLevel = Some(Level.toLevel(level.toUpperCase))))
-        .text(
-          "Default logging level to use. Available values are INFO, TRACE, DEBUG, WARN, and ERROR. Defaults to INFO."
-        )
+        .text("Default logging level to use. Available values are INFO, TRACE, DEBUG, WARN, and ERROR. Defaults to INFO.")
 
       opt[Unit]("eager-package-loading")
         .optional()
-        .text(
-          "Whether to load all the packages in the .dar files provided eagerly, rather than when needed as the commands come."
-        )
+        .text("Whether to load all the packages in the .dar files provided eagerly, rather than when needed as the commands come.")
         .action((_, config) => config.copy(eagerPackageLoading = true))
 
       JwtVerifierConfigurationCli.parse(this)((v, c) =>
-        c.copy(authService = Some(AuthServiceJWT(v)))
-      )
+        c.copy(authService = Some(AuthServiceJWT(v))))
 
       opt[Int]("events-page-size")
         .optional()
         .text(
-          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${SandboxConfig.DefaultEventsPageSize}."
-        )
+          s"Number of events fetched from the index for every round trip when serving streaming calls. Default is ${SandboxConfig.DefaultEventsPageSize}.")
         .action((eventsPageSize, config) => config.copy(eventsPageSize = eventsPageSize))
 
       opt[MetricsReporter]("metrics-reporter")
@@ -244,43 +206,34 @@ class CommonCli(name: LedgerName) {
       opt[Int]("max-commands-in-flight")
         .optional()
         .action((value, config) =>
-          config.copy(commandConfig = config.commandConfig.copy(maxCommandsInFlight = value))
-        )
-        .text(
-          "Maximum number of submitted commands waiting for completion for each party (only applied when using the CommandService). Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 256."
-        )
+          config.copy(commandConfig = config.commandConfig.copy(maxCommandsInFlight = value)))
+        .text("Maximum number of submitted commands waiting for completion for each party (only applied when using the CommandService). Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 256.")
 
       opt[Int]("max-parallel-submissions")
         .optional()
         .action((value, config) =>
-          config.copy(commandConfig = config.commandConfig.copy(maxParallelSubmissions = value))
-        )
-        .text(
-          "Maximum number of successfully interpreted commands waiting to be sequenced (applied only when running sandbox-classic). The threshold is shared across all parties. Overflowing it will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512."
-        )
+          config.copy(commandConfig = config.commandConfig.copy(maxParallelSubmissions = value)))
+        .text("Maximum number of successfully interpreted commands waiting to be sequenced (applied only when running sandbox-classic). The threshold is shared across all parties. Overflowing it will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512.")
 
       opt[Int]("input-buffer-size")
         .optional()
         .action((value, config) =>
-          config.copy(commandConfig = config.commandConfig.copy(inputBufferSize = value))
-        )
-        .text(
-          "The maximum number of commands waiting to be submitted for each party. Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512."
-        )
+          config.copy(commandConfig = config.commandConfig.copy(inputBufferSize = value)))
+        .text("The maximum number of commands waiting to be submitted for each party. Overflowing this threshold will cause back-pressure, signaled by a RESOURCE_EXHAUSTED error code. Default is 512.")
 
       opt[Long]("max-lf-value-translation-cache-entries")
         .optional()
         .text(
-          s"The maximum size of the cache used to deserialize Daml-LF values, in number of allowed entries. By default, nothing is cached."
-        )
-        .action((maximumLfValueTranslationCacheEntries, config) =>
-          config.copy(
-            lfValueTranslationEventCacheConfiguration =
-              config.lfValueTranslationEventCacheConfiguration
-                .copy(maximumSize = maximumLfValueTranslationCacheEntries),
-            lfValueTranslationContractCacheConfiguration =
-              config.lfValueTranslationContractCacheConfiguration
-                .copy(maximumSize = maximumLfValueTranslationCacheEntries),
+          s"The maximum size of the cache used to deserialize Daml-LF values, in number of allowed entries. By default, nothing is cached.")
+        .action(
+          (maximumLfValueTranslationCacheEntries, config) =>
+            config.copy(
+              lfValueTranslationEventCacheConfiguration =
+                config.lfValueTranslationEventCacheConfiguration
+                  .copy(maximumSize = maximumLfValueTranslationCacheEntries),
+              lfValueTranslationContractCacheConfiguration =
+                config.lfValueTranslationContractCacheConfiguration
+                  .copy(maximumSize = maximumLfValueTranslationCacheEntries)
           )
         )
 
@@ -305,31 +258,28 @@ class CommonCli(name: LedgerName) {
           config.copy(ledgerConfig = config.ledgerConfig.copy(initialConfiguration = ledgerConfig))
         })
         .text(
-          s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${v1.TimeModel.reasonableDefault.minSkew.getSeconds}."
-        )
+          s"Maximum skew (in seconds) between the ledger time and the record time. Default is ${v1.TimeModel.reasonableDefault.minSkew.getSeconds}.")
 
       opt[Duration]("management-service-timeout")
         .hidden()
         .optional()
         .action((value, config) => config.copy(managementServiceTimeout = value))
         .text(
-          s"The timeout used for requests by management services of the Ledger API. The default is set to ${SandboxConfig.DefaultManagementServiceTimeout.getSeconds} seconds."
-        )
+          s"The timeout used for requests by management services of the Ledger API. The default is set to ${SandboxConfig.DefaultManagementServiceTimeout.getSeconds} seconds.")
 
       help("help").text("Print the usage text")
 
       checkConfig(c => {
         if (c.scenario.isDefined && c.timeProviderType.contains(TimeProviderType.WallClock))
           failure(
-            "Wall-clock time mode (`-w`/`--wall-clock-time`) and scenario initialization (`--scenario`) may not be used together."
-          )
+            "Wall-clock time mode (`-w`/`--wall-clock-time`) and scenario initialization (`--scenario`) may not be used together.")
         else success
       })
     }
 
   def withContractIdSeeding(
       defaultConfig: SandboxConfig,
-      seedingModes: Option[Seeding]*
+      seedingModes: Option[Seeding]*,
   ): CommonCli = {
     val seedingModesMap =
       seedingModes.map(mode => (mode.map(_.name).getOrElse(Seeding.NoSeedingModeName), mode)).toMap
@@ -340,16 +290,29 @@ class CommonCli(name: LedgerName) {
       .opt[String]("contract-id-seeding")
       .optional()
       .text(
-        s"""Set the seeding mode of contract IDs. Possible values are $allSeedingModeNames. "$defaultSeedingModeName" mode is not compatible with development mode. Default is "$defaultSeedingModeName"."""
-      )
-      .validate(v =>
-        Either.cond(
-          seedingModesMap.contains(v.toLowerCase),
-          (),
-          s"seeding mode must be one of $allSeedingModeNames",
-        )
-      )
+        s"""Set the seeding mode of contract IDs. Possible values are $allSeedingModeNames. "$defaultSeedingModeName" mode is not compatible with development mode. Default is "$defaultSeedingModeName".""")
+      .validate(
+        v =>
+          Either.cond(
+            seedingModesMap.contains(v.toLowerCase),
+            (),
+            s"seeding mode must be one of $allSeedingModeNames"))
       .action((text, config) => config.copy(seeding = seedingModesMap(text)))
+    this
+  }
+
+  def withEarlyAccess: CommonCli = {
+    parser
+      .opt[Unit]("early-access-unsafe")
+      .optional()
+      .action((_, c) =>
+        if (c.engineMode == SandboxConfig.EngineMode.Stable) {
+          c.copy(engineMode = SandboxConfig.EngineMode.EarlyAccess)
+        } else {
+          c
+      })
+      .text(
+        "Enable preview version of the next Daml-LF language. Should not be used in production.")
     this
   }
 
@@ -363,8 +326,7 @@ object CommonCli {
   ): SandboxConfig = {
     if (config.timeProviderType.exists(_ != timeProviderType)) {
       throw new IllegalStateException(
-        "Static time mode (`-s`/`--static-time`) and wall-clock time mode (`-w`/`--wall-clock-time`) are mutually exclusive. The time mode must be unambiguous."
-      )
+        "Static time mode (`-s`/`--static-time`) and wall-clock time mode (`-w`/`--wall-clock-time`) are mutually exclusive. The time mode must be unambiguous.")
     }
     config.copy(timeProviderType = Some(timeProviderType))
   }
@@ -375,7 +337,7 @@ object CommonCli {
       val raf = new RandomAccessFile(f, "r")
       val n = raf.readInt
       raf.close()
-      n == 0x504b0304 //non-empty, non-spanned ZIPs are always beginning with this
+      n == 0x504B0304 //non-empty, non-spanned ZIPs are always beginning with this
     }.getOrElse(false)
   }
 

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -18,8 +18,7 @@ import com.daml.platform.configuration.{CommandConfiguration, LedgerConfiguratio
 import com.daml.platform.services.time.TimeProviderType
 import com.daml.ports.Port
 
-/**
-  * Defines the basic configuration for running sandbox
+/** Defines the basic configuration for running sandbox
   */
 final case class SandboxConfig(
     address: Option[String],
@@ -48,7 +47,7 @@ final case class SandboxConfig(
     profileDir: Option[Path],
     stackTraces: Boolean,
     engineMode: SandboxConfig.EngineMode,
-    managementServiceTimeout: Duration
+    managementServiceTimeout: Duration,
 )
 
 object SandboxConfig {

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -18,7 +18,8 @@ import com.daml.platform.configuration.{CommandConfiguration, LedgerConfiguratio
 import com.daml.platform.services.time.TimeProviderType
 import com.daml.ports.Port
 
-/** Defines the basic configuration for running sandbox
+/**
+  * Defines the basic configuration for running sandbox
   */
 final case class SandboxConfig(
     address: Option[String],
@@ -46,8 +47,8 @@ final case class SandboxConfig(
     lfValueTranslationContractCacheConfiguration: SizedCache.Configuration,
     profileDir: Option[Path],
     stackTraces: Boolean,
-    devMode: Boolean,
-    managementServiceTimeout: Duration,
+    engineMode: SandboxConfig.EngineMode,
+    managementServiceTimeout: Duration
 )
 
 object SandboxConfig {
@@ -94,8 +95,16 @@ object SandboxConfig {
       lfValueTranslationContractCacheConfiguration = DefaultLfValueTranslationCacheConfiguration,
       profileDir = None,
       stackTraces = true,
-      devMode = false,
+      engineMode = EngineMode.Stable,
       managementServiceTimeout = DefaultManagementServiceTimeout,
     )
+
+  sealed abstract class EngineMode extends Product with Serializable
+
+  object EngineMode {
+    final case object Stable extends EngineMode
+    final case object EarlyAccess extends EngineMode
+    final case object Dev extends EngineMode
+  }
 
 }

--- a/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/AbstractSandboxFixture.scala
+++ b/ledger/sandbox-common/src/test/lib/scala/platform/sandbox/AbstractSandboxFixture.scala
@@ -67,7 +67,7 @@ trait AbstractSandboxFixture extends AkkaBeforeAndAfterAll {
       scenario = scenario,
       ledgerIdMode = LedgerIdMode.Static(LedgerId("sandbox-server")),
       seeding = Some(Seeding.Weak),
-      devMode = true,
+      engineMode = SandboxConfig.EngineMode.Dev,
       authService = authService,
     )
 

--- a/ledger/sandbox/BUILD.bazel
+++ b/ledger/sandbox/BUILD.bazel
@@ -28,6 +28,7 @@ da_scala_library(
         "//daml-lf/archive:daml_lf_dev_archive_proto_java",
         "//daml-lf/data",
         "//daml-lf/engine",
+        "//daml-lf/language",
         "//language-support/scala/bindings",
         "//ledger/caching",
         "//ledger/ledger-api-auth",

--- a/ledger/sandbox/src/main/scala/platform/sandboxnext/Cli.scala
+++ b/ledger/sandbox/src/main/scala/platform/sandboxnext/Cli.scala
@@ -13,7 +13,7 @@ private[sandboxnext] object Cli extends SandboxCli {
   override def defaultConfig: SandboxConfig = SandboxConfig.defaultConfig
 
   override protected val parser: OptionParser[SandboxConfig] = {
-    val parser = new CommonCli(Name)
+    val parser = new CommonCli(Name).withEarlyAccess
       .withContractIdSeeding(
         defaultConfig,
         Some(Seeding.Strong),


### PR DESCRIPTION
The flag allows the sandboxes (both classic and next) to use preview
version of the upcoming Daml-LF version (currently LF 1.11).

CHANGELOG_BEGIN
* [Sandbox-classic] add a flag to allow early access to the next
  Daml-LF to be released.
* [Sandbox] add a flag to allow early access to the next Daml-LF
  to be released.
CHANGLEOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
