### PR TITLE
Ensure the pre-load executor is reused across calls

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/PackageCommitter.scala
@@ -298,7 +298,7 @@ final private[kvutils] class PackageCommitter(
     }
   }
 
-  private[this] def preloadExecutor =
+  private[this] lazy val preloadExecutor =
     Executors.newSingleThreadExecutor { (runnable: Runnable) =>
       val t = new Thread(runnable)
       t.setDaemon(true)


### PR DESCRIPTION
changelog_begin
changelog_end

The current behavior is that of creating a new preload executor at every call,
which is a very complex way of simply spawning a thread and defeats the purpose
of having a shared executor, sequencing the pre-loading of packages to maximize
the usage of cache (among other things).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
