### PR TITLE
ci: gc linux cache

### DIFF
--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -34,11 +34,23 @@ steps:
       # infra/macos/2-common-box/init.sh:echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
       # infra/vsts_agent_linux_startup.sh:echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
       disk_cache=$HOME/.bazel-cache
-      if [ $(du -ms $disk_cache | awk '{print $1}') -gt 80000 ]; then
-          echo "Deleting $disk_cache"
-          rm -rf $disk_cache
+      if [ $(du -ms "$disk_cache" | awk '{print $1}') -gt 80000 ]; then
+          echo "Deleting '$disk_cache'..."
+          rm -rf "$disk_cache"
       else
-          echo "Disk cache small enough: $(du -hs $disk_cache)."
+          echo "Disk cache small enough:\n$(du -hs "$disk_cache")"
+      fi
+      local_cache=$HOME/.cache/bazel
+      if [ -d "$local_cache" ]; then
+          if [ $(du -ms "$local_cache" | awk '{print $1}') -gt 80000 ]; then
+              echo "Deleting '$local_cache'..."
+              find "$local_cache" -type d | xargs chmod +w
+              rm -rf "$local_cache"
+          else
+              echo "Local cache small enough:\n$(du -hs "$local_cache")"
+          fi
+      else
+          echo "No '$local_cache', moving on."
       fi
     displayName: clean-up disk cache
 


### PR DESCRIPTION
This is the equivalent of #8515 for Linux. There was some concern that `bazel` would be upset at having that cache removed, so I spent a fair amount of time trying to break it (on a Linux VM, as for some reason `bazel` chooses not to use `~/.cache` on macOS). I could not make `bazel` unhappy by deleting the whole thing. Deleting random files, however, did end up producing error messages along the lines of:

```
$ bazel build //...
FATAL: corrupt installation: file '/home/vagrant/.cache/bazel/_bazel_vagrant/install/73d06d52dbf3a8e6ed43f5bf5f115eb0/embedded_tools/src/BUILD' is missing or modified.  Please remove '/home/vagrant/.cache/bazel/_bazel_vagrant/install/73d06d52dbf3a8e6ed43f5bf5f115eb0' and try again.
```

which suggest busting the entire thing as a solution, so I think we're
safe here.

CHANGELOG_BEGIN
CHANGELOG_END