### PR TITLE
Relax party validation in DAML Script over JSON API

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -986,9 +986,9 @@ class JsonLedgerClient(
       actAs: OneAnd[Set, Ref.Party],
       readAs: Set[Ref.Party],
   ): Future[Unit] = {
-    JsonLedgerClient.validateSubmitParties(actAs, readAs, tokenPayload).fold(
-      s => Future.failed(new RuntimeException(s)),
-      Future.successful(_))
+    JsonLedgerClient
+      .validateSubmitParties(actAs, readAs, tokenPayload)
+      .fold(s => Future.failed(new RuntimeException(s)), Future.successful(_))
   }
 
   private def create(
@@ -1127,12 +1127,11 @@ class JsonLedgerClient(
 
 object JsonLedgerClient {
 
-
   def validateSubmitParties(
-                                     actAs: OneAnd[Set, Ref.Party],
-                                     readAs: Set[Ref.Party],
-                                     tokenPayload: AuthServiceJWTPayload
-                                   ): Either[String, Unit] = {
+      actAs: OneAnd[Set, Ref.Party],
+      readAs: Set[Ref.Party],
+      tokenPayload: AuthServiceJWTPayload,
+  ): Either[String, Unit] = {
     val tokenActAs = tokenPayload.actAs.toSet
     // Relax once the JSON API supports multi-party read/write
     import scalaz.std.string._
@@ -1140,16 +1139,18 @@ object JsonLedgerClient {
     val tokenOnlyReadAs = tokenPayload.readAs.toSet.diff(tokenActAs)
     if (tokenPayload.actAs.isEmpty) {
       Left(
-          s"Tried to submit a command with actAs = [${actAs.toList.mkString(", ")}] but token contains no actAs parties."
-        )
+        s"Tried to submit a command with actAs = [${actAs.toList.mkString(", ")}] but token contains no actAs parties."
+      )
 
     } else if (actAs.toList.toSet[String] /== tokenActAs) {
-      Left(s"Tried to submit a command with actAs = [${actAs.toList.mkString(", ")}] but token provides claims for actAs = [${tokenPayload.actAs
-            .mkString(" ")}]"
-        )
+      Left(
+        s"Tried to submit a command with actAs = [${actAs.toList.mkString(", ")}] but token provides claims for actAs = [${tokenPayload.actAs
+          .mkString(" ")}]"
+      )
     } else if (onlyReadAs.toSet[String] /== tokenOnlyReadAs) {
-      Left(s"Tried to submit a command with readAs = [${readAs.mkString(", ")}] but token provides claims for readAs = [${tokenPayload.readAs
-            .mkString(" ")}]"
+      Left(
+        s"Tried to submit a command with readAs = [${readAs.mkString(", ")}] but token provides claims for readAs = [${tokenPayload.readAs
+          .mkString(" ")}]"
       )
     } else {
       Right(())

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -986,31 +986,9 @@ class JsonLedgerClient(
       actAs: OneAnd[Set, Ref.Party],
       readAs: Set[Ref.Party],
   ): Future[Unit] = {
-    // Relax once the JSON API supports multi-party read/write
-    import scalaz.std.string._
-    if (tokenPayload.actAs.isEmpty) {
-      Future.failed(
-        new RuntimeException(
-          s"Tried to submit a command with actAs = ${actAs.toList.mkString(", ")} but token contains no actAs parties."
-        )
-      )
-    } else if ((actAs.toList: List[String]) /== tokenPayload.actAs) {
-      Future.failed(
-        new RuntimeException(
-          s"Tried to submit a command with actAs = ${actAs.toList.mkString(", ")} but token provides claims for actAs = ${tokenPayload.actAs
-            .mkString(" ")}"
-        )
-      )
-    } else if ((readAs.toList: List[String]) /== tokenPayload.readAs) {
-      Future.failed(
-        new RuntimeException(
-          s"Tried to submit a command with readAs = ${readAs.mkString(", ")} but token provides claims for readAs = ${tokenPayload.readAs
-            .mkString(" ")}"
-        )
-      )
-    } else {
-      Future.unit
-    }
+    JsonLedgerClient.validateSubmitParties(actAs, readAs, tokenPayload).fold(
+      s => Future.failed(new RuntimeException(s)),
+      Future.successful(_))
   }
 
   private def create(
@@ -1148,6 +1126,36 @@ class JsonLedgerClient(
 }
 
 object JsonLedgerClient {
+
+
+  def validateSubmitParties(
+                                     actAs: OneAnd[Set, Ref.Party],
+                                     readAs: Set[Ref.Party],
+                                     tokenPayload: AuthServiceJWTPayload
+                                   ): Either[String, Unit] = {
+    val tokenActAs = tokenPayload.actAs.toSet
+    // Relax once the JSON API supports multi-party read/write
+    import scalaz.std.string._
+    val onlyReadAs = readAs.diff(actAs.toSet)
+    val tokenOnlyReadAs = tokenPayload.readAs.toSet.diff(tokenActAs)
+    if (tokenPayload.actAs.isEmpty) {
+      Left(
+          s"Tried to submit a command with actAs = [${actAs.toList.mkString(", ")}] but token contains no actAs parties."
+        )
+
+    } else if (actAs.toList.toSet[String] /== tokenActAs) {
+      Left(s"Tried to submit a command with actAs = [${actAs.toList.mkString(", ")}] but token provides claims for actAs = [${tokenPayload.actAs
+            .mkString(" ")}]"
+        )
+    } else if (onlyReadAs.toSet[String] /== tokenOnlyReadAs) {
+      Left(s"Tried to submit a command with readAs = [${readAs.mkString(", ")}] but token provides claims for readAs = [${tokenPayload.readAs
+            .mkString(" ")}]"
+      )
+    } else {
+      Right(())
+    }
+  }
+
   sealed trait Response[A] {
     def status: StatusCode
   }

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonApiIt.scala
@@ -296,7 +296,7 @@ final class JsonApiIt
         )
       } yield {
         assert(
-          exception.getMessage === "Tried to submit a command with actAs = Bob but token provides claims for actAs = Alice"
+          exception.getMessage === "Tried to submit a command with actAs = [Bob] but token provides claims for actAs = [Alice]"
         )
       }
     }
@@ -340,7 +340,7 @@ final class JsonApiIt
         )
       } yield {
         assert(
-          exception.getMessage === "Tried to submit a command with actAs = Alice but token contains no actAs parties."
+          exception.getMessage === "Tried to submit a command with actAs = [Alice] but token contains no actAs parties."
         )
       }
     }

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonPartyValidation.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonPartyValidation.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.script.test
+
+import com.daml.ledger.api.auth.AuthServiceJWTPayload
+import com.daml.lf.data.Ref
+import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import com.daml.lf.engine.script.JsonLedgerClient
+import scalaz.OneAnd
+
+final class JsonPartyValidation
+    extends AnyWordSpec
+    with Matchers {
+
+  import JsonLedgerClient._
+
+  private def token(actAs: List[String], readAs: List[String]): AuthServiceJWTPayload =
+    AuthServiceJWTPayload(
+      ledgerId = None,
+      participantId = None,
+      applicationId = None,
+      exp = None,
+      admin = false,
+      actAs = actAs,
+      readAs = readAs)
+
+  private val alice = Ref.Party.assertFromString("Alice")
+  private val bob = Ref.Party.assertFromString("Bob")
+
+  "validateSubmitParties" should {
+
+    "handle a single actAs party" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set.empty, token(List(alice), List())) shouldBe Right(())
+    }
+    "fail for no actAs party" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set.empty, token(List(), List())) shouldBe a[Left[_, _]]
+    }
+    "handle duplicate actAs in token" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set.empty, token(List(alice, alice), List())) shouldBe Right(())
+    }
+    "handle duplicate actAs in submit" in {
+      validateSubmitParties(OneAnd(alice, Set(alice)), Set.empty, token(List(alice), List())) shouldBe Right(())
+    }
+    "fail for missing readAs party" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set(bob), token(List(alice), List())) shouldBe a[Left[_, _]]
+    }
+    "handle single readAs party" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set(bob), token(List(alice), List(bob))) shouldBe Right(())
+    }
+    "ignore party that is in readAs and actAs in token" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set(), token(List(alice), List(alice))) shouldBe Right(())
+    }
+    "ignore party that is in readAs and actAs in submit" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set(alice), token(List(alice), List())) shouldBe Right(())
+    }
+    "fail if party is in actAs in submit but only in readAs in token" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set(), token(List(), List(alice))) shouldBe a[Left[_, _]]
+    }
+    "handle duplicate readAs in token" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set(bob), token(List(alice), List(bob, bob))) shouldBe Right(())
+    }
+    "handle duplicate readAs in submit" in {
+      validateSubmitParties(OneAnd(alice, Set.empty), Set(bob, bob), token(List(alice), List(bob))) shouldBe Right(())
+    }
+  }
+}

--- a/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonPartyValidation.scala
+++ b/daml-script/test/src/com/digitalasset/daml/lf/engine/script/test/JsonPartyValidation.scala
@@ -11,9 +11,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import com.daml.lf.engine.script.JsonLedgerClient
 import scalaz.OneAnd
 
-final class JsonPartyValidation
-    extends AnyWordSpec
-    with Matchers {
+final class JsonPartyValidation extends AnyWordSpec with Matchers {
 
   import JsonLedgerClient._
 
@@ -25,7 +23,8 @@ final class JsonPartyValidation
       exp = None,
       admin = false,
       actAs = actAs,
-      readAs = readAs)
+      readAs = readAs,
+    )
 
   private val alice = Ref.Party.assertFromString("Alice")
   private val bob = Ref.Party.assertFromString("Bob")
@@ -33,37 +32,77 @@ final class JsonPartyValidation
   "validateSubmitParties" should {
 
     "handle a single actAs party" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set.empty, token(List(alice), List())) shouldBe Right(())
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set.empty,
+        token(List(alice), List()),
+      ) shouldBe Right(())
     }
     "fail for no actAs party" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set.empty, token(List(), List())) shouldBe a[Left[_, _]]
+      validateSubmitParties(OneAnd(alice, Set.empty), Set.empty, token(List(), List())) shouldBe a[
+        Left[_, _]
+      ]
     }
     "handle duplicate actAs in token" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set.empty, token(List(alice, alice), List())) shouldBe Right(())
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set.empty,
+        token(List(alice, alice), List()),
+      ) shouldBe Right(())
     }
     "handle duplicate actAs in submit" in {
-      validateSubmitParties(OneAnd(alice, Set(alice)), Set.empty, token(List(alice), List())) shouldBe Right(())
+      validateSubmitParties(
+        OneAnd(alice, Set(alice)),
+        Set.empty,
+        token(List(alice), List()),
+      ) shouldBe Right(())
     }
     "fail for missing readAs party" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set(bob), token(List(alice), List())) shouldBe a[Left[_, _]]
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set(bob),
+        token(List(alice), List()),
+      ) shouldBe a[Left[_, _]]
     }
     "handle single readAs party" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set(bob), token(List(alice), List(bob))) shouldBe Right(())
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set(bob),
+        token(List(alice), List(bob)),
+      ) shouldBe Right(())
     }
     "ignore party that is in readAs and actAs in token" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set(), token(List(alice), List(alice))) shouldBe Right(())
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set(),
+        token(List(alice), List(alice)),
+      ) shouldBe Right(())
     }
     "ignore party that is in readAs and actAs in submit" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set(alice), token(List(alice), List())) shouldBe Right(())
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set(alice),
+        token(List(alice), List()),
+      ) shouldBe Right(())
     }
     "fail if party is in actAs in submit but only in readAs in token" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set(), token(List(), List(alice))) shouldBe a[Left[_, _]]
+      validateSubmitParties(OneAnd(alice, Set.empty), Set(), token(List(), List(alice))) shouldBe a[
+        Left[_, _]
+      ]
     }
     "handle duplicate readAs in token" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set(bob), token(List(alice), List(bob, bob))) shouldBe Right(())
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set(bob),
+        token(List(alice), List(bob, bob)),
+      ) shouldBe Right(())
     }
     "handle duplicate readAs in submit" in {
-      validateSubmitParties(OneAnd(alice, Set.empty), Set(bob, bob), token(List(alice), List(bob))) shouldBe Right(())
+      validateSubmitParties(
+        OneAnd(alice, Set.empty),
+        Set(bob, bob),
+        token(List(alice), List(bob)),
+      ) shouldBe Right(())
     }
   }
 }


### PR DESCRIPTION
Since the JSON API infers parties from the token instead of accepting
them explicitly, we have to ensure that the parties in the token match
the parties passed to `submit`/`submitMulti` exactly. However, we were
a bit too strict and required a party to be in `readAs` even if it is
already in `actAs`. This caused issues on DamlHub because they issue
tokens with the party in both `actAs` and `readAs` so regular `submit`
doesn’t work.

changelog_begin

- [DAML Script] When running DAML Script over the JSON API, the check
  that the parties in the DAML Script match the parties in the token
  has been relaxed and now allows for duplicate parties as well as
  parties that are only in actAs in the DAML Script but in both actAs
  and readAs in the token.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
