### PR TITLE
Update offset when party/config rejected on a duplicate

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoConfigurationSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoConfigurationSpec.scala
@@ -87,7 +87,6 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
         nextOffset(),
         submissionId,
         newConfig.copy(generation = config.generation + 1),
-        shouldUpdateLedgerEnd = false,
       )
 
       // Submission with mismatching generation is rejected
@@ -142,7 +141,6 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
       submissionId: String,
       lastConfig: Configuration,
       rejectionReason: Option[String] = None,
-      shouldUpdateLedgerEnd: Boolean = true,
       maybePreviousOffset: Option[Offset] = Option.empty,
   ) =
     ledgerDao
@@ -157,7 +155,7 @@ trait JdbcLedgerDaoConfigurationSpec { this: AsyncFlatSpec with Matchers with Jd
         rejectionReason,
       )
       .map { r =>
-        if (shouldUpdateLedgerEnd) previousOffset.set(Some(offset))
+        previousOffset.set(Some(offset))
         r
       }
 }

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPartiesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoPartiesSpec.scala
@@ -103,7 +103,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
     for {
       response <- storePartyEntry(fred, nextOffset())
       _ = response should be(PersistenceResponse.Ok)
-      response <- storePartyEntry(fred, nextOffset(), shouldUpdateLegerEnd = false)
+      response <- storePartyEntry(fred, nextOffset())
     } yield {
       response should be(PersistenceResponse.Duplicate)
     }
@@ -123,10 +123,39 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
     )
   }
 
+  it should "store just offset when duplicate party update encountered" in {
+    val party = Ref.Party.assertFromString(s"Alice-${UUID.randomUUID()}")
+    val aliceDetails = PartyDetails(
+      party,
+      displayName = Some("Alice Arkwright"),
+      isLocal = true,
+    )
+    val aliceAgain = PartyDetails(
+      party,
+      displayName = Some("Alice Carthwright"),
+      isLocal = true,
+    )
+    val bobDetails = PartyDetails(
+      party = Ref.Party.assertFromString(s"Bob-${UUID.randomUUID()}"),
+      displayName = Some("Bob Bobertson"),
+      isLocal = true,
+    )
+    for {
+      response <- storePartyEntry(aliceDetails, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      response <- storePartyEntry(aliceAgain, nextOffset())
+      _ = response should be(PersistenceResponse.Duplicate)
+      response <- storePartyEntry(bobDetails, nextOffset())
+      _ = response should be(PersistenceResponse.Ok)
+      parties <- ledgerDao.listKnownParties()
+    } yield {
+      parties should contain allOf (aliceDetails, bobDetails)
+    }
+  }
+
   private def storePartyEntry(
       partyDetails: PartyDetails,
       offset: Offset,
-      shouldUpdateLegerEnd: Boolean = true,
   ) =
     ledgerDao
       .storePartyEntry(
@@ -134,7 +163,7 @@ private[dao] trait JdbcLedgerDaoPartiesSpec {
         allocationAccepted(partyDetails),
       )
       .map { response =>
-        if (shouldUpdateLegerEnd) previousOffset.set(Some(offset))
+        previousOffset.set(Some(offset))
         response
       }
 


### PR DESCRIPTION
CHANGELOG_BEGIN
Advance ledger end when the indexer encounters an duplicate party or configuration update. This allows indexer to skip-over the unexpected message and continue processing subsequent updates.
CHANGELOG_END
