### PR TITLE
Add google-java-format to devenv as javafmt

### DIFF
--- a/dev-env/bin/javafmt
+++ b/dev-env/bin/javafmt
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -66,6 +66,8 @@ in rec {
     jstack = jdk;
     jar    = jdk;
 
+    javafmt = pkgs.callPackage ./tools/google-java-format {};
+
     # The package itself is called bazel-watcher. However, the executable is
     # called ibazel. We call the attribute ibazel so that the default dev-env
     # wrapper works.

--- a/nix/tools/google-java-format/default.nix
+++ b/nix/tools/google-java-format/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, jdk11, pkgs }:
+
+let version = "1.9"; in
+stdenv.mkDerivation rec {
+  buildInputs = [ pkgs.makeWrapper ];
+  name = "google-java-format";
+  dontUnpack = true;
+  src = fetchurl {
+    url = "https://github.com/google/${name}/releases/download/${name}-${version}/${name}-${version}-all-deps.jar";
+    sha256 = "1d98720a5984de85a822aa32a378eeacd4d17480d31cba6e730caae313466b97";
+  };
+  installPhase = ''
+    mkdir -pv $out/share/java $out/bin
+    cp ${src} $out/share/java/${name}-${version}.jar
+    makeWrapper ${jdk11}/bin/java $out/bin/javafmt --add-flags "-jar $out/share/java/${name}-${version}.jar"
+  '';
+}


### PR DESCRIPTION
Add the https://github.com/google/google-java-format code formatting tool to dev-env.

Uses the name javafmt to call it, to mirror scalafmt.

Making it part of our checks will be done in a follow-up PR (https://github.com/digital-asset/daml/pull/8686) to make this easy to review.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
