### PR TITLE
KV fix: add exercise key to inputs (forward-ports #8529) [KVL-797]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -71,6 +71,16 @@ private[kvutils] object InputsAndEffects {
       if (!localContract.isDefinedAt(coid))
         inputs += contractIdToStateKey(coid)
 
+    def addKeyInput(
+        templateId: Identifier,
+        keyWithMaintainers: Node.KeyWithMaintainers[Value[ContractId]],
+    ): Unit = {
+      inputs += globalKeyToStateKey(
+        GlobalKey(templateId, forceNoContractIds(keyWithMaintainers.key))
+      )
+      ()
+    }
+
     def partyInputs(parties: Set[Party]): List[DamlStateKey] = {
       import Party.ordering
       parties.toList.sorted.map(partyStateKey)
@@ -81,28 +91,25 @@ private[kvutils] object InputsAndEffects {
         case fetch: Node.NodeFetch[Value.ContractId] =>
           addContractInput(fetch.coid)
           fetch.key.foreach { keyWithMaintainers =>
-            inputs += globalKeyToStateKey(
-              GlobalKey(fetch.templateId, forceNoContractIds(keyWithMaintainers.key))
-            )
+            addKeyInput(fetch.templateId, keyWithMaintainers)
           }
 
         case create: Node.NodeCreate[Value.ContractId] =>
           create.key.foreach { keyWithMaintainers =>
-            inputs += globalKeyToStateKey(
-              GlobalKey(create.coinst.template, forceNoContractIds(keyWithMaintainers.key))
-            )
+            addKeyInput(create.coinst.template, keyWithMaintainers)
           }
 
         case exe: Node.NodeExercises[NodeId, Value.ContractId] =>
           addContractInput(exe.targetCoid)
+          exe.key.foreach { keyWithMaintainers =>
+            addKeyInput(exe.templateId, keyWithMaintainers)
+          }
 
         case lookup: Node.NodeLookupByKey[Value.ContractId] =>
           // We need both the contract key state and the contract state. The latter is used to verify
           // that the submitter can access the contract.
           lookup.result.foreach(addContractInput)
-          inputs += globalKeyToStateKey(
-            GlobalKey(lookup.templateId, forceNoContractIds(lookup.key.key))
-          )
+          addKeyInput(lookup.templateId, lookup.key)
       }
 
       inputs ++= partyInputs(node.informeesOfNode)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -31,7 +31,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.collection.compat.immutable.LazyList
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
 


### PR DESCRIPTION
CHANGELOG_BEGIN
[KV] Fix: add exercise key to submission inputs
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
