### PR TITLE
Pin scalafmt version in configuration file

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,8 +1,8 @@
+version = 2.7.5
+
 project.git = true
 
 align.preset = none # never align to make the fmt more diff friendly
 maxColumn = 100
 runner.fatalWarnings = true
 trailingCommas = multiple
-
-version = 2.7.5

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,3 +4,5 @@ align.preset = none # never align to make the fmt more diff friendly
 maxColumn = 100
 runner.fatalWarnings = true
 trailingCommas = multiple
+
+version = 2.7.5


### PR DESCRIPTION
Looks like there is no other way for IntelliJ to pick up an arbitrary version.

See: https://www.jetbrains.com/help/idea/work-with-scala-formatter.html#change_scalafmt

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
