### PR TITLE
lengthen timeout for FlowUtilTest from 150ms to 5s

### DIFF
--- a/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
+++ b/ledger-service/http-json/src/test/scala/com/digitalasset/http/util/FlowUtilTest.scala
@@ -15,6 +15,7 @@ import org.scalatest.matchers.should.Matchers
 import scalaz.{-\/, \/, \/-}
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class FlowUtilTest
     extends AnyFlatSpec
@@ -41,7 +42,7 @@ class FlowUtilTest
         .via(allowOnlyFirstInput[String, Int](error))
         .runFold(Vector.empty[String \/ Int])(_ :+ _)
 
-    whenReady(actualF) { actual =>
+    whenReady(actualF, timeout(5.seconds), interval(100.milliseconds)) { actual =>
       actual shouldBe expected
     }
   }


### PR DESCRIPTION
Fixes a flake; thanks @stefanobaghino-da and @garyverhaegen-da for reporting.

We could rework this to use `forAllAsync` to use the combined integration test patiences configured for most tests like this, but this is a simpler fix.

https://github.com/digital-asset/daml/blob/22ce9409545202ef134e20d2cfb126dd6bb19149/libs-scala/scalatest-utils/src/main/scala/scalatest/AsyncForAll.scala#L19-L36

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
