### PR TITLE
publish docs bundle as pipeline artifact

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -56,6 +56,10 @@ jobs:
         bazel build //release:release
         ./bazel-bin/release/release --release-dir "$(mktemp -d)"
       condition: and(succeeded(), ne(variables['is_release'], 'true'))
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathtoPublish: 'bazel-bin/docs/html.tar.gz'
+        artifactName: 'Docs bundle'
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'


### PR DESCRIPTION
This make the docs bundle available as a download from any (future) build on Azure. I mostly thought of this as a workaround for @bame-da because of the Big Sur thing, but I figure that may occasionally useful to other people too.

CHANGELOG_BEGIN
CHANGELOG_END