### PR TITLE
Moved default timeout definition up in callstack

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Envelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Envelope.scala
@@ -53,12 +53,14 @@ object Envelope {
     private val Prefix = Envelope.Prefix :+ "Throughput"
 
     val All: immutable.Seq[Envelope] =
-      Vector(NoThroughput, FivePerSecond, TwentyPerSecond, FiftyPerSecond, FiveHundredPerSecond)
+      Vector(NoThroughput, FivePerSecond, TwentyPerSecond, FiftyPerSecond, HundredPerSecond, TwoFiftyPerSecond, FiveHundredPerSecond)
 
     case object NoThroughput extends Throughput("ZeroOPS", operationsPerSecond = 0)
     case object FivePerSecond extends Throughput("FiveOPS", operationsPerSecond = 5)
     case object TwentyPerSecond extends Throughput("TwentyOPS", operationsPerSecond = 20)
     case object FiftyPerSecond extends Throughput("FiftyOPS", operationsPerSecond = 50)
+    case object HundredPerSecond extends Throughput("HundredOPS", operationsPerSecond = 100)
+    case object TwoFiftyPerSecond extends Throughput("TwoFiftyOPS", operationsPerSecond = 250)
     case object FiveHundredPerSecond extends Throughput("FiveHundredOPS", operationsPerSecond = 500)
 
   }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Envelope.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Envelope.scala
@@ -53,7 +53,15 @@ object Envelope {
     private val Prefix = Envelope.Prefix :+ "Throughput"
 
     val All: immutable.Seq[Envelope] =
-      Vector(NoThroughput, FivePerSecond, TwentyPerSecond, FiftyPerSecond, HundredPerSecond, TwoFiftyPerSecond, FiveHundredPerSecond)
+      Vector(
+        NoThroughput,
+        FivePerSecond,
+        TwentyPerSecond,
+        FiftyPerSecond,
+        HundredPerSecond,
+        TwoFiftyPerSecond,
+        FiveHundredPerSecond,
+      )
 
     case object NoThroughput extends Throughput("ZeroOPS", operationsPerSecond = 0)
     case object FivePerSecond extends Throughput("FiveOPS", operationsPerSecond = 5)

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
@@ -16,6 +16,7 @@ import com.daml.platform.configuration.ServerRole
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
 private[platform] final class DbDispatcher private (
@@ -83,6 +84,7 @@ private[platform] object DbDispatcher {
       serverRole: ServerRole,
       jdbcUrl: String,
       maxConnections: Int,
+      connectionTimeout: FiniteDuration,
       metrics: Metrics,
       connectionAsyncCommit: Boolean,
   )(implicit loggingContext: LoggingContext): ResourceOwner[DbDispatcher] =
@@ -91,9 +93,9 @@ private[platform] object DbDispatcher {
         serverRole,
         jdbcUrl,
         maxConnections,
+        connectionTimeout,
         metrics.registry,
-        connectionAsyncCommit,
-      )
+        connectionAsyncCommit)
       executor <- ResourceOwner.forExecutorService(() =>
         Executors.newFixedThreadPool(
           maxConnections,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
@@ -95,7 +95,8 @@ private[platform] object DbDispatcher {
         maxConnections,
         connectionTimeout,
         metrics.registry,
-        connectionAsyncCommit)
+        connectionAsyncCommit,
+      )
       executor <- ResourceOwner.forExecutorService(() =>
         Executors.newFixedThreadPool(
           maxConnections,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/HikariJdbcConnectionProvider.scala
@@ -174,6 +174,7 @@ private[platform] object HikariJdbcConnectionProvider {
       serverRole: ServerRole,
       jdbcUrl: String,
       maxConnections: Int,
+      connectionTimeout: FiniteDuration,
       metrics: MetricRegistry,
       connectionAsyncCommit: Boolean = false,
   )(implicit loggingContext: LoggingContext): ResourceOwner[HikariJdbcConnectionProvider] =
@@ -184,7 +185,7 @@ private[platform] object HikariJdbcConnectionProvider {
         jdbcUrl,
         maxConnections,
         maxConnections,
-        250.millis,
+        connectionTimeout,
         Some(metrics),
         connectionAsyncCommit,
       )

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -55,6 +55,7 @@ import com.daml.platform.store.entries.{
 import scalaz.syntax.tag._
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -1023,6 +1024,7 @@ private[platform] object JdbcLedgerDao {
         serverRole,
         jdbcUrl,
         maxConnections,
+        250.millis,
         metrics,
         jdbcAsyncCommits,
       )

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/persistence/PostgresIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/persistence/PostgresIT.scala
@@ -33,6 +33,7 @@ class PostgresIT extends AsyncWordSpec with Matchers with PostgresAroundAll with
           ServerRole.Testing(getClass),
           postgresDatabase.url,
           maxConnections = 4,
+          3.seconds,
           new MetricRegistry,
         )
         .acquire()(ResourceContext(DirectExecutionContext))


### PR DESCRIPTION
The default timeout of 250ms turned out to be problematic for Canton.
Therefore, I'm moving the hard coded 250ms up such that we can override
it from within the Canton code. Other users shouldn't be affected by the
change. Therefore, this is just an internal code change.

Additionally, I've added two new performance targets for the performance
envelope test.

Related to https://github.com/DACH-NY/canton/issues/4996

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
