### PR TITLE
Remove fake types from JdbcLedgerDao*spec tests

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoActiveContractsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoActiveContractsSpec.scala
@@ -7,9 +7,10 @@ import java.util.UUID
 
 import akka.NotUsed
 import akka.stream.scaladsl.{Sink, Source}
-import com.daml.lf.data.Ref.{Identifier, Party}
+import com.daml.lf.data.Ref.Party
 import com.daml.ledger.api.v1.active_contracts_service.GetActiveContractsResponse
 import com.daml.ledger.api.v1.event.CreatedEvent
+import com.daml.platform.participant.util.LfEngineToApi
 import org.scalatest._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -100,9 +101,9 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
         multipleCreates(
           operator = "operator",
           signatoriesAndTemplates = Seq(
-            party1 -> "acs:mod:Template1",
-            party2 -> "acs:mod:Template3",
-            party1 -> "acs:mod:Template3",
+            (party1, someTemplateId, someContractArgument),
+            (party2, otherTemplateId, otherContractArgument),
+            (party1, otherTemplateId, otherContractArgument),
           ),
         )
       )
@@ -111,17 +112,14 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
         ledgerDao.transactionsReader
           .getActiveContracts(
             activeAt = ledgerEnd,
-            filter = Map(party1 -> Set(Identifier.assertFromString("acs:mod:Template3"))),
+            filter = Map(party1 -> Set(otherTemplateId)),
             verbose = true,
           )
       )
     } yield {
       val create = result.loneElement
       create.witnessParties.loneElement shouldBe party1
-      val identifier = create.templateId.value
-      identifier.packageId shouldBe "acs"
-      identifier.moduleName shouldBe "mod"
-      identifier.entityName shouldBe "Template3"
+      create.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
     }
   }
 
@@ -133,9 +131,9 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
         multipleCreates(
           operator = "operator",
           signatoriesAndTemplates = Seq(
-            party1 -> "acs:mod:Template1",
-            party2 -> "acs:mod:Template3",
-            party1 -> "acs:mod:Template3",
+            (party1, someTemplateId, someContractArgument),
+            (party2, otherTemplateId, otherContractArgument),
+            (party1, otherTemplateId, otherContractArgument),
           ),
         )
       )
@@ -145,12 +143,8 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
           .getActiveContracts(
             activeAt = ledgerEnd,
             filter = Map(
-              party1 -> Set(
-                Identifier.assertFromString("acs:mod:Template3")
-              ),
-              party2 -> Set(
-                Identifier.assertFromString("acs:mod:Template3")
-              ),
+              party1 -> Set(otherTemplateId),
+              party2 -> Set(otherTemplateId),
             ),
             verbose = true,
           )
@@ -161,17 +155,11 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
 
       val create1 = activeContracts(0)
       create1.witnessParties.loneElement shouldBe party2
-      val identifier1 = create1.templateId.value
-      identifier1.packageId shouldBe "acs"
-      identifier1.moduleName shouldBe "mod"
-      identifier1.entityName shouldBe "Template3"
+      create1.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
 
       val create2 = activeContracts(1)
       create2.witnessParties.loneElement shouldBe party1
-      val identifier2 = create2.templateId.value
-      identifier2.packageId shouldBe "acs"
-      identifier2.moduleName shouldBe "mod"
-      identifier2.entityName shouldBe "Template3"
+      create2.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
     }
   }
 
@@ -183,9 +171,9 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
         multipleCreates(
           operator = "operator",
           signatoriesAndTemplates = Seq(
-            party1 -> "acs:mod:Template1",
-            party2 -> "acs:mod:Template3",
-            party1 -> "acs:mod:Template3",
+            (party1, someTemplateId, someContractArgument),
+            (party2, otherTemplateId, otherContractArgument),
+            (party1, otherTemplateId, otherContractArgument),
           ),
         )
       )
@@ -195,12 +183,8 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
           .getActiveContracts(
             activeAt = ledgerEnd,
             filter = Map(
-              party1 -> Set(
-                Identifier.assertFromString("acs:mod:Template1")
-              ),
-              party2 -> Set(
-                Identifier.assertFromString("acs:mod:Template3")
-              ),
+              party1 -> Set(someTemplateId),
+              party2 -> Set(otherTemplateId),
             ),
             verbose = true,
           )
@@ -211,17 +195,11 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
 
       val create2 = activeContracts(0)
       create2.witnessParties.loneElement shouldBe party1
-      val identifier2 = create2.templateId.value
-      identifier2.packageId shouldBe "acs"
-      identifier2.moduleName shouldBe "mod"
-      identifier2.entityName shouldBe "Template1"
+      create2.templateId.value shouldBe LfEngineToApi.toApiIdentifier(someTemplateId)
 
       val create1 = activeContracts(1)
       create1.witnessParties.loneElement shouldBe party2
-      val identifier1 = create1.templateId.value
-      identifier1.packageId shouldBe "acs"
-      identifier1.moduleName shouldBe "mod"
-      identifier1.entityName shouldBe "Template3"
+      create1.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
     }
   }
 
@@ -233,9 +211,9 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
         multipleCreates(
           operator = "operator",
           signatoriesAndTemplates = Seq(
-            party1 -> "acs:mod:Template1",
-            party2 -> "acs:mod:Template3",
-            party1 -> "acs:mod:Template3",
+            (party1, someTemplateId, someContractArgument),
+            (party2, otherTemplateId, otherContractArgument),
+            (party1, otherTemplateId, otherContractArgument),
           ),
         )
       )
@@ -245,9 +223,7 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
           .getActiveContracts(
             activeAt = ledgerEnd,
             filter = Map(
-              party1 -> Set(
-                Identifier.assertFromString("acs:mod:Template1")
-              ),
+              party1 -> Set(someTemplateId),
               party2 -> Set.empty,
             ),
             verbose = true,
@@ -259,17 +235,11 @@ private[dao] trait JdbcLedgerDaoActiveContractsSpec
 
       val create2 = activeContracts(0)
       create2.witnessParties.loneElement shouldBe party1
-      val identifier2 = create2.templateId.value
-      identifier2.packageId shouldBe "acs"
-      identifier2.moduleName shouldBe "mod"
-      identifier2.entityName shouldBe "Template1"
+      create2.templateId.value shouldBe LfEngineToApi.toApiIdentifier(someTemplateId)
 
       val create1 = activeContracts(1)
       create1.witnessParties.loneElement shouldBe party2
-      val identifier1 = create1.templateId.value
-      identifier1.packageId shouldBe "acs"
-      identifier1.moduleName shouldBe "mod"
-      identifier1.entityName shouldBe "Template3"
+      create1.templateId.value shouldBe LfEngineToApi.toApiIdentifier(otherTemplateId)
     }
   }
 

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoDivulgenceSpec.scala
@@ -6,7 +6,7 @@ package com.daml.platform.store.dao
 import java.time.Instant
 import java.util.UUID
 
-import com.daml.lf.data.{ImmArray, Ref}
+import com.daml.lf.data.ImmArray
 import com.daml.lf.transaction.Node.{KeyWithMaintainers, NodeCreate, NodeExercises, NodeFetch}
 import com.daml.lf.transaction.TransactionVersion
 import com.daml.lf.transaction.test.TransactionBuilder
@@ -29,7 +29,7 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
         NodeCreate(
           coid = contractId,
           templateId = someTemplateId,
-          arg = someValueRecord,
+          arg = someContractArgument,
           agreementText = someAgreement,
           optLocation = None,
           signatories = Set(alice),
@@ -47,13 +47,13 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
         NodeCreate(
           coid = contractId,
           someTemplateId,
-          someValueRecord,
+          someContractArgument,
           someAgreement,
           optLocation = None,
           signatories = Set(bob),
           stakeholders = Set(bob),
           key = Some(
-            KeyWithMaintainers(ValueParty(bob), Set(bob))
+            KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
           ),
           version = TransactionVersion.minVersion,
         )
@@ -66,18 +66,18 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
         NodeExercises(
           targetCoid = create1,
           templateId = someTemplateId,
-          choiceId = Ref.ChoiceName.assertFromString("SomeChoice"),
+          choiceId = someChoiceName,
           optLocation = None,
           consuming = true,
           actingParties = Set(bob),
-          chosenValue = someValueRecord,
+          chosenValue = someChoiceArgument,
           stakeholders = Set(alice, bob),
           signatories = Set(alice),
           // TODO https://github.com/digital-asset/daml/issues/7709
           //  also test the case of non-empty choice-observers
           choiceObservers = Set.empty,
           children = ImmArray.empty,
-          exerciseResult = None,
+          exerciseResult = Some(someChoiceResult),
           key = None,
           byKey = false,
           version = TransactionVersion.minVersion,
@@ -103,18 +103,18 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
         NodeExercises(
           targetCoid = create2,
           templateId = someTemplateId,
-          choiceId = Ref.ChoiceName.assertFromString("SomeChoice"),
+          choiceId = someChoiceName,
           optLocation = None,
           consuming = true,
           actingParties = Set(bob),
-          chosenValue = someValueRecord,
+          chosenValue = someChoiceArgument,
           stakeholders = Set(bob),
           signatories = Set(bob),
           choiceObservers = Set.empty,
           children = ImmArray.empty,
-          exerciseResult = None,
+          exerciseResult = Some(someChoiceResult),
           key = Some(
-            KeyWithMaintainers(ValueParty(bob), Set(bob))
+            KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
           ),
           byKey = false,
           version = TransactionVersion.minVersion,
@@ -125,13 +125,13 @@ private[dao] trait JdbcLedgerDaoDivulgenceSpec extends LoneElement with Inside {
         NodeCreate(
           coid = builder.newCid,
           someTemplateId,
-          someValueRecord,
+          someContractArgument,
           someAgreement,
           optLocation = None,
           signatories = Set(bob),
           stakeholders = Set(alice, bob),
           key = Some(
-            KeyWithMaintainers(ValueParty(bob), Set(bob))
+            KeyWithMaintainers(someContractKey(bob, "some key"), Set(bob))
           ),
           version = TransactionVersion.minVersion,
         ),

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoSuite.scala
@@ -16,12 +16,12 @@ import com.daml.ledger.participant.state.v1
 import com.daml.ledger.participant.state.v1.{DivulgedContract, Offset, SubmitterInfo}
 import com.daml.lf.archive.DarReader
 import com.daml.lf.data.Ref.{Identifier, Party}
-import com.daml.lf.data.{ImmArray, Ref}
+import com.daml.lf.data.{FrontStack, ImmArray, Ref, Time}
 import com.daml.lf.transaction.Node._
 import com.daml.lf.transaction.test.TransactionBuilder
 import com.daml.lf.transaction._
-import com.daml.lf.value.Value
-import com.daml.lf.value.Value.{ContractId, ContractInst, ValueRecord, ValueText, ValueUnit}
+import com.daml.lf.value.{Value => LfValue}
+import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.LoggingContext
 import com.daml.platform.indexer.OffsetStep
 import com.daml.platform.store.dao.events.TransactionsWriter
@@ -52,49 +52,6 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
     def toLong: Long = BigInt(offset.toByteArray).toLong
   }
 
-  protected final val alice = Party.assertFromString("Alice")
-  protected final val bob = Party.assertFromString("Bob")
-  protected final val charlie = Party.assertFromString("Charlie")
-  protected final val david = Party.assertFromString("David")
-  protected final val emma = Party.assertFromString("Emma")
-
-  protected final val defaultAppId = "default-app-id"
-  protected final val defaultWorkflowId = "default-workflow-id"
-  protected final val someAgreement = "agreement"
-  protected final val someTemplateId = Identifier(
-    Ref.PackageId.assertFromString("packageId"),
-    Ref.QualifiedName(
-      Ref.ModuleName.assertFromString("moduleName"),
-      Ref.DottedName.assertFromString("someTemplate"),
-    ),
-  )
-  protected final val someRecordId = Identifier(
-    Ref.PackageId.assertFromString("packageId"),
-    Ref.QualifiedName(
-      Ref.ModuleName.assertFromString("moduleName"),
-      Ref.DottedName.assertFromString("someRecord"),
-    ),
-  )
-  protected final val someValueText = ValueText("some text")
-  protected final val someValueRecord = ValueRecord(
-    Some(someRecordId),
-    ImmArray(Some(Ref.Name.assertFromString("field")) -> someValueText),
-  )
-  protected final val someContractKey = someValueText
-  protected final val someContractInstance = ContractInst(
-    someTemplateId,
-    someValueRecord,
-    someAgreement,
-  )
-  protected final val someVersionedContractInstance =
-    TransactionBuilder().versionContract(someContractInstance)
-
-  protected final val defaultConfig = v1.Configuration(
-    generation = 0,
-    timeModel = v1.TimeModel.reasonableDefault,
-    Duration.ofDays(1),
-  )
-
   private val reader = DarReader { (_, stream) =>
     Try(DamlLf.Archive.parseFrom(stream))
   }
@@ -104,6 +61,106 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
 
   protected final val packages: List[(DamlLf.Archive, v2.PackageDetails)] =
     dar.all.map(dar => dar -> v2.PackageDetails(dar.getSerializedSize.toLong, now, None))
+  private val testPackageId: Ref.PackageId = Ref.PackageId.assertFromString(dar.main.getHash)
+
+  protected final val alice = Party.assertFromString("Alice")
+  protected final val bob = Party.assertFromString("Bob")
+  protected final val charlie = Party.assertFromString("Charlie")
+  protected final val david = Party.assertFromString("David")
+  protected final val emma = Party.assertFromString("Emma")
+
+  protected final val defaultAppId = "default-app-id"
+  protected final val defaultWorkflowId = "default-workflow-id"
+  protected final val someAgreement = "agreement"
+
+  // Note: *identifiers* and *values* defined below MUST correspond to //ledger/test-common/src/main/daml/model/Test.daml
+  // This is because some tests request values in verbose mode, which requires filling in missing type information,
+  // which in turn requires loading DAML-LF packages with valid DAML-LF types that correspond to the DAML-LF values.
+  //
+  // On the other hand, *transactions* do not need to correspond to valid transactions that could be produced by the
+  // above mentioned DAML code, e.g., signatories/stakeholders may not correspond to the contract/choice arguments.
+  // This is because JdbcLedgerDao is only concerned with serialization, and does not verify the DAML ledger model.
+  private def testIdentifier(name: String) = Identifier(
+    testPackageId,
+    Ref.QualifiedName(
+      Ref.ModuleName.assertFromString("Test"),
+      Ref.DottedName.assertFromString(name),
+    ),
+  )
+  private def recordFieldName(name: String) = Some(Ref.Name.assertFromString(name))
+  protected final val someTemplateId = testIdentifier("ParameterShowcase")
+  protected final val someValueText = LfValue.ValueText("some text")
+  protected final val someValueInt = LfValue.ValueInt64(1)
+  protected final val someValueNumeric =
+    LfValue.ValueNumeric(com.daml.lf.data.Numeric.assertFromString("1.1"))
+  protected final val someNestedOptionalInteger = LfValue.ValueRecord(
+    Some(testIdentifier("NestedOptionalInteger")),
+    ImmArray(
+      Some(Ref.Name.assertFromString("value")) -> LfValue.ValueVariant(
+        Some(testIdentifier("OptionalInteger")),
+        Ref.Name.assertFromString("SomeInteger"),
+        someValueInt,
+      )
+    ),
+  )
+  protected final val someContractArgument = LfValue.ValueRecord(
+    Some(someTemplateId),
+    ImmArray(
+      recordFieldName("operator") -> LfValue.ValueParty(alice),
+      recordFieldName("integer") -> someValueInt,
+      recordFieldName("decimal") -> someValueNumeric,
+      recordFieldName("text") -> someValueText,
+      recordFieldName("bool") -> LfValue.ValueBool(true),
+      recordFieldName("time") -> LfValue.ValueTimestamp(Time.Timestamp.Epoch),
+      recordFieldName("nestedOptionalInteger") -> someNestedOptionalInteger,
+      recordFieldName("integerList") -> LfValue.ValueList(FrontStack(someValueInt)),
+      recordFieldName("optionalText") -> LfValue.ValueOptional(Some(someValueText)),
+    ),
+  )
+  protected final val someChoiceName = Ref.Name.assertFromString("Choice1")
+  protected final val someChoiceArgument = LfValue.ValueRecord(
+    Some(testIdentifier(someChoiceName)),
+    ImmArray(
+      recordFieldName("newInteger") -> someValueInt,
+      recordFieldName("newDecimal") -> someValueNumeric,
+      recordFieldName("newText") -> someValueText,
+      recordFieldName("newBool") -> LfValue.ValueBool(true),
+      recordFieldName("newTime") -> LfValue.ValueTimestamp(Time.Timestamp.Epoch),
+      recordFieldName("newNestedOptionalInteger") -> someNestedOptionalInteger,
+      recordFieldName("newIntegerList") -> LfValue.ValueList(FrontStack(someValueInt)),
+      recordFieldName("newOptionalText") -> LfValue.ValueOptional(Some(someValueText)),
+    ),
+  )
+  protected final val someChoiceResult =
+    LfValue.ValueContractId[ContractId](ContractId.V0.assertFromString("#1"))
+  protected final def someContractKey(party: Party, value: String) = LfValue.ValueRecord(
+    None,
+    ImmArray(
+      None -> LfValue.ValueParty(party),
+      None -> LfValue.ValueText(value),
+    ),
+  )
+  protected final val someContractInstance = ContractInst(
+    someTemplateId,
+    someContractArgument,
+    someAgreement,
+  )
+  protected final val someVersionedContractInstance =
+    TransactionBuilder().versionContract(someContractInstance)
+
+  protected final val otherTemplateId = testIdentifier("Dummy")
+  protected final val otherContractArgument = LfValue.ValueRecord(
+    Some(otherTemplateId),
+    ImmArray(
+      recordFieldName("operator") -> LfValue.ValueParty(alice)
+    ),
+  )
+
+  protected final val defaultConfig = v1.Configuration(
+    generation = 0,
+    timeModel = v1.TimeModel.reasonableDefault,
+    Duration.ofDays(1),
+  )
 
   private[dao] def store(
       submitterInfo: Option[SubmitterInfo],
@@ -121,19 +178,23 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
   protected final def create(
       absCid: ContractId,
       signatories: Set[Party] = Set(alice, bob),
+      templateId: Identifier = someTemplateId,
+      contractArgument: LfValue[ContractId] = someContractArgument,
   ): NodeCreate[ContractId] =
-    createNode(absCid, signatories, signatories, None)
+    createNode(absCid, signatories, signatories, None, templateId, contractArgument)
 
   protected final def createNode(
       absCid: ContractId,
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[KeyWithMaintainers[Value[ContractId]]] = None,
+      key: Option[KeyWithMaintainers[LfValue[ContractId]]] = None,
+      templateId: Identifier = someTemplateId,
+      contractArgument: LfValue[ContractId] = someContractArgument,
   ): NodeCreate[ContractId] =
     NodeCreate(
       coid = absCid,
-      templateId = someTemplateId,
-      arg = someValueRecord,
+      templateId = templateId,
+      arg = contractArgument,
       agreementText = someAgreement,
       optLocation = None,
       signatories = signatories,
@@ -148,16 +209,16 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
     NodeExercises(
       targetCoid = targetCid,
       templateId = someTemplateId,
-      choiceId = Ref.Name.assertFromString("choice"),
+      choiceId = someChoiceName,
       optLocation = None,
       consuming = true,
       actingParties = Set(alice),
-      chosenValue = ValueText("some choice value"),
+      chosenValue = someChoiceArgument,
       stakeholders = Set(alice, bob),
       signatories = Set(alice, bob),
       choiceObservers = Set.empty,
       children = ImmArray.empty,
-      exerciseResult = Some(ValueText("some exercise result")),
+      exerciseResult = Some(someChoiceResult),
       key = None,
       byKey = false,
       version = TransactionVersion.minVersion,
@@ -208,7 +269,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
       submittingParties: Set[Party],
       signatories: Set[Party],
       stakeholders: Set[Party],
-      key: Option[KeyWithMaintainers[Value[ContractId]]],
+      key: Option[KeyWithMaintainers[LfValue[ContractId]]],
   ): Future[(Offset, LedgerEntry.Transaction)] =
     store(
       singleCreate(
@@ -243,16 +304,16 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
       NodeExercises(
         targetCoid = id,
         templateId = someTemplateId,
-        choiceId = Ref.ChoiceName.assertFromString("someChoice"),
+        choiceId = someChoiceName,
         optLocation = None,
         consuming = false,
         actingParties = Set(alice),
-        chosenValue = ValueUnit,
+        chosenValue = someChoiceArgument,
         stakeholders = divulgees,
         signatories = divulgees,
         choiceObservers = Set.empty,
         children = ImmArray.empty,
-        exerciseResult = Some(ValueUnit),
+        exerciseResult = Some(someChoiceResult),
         key = None,
         byKey = false,
         version = TransactionVersion.minVersion,
@@ -487,22 +548,16 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
     */
   protected def multipleCreates(
       operator: String,
-      signatoriesAndTemplates: Seq[(String, String)],
+      signatoriesAndTemplates: Seq[(Party, Identifier, LfValue[ContractId])],
   ): (Offset, LedgerEntry.Transaction) = {
     require(signatoriesAndTemplates.nonEmpty, "multipleCreates cannot create empty transactions")
     val txBuilder = TransactionBuilder()
     val disclosure = for {
       entry <- signatoriesAndTemplates
-      (signatory, template) = entry
-      contract = create(txBuilder.newCid)
+      (signatory, template, argument) = entry
+      contract = create(txBuilder.newCid, Set(signatory), template, argument)
       parties = Set[Party](operator, signatory)
-      nodeId = txBuilder.add(
-        contract.copy(
-          signatories = parties,
-          stakeholders = parties,
-          templateId = Identifier.assertFromString(template),
-        )
-      )
+      nodeId = txBuilder.add(contract)
     } yield nodeId -> parties
     nextOffset() -> LedgerEntry.Transaction(
       commandId = Some(UUID.randomUUID().toString),
@@ -597,12 +652,12 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
       NodeCreate(
         coid = txBuilder.newCid,
         templateId = someTemplateId,
-        arg = someValueRecord,
+        arg = someContractArgument,
         agreementText = someAgreement,
         optLocation = None,
         signatories = Set(party),
         stakeholders = Set(party),
-        key = Some(KeyWithMaintainers(ValueText(key), Set(party))),
+        key = Some(KeyWithMaintainers(someContractKey(party, key), Set(party))),
         version = TransactionVersion.minVersion,
       )
     )
@@ -635,13 +690,13 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
         optLocation = None,
         consuming = true,
         actingParties = Set(party),
-        chosenValue = ValueUnit,
+        chosenValue = LfValue.ValueUnit,
         stakeholders = Set(party),
         signatories = Set(party),
         choiceObservers = Set.empty,
         children = ImmArray.empty,
-        exerciseResult = Some(ValueUnit),
-        key = maybeKey.map(k => KeyWithMaintainers(ValueText(k), Set(party))),
+        exerciseResult = Some(LfValue.ValueUnit),
+        key = maybeKey.map(k => KeyWithMaintainers(someContractKey(party, k), Set(party))),
         byKey = false,
         version = TransactionVersion.minVersion,
       )
@@ -670,7 +725,7 @@ private[dao] trait JdbcLedgerDaoSuite extends JdbcLedgerDaoBackend {
       NodeLookupByKey(
         someTemplateId,
         None,
-        KeyWithMaintainers(ValueText(key), Set(party)),
+        KeyWithMaintainers(someContractKey(party, key), Set(party)),
         result,
         version = TransactionVersion.minVersion,
       )

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionTreesSpec.scala
@@ -228,7 +228,15 @@ private[dao] trait JdbcLedgerDaoTransactionTreesSpec
   it should "filter correctly by party" in {
     for {
       from <- ledgerDao.lookupLedgerEnd()
-      (_, tx) <- store(multipleCreates(charlie, Seq(alice -> "foo:bar:baz", bob -> "foo:bar:baz")))
+      (_, tx) <- store(
+        multipleCreates(
+          charlie,
+          Seq(
+            (alice, someTemplateId, someContractArgument),
+            (bob, someTemplateId, someContractArgument),
+          ),
+        )
+      )
       to <- ledgerDao.lookupLedgerEnd()
       individualLookupForAlice <- lookupIndividually(Seq(tx), as = Set(alice))
       individualLookupForBob <- lookupIndividually(Seq(tx), as = Set(bob))

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcPipelinedInsertionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcPipelinedInsertionsSpec.scala
@@ -49,7 +49,7 @@ trait JdbcPipelinedInsertionsSpec extends Inside with OptionValues with Matchers
           created.eventId shouldBe EventId(tx.transactionId, nodeId).toLedgerString
           created.witnessParties should contain only (tx.actAs: _*)
           created.agreementText.getOrElse("") shouldBe createNode.coinst.agreementText
-          created.contractKey.value.sum.text.value shouldBe key
+          created.contractKey shouldNot be(None)
           created.createArguments shouldNot be(None)
           created.signatories should contain theSameElementsAs createNode.signatories
           created.observers should contain theSameElementsAs createNode.stakeholders.diff(

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoH2DatabaseSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoH2DatabaseSpec.scala
@@ -12,12 +12,12 @@ final class JdbcLedgerDaoH2DatabaseSpec
     with Matchers
     with JdbcLedgerDaoSuite
     with JdbcLedgerDaoBackendH2Database
+    with JdbcLedgerDaoPackagesSpec
     with JdbcLedgerDaoActiveContractsSpec
     with JdbcLedgerDaoCompletionsSpec
     with JdbcLedgerDaoConfigurationSpec
     with JdbcLedgerDaoContractsSpec
     with JdbcLedgerDaoDivulgenceSpec
-    with JdbcLedgerDaoPackagesSpec
     with JdbcLedgerDaoPartiesSpec
     with JdbcLedgerDaoTransactionsSpec
     with JdbcLedgerDaoTransactionTreesSpec

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPipelinedPostgresqlSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPipelinedPostgresqlSpec.scala
@@ -11,6 +11,7 @@ final class JdbcLedgerDaoPipelinedPostgresqlSpec
     with Matchers
     with JdbcLedgerDaoSuite
     with JdbcLedgerDaoBackendPostgresql
+    with JdbcLedgerDaoPackagesSpec
     with JdbcLedgerDaoActiveContractsSpec
     with JdbcLedgerDaoCompletionsSpec
     with JdbcLedgerDaoContractsSpec

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPostgresqlSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/JdbcLedgerDaoPostgresqlSpec.scala
@@ -12,12 +12,12 @@ final class JdbcLedgerDaoPostgresqlSpec
     with Matchers
     with JdbcLedgerDaoSuite
     with JdbcLedgerDaoBackendPostgresql
+    with JdbcLedgerDaoPackagesSpec
     with JdbcLedgerDaoActiveContractsSpec
     with JdbcLedgerDaoCompletionsSpec
     with JdbcLedgerDaoConfigurationSpec
     with JdbcLedgerDaoContractsSpec
     with JdbcLedgerDaoDivulgenceSpec
-    with JdbcLedgerDaoPackagesSpec
     with JdbcLedgerDaoPartiesSpec
     with JdbcLedgerDaoTransactionsSpec
     with JdbcLedgerDaoTransactionTreesSpec

--- a/ledger/test-common/src/main/daml/model/Test.daml
+++ b/ledger/test-common/src/main/daml/model/Test.daml
@@ -121,6 +121,9 @@ template ParameterShowcase
   where
     signatory operator
 
+    key (operator, text) : (Party, Text)
+    maintainer key._1
+
     -- multiple argument choice
     controller operator can
       Choice1 : ContractId ParameterShowcase


### PR DESCRIPTION
This PR refactors `JdbcLedgerDao*Spec` so that the tests use real DAML-LF type identifiers and values. This is required for https://github.com/digital-asset/daml/pull/8656.