### PR TITLE
Pass MetricsRegistry to commitStrategySupport from IntegrityChecker

### DIFF
--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -57,6 +57,7 @@ da_scala_test(
         "@maven//:org_scalatest_scalatest",
     ],
     deps = [
+        "//ledger/metrics",
         "//ledger/participant-integration-api",
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils/tools",
@@ -89,7 +90,6 @@ da_scala_binary(
         "//ledger/participant-state/kvutils:daml_kvutils_proto_java",
         "//ledger/participant-state/kvutils/tools",
         "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:io_dropwizard_metrics_metrics_core",
     ],
 )
 

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
@@ -3,7 +3,6 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
-import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.on.memory.{InMemoryLedgerStateOperations, Index}
 import com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
@@ -21,10 +20,9 @@ import com.daml.metrics.Metrics
 
 import scala.concurrent.ExecutionContext
 
-final class LogAppendingCommitStrategySupport(implicit executionContext: ExecutionContext)
-    extends CommitStrategySupport[Index] {
-  private val metrics = new Metrics(new MetricRegistry)
-
+final class LogAppendingCommitStrategySupport(metrics: Metrics)(implicit
+    executionContext: ExecutionContext
+) extends CommitStrategySupport[Index] {
   private val ledgerStateOperations =
     InMemoryLedgerStateOperations()
 

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/Main.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/Main.scala
@@ -3,12 +3,14 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
+import com.daml.metrics.Metrics
+
 import scala.concurrent.ExecutionContext
 
 object Main {
   def main(args: Array[String]): Unit =
     IntegrityChecker.run(args, commitStrategySupportFactory _)
 
-  private def commitStrategySupportFactory(executionContext: ExecutionContext) =
-    new LogAppendingCommitStrategySupport()(executionContext)
+  private def commitStrategySupportFactory(metrics: Metrics, executionContext: ExecutionContext) =
+    new LogAppendingCommitStrategySupport(metrics)(executionContext)
 }

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupportSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupportSpec.scala
@@ -3,6 +3,7 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
+import com.codahale.metrics.MetricRegistry
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlConfigurationEntry,
   DamlLogEntry,
@@ -14,6 +15,7 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.LogAppendingCommitStrategySupportSpec._
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Envelope, Raw, Version}
 import com.daml.ledger.participant.state.protobuf.LedgerConfiguration
+import com.daml.metrics.Metrics
 import com.google.protobuf.{ByteString, Empty}
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
@@ -22,7 +24,9 @@ import org.scalatest.wordspec.AnyWordSpec
 import scala.concurrent.ExecutionContext
 
 final class LogAppendingCommitStrategySupportSpec extends AnyWordSpec with Matchers with Inside {
-  private val support = new LogAppendingCommitStrategySupport()(ExecutionContext.global)
+  private val support = new LogAppendingCommitStrategySupport(new Metrics(new MetricRegistry))(
+    ExecutionContext.global
+  )
 
   "checking the entries are readable" should {
     "parse a log entry" in {

--- a/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
+++ b/ledger/participant-state/kvutils/tools/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityCheckerSpec.scala
@@ -27,7 +27,7 @@ final class IntegrityCheckerSpec
           .explainMismatchingValue(any[Raw.Key], any[Raw.Value], any[Raw.Value])
       )
         .thenReturn(None)
-      val instance = new IntegrityChecker[Unit](mockCommitStrategySupport)
+      val instance = new IntegrityChecker[Unit](_ => mockCommitStrategySupport)
 
       instance.compareSameSizeWriteSets(
         writeSet("key" -> "a"),
@@ -49,7 +49,7 @@ final class IntegrityCheckerSpec
           .explainMismatchingValue(any[Raw.Key], any[Raw.Value], any[Raw.Value])
       )
         .thenReturn(Some("expected explanation"))
-      val instance = new IntegrityChecker[Unit](mockCommitStrategySupport)
+      val instance = new IntegrityChecker[Unit](_ => mockCommitStrategySupport)
 
       val actual =
         instance.compareSameSizeWriteSets(writeSet("key" -> "a"), writeSet("key" -> "b"))
@@ -67,7 +67,7 @@ final class IntegrityCheckerSpec
           .explainMismatchingValue(any[Raw.Key], any[Raw.Value], any[Raw.Value])
       )
         .thenReturn(Some("first explanation"), Some("second explanation"))
-      val instance = new IntegrityChecker[Unit](mockCommitStrategySupport)
+      val instance = new IntegrityChecker[Unit](_ => mockCommitStrategySupport)
 
       val actual =
         instance.compareSameSizeWriteSets(
@@ -159,7 +159,7 @@ final class IntegrityCheckerSpec
 
   private def createMockIntegrityChecker(): IntegrityChecker[Unit] = {
     val mockCommitStrategySupport = mock[CommitStrategySupport[Unit]]
-    val instance = new IntegrityChecker[Unit](mockCommitStrategySupport)
+    val instance = new IntegrityChecker[Unit](_ => mockCommitStrategySupport)
     instance
   }
 


### PR DESCRIPTION
Enables third-party users of the SDK integrity checker to register and log metrics to the detailed report.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [x] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
