### PR TITLE
fix perf_speedy report

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -116,7 +116,7 @@ jobs:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
       - template: ../daily_tell_slack.yml
         parameters:
-          success-message: '$(cat $(Build.StagingDirectory)/perf-results.json | jq . | jq -sR ''"perf for ''"$COMMIT_LINK"'':```\(.)```"'')'
+          success-message: $(jq --arg stats "$(cat $(Build.StagingDirectory)/perf-results.json)" --arg link "$COMMIT_LINK" -n '"perf for " + $link + ":```" + $stats + "```"')
 
   - job: perf_http_json
     timeoutInMinutes: 120


### PR DESCRIPTION
The report currently chokes on quotes in the commit message (see 550aa48fc52cb6dfa19de6b86e27b481d3835048). Rather than trying to correctly excape things in Bash, this PR delegates the quote handling to jq, because having to deal with Bash embedded in YAML is hard enough.

CHANGELOG_BEGIN
CHANGELOG_END