### PR TITLE
fix: project parties are not required

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Util.hs
@@ -89,8 +89,9 @@ getProjectVersion = do
 getProjectParties :: IO [String]
 getProjectParties = do
     projectConfig <- getProjectConfig
-    requiredE "Failed to read list of parties from project config" $
-        queryProjectConfigRequired ["parties"] projectConfig
+    fmap maybeToList $
+        requiredE "Failed to read list of parties from project config" $
+        queryProjectConfig ["parties"] projectConfig
 
 getProjectLedgerPort :: IO Int
 getProjectLedgerPort = do

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -600,6 +600,23 @@ damlStartTests getDamlStart =
           withTempDir $ \tmpDir -> do
             DamlStartResource{startPh} <- damlStart EnvAbsoluteDir tmpDir
             terminateProcess startPh
+        , testCase "run a daml deploy without project parties" $ do
+              DamlStartResource {projDir, sandboxPort} <- getDamlStart
+              withCurrentDirectory projDir $ do
+                  copyFile "daml.yaml" "daml.yaml.back"
+                  writeFileUTF8 "daml.yaml" $ unlines
+                      [ "sdk-version: " <> sdkVersion
+                      , "name: proj1"
+                      , "version: 0.0.1"
+                      , "source: daml"
+                      , "dependencies:"
+                      , "  - daml-prim"
+                      , "  - daml-stdlib"
+                      , "  - daml-script"
+                      ]
+                  callCommand $
+                    unwords ["daml", "deploy", "--host localhost", "--port", show sandboxPort]
+                  copyFile "daml.yaml.back" "daml.yaml"
         ]
 
 quickstartTests :: FilePath -> FilePath -> IO QuickSandboxResource -> TestTree


### PR DESCRIPTION
This fixes a bug in daml assistant. `daml deploy` would fail if there
were no project parties listed in the daml.yaml project config file. Now
project parties are not required anymore.

Fixes #8487.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
