### PR TITLE
support exceptions in speedy

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -87,6 +87,8 @@ final class Conversions(
         setCrash(reason)
       case SError.DamlEArithmeticError(reason) =>
         setCrash(reason)
+      case SError.DamlEUnhandledException(message) =>
+        setCrash(message)
       case SError.DamlEUserError(msg) =>
         builder.setUserError(msg)
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -365,6 +365,16 @@ private[lf] object Anf {
         )
       }
 
+      case SETryCatch(body0, handler0) =>
+        // we must not lift applications from either the body or the handler outside of
+        // the try-catch block, so we flatten each separately:
+        val body: SExpr = flattenExp(depth, env, body0)(anf => Land(anf.wrapped)).bounce
+        val handler: SExpr =
+          flattenExp(depth.incr(1), trackBindings(depth, env, 1), handler0)(anf =>
+            Land(anf.wrapped)
+          ).bounce
+        Bounce(() => transform(depth, SETryCatch(body, handler), k))
+
       case x: SEAbs => throw CompilationError(s"flatten: unexpected: $x")
       case x: SEDamlException => throw CompilationError(s"flatten: unexpected: $x")
       case x: SEAppAtomicFun => throw CompilationError(s"flatten: unexpected: $x")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -56,6 +56,8 @@ private[lf] object Pretty {
         text(prettyFailedAuthorization(nid, fa))
       case DamlEArithmeticError(message) =>
         text(message)
+      case DamlEUnhandledException(message) =>
+        text(s"unhandled exception: $message")
       case DamlEUserError(message) =>
         text(s"User abort: $message")
       case DamlETransactionError(reason) =>
@@ -551,6 +553,10 @@ private[lf] object Pretty {
           prettySExpr(index)(SELet(List(rhs), body))
         case SELet1Builtin(builtin, args, body) =>
           prettySExpr(index)(SELet1General(SEAppAtomicSaturatedBuiltin(builtin, args), body))
+
+        case SETryCatch(body, handler) =>
+          text("try-catch") + char('(') + prettySExpr(index)(body) + text(", ") +
+            prettySExpr(index)(handler) + char(')')
 
         case x: SEBuiltinRecursiveDefinition => str(x)
         case x: SEImportValue => str(x)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -204,6 +204,7 @@ object Profile {
       implicit val choiceByKeyDefRef: Allowed[ChoiceByKeyDefRef] = allowAll
       implicit val fetchByKeyDefRef: Allowed[FetchByKeyDefRef] = allowAll
       implicit val lookupByKeyDefRef: Allowed[LookupByKeyDefRef] = allowAll
+      implicit val exceptionMessageDefRef: Allowed[ExceptionMessageDefRef] = allowAll
       implicit val sebrdr: Allowed[SEBuiltinRecursiveDefinition.Reference] = allowAll
       implicit val str: Allowed[String] = allowAll
 
@@ -221,6 +222,7 @@ object Profile {
             s"exerciseByKey @${tmplRef.qualifiedName} ${name}"
           case FetchByKeyDefRef(tmplRef) => s"fetchByKey @${tmplRef.qualifiedName}"
           case LookupByKeyDefRef(tmplRef) => s"lookupByKey @${tmplRef.qualifiedName}"
+          case ExceptionMessageDefRef(typeId) => s"message @${typeId.qualifiedName}"
           case ref: SEBuiltinRecursiveDefinition.Reference => ref.toString().toLowerCase()
           case str: String => str
           case any => s"<unknown ${any}>"

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -41,6 +41,14 @@ object SError {
     */
   sealed abstract class SErrorDamlException extends SError
 
+  /** Unhandled exceptions */
+  // TODO https://github.com/digital-asset/daml/issues/8020
+  // Have the unhandled-exception contain directly the original payload value & type
+  // as well as (or perhaps instead of) the computed message text
+  final case class DamlEUnhandledException(message: String) extends SErrorDamlException {
+    override def toString: String = message
+  }
+
   /** Arithmetic error such as division by zero */
   final case class DamlEArithmeticError(message: String) extends SErrorDamlException {
     override def toString: String = message

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -374,6 +374,14 @@ object SExpr {
     }
   }
 
+  /** Exception handler */
+  final case class SETryCatch(body: SExpr, handler: SExpr) extends SExpr {
+    def execute(machine: Machine): Unit = {
+      machine.pushKont(KTryCatchHandler(machine, handler))
+      machine.ctrl = body
+    }
+  }
+
   /** Case patterns */
   sealed trait SCasePat
 
@@ -422,6 +430,7 @@ object SExpr {
   final case class FetchDefRef(ref: DefinitionRef) extends SDefinitionRef
   final case class FetchByKeyDefRef(ref: DefinitionRef) extends SDefinitionRef
   final case class LookupByKeyDefRef(ref: DefinitionRef) extends SDefinitionRef
+  final case class ExceptionMessageDefRef(ref: DefinitionRef) extends SDefinitionRef
 
   //
   // List builtins (equalList) are implemented as recursive

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SValue.scala
@@ -64,6 +64,12 @@ sealed trait SValue {
         throw SErrorCrash("SValue.toValue: unexpected SStruct")
       case SAny(_, _) =>
         throw SErrorCrash("SValue.toValue: unexpected SAny")
+      case SAnyException(_, _, _) =>
+        throw SErrorCrash("SValue.toValue: unexpected SAnyException")
+      case SBuiltinException(_, _) =>
+        // TODO https://github.com/digital-asset/daml/issues/8020
+        // builtin exceptions values are serializable, so this should work
+        throw SErrorCrash("SValue.toValue: unexpected SBuiltinException")
       case STypeRep(_) =>
         throw SErrorCrash("SValue.toValue: unexpected STypeRep")
       case STNat(_) =>
@@ -103,6 +109,10 @@ sealed trait SValue {
         )
       case SAny(ty, value) =>
         SAny(ty, value.mapContractId(f))
+      case SAnyException(ty, sel, value) =>
+        SAnyException(ty, sel, value.mapContractId(f))
+      case SBuiltinException(tag, value) =>
+        SBuiltinException(tag, value.mapContractId(f))
     }
 }
 
@@ -187,6 +197,10 @@ object SValue {
   }
 
   final case class SAny(ty: Type, value: SValue) extends SValue
+  final case class SAnyException(ty: Type, messageFunction: SExpr, value: SValue) extends SValue
+
+  // A value of one of the builtin exception types: GeneralError, ArithmeticError, ContractError
+  final case class SBuiltinException(tag: String, value: SValue) extends SValue
 
   // Corresponds to a DAML-LF Nat type reified as a Speedy value.
   // It is currently used to track at runtime the scale of the

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/svalue/Equality.scala
@@ -60,10 +60,16 @@ private[lf] object Equality {
         case (SAny(xType, x), SAny(yType, y)) =>
           push(Iterator.single(x), Iterator.single(y))
           success = xType == yType
+        case (SAnyException(xType, _, x), SAnyException(yType, _, y)) =>
+          push(Iterator.single(x), Iterator.single(y))
+          success = xType == yType
+        case (SBuiltinException(xTag, x), SBuiltinException(yTag, y)) =>
+          push(Iterator.single(x), Iterator.single(y))
+          success = xTag == yTag
         case (STypeRep(xType), STypeRep(yType)) =>
           success = xType == yType
-        case _ =>
-          throw SErrorCrash("trying to compare incomparable types")
+        case (x, y) =>
+          throw SErrorCrash(s"trying to compare incomparable types:\n- $x\n- $y")
       }
 
     while (success && stackX.nonEmpty) {

--- a/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
+++ b/daml-lf/interpreter/src/test/scala/com/digitalasset/daml/lf/speedy/ExceptionTest.scala
@@ -1,0 +1,594 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf
+package speedy
+
+import com.daml.lf.PureCompiledPackages
+import com.daml.lf.data
+import com.daml.lf.language.Ast.{Expr, Package}
+import com.daml.lf.speedy.Compiler.FullStackTrace
+import com.daml.lf.speedy.SResult.{SResultFinalValue, SResultError}
+import com.daml.lf.speedy.SError.DamlEUnhandledException
+import com.daml.lf.testing.parser.Implicits._
+import com.daml.lf.validation.Validation
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ExceptionTest extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+
+  "builtin exception types: constructors & destructors" should {
+
+    // Construction/Deconstruction of builtin-exception types are inverses.
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+       module M {
+         val text : Text = "Hello!";
+         val t2 : Text = GENERAL_ERROR_MESSAGE (MAKE_GENERAL_ERROR M:text);
+         val t3 : Text = ARITHMETIC_ERROR_MESSAGE (MAKE_ARITHMETIC_ERROR M:text);
+         val t4 : Text = CONTRACT_ERROR_MESSAGE (MAKE_CONTRACT_ERROR M:text);
+       }
+      """)
+
+    val testCases = Table[String, String](
+      ("expression", "string-result"),
+      ("M:text", "Hello!"),
+      ("M:t2", "Hello!"),
+      ("M:t3", "Hello!"),
+      ("M:t4", "Hello!"),
+    )
+
+    forEvery(testCases) { (exp: String, res: String) =>
+      s"""eval[$exp] --> "$res"""" in {
+        val expected: SResult = SResultFinalValue(SValue.SText(res))
+        runExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "builtin exceptions: to/from-any-exception" should {
+
+    // Convertion to/from AnyException works as expected:
+    // specifically: we can only extract the inner value if the
+    // expected-type (on: from_any_exception) matches the actual-type (on: to_any_exception)
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+       module M {
+         val G : AnyException = to_any_exception @GeneralError (MAKE_GENERAL_ERROR "G");
+         val A : AnyException = to_any_exception @ArithmeticError (MAKE_ARITHMETIC_ERROR "A");
+         val C : AnyException = to_any_exception @ContractError (MAKE_CONTRACT_ERROR "C");
+         val fromG : AnyException -> Text = \(e:AnyException) -> case from_any_exception @GeneralError e of None -> "NONE" | Some x -> GENERAL_ERROR_MESSAGE x;
+         val fromA : AnyException -> Text = \(e:AnyException) -> case from_any_exception @ArithmeticError e of None -> "NONE" | Some x -> ARITHMETIC_ERROR_MESSAGE x;
+         val fromC : AnyException -> Text = \(e:AnyException) -> case from_any_exception @ContractError e of None -> "NONE" | Some x -> CONTRACT_ERROR_MESSAGE x;
+       }
+      """)
+
+    val testCases = Table[String, String](
+      ("expression", "string-result"),
+      ("M:fromG M:G", "G"),
+      ("M:fromA M:A", "A"),
+      ("M:fromC M:C", "C"),
+      ("M:fromG M:A", "NONE"),
+      ("M:fromG M:C", "NONE"),
+      ("M:fromA M:G", "NONE"),
+      ("M:fromA M:C", "NONE"),
+      ("M:fromC M:G", "NONE"),
+      ("M:fromC M:A", "NONE"),
+    )
+
+    forEvery(testCases) { (exp: String, res: String) =>
+      s"""eval[$exp] --> "$res"""" in {
+        val expected: SResult = SResultFinalValue(SValue.SText(res))
+        runExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "ANY_EXCEPTION_MESSAGE" should {
+
+    // Application of ANY_EXCEPTION_MESSAGE for various cases:
+    // all 3 builtin exception types & 2 user-defined exceptions.
+    // MyException1 contains the message text directly
+    // MyException2 composes the message string from two text contained in the payload
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+       module M {
+
+         record @serializable MyException1 = { message: Text } ;
+         exception MyException1 = {
+           message \(e: M:MyException1) -> M:MyException1 {message} e
+         };
+
+        val e1 : AnyException = to_any_exception @M:MyException1 (M:MyException1 { message = "Message1" });
+        val t1 : Text = ANY_EXCEPTION_MESSAGE M:e1;
+
+         record @serializable MyException2 = { front: Text, back: Text } ;
+
+         exception MyException2 = {
+           message \(e: M:MyException2) -> APPEND_TEXT (M:MyException2 {front} e) (M:MyException2 {back} e)
+         };
+
+        val e2 : AnyException = to_any_exception @M:MyException2 (M:MyException2 { front = "Mess", back = "age2" });
+        val t2 : Text = ANY_EXCEPTION_MESSAGE M:e2;
+
+        val e3 : AnyException = to_any_exception @GeneralError (MAKE_GENERAL_ERROR "MessageG");
+        val t3 : Text = ANY_EXCEPTION_MESSAGE M:e3;
+
+        val e4 : AnyException = to_any_exception @ArithmeticError (MAKE_ARITHMETIC_ERROR "MessageA");
+        val t4 : Text = ANY_EXCEPTION_MESSAGE M:e4;
+
+        val e5 : AnyException = to_any_exception @ContractError (MAKE_CONTRACT_ERROR "MessageC");
+        val t5 : Text = ANY_EXCEPTION_MESSAGE M:e5;
+       }
+      """)
+
+    val testCases = Table[String, String](
+      ("expression", "expected-string"),
+      ("M:t1", "Message1"),
+      ("M:t2", "Message2"),
+      ("M:t3", "MessageG"),
+      ("M:t4", "MessageA"),
+      ("M:t5", "MessageC"),
+    )
+
+    forEvery(testCases) { (exp: String, res: String) =>
+      s"""eval[$exp] --> "$res"""" in {
+        val expected: SResult = SResultFinalValue(SValue.SText(res))
+        runExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "unhandled throw" should {
+
+    // Behaviour when no handler catches a throw:
+    // 1: GeneralError thrown; no try-catch in scope
+    // 2. GeneralError thrown; try catch in scope, but handler does not catch
+    // 3. User Exception thrown; no handler in scope
+    // 4. User Exception thrown; no handler in scope; secondary throw from the message function of the 1st exception
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+       module M {
+
+         val unhandled1 : Update Int64 =
+            upure @Int64 (ADD_INT64 10 (throw @Int64 @GeneralError (MAKE_GENERAL_ERROR "oops1")));
+
+         val unhandled2 : Update Int64 =
+            try @Int64 (upure @Int64 (ADD_INT64 10 (throw @Int64 @GeneralError (MAKE_GENERAL_ERROR "oops2"))))
+            catch e -> None @(Update Int64);
+
+         record @serializable E1 = { } ;
+         exception E1 = { message \(e: M:E1) -> "E1" };
+         val unhandled3 : Update Int64 = upure @Int64 (throw @Int64 @M:E1 (M:E1 {})) ;
+
+         record @serializable E2 = { } ;
+         exception E2 = { message \(e: M:E2) -> throw @Text @M:E1 (M:E1 {}) } ; //throw from the message function
+         val unhandled4 : Update Int64 = upure @Int64 (throw @Int64 @M:E2 (M:E2 {})) ;
+
+       }
+      """)
+
+    val testCases = Table[String, SResult](
+      ("expression", "expected"),
+      ("M:unhandled1", SResultError(DamlEUnhandledException("oops1"))),
+      ("M:unhandled2", SResultError(DamlEUnhandledException("oops2"))),
+      ("M:unhandled3", SResultError(DamlEUnhandledException("E1"))),
+      ("M:unhandled4", SResultError(DamlEUnhandledException("E1"))),
+    )
+
+    forEvery(testCases) { (exp: String, expected: SResult) =>
+      s"eval[$exp] --> $expected" in {
+        runUpdateExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "throw/catch (GeneralError)" should {
+
+    // Basic throw/catch example for a builtin (GeneralError) exception
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+       module M {
+         val throwAndCatch : Update Int64 =
+           try @Int64 (upure @Int64 (ADD_INT64 10 (throw @Int64 @GeneralError (MAKE_GENERAL_ERROR "oops"))))
+           catch e -> Some @(Update Int64) (upure @Int64 77);
+       }
+      """)
+
+    val testCases = Table[String, Long](
+      ("expression", "expected"),
+      ("M:throwAndCatch", 77),
+    )
+
+    forEvery(testCases) { (exp: String, num: Long) =>
+      s"eval[$exp] --> $num" in {
+        val expected: SResult = SResultFinalValue(SValue.SInt64(num))
+        runUpdateExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "throw/catch (UserDefined)" should {
+
+    // Basic throw/catch example a user defined exception
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+       module M {
+
+         record @serializable MyException = { message: Text } ;
+
+         exception MyException = {
+           message \(e: M:MyException) -> M:MyException {message} e
+         };
+
+         val throwAndCatch : Update Int64 =
+           try @Int64 (upure @Int64 (throw @Int64 @M:MyException (M:MyException {message = "oops"})))
+           catch e -> Some @(Update Int64) (upure @Int64 77);
+
+       }
+      """)
+
+    val testCases = Table[String, Long](
+      ("expression", "expected"),
+      ("M:throwAndCatch", 77),
+    )
+
+    forEvery(testCases) { (exp: String, num: Long) =>
+      s"eval[$exp] --> $num" in {
+        val expected: SResult = SResultFinalValue(SValue.SInt64(num))
+        runUpdateExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "throw/catch (UserDefined, with integer payload)" should {
+
+    // Throw/catch example of a user defined exception, passing an integer payload.
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+       module M {
+
+         record @serializable MyException = { message: Text, payload : Int64 } ;
+
+         exception MyException = {
+           message \(e: M:MyException) -> M:MyException {message} e
+         };
+
+         val throwAndCatch : Update Int64 =
+             try @Int64 (upure @Int64 (throw @Int64 @M:MyException (M:MyException {message = "oops", payload = 77})))
+             catch e ->
+               case (from_any_exception @M:MyException e) of
+                  None -> Some @(Update Int64) (upure @Int64 999)
+                | Some my -> Some @(Update Int64) (upure @Int64 (M:MyException {payload} my))
+             ;
+       }
+      """)
+
+    val testCases = Table[String, Long](
+      ("expression", "expected"),
+      ("M:throwAndCatch", 77),
+    )
+
+    forEvery(testCases) { (exp: String, num: Long) =>
+      s"eval[$exp] --> $num" in {
+        val expected: SResult = SResultFinalValue(SValue.SInt64(num))
+        runUpdateExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "selective exception handling" should {
+
+    // Example which nests two try-catch block around an expression which throws:
+    // 3 variants: (with one source line changed,marked)
+    // -- The inner handler catches (some)
+    // -- The inner handler does not catch (none); allowing the outer handler to catch
+    // -- The inner handler throws while deciding whether to catch
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+      module M {
+        record @serializable MyException = { message: Text } ;
+
+        exception MyException = {
+          message \(e: M:MyException) -> M:MyException {message} e
+        };
+
+        val innerCatch : Update Int64 =
+            ubind x: Int64 <-
+                try @Int64
+                    ubind x: Int64 <-
+                        try @Int64
+                            upure @Int64 (throw @Int64 @M:MyException (M:MyException {message = "oops"}))
+                        catch e ->
+                            Some @(Update Int64) (upure @Int64 77)
+                    in
+                        upure @Int64 (ADD_INT64 200 x)
+                catch e ->
+                    Some @(Update Int64) (upure @Int64 88)
+            in
+                upure @Int64 (ADD_INT64 100 x)
+         ;
+
+        val outerCatch : Update Int64 =
+            ubind x: Int64 <-
+                try @Int64
+                    ubind x: Int64 <-
+                        try @Int64
+                            upure @Int64 (throw @Int64 @M:MyException (M:MyException {message = "oops"}))
+                        catch e ->
+                            None @(Update Int64) // THIS IS THE ONLY LINE CHANGED
+                    in
+                        upure @Int64 (ADD_INT64 200 x)
+                catch e ->
+                    Some @(Update Int64) (upure @Int64 88)
+            in
+                upure @Int64 (ADD_INT64 100 x)
+         ;
+
+        val throwWhileInnerHandlerDecides : Update Int64 =
+            ubind x: Int64 <-
+                try @Int64
+                    ubind x: Int64 <-
+                        try @Int64
+                            upure @Int64 (throw @Int64 @M:MyException (M:MyException {message = "oops"}))
+                        catch e ->
+                            throw @(Option (Update Int64)) @M:MyException (M:MyException {message = "oops"}) //CHANGE
+                    in
+                        upure @Int64 (ADD_INT64 200 x)
+                catch e ->
+                    Some @(Update Int64) (upure @Int64 88)
+            in
+                upure @Int64 (ADD_INT64 100 x)
+         ;
+
+       }
+      """)
+
+    val testCases = Table[String, Long](
+      ("expression", "expected"),
+      ("M:innerCatch", 377),
+      ("M:outerCatch", 188),
+      ("M:throwWhileInnerHandlerDecides", 188),
+    )
+
+    forEvery(testCases) { (exp: String, num: Long) =>
+      s"eval[$exp] --> $num" in {
+        val expected: SResult = SResultFinalValue(SValue.SInt64(num))
+        runUpdateExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "selective exception handling (using payload)" should {
+
+    // Selective handling, where either an inner or outer handler may access the exception payload:
+    // 3 variantions, this time seleced dynamically using a pair of bool
+    //
+    // 1. True/False  -- The inner handler catches (some)
+    // 2. False/False -- The inner handler does not catch (none); allowing the outer handler to catch
+    // 3. False/True  -- The inner handler throws while deciding whether to catch
+    //
+    // The test result is an integer, composed by adding components demonstrating the control flow taken
+    // 1000 -- exception payload or original throw
+    // 2000 -- exception payload of secondary throw (variation-3)
+    // 77 -- inner handler catches
+    // 88 -- outer handler catches
+    // 200 -- normal controlflow following inner catch
+    // 100 -- normal controlflow following outer catch
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+      module M {
+        record @serializable MyException = { payload: Int64 } ;
+
+        exception MyException = {
+          message \(e: M:MyException) -> "no-message"
+        };
+
+        val maybeInnerCatch : Bool -> Bool -> Update Int64 = \(catchAtInner: Bool) (throwAtInner: Bool) ->
+          ubind x: Int64 <-
+            try @Int64
+              ubind x: Int64 <-
+                try @Int64
+                  upure @Int64 (throw @Int64 @M:MyException (M:MyException {payload = 1000}))
+                catch e ->
+                  case catchAtInner of
+                    True ->
+                      (case (from_any_exception @M:MyException e) of
+                        None -> None @(Update Int64)
+                      | Some my -> Some @(Update Int64) (upure @Int64 (ADD_INT64 77 (M:MyException {payload} my))))
+                  | False ->
+                      (case throwAtInner of
+                         True -> throw @(Option (Update Int64)) @M:MyException (M:MyException {payload = 2000})
+                       | False -> None @(Update Int64))
+              in
+                upure @Int64 (ADD_INT64 200 x)
+            catch e ->
+              case (from_any_exception @M:MyException e) of
+                None -> None @(Update Int64)
+              | Some my -> Some @(Update Int64) (upure @Int64 (ADD_INT64 88 (M:MyException {payload} my)))
+
+          in
+            upure @Int64 (ADD_INT64 100 x) ;
+       }
+      """)
+
+    val testCases = Table[String, Long](
+      ("expression", "expected"),
+      ("M:maybeInnerCatch True False", 1377),
+      ("M:maybeInnerCatch False False", 1188),
+      ("M:maybeInnerCatch False True", 2188),
+    )
+
+    forEvery(testCases) { (exp: String, num: Long) =>
+      s"eval[$exp] --> $num" in {
+        val expected: SResult = SResultFinalValue(SValue.SInt64(num))
+        runUpdateExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "throw/catch (control flow)" should {
+
+    // Another example allowing dynamic control of different test paths. Novelty here:
+    // - uses GeneralError, with Text payload encoding an int
+    // - variations 1..4 selected by an integer arg
+    // - final result contains elements which demonstrate the control flow taken
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+      module M {
+
+        val myThrow : forall (a: *). (Text -> a) =
+          /\ (a: *). \(mes : Text) ->
+            throw @a @GeneralError (MAKE_GENERAL_ERROR mes);
+
+        val isPayLoad : AnyException -> Text -> Bool =
+          \(e: AnyException) (mes: Text) ->
+            EQUAL @AnyException e (to_any_exception @GeneralError (MAKE_GENERAL_ERROR mes)) ;
+
+        val extractPayload : AnyException -> Int64 =
+          \(e: AnyException) ->
+            case (M:isPayLoad e "payload2") of True -> 2 | False ->
+            case (M:isPayLoad e "payload3") of True -> 3 | False ->
+            1000000 ;
+
+        val myCatch : forall (a: *). (Int64 -> a) -> (Text -> Update a) -> Update a =
+          /\ (a: *). \ (handler: Int64 -> a) (body: Text -> Update a) ->
+            try @a
+              (body "body-unitish")
+            catch e ->
+              Some @(Update a) (upure @a (handler (M:extractPayload e))) ;
+
+        val throwCatchTest : (Int64 -> Update Int64) = \ (x: Int64) ->
+          ubind x: Int64 <-
+            M:myCatch @Int64 (\(pay : Int64) -> ADD_INT64 100 pay) (\(u : Text) ->
+              ubind x: Int64 <-
+                M:myCatch @Int64 (\(pay : Int64) -> ADD_INT64 200 pay) (\(u : Text) ->
+                  upure @Int64
+                    (ADD_INT64 4000
+                      (case (EQUAL @Int64 x 1) of True -> x | False ->
+                       case (EQUAL @Int64 x 2) of True -> M:myThrow @Int64 "payload2" | False ->
+                       case (EQUAL @Int64 x 3) of True -> M:myThrow @Int64 "payload3" | False ->
+                       case (EQUAL @Int64 x 4) of True -> x | False ->
+                       2000000)))
+              in
+                upure @Int64 (ADD_INT64 2000 x))
+          in
+            upure @Int64 (ADD_INT64 1000 x) ;
+
+      }""")
+
+    val testCases = Table[String, Long](
+      ("expression", "expected"),
+      ("M:throwCatchTest 1", 7001),
+      ("M:throwCatchTest 2", 3202),
+      ("M:throwCatchTest 3", 3203),
+      ("M:throwCatchTest 4", 7004),
+    )
+
+    forEvery(testCases) { (exp: String, num: Long) =>
+      s"eval[$exp] --> $num" in {
+        val expected: SResult = SResultFinalValue(SValue.SInt64(num))
+        runUpdateExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  "throws from various places" should {
+
+    // Example define a common "wrap" function which handles just a specific user exception:
+    // Series of tests which may throw within its context:
+    //
+    // - example1 -- no thow
+    // - example2 -- throw handled exception
+    // - example3 -- throw unhandled exception
+    // - example4 -- throw handled exception on left & right of a binary op
+    // - example5 -- throw handled exception which computing the payload of an outer throw
+
+    val pkgs: PureCompiledPackages = typeAndCompile(p"""
+      module M {
+
+        record @serializable MyExceptionH = { message: Text } ;
+
+        // H,U -- handled/unhandled user exceptions
+
+        exception MyExceptionH = {
+          message \(e: M:MyExceptionH) -> M:MyExceptionH {message} e
+        } ;
+
+        record @serializable MyExceptionU = { message: Text } ;
+
+        exception MyExceptionU = {
+          message \(e: M:MyExceptionU) -> M:MyExceptionU {message} e
+        } ;
+
+        val wrap : (Unit -> Text) -> Update Text = \(body: Unit -> Text) ->
+          try @Text (upure @Text (APPEND_TEXT "RESULT: " (body ())))
+          catch e ->
+            Some @(Update Text)
+              upure @Text
+                case (from_any_exception @M:MyExceptionH e) of
+                  None -> "UNHANDLED"
+                | Some my -> APPEND_TEXT "HANDLED: " (M:MyExceptionH {message} my) ;
+
+        val example1 : Update Text =
+          M:wrap (\(u: Unit) ->
+            "Happy Path") ;
+
+        val example2 : Update Text =
+          M:wrap (\(u: Unit) ->
+            throw @Text @M:MyExceptionH (M:MyExceptionH {message = "oops1"})) ;
+
+        val example3 : Update Text =
+          M:wrap (\(u: Unit) ->
+            throw @Text @M:MyExceptionU (M:MyExceptionU {message = "oops2"})) ;
+
+        val example4 : Update Text =
+          M:wrap (\(u: Unit) ->
+            APPEND_TEXT
+              (throw @Text @M:MyExceptionH (M:MyExceptionH {message = "left"}))
+              (throw @Text @M:MyExceptionH (M:MyExceptionH {message = "right"}))
+          );
+
+        val example5 : Update Text =
+          M:wrap (\(u: Unit) ->
+            throw @Text @M:MyExceptionH (throw @M:MyExceptionH @M:MyExceptionH (M:MyExceptionH {message = "throw-in-throw"}))
+          );
+
+      } """)
+
+    val testCases = Table[String, String](
+      ("expression", "expected"),
+      ("M:example1", "RESULT: Happy Path"),
+      ("M:example2", "HANDLED: oops1"),
+      ("M:example3", "UNHANDLED"),
+      ("M:example4", "HANDLED: left"),
+      ("M:example5", "HANDLED: throw-in-throw"),
+    )
+
+    forEvery(testCases) { (exp: String, str: String) =>
+      s"eval[$exp] --> $str" in {
+        val expected: SResult = SResultFinalValue(SValue.SText(str))
+        runUpdateExpr(pkgs)(e"$exp") shouldBe expected
+      }
+    }
+  }
+
+  private def typeAndCompile(pkg: Package): PureCompiledPackages = {
+    val rawPkgs = Map(defaultParserParameters.defaultPackageId -> pkg)
+    Validation.checkPackage(rawPkgs, defaultParserParameters.defaultPackageId, pkg)
+    data.assertRight(
+      PureCompiledPackages(rawPkgs, Compiler.Config.Default.copy(stacktracing = FullStackTrace))
+    )
+  }
+
+  private def runExpr(pkgs1: PureCompiledPackages)(e: Expr): SResult = {
+    Speedy.Machine.fromPureExpr(pkgs1, e).run()
+  }
+
+  private def runUpdateExpr(pkgs1: PureCompiledPackages)(e: Expr): SResult = {
+    def transactionSeed: crypto.Hash = crypto.Hash.hashPrivateKey("ExceptionTest.scala")
+    Speedy.Machine.fromScenarioExpr(pkgs1, transactionSeed, e).run()
+  }
+
+}

--- a/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
+++ b/daml-lf/parser/src/main/scala/com/digitalasset/daml/lf/testing/parser/ExprParser.scala
@@ -300,6 +300,7 @@ private[parser] class ExprParser[P](parserParameters: ParserParameters[P]) {
     "ANY_EXCEPTION_MESSAGE" -> BAnyExceptionMessage,
     "GENERAL_ERROR_MESSAGE" -> BGeneralErrorMessage,
     "ARITHMETIC_ERROR_MESSAGE" -> BArithmeticErrorMessage,
+    "CONTRACT_ERROR_MESSAGE" -> BContractErrorMessage,
   )
 
   /* Scenarios */

--- a/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
+++ b/daml-lf/parser/src/test/scala/com/digitalasset/daml/lf/testing/parser/ParsersSpec.scala
@@ -237,6 +237,7 @@ class ParsersSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matcher
         "ANY_EXCEPTION_MESSAGE" -> BAnyExceptionMessage,
         "GENERAL_ERROR_MESSAGE" -> BGeneralErrorMessage,
         "ARITHMETIC_ERROR_MESSAGE" -> BArithmeticErrorMessage,
+        "CONTRACT_ERROR_MESSAGE" -> BContractErrorMessage,
       )
 
       forEvery(testCases)((stringToParse, expectedBuiltin) =>


### PR DESCRIPTION
This PR introduces evaluation support in speedy for exceptions in DAML LF.

## Performance check

`collectAuthority` benchmark; this PR vs main. No significant change:
```
  25.780 ±(99.9%) 0.203 ms/op [Average]     (main)
  25.778 ±(99.9%) 0.179 ms/op [Average]     (here)
```

## Overview of new types:

- New speedy builtins: `SBThrow`, `SBTryHandler`, `SBMakeBuiltinError`, `SBBuiltinErrorMessage`, `SBToAnyException`, `SBFromAnyException`, `SBAnyExceptionMessage`

- New speedy expression constructs: `SETryCatch`

(Supporting an expression form in speedy is more work than a builtin, so we only choose it for the `SETryCatch` where the evaluation rules are non standard. And so it can be treated specially in Anf.)

- New speedy values: `SAnyException`, `SBuiltinException`

- New daml-exception: `DamlEUnhandledException`

- New speedy continuation forms: `KTryCatchHandler`, `KUnhandledException`


## Changes to speedy compiler:

- Process exception defs & create top level defs for the message function with: `ExceptionMessageDefRef`

- Support new LF expression forms: `EToAnyException`, `EFromAnyException`, `EThrow`

- `compileExceptionType` provides access to `ExceptionMessageDefRef` for to-any-exception and throw.

- Support new LF builtins: `BMakeGeneralError`, `BMakeArithmeticError`, `BMakeContractError`, `BGeneralErrorMessage`, `BArithmeticErrorMessage`, `BContractErrorMessage`, `BAnyExceptionMessage`

- Support new LF update form `UpdateTryCatch`. Compiler to speedy expression `SETryCatch` and builtin `SBTryHandler`.


## Runtime values:

- At runtime a value of type `AnyException` is represented by a new form of speedy value `SAnyException`.  Like the existing `AnyValue`, this contains an inner value and a type. The type supports the checked destructuring required by `SBFromAnyException`.  In addition there is a 3rd component to `AnyException`, a `messageFunction` value, This is supplied statically by `SBToAnyException` and used to support the new LF expression forms `EToAnyException` and `EThrow`.

- In addition, there is a new speedy runtime value `SBuiltinException` which is used to represent all three builtin exception types: `ArithException`, `GeneralError`, `ContractError`. The speedy value distinguishes the cases with a string tag, but actually makes no use of this tag itself.


## Evaluation stratgey:

- When an `SETryCatch` form is encountered, we push a new kind of continuation `KTryCatchHandler` on the kont-stack, and then evaluate the body of the expression form.

- The new continuation marks the kont-stack to allow unwinding if a throw is executed. If the catch-handler continuation is encountered _normally_, we simply reset the environment in common with most continuations, and the handler code is never executed.

- When a throw is executed, the kont-stack is unwound to the nearest enclosing catch-handler `KTryCatchHandler` continuation (if there is one), and the code for the handler executed.

- The handler expects the payload value (of type `AnyException`) to be on the env-stack. The handler will conclude by calling the speedy builtin `SBTryHandler`. This is setup by the speedy compiler. The speedy-builtin `SBTryHandler` checks the optional value to see if the handler chose to handle or not, and then proceeds to either evaluate the handler update code, or to re-throw the exception.

- When an exception is re-thrown and caught by the next enclosing catch-handler, the exception payload must be re-placed on the stack to access by the outer handler code.

- If unwinding fails to find any `KTryCatchHandler`, then we initiate evaluation of the `messageFunction` contained in the `SAnyException` to produce text for the new daml-error/exception - `DamlEUnhandledException`.


## Miscellaneuous:

- Anf: handle `SETryCatch`
- Profile: add case for `ExceptionMessageDefRef`
- svalue.Equality: support equality for: `SAnyException` and `SBuiltinException`


## Somewhat unrelated changes

Aside from new exception support this PR contains some tangental changes.

- 1: Fix missing case in scala-parser for `CONTRACT_ERROR`

- 2: change to `compilePure`, so token is checked in builtin `SBSPure`. We make this runtime check for other `Update` builtins. It seems good to make it here also.
