### PR TITLE
LF: get ride of user-defined patterns in ValueTranslation.

### DIFF
--- a/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/SortedLookupList.scala
+++ b/daml-lf/data/src/main/scala/com/digitalasset/daml/lf/data/SortedLookupList.scala
@@ -17,6 +17,8 @@ import scala.collection.compat._
 // Note that keys are ordered using Utf8 ordering
 final class SortedLookupList[+X] private (entries: ImmArray[(String, X)]) extends Equals {
 
+  def isEmpty: Boolean = entries.isEmpty
+
   def mapValue[Y](f: X => Y) = new SortedLookupList(entries.map { case (k, v) => k -> f(v) })
 
   def toImmArray: ImmArray[(String, X)] = entries

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -22,7 +22,7 @@ private[engine] final class ValueTranslator(compiledPackages: CompiledPackages) 
   // this is not tail recursive, but it doesn't really matter, since types are bounded
   // by what's in the source, which should be short enough...
   @throws[PreprocessorException]
-  private[this] def replaceParameters(params: Traversable[(TypeVarName, Type)], typ0: Type): Type =
+  private[this] def replaceParameters(params: Iterable[(TypeVarName, Type)], typ0: Type): Type =
     if (params.isEmpty) { // optimization
       typ0
     } else {

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -168,7 +168,7 @@ private[engine] final class ValueTranslator(compiledPackages: CompiledPackages) 
                 (bt, value) match {
                   case (BTGenMap, ValueGenMap(entries)) =>
                     if (entries.isEmpty) {
-                      SValue.SValue.EmptyTextMap
+                      SValue.SValue.EmptyGenMap
                     } else {
                       SValue.SGenMap(
                         isTextMap = false,

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/ValueTranslator.scala
@@ -5,9 +5,7 @@ package com.daml.lf.engine
 package preprocessing
 
 import com.daml.lf.CompiledPackages
-import com.daml.lf.data.Ref.Identifier
-import com.daml.lf.data.{Ref, _}
-import com.daml.lf.engine.preprocessing.Preprocessor.fail
+import com.daml.lf.data._
 import com.daml.lf.language.Ast._
 import com.daml.lf.speedy.SValue
 import com.daml.lf.value.Value
@@ -28,7 +26,7 @@ private[engine] final class ValueTranslator(compiledPackages: CompiledPackages) 
     if (params.isEmpty) { // optimization
       typ0
     } else {
-      val paramsMap: Map[TypeVarName, Type] = Map(params.toSeq: _*)
+      val paramsMap: Map[TypeVarName, Type] = params.toMap
 
       def go(typ: Type): Type =
         typ match {
@@ -157,7 +155,7 @@ private[engine] final class ValueTranslator(compiledPackages: CompiledPackages) 
                       SValue.SValue.EmptyTextMap
                     } else {
                       SValue.SGenMap(
-                        isTextMap = false,
+                        isTextMap = true,
                         entries = entries.iterator.map { case (k, v) =>
                           SValue.SText(k) -> go(typeArg0, v, newNesting)
                         },
@@ -173,7 +171,7 @@ private[engine] final class ValueTranslator(compiledPackages: CompiledPackages) 
                       SValue.SValue.EmptyTextMap
                     } else {
                       SValue.SGenMap(
-                        isTextMap = true,
+                        isTextMap = false,
                         entries = entries.iterator.map { case (k, v) =>
                           go(typeArg0, k, newNesting) -> go(typeArg1, v, newNesting)
                         },

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
@@ -6,7 +6,7 @@ package engine
 package preprocessing
 
 import com.daml.lf.data._
-import com.daml.lf.language.Ast.{TNat, TTyCon}
+import com.daml.lf.language.Ast.{BTList, TApp, TBuiltin, TNat, TTyCon}
 import com.daml.lf.language.Util._
 import com.daml.lf.testing.parser.Implicits._
 import com.daml.lf.value.Value._
@@ -25,14 +25,17 @@ class PreprocessorSpec extends AnyWordSpec with Matchers with TableDrivenPropert
   val recordCon = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Module:Record"))
   val variantCon = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Module:Variant"))
   val enumCon = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Module:Enum"))
+  val tricky = Ref.Identifier(pkgId, Ref.QualifiedName.assertFromString("Module:Tricky"))
 
   val pkg =
     p"""
         module Module {
 
           record Record = { field : Int64 };
-          variant Variant = variant1 : Text | variant2 : Int64 ;
+          variant Variant = variant1 : Text | variant2 : Int64;
           enum Enum = value1 | value2;
+
+          record Tricky (b: * -> *) = { x : b Unit };
 
         }
 
@@ -74,6 +77,8 @@ class PreprocessorSpec extends AnyWordSpec with Matchers with TableDrivenPropert
         ValueVariant(None, "variant1", ValueText("some test")),
       TTyCon(enumCon) ->
         ValueEnum(None, "value1"),
+      TApp(TTyCon(tricky), TBuiltin(BTList))  ->
+        ValueRecord(None, ImmArray(None -> ValueNil))
     )
 
     val compiledPackage = ConcurrentCompiledPackages()

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/PreprocessorSpec.scala
@@ -77,8 +77,8 @@ class PreprocessorSpec extends AnyWordSpec with Matchers with TableDrivenPropert
         ValueVariant(None, "variant1", ValueText("some test")),
       TTyCon(enumCon) ->
         ValueEnum(None, "value1"),
-      TApp(TTyCon(tricky), TBuiltin(BTList))  ->
-        ValueRecord(None, ImmArray(None -> ValueNil))
+      TApp(TTyCon(tricky), TBuiltin(BTList)) ->
+        ValueRecord(None, ImmArray(None -> ValueNil)),
     )
 
     val compiledPackage = ConcurrentCompiledPackages()


### PR DESCRIPTION
We prune the code of ValueTransalation from the user-defined patterns
in the code of Speedy's ValueTranslation. In particular we remove the usage of
com.daml.lf.language.Util.TTyConApp which:
- induces bad complexity,
- make difficult optimization.

CHANGELOG_BEGIN
CHANGELOG_END 

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
