### PR TITLE
faster cleanup on Linux

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -8,15 +8,28 @@ steps:
     # infra/macos/2-common-box/init.sh:echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
     # infra/vsts_agent_linux_startup.sh:echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
     if [ $(df -m . | sed 1d | awk '{print $4}') -lt 30000 ]; then
-        echo "Disk full, cleaning up..."
+        echo "$(date -Is) Disk full, cleaning up..."
         disk_cache="$HOME/.bazel-cache"
         rm -rf "$disk_cache"
-        echo "removed '$disk_cache'"
+        echo "$(date -Is) Removed '$disk_cache'."
         local_cache="$HOME/.cache/bazel"
-        if [ -d "$local_cache" ]; then
-            chmod -R +w "$local_cache"
-            rm -rf "$local_cache"
-            echo "removed '$local_cache'"
+        # This executable does not exist on macOS
+        if [ -f "/usr/local/bin/remount_cache" ]; then
+            echo "$(date -Is) Removing any dangling Bazel server..."
+            for pid in $(lsof "$local_cache" | sed 1d | awk '{print $2}' | sort -u); do
+                kill -s KILL $pid
+            done
+            echo "$(date -Is) Nuking the cache partition..."
+            /usr/local/bin/remount_cache
+            echo "$(date -Is) Done."
+        else
+            # This path does not exist on macOS
+            if [ -d "$local_cache" ]; then
+                echo "$(date -Is) Removing all files under '$local_cache'..."
+                chmod -R +w "$local_cache"
+                rm -rf "$local_cache"
+                echo "$(date -Is) Removed '$local_cache'."
+            fi
         fi
     fi
     df -h .


### PR DESCRIPTION
I have seen the cleanup step taking up to an hour, just to delete the Bazel cache. This is obviously not great.

I've been researching how to do this faster, and it looks like the best approach here is to create a partition for the cache, and just drop it and reformat it when we want to clear it. This is a conceptually simple approach, but it unfortunately requires access to the `mount` command. There are a couple ways to achieve that, but after a bit of research it seems to me that the safest one is to have a setuid-root executable that normal users can call.

So this PR includes a new C program that's essentially a _safer_ version of a bash script that would do the same thing, somehow, because it has to run as root.

Please review carefully.

CHANGELOG_BEGIN
CHANGELOG_END