### PR TITLE
Desperate attempt at reducing the flakiness in the hs bindings tests

### DIFF
--- a/language-support/hs/bindings/BUILD.bazel
+++ b/language-support/hs/bindings/BUILD.bazel
@@ -53,7 +53,13 @@ da_haskell_test(
         ":for-upload.dar",
         "//ledger/sandbox:sandbox-binary",
     ],
-    # The tests are flaky probably due to issues in gRPC-haskell.
+    # The tests throw flaky timeout errors. It looks like this comes
+    # from a fundamental issue in the Haskell bindings: They eagerly pull
+    # from streams and those stream receives have a timeout. If we create the
+    # stream too early and do a bunch of other stuff in between, this will then timeout.
+    # We could increase the timeout to an absurd value but that also seems silly
+    # and affects other operations as well so for now, we still keep it flaky
+    # and try not to cry.
     flaky = True,
     hackage_deps = [
         "aeson",
@@ -80,6 +86,9 @@ da_haskell_test(
     ],
     main_function = "DA.Ledger.Tests.main",
     src_strip_prefix = "test",
+    # We spin up Sandbox as a separate process, so
+    # try not to overload the machine.
+    tags = ["cpu:2"],
     visibility = ["//visibility:public"],
     deps = [
         "//compiler/daml-lf-ast",


### PR DESCRIPTION
At the very least this should produce better error messages and at
least on my machine it does reduce flakiness significantly by bumping
the timeout and increasing Bazel’s resource allocation (and thereby
reducing parallel runs).

Unfortunately, a proper fix here is much more involved than I have
time for right now.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
