### PR TITLE
Add choice observers in LF spec.

### DIFF
--- a/compiler/damlc/tests/daml-test-files/SemanticsEvalOrderSince1_11.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsEvalOrderSince1_11.daml
@@ -1,0 +1,41 @@
+
+-- | Test operational semantics for 1.11 features.
+--
+-- @SINCE-LF 1.11
+module SemanticsEvalOrderSince1_11 where
+
+-- @ERROR EvUpdExercWithoutActorsErr OK
+template T_EvUpdExercWithoutActorsErr
+    with
+        p : Party
+    where
+        signatory p
+        choice C_EvUpdExercWithoutActorsErr : ()
+          observer error @Party "EvUpdExercWithoutActorsErr failed at observers"
+          controller error @Party "EvUpdExercWithoutActorsErr OK"
+          do error "EvUpdExercWithoutActorsErr failed at body"
+
+evUpdExercWithoutActorsErr = scenario do
+    p <- getParty "Alice"
+    submit p do
+        t <- create (T_EvUpdExercWithoutActorsErr p)
+        exercise t C_EvUpdExercWithoutActorsErr
+        abort "EvUpdExercWithoutActorsErr failed after exercise"
+
+-- @ERROR EvUpdExercObserversErr OK
+template T_EvUpdExercObserversErr
+    with
+        p : Party
+    where
+        signatory p
+        choice C_EvUpdExercObserversErr : ()
+          observer error @Party "EvUpdExercObserversErr OK"
+          controller p
+          do error "EvUpdExercObserversErr failed at body"
+
+evUpdExercObserversErr = scenario do
+    p <- getParty "Alice"
+    submit p do
+        t <- create (T_EvUpdExercObserversErr p)
+        exercise t C_EvUpdExercObserversErr
+        abort "EvUpdExercObserversErr failed after exercise"

--- a/compiler/damlc/tests/daml-test-files/SemanticsValueSince1_7.daml
+++ b/compiler/damlc/tests/daml-test-files/SemanticsValueSince1_7.daml
@@ -2,7 +2,7 @@
 -- | Tests new "value cases" available since Daml 1.7
 --
 -- @SINCE-LF 1.7
-module SemanticsValueSince17 where
+module SemanticsValueSince1_7 where
 
 main = scenario do
     let x : forall (n:GHC.Types.Nat). Numeric n

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -685,13 +685,8 @@ available for usage::
       ::= 'no_key'
        |  'key' τ eₖ eₘ
 
-  Template choice observers
-    ChObs
-      ::= 'no_observers'
-        | 'observers' eₒ
-
   Template choice definition
-    ChDef ::= 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ e
+    ChDef ::= 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ e
                                                     -- ChDef
 
   Definitions
@@ -1552,20 +1547,9 @@ for the ``DefTemplate`` rule). ::
     ⊢ₛ  σ
     y : 'ContractId' Mod:T · z : τ · x : Mod:T  ⊢  e  :  'Update' σ
     z : τ · x : Mod:T  ⊢  eₚ  :  'List' 'Party'
-    z : τ · x : Mod:T  ⊢  ChObs
+    z : τ · x : Mod:T  ⊢  eₒ  :  'List' 'Party'
   ——————————————————————————————————————————————————————————————— ChDef
-    x : Mod:T  ⊢  'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ e
-
-                                   ┌───────────┐
-  Well-formed choice observers     │ Γ ⊢ ChObs │
-                                   └───────────┘
-
-  —————————————————————————— ChObsNone
-    Γ  ⊢  'no_observers'
-
-    Γ  ⊢  e : 'List' 'Party'
-  —————————————————————————— ChObsSome
-    Γ  ⊢  'observers' e
+    x : Mod:T  ⊢  'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ e
 
             ┌────────────┐
   Valid key │ ⊢ₖ e  :  τ │
@@ -2677,18 +2661,6 @@ exact output.
     —————————————————————————————————————————————————————————————————————— EvExpScenarioGetParty
       'sget_party' e  ⇓  Ok ('sget_party' v)
 
-                                               ┌──────────────┐
-  Big-step evaluation for choice observers     │ ChObs  ⇓  r  │
-                                               └──────────────┘
-
-    —————————————————————————————————————————————————— EvChObsNone
-     'no_observers'  ⇓  Ok ('Nil' @'Party')
-
-     e  ⇓  r
-    —————————————————————————————————————————————————— EvChObsSome
-     'observers' e  ⇓  r
-
-
 Note that the rules are designed such that for every expression, there is at
 most one possible outcome. In other words, results are deterministic. When
 two or more derivations apply for the same expression, they yield the same result. For
@@ -2944,7 +2916,7 @@ as described by the ledger model::
      (Err @'ContractError' v, ε)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'inactive')
      v = 'MAKE_CONTRACT_ERROR' "Exercise on inactive contract"
@@ -2954,7 +2926,7 @@ as described by the ledger model::
      (Err @'ContractError' v, ε)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Err @τ v
@@ -2962,7 +2934,7 @@ as described by the ledger model::
      'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)  ⇓ᵤ  (Err @τ v, ε)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
@@ -2974,24 +2946,24 @@ as described by the ledger model::
      (Err @'ContractError' v, ε)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ …, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ …, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
      v₁ =ₛ vₚ
-     ChObs[x ↦ vₜ, z ↦ v₂]  ⇓  Err @τ v
+     eₒ[x ↦ vₜ, z ↦ v₂]  ⇓  Err @τ v
    —————————————————————————————————————————————————————————————————————— EvUpdExercObserversErr
      'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)
        ⇓ᵤ
      (Err @τ v, ε)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
      v₁ =ₛ vₚ
-     ChObs[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
+     eₒ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
      eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Err @τ v
    —————————————————————————————————————————————————————————————————————— EvUpdExercBodyEvalErr
      'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)
@@ -2999,12 +2971,12 @@ as described by the ledger model::
      (Err @τ v, 'iexercise' v₁ (cid, Mod:T, vₜ) ChKind ε)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
      v₁ =ₛ vₚ
-     ChObs[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
+     eₒ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
      eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Ok uₐ
      keys₁ = keys₀ - keys₀⁻¹(cid)
      st₁ = st₀[cid ↦ (Mod:T, vₜ, 'inactive')]
@@ -3015,12 +2987,12 @@ as described by the ledger model::
      (Err @τ v, 'iexercise' v₁ (cid, Mod:T, vₜ) 'consuming' itr)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
      v₁ =ₛ vₚ
-     ChObs[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
+     eₒ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
      eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Ok uₐ
      keys₁ = keys₀ - keys₀⁻¹(cid)
      st₁ = st₀[cid ↦ (Mod:T, vₜ, 'inactive')]
@@ -3031,12 +3003,12 @@ as described by the ledger model::
      Ok (vₐ, 'exercise' v₁ (cid, Mod:T, vₜ) 'consuming' trₐ) ‖ (st₂, keys₂)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' 'non-consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' 'non-consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
      v₁ =ₛ vₚ
-     ChObs[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
+     eₒ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
      eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Ok uₐ
      uₐ ‖ (st₀; keys₀)  ⇓ᵤ  (Err @τ v, itr)
    —————————————————————————————————————————————————————————————————————— EvUpdExercNonConsumErr
@@ -3045,12 +3017,12 @@ as described by the ledger model::
      (Err @τ v, 'iexercise' v₁ (cid, Mod:T, vₜ) 'non-consuming' itr)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' 'non-consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' 'non-consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
      v₁ =ₛ vₚ
-     ChObs[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
+     eₒ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
      eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Ok uₐ
      uₐ ‖ (st₀; keys₀)  ⇓ᵤ  Ok (vₐ, trₐ) ‖ (st₁, keys₁)
    —————————————————————————————————————————————————————————————————————— EvUpdExercNonConsum
@@ -3066,7 +3038,7 @@ as described by the ledger model::
      (Err @'ContractError' v, ε)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₁]  ⇓  Err @τ v
@@ -3074,7 +3046,7 @@ as described by the ledger model::
      'exercise_without_actors' Mod:T.Ch cid v₁ ‖ (st₀, keys₀)  ⇓ᵤ  (Err @τ v, ε)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
+         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ 'observers' eₒ ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')
      eₚ[x ↦ vₜ, z ↦ v₁]  ⇓  Ok vₚ

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -4629,7 +4629,8 @@ the sub-transaction is disclosed.
 
 The deserialization process will reject any Daml-LF 1.8 (or earlier)
 program using the field ``observers`` in the ``TemplateChoice``
-message.
+message. The missing ``observers`` field is interpreted as an
+empty list of observers.
 
 Exception
 .........

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -2999,19 +2999,6 @@ as described by the ledger model::
      (Err @τ v, 'iexercise' v₁ (cid, Mod:T, vₜ) ChKind ε)
 
      'tpl' (x : T)
-         ↦ { 'choices' { …, 'choice' ChKind Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
-     cid ∈ dom(st₀)
-     st₀(cid) = (Mod:T, vₜ, 'active')
-     eₚ[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₚ
-     v₁ =ₛ vₚ
-     ChObs[x ↦ vₜ, z ↦ v₂]  ⇓  Ok vₒ
-     eₐ[x ↦ vₜ, y ↦ cid, z ↦ v₂]  ⇓  Err @τ v
-   —————————————————————————————————————————————————————————————————————— EvUpdExercBodyEvalErr
-     'exercise' Mod:T.Ch cid v₁ v₂ ‖ (st₀, keys₀)
-       ⇓ᵤ
-     (Err @τ v, 'iexercise' v₁ (cid, Mod:T, vₜ) ChKind ε)
-
-     'tpl' (x : T)
          ↦ { 'choices' { …, 'choice' 'consuming' Ch (y : 'ContractId' Mod:T) (z : τ) : σ 'by' eₚ ChObs ↦ eₐ, … }, … }  ∈  〚Ξ〛Mod
      cid ∈ dom(st₀)
      st₀(cid) = (Mod:T, vₜ, 'active')

--- a/daml-lf/spec/daml-lf-1.rst
+++ b/daml-lf/spec/daml-lf-1.rst
@@ -685,7 +685,7 @@ available for usage::
       ::= 'no_key'
        |  'key' τ eₖ eₘ
 
-  Temeplate choice observers
+  Template choice observers
     ChObs
       ::= 'no_observers'
         | 'observers' eₒ


### PR DESCRIPTION
Part of #7709. Adds choice observers to the syntax, type system, and
and operational semantics of LF. Adds a test for the operational
semantics of choice observers.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
