### PR TITLE
1.9.x, KV fix: add exercise key to inputs (back-ports #8538) [KVL-797]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/InputsAndEffects.scala
@@ -71,6 +71,16 @@ private[kvutils] object InputsAndEffects {
       if (!localContract.isDefinedAt(coid))
         inputs += contractIdToStateKey(coid)
 
+    def addKeyInput(
+        templateId: Identifier,
+        keyWithMaintainers: Node.KeyWithMaintainers[Value[ContractId]],
+    ): Unit = {
+      inputs += globalKeyToStateKey(
+        GlobalKey(templateId, forceNoContractIds(keyWithMaintainers.key))
+      )
+      ()
+    }
+
     def partyInputs(parties: Set[Party]): List[DamlStateKey] = {
       import Party.ordering
       parties.toList.sorted.map(partyStateKey)
@@ -81,28 +91,25 @@ private[kvutils] object InputsAndEffects {
         case fetch: Node.NodeFetch[Value.ContractId] =>
           addContractInput(fetch.coid)
           fetch.key.foreach { keyWithMaintainers =>
-            inputs += globalKeyToStateKey(
-              GlobalKey(fetch.templateId, forceNoContractIds(keyWithMaintainers.key))
-            )
+            addKeyInput(fetch.templateId, keyWithMaintainers)
           }
 
         case create: Node.NodeCreate[Value.ContractId] =>
           create.key.foreach { keyWithMaintainers =>
-            inputs += globalKeyToStateKey(
-              GlobalKey(create.coinst.template, forceNoContractIds(keyWithMaintainers.key))
-            )
+            addKeyInput(create.coinst.template, keyWithMaintainers)
           }
 
         case exe: Node.NodeExercises[NodeId, Value.ContractId] =>
           addContractInput(exe.targetCoid)
+          exe.key.foreach { keyWithMaintainers =>
+            addKeyInput(exe.templateId, keyWithMaintainers)
+          }
 
         case lookup: Node.NodeLookupByKey[Value.ContractId] =>
           // We need both the contract key state and the contract state. The latter is used to verify
           // that the submitter can access the contract.
           lookup.result.foreach(addContractInput)
-          inputs += globalKeyToStateKey(
-            GlobalKey(lookup.templateId, forceNoContractIds(lookup.key.key))
-          )
+          addKeyInput(lookup.templateId, lookup.key)
       }
 
       inputs ++= partyInputs(node.informeesOfNode)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -31,7 +31,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.collection.compat.immutable.LazyList
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
 

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -30,6 +30,9 @@ import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.collection.compat.immutable.LazyList
+import scala.collection.JavaConverters._
+
 class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
   import KVTest._
@@ -77,6 +80,40 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
 
     val p0 = mkParticipantId(0)
     val p1 = mkParticipantId(1)
+
+    "add the key of an exercised contract as a submission input" in KVTest.runTestWithSimplePackage(
+      alice,
+      bob,
+      eve,
+    ) { simplePackage =>
+      val seed0 = seed(0)
+      val seed1 = seed(1)
+      for {
+        transaction1 <- runSimpleCommand(alice, seed0, simpleCreateCmd(simplePackage))
+        result <- submitTransaction(
+          submitter = alice,
+          transaction = transaction1,
+          submissionSeed = seed0,
+        )
+        (entryId, logEntry) = result
+        contractId = contractIdOfCreateTransaction(
+          KeyValueConsumption.logEntryToUpdate(entryId, logEntry)
+        )
+
+        transaction2 <- runSimpleCommand(
+          alice,
+          seed1,
+          simplePackage.simpleExerciseConsumeCmd(contractId),
+        )
+        submission <- prepareTransactionSubmission(
+          submitter = alice,
+          transaction = transaction2,
+          submissionSeed = seed1,
+        )
+      } yield {
+        submission.getInputDamlStateList.asScala.filter(_.hasContractKey) should not be empty
+      }
+    }
 
     "be able to submit a transaction" in KVTest.runTestWithSimplePackage(alice, bob, eve) {
       simplePackage =>
@@ -265,7 +302,7 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
       val seeds =
         Stream
           .from(0)
-          .map(i => crypto.Hash.hashPrivateKey(this.getClass.getName + i.toString))
+          .map(i => seed(i))
       for {
         transaction1 <- runSimpleCommand(alice, seeds.head, simpleCreateCmd(simplePackage))
         result <- submitTransaction(
@@ -439,7 +476,7 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
       val seeds =
         Stream
           .from(0)
-          .map(i => crypto.Hash.hashPrivateKey(this.getClass.getName + i.toString))
+          .map(i => seed(i))
 
       val simpleCreateAndExerciseCmd =
         simplePackage.simpleCreateAndExerciseConsumeCmd(mkSimpleCreateArg(simplePackage))
@@ -507,6 +544,10 @@ class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {
         create.coid
       }
     }
+
+  private def seed(i: Int) = {
+    crypto.Hash.hashPrivateKey(this.getClass.getName + i.toString)
+  }
 
   private def hash(s: String) = crypto.Hash.hashPrivateKey(s)
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/KVUtilsTransactionSpec.scala
@@ -30,7 +30,6 @@ import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.collection.compat.immutable.LazyList
 import scala.jdk.CollectionConverters._
 
 class KVUtilsTransactionSpec extends AnyWordSpec with Matchers with Inside {


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
