### PR TITLE
tweak local cache cleanup

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -7,13 +7,17 @@ steps:
     # Location of the disk cache for CI servers set in their init files:
     # infra/macos/2-common-box/init.sh:echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
     # infra/vsts_agent_linux_startup.sh:echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
-    if [ $(df -m . | sed 1d | awk '{print $4}') -lt 30000 ]; then
+
+    if [ $(df -m . | sed 1d | awk '{print $4}') -lt 40000 ]; then
         echo "Disk full, cleaning up..."
         disk_cache="$HOME/.bazel-cache"
         rm -rf "$disk_cache"
         echo "removed '$disk_cache'"
         local_cache="$HOME/.cache/bazel"
         if [ -d "$local_cache" ]; then
+            for pid in $(lsof "$local_cache" | sed 1d | awk '{print $2}' | sort -u); do
+                kill -s KILL $pid
+            done
             chmod -R +w "$local_cache"
             rm -rf "$local_cache"
             echo "removed '$local_cache'"


### PR DESCRIPTION
For various reasons, my attempts at improving the cache cleanup process have been delayed. There are, however, two simple, non-controversial changes I can "backport" without having to wait for consensus on the whole thing:

1. Increase the threshold. At least for the compat jobs, we have seen builds failing after starting with ~32GB free.
2. Kill dangling Bazel processes, which keep some files open and sometimes cause the clean-up process to crash.

CHANGELOG_BEGIN
CHANGELOG_END