### PR TITLE
Add buffer to speed up transaction streaming

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
@@ -5,6 +5,7 @@ package com.daml.platform.store.dao.events
 
 import java.sql.Connection
 
+import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Source
 import akka.{Done, NotUsed}
 import com.daml
@@ -49,6 +50,10 @@ private[dao] final class TransactionsReader(
   private val sqlFunctions = SqlFunctions(dbType)
 
   private val logger = ContextualizedLogger.get(this.getClass)
+
+  // TransactionReader adds an Akka stream buffer at the end of all streaming queries.
+  // This significantly improves the performance of the transaction service.
+  private val outputStreamBufferSize = 128
 
   private def offsetFor(response: GetTransactionsResponse): Offset =
     ApiOffset.assertFromString(response.transactions.head.offset)
@@ -115,6 +120,7 @@ private[dao] final class TransactionsReader(
         val response = EventsTable.Entry.toGetTransactionsResponse(events)
         response.map(r => offsetFor(r) -> r)
       }
+      .buffer(outputStreamBufferSize, OverflowStrategy.backpressure)
       .wireTap(_ match {
         case (_, response) =>
           response.transactions.foreach(txn =>
@@ -201,6 +207,7 @@ private[dao] final class TransactionsReader(
         val response = EventsTable.Entry.toGetTransactionTreesResponse(events)
         response.map(r => offsetFor(r) -> r)
       }
+      .buffer(outputStreamBufferSize, OverflowStrategy.backpressure)
       .wireTap(_ match {
         case (_, response) =>
           response.transactions.foreach(txn =>
@@ -280,6 +287,7 @@ private[dao] final class TransactionsReader(
 
     groupContiguous(events)(by = _.transactionId)
       .mapConcat(EventsTable.Entry.toGetActiveContractsResponse)
+      .buffer(outputStreamBufferSize, OverflowStrategy.backpressure)
       .wireTap(response => {
         span.addEvent(
           com.daml.metrics.Event("contract", Map((SpanAttribute.Offset.key, response.offset)))

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/package.scala
@@ -3,6 +3,7 @@
 
 package com.daml.platform.store.dao
 
+import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Source
 import anorm.{BatchSql, NamedParameter}
 import com.daml.lf.transaction.Node.KeyWithMaintainers
@@ -74,6 +75,7 @@ package object events {
       .map(_._1)
       .fold(Vector.empty[A])(_ :+ _)
       .concatSubstreams
+      .buffer(128, OverflowStrategy.backpressure)
 
   // Dispatches the call to either function based on the cardinality of the input
   // This is mostly designed to route requests to queries specialized for single/multi-party subs

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/package.scala
@@ -3,7 +3,6 @@
 
 package com.daml.platform.store.dao
 
-import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Source
 import anorm.{BatchSql, NamedParameter}
 import com.daml.lf.transaction.Node.KeyWithMaintainers
@@ -75,7 +74,6 @@ package object events {
       .map(_._1)
       .fold(Vector.empty[A])(_ :+ _)
       .concatSubstreams
-      .buffer(128, OverflowStrategy.backpressure)
 
   // Dispatches the call to either function based on the cardinality of the input
   // This is mostly designed to route requests to queries specialized for single/multi-party subs


### PR DESCRIPTION
This PR fixes an issue that was causing the transaction service to become almost twice as slow. I still don't understand what exactly is going on, but this small PR restores the original performance. 

## Changelog

```
CHANGELOG_BEGIN
- [Ledger API Server] Fixed an issue that was causing a slowdown of the
  transaction service.
CHANGELOG_END
```

## Measuring the impact

Method:
- Generate an index database with huntsman (many thanks to Martino)
- Build ledger-on-memory from commit 9ed787cb
- Run ledger-on-memory in ledger-api-only mode, connect to the existing index database
- Run spider-mock to measure the speed of the transaction service
- Repeat with ledger-on-memory where the out-of-order fix was reverted

## Results

Reading 17009 transactions took:
```
mergeSubstreams():                 18.602 secs (before the out-of-order fix)
concatSubstreams():                29.007 secs (after the out-of-order fix)
statefulMapConcat():               28.656 secs (first attempt: code without substreams)
statefulMapConcat() + 2x buffer(): 18.767 secs (second attempt: add buffers)
concatSubstreams() + buffer():     18.981 secs (third attempt: smallest change)
```

Code for the `statefulMapConcat` versions: 
```
source
  .map(Some(_))
  .concat(Source.single(None))
  .statefulMapConcat(() => {
    var previousSegmentKey: K = null.asInstanceOf[K]
    val builder = new VectorBuilder[A]
    entryO => {
      entryO match {
        case Some(entry) =>
          val keyForEntry = by(entry)
          if (keyForEntry != previousSegmentKey) {
            previousSegmentKey = keyForEntry
            val result = builder.result()
            builder.clear()
            builder += entry
            List(result)
          } else {
            builder += entry
            List.empty
          }
        case None =>
          List(builder.result())
      }
    }
  })
```