### PR TITLE
fix: set LOCAL_ARCHIVE when unset

### DIFF
--- a/bazel_tools/packaging/package-app.sh
+++ b/bazel_tools/packaging/package-app.sh
@@ -152,6 +152,9 @@ if [ "$(uname -s)" == "Linux" ]; then
 #!/usr/bin/env sh
 SOURCE_DIR="\$(cd \$(dirname \$(readlink -f "\$0")); pwd)"
 LIB_DIR="\$SOURCE_DIR/lib"
+if [ -z "\${LOCALE_ARCHIVE}" -a -f "/usr/lib/locale/locale-archive" ]; then
+  export LOCALE_ARCHIVE="/usr/lib/locale/locale-archive"
+fi
 # Execute the wrapped application through the provided dynamic linker
 exec \$LIB_DIR/ld-linux-x86-64.so.2 --library-path "\$LIB_DIR" "\$LIB_DIR/$NAME" "\$@"
 EOF


### PR DESCRIPTION
Fixes #8573.
Fixes #8574.

We set the LOCA_ARCHIVE environment variable when a locales archive
exists and the variable is unset.

CHANGELOG_BEGIN
CHANGELOG_END


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
