### PR TITLE
assistant: move cache to new cache folder.

### DIFF
--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -188,7 +188,7 @@ runCommand :: Env -> Command -> IO ()
 runCommand env@Env{..} = \case
     Builtin (Version VersionOptions{..}) -> do
         installedVersionsE <- tryAssistant $ getInstalledSdkVersions envDamlPath
-        availableVersionsE <- tryAssistant $ refreshAvailableSdkVersions envDamlPath
+        availableVersionsE <- tryAssistant $ refreshAvailableSdkVersions envCachePath
         defaultVersionM <- tryAssistantM $ getDefaultSdkVersion envDamlPath
         projectVersionM <- mapM getSdkVersionFromProjectPath envProjectPath
         envSelectedVersionM <- lookupEnv sdkVersionEnvVar

--- a/daml-assistant/src/DA/Daml/Assistant/Cache.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Cache.hs
@@ -43,27 +43,28 @@ versionsKey :: CacheKey
 versionsKey = "versions.txt"
 
 saveAvailableSdkVersions
-    :: DamlPath
+    :: CachePath
     -> [SdkVersion]
     -> IO ()
-saveAvailableSdkVersions damlPath =
-    saveToCacheWith damlPath versionsKey serializeVersions
+saveAvailableSdkVersions cachePath =
+    saveToCacheWith cachePath versionsKey serializeVersions
 
 cacheAvailableSdkVersions
     :: DamlPath
+    -> CachePath
     -> IO [SdkVersion]
     -> IO [SdkVersion]
-cacheAvailableSdkVersions damlPath getVersions = do
+cacheAvailableSdkVersions damlPath cachePath getVersions = do
     damlConfigE <- tryConfig $ readDamlConfig damlPath
     let updateCheckM = join $ eitherToMaybe (queryDamlConfig ["update-check"] =<< damlConfigE)
         defaultUpdateCheck = UpdateCheckEvery (CacheTimeout 86400)
     case fromMaybe defaultUpdateCheck updateCheckM of
         UpdateCheckNever -> do
-            valueAgeM <- loadFromCacheWith damlPath versionsKey (CacheTimeout 0) deserializeVersions
+            valueAgeM <- loadFromCacheWith cachePath versionsKey (CacheTimeout 0) deserializeVersions
             pure (maybe [] fst valueAgeM)
 
         UpdateCheckEvery timeout ->
-            cacheWith damlPath versionsKey timeout
+            cacheWith cachePath versionsKey timeout
                 serializeVersions deserializeVersions
                 getVersions
 
@@ -75,22 +76,19 @@ deserializeVersions :: Deserialize [SdkVersion]
 deserializeVersions =
     Just . mapMaybe (eitherToMaybe . parseVersion . pack) . lines
 
-cacheDirPath :: DamlPath -> FilePath
-cacheDirPath (DamlPath damlPath) = damlPath </> "cache"
-
-cacheFilePath :: DamlPath -> CacheKey -> FilePath
-cacheFilePath damlPath (CacheKey key) = cacheDirPath damlPath </> key
+cacheFilePath :: CachePath -> CacheKey -> FilePath
+cacheFilePath cachePath (CacheKey key) = unwrapCachePath cachePath </> key
 
 cacheWith
-    :: DamlPath
+    :: CachePath
     -> CacheKey
     -> CacheTimeout
     -> Serialize t
     -> Deserialize t
     -> IO t
     -> IO t
-cacheWith damlPath key timeout serialize deserialize getFresh = do
-    valueAgeM <- loadFromCacheWith damlPath key timeout deserialize
+cacheWith cachePath key timeout serialize deserialize getFresh = do
+    valueAgeM <- loadFromCacheWith cachePath key timeout deserialize
     case valueAgeM of
         Just (value, Fresh) -> pure value
         Just (value, Stale) -> do
@@ -98,11 +96,11 @@ cacheWith damlPath key timeout serialize deserialize getFresh = do
             case valueE of
                 Left _ -> pure value
                 Right value' -> do
-                    saveToCacheWith damlPath key serialize value'
+                    saveToCacheWith cachePath key serialize value'
                     pure value'
         Nothing -> do
             value <- getFresh
-            saveToCacheWith damlPath key serialize value
+            saveToCacheWith cachePath key serialize value
             pure value
 
 -- | A representation of the age of a cache value. We only care if the value is stale or fresh.
@@ -111,22 +109,22 @@ data CacheAge
     | Fresh
 
 -- | Save value to cache. Never raises an exception.
-saveToCache :: DamlPath -> CacheKey -> String -> IO ()
-saveToCache damlPath key value =
+saveToCache :: CachePath -> CacheKey -> String -> IO ()
+saveToCache cachePath key value =
     void . tryIO $ do
-        let dirPath = cacheDirPath damlPath
-            filePath = cacheFilePath damlPath key
+        let dirPath = unwrapCachePath cachePath
+            filePath = cacheFilePath cachePath key
         createDirectoryIfMissing True dirPath
         writeFileUTF8 filePath value
 
 -- | Save value to cache, with serialization function.
-saveToCacheWith :: DamlPath -> CacheKey -> Serialize t -> t -> IO ()
-saveToCacheWith damlPath key serialize value = saveToCache damlPath key (serialize value)
+saveToCacheWith :: CachePath -> CacheKey -> Serialize t -> t -> IO ()
+saveToCacheWith cachePath key serialize value = saveToCache cachePath key (serialize value)
 
 -- | Read value from cache, including its age. Never raises an exception.
-loadFromCache :: DamlPath -> CacheKey -> CacheTimeout -> IO (Maybe (String, CacheAge))
-loadFromCache damlPath key (CacheTimeout timeout) = do
-    let path = cacheFilePath damlPath key
+loadFromCache :: CachePath -> CacheKey -> CacheTimeout -> IO (Maybe (String, CacheAge))
+loadFromCache cachePath key (CacheTimeout timeout) = do
+    let path = cacheFilePath cachePath key
     modTimeE <- tryIO (getModificationTime path)
     curTimeE <- tryIO getCurrentTime
     let isStaleE = liftM2 (\mt ct -> diffUTCTime ct mt >= timeout) modTimeE curTimeE
@@ -136,9 +134,9 @@ loadFromCache damlPath key (CacheTimeout timeout) = do
     pure $ fmap (, age) valueM
 
 -- | Read value from cache, including its age, with deserialization function.
-loadFromCacheWith :: DamlPath -> CacheKey -> CacheTimeout -> Deserialize t -> IO (Maybe (t, CacheAge))
-loadFromCacheWith damlPath key timeout deserialize = do
-    valueAgeM <- loadFromCache damlPath key timeout
+loadFromCacheWith :: CachePath -> CacheKey -> CacheTimeout -> Deserialize t -> IO (Maybe (t, CacheAge))
+loadFromCacheWith cachePath key timeout deserialize = do
+    valueAgeM <- loadFromCache cachePath key timeout
     pure $ do
         (valueStr, age) <- valueAgeM
         value <- deserialize valueStr

--- a/daml-assistant/src/DA/Daml/Assistant/Env.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Env.hs
@@ -36,8 +36,8 @@ getDamlEnv envDamlPath lookForProjectPath = do
     envDamlAssistantPath <- getDamlAssistantPath envDamlPath
     envProjectPath <- getProjectPath lookForProjectPath
     (envSdkVersion, envSdkPath) <- getSdk envDamlPath envProjectPath
-    envLatestStableSdkVersion <- getLatestStableSdkVersion envDamlPath
     envCachePath <- getCachePath
+    envLatestStableSdkVersion <- getLatestStableSdkVersion envDamlPath envCachePath
     pure Env {..}
 
 -- | (internal) Override function with environment variable
@@ -73,10 +73,10 @@ overrideWithEnvVarMaybe envVar normalize parse calculate = do
 
 -- | Get the latest stable SDK version. Can be overriden with
 -- DAML_SDK_LATEST_VERSION environment variable.
-getLatestStableSdkVersion :: DamlPath -> IO (Maybe SdkVersion)
-getLatestStableSdkVersion damlPath =
+getLatestStableSdkVersion :: DamlPath -> CachePath -> IO (Maybe SdkVersion)
+getLatestStableSdkVersion damlPath cachePath =
     overrideWithEnvVarMaybe sdkVersionLatestEnvVar pure (parseVersion . pack) $
-        getLatestSdkVersionCached damlPath
+        getLatestSdkVersionCached damlPath cachePath
 
 -- | Determine the viability of running sdk commands in the environment.
 -- Returns the first failing test's error message.

--- a/daml-assistant/src/DA/Daml/Assistant/Version.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Version.hs
@@ -164,22 +164,22 @@ getAvailableSdkSnapshotVersions = wrapErr "Fetching list of available SDK snapsh
     pure . sort $ mapMaybe (eitherToMaybe . parseVersion) (M.keys versionsMap)
 
 -- | Same as getAvailableSdkVersions, but writes result to cache.
-refreshAvailableSdkVersions :: DamlPath -> IO [SdkVersion]
-refreshAvailableSdkVersions damlPath = do
+refreshAvailableSdkVersions :: CachePath -> IO [SdkVersion]
+refreshAvailableSdkVersions cachePath = do
     versions <- getAvailableSdkVersions
-    saveAvailableSdkVersions damlPath versions
+    saveAvailableSdkVersions cachePath versions
     pure versions
 
 -- | Same as getAvailableSdkVersions, but result is cached based on the duration
 -- of the update-check value in daml-config.yaml (defaults to 1 day).
-getAvailableSdkVersionsCached :: DamlPath -> IO [SdkVersion]
-getAvailableSdkVersionsCached damlPath =
-    cacheAvailableSdkVersions damlPath getAvailableSdkVersions
+getAvailableSdkVersionsCached :: DamlPath -> CachePath -> IO [SdkVersion]
+getAvailableSdkVersionsCached damlPath cachePath =
+    cacheAvailableSdkVersions damlPath cachePath getAvailableSdkVersions
 
 -- | Get the latest released SDK version, cached as above.
-getLatestSdkVersionCached :: DamlPath -> IO (Maybe SdkVersion)
-getLatestSdkVersionCached damlPath = do
-    versionsE <- tryAssistant $ getAvailableSdkVersionsCached damlPath
+getLatestSdkVersionCached :: DamlPath -> CachePath -> IO (Maybe SdkVersion)
+getLatestSdkVersionCached damlPath cachePath = do
+    versionsE <- tryAssistant $ getAvailableSdkVersionsCached damlPath cachePath
     pure $ do
         versions <- eitherToMaybe versionsE
         maximumMay versions


### PR DESCRIPTION
We use the new cache folder specified with `DAML_CACHE` defaulting to
`.cache/daml` as a new cache folder for the assistant to store available
versions etc.

This does not migrate an existing cache folder and just starts a new
one.

CHANGELOG_BEGIN
CHANGELOG_END



### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
