### PR TITLE
fix: package locale-archive with binaries

### DIFF
--- a/bazel_tools/packaging/BUILD.bazel
+++ b/bazel_tools/packaging/BUILD.bazel
@@ -1,16 +1,19 @@
 # Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@os_info//:os_info.bzl", "is_windows")
+load("@os_info//:os_info.bzl", "is_linux", "is_windows")
 
 sh_binary(
     name = "package-app",
     srcs = ["package-app.sh"],
     data = [
-        "@gzip_dev_env//:gzip",
-        "@tar_dev_env//:tar",
-        "//bazel_tools/sh:mktgz",
-    ] + (["@patchelf_nix//:bin/patchelf"] if not is_windows else []),
+               "@gzip_dev_env//:gzip",
+               "@tar_dev_env//:tar",
+               "//bazel_tools/sh:mktgz",
+           ] + ([
+               "@patchelf_nix//:bin/patchelf",
+           ] if not is_windows else []) +
+           (["@glibc_locales//:locale-archive"] if is_linux else []),
     visibility = ["//visibility:public"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/bazel_tools/packaging/package-app.sh
+++ b/bazel_tools/packaging/package-app.sh
@@ -47,6 +47,12 @@ if [[ -n ${RUNFILES_MANIFEST_FILE:-} ]]; then
 fi
 
 case "$(uname -s)" in
+  Linux)
+    locale_archive=$(abspath $(rlocation glibc_locales/lib/locale/locale-archive))
+    ;;
+esac
+
+case "$(uname -s)" in
   Darwin|Linux)
     tar=$(abspath $(rlocation tar_dev_env/tar))
     gzip=$(abspath $(rlocation gzip_dev_env/gzip))
@@ -129,6 +135,9 @@ if [ "$(uname -s)" == "Linux" ]; then
   # Copy the binary's dynamic library dependencies.
   copy_deps "$binary" "$WORKDIR/$NAME/lib"
 
+  # Copy nix's locale-archive
+  cp $locale_archive "$WORKDIR/$NAME/lib/locale-archive"
+
   # Workaround for dynamically loaded name service switch libraries
   (shopt -s nullglob
    for rpath in $rpaths_binary; do
@@ -152,6 +161,7 @@ if [ "$(uname -s)" == "Linux" ]; then
 #!/usr/bin/env sh
 SOURCE_DIR="\$(cd \$(dirname \$(readlink -f "\$0")); pwd)"
 LIB_DIR="\$SOURCE_DIR/lib"
+export LOCALE_ARCHIVE="\$SOURCE_DIR/lib/locale-archive"
 # Execute the wrapped application through the provided dynamic linker
 exec \$LIB_DIR/ld-linux-x86-64.so.2 --library-path "\$LIB_DIR" "\$LIB_DIR/$NAME" "\$@"
 EOF


### PR DESCRIPTION
Fixes #8573.
Fixes #8574.

We ship the `locale-archive` packaged with `nix` along binaries and set
the LOCALE_ARCHIVE environment variable. This makes sure the shipped
binaries behave the same as in our dev-env.

I tested this locally but it would be good if someone else also gives it a spin. Especially the two issues reported in #8573 and #8574.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
