### PR TITLE
Update both hidden.json and snapshots.json

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -141,7 +141,7 @@ update_s3 opts temp vs = do
     let hidden = Data.List.sortOn Data.Ord.Down $ Set.toList $ all_versions vs `Set.difference` (Set.fromList $ dropdown vs)
     let push f = proc_ ["aws", "s3", "cp", temp </> f, s3Path opts f, "--acl", "public-read"]
     let hiddenVersionFiles = ["hidden.json", "snapshots.json"]
-    forM_ hiddenVersionFiles $ \f ->
+    Data.Foldable.for_ hiddenVersionFiles $ \f -> do
         create_versions_json hidden (temp </> f)
         push f
     push "versions.json"


### PR DESCRIPTION
The assistant relies on the latter, our docs cronjob on the former. I
have no idea why we have two but keeping them in sync should be fine.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
