### PR TITLE
resources: Add `Resource#transform`, and mirror `Resource#transform{,With}` in `ResourceOwner`.

### DIFF
--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/AbstractResourceOwner.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/AbstractResourceOwner.scala
@@ -6,7 +6,7 @@ package com.daml.resources
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-/** A ResourceOwner of type [[A]] is can acquire a [[Resource]] of the same type and its operations
+/** A ResourceOwner of type `A` is can acquire a [[Resource]] of the same type and its operations
   * are applied to the [[Resource]] after it has been acquired.
   *
   * @tparam A The [[Resource]] value type.
@@ -26,19 +26,19 @@ abstract class AbstractResourceOwner[Context: HasExecutionContext, +A] {
     */
   def acquire()(implicit context: Context): Resource[Context, A]
 
-  /** @see [[Resource#map()]] */
+  /** @see [[Resource.map]] */
   def map[B](f: A => B): R[B] = new R[B] {
     override def acquire()(implicit context: Context): Resource[Context, B] =
       self.acquire().map(f)
   }
 
-  /** @see [[Resource#flatMap()]] */
+  /** @see [[Resource.flatMap]] */
   def flatMap[B](f: A => R[B]): R[B] = new R[B] {
     override def acquire()(implicit context: Context): Resource[Context, B] =
       self.acquire().flatMap(value => f(value).acquire())
   }
 
-  /** @see [[Resource#withFilter()]] */
+  /** @see [[Resource.withFilter]] */
   def withFilter(p: A => Boolean): R[A] = new R[A] {
     override def acquire()(implicit context: Context): Resource[Context, A] =
       self.acquire().withFilter(p)

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/AbstractResourceOwner.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/AbstractResourceOwner.scala
@@ -4,7 +4,7 @@
 package com.daml.resources
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 /** A ResourceOwner of type `A` is can acquire a [[Resource]] of the same type and its operations
   * are applied to the [[Resource]] after it has been acquired.
@@ -42,6 +42,18 @@ abstract class AbstractResourceOwner[Context: HasExecutionContext, +A] {
   def withFilter(p: A => Boolean): R[A] = new R[A] {
     override def acquire()(implicit context: Context): Resource[Context, A] =
       self.acquire().withFilter(p)
+  }
+
+  /** @see [[Resource.transform]] */
+  def transform[B](f: Try[A] => Try[B]): R[B] = new R[B] {
+    override def acquire()(implicit context: Context): Resource[Context, B] =
+      self.acquire().transform(f)
+  }
+
+  /** @see [[Resource.transformWith]] */
+  def transformWith[B](f: Try[A] => R[B]): R[B] = new R[B] {
+    override def acquire()(implicit context: Context): Resource[Context, B] =
+      self.acquire().transformWith(result => f(result).acquire())
   }
 
   /** Acquire the [[Resource]]'s value, use it asynchronously, and release it afterwards.

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/Resource.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/Resource.scala
@@ -22,7 +22,7 @@ abstract class Resource[Context: HasExecutionContext, +A] {
   def asFuture: Future[A]
 
   /** Every [[Resource]] can be (asynchronously) released. Releasing a resource will also release
-    * all earlier resources constructed via [[flatMap()]] or a `for` comprehension.
+    * all earlier resources constructed via [[flatMap]] or a `for` comprehension.
     */
   def release(): Future[Unit]
 

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceFactories.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceFactories.scala
@@ -7,6 +7,7 @@ import com.daml.resources.HasExecutionContext.executionContext
 
 import scala.collection.compat._
 import scala.concurrent.Future
+import scala.util.Try
 
 final class ResourceFactories[Context: HasExecutionContext] {
 
@@ -23,6 +24,11 @@ final class ResourceFactories[Context: HasExecutionContext] {
     */
   def fromFuture[T](future: Future[T]): R[T] =
     PureResource(future)
+
+  /** Wraps a simple [[Try]] in a [[Resource]] that doesn't need to be released.
+    */
+  def fromTry[T](result: Try[T]): R[T] =
+    PureResource(Future.fromTry(result))
 
   /** Produces a [[Resource]] that has already succeeded with the [[Unit]] value.
     */

--- a/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceOwnerFactories.scala
+++ b/libs-scala/resources/src/main/scala/com/digitalasset/resources/ResourceOwnerFactories.scala
@@ -10,7 +10,7 @@ import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
 import scala.util.Try
 
-/** Convenient [[ResourceOwner]] factory methods.
+/** Convenient [[AbstractResourceOwner]] factory methods.
   */
 trait ResourceOwnerFactories[Context] {
   protected implicit val hasExecutionContext: HasExecutionContext[Context]

--- a/libs-scala/resources/src/test/suite/scala/com/digitalasset/resources/ResourceOwnerSpec.scala
+++ b/libs-scala/resources/src/test/suite/scala/com/digitalasset/resources/ResourceOwnerSpec.scala
@@ -7,7 +7,10 @@ import java.util.concurrent.CompletableFuture.completedFuture
 import java.util.concurrent.{Executors, RejectedExecutionException}
 import java.util.{Timer, TimerTask}
 
-import com.daml.resources.FailingResourceOwner.FailingResourceFailedToOpen
+import com.daml.resources.FailingResourceOwner.{
+  FailingResourceFailedToOpen,
+  TriedToReleaseAFailedResource,
+}
 import com.daml.resources.{Resource => AbstractResource}
 import com.daml.timer.Delayed
 import com.github.ghik.silencer.silent
@@ -240,6 +243,96 @@ final class ResourceOwnerSpec extends AsyncWordSpec with Matchers {
         withClue("after releasing,") {
           innerResourceOwner.hasBeenAcquired should be(false)
           outerResourceOwner.hasBeenAcquired should be(false)
+        }
+      }
+    }
+
+    "transform success into another success" in {
+      val owner = TestResourceOwner(5)
+      val resource = owner.acquire()
+
+      val transformedResource = resource.transform {
+        case Success(value) =>
+          Success(value + 1)
+        case Failure(_) =>
+          fail("The failure path should never be called.")
+      }
+
+      for {
+        value <- transformedResource.asFuture
+        _ <- transformedResource.release()
+      } yield {
+        withClue("after releasing,") {
+          value should be(6)
+        }
+      }
+    }
+
+    "transform success into a failure" in {
+      val owner = TestResourceOwner(9)
+      val resource = owner.acquire()
+
+      val transformedResource = resource.transform[Int] {
+        case Success(value) =>
+          Failure(new RuntimeException(s"Oh no! The value was $value."))
+        case Failure(_) =>
+          fail("The failure path should never be called.")
+      }
+
+      for {
+        exception <- transformedResource.asFuture.failed
+        _ <- transformedResource.release()
+      } yield {
+        withClue("after releasing,") {
+          exception.getMessage should be("Oh no! The value was 9.")
+        }
+      }
+    }
+
+    "transform failure into a success" in {
+      val owner = new TestResourceOwner[Int](
+        Future.failed(new Exception("This one didn't work.")),
+        _ => Future.failed(new TriedToReleaseAFailedResource),
+      )
+      val resource = owner.acquire()
+
+      val transformedResource = resource.transform {
+        case Success(_) =>
+          fail("The success path should never be called.")
+        case Failure(exception) =>
+          Success(exception.getMessage)
+      }
+
+      for {
+        value <- transformedResource.asFuture
+        _ <- transformedResource.release()
+      } yield {
+        withClue("after releasing,") {
+          value should be("This one didn't work.")
+        }
+      }
+    }
+
+    "transform failure into another failure" in {
+      val owner = new TestResourceOwner[Int](
+        Future.failed(new Exception("This also didn't work.")),
+        _ => Future.failed(new TriedToReleaseAFailedResource),
+      )
+      val resource = owner.acquire()
+
+      val transformedResource = resource.transform[Int] {
+        case Success(_) =>
+          fail("The success path should never be called.")
+        case Failure(exception) =>
+          Failure(new Exception(exception.getMessage + " Boo."))
+      }
+
+      for {
+        exception <- transformedResource.asFuture.failed
+        _ <- transformedResource.release()
+      } yield {
+        withClue("after releasing,") {
+          exception.getMessage should be("This also didn't work. Boo.")
         }
       }
     }


### PR DESCRIPTION
As requested by @stefanobaghino-da.

This also fixes some Scaladoc.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
