### PR TITLE
Improve browser compatbility of auth middleware

### DIFF
--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -84,7 +84,9 @@ object Config {
 
       opt[Boolean]("cookie-secure")
         .action((x, c) => c.copy(cookieSecure = x))
-        .text("Enable the Secure attribute on the cookie that stores the token.")
+        .text(
+          "Enable the Secure attribute on the cookie that stores the token. Defaults to true. Only disable this for testing and development purposes."
+        )
 
       opt[Long]("login-request-timeout")
         .action((x, c) => c.copy(loginTimeout = FiniteDuration(x, duration.SECONDS)))

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -20,6 +20,7 @@ case class Config(
     callbackUri: Option[Uri],
     maxLoginRequests: Int,
     loginTimeout: FiniteDuration,
+    cookieSecure: Boolean,
     // OAuth2 server endpoints
     oauthAuth: Uri,
     oauthToken: Uri,
@@ -35,6 +36,7 @@ case class Config(
 )
 
 object Config {
+  val DefaultCookieSecure: Boolean = true
   val DefaultMaxLoginRequests: Int = 100
   val DefaultLoginTimeout: FiniteDuration = FiniteDuration(5, duration.MINUTES)
 
@@ -44,6 +46,7 @@ object Config {
       callbackUri = None,
       maxLoginRequests = DefaultMaxLoginRequests,
       loginTimeout = DefaultLoginTimeout,
+      cookieSecure = DefaultCookieSecure,
       oauthAuth = null,
       oauthToken = null,
       oauthAuthTemplate = None,
@@ -78,6 +81,10 @@ object Config {
         .text(
           "Maximum number of simultaneously pending login requests. Requests will be denied when exceeded until earlier requests have been completed or timed out."
         )
+
+      opt[Boolean]("cookie-secure")
+        .action((x, c) => c.copy(cookieSecure = x))
+        .text("Enable the Secure attribute on the cookie that stores the token.")
 
       opt[Long]("login-request-timeout")
         .action((x, c) => c.copy(loginTimeout = FiniteDuration(x, duration.SECONDS)))

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
@@ -200,7 +200,7 @@ class Server(config: Config) extends StrictLogging {
                           value = token.toCookieValue,
                           path = Some("/"),
                           maxAge = token.expiresIn.map(_.toLong),
-                          secure = true,
+                          secure = config.cookieSecure,
                           httpOnly = true,
                         )
                       ) {

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -90,6 +90,7 @@ trait TestFixture
             callbackUri = middlewareCallbackUri,
             maxLoginRequests = maxMiddlewareLogins,
             loginTimeout = Config.DefaultLoginTimeout,
+            cookieSecure = Config.DefaultCookieSecure,
             oauthAuth = serverUri.withPath(Uri.Path./("authorize")),
             oauthToken = serverUri.withPath(Uri.Path./("token")),
             oauthAuthTemplate = None,

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -214,6 +214,7 @@ trait AuthMiddlewareFixture
             callbackUri = None,
             maxLoginRequests = MiddlewareConfig.DefaultMaxLoginRequests,
             loginTimeout = MiddlewareConfig.DefaultLoginTimeout,
+            cookieSecure = MiddlewareConfig.DefaultCookieSecure,
             oauthAuth = uri.withPath(Path./("authorize")),
             oauthToken = uri.withPath(Path./("token")),
             oauthAuthTemplate = None,


### PR DESCRIPTION
- Includes the authentication challenge in response body
  Some browsers make it difficult to access the `WWW-Authenticate` response header from Javascript. For example, Firefox 84.0.2 (64-bit) on Linux does not expose the `WWW-Authenticate` header in the result of the `fetch` function, independent of the server's access control headers. In that case the header is only accessible through the `XMLHttpRequest` API, which is more cumbersome to use.

  This adds the challenge to the response body in JSON format as well to avoid exposing users to any such browser related issues.
- Make the `Secure` `Set-Cookie` attribute configurable
  Since [Chrome 80][1] `Set-Cookie` with the `Secure` attribute enabled is reject for connections that don't use `https`. This includes `localhost`. Firefox, at least as of version 84.0.2, allows such cookies on `localhost`.

  This adds a command-line flag to the authorization middleware to make the value of the `Secure` attribute configurable. This way it can be disabled for development purposes.

[1]: https://blog.chromium.org/2019/10/developers-get-ready-for-new.html



### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
