### PR TITLE
kvutils: Add the record time to the pre-execution log entries. [KVL-822]

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/KeyValueCommitting.scala
@@ -16,7 +16,6 @@ import com.daml.ledger.participant.state.kvutils.committer.{
 }
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId}
 import com.daml.lf.data.Time.Timestamp
-
 import com.daml.lf.engine.Engine
 import com.daml.lf.transaction.{GlobalKey, TransactionCoder, TransactionOuterClass}
 import com.daml.lf.value.ValueCoder
@@ -109,16 +108,14 @@ class KeyValueCommitting private[daml] (
 
   @throws(classOf[Err])
   def preExecuteSubmission(
+      recordTime: Timestamp,
       defaultConfig: Configuration,
       submission: DamlSubmission,
       participantId: ParticipantId,
       inputState: DamlStateMap,
   ): PreExecutionResult =
-    createCommitter(engine, defaultConfig, submission).runWithPreExecution(
-      submission,
-      participantId,
-      inputState,
-    )
+    createCommitter(engine, defaultConfig, submission)
+      .runWithPreExecution(Some(recordTime), submission, participantId, inputState)
 
   private def createCommitter(
       engine: Engine,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContext.scala
@@ -25,6 +25,7 @@ private[kvutils] case class CommitContext(
     private val inputs: DamlStateMap,
     recordTime: Option[Timestamp],
     participantId: ParticipantId,
+    preExecute: Boolean,
 ) {
   private[this] val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -43,8 +44,6 @@ private[kvutils] case class CommitContext(
   // Rejection log entry used for generating an out-of-time-bounds log entry in case of
   // pre-execution.
   var outOfTimeBoundsLogEntry: Option[DamlLogEntry] = None
-
-  def preExecute: Boolean = recordTime.isEmpty
 
   /** Retrieve value from output state, or if not found, from input state.
     * Throws an exception if the key is not found in either.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/Committer.scala
@@ -14,8 +14,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlSubmission,
 }
 import com.daml.ledger.participant.state.kvutils.KeyValueCommitting.PreExecutionResult
-import com.daml.ledger.participant.state.kvutils.committer.Committer._
 import com.daml.ledger.participant.state.kvutils._
+import com.daml.ledger.participant.state.kvutils.committer.Committer._
 import com.daml.ledger.participant.state.v1.{Configuration, ParticipantId}
 import com.daml.lf.data.Time
 import com.daml.lf.data.Time.Timestamp
@@ -81,18 +81,19 @@ private[committer] trait Committer[PartialResult] extends SubmissionExecutor {
       inputState: DamlStateMap,
   ): (DamlLogEntry, Map[DamlStateKey, DamlStateValue]) =
     runTimer.time { () =>
-      val commitContext = CommitContext(inputState, recordTime, participantId)
+      val commitContext = CommitContext(inputState, recordTime, participantId, preExecute = false)
       val logEntry = runSteps(commitContext, submission)
       logEntry -> commitContext.getOutputs.toMap
     }
 
   def runWithPreExecution(
+      recordTime: Option[Time.Timestamp],
       submission: DamlSubmission,
       participantId: ParticipantId,
       inputState: DamlStateMap,
   ): PreExecutionResult =
     preExecutionRunTimer.time { () =>
-      val commitContext = CommitContext(inputState, recordTime = None, participantId)
+      val commitContext = CommitContext(inputState, recordTime, participantId, preExecute = true)
       preExecute(submission, commitContext)
     }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/SubmissionExecutor.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/committer/SubmissionExecutor.scala
@@ -23,6 +23,7 @@ trait SubmissionExecutor {
   ): (DamlLogEntry, Map[DamlStateKey, DamlStateValue])
 
   def runWithPreExecution(
+      recordTime: Option[Time.Timestamp],
       submission: DamlSubmission,
       participantId: ParticipantId,
       inputState: DamlStateMap,

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -7,12 +7,11 @@ import java.time.Instant
 
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.DamlStateKey
 import com.daml.ledger.participant.state.kvutils.Raw
-import com.daml.ledger.participant.state.kvutils.`export`.{
+import com.daml.ledger.participant.state.kvutils.export.{
+  LedgerDataExporter,
   SubmissionAggregatorWriteOperations,
   SubmissionInfo,
 }
-import com.daml.ledger.participant.state.kvutils.export.LedgerDataExporter
-import com.daml.ledger.participant.state.v1
 import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.reading.{LedgerStateReader, StateReader}
 import com.daml.ledger.validator.{
@@ -31,7 +30,6 @@ import scala.util.{Failure, Success}
   * fingerprints alongside values), parametric in the logic that produces a fingerprint given a
   * value.
   *
-  * @param participantId                 The ID of the participant.
   * @param now                           Returns the current time.
   * @param transformStateReader          Transforms the state reader into the format used by the underlying store.
   * @param validator                     The pre-execution validator.
@@ -40,7 +38,6 @@ import scala.util.{Failure, Success}
   * @param ledgerDataExporter            Exports to a file.
   */
 class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
-    participantId: v1.ParticipantId,
     now: () => Instant,
     transformStateReader: LedgerStateReader => StateReader[DamlStateKey, StateValue],
     validator: PreExecutingSubmissionValidator[StateValue, ReadSet, WriteSet],
@@ -59,13 +56,15 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
   /** Pre-executes and then commits a submission.
     */
   def commit(
+      submittingParticipantId: ParticipantId,
       correlationId: String,
       submissionEnvelope: Raw.Value,
-      submittingParticipantId: ParticipantId,
+      recordTime: Instant,
       ledgerStateAccess: LedgerStateAccess[Any],
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
     LoggingContext.newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>
-      val submissionInfo = SubmissionInfo(participantId, correlationId, submissionEnvelope, now())
+      val submissionInfo =
+        SubmissionInfo(submittingParticipantId, correlationId, submissionEnvelope, recordTime)
       val submissionAggregator = ledgerDataExporter.addSubmission(submissionInfo)
       // Sequential pre-execution, implemented by enclosing the whole pre-post-exec pipeline is a single transaction.
       ledgerStateAccess.inTransaction { ledgerStateOperations =>
@@ -73,8 +72,9 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
           transformStateReader(new LedgerStateOperationsReaderAdapter(ledgerStateOperations))
         for {
           preExecutionOutput <- validator.validate(
-            submissionEnvelope,
             submittingParticipantId,
+            submissionEnvelope,
+            recordTime,
             stateReader,
           )
           _ <- retry { case _: ConflictDetectedException =>

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/KVTest.scala
@@ -376,6 +376,7 @@ object KVTest {
       inputKeys = damlSubmission.getInputDamlStateList.asScala
       inputState <- createInputState(inputKeys)
       preExecutionResult = testState.keyValueCommitting.preExecuteSubmission(
+        recordTime = testState.recordTime,
         defaultConfig = testState.defaultConfig,
         submission = damlSubmission,
         participantId = testState.participantId,

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/TestHelpers.scala
@@ -47,5 +47,10 @@ object TestHelpers {
       inputs: DamlStateMap = Map.empty,
       participantId: Int = 0,
   ): CommitContext =
-    CommitContext(inputs, recordTime, mkParticipantId(participantId))
+    CommitContext(
+      inputs,
+      recordTime,
+      mkParticipantId(participantId),
+      preExecute = recordTime.isEmpty,
+    )
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/CommitContextSpec.scala
@@ -143,18 +143,6 @@ class CommitContextSpec extends AnyWordSpec with Matchers {
       context.getOutputs should have size 0
     }
   }
-
-  "preExecute" should {
-    "return false in case record time is set" in {
-      val context = newInstance(recordTime = Some(Time.Timestamp.now()))
-      context.preExecute shouldBe false
-    }
-
-    "return true in case record time is not set" in {
-      val context = newInstance(recordTime = None)
-      context.preExecute shouldBe true
-    }
-  }
 }
 
 object CommitContextSpec {
@@ -173,8 +161,9 @@ object CommitContextSpec {
   private def newInstance(
       recordTime: Option[Time.Timestamp] = Some(Time.Timestamp.now()),
       inputs: DamlStateMap = Map.empty,
+      preExecute: Boolean = false,
   ) =
-    CommitContext(inputs, recordTime, TestHelpers.mkParticipantId(1))
+    CommitContext(inputs, recordTime, TestHelpers.mkParticipantId(1), preExecute)
 
   private def newDamlStateMap(keyAndValues: (DamlStateKey, DamlStateValue)*): DamlStateMap =
     (for ((key, value) <- keyAndValues)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/committer/transaction/TransactionCommitterSpec.scala
@@ -212,9 +212,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
         val context =
           createCommitContext(recordTime = Some(recordTime), inputs = inputs)
 
-        val actual =
-          transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)
-
+        val actual = transactionCommitter.deduplicateCommand(context, aTransactionEntrySummary)
         actual match {
           case StepContinue(_) => fail()
           case StepStop(actualLogEntry) =>
@@ -284,8 +282,10 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
           .minusMillis(1)
       val upperBound =
         recordTimeInstant.plus(theDefaultConfig.timeModel.maxSkew).plusMillis(1)
-      val inputWithDeclaredConfig =
-        Map(Conversions.configurationStateKey -> Some(emptyConfigurationStateValue))
+      val inputWithDeclaredConfig = Map(
+        Conversions.configurationStateKey -> Some(emptyConfigurationStateValue),
+        aDedupKey -> None,
+      )
 
       for (ledgerEffectiveTime <- Iterable(lowerBound, upperBound)) {
         val context =
@@ -299,9 +299,7 @@ class TransactionCommitterSpec extends AnyWordSpec with Matchers with MockitoSug
             )
             .build
         )
-        val actual =
-          transactionCommitter.validateLedgerTime(context, transactionEntrySummary)
-
+        val actual = transactionCommitter.validateLedgerTime(context, transactionEntrySummary)
         actual match {
           case StepContinue(_) => fail()
           case StepStop(actualLogEntry) =>

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -60,7 +60,12 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
       val ledgerStateReader = createLedgerStateReader(actualInputState)
 
       instance
-        .validate(anEnvelope(expectedReadSet), aParticipantId, ledgerStateReader)
+        .validate(
+          submittingParticipantId = aParticipantId,
+          submissionEnvelope = anEnvelope(expectedReadSet),
+          recordTime = recordTime.toInstant,
+          ledgerStateReader = ledgerStateReader,
+        )
         .map { actual =>
           actual.minRecordTime shouldBe expectedMinRecordTime
           actual.maxRecordTime shouldBe expectedMaxRecordTime
@@ -79,7 +84,12 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
       val ledgerStateReader = createLedgerStateReader(actualInputState)
 
       instance
-        .validate(anEnvelope(expectedReadSet), aParticipantId, ledgerStateReader)
+        .validate(
+          submittingParticipantId = aParticipantId,
+          submissionEnvelope = anEnvelope(expectedReadSet),
+          recordTime = recordTime.toInstant,
+          ledgerStateReader = ledgerStateReader,
+        )
         .map(verifyReadSet(_, expectedReadSet))
     }
 
@@ -95,9 +105,10 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
 
       instance
         .validate(
-          Envelope.enclose(aBatchedSubmission),
-          aParticipantId,
-          mock[StateReader[DamlStateKey, TestValue]],
+          submittingParticipantId = aParticipantId,
+          submissionEnvelope = Envelope.enclose(aBatchedSubmission),
+          recordTime = recordTime.toInstant,
+          ledgerStateReader = mock[StateReader[DamlStateKey, TestValue]],
         )
         .failed
         .map { case ValidationError(actualReason) =>
@@ -109,7 +120,12 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
       val instance = createInstance()
 
       instance
-        .validate(anInvalidEnvelope, aParticipantId, mock[StateReader[DamlStateKey, TestValue]])
+        .validate(
+          submittingParticipantId = aParticipantId,
+          submissionEnvelope = anInvalidEnvelope,
+          recordTime = recordTime.toInstant,
+          ledgerStateReader = mock[StateReader[DamlStateKey, TestValue]],
+        )
         .failed
         .map { case ValidationError(actualReason) =>
           actualReason should include("Cannot open envelope")
@@ -122,9 +138,10 @@ class PreExecutingSubmissionValidatorSpec extends AsyncWordSpec with Matchers wi
 
       instance
         .validate(
-          anEnvelopedDamlLogEntry,
-          aParticipantId,
-          mock[StateReader[DamlStateKey, TestValue]],
+          submittingParticipantId = aParticipantId,
+          submissionEnvelope = anEnvelopedDamlLogEntry,
+          recordTime = recordTime.toInstant,
+          ledgerStateReader = mock[StateReader[DamlStateKey, TestValue]],
         )
         .failed
         .map { case ValidationError(actualReason) =>
@@ -183,6 +200,7 @@ object PreExecutingSubmissionValidatorSpec {
     )
     when(
       mockCommitter.preExecuteSubmission(
+        any[Timestamp],
         any[Configuration],
         any[DamlSubmission],
         any[ParticipantId],


### PR DESCRIPTION
This _feels_ like an omission, but I could be totally wrong.

This makes it easier to support pre-execution in the kvutils integrity checker, because we can use the log entry timestamp for the second run.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
