### PR TITLE
Enhance grpc-test-utils and grpc-reverse-proxy to use Resources

### DIFF
--- a/libs-scala/grpc-reverse-proxy/BUILD.bazel
+++ b/libs-scala/grpc-reverse-proxy/BUILD.bazel
@@ -16,10 +16,14 @@ da_scala_library(
     ],
     deps = [
         "//libs-scala/grpc-server-reflection-client",
+        "//libs-scala/resources",
+        "//libs-scala/resources-grpc",
         "@maven//:com_google_guava_guava",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_services",
         "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_netty_netty_common",
+        "@maven//:io_netty_netty_transport",
     ],
 )
 
@@ -32,10 +36,15 @@ da_scala_test_suite(
     deps = [
         ":grpc-reverse-proxy",
         "//libs-scala/grpc-test-utils",
+        "//libs-scala/grpc-utils",
+        "//libs-scala/resources",
+        "//libs-scala/resources-grpc",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_services",
         "@maven//:io_grpc_grpc_stub",
+        "@maven//:io_netty_netty_common",
+        "@maven//:io_netty_netty_transport",
     ],
 )

--- a/libs-scala/grpc-reverse-proxy/src/main/scala/com/daml/grpc/ReverseProxy.scala
+++ b/libs-scala/grpc-reverse-proxy/src/main/scala/com/daml/grpc/ReverseProxy.scala
@@ -6,7 +6,7 @@ package com.daml.grpc
 import com.daml.grpc.reflection.{ServerReflectionClient, ServiceDescriptorInfo}
 import com.daml.resources.grpc.GrpcResourceOwnerFactories
 import com.daml.resources.{AbstractResourceOwner, HasExecutionContext, ResourceOwnerFactories}
-import io.grpc._
+import io.grpc.{Channel, Server, ServerBuilder, ServerInterceptor, ServerInterceptors}
 import io.grpc.reflection.v1alpha.ServerReflectionGrpc
 
 import scala.concurrent.duration.DurationInt

--- a/libs-scala/grpc-reverse-proxy/src/test/scala/com/daml/grpc/ReverseProxySpec.scala
+++ b/libs-scala/grpc-reverse-proxy/src/test/scala/com/daml/grpc/ReverseProxySpec.scala
@@ -5,33 +5,14 @@ package com.daml.grpc
 
 import java.util.concurrent.atomic.AtomicReference
 
+import com.daml.grpc.interceptors.ForwardingServerCallListener
 import com.daml.grpc.test.GrpcServer
-import io.grpc.ForwardingServerCall.SimpleForwardingServerCall
-import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener
-import io.grpc.health.v1.HealthCheckResponse.ServingStatus
 import io.grpc.health.v1.{HealthCheckRequest, HealthGrpc}
 import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
-import io.grpc.reflection.v1alpha.{
-  ServerReflectionGrpc,
-  ServerReflectionRequest,
-  ServerReflectionResponse,
-}
-import io.grpc.stub.StreamObserver
-import io.grpc.{
-  Channel,
-  Metadata,
-  ServerCall,
-  ServerCallHandler,
-  ServerInterceptor,
-  StatusRuntimeException,
-}
+import io.grpc._
 import org.scalatest.Inside
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-
-import scala.concurrent.{Await, Promise}
-import scala.concurrent.duration.DurationInt
-import scala.jdk.CollectionConverters._
 
 final class ReverseProxySpec extends AsyncFlatSpec with Matchers with GrpcServer with Inside {
 
@@ -40,39 +21,44 @@ final class ReverseProxySpec extends AsyncFlatSpec with Matchers with GrpcServer
 
   behavior of "ReverseProxy.create"
 
-  it should "fail if the backend does not support reflection" in withServices(health) { backend =>
+  it should "fail if the backend does not support reflection" in withServices(
+    Health.newInstance
+  ) { backend =>
     val proxyBuilder = InProcessServerBuilder.forName(InProcessServerBuilder.generateName())
     ReverseProxy
-      .create(backend, proxyBuilder, interceptors = Map.empty)
+      .owner(backend, proxyBuilder, interceptors = Map.empty)
+      .use(_ => fail("The proxy started but the backend does not support reflection"))
       .failed
       .map(_ shouldBe a[StatusRuntimeException])
   }
 
-  it should "expose the backend's own services" in withServices(health, reflection) { backend =>
+  it should "expose the backend's own services" in withServices(
+    Health.newInstance,
+    Reflection.newInstance,
+  ) { backend =>
     val proxyName = InProcessServerBuilder.generateName()
     val proxyBuilder = InProcessServerBuilder.forName(proxyName)
-    ReverseProxy
-      .create(backend, proxyBuilder, interceptors = Map.empty)
-      .map { proxyServer =>
-        proxyServer.start()
-        val proxy = InProcessChannelBuilder.forName(proxyName).build()
-        getHealthStatus(backend) shouldEqual getHealthStatus(proxy)
-        listServices(backend) shouldEqual listServices(proxy)
-      }
+    ReverseProxy.owner(backend, proxyBuilder, interceptors = Map.empty).use { _ =>
+      val proxy = InProcessChannelBuilder.forName(proxyName).build()
+      Health.getHealthStatus(backend) shouldEqual Health.getHealthStatus(proxy)
+      Reflection.listServices(backend) shouldEqual Reflection.listServices(proxy)
+    }
   }
 
-  it should "correctly set up an interceptor" in withServices(health, reflection) { backend =>
+  it should "correctly set up an interceptor" in withServices(
+    Health.newInstance,
+    Reflection.newInstance,
+  ) { backend =>
     val proxyName = InProcessServerBuilder.generateName()
     val proxyBuilder = InProcessServerBuilder.forName(proxyName)
     val recorder = new RecordingInterceptor
     ReverseProxy
-      .create(backend, proxyBuilder, Map(HealthGrpc.SERVICE_NAME -> Seq(recorder)))
-      .map { proxyServer =>
-        proxyServer.start()
+      .owner(backend, proxyBuilder, Map(HealthGrpc.SERVICE_NAME -> Seq(recorder)))
+      .use { _ =>
         val proxy = InProcessChannelBuilder.forName(proxyName).build()
-        getHealthStatus(backend)
+        Health.getHealthStatus(backend)
         recorder.latestRequest() shouldBe empty
-        getHealthStatus(proxy)
+        Health.getHealthStatus(proxy)
         inside(recorder.latestRequest()) { case Some(request: Array[Byte]) =>
           HealthCheckRequest.parseFrom(request)
           succeed
@@ -84,53 +70,12 @@ final class ReverseProxySpec extends AsyncFlatSpec with Matchers with GrpcServer
 
 object ReverseProxySpec {
 
-  private def listServices(channel: Channel): Iterable[String] = {
-    val response = Promise[Iterable[String]]()
-    lazy val serverStream: StreamObserver[ServerReflectionRequest] =
-      ServerReflectionGrpc
-        .newStub(channel)
-        .serverReflectionInfo(new StreamObserver[ServerReflectionResponse] {
-          override def onNext(value: ServerReflectionResponse): Unit = {
-            if (value.hasListServicesResponse) {
-              val services = value.getListServicesResponse.getServiceList.asScala.map(_.getName)
-              response.trySuccess(services)
-            } else {
-              response.tryFailure(new IllegalStateException("Received unexpected response type"))
-            }
-            serverStream.onCompleted()
-          }
-
-          override def onError(throwable: Throwable): Unit = {
-            val _ = response.tryFailure(throwable)
-          }
-
-          override def onCompleted(): Unit = {
-            val _ = response.tryFailure(new IllegalStateException("No response received"))
-          }
-        })
-    serverStream.onNext(ServerReflectionRequest.newBuilder().setListServices("").build())
-    Await.result(response.future, 5.seconds)
-  }
-
-  private def getHealthStatus(channel: Channel): ServingStatus =
-    HealthGrpc
-      .newBlockingStub(channel)
-      .check(HealthCheckRequest.newBuilder().build())
-      .getStatus
-
-  final class Forward[ReqT, RespT](call: ServerCall[ReqT, RespT])
-      extends SimpleForwardingServerCall[ReqT, RespT](call) {
-    override def sendMessage(message: RespT): Unit = {
-      super.sendMessage(message)
-    }
-  }
-
   final class Callback[ReqT, RespT](
       call: ServerCall[ReqT, RespT],
       headers: Metadata,
       next: ServerCallHandler[ReqT, RespT],
       callback: ReqT => Unit,
-  ) extends SimpleForwardingServerCallListener[ReqT](next.startCall(new Forward(call), headers)) {
+  ) extends ForwardingServerCallListener(call, headers, next) {
     override def onMessage(message: ReqT): Unit = {
       callback(message)
       super.onMessage(message)

--- a/libs-scala/grpc-server-reflection-client/src/test/scala/com/daml/grpc/reflection/ServerReflectionClientSpec.scala
+++ b/libs-scala/grpc-server-reflection-client/src/test/scala/com/daml/grpc/reflection/ServerReflectionClientSpec.scala
@@ -17,13 +17,16 @@ final class ServerReflectionClientSpec extends AsyncFlatSpec with Matchers with 
 
   behavior of "getAllServices"
 
-  it should "fail if reflection is not supported" in withServices(health) { channel =>
+  it should "fail if reflection is not supported" in withServices(Health.newInstance) { channel =>
     val stub = ServerReflectionGrpc.newStub(channel)
     val client = new ServerReflectionClient(stub)
     client.getAllServices().failed.map(_ shouldBe a[StatusRuntimeException])
   }
 
-  it should "show all if reflection is supported" in withServices(health, reflection) { channel =>
+  it should "show all if reflection is supported" in withServices(
+    Health.newInstance,
+    Reflection.newInstance,
+  ) { channel =>
     val expected = Set(healthDescriptor, reflectionDescriptor)
     val stub = ServerReflectionGrpc.newStub(channel)
     val client = new ServerReflectionClient(stub)

--- a/libs-scala/grpc-test-utils/BUILD.bazel
+++ b/libs-scala/grpc-test-utils/BUILD.bazel
@@ -14,12 +14,19 @@ da_scala_library(
         "@maven//:org_scalactic_scalactic",
     ],
     tags = ["maven_coordinates=com.daml:grpc-test-utils:__VERSION__"],
+    versioned_scala_deps = {
+        "2.12": ["@maven//:org_scala_lang_modules_scala_collection_compat"],
+    },
     visibility = [
         "//:__subpackages__",
     ],
     deps = [
+        "//libs-scala/resources",
+        "//libs-scala/resources-grpc",
+        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_services",
+        "@maven//:io_grpc_grpc_stub",
     ],
 )

--- a/libs-scala/grpc-test-utils/src/main/scala/com/daml/grpc/test/GrpcServer.scala
+++ b/libs-scala/grpc-test-utils/src/main/scala/com/daml/grpc/test/GrpcServer.scala
@@ -104,14 +104,13 @@ trait GrpcServer { this: AsyncFlatSpec =>
       serverBuilder.addService(additionalService)
     }
     val channelBuilder = InProcessChannelBuilder.forName(serverName)
-    val testResult =
+    val channelOwner =
       for {
-        _ <- Resources.forServer(serverBuilder, 5.seconds).acquire()
-        channel <- Resources.forChannel(channelBuilder, 5.seconds).acquire()
-        result <- Resources.forFuture(() => test(channel)).acquire()
-      } yield result
+        _ <- Resources.forServer(serverBuilder, 5.seconds)
+        channel <- Resources.forChannel(channelBuilder, 5.seconds)
+      } yield channel
 
-    testResult.release().flatMap(_ => testResult.asFuture)
+    channelOwner.use(test)
   }
 
 }

--- a/libs-scala/grpc-utils/src/main/scala/com/digitalasset/grpc/interceptors/ForwardingServerCall.scala
+++ b/libs-scala/grpc-utils/src/main/scala/com/digitalasset/grpc/interceptors/ForwardingServerCall.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.grpc.interceptors
+
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall
+import io.grpc.ServerCall
+
+final class ForwardingServerCall[ReqT, RespT](call: ServerCall[ReqT, RespT])
+    extends SimpleForwardingServerCall[ReqT, RespT](call) {}

--- a/libs-scala/grpc-utils/src/main/scala/com/digitalasset/grpc/interceptors/ForwardingServerCallListener.scala
+++ b/libs-scala/grpc-utils/src/main/scala/com/digitalasset/grpc/interceptors/ForwardingServerCallListener.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.grpc.interceptors
+
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener
+import io.grpc.{Metadata, ServerCall, ServerCallHandler}
+
+abstract class ForwardingServerCallListener[ReqT, RespT](
+    call: ServerCall[ReqT, RespT],
+    headers: Metadata,
+    next: ServerCallHandler[ReqT, RespT],
+) extends SimpleForwardingServerCallListener[ReqT](
+      next.startCall(new ForwardingServerCall(call), headers)
+    )


### PR DESCRIPTION
This is the second of four PRs in which https://github.com/digital-asset/daml/commit/6ea70c4b45d55cbf62caa3cc03dd70310ca79b87
has been broken up to facilitate review.

The endgame is to have the non-repudiation prototype merged. The
grpc-test-utils and grpc-server-proxy libraries have been
enhanced to use the ResouceOwner/Resource abstraction to handle
the lifecycle of components, making resource management easier
when testing.

Part of #8598

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
