### PR TITLE
Restrict extensibility of ServerResourceOwner

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
@@ -8,18 +8,18 @@ import java.net.{BindException, InetAddress, InetSocketAddress}
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit.SECONDS
 
-import com.daml.ledger.resources.{Resource, ResourceContext}
+import com.daml.ledger.resources.{ResourceContext, ResourceOwner}
 import com.daml.metrics.Metrics
 import com.daml.ports.Port
-import com.daml.resources.grpc.ServerResourceOwner
+import com.daml.resources.AbstractResourceOwner
 import com.google.protobuf.Message
 import io.grpc._
 import io.grpc.netty.NettyServerBuilder
 import io.netty.handler.ssl.SslContext
 
 import scala.concurrent.duration.DurationInt
+import scala.util.Failure
 import scala.util.control.NoStackTrace
-import scala.util.{Failure, Success}
 
 private[apiserver] object GrpcServer {
 
@@ -30,16 +30,16 @@ private[apiserver] object GrpcServer {
   // allow for extra information such as the exception stack trace.
   private val MaximumStatusDescriptionLength = 4 * 1024 // 4 KB
 
-  private def makeBuilder(
+  def owner(
       address: Option[String],
       desiredPort: Port,
       maxInboundMessageSize: Int,
-      sslContext: Option[SslContext],
-      interceptors: List[ServerInterceptor],
+      sslContext: Option[SslContext] = None,
+      interceptors: List[ServerInterceptor] = List.empty,
       metrics: Metrics,
       servicesExecutor: Executor,
       services: Iterable[BindableService],
-  ): NettyServerBuilder = {
+  ): AbstractResourceOwner[ResourceContext, Server] = {
     val host = address.map(InetAddress.getByName).getOrElse(InetAddress.getLoopbackAddress)
     val builder = NettyServerBuilder.forAddress(new InetSocketAddress(host, desiredPort.value))
     builder.sslContext(sslContext.orNull)
@@ -54,44 +54,12 @@ private[apiserver] object GrpcServer {
       builder.addService(service)
       toLegacyService(service).foreach(builder.addService)
     }
-    builder
-  }
-
-  private def causedByBindException(e: IOException): Boolean =
-    e.getCause != null && e.getCause.isInstanceOf[BindException]
-
-  final class Owner(
-      address: Option[String],
-      desiredPort: Port,
-      maxInboundMessageSize: Int,
-      sslContext: Option[SslContext] = None,
-      interceptors: List[ServerInterceptor] = List.empty,
-      metrics: Metrics,
-      servicesExecutor: Executor,
-      services: Iterable[BindableService],
-  ) extends ServerResourceOwner[ResourceContext](
-        builder = makeBuilder(
-          address,
-          desiredPort,
-          maxInboundMessageSize,
-          sslContext,
-          interceptors,
-          metrics,
-          servicesExecutor,
-          services,
-        ),
-        shutdownTimeout = 1.second,
-      ) {
-    override def acquire()(implicit context: ResourceContext): Resource[Server] = {
-      super.acquire().transformWith {
-        case Success(server) =>
-          Resource.successful(server)
-        case Failure(e: IOException) if causedByBindException(e) =>
-          Resource.failed(new UnableToBind(desiredPort, e.getCause))
-        case Failure(exception) =>
-          Resource.failed(exception)
-      }
-    }
+    ResourceOwner
+      .forServer(builder, shutdownTimeout = 1.second)
+      .transform(_.recoverWith {
+        case e: IOException if e.getCause != null && e.getCause.isInstanceOf[BindException] =>
+          Failure(new UnableToBind(desiredPort, e.getCause))
+      })
   }
 
   final class UnableToBind(port: Port, cause: Throwable)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/GrpcServer.scala
@@ -8,10 +8,9 @@ import java.net.{BindException, InetAddress, InetSocketAddress}
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit.SECONDS
 
-import com.daml.ledger.resources.{ResourceContext, ResourceOwner}
+import com.daml.ledger.resources.ResourceOwner
 import com.daml.metrics.Metrics
 import com.daml.ports.Port
-import com.daml.resources.AbstractResourceOwner
 import com.google.protobuf.Message
 import io.grpc._
 import io.grpc.netty.NettyServerBuilder
@@ -39,7 +38,7 @@ private[apiserver] object GrpcServer {
       metrics: Metrics,
       servicesExecutor: Executor,
       services: Iterable[BindableService],
-  ): AbstractResourceOwner[ResourceContext, Server] = {
+  ): ResourceOwner[Server] = {
     val host = address.map(InetAddress.getByName).getOrElse(InetAddress.getLoopbackAddress)
     val builder = NettyServerBuilder.forAddress(new InetSocketAddress(host, desiredPort.value))
     builder.sslContext(sslContext.orNull)

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/LedgerApiServer.scala
@@ -36,16 +36,18 @@ private[daml] final class LedgerApiServer(
       apiServices <- apiServicesResource
       sslContext = tlsConfiguration.flatMap(_.server)
       _ = tlsConfiguration.map(_.setJvmTlsProperties())
-      server <- new GrpcServer.Owner(
-        address,
-        desiredPort,
-        maxInboundMessageSize,
-        sslContext,
-        interceptors,
-        metrics,
-        servicesExecutor,
-        apiServices.services,
-      ).acquire()
+      server <- GrpcServer
+        .owner(
+          address,
+          desiredPort,
+          maxInboundMessageSize,
+          sslContext,
+          interceptors,
+          metrics,
+          servicesExecutor,
+          apiServices.services,
+        )
+        .acquire()
       // Notify the caller that the services have been closed, so a reset request can complete
       // without blocking on the server terminating.
       _ <- Resource(Future.unit)(_ =>

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/apiserver/GrpcServerSpec.scala
@@ -105,7 +105,7 @@ object GrpcServerSpec {
   private def resources(): ResourceOwner[ManagedChannel] =
     for {
       executor <- ResourceOwner.forExecutorService(() => Executors.newSingleThreadExecutor())
-      server <- new GrpcServer.Owner(
+      server <- GrpcServer.owner(
         address = None,
         desiredPort = Port.Dynamic,
         maxInboundMessageSize = maxInboundMessageSize,

--- a/libs-scala/resources-grpc/src/main/scala/com/daml/resources/grpc/ServerResourceOwner.scala
+++ b/libs-scala/resources-grpc/src/main/scala/com/daml/resources/grpc/ServerResourceOwner.scala
@@ -9,7 +9,7 @@ import io.grpc.{Server, ServerBuilder}
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
-class ServerResourceOwner[Context: HasExecutionContext](
+private[grpc] final class ServerResourceOwner[Context: HasExecutionContext](
     builder: ServerBuilder[_],
     shutdownTimeout: FiniteDuration,
 ) extends AbstractResourceOwner[Context, Server] {


### PR DESCRIPTION
Following https://github.com/digital-asset/daml/pull/8649 this commit
fixes the last open comment from https://github.com/digital-asset/daml/pull/8604
as explained in the comment https://github.com/digital-asset/daml/pull/8604#issuecomment-766620042

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
