### PR TITLE
ghcide: cached goto definitions

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -17,8 +17,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
-GHCIDE_REV = "0fdad67601eb7c6521c4a4a712bbc396d1c012b8"
-GHCIDE_SHA256 = "14d4028eb1e52fd3a1ac0710fb2a6fc0a7b5f1d1b8bc8d0a79c23837bc63b903"
+GHCIDE_REV = "a6879b77da2968bae9256bb2f5658b909056d4ef"
+GHCIDE_SHA256 = "94be2607354c7ab111b87fa2b4afe8f6ef50981277864a05e906b7b0a783c58f"
 GHCIDE_VERSION = "0.1.0"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"

--- a/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
+++ b/compiler/damlc/daml-doc/src/DA/Daml/Doc/Extract.hs
@@ -54,6 +54,8 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Either
 
+
+
 -- | Extract documentation in a dependency graph of modules.
 extractDocs ::
     ExtractOptions
@@ -192,9 +194,12 @@ haddockParse diagsLogger opts f = MaybeT $ do
           Service.discardInternalModules (optUnitId opts) f
       liftIO $ Service.setFilesOfInterest service (HashSet.fromList nonInternal)
       Service.runActionSync service $ runMaybeT $ do
-          deps <- Service.usesE Service.GetDependencies f
-          Service.usesE Service.TypeCheck $ nubOrd $ f ++ concatMap Service.transitiveModuleDeps deps
+          deps <- usesE' Service.GetDependencies f
+          usesE' Service.TypeCheck $ nubOrd $ f ++ concatMap Service.transitiveModuleDeps deps
               -- We enable Opt_Haddock in the opts for daml-doc.
+              --
+          where
+            usesE' k = fmap (map fst) . Service.usesE k
 
 ------------------------------------------------------------
 

--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -24,23 +24,17 @@ import Maybes (MaybeErr(..))
 import TcRnMonad (initIfaceLoad)
 
 import Control.Concurrent.Extra
+import Control.DeepSeq (NFData())
 import Control.Exception
 import Control.Monad.Except
 import Control.Monad.Extra
 import Control.Monad.Trans.Maybe
-import Development.IDE.Core.Compile
-import Development.IDE.GHC.Error
-import Development.IDE.GHC.Warnings
-import Development.IDE.Core.OfInterest
-import Development.IDE.GHC.Util
-import Development.IDE.Types.Logger hiding (Priority)
 import DA.Daml.Options
 import DA.Daml.Options.Packaging.Metadata
 import DA.Daml.Options.Types
-import qualified Text.PrettyPrint.Annotated.HughesPJClass as HughesPJPretty
-import Development.IDE.Types.Location as Base
 import Data.Aeson hiding (Options)
 import Data.Bifunctor (bimap)
+import Data.Binary (Binary())
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.UTF8 as BS
@@ -48,9 +42,10 @@ import Data.Either.Extra
 import Data.Foldable
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashSet as HashSet
+import Data.Hashable (Hashable())
+import qualified Data.IntMap.Strict as IntMap
 import Data.List.Extra
 import qualified Data.List.NonEmpty as NonEmpty
-import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Map.Strict as Map
 import Data.Maybe
 import qualified Data.NameMap as NM
@@ -59,15 +54,24 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Extended as T
 import qualified Data.Text.Lazy as TL
 import Data.Tuple.Extra
+import Data.Typeable (Typeable())
+import Development.IDE.Core.Compile
+import Development.IDE.Core.OfInterest
+import Development.IDE.GHC.Error
+import Development.IDE.GHC.Util
+import Development.IDE.GHC.Warnings
+import Development.IDE.Types.Location as Base
+import Development.IDE.Types.Logger hiding (Priority)
 import Development.Shake hiding (Diagnostic, Env, doesFileExist)
-import "ghc-lib" GHC hiding (typecheckModule, Succeeded)
-import "ghc-lib-parser" Module (stringToUnitId, UnitId(..), DefUnitId(..))
+import "ghc-lib" GHC hiding (Succeeded, typecheckModule)
+import "ghc-lib-parser" Module (DefUnitId(..), UnitId(..), stringToUnitId)
 import Safe
+import System.Directory.Extra as Dir
 import System.Environment
+import System.FilePath
 import System.IO
 import System.IO.Error
-import System.Directory.Extra as Dir
-import System.FilePath
+import qualified Text.PrettyPrint.Annotated.HughesPJClass as HughesPJPretty
 
 import qualified Network.HTTP.Types as HTTP.Types
 import qualified Network.URI as URI
@@ -188,7 +192,7 @@ data DalfDependency = DalfDependency
   }
 
 getDlintIdeas :: NormalizedFilePath -> Action (Maybe ())
-getDlintIdeas f = runMaybeT $ useE GetDlintDiagnostics f
+getDlintIdeas f = runMaybeT $ fst <$> useE GetDlintDiagnostics f
 
 ideErrorPretty :: Pretty.Pretty e => NormalizedFilePath -> e -> FileDiagnostic
 ideErrorPretty fp = ideErrorText fp . T.pack . HughesPJPretty.prettyShow
@@ -206,8 +210,8 @@ diagsToIdeResult fp diags = (map (fp, ShowDiag,) diags, r)
 -- | Dependencies on other packages excluding stable DALFs.
 getUnstableDalfDependencies :: [NormalizedFilePath] -> MaybeT Action (Map.Map UnitId LF.DalfPackage)
 getUnstableDalfDependencies files = do
-    unitIds <- concatMap transitivePkgDeps <$> usesE GetDependencies files
-    pkgMap <- Map.unions . map getPackageMap <$> usesE GeneratePackageMap files
+    unitIds <- concatMap transitivePkgDeps <$> usesE' GetDependencies files
+    pkgMap <- Map.unions . map getPackageMap <$> usesE' GeneratePackageMap files
     pure $ Map.restrictKeys pkgMap (Set.fromList $ map (DefiniteUnitId . DefUnitId) unitIds)
 
 getDalfDependencies :: [NormalizedFilePath] -> MaybeT Action (Map.Map UnitId LF.DalfPackage)
@@ -654,10 +658,10 @@ generatePackageRule =
 -- and having it be a function makes the merging a bit easier.
 generateSerializedPackage :: LF.PackageName -> Maybe LF.PackageVersion -> [NormalizedFilePath] -> MaybeT Action LF.Package
 generateSerializedPackage pkgName pkgVersion rootFiles = do
-    fileDeps <- usesE GetDependencies rootFiles
+    fileDeps <- usesE' GetDependencies rootFiles
     let allFiles = nubSort $ rootFiles <> concatMap transitiveModuleDeps fileDeps
     files <- lift $ discardInternalModules (Just $ pkgNameVersion pkgName pkgVersion) allFiles
-    dalfs <- usesE ReadSerializedDalf files
+    dalfs <- usesE' ReadSerializedDalf files
     lfVersion <- lift getDamlLfVersion
     pure $ buildPackage (Just pkgName) pkgVersion lfVersion dalfs
 
@@ -1193,6 +1197,23 @@ discardInternalModules mbPackageName files = do
                           moduleNameFile modName `isSuffixOf` fromNormalizedFilePath f)
                      $ Map.keys stablePackages)
         moduleNameFile (LF.ModuleName segments) = joinPath (map T.unpack segments) <.> "daml"
+
+usesE' ::
+       ( Eq k
+       , Hashable k
+       , Binary k
+       , Show k
+       , Show (RuleResult k)
+       , Typeable k
+       , Typeable (RuleResult k)
+       , NFData k
+       , NFData (RuleResult k)
+       )
+    => k
+    -> [NormalizedFilePath]
+    -> MaybeT Action [RuleResult k]
+usesE' k = fmap (map fst) . usesE k
+
 
 internalModules :: [FilePath]
 internalModules = map normalise

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -103,7 +103,7 @@ createProjectPackageDb projectRoot (disableScenarioService -> opts) (PackageSdkV
       loggerH <- getLogger opts "generate package maps"
       mbRes <- withDamlIdeState opts loggerH diagnosticsLogger $ \ide -> runActionSync ide $ runMaybeT $
           (,) <$> useNoFileE GenerateStablePackages
-              <*> useE GeneratePackageMap projectRoot
+              <*> (fst <$> useE GeneratePackageMap projectRoot)
       (stablePkgs, PackageMap dependenciesInPkgDb) <- maybe (fail "Failed to generate package info") pure mbRes
       let stablePkgIds :: Set LF.PackageId
           stablePkgIds = Set.fromList $ map LF.dalfPackageId $ MS.elems stablePkgs
@@ -620,7 +620,7 @@ getExposedModules opts projectRoot = do
     hscEnv <-
         (maybe (exitWithError "Failed to list exposed modules") (pure . hscEnv) =<<) $
         withDamlIdeState opts logger diagnosticsLogger $ \ide ->
-        runActionSync ide $ runMaybeT $ useE GhcSession projectRoot
+        runActionSync ide $ runMaybeT $ fst <$> useE GhcSession projectRoot
     pure $! exposedModulesFromDynFlags $ hsc_dflags hscEnv
   where
     exposedModulesFromDynFlags :: DynFlags -> MS.Map UnitId (UniqSet GHC.ModuleName)

--- a/compiler/lsp-tests/src/Main.hs
+++ b/compiler/lsp-tests/src/Main.hs
@@ -398,6 +398,28 @@ requestTests run _runScenarios = testGroup "requests"
           -- answerFromTest
           locs <- getDefinitions main' (Position 2 8)
           liftIO $ locs @?= [Location (test ^. uri) (Range (Position 1 0) (Position 1 14))]
+
+          -- introduce syntax error
+          changeDoc main' [TextDocumentContentChangeEvent (Just (Range (Position 6 6) (Position 6 6))) Nothing "+\n"]
+          expectDiagnostics [("Main.daml", [(DsError, (6, 6), "Parse error")])]
+
+          -- everything should still work because we use stale information.
+          -- thisIsAParam
+          locs <- getDefinitions main' (Position 3 24)
+          liftIO $ locs @?= [Location (main' ^. uri) (Range (Position 3 4) (Position 3 16))]
+          -- letParam
+          locs <- getDefinitions main' (Position 4 37)
+          liftIO $ locs @?= [Location (main' ^. uri) (Range (Position 4 16) (Position 4 24))]
+          -- import Test
+          locs <- getDefinitions main' (Position 1 10)
+          liftIO $ locs @?= [Location (test ^. uri) (Range (Position 0 0) (Position 0 0))]
+          -- use of `bar` in template
+          locs <- getDefinitions main' (Position 14 20)
+          liftIO $ locs @?= [Location (main' ^. uri) (Range (Position 2 0) (Position 2 3))]
+          -- answerFromTest
+          locs <- getDefinitions main' (Position 2 8)
+          liftIO $ locs @?= [Location (test ^. uri) (Range (Position 1 0) (Position 1 14))]
+
           closeDoc main'
           closeDoc test
     ]


### PR DESCRIPTION
We update ghcide, which enables cached goto definitions that keep
working when the document doesn't compile anymore. This also adds a test
to lsp-tests for this feature.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
