### PR TITLE
LF: Flatten ContractInstance inside NodeCreate

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -6,7 +6,7 @@ package engine
 
 import com.daml.lf.data.Ref.{Identifier, Name, PackageId}
 import com.daml.lf.language.Ast
-import com.daml.lf.language.Ast.PackageSignature
+import com.daml.lf.language.Ast.{PackageSignature, TTyCon}
 import com.daml.lf.transaction.Node.{GenNode, KeyWithMaintainers}
 import com.daml.lf.transaction.{CommittedTransaction, Node, NodeId, VersionedTransaction}
 import com.daml.lf.value.Value
@@ -111,9 +111,9 @@ final class ValueEnricher(engine: Engine) {
     node match {
       case create: Node.NodeCreate[ContractId] =>
         for {
-          contractInstance <- enrichContract(create.coinst)
+          arg <- enrichValue(TTyCon(create.templateId), create.arg)
           key <- enrichContractKey(create.templateId, create.key)
-        } yield create.copy(coinst = contractInstance, key = key)
+        } yield create.copy(arg = arg, key = key)
       case fetch: Node.NodeFetch[ContractId] =>
         for {
           key <- enrichContractKey(fetch.templateId, fetch.key)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -37,19 +37,20 @@ private[preprocessing] final class TransactionPreprocessor(
     node match {
       case Node.NodeCreate(
             coid @ _,
-            coinst,
+            templateId,
+            arg,
+            agreementText @ _,
             optLoc @ _,
             sigs @ _,
             stks @ _,
             key @ _,
             version @ _,
           ) =>
-        val identifier = coinst.template
         if (globalCids(coid))
           fail("Conflicting discriminators between a global and local contract ID.")
 
         val (cmd, newCids) =
-          commandPreprocessor.unsafePreprocessCreate(identifier, coinst.arg)
+          commandPreprocessor.unsafePreprocessCreate(templateId, arg)
         val newGlobalCids = globalCids + coid
         val newLocalCids = localCids | newCids.filterNot(globalCids)
         cmd -> (newLocalCids -> newGlobalCids)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -1258,9 +1258,9 @@ class EngineTest
       }
 
       findNodeByIdx(bobView.nodes, 1).getOrElse(fail("node not found")) match {
-        case Node.NodeCreate(_, coins, _, _, stakeholders, _, _) =>
-          coins.template shouldBe templateId
-          stakeholders shouldBe Set(alice, clara)
+        case create: Node.NodeCreate[ContractId] =>
+          create.templateId shouldBe templateId
+          create.stakeholders shouldBe Set(alice, clara)
         case _ => fail("create event is expected")
       }
 
@@ -1270,9 +1270,9 @@ class EngineTest
 
       claraView.nodes.size shouldBe 1
       findNodeByIdx(claraView.nodes, 1).getOrElse(fail("node not found")) match {
-        case Node.NodeCreate(_, coins, _, _, stakeholders, _, _) =>
-          coins.template shouldBe templateId
-          stakeholders shouldBe Set(alice, clara)
+        case create: Node.NodeCreate[ContractId] =>
+          create.templateId shouldBe templateId
+          create.stakeholders shouldBe Set(alice, clara)
         case _ => fail("create event is expected")
       }
     }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -907,8 +907,9 @@ private[lf] object SBuiltin {
       val (coid, newPtx) = onLedger.ptx
         .insertCreate(
           auth = auth,
-          coinst =
-            V.ContractInst(template = templateId, arg = createArgValue, agreementText = agreement),
+          templateId = templateId,
+          arg = createArgValue,
+          agreementText = agreement,
           optLocation = machine.lastLocation,
           signatories = sigs,
           stakeholders = sigs union obs,

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -95,11 +95,9 @@ final class TransactionBuilder(
     val templateId = Ref.Identifier.assertFromString(template)
     Create(
       coid = ContractId.assertFromString(id),
-      coinst = ContractInst(
-        template = templateId,
-        arg = argument,
-        agreementText = "",
-      ),
+      templateId = templateId,
+      arg = argument,
+      agreementText = "",
       optLocation = None,
       signatories = signatories.map(Ref.Party.assertFromString).toSet,
       stakeholders = signatories.toSet.union(observers.toSet).map(Ref.Party.assertFromString),

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -299,11 +299,23 @@ object ValueGenerators {
     for {
       version <- transactionVersionGen()
       coid <- coidGen
-      coinst <- contractInstanceGen
+      templateId <- idGen
+      arg <- valueGen
+      agreement <- Arbitrary.arbitrary[String]
       signatories <- genNonEmptyParties
       stakeholders <- genNonEmptyParties
       key <- Gen.option(keyWithMaintainersGen)
-    } yield NodeCreate(coid, coinst, None, signatories, stakeholders, key, version)
+    } yield NodeCreate(
+      coid,
+      templateId,
+      arg,
+      agreement,
+      None,
+      signatories,
+      stakeholders,
+      key,
+      version,
+    )
   }
 
   val fetchNodeGen: Gen[NodeFetch[ContractId]] = {

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -5,10 +5,10 @@ package com.daml.lf
 package transaction
 
 import com.daml.lf.data.ImmArray
-import com.daml.lf.data.Ref.{Identifier, PackageId, Party, QualifiedName}
+import com.daml.lf.data.Ref.{Identifier, Party}
 import com.daml.lf.transaction.Node._
 import com.daml.lf.transaction.{TransactionOuterClass => proto}
-import com.daml.lf.value.Value.{ContractId, ContractInst, ValueParty}
+import com.daml.lf.value.Value.{ContractId, ValueParty}
 import com.daml.lf.value.ValueCoder.{DecodeError, EncodeError}
 import com.daml.lf.value.ValueCoder
 import org.scalacheck.{Arbitrary, Gen}
@@ -249,14 +249,9 @@ class TransactionCoderSpec
       val node =
         NodeCreate[ContractId](
           coid = absCid("#test-cid"),
-          coinst = ContractInst(
-            Identifier(
-              PackageId.assertFromString("pkg-id"),
-              QualifiedName.assertFromString("Test:Name"),
-            ),
-            ValueParty(Party.assertFromString("francesco")),
-            "agreement",
-          ),
+          templateId = Identifier.assertFromString("pkg-id:Test:Name"),
+          arg = ValueParty(Party.assertFromString("francesco")),
+          agreementText = "agreement",
           optLocation = None,
           signatories = Set(Party.assertFromString("alice")),
           stakeholders = Set(Party.assertFromString("alice"), Party.assertFromString("bob")),

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -221,7 +221,7 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
         cid2 -> V.ContractId.V1.assertBuild(cid2.discriminator, suffix2),
       )
 
-      dummyCreateNode("dd").coinst.suffixCid(mapping1)
+      dummyCreateNode("dd").arg.suffixCid(mapping1)
 
       val tx1 = tx.suffixCid(mapping1)
       val tx2 = tx.suffixCid(mapping1)
@@ -275,14 +275,9 @@ object TransactionSpec {
   def dummyCreateNode(cid: String): NodeCreate[V.ContractId] =
     NodeCreate(
       coid = toCid(cid),
-      coinst = V.ContractInst(
-        Ref.Identifier(
-          Ref.PackageId.assertFromString("-dummyPkg-"),
-          Ref.QualifiedName.assertFromString("DummyModule:dummyName"),
-        ),
-        V.ValueContractId(dummyCid),
-        "dummyAgreement",
-      ),
+      templateId = Ref.Identifier.assertFromString("-dummyPkg-:DummyModule:dummyName"),
+      arg = V.ValueContractId(dummyCid),
+      agreementText = "dummyAgreement",
       optLocation = None,
       signatories = Set.empty,
       stakeholders = Set.empty,

--- a/ledger/participant-integration-api/src/main/scala/db/migration/h2database/V5_1__Populate_Event_Data.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/h2database/V5_1__Populate_Event_Data.scala
@@ -51,8 +51,9 @@ private[migration] class V5_1__Populate_Event_Data extends BaseJavaMigration {
 
     val txs = loadTransactions(conn)
     val data = txs.flatMap { case (txId, tx) =>
-      tx.nodes.collect { case (nodeId, NodeCreate(cid, _, _, signatories, stakeholders, _, _)) =>
-        (cid, EventId(txId, nodeId), signatories, stakeholders -- signatories)
+      tx.nodes.collect {
+        case (nodeId, NodeCreate(cid, _, _, _, _, signatories, stakeholders, _, _)) =>
+          (cid, EventId(txId, nodeId), signatories, stakeholders -- signatories)
       }
     }
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V10_1__Populate_Event_Data.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V10_1__Populate_Event_Data.scala
@@ -51,8 +51,9 @@ private[migration] class V10_1__Populate_Event_Data extends BaseJavaMigration {
 
     val txs = loadTransactions(conn)
     val data = txs.flatMap { case (txId, tx) =>
-      tx.nodes.collect { case (nodeId, NodeCreate(cid, _, _, signatories, stakeholders, _, _)) =>
-        (cid, EventId(txId, nodeId), signatories, stakeholders -- signatories)
+      tx.nodes.collect {
+        case (nodeId, NodeCreate(cid, _, _, _, _, signatories, stakeholders, _, _)) =>
+          (cid, EventId(txId, nodeId), signatories, stakeholders -- signatories)
       }
     }
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
@@ -28,7 +28,9 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
       builder.add(
         NodeCreate(
           coid = contractId,
-          coinst = someContractInstance,
+          templateId = someTemplateId,
+          arg = someValueRecord,
+          agreementText = someAgreement,
           optLocation = None,
           signatories = Set(alice),
           stakeholders = Set(alice),
@@ -44,7 +46,9 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
       builder.add(
         NodeCreate(
           coid = contractId,
-          coinst = someContractInstance,
+          someTemplateId,
+          someValueRecord,
+          someAgreement,
           optLocation = None,
           signatories = Set(bob),
           stakeholders = Set(bob),
@@ -120,7 +124,9 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
       builder.add(
         NodeCreate(
           coid = builder.newCid,
-          coinst = someContractInstance,
+          someTemplateId,
+          someValueRecord,
+          someAgreement,
           optLocation = None,
           signatories = Set(bob),
           stakeholders = Set(alice, bob),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -129,7 +129,9 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
   ): NodeCreate[ContractId] =
     NodeCreate(
       coid = absCid,
-      coinst = someContractInstance,
+      templateId = someTemplateId,
+      arg = someValueRecord,
+      agreementText = someAgreement,
       optLocation = None,
       signatories = signatories,
       stakeholders = stakeholders,
@@ -495,7 +497,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
         contract.copy(
           signatories = parties,
           stakeholders = parties,
-          coinst = contract.coinst.copy(template = Identifier.assertFromString(template)),
+          templateId = Identifier.assertFromString(template),
         )
       )
     } yield nodeId -> parties
@@ -593,7 +595,9 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
     val createNodeId = txBuilder.add(
       NodeCreate(
         coid = txBuilder.newCid,
-        coinst = someContractInstance,
+        someTemplateId,
+        someValueRecord,
+        someAgreement,
         optLocation = None,
         signatories = Set(party),
         stakeholders = Set(party),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -595,9 +595,9 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
     val createNodeId = txBuilder.add(
       NodeCreate(
         coid = txBuilder.newCid,
-        someTemplateId,
-        someValueRecord,
-        someAgreement,
+        templateId = someTemplateId,
+        arg = someValueRecord,
+        agreementText = someAgreement,
         optLocation = None,
         signatories = Set(party),
         stakeholders = Set(party),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/ProjectionsSpec.scala
@@ -9,7 +9,7 @@ import com.daml.lf.engine.Blinding
 import com.daml.lf.transaction.Transaction.Transaction
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.transaction.{Node, TransactionVersion}
-import com.daml.lf.value.Value.{ContractId, ContractInst, ValueText}
+import com.daml.lf.value.Value.{ContractId, ValueText}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -18,14 +18,9 @@ class ProjectionsSpec extends AnyWordSpec with Matchers {
   def makeCreateNode(cid: ContractId, signatories: Set[Party], stakeholders: Set[Party]) =
     Node.NodeCreate(
       coid = cid,
-      coinst = ContractInst(
-        Identifier(
-          PackageId.assertFromString("some-package"),
-          QualifiedName.assertFromString("Foo:Bar"),
-        ),
-        ValueText("foo"),
-        "agreement",
-      ),
+      templateId = Identifier.assertFromString("some-package:Foo:Bar"),
+      arg = ValueText("foo"),
+      agreementText = "agreement",
       optLocation = None,
       signatories = signatories,
       stakeholders = stakeholders,

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Adapter.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Adapter.scala
@@ -28,7 +28,8 @@ private[benchmark] final class Adapter(
     node match {
       case create: Node.NodeCreate[ContractId] =>
         create.copy(
-          coinst = create.coinst.copy(adapt(create.coinst.template), adapt(create.coinst.arg)),
+          templateId = adapt(create.templateId),
+          arg = adapt(create.arg),
           optLocation = None,
           key = create.key.map(adapt),
         )
@@ -48,11 +49,12 @@ private[benchmark] final class Adapter(
           key = fetch.key.map(adapt),
         )
       case lookup: Node.NodeLookupByKey[ContractId] =>
-        lookup.copy(
-          templateId = adapt(lookup.templateId),
-          optLocation = None,
-          key = adapt(lookup.key),
-        )
+        lookup
+          .copy(
+            templateId = adapt(lookup.templateId),
+            optLocation = None,
+            key = adapt(lookup.key),
+          )
     }
 
   // drop value version


### PR DESCRIPTION
The `ContractInstance` is a concept a bit off. For instance it is not
clear why `agreementText`, is more important for a contract that the
signatories, the stockholders or the key. In this PR, we get ride of
the `ContractInstance` inside LF code, except from the Engine/Ledger API
(i.e. `com.daml.lf.engine.ResultNeedContract`)

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
