### PR TITLE
Fixed a flaky RecoveringIndexerSpec test case [DPP-197]

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/indexer/RecoveringIndexerSpec.scala
@@ -111,7 +111,8 @@ final class RecoveringIndexerSpec
       val resource = recoveringIndexer.start(() => testIndexer.subscribe())
       resource.asFuture
         .map { complete =>
-          readLog() should contain theSameElementsInOrderAs Seq(
+          // at this point the read log should at least contain logs informing about a successful indexer server startup
+          readLog().take(2) should contain theSameElementsInOrderAs Seq(
             Level.INFO -> "Starting Indexer Server",
             Level.INFO -> "Started Indexer Server",
           )


### PR DESCRIPTION
The `"wait until the subscription completes"` test case of `RecoveringIndexerSpec` is flaky.
The failure is:
```
Vector((INFO,Starting Indexer Server), (INFO,Started Indexer Server), (INFO,Successfully finished processing state updates)) did not contain the same elements in the same (iterated) order as List((INFO,Starting Indexer Server), (INFO,Started Indexer Server)) (RecoveringIndexerSpec.scala:114)
```

This means that the indexer may be progressing faster than the test case expects - it's not only able to start the indexer server but also to process the subscription.

I propose the simplest solution for this which (as far as I understand) doesn't weaken the test case logic.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
