### PR TITLE
Use cliopts.Http for OAuth 2.0 middleware

### DIFF
--- a/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
+++ b/daml-assistant/integration-tests/src/DA/Daml/Assistant/IntegrationTests.hs
@@ -332,7 +332,9 @@ damlToolTests =
                                unwords
                                    [ "daml"
                                    , "oauth2-middleware"
-                                   , "--port"
+                                   , "--address"
+                                   , "localhost"
+                                   , "--http-port"
                                    , show middlewarePort
                                    , "--oauth-auth"
                                    , "http://localhost:0/authorize"

--- a/docs/source/tools/auth-middleware/oauth2.rst
+++ b/docs/source/tools/auth-middleware/oauth2.rst
@@ -189,7 +189,8 @@ You would invoke the OAuth 2.0 auth middleware with the following flags:
 
     oauth2-middleware \
         --callback https://example.com/auth/cb \
-        --port 3000
+        --address localhost
+        --http-port 3000
 
 Some browsers reject ``Secure`` cookies on unencrypted connections even on localhost.
 You can pass the command-line flag ``--cookie-secure no`` for testing and development on localhost to avoid this.

--- a/docs/source/tools/trigger-service/auth0_example.rst
+++ b/docs/source/tools/trigger-service/auth0_example.rst
@@ -176,7 +176,8 @@ The ``--callback`` flag defines the middleware's callback URL as exposed through
   DAML_CLIENT_ID="Client_ID" \
   DAML_CLIENT_SECRET="Client_Secret" \
   daml oauth2-middleware \
-    --port 3000 \
+    --address localhost \
+    --http-port 3000 \
     --oauth-auth "OAuth_Authorization_URL" \
     --oauth-token "OAuth_Token_URL" \
     --auth-jwt-rs256-jwks "JSON_Web_Key_Set" \

--- a/triggers/service/auth/BUILD.bazel
+++ b/triggers/service/auth/BUILD.bazel
@@ -57,6 +57,7 @@ da_scala_library(
         ":oauth2-api",
         "//daml-lf/data",
         "//language-support/scala/bindings",
+        "//ledger-service/cli-opts",
         "//ledger-service/jwt",
         "//ledger/cli-opts",
         "//ledger/ledger-api-auth",

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -6,15 +6,17 @@ package com.daml.auth.middleware.oauth2
 import java.nio.file.{Path, Paths}
 
 import akka.http.scaladsl.model.Uri
+import com.daml.cliopts
 import com.daml.jwt.{JwtVerifierBase, JwtVerifierConfigurationCli}
-import com.daml.ports.Port
 
 import scala.concurrent.duration
 import scala.concurrent.duration.FiniteDuration
 
 case class Config(
-    // Port the middleware listens on
-    port: Port,
+    // Host and port the middleware listens on
+    address: String,
+    port: Int,
+    portFile: Option[Path],
     // The URI to which the OAuth2 server will redirect after a completed login flow.
     // Must map to the `/cb` endpoint of the auth middleware.
     callbackUri: Option[Uri],
@@ -36,13 +38,16 @@ case class Config(
 )
 
 object Config {
+  val DefaultHttpPort: Int = 3000
   val DefaultCookieSecure: Boolean = true
   val DefaultMaxLoginRequests: Int = 100
   val DefaultLoginTimeout: FiniteDuration = FiniteDuration(5, duration.MINUTES)
 
   private val Empty =
     Config(
-      port = Port.Dynamic,
+      address = cliopts.Http.defaultAddress,
+      port = DefaultHttpPort,
+      portFile = None,
       callbackUri = None,
       maxLoginRequests = DefaultMaxLoginRequests,
       loginTimeout = DefaultLoginTimeout,
@@ -65,10 +70,12 @@ object Config {
     new scopt.OptionParser[Config]("oauth-middleware") {
       head("OAuth2 Middleware")
 
-      opt[Int]("port")
-        .action((x, c) => c.copy(port = Port(x)))
-        .required()
-        .text("Port to listen on")
+      cliopts.Http.serverParse(this, serviceName = "Trigger")(
+        address = (f, c) => c.copy(address = f(c.address)),
+        httpPort = (f, c) => c.copy(port = f(c.port)),
+        defaultHttpPort = Some(DefaultHttpPort),
+        portFile = Some((f, c) => c.copy(portFile = f(c.portFile))),
+      )
 
       opt[String]("callback")
         .action((x, c) => c.copy(callbackUri = Some(Uri(x))))

--- a/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
+++ b/triggers/service/auth/src/main/scala/com/daml/auth/middleware/oauth2/Config.scala
@@ -70,7 +70,7 @@ object Config {
     new scopt.OptionParser[Config]("oauth-middleware") {
       head("OAuth2 Middleware")
 
-      cliopts.Http.serverParse(this, serviceName = "Trigger")(
+      cliopts.Http.serverParse(this, serviceName = "OAuth2 Middleware")(
         address = (f, c) => c.copy(address = f(c.address)),
         httpPort = (f, c) => c.copy(port = f(c.port)),
         defaultHttpPort = Some(DefaultHttpPort),

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Resources.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/Resources.scala
@@ -3,6 +3,8 @@
 
 package com.daml.auth.middleware.oauth2
 
+import java.io.File
+import java.nio.file.Files
 import java.time.{Clock, Duration, Instant, ZoneId}
 
 import akka.actor.ActorSystem
@@ -16,6 +18,7 @@ import com.daml.clock.AdjustableClock
 import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
 import com.daml.auth.oauth2.test.server.{Server => OAuthServer}
 import com.daml.ports.{LockedFreePort, Port}
+import com.daml.scalautil.Statement.discard
 
 import scala.concurrent.Future
 
@@ -27,6 +30,13 @@ object Resources {
           Future(())
         )
       }
+    }
+  def temporaryDirectory(): ResourceOwner[File] =
+    new ResourceOwner[File] {
+      override def acquire()(implicit context: ResourceContext): Resource[File] =
+        Resource(Future(Files.createTempDirectory("daml-oauth2-middleware").toFile))(dir =>
+          Future(discard { dir.delete() })
+        )
     }
   def authServerBinding(
       server: OAuthServer

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -86,7 +86,9 @@ trait TestFixture
           )
         middlewareBinding <- Resources.authMiddlewareBinding(
           Config(
-            port = Port.Dynamic,
+            address = "localhost",
+            port = 0,
+            portFile = None,
             callbackUri = middlewareCallbackUri,
             maxLoginRequests = maxMiddlewareLogins,
             loginTimeout = Config.DefaultLoginTimeout,

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestFixture.scala
@@ -3,6 +3,7 @@
 
 package com.daml.auth.middleware.oauth2
 
+import java.io.File
 import java.time.{Instant, ZoneId}
 import java.util.Date
 
@@ -33,6 +34,7 @@ case class TestResources(
     clock: AdjustableClock,
     authServer: OAuthServer,
     authServerBinding: ServerBinding,
+    authMiddlewarePortFile: File,
     authMiddlewareBinding: ServerBinding,
     authMiddlewareClient: Client,
     authMiddlewareClientBinding: ServerBinding,
@@ -52,6 +54,7 @@ trait TestFixture
   lazy protected val clock: AdjustableClock = suiteResource.value.clock
   lazy protected val server: OAuthServer = suiteResource.value.authServer
   lazy protected val serverBinding: ServerBinding = suiteResource.value.authServerBinding
+  lazy protected val middlewarePortFile: File = suiteResource.value.authMiddlewarePortFile
   lazy protected val middlewareBinding: ServerBinding = suiteResource.value.authMiddlewareBinding
   lazy protected val middlewareClient: Client = suiteResource.value.authMiddlewareClient
   lazy protected val middlewareClientBinding: ServerBinding = {
@@ -84,11 +87,13 @@ trait TestFixture
             serverBinding.localAddress.getHostString,
             serverBinding.localAddress.getPort,
           )
+        tempDir <- Resources.temporaryDirectory()
+        middlewarePortFile = new File(tempDir, "port")
         middlewareBinding <- Resources.authMiddlewareBinding(
           Config(
             address = "localhost",
             port = 0,
-            portFile = None,
+            portFile = Some(middlewarePortFile.toPath),
             callbackUri = middlewareCallbackUri,
             maxLoginRequests = maxMiddlewareLogins,
             loginTimeout = Config.DefaultLoginTimeout,
@@ -135,6 +140,7 @@ trait TestFixture
         clock = clock,
         authServer = server,
         authServerBinding = serverBinding,
+        authMiddlewarePortFile = middlewarePortFile,
         authMiddlewareBinding = middlewareBinding,
         authMiddlewareClient = middlewareClient,
         authMiddlewareClientBinding = middlewareClientBinding,

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
@@ -24,6 +24,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
 import scala.collection.immutable
+import scala.io.Source
 import scala.util.{Failure, Success}
 
 class TestMiddleware extends AsyncWordSpec with TestFixture with SuiteResourceManagementAroundAll {
@@ -54,6 +55,13 @@ class TestMiddleware extends AsyncWordSpec with TestFixture with SuiteResourceMa
       refreshToken = None,
       scope = Some(claims.toQueryString()),
     )
+  }
+  "the port file" should {
+    "list the HTTP port" in {
+      val bindingPort = middlewareBinding.localAddress.getPort.toString
+      val filePort = Source.fromFile(middlewarePortFile).mkString.stripLineEnd
+      assert(bindingPort == filePort)
+    }
   }
   "the /auth endpoint" should {
     "return unauthorized without cookie" in {

--- a/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
+++ b/triggers/service/auth/src/test/scala/com/daml/auth/middleware/oauth2/TestMiddleware.scala
@@ -59,7 +59,14 @@ class TestMiddleware extends AsyncWordSpec with TestFixture with SuiteResourceMa
   "the port file" should {
     "list the HTTP port" in {
       val bindingPort = middlewareBinding.localAddress.getPort.toString
-      val filePort = Source.fromFile(middlewarePortFile).mkString.stripLineEnd
+      val filePort = {
+        val source = Source.fromFile(middlewarePortFile)
+        try {
+          source.mkString.stripLineEnd
+        } finally {
+          source.close()
+        }
+      }
       assert(bindingPort == filePort)
     }
   }

--- a/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
+++ b/triggers/service/src/test/scala/com/digitalasset/daml/lf/engine/trigger/TriggerServiceFixture.scala
@@ -210,7 +210,9 @@ trait AuthMiddlewareFixture
             .withScheme("http")
             .withAuthority(oauth.localAddress.getHostString, oauth.localAddress.getPort)
           middlewareConfig = MiddlewareConfig(
-            port = Port.Dynamic,
+            address = "localhost",
+            port = 0,
+            portFile = None,
             callbackUri = None,
             maxLoginRequests = MiddlewareConfig.DefaultMaxLoginRequests,
             loginTimeout = MiddlewareConfig.DefaultLoginTimeout,


### PR DESCRIPTION
- Use `com.daml.cliopts.Http` for OAuth 2.0 middleware host and port command-line flags.
  - This is consistent with the flags that the trigger service offers.
  - This allows configuring the list host to something else than "localhost", e.g. "0.0.0.0".
  - This adds a `--port-file` flag as well.
- Add test-case for the `--port-file` option.
- Update the docs.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
