### PR TITLE
Disable async commit on h2database

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -952,7 +952,7 @@ private[platform] object JdbcLedgerDao {
       validate = false,
       metrics,
       lfValueTranslationCache,
-      jdbcAsyncCommits = jdbcAsyncCommits,
+      jdbcAsyncCommits = jdbcAsyncCommits && dbType.supportsParallelWrites,
     ).map(new MeteredLedgerDao(_, metrics))
   }
 


### PR DESCRIPTION
This produces a warning in the log that H2database does not support async commit
ever since we pass the flag through the DbDispatcher to the HikariConnection builder.

Disabling the flag when the DbType indicates that the db does not support async commit.

Found during 1.9.0 release candidate testing of `1.9.0-snapshot.20200113`.

Fixes #8501

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
