### PR TITLE
Expose transaction trees in DAML Script

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -8,6 +8,9 @@ module Daml.Script
   , submitMustFail
   , submitMulti
   , submitMultiMustFail
+  , submitTree
+  , submitTreeMulti
+  , createdCid
   , query
   , queryContractId
   , queryContractKey
@@ -32,10 +35,17 @@ module Daml.Script
   , passTime
   , sleep
   , script
+  , TransactionTree(..)
+  , TreeEvent(..)
+  , Created(..)
+  , Exercised(..)
+  , AnyContractId
+  , fromAnyContractId
   ) where
 
 import DA.Functor
 import DA.NonEmpty (NonEmpty(..))
+import DA.List.Total
 import DA.Optional
 import DA.Stack
 import DA.Time
@@ -75,6 +85,7 @@ newtype Commands a = Commands (Ap CommandsF a)
 data ScriptF a
   = Submit (SubmitCmd a)
   | SubmitMustFail (SubmitMustFailCmd a)
+  | SubmitTree (SubmitTreePayload a)
   | Query (QueryACS a)
   | QueryContractId (QueryContractIdPayload a)
   | QueryContractKey (QueryContractKeyPayload a)
@@ -452,3 +463,128 @@ lift m = Script with
 -- it is implemented using `script` or not.
 script : Script a -> Script a
 script = identity
+
+-- | HIDE This is an early access feature.
+data TransactionTree = TransactionTree
+  with
+    rootEvents: [TreeEvent]
+  deriving Show
+
+-- | HIDE Select a contract id using a list of child indices.
+-- TODO (MK) Come up with a clearer API for this.
+createdCid : Template t => [Int] -> TransactionTree -> ContractId t
+createdCid [] _ = error "List of selectors passed to createdCid was empty"
+createdCid (i :: ss) (TransactionTree evs) =
+  case evs !! i of
+    None ->
+      error $ "Transaction tree has only " <> show (length evs) <> " root events but selected " <> show i
+    Some t -> createdCidGo ss t
+
+createdCidGo : Template t => [Int] -> TreeEvent -> ContractId t
+createdCidGo [] (CreatedEvent (Created cid _)) =
+  case fromAnyContractId cid of
+    None -> error "createdCid selected a create node of the wrong template type"
+    Some cid -> cid
+createdCidGo [] (ExercisedEvent _) =
+  error "createdCid selected an exercise event"
+createdCidGo ss@(_ :: _) (CreatedEvent _) =
+  error $ "createdCid reached created event before the following selectors have been applied: " <> show ss
+createdCidGo (i :: ss) (ExercisedEvent ex) =
+  case ex.childEvents !! i of
+    None ->
+      error $
+        "Exercised event has only " <>
+        show (length ex.childEvents) <> " child events but selected " <>
+        show i
+    Some e -> createdCidGo ss e
+
+-- | HIDE This is an early access feature.
+data TreeEvent
+  = CreatedEvent Created
+  | ExercisedEvent Exercised
+  deriving Show
+
+-- | HIDE This is an early access feature.
+data Created = Created
+  with
+    contractId : AnyContractId
+    argument : AnyTemplate
+
+-- | Custom Show instance since we cannot show AnyTemplate
+instance Show Created where
+  showsPrec d (Created contractId _) =
+    showString "Created {" .
+    showString "contractId = " .
+    showsPrec 0 contractId .
+    showString "}"
+
+-- | HIDE This is an early access feature.
+data Exercised = Exercised
+  with
+    contractId : AnyContractId
+    choice : Text
+    argument : AnyChoice
+    childEvents: [TreeEvent]
+
+-- | Custom Show instance since we cannot
+-- show AnyChoice.
+instance Show Exercised where
+  showsPrec d (Exercised cid choice _arg childEvents) =
+    showString "Exercised {" .
+    showString "contractId = " .
+    showsPrec 0 cid .
+    showCommaSpace .
+    showString "choice = " .
+    showsPrec 0 choice .
+    showCommaSpace .
+    showString "childEvents = " .
+    showsPrec 0 childEvents .
+    showString "}"
+
+-- | HIDE This is an early access feature
+data AnyContractId = AnyContractId
+  { templateId : TemplateTypeRep
+  , contractId : ContractId ()
+  } deriving Eq
+
+instance Show AnyContractId where
+  showsPrec d (AnyContractId _ cid) = showParen (d > app_prec) $
+    showString "AnyContractId " . showsPrec (app_prec +1) cid
+    where app_prec = 10
+
+-- | HIDE This is an early access feature.
+fromAnyContractId : forall t. Template t => AnyContractId -> Optional (ContractId t)
+fromAnyContractId cid
+  | cid.templateId == templateTypeRep @t = Some (coerceContractId cid.contractId)
+  | otherwise = None
+
+data SubmitTreePayload a = SubmitTreePayload
+  with
+    actAs : NonEmpty Party
+    readAs : [Party]
+    commands : Commands ()
+    continue : TransactionTree -> a
+    locations : [(Text, SrcLoc)]
+  deriving Functor
+
+-- | HIDE Equivalent to `submit` but returns the full transaction tree.
+-- This is an early access feature.
+submitTree : HasCallStack => Party -> Commands a -> Script TransactionTree
+submitTree p cmds =
+  lift $ Free $ fmap pure $ SubmitTree $ SubmitTreePayload with
+    actAs = NonEmpty p []
+    readAs = []
+    commands = void cmds
+    locations = getCallStack callStack
+    continue = identity
+
+-- | HIDE Equivalent to `submitMulti` but returns the full transaction tree.
+-- This is an early access feature.
+submitTreeMulti : HasCallStack => [Party] -> [Party] -> Commands a -> Script TransactionTree
+submitTreeMulti actAs readAs cmds =
+  lift $ Free $ fmap pure $ SubmitTree $ SubmitTreePayload with
+    actAs = actAsNonEmpty actAs
+    readAs = readAs
+    commands = void cmds
+    locations = getCallStack callStack
+    continue = identity

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/LedgerInteraction.scala
@@ -33,7 +33,7 @@ import com.daml.lf.data.{ImmArray, Ref}
 import com.daml.lf.data.Time
 import com.daml.lf.iface.{EnvironmentInterface, InterfaceType}
 import com.daml.lf.language.Ast._
-import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises}
+import com.daml.lf.transaction.Node.{NodeCreate, NodeExercises, NodeFetch, NodeLookupByKey}
 import com.daml.lf.speedy.{ScenarioRunner, TraceLog, svalue}
 import com.daml.lf.speedy.Speedy.{Machine, OffLedger, OnLedger}
 import com.daml.lf.speedy.{PartialTransaction, SValue}
@@ -41,7 +41,7 @@ import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SValue._
 import com.daml.lf.speedy.SResult._
-import com.daml.lf.transaction.GlobalKey
+import com.daml.lf.transaction.{GlobalKey, NodeId}
 import com.daml.lf.value.Value
 import com.daml.lf.value.Value.ContractId
 import com.daml.jwt.domain.Jwt
@@ -57,6 +57,7 @@ import com.daml.ledger.api.v1.transaction.TreeEvent
 import com.daml.ledger.api.v1.transaction_filter.{Filters, InclusiveFilters, TransactionFilter}
 import com.daml.ledger.api.validation.ValueValidator
 import com.daml.ledger.client.LedgerClient
+import com.daml.lf.scenario.ScenarioLedger.{RichTransaction}
 import com.daml.platform.participant.util.LfEngineToApi.{
   lfValueToApiRecord,
   lfValueToApiValue,
@@ -97,6 +98,21 @@ object ScriptLedgerClient {
       contractId: ContractId,
       argument: Value[ContractId],
   )
+
+  final case class TransactionTree(rootEvents: List[TreeEvent])
+  sealed trait TreeEvent
+  final case class Exercised(
+      templateId: Identifier,
+      contractId: ContractId,
+      choice: ChoiceName,
+      argument: Value[ContractId],
+      childEvents: List[TreeEvent],
+  ) extends TreeEvent
+  final case class Created(
+      templateId: Identifier,
+      contractId: ContractId,
+      argument: Value[ContractId],
+  ) extends TreeEvent
 }
 
 // This abstracts over the interaction with the ledger. This allows
@@ -140,6 +156,13 @@ trait ScriptLedgerClient {
       commands: List[command.Command],
       optLocation: Option[Location],
   )(implicit ec: ExecutionContext, mat: Materializer): Future[Either[Unit, Unit]]
+
+  def submitTree(
+      actAs: OneAnd[Set, Ref.Party],
+      readAs: Set[Ref.Party],
+      commands: List[command.Command],
+      optLocation: Option[Location],
+  )(implicit ec: ExecutionContext, mat: Materializer): Future[ScriptLedgerClient.TransactionTree]
 
   def allocateParty(partyIdHint: String, displayName: String)(implicit
       ec: ExecutionContext,
@@ -319,6 +342,35 @@ class GrpcLedgerClient(val grpcClient: LedgerClient, val applicationId: Applicat
       case Right(_) => Left(())
       case Left(_) => Right(())
     })
+  }
+
+  override def submitTree(
+      actAs: OneAnd[Set, Ref.Party],
+      readAs: Set[Ref.Party],
+      commands: List[command.Command],
+      optLocation: Option[Location],
+  )(implicit
+      ec: ExecutionContext,
+      mat: Materializer,
+  ): Future[ScriptLedgerClient.TransactionTree] = {
+    import scalaz.std.list._
+    import scalaz.syntax.traverse._
+    for {
+      ledgerCommands <- Converter.toFuture(commands.traverse(toCommand(_)))
+      apiCommands = Commands(
+        party = actAs.head,
+        actAs = actAs.toList,
+        readAs = readAs.toList,
+        commands = ledgerCommands,
+        ledgerId = grpcClient.ledgerId.unwrap,
+        applicationId = applicationId.unwrap,
+        commandId = UUID.randomUUID.toString,
+      )
+      request = SubmitAndWaitRequest(Some(apiCommands))
+      resp <- grpcClient.commandServiceClient
+        .submitAndWaitForTransactionTree(request)
+      converted <- Converter.toFuture(Converter.fromTransactionTree(resp.getTransaction))
+    } yield converted
   }
 
   override def allocateParty(partyIdHint: String, displayName: String)(implicit
@@ -528,96 +580,100 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       readAs: Set[Ref.Party],
       commands: List[command.Command],
       optLocation: Option[Location],
-  )(implicit
-      ec: ExecutionContext
-  ): Future[Either[StatusRuntimeException, Seq[ScriptLedgerClient.CommandResult]]] = Future {
-    // Clear state at the beginning like in SBSBeginCommit for scenarios.
-    machine.returnValue = null
-    onLedger.commitLocation = optLocation
-    onLedger.localContracts = Map.empty
-    onLedger.globalDiscriminators = Set.empty
-    val speedyCommands = preprocessor.unsafePreprocessCommands(commands.to(ImmArray))._1
-    val translated = compiledPackages.compiler.unsafeCompile(speedyCommands)
-    machine.setExpressionToEvaluate(SEApp(translated, Array(SEValue.Token)))
-    onLedger.committers = actAs.toList.toSet
-    var result: Seq[ScriptLedgerClient.CommandResult] = null
-    while (result == null) {
-      machine.run() match {
-        case SResultNeedContract(coid, tid @ _, committers @ _, cbMissing, cbPresent) =>
-          scenarioRunner.lookupContract(coid, actAs.toSet, readAs, cbMissing, cbPresent).toTry.get
-        case SResultNeedKey(keyWithMaintainers, committers @ _, cb) =>
-          scenarioRunner.lookupKey(keyWithMaintainers.globalKey, actAs.toSet, readAs, cb).toTry.get
-        case SResultFinalValue(SUnit) =>
-          onLedger.ptx.finish match {
-            case PartialTransaction.CompleteTransaction(tx) =>
-              val results: ImmArray[ScriptLedgerClient.CommandResult] = tx.roots.map { n =>
-                tx.nodes(n) match {
-                  case create: NodeCreate[ContractId] =>
-                    ScriptLedgerClient.CreateResult(create.coid)
-                  case exercise: NodeExercises[_, ContractId] =>
-                    ScriptLedgerClient.ExerciseResult(
-                      exercise.templateId,
-                      exercise.choiceId,
-                      exercise.exerciseResult.get,
-                    )
-                  case n =>
-                    // Root nodes can only be creates and exercises.
-                    throw new RuntimeException(s"Unexpected node: $n")
+  )(implicit ec: ExecutionContext): Future[
+    Either[StatusRuntimeException, (RichTransaction, Seq[ScriptLedgerClient.CommandResult])]
+  ] =
+    Future {
+      // Clear state at the beginning like in SBSBeginCommit for scenarios.
+      machine.returnValue = null
+      onLedger.commitLocation = optLocation
+      onLedger.localContracts = Map.empty
+      onLedger.globalDiscriminators = Set.empty
+      val speedyCommands = preprocessor.unsafePreprocessCommands(commands.to(ImmArray))._1
+      val translated = compiledPackages.compiler.unsafeCompile(speedyCommands)
+      machine.setExpressionToEvaluate(SEApp(translated, Array(SEValue.Token)))
+      onLedger.committers = actAs.toSet
+      var result: (RichTransaction, Seq[ScriptLedgerClient.CommandResult]) = null
+      while (result == null) {
+        machine.run() match {
+          case SResultNeedContract(coid, tid @ _, committers @ _, cbMissing, cbPresent) =>
+            scenarioRunner.lookupContract(coid, actAs.toSet, readAs, cbMissing, cbPresent).toTry.get
+          case SResultNeedKey(keyWithMaintainers, committers @ _, cb) =>
+            scenarioRunner
+              .lookupKey(keyWithMaintainers.globalKey, actAs.toSet, readAs, cb)
+              .toTry
+              .get
+          case SResultFinalValue(SUnit) =>
+            onLedger.ptx.finish match {
+              case PartialTransaction.CompleteTransaction(tx) =>
+                val results: ImmArray[ScriptLedgerClient.CommandResult] = tx.roots.map { n =>
+                  tx.nodes(n) match {
+                    case create: NodeCreate[ContractId] =>
+                      ScriptLedgerClient.CreateResult(create.coid)
+                    case exercise: NodeExercises[_, ContractId] =>
+                      ScriptLedgerClient.ExerciseResult(
+                        exercise.templateId,
+                        exercise.choiceId,
+                        exercise.exerciseResult.get,
+                      )
+                    case n =>
+                      // Root nodes can only be creates and exercises.
+                      throw new RuntimeException(s"Unexpected node: $n")
+                  }
                 }
-              }
-              ScenarioLedger.commitTransaction(
-                actAs = actAs.toSet,
-                readAs = readAs,
-                effectiveAt = scenarioRunner.ledger.currentTime,
-                optLocation = onLedger.commitLocation,
-                tx = tx,
-                l = scenarioRunner.ledger,
-              ) match {
-                case Left(fas) =>
-                  // Capture the error and exit.
-                  throw ScenarioErrorCommitError(fas)
-                case Right(commitResult) =>
-                  scenarioRunner.ledger = commitResult.newLedger
-                  // Capture the result and exit.
-                  result = results.toSeq
-              }
-            case PartialTransaction.IncompleteTransaction(ptx) =>
-              throw new RuntimeException(s"Unexpected abort: $ptx")
-          }
-        case SResultFinalValue(v) =>
-          // The final result should always be unit.
-          throw new RuntimeException(s"FATAL: Unexpected non-unit final result: $v")
-        case SResultScenarioCommit(_, _, _, _) =>
-          throw new RuntimeException("FATAL: Encountered scenario commit in DAML Script")
-        case SResultError(err) =>
-          // Capture the error and exit.
-          throw err
-        case SResultNeedTime(callback) =>
-          callback(scenarioRunner.ledger.currentTime)
-        case SResultNeedPackage(pkg, callback @ _) =>
-          throw new RuntimeException(
-            s"FATAL: Missing package $pkg should have been reported at Script compilation"
-          )
-        case SResultScenarioInsertMustFail(committers @ _, optLocation @ _) =>
-          throw new RuntimeException(
-            "FATAL: Encountered scenario instruction for submitMustFail in DAML script"
-          )
-        case SResultScenarioMustFail(ptx @ _, committers @ _, callback @ _) =>
-          throw new RuntimeException(
-            "FATAL: Encountered scenario instruction for submitMustFail in DAML Script"
-          )
-        case SResultScenarioPassTime(relTime @ _, callback @ _) =>
-          throw new RuntimeException(
-            "FATAL: Encountered scenario instruction setTime in DAML Script"
-          )
-        case SResultScenarioGetParty(partyText @ _, callback @ _) =>
-          throw new RuntimeException(
-            "FATAL: Encountered scenario instruction getParty in DAML Script"
-          )
+                ScenarioLedger.commitTransaction(
+                  actAs = actAs.toSet,
+                  readAs = readAs,
+                  effectiveAt = scenarioRunner.ledger.currentTime,
+                  optLocation = onLedger.commitLocation,
+                  tx = tx,
+                  l = scenarioRunner.ledger,
+                ) match {
+                  case Left(fas) =>
+                    // Capture the error and exit.
+                    throw ScenarioErrorCommitError(fas)
+                  case Right(commitResult) =>
+                    scenarioRunner.ledger = commitResult.newLedger
+                    // Capture the result and exit.
+                    result = (commitResult.richTransaction, results.toSeq)
+                }
+              case PartialTransaction.IncompleteTransaction(ptx) =>
+                throw new RuntimeException(s"Unexpected abort: $ptx")
+            }
+          case SResultFinalValue(v) =>
+            // The final result should always be unit.
+            throw new RuntimeException(s"FATAL: Unexpected non-unit final result: $v")
+          case SResultScenarioCommit(_, _, _, _) =>
+            throw new RuntimeException("FATAL: Encountered scenario commit in DAML Script")
+          case SResultError(err) =>
+            // Capture the error and exit.
+            throw err
+          case SResultNeedTime(callback) =>
+            callback(scenarioRunner.ledger.currentTime)
+          case SResultNeedPackage(pkg, callback @ _) =>
+            throw new RuntimeException(
+              s"FATAL: Missing package $pkg should have been reported at Script compilation"
+            )
+          case SResultScenarioInsertMustFail(committers @ _, optLocation @ _) =>
+            throw new RuntimeException(
+              "FATAL: Encountered scenario instruction for submitMustFail in DAML script"
+            )
+          case SResultScenarioMustFail(ptx @ _, committers @ _, callback @ _) =>
+            throw new RuntimeException(
+              "FATAL: Encountered scenario instruction for submitMustFail in DAML Script"
+            )
+          case SResultScenarioPassTime(relTime @ _, callback @ _) =>
+            throw new RuntimeException(
+              "FATAL: Encountered scenario instruction setTime in DAML Script"
+            )
+          case SResultScenarioGetParty(partyText @ _, callback @ _) =>
+            throw new RuntimeException(
+              "FATAL: Encountered scenario instruction getParty in DAML Script"
+            )
+        }
       }
+      Right(result)
     }
-    Right(result)
-  }
 
   override def submit(
       actAs: OneAnd[Set, Ref.Party],
@@ -632,7 +688,7 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
       case Right(x) =>
         // Expected successful commit so clear.
         machine.clearCommit
-        Right(x)
+        Right(x._2)
       case Left(err) =>
         // Unexpected failure, do not clear so we can display the partial
         // transaction.
@@ -657,6 +713,41 @@ class IdeClient(val compiledPackages: CompiledPackages) extends ScriptLedgerClie
         machine.clearCommit
         Future.successful(Right(()))
       })
+  }
+
+  override def submitTree(
+      actAs: OneAnd[Set, Ref.Party],
+      readAs: Set[Ref.Party],
+      commands: List[command.Command],
+      optLocation: Option[Location],
+  )(implicit
+      ec: ExecutionContext,
+      mat: Materializer,
+  ): Future[ScriptLedgerClient.TransactionTree] = {
+    unsafeSubmit(actAs, readAs, commands, optLocation).map {
+      case Right(x) =>
+        // Expected successful commit so clear.
+        machine.clearCommit
+        val y = x._1.transaction
+        def convEvent(id: NodeId): Option[ScriptLedgerClient.TreeEvent] = y.nodes(id) match {
+          case create: NodeCreate[ContractId] =>
+            Some(ScriptLedgerClient.Created(create.templateId, create.coid, create.arg))
+          case exercise: NodeExercises[NodeId, ContractId] =>
+            Some(
+              ScriptLedgerClient.Exercised(
+                exercise.templateId,
+                exercise.targetCoid,
+                exercise.choiceId,
+                exercise.chosenValue,
+                exercise.children.collect(Function.unlift(convEvent(_))).toList,
+              )
+            )
+          case _: NodeFetch[ContractId] => None
+          case _: NodeLookupByKey[ContractId] => None
+        }
+        ScriptLedgerClient.TransactionTree(y.roots.collect(Function.unlift(convEvent(_))).toList)
+      case Left(err) => throw new IllegalStateException(err)
+    }
   }
 
   // All parties known to the ledger. This may include parties that were not
@@ -925,6 +1016,23 @@ class JsonLedgerClient(
       case Left(_) => Right(())
     })
   }
+
+  override def submitTree(
+      actAs: OneAnd[Set, Ref.Party],
+      readAs: Set[Ref.Party],
+      commands: List[command.Command],
+      optLocation: Option[Location],
+  )(implicit
+      ec: ExecutionContext,
+      mat: Materializer,
+  ): Future[ScriptLedgerClient.TransactionTree] = {
+    Future.failed(
+      new RuntimeException(
+        "submitTree is not supported when running DAML Script over the JSON API."
+      )
+    )
+  }
+
   override def allocateParty(partyIdHint: String, displayName: String)(implicit
       ec: ExecutionContext,
       mat: Materializer,

--- a/daml-script/test/daml-script-test-runner.sh
+++ b/daml-script/test/daml-script-test-runner.sh
@@ -62,6 +62,7 @@ ScriptTest:testQueryContractKey SUCCESS
 ScriptTest:testSetTime SUCCESS
 ScriptTest:testStack SUCCESS
 ScriptTest:traceOrder SUCCESS
+ScriptTest:tree SUCCESS
 ScriptTest:tupleKey SUCCESS
 EOF
 )"

--- a/daml-script/test/daml/ScriptTest.daml
+++ b/daml-script/test/daml/ScriptTest.daml
@@ -369,6 +369,23 @@ tupleKey = do
   r === Some (cid, TTupleKey p1 p2)
   pure ()
 
+tree : Script ()
+tree = do
+  p1 <- allocateParty "p1"
+  TransactionTree [CreatedEvent (Created cid arg)] <- submitTree p1 (createCmd (T p1 p1))
+  fromAnyTemplate arg === Some (T p1 p1)
+  let Some cid' = fromAnyContractId @T cid
+  optT <- queryContractId p1 cid'
+  optT === Some (T p1 p1)
+  cid <- submit p1 (createCmd (MessageSize p1))
+  TransactionTree [ExercisedEvent ex] <- submitTree p1 (exerciseCmd cid (CreateN 3))
+  fromAnyContractId @MessageSize ex.contractId === Some cid
+  let [CreatedEvent c1, CreatedEvent c2, CreatedEvent c3] = ex.childEvents
+  fromAnyTemplate c1.argument === Some (MessageSize p1)
+  fromAnyTemplate c2.argument === Some (MessageSize p1)
+  fromAnyTemplate c3.argument === Some (MessageSize p1)
+  pure ()
+
 -- Create a contract only visible to one party to test readAs
 jsonMultiPartySubmissionCreateSingle : Party -> Script (ContractId MultiPartyContract)
 jsonMultiPartySubmissionCreateSingle p = do


### PR DESCRIPTION
This is spun off from #7934 for ease of review.

For now, all of this is hidden (and for extra caution also marked as
early access). I expect we’ll tweak the API in a bunch of ways before
marking it stable but this at least is sufficient for the prototype.

At this point, we cannot support this over the JSON API. Not too
worried about that at least for now.

fixes #7847

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
