### PR TITLE
Rework scenario execution

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -328,20 +328,10 @@ private[lf] object Anf {
       case SELet1General(rhs, body) =>
         Bounce(() => transformLet1(depth, env, rhs, body, k, transform))
 
-      case SECatch(body0, handler0, fin0) =>
+      case SECatch(body0) =>
         Bounce(() =>
           flattenExp(depth, env, body0) { body =>
-            Bounce(() =>
-              flattenExp(depth, env, handler0) { handler =>
-                Bounce(() =>
-                  flattenExp(depth, env, fin0) { fin =>
-                    Bounce(() =>
-                      transform(depth, SECatch(body.wrapped, handler.wrapped, fin.wrapped), k)
-                    )
-                  }
-                )
-              }
-            )
+            Bounce(() => transform(depth, SECatch(body.wrapped), k))
           }
         )
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -772,7 +772,7 @@ private[lf] final class Compiler(
 
   @inline
   //private[this]
-  def compileCommit(partyE: Expr, updateE: Expr, optLoc: Option[Location]): SExpr =
+  def old_compileCommit(partyE: Expr, updateE: Expr, optLoc: Option[Location]): SExpr =
     // let party = <partyE>
     //     update = <updateE>
     // in \token ->
@@ -796,7 +796,7 @@ private[lf] final class Compiler(
   // NICK hacking here...
   @inline
   //private[this]
-  def new_explore_compileCommit(party: Expr, update: Expr, optLoc: Option[Location]): SExpr = {
+  def compileCommit(party: Expr, update: Expr, optLoc: Option[Location]): SExpr = {
     withEnv { _ =>
       labeledUnaryFunction("submit_WHAT") { tokenPos =>
         SB_Submit(optLoc,compile(party),compile(update))(svar(tokenPos))

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -771,7 +771,8 @@ private[lf] final class Compiler(
     }
 
   @inline
-  private[this] def compileCommit(partyE: Expr, updateE: Expr, optLoc: Option[Location]): SExpr =
+  //private[this]
+  def compileCommit(partyE: Expr, updateE: Expr, optLoc: Option[Location]): SExpr =
     // let party = <partyE>
     //     update = <updateE>
     // in \token ->
@@ -792,8 +793,20 @@ private[lf] final class Compiler(
       }
     }
 
+  // NICK hacking here...
   @inline
-  private[this] def compileMustFail(party: Expr, update: Expr, optLoc: Option[Location]): SExpr =
+  //private[this]
+  def new_explore_compileCommit(party: Expr, update: Expr, optLoc: Option[Location]): SExpr = {
+    withEnv { _ =>
+      labeledUnaryFunction("submit_WHAT") { tokenPos =>
+        SB_Submit(optLoc,compile(party),compile(update))(svar(tokenPos))
+      }
+    }
+  }
+
+  @inline
+  //private[this]
+  def compileMustFail(party: Expr, update: Expr, optLoc: Option[Location]): SExpr =
     // \token ->
     //   let _ = $beginCommit [party] <token>
     //       <r> = $catch ([update] <token>) true false
@@ -807,6 +820,19 @@ private[lf] final class Compiler(
         }
       }
     }
+
+/*
+  // NICK hacking here...
+  @inline
+  //private[this]
+  def new_explore_compileMustFail(partyE: Expr, updateE: Expr, optLoc: Option[Location]): SExpr = {
+    withEnv { _ =>
+      labeledUnaryFunction("submitMustFail_WHAT") { tokenPos =>
+        SB_SubmitMustFail(optLoc)(partyE,updateE,svar(tokenPos))
+      }
+    }
+  }
+ */
 
   @inline
   private[this] def compileGetParty(expr: Expr): SExpr =

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -521,10 +521,8 @@ private[lf] object Pretty {
             text("-> ")
           prettySExpr(index + n)(body).tightBracketBy(prefix, char(')'))
 
-        case SECatch(body, handler, fin) =>
-          text("$catch") + char('(') + prettySExpr(index)(body) + text(", ") +
-            prettySExpr(index)(handler) + text(", ") +
-            prettySExpr(index)(fin) + char(')')
+        case SECatch(body) =>
+          text("$catch") + char('(') + prettySExpr(index)(body) + char(')')
 
         case SELocation(loc @ _, body) =>
           prettySExpr(index)(body)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1224,6 +1224,44 @@ private[lf] object SBuiltin {
     }
   }
 
+  // NICK hacking here...
+  final case class SB_Submit(
+    optLocation: Option[Location],
+    party: SExpr,
+    update: SExpr,
+  ) extends SBuiltin(1) {
+
+    override private[speedy] final def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+    ): Unit = {
+      checkToken(args.get(0))
+      println("**SB_Submit, about to call goingOnLedger");
+      machine.goingOnLedger(productPrefix,update){ inner => // NICK: what is productPrefix???
+        val _ : Machine = inner
+        println("**SB_Submit, body of goingOnLedger, about to call run()");
+        val res = inner.run()
+        println(s"**SB_Submit, body of goingOnLedger, run() returned $res");
+        //what should I do with res??
+      }
+
+    }
+
+  }
+
+  final case class SB_SubmitMustFail(optLocation: Option[Location]) extends OnLedgerBuiltin(2) {
+    override protected final def execute(
+        args: util.ArrayList[SValue],
+        machine: Machine,
+        onLedger: OnLedger,
+    ): Unit = {
+      println("**SB_SubmitMustFail, about to fail with triple-?");
+      ???
+    }
+  }
+
+
+
   /** $beginCommit :: Party -> Token -> () */
   final case class SBSBeginCommit(optLocation: Option[Location]) extends OnLedgerBuiltin(2) {
     override protected final def execute(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -330,14 +330,13 @@ object SExpr {
 
   /** A catch expression. This is used internally solely for the purpose of implementing
     * mustFailAt. If the evaluation of 'body' causes an exception of type 'DamlException'
-    * (see SError), then the environment and continuation stacks are reset and 'handler'
-    * is executed. If the evaluation is successful, then the 'fin' expression is evaluated.
-    * This is on purpose very limited, with no mechanism to inspect the exception, nor a way
-    * to access the value returned from 'body'.
+    * (see SError), then 'True' is evaluated. If the evaluation is successful, then 'False'
+    * is evaluated.  This is on purpose very limited, with no mechanism to inspect the
+    * exception, nor a way to access the value returned from 'body'.
     */
-  final case class SECatch(body: SExpr, handler: SExpr, fin: SExpr) extends SExpr {
+  final case class SECatch(body: SExpr) extends SExpr {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KCatch(machine, handler, fin))
+      machine.pushKont(KCatch(machine))
       machine.ctrl = body
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -427,7 +427,7 @@ private[lf] object Speedy {
         val kcatch = kontStack.get(catchIndex).asInstanceOf[KCatch]
         kontStack.subList(catchIndex, kontStack.size).clear()
         env.subList(kcatch.envSize, env.size).clear()
-        ctrl = kcatch.handler
+        ctrl = SEValue.True
         envBase = env.size
         true
       } else
@@ -1226,13 +1226,11 @@ private[lf] object Speedy {
 
   /** A catch frame marks the point to which an exception (of type 'SErrorDamlException')
     * is unwound. The 'envSize' specifies the size to which the environment must be pruned.
-    * If an exception is raised and 'KCatch' is found from kont-stack, then 'handler' is
-    * evaluated. If 'KCatch' is encountered naturally, then 'fin' is evaluated.
+    * If an exception is raised and 'KCatch' is found from kont-stack, then 'True' is
+    * evaluated. If 'KCatch' is encountered naturally, then 'False' is evaluated.
     */
   private[speedy] final case class KCatch(
-      machine: Machine,
-      handler: SExpr,
-      fin: SExpr,
+      machine: Machine
   ) extends Kont
       with SomeArrayEquals {
 
@@ -1249,7 +1247,7 @@ private[lf] object Speedy {
     def execute(v: SValue) = {
       machine.restoreBase(savedBase);
       machine.restoreFrameAndActuals(frame, actuals)
-      machine.ctrl = fin
+      machine.ctrl = SEValue.False
     }
   }
 

--- a/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
+++ b/daml-lf/scenario-interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/ScenarioRunner.scala
@@ -11,7 +11,7 @@ import com.daml.lf.engine.Engine
 import com.daml.lf.language.Ast
 import com.daml.lf.transaction.{GlobalKey, SubmittedTransaction}
 import com.daml.lf.value.Value.{ContractId, ContractInst}
-import com.daml.lf.speedy.Speedy.{OffLedger, OnLedger}
+import com.daml.lf.speedy.Speedy.{OnLedger}
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.value.Value
@@ -32,9 +32,17 @@ final case class ScenarioRunner(
     partyNameMangler: (String => String) = identity,
 ) {
   var ledger: ScenarioLedger = ScenarioLedger.initialLedger(Time.Timestamp.Epoch)
-  val onLedger = machine.ledgerMode match {
+
+  // this is the original version. it assumes we start in the on-ledger state
+  /*val onLedger = machine.ledgerMode match {
     case OffLedger => throw SRequiresOnLedger("ScenarioRunner")
     case onLedger: OnLedger => onLedger
+  }*/
+
+  // this version assumes we start off-ledger, but are able to go on-ledger later
+  val onLedger : OnLedger = machine.sep_onLedger match {
+    case None => throw SRequiresOnLedger("ScenarioRunner, sep_onLedger=None")
+    case Some(onLedger) => onLedger
   }
 
   import scala.util.{Try, Success, Failure}

--- a/daml-lf/tests/BUILD.bazel
+++ b/daml-lf/tests/BUILD.bazel
@@ -11,6 +11,7 @@ TEST_FILES = \
         "BasicTests",
         "AuthorizedDivulgence",
         "DontDiscloseNonConsumingExercisesToObservers",
+        "OnOff",
         "LargeTransaction",
         "ConjunctionChoices",
         "ContractKeys",

--- a/daml-lf/tests/OnOff.daml
+++ b/daml-lf/tests/OnOff.daml
@@ -1,0 +1,37 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+module OnOff where
+
+-- @SINCE-LF 1.11
+
+-- Example to explore on/off ledger interaction...
+
+template MyTemplate with
+    owner : Party
+    value : Int
+
+  where
+    signatory owner
+    nonconsuming choice Increase: ContractId MyTemplate
+      with
+        myArg: Int
+      controller owner
+      do create this with value = this.value + myArg
+
+    nonconsuming choice Check: ()
+      with
+        expected: Int
+      controller owner
+      do
+        if value == expected then pure () else error "oops"
+
+
+test : Scenario ()
+test = scenario do
+  alice <- getParty "Alice"
+  id <- submit alice do
+    create MyTemplate with owner = alice; value = 42
+  --submitMustFail alice do
+  --  exercise id Check with expected = 55
+  pure ()


### PR DESCRIPTION
WIP

Currently `submitMustFail` is implemented using a _kind-of_ exception catch mechanism.
We would like to rip this out in preparation for support of real exceptions.

The idea is to execute expressions within `submit` or `submitMustFail` on separate _inner_ speedy machines.
This will make the _on-ledger_/_off-ledger_ distinction clearer.
And to prepare for support of new full exceptions, which only make sense _on-ledger_.

Initial steps:
- simplify existing SECatch/KCatch, replacing handler/fin with fixed: `SEValue.True/False`


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
