### PR TITLE
fix: daml-extension: turn breadcrumbs off.

### DIFF
--- a/compiler/daml-extension/src/extension.ts
+++ b/compiler/daml-extension/src/extension.ts
@@ -33,6 +33,8 @@ var damlLanguageClient: LanguageClient;
 // and then `Toggle Developer Tools` in VSCode. This will show
 // output in the Console tab once the extension is activated.
 export async function activate(context: vscode.ExtensionContext) {
+    // Turn symbol breadcrumbs off because they point to internals.
+    vscode.workspace.getConfiguration('breadcrumbs').update('symbolpath', 'off')
     // Start the language clients
     let config = vscode.workspace.getConfiguration('daml')
     // Get telemetry consent


### PR DESCRIPTION
This fixes #8410.

This turns the symbol breadcrumbs off for daml workspaces, because they
point to internals.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
