### PR TITLE
Add test to verify that TLSv1.2 and TLSv1.3 work

### DIFF
--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
@@ -8,7 +8,7 @@ import java.io.File
 import io.grpc.netty.GrpcSslContexts
 import io.netty.handler.ssl.{ClientAuth, SslContext}
 
-import scala.collection.JavaConverters.asJavaIterableConverter
+import scala.jdk.CollectionConverters._
 
 final case class TlsConfiguration(
     enabled: Boolean,

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
@@ -8,6 +8,8 @@ import java.io.File
 import io.grpc.netty.GrpcSslContexts
 import io.netty.handler.ssl.{ClientAuth, SslContext}
 
+import scala.collection.JavaConverters.asJavaIterableConverter
+
 final case class TlsConfiguration(
     enabled: Boolean,
     keyCertChainFile: Option[File], // mutual auth is disabled if null
@@ -16,6 +18,7 @@ final case class TlsConfiguration(
     clientAuth: ClientAuth =
       ClientAuth.REQUIRE, // Client auth setting used by the server. This is not used in the client configuration.
     enableCertRevocationChecking: Boolean = false,
+    protocols: Seq[String] = Seq.empty,
 ) {
 
   def keyFileOrFail: File =
@@ -40,6 +43,7 @@ final case class TlsConfiguration(
           .forClient()
           .keyManager(keyCertChainFile.orNull, keyFile.orNull)
           .trustManager(trustCertCollectionFile.orNull)
+          .protocols(if (protocols.nonEmpty) protocols.asJava else null)
           .build()
       )
     else None
@@ -56,6 +60,7 @@ final case class TlsConfiguration(
           )
           .trustManager(trustCertCollectionFile.orNull)
           .clientAuth(clientAuth)
+          .protocols(if (protocols.nonEmpty) protocols.asJava else null)
           .build
       )
     else None

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
@@ -72,7 +72,7 @@ final case class TlsConfiguration(
 }
 
 object TlsConfiguration {
-  val Empty = TlsConfiguration(
+  val Empty: TlsConfiguration = TlsConfiguration(
     enabled = true,
     keyCertChainFile = None,
     keyFile = None,

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/TlsIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/TlsIT.scala
@@ -8,6 +8,7 @@ import java.io.File
 import com.daml.bazeltools.BazelRunfiles._
 import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
 import com.daml.ledger.api.tls.TlsConfiguration
+import com.daml.ledger.api.v1.transaction_service.GetLedgerEndResponse
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
@@ -17,6 +18,8 @@ import com.daml.ledger.client.configuration.{
 import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.platform.sandbox.services.SandboxFixture
 import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.Future
 
 class TlsIT extends AsyncWordSpec with SandboxFixture with SuiteResourceManagementAroundAll {
 
@@ -32,17 +35,24 @@ class TlsIT extends AsyncWordSpec with SandboxFixture with SuiteResourceManageme
     }
   }
 
-  private lazy val tlsEnabledConfig = LedgerClientConfiguration(
-    "appId",
-    LedgerIdRequirement.none,
-    CommandClientConfiguration.default,
-    TlsConfiguration(
-      enabled = true,
-      Some(clientCertChainFilePath),
-      Some(clientPrivateKeyFilePath),
-      Some(trustCertCollectionFilePath),
-    ).client,
-  )
+  private lazy val baseConfig: LedgerClientConfiguration =
+    LedgerClientConfiguration(
+      "appId",
+      LedgerIdRequirement.none,
+      CommandClientConfiguration.default,
+      None,
+    )
+
+  private def tlsEnabledConfig(protocols: Seq[String]): LedgerClientConfiguration =
+    baseConfig.copy(sslContext =
+      TlsConfiguration(
+        enabled = true,
+        Some(clientCertChainFilePath),
+        Some(clientPrivateKeyFilePath),
+        Some(trustCertCollectionFilePath),
+        protocols = protocols,
+      ).client
+    )
 
   override protected lazy val config: SandboxConfig =
     super.config.copy(
@@ -56,19 +66,28 @@ class TlsIT extends AsyncWordSpec with SandboxFixture with SuiteResourceManageme
       )
     )
 
-  private lazy val clientF = LedgerClient.singleHost(serverHost, serverPort.value, tlsEnabledConfig)
+  private def clientF(protocol: String) =
+    LedgerClient.singleHost(serverHost, serverPort.value, tlsEnabledConfig(Seq(protocol)))
 
   "A TLS-enabled server" should {
     "reject ledger queries when the client connects without tls" in {
       recoverToSucceededIf[io.grpc.StatusRuntimeException] {
         LedgerClient
-          .singleHost(serverHost, serverPort.value, tlsEnabledConfig.copy(sslContext = None))
+          .singleHost(serverHost, serverPort.value, baseConfig)
           .flatMap(_.transactionClient.getLedgerEnd())
       }
     }
 
     "serve ledger queries when the client presents a valid certificate" in {
-      clientF.flatMap(_.transactionClient.getLedgerEnd()).map(_ => succeed)
+      def testWith(protocol: String): Future[GetLedgerEndResponse] =
+        withClue(s"Testing with $protocol") {
+          clientF(protocol).flatMap(_.transactionClient.getLedgerEnd())
+        }
+
+      for {
+        _ <- testWith("TLSv1.2")
+        _ <- testWith("TLSv1.3")
+      } yield succeed
     }
   }
 }


### PR DESCRIPTION
As raised here: https://discuss.daml.com/t/what-version-of-tls-is-supported-by-the-ledger-api/1982

This has been effectively fixed by upgrading Netty here: https://github.com/digital-asset/daml/pull/8558

Note that this is an integration test for sandbox-classic only, but the
infrastructure used is shared with other Ledger API server
implementations, so this should be enough.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
