### PR TITLE
Don't always redirect to /login automatically 

### DIFF
--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -123,6 +123,7 @@ da_scala_library(
         "//libs-scala/resources",
         "//libs-scala/scala-utils",
         "//libs-scala/timer-utils",
+        "//triggers/service/auth:middleware-api",
         "//triggers/service/auth:oauth2-middleware",
         "//triggers/service/auth:oauth2-test-server",
         "@maven//:ch_qos_logback_logback_classic",

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Client.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Client.scala
@@ -53,21 +53,21 @@ class Client(config: Client.Config) {
       }
     }
 
-  private val isJsonRequest: Directive1[Boolean] = extractRequest.map { req =>
+  private val isHtmlRequest: Directive1[Boolean] = extractRequest.map { req =>
     val negotiator = ContentNegotiator(req.headers)
     val contentTypes = List(
       ContentNegotiator.Alternative(MediaTypes.`application/json`),
       ContentNegotiator.Alternative(MediaTypes.`text/html`),
     )
     val preferred = negotiator.pickContentType(contentTypes)
-    preferred == Some(MediaTypes.`application/json`.toContentType)
+    preferred.map(_.mediaType) == Some(MediaTypes.`text/html`)
   }
 
   private val redirectToLogin: Directive1[Boolean] =
     config.redirectToLogin match {
       case RedirectToLogin.No => provide(false)
       case RedirectToLogin.Yes => provide(true)
-      case RedirectToLogin.Auto => isJsonRequest.map(!_)
+      case RedirectToLogin.Auto => isHtmlRequest
     }
 
   /** This directive requires authorization for the given claims via the auth middleware.

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/api/Request.scala
@@ -102,12 +102,10 @@ object Request {
     * @param claims Required ledger claims.
     * @param state State that will be forwarded to the callback URI after authentication and authorization.
     */
-  case class Login(redirectUri: Uri, claims: Claims, state: Option[String]) {
+  case class Login(redirectUri: Option[Uri], claims: Claims, state: Option[String]) {
     def toQuery: Uri.Query = {
-      var params = Seq(
-        "redirect_uri" -> redirectUri.toString,
-        "claims" -> claims.toQueryString(),
-      )
+      var params = Seq("claims" -> claims.toQueryString())
+      redirectUri.foreach(x => params ++= Seq("redirect_uri" -> x.toString()))
       state.foreach(x => params ++= Seq("state" -> x))
       Uri.Query(params: _*)
     }

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -36,7 +36,7 @@ case class Config(
 
 object Config {
   val DefaultMaxLoginRequests: Int = 100
-  val DefaultLoginTimeout: FiniteDuration = FiniteDuration(1, duration.MINUTES)
+  val DefaultLoginTimeout: FiniteDuration = FiniteDuration(1, duration.HOURS)
 
   private val Empty =
     Config(

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -36,7 +36,7 @@ case class Config(
 
 object Config {
   val DefaultMaxLoginRequests: Int = 100
-  val DefaultLoginTimeout: FiniteDuration = FiniteDuration(1, duration.HOURS)
+  val DefaultLoginTimeout: FiniteDuration = FiniteDuration(5, duration.MINUTES)
 
   private val Empty =
     Config(

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
@@ -194,7 +194,16 @@ class Server(config: Config) extends StrictLogging {
                           }
                       } yield tokenResp
                     onSuccess(tokenRequest) { token =>
-                      setCookie(HttpCookie(cookieName, token.toCookieValue)) {
+                      setCookie(
+                        HttpCookie(
+                          name = cookieName,
+                          value = token.toCookieValue,
+                          path = Some("/"),
+                          maxAge = token.expiresIn.map(_.toLong),
+                          secure = true,
+                          httpOnly = true,
+                        )
+                      ) {
                         redirectUri match {
                           case Some(uri) =>
                             redirect(uri, StatusCodes.Found)

--- a/triggers/service/auth/src/main/scala/com/daml/auth/oauth2/api/Request.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/oauth2/api/Request.scala
@@ -168,7 +168,7 @@ object JsonProtocol extends DefaultJsonProtocol {
     }
     def write(uri: Uri) = JsString(uri.toString)
   }
-  implicit val tokenRespFormat: RootJsonFormat[Response.Token] =
+  implicit val tokenRespFormat: RootJsonFormat[Response.Token] = {
     jsonFormat(
       Response.Token.apply,
       "access_token",
@@ -177,4 +177,14 @@ object JsonProtocol extends DefaultJsonProtocol {
       "refresh_token",
       "scope",
     )
+  }
+  implicit val errorRespFormat: RootJsonFormat[Response.Error] = {
+    jsonFormat(
+      Response.Error.apply,
+      "error",
+      "error_description",
+      "error_uri",
+      "state",
+    )
+  }
 }

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Resources.scala
@@ -60,6 +60,27 @@ object Resources {
             )
             .bind {
               concat(
+                path("authorize") {
+                  get {
+                    parameters('claims.as[Claims]) { claims =>
+                      client.authorize(claims) {
+                        case Client.Authorized(authorization) =>
+                          import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+                          import com.daml.auth.middleware.api.JsonProtocol.responseAuthorizeFormat
+                          complete(StatusCodes.OK, authorization)
+                        case Client.Unauthorized =>
+                          complete(StatusCodes.Unauthorized)
+                        case Client.LoginFailed(loginError) =>
+                          import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+                          import com.daml.auth.middleware.api.JsonProtocol.ResponseLoginFormat
+                          complete(
+                            StatusCodes.Forbidden,
+                            loginError: com.daml.auth.middleware.api.Response.Login,
+                          )
+                      }
+                    }
+                  }
+                },
                 path("login") {
                   get {
                     parameters('claims.as[Claims]) { claims =>

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -48,6 +48,7 @@ trait TestFixture
   protected val maxMiddlewareLogins: Int = Config.DefaultMaxLoginRequests
   protected val maxClientAuthCallbacks: Int = 1000
   protected val middlewareCallbackUri: Option[Uri] = None
+  protected val redirectToLogin: Client.RedirectToLogin = Client.RedirectToLogin.Yes
   lazy protected val clock: AdjustableClock = suiteResource.value.clock
   lazy protected val server: OAuthServer = suiteResource.value.authServer
   lazy protected val serverBinding: ServerBinding = suiteResource.value.authServerBinding
@@ -114,7 +115,7 @@ trait TestFixture
               middlewareBinding.localAddress.getHostName,
               middlewareBinding.localAddress.getPort,
             ),
-          redirectToLogin = Client.RedirectToLogin.Yes,
+          redirectToLogin = redirectToLogin,
           callbackUri = Uri()
             .withScheme("http")
             .withAuthority("localhost", middlewareClientPort.value)

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -114,6 +114,7 @@ trait TestFixture
               middlewareBinding.localAddress.getHostName,
               middlewareBinding.localAddress.getPort,
             ),
+          redirectToLogin = Client.RedirectToLogin.Yes,
           callbackUri = Uri()
             .withScheme("http")
             .withAuthority("localhost", middlewareClientPort.value)

--- a/triggers/service/authentication.md
+++ b/triggers/service/authentication.md
@@ -40,14 +40,17 @@ all that much, they just need to be fixed once).
    status code.
 
 2. /login If /auth returned unauthorized, the trigger service will
-   redirect users to this. The parameters will include the requested
-   claims as well as a callback URL (note that this is not the OAuth2 callback url but a callback URL on the trigger service). This will start an auth flow,
+   redirect users to this.
+   For HTML requests via HTTP redirect, otherwise via a custom WWW-Authenticate challenge in a 401 resonse.
+   The parameters will include the requested claims as well as an optional callback URL (note that this is not the OAuth2 callback url but a callback URL on the trigger service). This will start an auth flow,
    e.g., an OAuth2 authorization code grant. If the flow succeeds the
    auth service will set a cookie with the access and refresh token
-   and redirect to the callback URL. At this point, a request to
+   and redirect to the callback URL if present or return status code 200.
+   At this point, a request to
    /auth will succeed (based on the cookie). If the flow failed the
    auth service will not set a cookie and redirect to the callback URL
-   with an additional error and optional error_description parameter.
+   with an additional error and optional error_description parameter
+   or return 403 with error and optional error_description in the response body.
 
 3. /refresh This accepts a refresh token and returns a new access
    token and optionally a new refresh token (or fails).

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -514,6 +514,7 @@ object Server {
           AuthClient(
             AuthClient.Config(
               authMiddlewareUri = uri,
+              redirectToLogin = AuthClient.RedirectToLogin.Yes,
               callbackUri = authCallback.getOrElse {
                 Uri().withScheme("http").withAuthority(host, port).withPath(Path./("cb"))
               },

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/Server.scala
@@ -490,6 +490,7 @@ object Server {
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
       authConfig: AuthConfig,
+      authRedirectToLogin: AuthClient.RedirectToLogin,
       authCallback: Option[Uri],
       ledgerConfig: LedgerConfig,
       restartConfig: TriggerRestartConfig,
@@ -514,7 +515,7 @@ object Server {
           AuthClient(
             AuthClient.Config(
               authMiddlewareUri = uri,
-              redirectToLogin = AuthClient.RedirectToLogin.Yes,
+              redirectToLogin = authRedirectToLogin,
               callbackUri = authCallback.getOrElse {
                 Uri().withScheme("http").withAuthority(host, port).withPath(Path./("cb"))
               },

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceMain.scala
@@ -10,6 +10,7 @@ import akka.actor.typed.scaladsl.AskPattern._
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.Uri
 import akka.util.Timeout
+import com.daml.auth.middleware.api.{Client => AuthClient}
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.dec.DirectExecutionContext
 import com.daml.lf.archive.{Dar, DarReader}
@@ -41,6 +42,7 @@ object ServiceMain {
       maxHttpEntityUploadSize: Long,
       httpEntityUploadTimeout: FiniteDuration,
       authConfig: AuthConfig,
+      authRedirectToLogin: AuthClient.RedirectToLogin,
       authCallback: Option[Uri],
       ledgerConfig: LedgerConfig,
       restartConfig: TriggerRestartConfig,
@@ -59,6 +61,7 @@ object ServiceMain {
           maxHttpEntityUploadSize,
           httpEntityUploadTimeout,
           authConfig,
+          authRedirectToLogin,
           authCallback,
           ledgerConfig,
           restartConfig,
@@ -137,6 +140,7 @@ object ServiceMain {
               config.maxHttpEntityUploadSize,
               config.httpEntityUploadTimeout,
               authConfig,
+              config.authRedirectToLogin,
               config.authCallbackUri,
               ledgerConfig,
               restartConfig,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -10,6 +10,7 @@ import java.util.{Date, UUID}
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 
 import io.grpc.Channel
+import com.daml.auth.middleware.api.{Client => AuthClient}
 import com.daml.ledger.api.testing.utils.OwnedResource
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.platform.apiserver.services.GrpcClientResource
@@ -474,6 +475,7 @@ trait TriggerServiceFixture
                 ServiceConfig.DefaultMaxHttpEntityUploadSize,
                 ServiceConfig.DefaultHttpEntityUploadTimeout,
                 authConfig,
+                AuthClient.RedirectToLogin.Yes,
                 authCallback,
                 ledgerConfig,
                 restartConfig,


### PR DESCRIPTION
Before, the middleware client would always automatically redirect to the middleware's `/login` endpoint when `/auth` return `Unauthorized`. This does not work well if login requires human interaction, e.g. typing credentials into a login form, and the client is not a browser, i.e. not able to display a login form.

With this PR the client will not always redirect automatically. The redirect mode can be configured to never redirect, always redirect, or redirect based on the request type (redirect for text/html). In case of no redirect the auth middleware client will reply with 401 Unauthorized with a custom WWW-Authenticate header containing a challenge to login on the auth middleware.

This PR adds test cases for the middleware client for the various redirect modes.

I have manually tested this against auth0 with a simple Python client. This test also highlighted some other minor issues that are fixed in this PR. Namely, any path prefix in the auth middleware URI was not preserved, the login timeout was often too short for login on a web form, the cookie headers required additional attributes to work across endpoints.


### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
