### PR TITLE
triggers: do not use the type information from SRecord

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -96,16 +96,10 @@ object Converter {
 
   def toAnyChoice(v: SValue): Either[String, AnyChoice] = {
     v match {
-      case SRecord(_, _, vals) if vals.size == 2 => {
-        vals.get(0) match {
-          case SAny(_, choiceVal @ SRecord(_, _, _)) =>
-            for { // This exploits the fact that in DAML, choice argument type names
-              // and choice names match up.
-              name <- ChoiceName.fromString(choiceVal.id.qualifiedName.name.toString)
-            } yield AnyChoice(name, choiceVal)
-          case _ => Left(s"Expected SAny but got $v")
-        }
-      }
+      case SRecord(_, _, JavaList(SAny(TTyCon(tyCon), choiceVal), _)) =>
+        // This exploits the fact that in DAML, choice argument type names
+        // and choice names match up.
+        ChoiceName.fromString(tyCon.qualifiedName.name.toString).map(AnyChoice(_, choiceVal))
       case _ => Left(s"Expected AnyChoice but got $v")
     }
   }

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TemplateHaskell, MultiWayIf #-}
 module Main (main) where
 
+
 import Control.Lens (view)
 import Control.Monad.Extra
 import Control.Monad.IO.Class


### PR DESCRIPTION
This type information is in `SRecord` for debugging purpose, one should not
use it.  We use type from `SAny` instead.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
