### PR TITLE
Drop early access tag on trigger service and auth middleware

### DIFF
--- a/daml-assistant/daml-sdk/BUILD.bazel
+++ b/daml-assistant/daml-sdk/BUILD.bazel
@@ -30,6 +30,7 @@ da_scala_library(
         "//navigator/backend:navigator-library",
         "//triggers/runner:trigger-runner-lib",
         "//triggers/service:trigger-service",
+        "//triggers/service/auth:oauth2-middleware",
         "@maven//:com_typesafe_akka_akka_http_spray_json_2_12",
         "@maven//:com_typesafe_scala_logging_scala_logging_2_12",
         "@maven//:io_spray_spray_json_2_12",

--- a/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
+++ b/daml-assistant/daml-sdk/src/main/scala/com/digitalasset/daml/sdk/SdkMain.scala
@@ -7,6 +7,7 @@ import com.daml.codegen.{CodegenMain => Codegen}
 import com.daml.lf.engine.script.{RunnerMain => Script, TestMain => TestScript}
 import com.daml.lf.engine.trigger.{RunnerMain => Trigger}
 import com.daml.lf.engine.trigger.{ServiceMain => TriggerService}
+import com.daml.auth.middleware.oauth2.{Main => Oauth2Middleware}
 import com.daml.extractor.{Main => Extractor}
 import com.daml.http.{Main => JsonApi}
 import com.daml.navigator.{NavigatorBackend => Navigator}
@@ -25,6 +26,7 @@ object SdkMain {
       case "extractor" => Extractor.main(rest)
       case "json-api" => JsonApi.main(rest)
       case "trigger-service" => TriggerService.main(rest)
+      case "oauth2-middleware" => Oauth2Middleware.main(rest)
       case "navigator" => Navigator.main(rest)
       case "sandbox" => Sandbox.main(rest)
       case "sandbox-classic" => SandboxClassic.main(rest)

--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -370,6 +370,7 @@ argWhitelist = S.fromList
     , "deploy"
     , "json-api"
     , "trigger", "trigger-service", "list"
+    , "oauth2-middleware"
     , "script"
     , "test-script"
     ]

--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -212,6 +212,7 @@ tests tmpDir =
             , testCase "daml new --list" $
               withCurrentDirectory tmpDir $ callCommandSilent "daml new --list"
             , packagingTests tmpDir
+            , damlToolTests
             , withResource (damlStart ProjDir tmpDir) (terminateProcess . startPh) damlStartTests
             , withResource (quickSandbox quickstartDir) (terminateProcess . quickSandboxPh) $
               quickstartTests quickstartDir mvnDir
@@ -315,6 +316,51 @@ packagingTests tmpDir =
           -- This also checks that we get the same Script type within an SDK version.
                       ]
               withCurrentDirectory (tmpDir </> "proj") $ callCommandSilent "daml build"
+        ]
+
+-- Test tools that can run outside a daml project
+damlToolTests :: TestTree
+damlToolTests =
+    testGroup
+        "daml tools"
+        [ testCase "OAuth 2.0 middleware startup" $ do
+              withDevNull $ \devNull1 -> do
+                  withDevNull $ \devNull2 -> do
+                      middlewarePort <- getFreePort
+                      let middlewareProc =
+                              (shell $
+                               unwords
+                                   [ "daml"
+                                   , "oauth2-middleware"
+                                   , "--port"
+                                   , show middlewarePort
+                                   , "--oauth-auth"
+                                   , "http://localhost:0/authorize"
+                                   , "--oauth-token"
+                                   , "http://localhost:0/token"
+                                   , "--auth-jwt-hs256-unsafe"
+                                   , "jwt-secret"
+                                   , "--id"
+                                   , "client-id"
+                                   , "--secret"
+                                   , "client-secret"
+                                   ])
+                                  { std_out = UseHandle devNull1
+                                  , std_err = UseHandle devNull2
+                                  , std_in = CreatePipe
+                                  }
+                      withCreateProcess middlewareProc $ \_ _ _ middlewarePh ->
+                          race_ (waitForProcess' middlewareProc middlewarePh) $ do
+                              let endpoint =
+                                      "http://localhost:" <> show middlewarePort <> "/livez"
+                              waitForHttpServer (threadDelay 100000) endpoint []
+                              req <- parseRequest endpoint
+                              manager <- newManager defaultManagerSettings
+                              resp <- httpLbs req manager
+                              responseBody resp @?= "{\"status\":\"pass\"}"
+                              -- waitForProcess' will block on Windows so we explicitly kill the
+                              -- process.
+                              terminateProcess middlewarePh
         ]
 
 -- We are trying to run as many tests with the same `daml start` process as possible to safe time.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,6 +51,9 @@ Daml Documentation
    upgrade/index
    app-dev/authorization
    app-dev/ledger-api
+   triggers/index
+   tools/trigger-service/index
+   tools/auth-middleware/index
 
 .. toctree::
    :titlesonly:
@@ -110,10 +113,7 @@ Daml Documentation
 
    tools/extractor
    daml-integration-kit/index
-   triggers/index
    tools/visual
-   tools/trigger-service/index
-   tools/auth-middleware/index
    concepts/interoperability
 
 .. toctree::

--- a/docs/source/tools/auth-middleware/index.rst
+++ b/docs/source/tools/auth-middleware/index.rst
@@ -4,8 +4,6 @@
 Auth Middleware
 ###############
 
-The auth middleware is currently an :doc:`Early Access Feature in Labs status </support/status-definitions>`.
-
 .. toctree::
    :hidden:
 

--- a/docs/source/tools/trigger-service/index.rst
+++ b/docs/source/tools/trigger-service/index.rst
@@ -4,8 +4,6 @@
 Trigger Service
 ###############
 
-The Trigger Service is currently an :doc:`Early Access Feature in Alpha status </support/status-definitions>`. At this time, the documentation is limited to basic usage. As more features become available the documentation will be updated to include them. We welcome feedback about the Trigger Service on our `our issue tracker <https://github.com/digital-asset/daml/issues/new>`_, or `on our forum <https://discuss.daml.com>`_.
-
 .. toctree::
    :hidden:
 

--- a/docs/source/triggers/index.rst
+++ b/docs/source/triggers/index.rst
@@ -9,11 +9,6 @@ Daml Triggers - Off-Ledger Automation in Daml
 
    api/index
 
-Daml Triggers are currently an :doc:`Early Access Feature in Alpha status </support/status-definitions>`.
-We welcome feedback about Daml triggers on
-`our issue tracker <https://github.com/digital-asset/daml/issues/new?milestone=Daml+Triggers>`_,
-or `our forum <https://discuss.daml.com>`_.
-
 In addition to the actual Daml logic which is uploaded to the Ledger
 and the UI, Daml applications often need to automate certain
 interactions with the ledger. This is commonly done in the form of a

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -84,16 +84,16 @@ commands:
   args: ["run-platform-jar", "--logback-config=json-api-logback.xml", "json-api"]
 - name: trigger-service
   path: daml-helper/daml-helper
-  desc: "Launch the trigger service (early access)"
+  desc: "Launch the trigger service"
   args: ["run-jar", "--logback-config=daml-sdk/trigger-service-logback.xml", "daml-sdk/daml-sdk.jar", "trigger-service"]
 - name: oauth2-middleware
   path: daml-helper/daml-helper
-  desc: "Launch the OAuth 2.0 middleware (early access)"
+  desc: "Launch the OAuth 2.0 middleware"
   args: ["run-jar", "--logback-config=daml-sdk/oauth2-middleware-logback.xml", "daml-sdk/daml-sdk.jar", "oauth2-middleware"]
 - name: trigger
   path: daml-helper/daml-helper
   args: ["run-jar", "--logback-config=daml-sdk/trigger-logback.xml", "daml-sdk/daml-sdk.jar", "trigger"]
-  desc: "Run a Daml trigger (early access)"
+  desc: "Run a Daml trigger"
 - name: script
   path: daml-helper/daml-helper
   args: ["run-jar", "--logback-config=daml-sdk/script-logback.xml", "daml-sdk/daml-sdk.jar", "script"]

--- a/release/sdk-config.yaml.tmpl
+++ b/release/sdk-config.yaml.tmpl
@@ -86,6 +86,10 @@ commands:
   path: daml-helper/daml-helper
   desc: "Launch the trigger service (early access)"
   args: ["run-jar", "--logback-config=daml-sdk/trigger-service-logback.xml", "daml-sdk/daml-sdk.jar", "trigger-service"]
+- name: oauth2-middleware
+  path: daml-helper/daml-helper
+  desc: "Launch the OAuth 2.0 middleware (early access)"
+  args: ["run-jar", "--logback-config=daml-sdk/oauth2-middleware-logback.xml", "daml-sdk/daml-sdk.jar", "oauth2-middleware"]
 - name: trigger
   path: daml-helper/daml-helper
   args: ["run-jar", "--logback-config=daml-sdk/trigger-logback.xml", "daml-sdk/daml-sdk.jar", "trigger"]

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -15,6 +15,7 @@ def sdk_tarball(name, version):
             "//navigator/backend:src/main/resources/logback.xml",
             "//extractor:src/main/resources/logback.xml",
             "//ledger-service/http-json:src/main/resources/logback.xml",
+            "//triggers/service/auth:release/oauth2-middleware-logback.xml",
             "//triggers/service:release/trigger-service-logback.xml",
             "//language-support/java/codegen:src/main/resources/logback.xml",
             "//triggers/runner:src/main/resources/logback.xml",

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -8,6 +8,8 @@ load(
     "da_scala_test",
 )
 
+exports_files(["release/oauth2-middleware-logback.xml"])
+
 scalacopts = []
 
 da_scala_library(

--- a/triggers/service/auth/release/oauth2-middleware-logback.xml
+++ b/triggers/service/auth/release/oauth2-middleware-logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.netty" level="WARN">
+        <appender-ref ref="stderr-appender"/>
+    </logger>
+    <logger name="io.grpc.netty" level="WARN">
+        <appender-ref ref="stderr-appender"/>
+    </logger>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Server.scala
@@ -23,6 +23,7 @@ import com.daml.jwt.{JwtDecoder, JwtVerifierBase}
 import com.daml.jwt.domain.Jwt
 import com.daml.ledger.api.auth.AuthServiceJWTCodec
 import com.daml.auth.middleware.api.Tagged.{AccessToken, RefreshToken}
+import spray.json._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
@@ -300,6 +301,9 @@ class Server(config: Config) extends StrictLogging {
       post {
         refresh
       }
+    },
+    path("livez") {
+      complete(StatusCodes.OK, JsObject("status" -> JsString("pass")))
     },
   )
 }

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/ServiceConfig.scala
@@ -134,8 +134,6 @@ private[trigger] object ServiceConfig {
       .optional()
       .action((t, c) => c.copy(authUri = Some(Uri(t))))
       .text("Auth middleware URI.")
-      // TODO[AH] Expose once the auth feature is fully implemented.
-      .hidden()
 
     opt[AuthClient.RedirectToLogin]("auth-redirect")
       .optional()
@@ -143,8 +141,6 @@ private[trigger] object ServiceConfig {
       .text(
         "Redirect to auth middleware login endpoint when unauthorized. One of 'yes', 'no', or 'auto'."
       )
-      // TODO[AH] Expose once the auth feature is fully implemented.
-      .hidden()
 
     opt[String]("auth-callback")
       .optional()
@@ -152,8 +148,6 @@ private[trigger] object ServiceConfig {
       .text(
         "URI to the auth login flow callback endpoint `/cb`. By default constructed from the incoming login request."
       )
-      // TODO[AH] Expose once the auth feature is fully implemented.
-      .hidden()
 
     opt[Int]("max-inbound-message-size")
       .action((x, c) => c.copy(maxInboundMessageSize = x))
@@ -182,8 +176,6 @@ private[trigger] object ServiceConfig {
       .text(
         s"Optional max number of pending authorization requests. Defaults to ${DefaultMaxAuthCallbacks}."
       )
-      // TODO[AH] Expose once the auth feature is fully implemented.
-      .hidden()
 
     opt[Long]("authorization-timeout")
       .action((x, c) => c.copy(authCallbackTimeout = FiniteDuration(x, duration.SECONDS)))
@@ -191,15 +183,11 @@ private[trigger] object ServiceConfig {
       .text(
         s"Optional authorization timeout. Defaults to ${DefaultAuthCallbackTimeout.toSeconds} seconds."
       )
-      // TODO[AH] Expose once the auth feature is fully implemented.
-      .hidden()
 
     opt[Long]("max-http-entity-upload-size")
       .action((x, c) => c.copy(maxHttpEntityUploadSize = x))
       .optional()
       .text(s"Optional max HTTP entity upload size. Defaults to ${DefaultMaxHttpEntityUploadSize}.")
-      // TODO[AH] Expose once the auth feature is fully implemented.
-      .hidden()
 
     opt[Long]("http-entity-upload-timeout")
       .action((x, c) => c.copy(httpEntityUploadTimeout = FiniteDuration(x, duration.SECONDS)))
@@ -207,8 +195,6 @@ private[trigger] object ServiceConfig {
       .text(
         s"Optional HTTP entity upload timeout. Defaults to ${DefaultHttpEntityUploadTimeout.toSeconds} seconds."
       )
-      // TODO[AH] Expose once the auth feature is fully implemented.
-      .hidden()
 
     opt[Unit]('w', "wall-clock-time")
       .action { (_, c) =>


### PR DESCRIPTION
- Drops the early access tag from Daml triggers, the trigger service, and the auth middleware
- Adds the OAuth 2.0 middleware to the SDK tarball and daml-assistant
- Adds a simple daml-assistant integration test for the OAuth 2.0 middleware (similar to the one for the trigger service)
- Adds a `/livez` endpoint to the OAuth 2.0 middleware for the integration test
- Unhides the auth flags on the trigger service.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
