### PR TITLE
Add //libs-scala/doobie-slf4j and replace usages of jdkLogHandler

### DIFF
--- a/ledger-service/http-json/BUILD.bazel
+++ b/ledger-service/http-json/BUILD.bazel
@@ -41,6 +41,7 @@ da_scala_library(
         "//ledger/ledger-api-auth",
         "//ledger/ledger-api-common",
         "//libs-scala/auth-utils",
+        "//libs-scala/doobie-slf4j",
         "//libs-scala/ports",
         "//libs-scala/scala-utils",
         "@maven//:com_chuusai_shapeless_2_12",

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/dbbackend/ContractDao.scala
@@ -5,6 +5,7 @@ package com.daml.http.dbbackend
 
 import cats.effect._
 import cats.syntax.apply._
+import com.daml.doobie.logging.Slf4jLogHandler
 import com.daml.http.domain
 import com.daml.http.json.JsonProtocol.LfValueDatabaseCodec
 import doobie.LogHandler
@@ -20,7 +21,7 @@ import scala.concurrent.ExecutionContext
 
 class ContractDao(xa: Connection.T) {
 
-  implicit val logHandler: log.LogHandler = doobie.util.log.LogHandler.jdkLogHandler
+  implicit val logHandler: log.LogHandler = Slf4jLogHandler(classOf[ContractDao])
 
   implicit val jdbcDriver: SupportedJdbcDriver = SupportedJdbcDriver.Postgres
 

--- a/libs-scala/doobie-slf4j/BUILD.bazel
+++ b/libs-scala/doobie-slf4j/BUILD.bazel
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_library",
+    "da_scala_test_suite",
+)
+
+da_scala_library(
+    name = "doobie-slf4j",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    scala_deps = [
+        "@maven//:org_tpolecat_doobie_core",
+    ],
+    tags = ["maven_coordinates=com.daml:doobie-slf4j:__VERSION__"],
+    visibility = [
+        "//:__subpackages__",
+    ],
+    deps = [
+        "@maven//:org_slf4j_slf4j_api",
+    ],
+)

--- a/libs-scala/doobie-slf4j/src/main/scala/com/daml/doobie/logging/Slf4jLogHandler.scala
+++ b/libs-scala/doobie-slf4j/src/main/scala/com/daml/doobie/logging/Slf4jLogHandler.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.doobie.logging
+
+import org.slf4j.{Logger, LoggerFactory}
+import doobie.util.log.{ExecFailure, LogHandler, ProcessingFailure, Success}
+
+object Slf4jLogHandler {
+
+  def apply(clazz: Class[_]): LogHandler =
+    apply(LoggerFactory.getLogger(clazz))
+
+  def apply(logger: Logger): LogHandler =
+    LogHandler {
+      case Success(s, a, e1, e2) =>
+        logger.debug(s"""Successful Statement Execution:
+                        |
+                        |  ${s.linesIterator.dropWhile(_.trim.isEmpty).mkString("\n  ")}
+                        |
+                        | arguments = [${a.mkString(", ")}]
+                        |   elapsed = ${e1.toMillis.toString} ms exec + ${e2.toMillis.toString} ms processing (${(e1 + e2).toMillis.toString} ms total)
+          """.stripMargin)
+      case ProcessingFailure(s, a, e1, e2, t) =>
+        logger.error(s"""Failed Resultset Processing:
+                        |
+                        |  ${s.linesIterator.dropWhile(_.trim.isEmpty).mkString("\n  ")}
+                        |
+                        | arguments = [${a.mkString(", ")}]
+                        |   elapsed = ${e1.toMillis.toString} ms exec + ${e2.toMillis.toString} ms processing (failed) (${(e1 + e2).toMillis.toString} ms total)
+                        |   failure = ${t.getMessage}
+          """.stripMargin)
+      case ExecFailure(s, a, e1, t) =>
+        logger.error(s"""Failed Statement Execution:
+                        |
+                        |  ${s.linesIterator.dropWhile(_.trim.isEmpty).mkString("\n  ")}
+                        |
+                        | arguments = [${a.mkString(", ")}]
+                        |   elapsed = ${e1.toMillis.toString} ms exec (failed)
+                        |   failure = ${t.getMessage}
+          """.stripMargin)
+    }
+}

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -167,6 +167,8 @@
   type: jar-scala
 - target: //libs-scala/contextualized-logging:contextualized-logging
   type: jar-scala
+- target: //libs-scala/doobie-slf4j:doobie-slf4j
+  type: jar-scala
 - target: //libs-scala/grpc-utils:grpc-utils
   type: jar-scala
 - target: //libs-scala/ports:ports

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -46,6 +46,7 @@ da_scala_library(
         "//ledger/ledger-api-common",
         "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",
+        "//libs-scala/doobie-slf4j",
         "//libs-scala/ports",
         "//libs-scala/scala-utils",
         "//triggers/runner:trigger-runner-lib",

--- a/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
+++ b/triggers/service/src/main/scala/com/digitalasset/daml/lf/engine/trigger/dao/DbTriggerDao.scala
@@ -24,6 +24,7 @@ import scalaz.Tag
 import java.io.{Closeable, IOException}
 
 import com.daml.auth.middleware.api.Tagged.{AccessToken, RefreshToken}
+import com.daml.doobie.logging.Slf4jLogHandler
 import javax.sql.DataSource
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -93,7 +94,7 @@ final class DbTriggerDao private (dataSource: DataSource with Closeable, xa: Con
   implicit val identifierGet: Get[Identifier] =
     implicitly[Get[String]].map(Identifier.assertFromString(_))
 
-  private implicit val logHandler: log.LogHandler = log.LogHandler.jdkLogHandler
+  private implicit val logHandler: log.LogHandler = Slf4jLogHandler(classOf[DbTriggerDao])
 
   private[this] val flywayMigrations = new DbFlywayMigrations(dataSource)
 


### PR DESCRIPTION
The `jdkLogHandler` provided by Doobie exists purely as an example and the library
itself does not recommend using it in production.

```
/**
 * A LogHandler that writes a default format to a JDK Logger. This is provided for demonstration
 * purposes and is not intended for production use.
 * @group Constructors
 */
```

Note that this slightly changes the runtime behavior, logging successful queries
at debug level rather then info. The message itself is preserved from the original
MIT-licensed example.

This uses Slf4j as most of our components, instead of java.util.logging.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
