### PR TITLE
LF: fix Transaction Decoder/Encoder

### DIFF
--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -347,8 +347,7 @@ object ValueGenerators {
         .map(_.map(NodeId(_)))
         .map(ImmArray(_))
       exerciseResultValue <- valueGen
-      key <- valueGen
-      maintainers <- genNonEmptyParties
+      key <- Gen.option(keyWithMaintainersGen)
       byKey <- Gen.oneOf(true, false)
     } yield NodeExercises(
       targetCoid,
@@ -363,7 +362,7 @@ object ValueGenerators {
       choiceObservers = choiceObservers,
       children,
       Some(exerciseResultValue),
-      Some(KeyWithMaintainers(key, maintainers)),
+      key,
       byKey,
       version,
     )
@@ -374,13 +373,12 @@ object ValueGenerators {
       version <- transactionVersionGen()
       targetCoid <- coidGen
       templateId <- idGen
-      key <- valueGen
-      maintainers <- genNonEmptyParties
+      key <- keyWithMaintainersGen
       result <- Gen.option(targetCoid)
     } yield NodeLookupByKey(
       templateId,
       None,
-      KeyWithMaintainers(key, maintainers),
+      key,
       result,
       version,
     )

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -13,6 +13,7 @@ import com.daml.lf.transaction.Node.{
   NodeCreate,
   NodeExercises,
   NodeFetch,
+  NodeLookupByKey,
 }
 import com.daml.lf.transaction.{
   BlindingInfo,
@@ -367,6 +368,22 @@ object ValueGenerators {
       version,
     )
   }
+
+  val lookupNodeGen: Gen[NodeLookupByKey[ContractId]] =
+    for {
+      version <- transactionVersionGen()
+      targetCoid <- coidGen
+      templateId <- idGen
+      key <- valueGen
+      maintainers <- genNonEmptyParties
+      result <- Gen.option(targetCoid)
+    } yield NodeLookupByKey(
+      templateId,
+      None,
+      KeyWithMaintainers(key, maintainers),
+      result,
+      version,
+    )
 
   @deprecated("use danglingRefExerciseNodeGen instead", since = "100.11.17")
   private[lf] def exerciseNodeGen = danglingRefExerciseNodeGen

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -60,7 +60,13 @@ object TransactionCoder {
           )
     }
 
-  def encodeVersionedValue[Cid](
+  def encodeValue[Cid](
+      cidEncoder: ValueCoder.EncodeCid[Cid],
+      value: VersionedValue[Cid],
+  ): Either[EncodeError, ValueOuterClass.VersionedValue] =
+    ValueCoder.encodeVersionedValue(cidEncoder, value)
+
+  private[this] def encodeVersionedValue[Cid](
       cidEncoder: ValueCoder.EncodeCid[Cid],
       nodeVersion: TransactionVersion,
       value: Value[Cid],
@@ -135,7 +141,7 @@ object TransactionCoder {
       value <- ValueCoder.decodeVersionedValue(decodeCid, protoCoinst.getValue)
     } yield Value.ContractInst(id, value, (protoCoinst.getAgreement))
 
-  private def encodeKeyWithMaintainers[Cid](
+  private[this] def encodeKeyWithMaintainers[Cid](
       encodeCid: ValueCoder.EncodeCid[Cid],
       nodeVersion: TransactionVersion,
       key: KeyWithMaintainers[Value[Cid]],

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/ValueCoder.scala
@@ -123,7 +123,7 @@ object ValueCoder {
 
   // For backward compatibility reasons, V10 is encoded as "6" when used inside a
   // proto.VersionedValue
-  private[this] def encodeValueVersion(version: TransactionVersion): String =
+  private[lf] def encodeValueVersion(version: TransactionVersion): String =
     if (version == TransactionVersion.V10) {
       "6"
     } else {


### PR DESCRIPTION
This includes the following changes: 

1. The Decoder was not verifying the value inside a node use the exact
  same version as the node itself.

2. We use the node version directly in the node encoder (instead of
  used `versionedX` node methods).

3. We avoid used of `.asJava` in the encoder.

4. We add test for testing the decode verify 1.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
