### PR TITLE
Tracker retention duration parameter [DPP-191]

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -7,6 +7,7 @@ import java.io.File
 import java.nio.file.Path
 import java.time.Duration
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 import com.daml.caching
 import com.daml.ledger.api.tls.TlsConfiguration
@@ -17,6 +18,8 @@ import com.daml.platform.configuration.Readers._
 import com.daml.platform.configuration.{IndexConfiguration, MetricsReporter}
 import com.daml.ports.Port
 import scopt.OptionParser
+
+import scala.concurrent.duration.FiniteDuration
 
 final case class Config[Extra](
     mode: Mode,
@@ -32,6 +35,7 @@ final case class Config[Extra](
     seeding: Seeding,
     metricsReporter: Option[MetricsReporter],
     metricsReportingInterval: Duration,
+    trackerRetentionPeriod: FiniteDuration,
     extra: Extra,
 ) {
   def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): Config[Extra] =
@@ -40,6 +44,7 @@ final case class Config[Extra](
 
 object Config {
   val DefaultPort: Port = Port(6865)
+  val DefaultTrackerRetentionPeriod: FiniteDuration = FiniteDuration(24, TimeUnit.HOURS)
 
   val DefaultMaxInboundMessageSize: Int = 64 * 1024 * 1024
   def createDefault[Extra](extra: Extra): Config[Extra] =
@@ -57,6 +62,7 @@ object Config {
       seeding = Seeding.Strong,
       metricsReporter = None,
       metricsReportingInterval = Duration.ofSeconds(10),
+      trackerRetentionPeriod = DefaultTrackerRetentionPeriod,
       extra = extra,
     )
 
@@ -174,6 +180,15 @@ object Config {
         )
         .action((checksEnabled, config) =>
           config.withTlsConfig(c => c.copy(enableCertRevocationChecking = checksEnabled))
+        )
+
+      opt[Duration]("tracker-retention-period")
+        .optional()
+        .action((value, config) =>
+          config.copy(trackerRetentionPeriod = FiniteDuration(value.getSeconds, TimeUnit.SECONDS))
+        )
+        .text(
+          "For how long the command service will keep an active command tracker for a given party. A longer retention period allows to not instantiate a new tracker for a party that seldom acts. A shorter retention period allows to quickly remove unused trackers. Default is 24 hours."
         )
 
       arg[File]("<archive>...")

--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/LedgerFactory.scala
@@ -69,7 +69,8 @@ trait ConfigProvider[ExtraConfig] {
 
     CommandConfiguration.default.copy(
       maxCommandsInFlight =
-        participantConfig.maxCommandsInFlight.getOrElse(defaultMaxCommandsInFlight)
+        participantConfig.maxCommandsInFlight.getOrElse(defaultMaxCommandsInFlight),
+      retentionPeriod = config.trackerRetentionPeriod,
     )
   }
 

--- a/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
+++ b/ledger/participant-state/kvutils/app/src/test/scala/com/daml/ledger/participant/state/kvutils/app/ConfigSpec.scala
@@ -3,11 +3,15 @@
 
 package com.daml.ledger.participant.state.kvutils.app
 
+import java.util.concurrent.TimeUnit
+
 import com.daml.ledger.participant.state.v1.ParticipantId
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scopt.OptionParser
+
+import scala.concurrent.duration.FiniteDuration
 
 final class ConfigSpec extends AnyFlatSpec with Matchers with OptionValues {
 
@@ -21,6 +25,7 @@ final class ConfigSpec extends AnyFlatSpec with Matchers with OptionValues {
   private val jdbcEnvVar = "JDBC_ENV_VAR"
 
   private val certRevocationChecking = "--cert-revocation-checking"
+  private val trackerRetentionPeriod = "--tracker-retention-period"
 
   object TestJdbcValues {
     val jdbcFromCli = "command-line-jdbc"
@@ -91,6 +96,21 @@ final class ConfigSpec extends AnyFlatSpec with Matchers with OptionValues {
         .getOrElse(parsingFailure())
 
     config.tlsConfig.value.enableCertRevocationChecking should be(true)
+  }
+
+  it should "get the tracker retention period when provided" in {
+    val periodStringRepresentation = "P0DT1H2M3S"
+    val expectedPeriod =
+      FiniteDuration(1, TimeUnit.HOURS) +
+        FiniteDuration(2, TimeUnit.MINUTES) +
+        FiniteDuration(3, TimeUnit.SECONDS)
+    val config =
+      configParser(parameters =
+        minimalValidOptions ++ List(trackerRetentionPeriod, periodStringRepresentation)
+      )
+        .getOrElse(parsingFailure())
+
+    config.trackerRetentionPeriod should be(expectedPeriod)
   }
 
   private def parsingFailure(): Nothing = fail("Config parsing failed.")


### PR DESCRIPTION
- New --tracker-retention-period parameter for kvutils CLI to be able to customize for how long the command service will keep an active command tracker for a given party.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
