### PR TITLE
DLint: Disable "Redundant pure" lint by default

### DIFF
--- a/compiler/damlc/daml-ide-core/dlint.yaml
+++ b/compiler/damlc/daml-ide-core/dlint.yaml
@@ -674,6 +674,8 @@
 - ignore: {name: Redundant $}
 # Don't warn on redundant do (DAML choice syntax *mandates* 'do'!)
 - ignore: {name: Redundant do}
+# ApplicativeDo syntax mandates 'pure's which seem redundant
+- ignore: {name: Redundant pure}
 # Not helpful for beginner DAML programmers
 - ignore: {name: Eta reduce}
 - ignore: {name: Avoid lambda}

--- a/compiler/damlc/tests/daml-test-files/ApplicativeDo.daml
+++ b/compiler/damlc/tests/daml-test-files/ApplicativeDo.daml
@@ -1,6 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
 -- @INFO Use let
--- @INFO Redundant pure
 module ApplicativeDo where
 
 -- This used to produce a reference to GHC.Base.return


### PR DESCRIPTION
When using `ApplicativeDo`, e.g. in Daml Scripts, a final pure might be
necessary although it would be redundant in a monadic context. This
leads to spurious warnings from the linter which I found quite
confusing.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/daml/8733)
<!-- Reviewable:end -->
