### PR TITLE
ledger-api-test-tool: Provide context when expecting a failing Future.

### DIFF
--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/Assertions.scala
@@ -9,7 +9,8 @@ import ai.x.diff.DiffShow
 import com.daml.grpc.{GrpcException, GrpcStatus}
 import io.grpc.Status
 
-import scala.language.higherKinds
+import scala.concurrent.Future
+import scala.language.{higherKinds, implicitConversions}
 import scala.util.control.NonFatal
 
 object Assertions extends DiffExtensions {
@@ -67,4 +68,8 @@ object Assertions extends DiffExtensions {
       if (pattern.isEmpty) None else Some(Pattern.compile(Pattern.quote(pattern))),
     )
   }
+
+  /** Allows for assertions with more information in the error messages. */
+  implicit def futureAssertions[T](future: Future[T]): FutureAssertions[T] =
+    new FutureAssertions[T](future)
 }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/FutureAssertions.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/infrastructure/FutureAssertions.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.api.testtool.infrastructure
+
+import com.daml.ledger.api.testtool.infrastructure.FutureAssertions.ExpectedFailureException
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+final class FutureAssertions[T](future: Future[T]) {
+
+  /** Checks that the future failed, and returns the throwable.
+    * We use this instead of `Future#failed` because the error message that delivers is unhelpful.
+    * It doesn't tell us what the value actually was.
+    */
+  def mustFail(context: String)(implicit executionContext: ExecutionContext): Future[Throwable] =
+    future.transform {
+      case Failure(throwable) =>
+        Success(throwable)
+      case Success(value) =>
+        Failure(new ExpectedFailureException(context, value))
+    }
+}
+
+object FutureAssertions {
+
+  final class ExpectedFailureException[T](context: String, value: T)
+      extends NoSuchElementException(
+        s"Expected a failure when $context, but got a successful result of: $value"
+      )
+
+}

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ActiveContractsServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ActiveContractsServiceIT.scala
@@ -37,7 +37,7 @@ class ActiveContractsServiceIT extends LedgerTestSuite {
       .activeContractsRequest(parties)
       .update(_.ledgerId := invalidLedgerId)
     for {
-      failure <- ledger.activeContracts(invalidRequest).failed
+      failure <- ledger.activeContracts(invalidRequest).mustFail("retrieving active contracts")
     } yield {
       assertGrpcError(failure, Status.Code.NOT_FOUND, "not found. Actual Ledger ID")
     }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ClosedWorldIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ClosedWorldIT.scala
@@ -3,13 +3,8 @@
 
 package com.daml.ledger.api.testtool.suites
 
-import com.daml.ledger.api.testtool.infrastructure.Allocation.{
-  Participant,
-  Participants,
-  SingleParty,
-  allocate,
-}
-import com.daml.ledger.api.testtool.infrastructure.Assertions.assertGrpcError
+import com.daml.ledger.api.testtool.infrastructure.Allocation._
+import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.client.binding
 import com.daml.ledger.test.semantic.SemanticTests.{Amount, Iou}
@@ -31,7 +26,7 @@ class ClosedWorldIT extends LedgerTestSuite {
     for {
       failure <- alpha
         .create(payer, Iou(payer, binding.Primitive.Party("unallocated"), onePound))
-        .failed
+        .mustFail("referencing an unallocated party")
     } yield {
       assertGrpcError(failure, Status.Code.INVALID_ARGUMENT, "Party not known on ledger")
     }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/ConfigManagementServiceIT.scala
@@ -60,7 +60,7 @@ final class ConfigManagementServiceIT extends LedgerTestSuite {
           generation = response3.configurationGeneration,
           newTimeModel = oldTimeModel,
         )
-        .failed
+        .mustFail("setting a time model with an expired MRT")
     } yield {
       assert(
         response1.configurationGeneration < response2.configurationGeneration,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/MultiPartySubmissionIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/MultiPartySubmissionIT.scala
@@ -69,7 +69,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
           readAs = List.empty,
           template = MultiPartyContract(PList(alice, bob, charlie), ""),
         )
-        .failed
+        .mustFail("submitting a contract with a missing authorizers")
     } yield {
       assertGrpcError(
         failure,
@@ -116,7 +116,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
           exercise =
             contract.exerciseMPAddSignatories(unusedActor, PList(alice, bob, charlie, david)),
         )
-        .failed
+        .mustFail("exercising a choice with a missing authorizers")
     } yield {
       assertGrpcError(
         failure,
@@ -167,7 +167,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
           readAs = List(bob, alice),
           exercise = contractB.exerciseMPFetchOther(unusedActor, contractA, PList(charlie, david)),
         )
-        .failed
+        .mustFail("exercising a choice without authorization to fetch another contract")
     } yield {
       assertGrpcError(
         failure,
@@ -197,7 +197,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
           readAs = List.empty,
           exercise = contractB.exerciseMPFetchOther(unusedActor, contractA, PList(charlie, david)),
         )
-        .failed
+        .mustFail("exercising a choice without authorization to fetch another contract")
     } yield {
       assertGrpcError(
         failure,
@@ -248,7 +248,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
           readAs = List(bob, alice),
           exercise = contractB.exerciseMPFetchOtherByKey(unusedActor, keyA, PList(charlie, david)),
         )
-        .failed
+        .mustFail("exercising a choice without authorization to fetch another contract by key")
     } yield {
       assertGrpcError(
         failure,
@@ -278,7 +278,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
           readAs = List.empty,
           exercise = contractB.exerciseMPFetchOtherByKey(unusedActor, keyA, PList(charlie, david)),
         )
-        .failed
+        .mustFail("exercising a choice without authorization to fetch another contract by key")
     } yield {
       assertGrpcError(
         failure,
@@ -331,7 +331,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
           exercise = contractB
             .exerciseMPLookupOtherByKey(unusedActor, keyA, PList(charlie, david), Some(contractA)),
         )
-        .failed
+        .mustFail("exercising a choice without authorization to look up another contract by key")
     } yield {
       assertGrpcError(
         failure,
@@ -362,7 +362,7 @@ final class MultiPartySubmissionIT extends LedgerTestSuite {
           exercise = contractB
             .exerciseMPLookupOtherByKey(unusedActor, keyA, PList(charlie, david), Some(contractA)),
         )
-        .failed
+        .mustFail("exercising a choice without authorization to look up another contract by key")
     } yield {
       assertGrpcError(
         failure,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageManagementServiceIT.scala
@@ -34,7 +34,7 @@ final class PackageManagementServiceIT extends LedgerTestSuite {
     allocate(NoParties),
   )(implicit ec => { case Participants(Participant(ledger)) =>
     for {
-      failure <- ledger.uploadDarFile(ByteString.EMPTY).failed
+      failure <- ledger.uploadDarFile(ByteString.EMPTY).mustFail("uploading an empty package")
     } yield {
       assertGrpcError(
         failure,

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PackageServiceIT.scala
@@ -48,7 +48,9 @@ final class PackageServiceIT extends LedgerTestSuite {
     allocate(NoParties),
   )(implicit ec => { case Participants(Participant(ledger)) =>
     for {
-      failure <- ledger.getPackage(unknownPackageId).failed
+      failure <- ledger
+        .getPackage(unknownPackageId)
+        .mustFail("getting the contents of an unknown package")
     } yield {
       assertGrpcError(failure, Status.Code.NOT_FOUND, "")
     }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/PartyManagementServiceIT.scala
@@ -4,7 +4,7 @@
 package com.daml.ledger.api.testtool.suites
 
 import com.daml.ledger.api.testtool.infrastructure.Allocation._
-import com.daml.ledger.api.testtool.infrastructure.Assertions.assertGrpcError
+import com.daml.ledger.api.testtool.infrastructure.Assertions._
 import com.daml.ledger.api.testtool.infrastructure.LedgerTestSuite
 import com.daml.ledger.api.v1.admin.party_management_service.PartyDetails
 import com.daml.ledger.client.binding
@@ -103,7 +103,7 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
           partyIdHint = Some(Random.alphanumeric.take(256).mkString),
           displayName = None,
         )
-        .failed
+        .mustFail("allocating a party with a very long identifier")
     } yield {
       assertGrpcError(error, Status.Code.INVALID_ARGUMENT, "Party is too long")
     }
@@ -121,7 +121,7 @@ final class PartyManagementServiceIT extends LedgerTestSuite {
           partyIdHint = Some("\uD83D\uDE00"),
           displayName = None,
         )
-        .failed
+        .mustFail("allocating a party with invalid characters")
     } yield {
       assertGrpcError(error, Status.Code.INVALID_ARGUMENT, "non expected character")
     }

--- a/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/WronglyTypedContractIdIT.scala
+++ b/ledger/ledger-api-test-tool/src/main/scala/com/daml/ledger/api/testtool/suites/WronglyTypedContractIdIT.scala
@@ -20,7 +20,7 @@ final class WronglyTypedContractIdIT extends LedgerTestSuite {
         fakeDummyWithParam = dummy.asInstanceOf[Primitive.ContractId[DummyWithParam]]
         exerciseFailure <- ledger
           .exercise(party, fakeDummyWithParam.exerciseDummyChoice2(_, "txt"))
-          .failed
+          .mustFail("exercising on a wrong type")
       } yield {
         assertGrpcError(exerciseFailure, Code.INVALID_ARGUMENT, "wrongly typed contract id")
       }
@@ -36,7 +36,7 @@ final class WronglyTypedContractIdIT extends LedgerTestSuite {
 
         fetchFailure <- ledger
           .exercise(party, delegation.exerciseFetchDelegated(_, fakeDelegated))
-          .failed
+          .mustFail("fetching the wrong type")
       } yield {
         assertGrpcError(fetchFailure, Code.INVALID_ARGUMENT, "wrongly typed contract id")
       }


### PR DESCRIPTION
We use `Future#failed` a _lot_ in the conformance tests. Usually, this works fine, but it has the unfortunate effect of yielding a useless error message when the future was actually a success:

```
Future.failed not completed with a throwable.
```

Combined with the lack of useful stack traces, because futures, this makes the test failure completely useless.

This changes all calls of `Future#failed` in our conformance tests to use a new extension method, `#mustFail`, which takes a mandatory "context" parameter to provide context, and includes both the context and the value in the future in case of success.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
