### PR TITLE
Correctly document and report malformed party names when allocating

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -155,6 +155,19 @@ excluded_test_tool_tests = [
             },
         ],
     },
+    {
+        "start": "0.0.0",  # TODO This should become the latest available snapshot when it becomes available
+        "platform_ranges": [
+            {
+                "end": "1.10.0-snapshot.20210120.6106.0.58ef725a",
+                "exclusions": [
+                    # See https://github.com/digital-asset/daml/pull/8642
+                    "PartyManagementServiceIT:PMRejectLongPartyHints",
+                    "PartyManagementServiceIT:PMRejectInvalidPartyHints",
+                ],
+            },
+        ],
+    },
 ]
 
 def in_range(version, range):

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/party_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/party_management_service.proto
@@ -61,7 +61,7 @@ service PartyManagementService {
   // canton: completely different globally unique identifier is allocated.
   // Behind the scenes calls to an internal protocol are made. As that protocol
   // is richer than the surface protocol, the arguments take implicit values
-  // Party names are required to be non-empty US-ASCII strings built from letters, digits, space,
+  // The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space,
   // colon, minus and underscore limited to 255 chars
   rpc AllocateParty (AllocatePartyRequest) returns (AllocatePartyResponse);
 }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/party_management_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/party_management_service.proto
@@ -61,6 +61,8 @@ service PartyManagementService {
   // canton: completely different globally unique identifier is allocated.
   // Behind the scenes calls to an internal protocol are made. As that protocol
   // is richer than the surface protocol, the arguments take implicit values
+  // Party names are required to be non-empty US-ASCII strings built from letters, digits, space,
+  // colon, minus and underscore limited to 255 chars
   rpc AllocateParty (AllocatePartyRequest) returns (AllocatePartyResponse);
 }
 

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -75,7 +75,9 @@ conformance_test(
         "--exclude=ContractKeysIT,ContractKeysIT:CKFetchOrLookup,ContractKeysIT:CKNoFetchUndisclosed,ContractKeysIT:CKMaintainerScoped" +
         ",ParticipantPruningIT" +  # see "conformance-test-participant-pruning" below
         ",ConfigManagementServiceIT,LedgerConfigurationServiceIT" +  # dynamic config management not supported by Canton
-        ",ClosedWorldIT",  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
+        ",ClosedWorldIT" +  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
+        # The following tests fail because Canton raises a different error (see https://github.com/digital-asset/daml/pull/8642)
+        ",PartyManagementServiceIT:PMRejectLongPartyHints,PartyManagementServiceIT:PMRejectInvalidPartyHints",
     ],
 ) if not is_windows else None
 

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
@@ -110,6 +110,24 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
   })
 
   test(
+    "PMRejectInvalidPartyHints",
+    "A party identifier that contains invalid characters should be rejected with the proper error",
+    allocate(NoParties),
+  )(implicit ec => { case Participants(Participant(ledger)) =>
+    for {
+      error <- ledger
+        .allocateParty(
+          // Assumption: emojis will never be acceptable in a party identifier
+          partyIdHint = Some("\uD83D\uDE00"),
+          displayName = None,
+        )
+        .failed
+    } yield {
+      assertGrpcError(error, Status.Code.INVALID_ARGUMENT, "non expected character")
+    }
+  })
+
+  test(
     "PMAllocateOneHundred",
     "It should create unique party names when allocating many parties",
     allocate(NoParties),

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
@@ -4,11 +4,13 @@
 package com.daml.ledger.api.testtool.suites
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
+import com.daml.ledger.api.testtool.infrastructure.Assertions.assertGrpcError
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.v1.admin.party_management_service.PartyDetails
 import com.daml.ledger.client.binding
 import com.daml.ledger.test.model.Test.Dummy
 import com.daml.lf.data.Ref
+import io.grpc.Status
 import scalaz.Tag
 import scalaz.syntax.tag.ToTagOps
 
@@ -87,6 +89,23 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
       assert(Tag.unwrap(p1).nonEmpty, "The first allocated party identifier is an empty string")
       assert(Tag.unwrap(p2).nonEmpty, "The second allocated party identifier is an empty string")
       assert(p1 != p2, "The two parties have the same party identifier")
+    }
+  })
+
+  test(
+    "PMRejectLongPartyHints",
+    "A party identifier which is too long should be rejected with the proper error",
+    allocate(NoParties),
+  )(implicit ec => { case Participants(Participant(ledger)) =>
+    for {
+      error <- ledger
+        .allocateParty(
+          partyIdHint = Some(Random.alphanumeric.take(256).mkString),
+          displayName = None,
+        )
+        .failed
+    } yield {
+      assertGrpcError(error, Status.Code.INVALID_ARGUMENT, "Party is too long")
     }
   })
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -90,7 +90,7 @@ private[apiserver] final class ApiPartyManagementService private (
           .fromString(request.partyIdHint)
           .fold(
             error => Future.failed(ErrorFactories.invalidArgument(error)),
-            party => Future(Some(party)),
+            party => Future.successful(Some(party)),
           )
       }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiPartyManagementService.scala
@@ -141,7 +141,7 @@ private[apiserver] object ApiPartyManagementService {
     // Suffix is `-` followed by a random UUID as a string
     private val SuffixLength: Int = 1 + UUID.randomUUID().toString.length
     private val MaxLength: Int = 255
-    val PrefixMaxLength: Int = MaxLength - SuffixLength
+    private val PrefixMaxLength: Int = MaxLength - SuffixLength
     def withPrefix(maybeParty: Option[Ref.Party]): v1.SubmissionId = {
       val uuid = UUID.randomUUID().toString
       val raw = maybeParty.fold(uuid)(party => s"${party.take(PrefixMaxLength)}-$uuid")


### PR DESCRIPTION
As reported here: https://discuss.daml.com/t/issues-allocating-parties-with-large-number-of-characters/1992

changelog_begin
[Ledger API] Documented the hard-coded limit of 255 characters for Daml-LF party names.
[Ledger API] Malformed party names are now correctly reported back with an INVALID_ARGUMENT error
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
