### PR TITLE
hide with-dlint option

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Options.hs
+++ b/compiler/damlc/lib/DA/Cli/Options.hs
@@ -216,16 +216,19 @@ dlintEnabledOpt = DlintEnabled
   <$> strOption
   ( long "with-dlint"
     <> metavar "DIR"
+    <> internal
     <> help "Enable linting with 'dlint.yaml' directory"
   )
   <*> switch
   ( long "allow-overrides"
+    <> internal
     <> help "Allow '.dlint.yaml' configuration overrides"
   )
 
 dlintDisabledOpt :: Parser DlintUsage
 dlintDisabledOpt = flag' DlintDisabled
   ( long "without-dlint"
+    <> internal
     <> help "Disable dlint"
   )
 


### PR DESCRIPTION
Quoting @cocreature on Slack:

> the fact that --with-dlint is exposed as a public option at all seems broken. I don’t think it was ever intended to be one.

```
CHANGELOG_BEGIN

- [Daml CLI] Three options that were never meant to be public are now
  hidden from the output of various `daml xxx --help` commands. The
  options still have the same effect when present, so this is not (yet)
  a breaking change. Using these options tends to result in very
  unhelpful, when not outright broken, dlint configurations, so we expect
  existing usage to be low to nonexistent. If you do use them please
  share your use-case with us. The options are:
  - `--with-dlint`
  - `--without-dlint`
  - `--allow-overrides`

CHANGELOG_END
```