### PR TITLE
Sandbox-classic: revert back the change of default contract ID seeding

### DIFF
--- a/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
+++ b/language-support/java/codegen/src/ledger-tests/scala/com/digitalasset/TestUtil.scala
@@ -48,7 +48,6 @@ object TestUtil {
   )(implicit resourceContext: ResourceContext): Future[Assertion] = {
     val config = sandbox.DefaultConfig.copy(
       port = Port.Dynamic,
-      seeding = None,
       damlPackages = List(testDalf),
       ledgerIdMode = LedgerIdMode.Static(LedgerId(LedgerID)),
       timeProviderType = Some(TimeProviderType.WallClock),

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/package.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/package.scala
@@ -3,7 +3,6 @@
 
 package com.daml.platform
 
-import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.daml.platform.configuration.LedgerConfiguration
 import com.daml.platform.sandbox.config.{LedgerName, SandboxConfig}
 
@@ -12,7 +11,7 @@ package object sandbox {
   private[sandbox] val Name = LedgerName("Sandbox")
 
   val DefaultConfig: SandboxConfig = SandboxConfig.defaultConfig.copy(
-    seeding = Some(Seeding.Weak),
+    seeding = None,
     ledgerConfig = LedgerConfiguration.defaultLedgerBackedIndex,
   )
 

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/EngineModeIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/EngineModeIT.scala
@@ -15,6 +15,7 @@ import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands.{Command, Commands, CreateCommand}
 import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value}
+import com.daml.ledger.participant.state.v1.SeedService.Seeding
 import com.daml.ledger.resources.TestResourceContext
 import com.daml.lf.language.LanguageVersion
 import com.daml.platform.apiserver.services.GrpcClientResource
@@ -53,14 +54,6 @@ class EngineModeIT
       commandClient = ledger.client.configuration.CommandClientConfiguration.default,
       sslContext = None,
       token = None,
-    )
-
-  private[this] def buildServer(mode: SandboxConfig.EngineMode) =
-    SandboxServer.owner(
-      DefaultConfig.copy(
-        port = Port.Dynamic,
-        engineMode = mode,
-      )
     )
 
   private[this] def buildRequest(pkgId: String, ledgerId: LedgerId) = {
@@ -116,6 +109,15 @@ class EngineModeIT
 
     import SandboxConfig.EngineMode
     import EngineMode._
+
+    def buildServer(mode: SandboxConfig.EngineMode) =
+      SandboxServer.owner(
+        DefaultConfig.copy(
+          port = Port.Dynamic,
+          engineMode = mode,
+          seeding = Some(Seeding.Weak),
+        )
+      )
 
     def load(langVersion: LanguageVersion, mode: EngineMode) =
       buildServer(mode).use(


### PR DESCRIPTION
We revert the change of default contract ID seeding that was
introduced in #7945.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
