### PR TITLE
Bump Maven timeouts and retries

### DIFF
--- a/release/src/Upload.hs
+++ b/release/src/Upload.hs
@@ -371,9 +371,9 @@ logStatusRetry shouldRetry _ status =
     else
         $logDebug ("Aborting staging repository check after " <> (tshow $ rsCumulativeDelay status) <> "µs.")
 
--- Retry for 10 minutes total, doubling delay starting with 200ms.
+-- Retry for 5 minutes total, doubling delay starting with 20ms.
 uploadRetryPolicy :: RetryPolicy
-uploadRetryPolicy = limitRetriesByCumulativeDelay (5 * 60 * 1000 * 1000) (exponentialBackoff (200 * 100))
+uploadRetryPolicy = limitRetriesByCumulativeDelay (5 * 60 * 1000 * 1000) (exponentialBackoff (20 * 100f))
 
 -- The status of the staging repository can take a number of minutes to change it's
 -- status to closed.

--- a/release/src/Upload.hs
+++ b/release/src/Upload.hs
@@ -373,7 +373,7 @@ logStatusRetry shouldRetry _ status =
 
 -- Retry for 5 minutes total, doubling delay starting with 20ms.
 uploadRetryPolicy :: RetryPolicy
-uploadRetryPolicy = limitRetriesByCumulativeDelay (5 * 60 * 1000 * 1000) (exponentialBackoff (20 * 100f))
+uploadRetryPolicy = limitRetriesByCumulativeDelay (5 * 60 * 1000 * 1000) (exponentialBackoff (20 * 1000))
 
 -- The status of the staging repository can take a number of minutes to change it's
 -- status to closed.

--- a/release/src/Upload.hs
+++ b/release/src/Upload.hs
@@ -62,8 +62,8 @@ uploadToMavenCentral MavenUploadConfig{..} releaseDir artifacts = do
     -- Note: TLS verification settings switchable by MavenUpload settings
     let managerSettings = if getAllowUnsecureTls mucAllowUnsecureTls then noVerifyTlsManagerSettings else tlsManagerSettings
 
-    -- Create HTTP Connection manager with 2min response timeout as the OSSRH can be slow...
-    manager <- liftIO $ newManager managerSettings { managerResponseTimeout = responseTimeoutMicro (120 * 1000 * 1000) }
+    -- Create HTTP Connection manager with 5min response timeout as the OSSRH can be slow...
+    manager <- liftIO $ newManager managerSettings { managerResponseTimeout = responseTimeoutMicro (5 * 60 * 1000 * 1000) }
 
     parsedUrlRequest <- parseUrlThrow $ T.unpack mucUrl -- Note: Will throw exception on non-2XX responses
     let baseRequest = setRequestMethod "PUT" $ setRequestBasicAuth (encodeUtf8 mucUser) (encodeUtf8 mucPassword) parsedUrlRequest
@@ -371,8 +371,9 @@ logStatusRetry shouldRetry _ status =
     else
         $logDebug ("Aborting staging repository check after " <> (tshow $ rsCumulativeDelay status) <> "µs.")
 
+-- Retry for 10 minutes total, doubling delay starting with 200ms.
 uploadRetryPolicy :: RetryPolicy
-uploadRetryPolicy = limitRetriesByCumulativeDelay (60 * 1000 * 1000) (exponentialBackoff (200 * 100))
+uploadRetryPolicy = limitRetriesByCumulativeDelay (5 * 60 * 1000 * 1000) (exponentialBackoff (200 * 100))
 
 -- The status of the staging repository can take a number of minutes to change it's
 -- status to closed.


### PR DESCRIPTION
Chosen fairly arbitrarily, I don’t have a good idea what sensible
values are but given that we keep running into issues the current ones
are apparently too low.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
