### PR TITLE
Increased compatibility test size for *classic-postgresql to 'large' [DPP-195]

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -466,6 +466,7 @@ def sdk_platform_test(sdk_version, platform_version):
 
     client_server_test(
         name = name + "-classic-postgresql",
+        size = "large",
         client = ledger_api_test_tool,
         client_args = [
             "localhost:6865",


### PR DESCRIPTION
This change is our current best guess on a fix (an experiment really) to get rid of timeouts in `*-classic-postgresql` conformance tests.
Change is done according to [the Bazel docs](https://docs.bazel.build/versions/master/be/common-definitions.html).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
