### PR TITLE
Retry asset downloads in check_releases

### DIFF
--- a/ci/cron/BUILD.bazel
+++ b/ci/cron/BUILD.bazel
@@ -28,6 +28,7 @@ da_haskell_binary(
         "proto3-suite",
         "regex-tdfa",
         "resourcet",
+        "retry",
         "safe",
         "safe-exceptions",
         "semver",


### PR DESCRIPTION
We’ve seen a number of "resource vanished (connection reset by peer)"
errors. Slapping some retries on that should hopefully make the CI job
a bit more robust.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
