### PR TITLE
Add choice observers in the ledger model.

### DIFF
--- a/docs/source/concepts/ledger-model/ledger-daml.rst
+++ b/docs/source/concepts/ledger-model/ledger-daml.rst
@@ -10,7 +10,7 @@ As described in preceeding sections, both the integrity and privacy notions depe
 a contract model, and such a model must specify:
 
 #. a set of allowed actions on the contracts, and
-#. the signatories, observers, and
+#. the signatories, contract observers, and
 #. an optional agreement text associated with each contract, and
 #. the optional key associated with each contract and its maintainers.
 
@@ -33,6 +33,7 @@ Intuitively, the allowed actions are:
 
    #. The actors match the controllers of the choice.
       That is, the controllers define the :ref:`required authorizers <da-ledgers-required-authorizers>` of the choice.
+   #. The choice observers match the observers annotated in the choice.
    #. The exercise kind matches.
    #. All assertions in the update block hold for the given choice arguments.
    #. Create, exercise, fetch and key statements in the update block are represented
@@ -59,7 +60,7 @@ is a triple of:
 #. the template arguments
 
 The signatories of a Daml contract are derived from the template arguments and the explicit signatory annotations on the contract template.
-The observers are also derived from the template arguments and include:
+The contract observers are also derived from the template arguments and include:
 
 1. the observers as explicitly annotated on the template
 2. all controllers `c` of every choice defined using the syntax :code:`controller c can...` (as opposed to the syntax :code:`choice ... controller c`)

--- a/docs/source/concepts/ledger-model/ledger-privacy.rst
+++ b/docs/source/concepts/ledger-model/ledger-privacy.rst
@@ -30,9 +30,9 @@ For example, Alice should be an observer of the `PaintOffer`, such that she is m
 Signatories are already determined by the contract model discussed so far.
 The full **contract model** additionally specifies the **contract observers** on each contract.
 A **stakeholder** of a contract (according to a given contract model) is then either a signatory or a contract observer on the contract.
-Note that in Daml, as detailed :ref:`later <da-model-daml>`, controllers specified using simple syntax are automatically made observers whenever possible.
+Note that in Daml, as detailed :ref:`later <da-model-daml>`, controllers specified using simple syntax are automatically made contract observers whenever possible.
 
-In the graphical representation of the paint offer acceptance below, observers who are not signatories are indicated by an underline.
+In the graphical representation of the paint offer acceptance below, contract observers who are not signatories are indicated by an underline.
 
 .. https://www.lucidchart.com/documents/edit/ea40a651-a2e0-4365-ae7d-4cee8cd07071/0
 .. image:: ./images/stakeholders-paint-offer.svg
@@ -255,7 +255,7 @@ the painter:
 In the example, the context is provided by consuming a `ShowIou` contract on which the painter is a stakeholder.
 This now requires an additional contract type, compared to the original paint offer example.
 An alternative approach to enable this workflow, without increasing the number of contracts required, is to
-replace the original `Iou` contract by one on which the painter is an observer.
+replace the original `Iou` contract by one on which the painter is a contract observer.
 This would require extending the contract model with a (consuming) exercise action on the `Iou` that creates a new
 `Iou`, with observers of Alice's choice.
 In addition to the different number of commits, the two approaches differ in one more aspect.

--- a/docs/source/concepts/ledger-model/ledger-privacy.rst
+++ b/docs/source/concepts/ledger-model/ledger-privacy.rst
@@ -99,10 +99,12 @@ This motivates the following definition: a party `p` is an **informee** of an ac
 
   * `A` is a **Create** on a contract `c` and `p` is a stakeholder of `c`.
 
-  * `A` is a consuming **Exercise** on a contract `c`, and `p` is a stakeholder of `c`, an actor on `A`, or a choice observer on `A`.
+  * `A` is a consuming **Exercise** on a contract `c`, and `p` is a stakeholder of `c` or an actor on `A`.
     Note that a Daml "flexible controller" :ref:`can be an exercise actor without being a contract stakeholder <da-model-daml>`.
 
-  * `A` is a non-consuming **Exercise** on a contract `c`, and `p` is a signatory of `c`, an actor on `A`, or a choice observer on `A`.
+  * `A` is a non-consuming **Exercise** on a contract `c`, and `p` is a signatory of `c` or an actor on `A`.
+
+  * `A` is an **Exercise** action and `p` is a choice observer on `A`.
 
   * `A` is a **Fetch** on a contract `c`, and `p` is a signatory of `c` or an actor on `A`.
 

--- a/docs/source/concepts/ledger-model/ledger-privacy.rst
+++ b/docs/source/concepts/ledger-model/ledger-privacy.rst
@@ -28,9 +28,8 @@ Generalizing this, **observers** are parties who might not be bound by the contr
 For example, Alice should be an observer of the `PaintOffer`, such that she is made aware that the offer exists.
 
 Signatories are already determined by the contract model discussed so far.
-The full **contract model** additionally specifies the observers on each contract.
-A **stakeholder** of a contract (according to a given
-contract model) is then either a signatory or an observer on the contract.
+The full **contract model** additionally specifies the **contract observers** on each contract.
+A **stakeholder** of a contract (according to a given contract model) is then either a signatory or a contract observer on the contract.
 Note that in Daml, as detailed :ref:`later <da-model-daml>`, controllers specified using simple syntax are automatically made observers whenever possible.
 
 In the graphical representation of the paint offer acceptance below, observers who are not signatories are indicated by an underline.
@@ -40,6 +39,13 @@ In the graphical representation of the paint offer acceptance below, observers w
    :align: center
    :width: 60%
 
+Choice Observers
+++++++++++++++++
+
+In addition to contract observers, we also have **choice observers** on individual contract choices.
+Choice observers get to see a specific exercise on a contract, and to view its consequences.
+Choice observers are not considered stakeholders of the contract, they only affect the set of informees
+on an action, for the purposes of projection (see below).
 
 .. _da-model-projections:
 
@@ -85,18 +91,18 @@ for, providing privacy to `A` and `P` with respect to the bank.
 
 .. _def-informee:
 
-As a design choice, Daml Ledgers show to observers on a contract only the
+As a design choice, Daml Ledgers show to contract observers only the
 :ref:`state changing <def-contract-state>` actions on the contract.
-More precisely, **Fetch** and non-consuming **Exercise** actions are not shown to the observers - except when they are
-the actors of these actions.
+More precisely, **Fetch** and non-consuming **Exercise** actions are not shown to contract observers - except when they are
+also actors or choice observers of these actions.
 This motivates the following definition: a party `p` is an **informee** of an action `A` if one of the following holds:
 
   * `A` is a **Create** on a contract `c` and `p` is a stakeholder of `c`.
 
-  * `A` is a consuming **Exercise** on a contract `c`, and `p` is a stakeholder of `c` or an actor on `A`.
+  * `A` is a consuming **Exercise** on a contract `c`, and `p` is a stakeholder of `c`, an actor on `A`, or a choice observer on `A`.
     Note that a Daml "flexible controller" :ref:`can be an exercise actor without being a contract stakeholder <da-model-daml>`.
 
-  * `A` is a non-consuming **Exercise** on a contract `c`, and `p` is a signatory of `c` or an actor on `A`.
+  * `A` is a non-consuming **Exercise** on a contract `c`, and `p` is a signatory of `c`, an actor on `A`, or a choice observer on `A`.
 
   * `A` is a **Fetch** on a contract `c`, and `p` is a signatory of `c` or an actor on `A`.
 
@@ -192,7 +198,7 @@ However, we demand that *all* maintainers must authorize it.
 This is to prevent spam in the projection of the maintainers.
 If only one maintainer sufficed to authorize a key assertion,
 then a valid ledger could contain **NoSuchKey** `k` assertions where the maintainers of `k` include, apart from the requester, arbitrary other parties.
-Unlike **Create** actions to observers, such assertions are of no value to the other parties.
+Unlike **Create** actions to contract observers, such assertions are of no value to the other parties.
 Since processing such assertions may be expensive, they can be considered spam.
 Requiring all maintainers to authorize a **NoSuchKey** assertion avoids the problem.
 

--- a/docs/source/concepts/ledger-model/ledger-privacy.rst
+++ b/docs/source/concepts/ledger-model/ledger-privacy.rst
@@ -42,7 +42,7 @@ In the graphical representation of the paint offer acceptance below, contract ob
 Choice Observers
 ++++++++++++++++
 
-In addition to contract observers, we also have **choice observers** on individual contract choices.
+In addition to contract observers, the contract model can also specify **choice observers** on individual **Exercise** actions.
 Choice observers get to see a specific exercise on a contract, and to view its consequences.
 Choice observers are not considered stakeholders of the contract, they only affect the set of informees
 on an action, for the purposes of projection (see below).


### PR DESCRIPTION
To keep the distinction between "observer" and "choice observer"
clear I'm trying to always refer to the former as "contract observer".

The section on divulgence should probably be reworked to favor choice
observers, at some point, but I'm not sure how to do that.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
