### PR TITLE
Publish JARs for trigger service and OAuth 2.0 middleware

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,8 @@ jobs:
     json-api: $[ dependencies.Linux.outputs['publish.json-api'] ]
     script-runner: $[ dependencies.Linux.outputs['publish.script-runner'] ]
     trigger-runner: $[ dependencies.Linux.outputs['publish.trigger-runner'] ]
+    trigger-service: $[ dependencies.Linux.outputs['publish.trigger-service'] ]
+    oauth2-middleware: $[ dependencies.Linux.outputs['publish.oauth2-middleware'] ]
     release_sha: $[ dependencies.check_for_release.outputs['out.release_sha'] ]
     release_tag: $[ dependencies.check_for_release.outputs['out.release_tag'] ]
     trigger_sha: $[ dependencies.check_for_release.outputs['out.trigger_sha'] ]
@@ -110,6 +112,16 @@ jobs:
     - task: DownloadPipelineArtifact@0
       inputs:
         artifactName: $(json-api)
+        targetPath: $(Build.StagingDirectory)/release
+      condition: not(eq(variables['skip-github'], 'TRUE'))
+    - task: DownloadPipelineArtifact@0
+      inputs:
+        artifactName: $(trigger-service)
+        targetPath: $(Build.StagingDirectory)/release
+      condition: not(eq(variables['skip-github'], 'TRUE'))
+    - task: DownloadPipelineArtifact@0
+      inputs:
+        artifactName: $(oauth2-middleware)
         targetPath: $(Build.StagingDirectory)/release
       condition: not(eq(variables['skip-github'], 'TRUE'))
     - task: DownloadPipelineArtifact@0

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -89,6 +89,18 @@ steps:
       cp bazel-bin/triggers/runner/trigger-runner_deploy.jar $(Build.StagingDirectory)/$TRIGGER
       echo "##vso[task.setvariable variable=trigger-runner;isOutput=true]$TRIGGER"
 
+      TRIGGER_SERVICE=trigger-service-${{parameters.release_tag}}.jar
+      ## Not built by default
+      bazel build //triggers/service:trigger-service-binary_deploy.jar
+      cp bazel-bin/triggers/service/trigger-service-binary_deploy.jar $(Build.StagingDirectory)/$TRIGGER_SERVICE
+      echo "##vso[task.setvariable variable=trigger-service;isOutput=true]$TRIGGER_SERVICE"
+
+      OAUTH2_MIDDLEWARE=oauth2-middleware-${{parameters.release_tag}}.jar
+      ## Not built by default
+      bazel build //triggers/service/auth:oauth2-middleware-binary_deploy.jar
+      cp bazel-bin/triggers/service/auth/oauth2-middleware-binary_deploy.jar $(Build.StagingDirectory)/$OAUTH2_MIDDLEWARE
+      echo "##vso[task.setvariable variable=oauth2-middleware;isOutput=true]$OAUTH2_MIDDLEWARE"
+
       SCRIPT=daml-script-${{parameters.release_tag}}.jar
       bazel build //daml-script/runner:script-runner_deploy.jar
       cp bazel-bin/daml-script/runner/script-runner_deploy.jar $(Build.StagingDirectory)/$SCRIPT
@@ -134,6 +146,22 @@ steps:
     inputs:
       targetPath: $(Build.StagingDirectory)/$(publish.trigger-runner)
       artifactName: $(publish.trigger-runner)
+    condition: and(succeeded(),
+                   eq(${{parameters.is_release}}, 'true'),
+                   eq(variables['Build.SourceBranchName'], 'main'),
+                   eq('${{parameters.name}}', 'linux'))
+  - task: PublishPipelineArtifact@0
+    inputs:
+      targetPath: $(Build.StagingDirectory)/$(publish.trigger-service)
+      artifactName: $(publish.trigger-service)
+    condition: and(succeeded(),
+                   eq(${{parameters.is_release}}, 'true'),
+                   eq(variables['Build.SourceBranchName'], 'main'),
+                   eq('${{parameters.name}}', 'linux'))
+  - task: PublishPipelineArtifact@0
+    inputs:
+      targetPath: $(Build.StagingDirectory)/$(publish.oauth2-middleware)
+      artifactName: $(publish.oauth2-middleware)
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
                    eq(variables['Build.SourceBranchName'], 'main'),

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -179,7 +179,3 @@
   type: jar-scala
 - target: //triggers/runner:trigger-runner-lib
   type: jar-scala
-- target: //triggers/service:trigger-service
-  type: jar-scala
-- target: //triggers/service/auth:oauth2-middleware
-  type: jar-scala

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -179,3 +179,7 @@
   type: jar-scala
 - target: //triggers/runner:trigger-runner-lib
   type: jar-scala
+- target: //triggers/service:trigger-service
+  type: jar-scala
+- target: //triggers/service/auth:oauth2-middleware
+  type: jar-scala

--- a/release/util.bzl
+++ b/release/util.bzl
@@ -73,6 +73,7 @@ def sdk_tarball(name, version):
           cp $(location //daml-assistant/daml-sdk:sdk_deploy.jar) $$OUT/daml-sdk/daml-sdk.jar
           cp -L $(location //ledger-service/http-json:src/main/resources/logback.xml) $$OUT/daml-sdk/json-api-logback.xml
           cp -L $(location //triggers/service:release/trigger-service-logback.xml) $$OUT/daml-sdk/
+          cp -L $(location //triggers/service/auth:release/oauth2-middleware-logback.xml) $$OUT/daml-sdk/
           cp -L $(location //ledger/sandbox-common:src/main/resources/logback.xml) $$OUT/daml-sdk/sandbox-logback.xml
           cp -L $(location //navigator/backend:src/main/resources/logback.xml) $$OUT/daml-sdk/navigator-logback.xml
           cp -L $(location //extractor:src/main/resources/logback.xml) $$OUT/daml-sdk/extractor-logback.xml


### PR DESCRIPTION
- Adds the oauth2-middleware logback config, I overlooked it in https://github.com/digital-asset/daml/pull/8611
- Adds steps to publish trigger service and OAuth 2.0 middleware JARs on GitHub.

Thanks @garyverhaegen-da for helping me with this!

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
