### PR TITLE
lsp-tests: test for no internal symbols

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -17,8 +17,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
-GHCIDE_REV = "7b5f999febee47a2443f2dd0e7a4b0d82bf1bd83"
-GHCIDE_SHA256 = "b95cd395c2fd32a9b5a7f68d29577e6441f0f49020553cf7ca103d462fe56767"
+GHCIDE_REV = "0fdad67601eb7c6521c4a4a712bbc396d1c012b8"
+GHCIDE_SHA256 = "14d4028eb1e52fd3a1ac0710fb2a6fc0a7b5f1d1b8bc8d0a79c23837bc63b903"
 GHCIDE_VERSION = "0.1.0"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -717,6 +717,23 @@ symbolsTests run =
               foo <- openDoc' "Foo.daml" damlId $ T.unlines ["module Foo where"]
               syms <- getDocumentSymbols foo
               liftIO $ preview (_Left . _head . children . _Just) syms @?= Just (List [])
+        , testCase "no internal imports for module with one template" $
+          run $ do
+              foo <-
+                  openDoc' "Foo.daml" damlId $
+                  T.unlines
+                      [ "module Foo where"
+                      , "template T with p1 : Party where"
+                      , "  signatory p1"
+                      , "  choice A : ()"
+                      , "      with p : Party"
+                      , "    controller p"
+                      , "      do return ()"
+                      ]
+              syms <- getDocumentSymbols foo
+              liftIO $
+                  fmap (length . toList) (preview (_Left . _head . children . _Just) syms) @?=
+                  Just 2
         ]
 
 completionTests


### PR DESCRIPTION
This updates the daml-ghcide dependency and also adds a test to check
that we are not showing any internal symbols and dependencies in the
outline in daml studio.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
