### PR TITLE
Remove redundant transaction decoding in TransactionCommitter

### DIFF
--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/TransactionCommitterSpec.scala
@@ -14,7 +14,6 @@ import com.daml.ledger.participant.state.kvutils.Err.MissingInputState
 import com.daml.ledger.participant.state.kvutils.TestHelpers._
 import com.daml.ledger.participant.state.kvutils.committer.TransactionCommitter.DamlTransactionEntrySummary
 import com.daml.ledger.participant.state.v1.{Configuration, RejectionReason}
-import com.daml.lf.data.ImmArray
 import com.daml.lf.data.Time.Timestamp
 import com.daml.lf.engine.{Engine, ReplayMismatch}
 import com.daml.lf.transaction
@@ -25,8 +24,6 @@ import com.daml.lf.transaction.{
   ReplayedNodeMissing,
   Transaction,
   TransactionOuterClass,
-  TransactionVersion,
-  VersionedTransaction,
 }
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.value.Value
@@ -43,14 +40,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
   private[this] val txBuilder = TransactionBuilder()
   private val metrics = new Metrics(new MetricRegistry)
   private val aDamlTransactionEntry = createTransactionEntry(List("aSubmitter"))
-  private val transactionMock = VersionedTransaction[NodeId, Value.ContractId](
-    TransactionVersion.VDev,
-    Map.empty,
-    ImmArray.empty,
-  )
-  private val aTransactionEntrySummary = damlTransactionEntrySummaryWithTxMock(
-    aDamlTransactionEntry
-  )
+  private val aTransactionEntrySummary = DamlTransactionEntrySummary(aDamlTransactionEntry)
   private val aRecordTime = Timestamp(100)
   private val instance = createTransactionCommitter() // Stateless, can be shared between tests
   private val dedupKey = Conversions
@@ -66,9 +56,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       .setLedgerEffectiveTime(aLedgerEffectiveTime)
       .build()
   private val aDamlTransactionEntrySummaryWithSubmissionAndLedgerEffectiveTimes =
-    damlTransactionEntrySummaryWithTxMock(
-      aDamlTransactionEntryWithSubmissionAndLedgerEffectiveTimes
-    )
+    DamlTransactionEntrySummary(aDamlTransactionEntryWithSubmissionAndLedgerEffectiveTimes)
   private val aDeduplicateUntil = createProtobufTimestamp(seconds = 3)
   private val dedupValue = DamlStateValue.newBuilder
     .setCommandDedup(DamlCommandDedupValue.newBuilder.setDeduplicatedUntil(aDeduplicateUntil))
@@ -111,12 +99,8 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       .addAllNodes(nodes.asJava)
       .build()
     val outTx = aDamlTransactionEntry.toBuilder.setTransaction(tx).build()
-
-    damlTransactionEntrySummaryWithTxMock(outTx)
+    DamlTransactionEntrySummary(outTx)
   }
-
-  private def damlTransactionEntrySummaryWithTxMock(entry: DamlTransactionEntry) =
-    DamlTransactionEntrySummary(entry, _ => transactionMock)
 
   private def createNode(nodeId: String)(
       nodeImpl: TransactionOuterClass.Node.Builder => TransactionOuterClass.Node.Builder
@@ -288,7 +272,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       for (ledgerEffectiveTime <- Iterable(lowerBound, upperBound)) {
         val context =
           createCommitContext(recordTime = Some(recordTime), inputs = inputWithDeclaredConfig)
-        val transactionEntrySummary = damlTransactionEntrySummaryWithTxMock(
+        val transactionEntrySummary = DamlTransactionEntrySummary(
           aDamlTransactionEntry.toBuilder
             .setLedgerEffectiveTime(
               com.google.protobuf.Timestamp.newBuilder
@@ -513,7 +497,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         ),
         participantId = ParticipantId,
       )
-      val tx = damlTransactionEntrySummaryWithTxMock(createTransactionEntry(List(Alice, Bob, Emma)))
+      val tx = DamlTransactionEntrySummary(createTransactionEntry(List(Alice, Bob, Emma)))
 
       assertThrows[MissingInputState](instance.authorizeSubmitters.apply(context, tx))
     }
@@ -527,7 +511,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         ),
         participantId = ParticipantId,
       )
-      val tx = damlTransactionEntrySummaryWithTxMock(createTransactionEntry(List(Alice, Bob)))
+      val tx = DamlTransactionEntrySummary(createTransactionEntry(List(Alice, Bob)))
 
       val result = instance.authorizeSubmitters.apply(context, tx)
       result shouldBe a[StepStop]
@@ -549,7 +533,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         ),
         participantId = ParticipantId,
       )
-      val tx = damlTransactionEntrySummaryWithTxMock(createTransactionEntry(List(Alice, Bob)))
+      val tx = DamlTransactionEntrySummary(createTransactionEntry(List(Alice, Bob)))
 
       val result = instance.authorizeSubmitters.apply(context, tx)
       result shouldBe a[StepStop]
@@ -574,7 +558,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         ),
         participantId = ParticipantId,
       )
-      val tx = damlTransactionEntrySummaryWithTxMock(createTransactionEntry(List(Alice, Bob, Emma)))
+      val tx = DamlTransactionEntrySummary(createTransactionEntry(List(Alice, Bob, Emma)))
 
       instance.authorizeSubmitters.apply(context, tx) shouldBe a[StepContinue[_]]
     }
@@ -604,15 +588,8 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
       }.toMap
   }
 
-  private def createTransactionCommitter(): TransactionCommitter = {
-    new TransactionCommitter(
-      theDefaultConfig,
-      mock[Engine],
-      metrics,
-      inStaticTimeMode = false,
-      _ => transactionMock,
-    )
-  }
+  private def createTransactionCommitter(): TransactionCommitter =
+    new TransactionCommitter(theDefaultConfig, mock[Engine], metrics, inStaticTimeMode = false)
 
   private def contextWithTimeModelAndEmptyCommandDeduplication() =
     createCommitContext(recordTime = None, inputs = inputWithTimeModelAndEmptyCommandDeduplication)


### PR DESCRIPTION
Removes double decoding of transactions in `TransactionCommitter`

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
