### PR TITLE
Remove redundant list of LF versions

### DIFF
--- a/compiler/damlc/pkg-db/BUILD.bazel
+++ b/compiler/damlc/pkg-db/BUILD.bazel
@@ -6,11 +6,11 @@ load(
     "daml_package_db",
     "daml_package_rule",
 )
-load("//compiler/damlc:util.bzl", "DAML_LF_VERSIONS")
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS")
 
 daml_package_db(
     name = "package_db_for_daml-prim",
-    daml_lf_versions = DAML_LF_VERSIONS,
+    daml_lf_versions = COMPILER_LF_VERSIONS,
     pkgs = [],
     visibility = ["//visibility:public"],
 )
@@ -25,7 +25,7 @@ daml_package_db(
         pkg_root = "compiler/damlc/daml-prim-src",
         visibility = ["//visibility:public"],
     )
-    for ver in DAML_LF_VERSIONS
+    for ver in COMPILER_LF_VERSIONS
 ]
 
 [
@@ -39,21 +39,21 @@ daml_package_db(
         pkg_root = "compiler/damlc/daml-stdlib-src",
         visibility = ["//visibility:public"],
     )
-    for ver in DAML_LF_VERSIONS
+    for ver in COMPILER_LF_VERSIONS
 ]
 
 daml_package_db(
     name = "package_db_for_daml-stdlib",
-    daml_lf_versions = DAML_LF_VERSIONS,
-    pkgs = [":daml-prim-{}".format(ver) for ver in DAML_LF_VERSIONS],
+    daml_lf_versions = COMPILER_LF_VERSIONS,
+    pkgs = [":daml-prim-{}".format(ver) for ver in COMPILER_LF_VERSIONS],
     visibility = ["//visibility:public"],
 )
 
 daml_package_db(
     name = "pkg-db",
-    daml_lf_versions = DAML_LF_VERSIONS,
+    daml_lf_versions = COMPILER_LF_VERSIONS,
     pkgs =
-        [":daml-prim-{}".format(ver) for ver in DAML_LF_VERSIONS] +
-        [":daml-stdlib-{}".format(ver) for ver in DAML_LF_VERSIONS],
+        [":daml-prim-{}".format(ver) for ver in COMPILER_LF_VERSIONS] +
+        [":daml-stdlib-{}".format(ver) for ver in COMPILER_LF_VERSIONS],
     visibility = ["//visibility:public"],
 )

--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -6,7 +6,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 load(":util.bzl", "damlc_compile_test")
 load("//rules_daml:daml.bzl", "daml_compile")
 load("@build_environment//:configuration.bzl", "sdk_version")
-load("//compiler/damlc:util.bzl", "DAML_LF_VERSIONS", "LATEST_STABLE_DAML_LF_VERSION", "ghc_pkg")
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS", "lf_latest_version")
+load("//compiler/damlc:util.bzl", "ghc_pkg")
 
 # Tests for the lax CLI parser
 da_haskell_test(
@@ -190,8 +191,8 @@ da_haskell_library(
             ":integration-lib",
         ],
     )
-    for version, skip_validation in [(version, False) for version in DAML_LF_VERSIONS] + [
-        (LATEST_STABLE_DAML_LF_VERSION, True),
+    for version, skip_validation in [(version, False) for version in COMPILER_LF_VERSIONS] + [
+        (lf_latest_version, True),
         ("1.dev", True),
     ]
 ]

--- a/compiler/damlc/util.bzl
+++ b/compiler/damlc/util.bzl
@@ -9,13 +9,3 @@ load("@os_info//:os_info.bzl", "is_windows")
 # not going to work. We thus use the dynamically linked executable in the runfiles of damlc
 # and the tarball produced by package_app in the resources of damlc-dist.
 ghc_pkg = "@rules_haskell_ghc_windows_amd64//:bin/ghc-pkg.exe" if is_windows else "@ghc_nix//:lib/ghc-8.6.5/bin/ghc-pkg"
-
-LATEST_STABLE_DAML_LF_VERSION = "1.8"
-
-DAML_LF_VERSIONS = [
-    "1.6",
-    "1.7",
-    "1.8",
-    "1.11",
-    "1.dev",
-]

--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -23,7 +23,7 @@ LF_VERSIONS = [
 
 # The subset of LF versions accepted by the compiler in the syntax
 # expected by the --target option.
-COMPILER_LF_VERSIONS = ["1.dev" if ver == "dev" else ver for ver in LF_VERSIONS if ver != "1.6"]
+COMPILER_LF_VERSIONS = ["1.dev" if ver == "dev" else ver for ver in LF_VERSIONS]
 
 LF_VERSION_PACKAGE_DIGITALASSET = {"1.6": "digitalasset", "1.7": "digitalasset", "1.8": "digitalasset", "1.11": "daml"}
 

--- a/daml-lf/language/daml-lf.bzl
+++ b/daml-lf/language/daml-lf.bzl
@@ -25,6 +25,9 @@ LF_VERSIONS = [
 # expected by the --target option.
 COMPILER_LF_VERSIONS = ["1.dev" if ver == "dev" else ver for ver in LF_VERSIONS]
 
+# We need Any in DAML Script so we require DAML-LF >= 1.7
+SCRIPT_LF_VERSIONS = [ver for ver in COMPILER_LF_VERSIONS if ver != "1.6"]
+
 LF_VERSION_PACKAGE_DIGITALASSET = {"1.6": "digitalasset", "1.7": "digitalasset", "1.8": "digitalasset", "1.11": "daml"}
 
 def lf_version_package(version):

--- a/daml-script/daml/BUILD.bazel
+++ b/daml-script/daml/BUILD.bazel
@@ -46,6 +46,7 @@ EOF
         visibility = ["//visibility:public"],
     )
     for lf_version in COMPILER_LF_VERSIONS + [""]
+    if lf_version != "1.6"
     for suffix in [("-" + lf_version) if lf_version else ""]
 ]
 
@@ -54,6 +55,7 @@ filegroup(
     srcs = [
         "daml-script-{}.dar".format(lf_version)
         for lf_version in COMPILER_LF_VERSIONS
+        if lf_version != "1.6"
     ],
     visibility = ["//visibility:public"],
 )

--- a/daml-script/daml/BUILD.bazel
+++ b/daml-script/daml/BUILD.bazel
@@ -4,7 +4,7 @@
 # TODO Once daml_compile uses build instead of package we should use
 # daml_compile instead of a genrule.
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS")
+load("//daml-lf/language:daml-lf.bzl", "SCRIPT_LF_VERSIONS")
 
 # Build one DAR per LF version to bundle with the SDK.
 # Also build one DAR with the default LF version for test-cases.
@@ -45,8 +45,7 @@ EOF
         tools = ["//compiler/damlc"],
         visibility = ["//visibility:public"],
     )
-    for lf_version in COMPILER_LF_VERSIONS + [""]
-    if lf_version != "1.6"
+    for lf_version in SCRIPT_LF_VERSIONS + [""]
     for suffix in [("-" + lf_version) if lf_version else ""]
 ]
 
@@ -54,8 +53,7 @@ filegroup(
     name = "daml-script-dars",
     srcs = [
         "daml-script-{}.dar".format(lf_version)
-        for lf_version in COMPILER_LF_VERSIONS
-        if lf_version != "1.6"
+        for lf_version in SCRIPT_LF_VERSIONS
     ],
     visibility = ["//visibility:public"],
 )

--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -5,7 +5,7 @@
 # daml_compile instead of a genrule.
 
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS")
+load("//daml-lf/language:daml-lf.bzl", "SCRIPT_LF_VERSIONS")
 
 # Build one DAR per LF version to bundle with the SDK.
 # Also build one DAR with the default LF version for test-cases.
@@ -51,8 +51,7 @@ EOF
         ],
         visibility = ["//visibility:public"],
     )
-    for lf_version in COMPILER_LF_VERSIONS + [""]
-    if lf_version != "1.6"
+    for lf_version in SCRIPT_LF_VERSIONS + [""]
     for suffix in [("-" + lf_version) if lf_version else ""]
 ]
 
@@ -60,8 +59,7 @@ filegroup(
     name = "daml-trigger-dars",
     srcs = [
         "daml-trigger-{}.dar".format(lf_version)
-        for lf_version in COMPILER_LF_VERSIONS
-        if lf_version != "1.6"
+        for lf_version in SCRIPT_LF_VERSIONS
     ],
     visibility = ["//visibility:public"],
 )

--- a/triggers/daml/BUILD.bazel
+++ b/triggers/daml/BUILD.bazel
@@ -5,12 +5,7 @@
 # daml_compile instead of a genrule.
 
 load("@build_environment//:configuration.bzl", "ghc_version", "sdk_version")
-
-DAML_LF_VERSIONS = [
-    "1.7",
-    "1.8",
-    "1.dev",
-]
+load("//daml-lf/language:daml-lf.bzl", "COMPILER_LF_VERSIONS")
 
 # Build one DAR per LF version to bundle with the SDK.
 # Also build one DAR with the default LF version for test-cases.
@@ -56,7 +51,8 @@ EOF
         ],
         visibility = ["//visibility:public"],
     )
-    for lf_version in DAML_LF_VERSIONS + [""]
+    for lf_version in COMPILER_LF_VERSIONS + [""]
+    if lf_version != "1.6"
     for suffix in [("-" + lf_version) if lf_version else ""]
 ]
 
@@ -64,7 +60,8 @@ filegroup(
     name = "daml-trigger-dars",
     srcs = [
         "daml-trigger-{}.dar".format(lf_version)
-        for lf_version in DAML_LF_VERSIONS
+        for lf_version in COMPILER_LF_VERSIONS
+        if lf_version != "1.6"
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
After #8472, I realized that there must be a list used for daml-stdlib
and daml-prim already and it turns out there is. I’ve removed that one
in favor of the one added in #8472 since I like having all in one
place and the one from #8472 is created by filtering an existing list
instead of creating a completely separate list like we do here.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
