### PR TITLE
ci: clean-up disk cache if it gets too big

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -27,6 +27,21 @@ steps:
       # to upload to the bazel cache
       GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
 
+  - bash: |
+      set -euo pipefail
+      eval "$(./dev-env/bin/dade-assist)"
+      # Location of the disk cache for CI servers set in their init files:
+      # infra/macos/2-common-box/init.sh:echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
+      # infra/vsts_agent_linux_startup.sh:echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
+      disk_cache=$HOME/.bazel-cache
+      if [ $(du -ms $disk_cache | awk '{print $1}') -gt 80000 ]; then
+          echo "Deleting $disk_cache"
+          rm -rf $disk_cache
+      else
+          echo "Disk cache small enough: $(du -hs $disk_cache)."
+      fi
+    displayName: clean-up disk cache
+
   - bash: ./fmt.sh --test
     displayName: 'Platform-agnostic lints and checks'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))


### PR DESCRIPTION
Hopefully this works around our recent CI disk space issues, while 80GB should be large enough that it only happens once per machine per day, so perf shouldn't be impacted too much.

CHANGELOG_BEGIN
CHANGELOG_END