### PR TITLE
Unified logging of commandId and submissionId into correlationId [DPP-231]

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiCommandService.scala
@@ -79,7 +79,7 @@ private[apiserver] final class ApiCommandService private (
       loggingContext: LoggingContext
   ): Future[Completion] =
     withEnrichedLoggingContext(
-      logging.commandId(request.getCommands.commandId),
+      logging.correlationId(request.getCommands.commandId),
       logging.party(request.getCommands.party),
       logging.actAs(request.getCommands.actAs),
       logging.readAs(request.getCommands.readAs),

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/ApiSubmissionService.scala
@@ -208,7 +208,7 @@ private[apiserver] final class ApiSubmissionService private (
                 val submissionId = v1.SubmissionId.assertFromString(UUID.randomUUID().toString)
                 withEnrichedLoggingContext(
                   logging.party(name),
-                  logging.submissionId(submissionId),
+                  logging.correlationId(submissionId),
                 ) { implicit loggingContext =>
                   logger.info("Implicit party allocation")
                   writeService

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiParticipantPruningService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/admin/ApiParticipantPruningService.scala
@@ -17,6 +17,7 @@ import com.daml.ledger.participant.state.v1.{
   SubmissionId,
   WriteParticipantPruningService,
 }
+import com.daml.platform.apiserver.services.logging
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.platform.ApiOffset
 import com.daml.platform.ApiOffset.ApiOffsetConverter
@@ -50,7 +51,7 @@ final class ApiParticipantPruningService private (
     submissionIdOrErr.fold(
       Future.failed,
       submissionId =>
-        LoggingContext.withEnrichedLoggingContext("submissionId" -> submissionId) {
+        LoggingContext.withEnrichedLoggingContext(logging.correlationId(submissionId)) {
           implicit logCtx =>
             (for {
 

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -44,10 +44,10 @@ package object logging {
     }
   private[services] def applicationId(id: ApplicationId): (String, String) =
     "applicationId" -> id.unwrap
-  private[services] def commandId(id: String): (String, String) =
-    "commandId" -> id
-  private[services] def commandId(id: CommandId): (String, String) =
-    "commandId" -> id.unwrap
+  private[services] def correlationId(id: String): (String, String) =
+    "correlationId" -> id
+  private[services] def correlationId(id: CommandId): (String, String) =
+    "correlationId" -> id.unwrap
   private[services] def deduplicateUntil(t: Instant): (String, String) =
     "deduplicateUntil" -> t.toString
   private[services] def eventId(id: EventId): (String, String) =
@@ -62,8 +62,6 @@ package object logging {
           )
         )
     }.toMap
-  private[services] def submissionId(id: String): (String, String) =
-    "submissionId" -> id
   private[services] def submittedAt(t: Instant): (String, String) =
     "submittedAt" -> t.toString
   private[services] def transactionId(id: TransactionId): (String, String) =
@@ -73,7 +71,7 @@ package object logging {
   private[services] def commands(cmds: Commands): Map[String, String] = {
     val context =
       Map(
-        commandId(cmds.commandId),
+        correlationId(cmds.commandId),
         deduplicateUntil(cmds.deduplicateUntil),
         applicationId(cmds.applicationId),
         submittedAt(cmds.submittedAt),


### PR DESCRIPTION
**Motivation**
This is a proposal to unify `commandId` and `submissionId` keys of the logging context into a single `correlationId`.

```
CHANGELOG_BEGIN
- replaced commandId and submissionId with correlationId in logging context
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
