### PR TITLE
Add first metrics to non-repudiation proxy

### DIFF
--- a/runtime-components/non-repudiation-postgresql/BUILD.bazel
+++ b/runtime-components/non-repudiation-postgresql/BUILD.bazel
@@ -77,6 +77,7 @@ da_scala_test(
         "//runtime-components/non-repudiation",
         "//runtime-components/non-repudiation-client",
         "@maven//:com_zaxxer_HikariCP",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_netty",

--- a/runtime-components/non-repudiation-postgresql/BUILD.bazel
+++ b/runtime-components/non-repudiation-postgresql/BUILD.bazel
@@ -77,7 +77,6 @@ da_scala_test(
         "//runtime-components/non-repudiation",
         "//runtime-components/non-repudiation-client",
         "@maven//:com_zaxxer_HikariCP",
-        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_netty",

--- a/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
+++ b/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
@@ -77,6 +77,7 @@ final class NonRepudiationProxyConformance
           sandboxChannelBuilder,
           shutdownTimeout = 5.seconds,
         )
+        _ <- MetricsReporterOwner.slf4j[ResourceContext](period = 5.seconds)
         transactor <- managedHikariTransactor(postgresDatabase.url, maxPoolSize = 10)
         db = Tables.initialize(transactor)
         _ = db.certificates.put(certificate)
@@ -85,7 +86,6 @@ final class NonRepudiationProxyConformance
           proxyBuilder,
           db.certificates,
           db.signedPayloads,
-          MetricsReporterOwner.slf4j(period = 5.seconds),
           Clock.systemUTC(),
           CommandService.scalaDescriptor.fullName,
           CommandSubmissionService.scalaDescriptor.fullName,

--- a/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
+++ b/runtime-components/non-repudiation-postgresql/src/test/scala/com/daml/nonrepudiation/postgresql/NonRepudiationProxyConformance.scala
@@ -20,7 +20,7 @@ import com.daml.ledger.api.v1.command_service.CommandServiceGrpc.CommandService
 import com.daml.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc.CommandSubmissionService
 import com.daml.ledger.resources.{ResourceContext, ResourceOwner}
 import com.daml.nonrepudiation.client.SigningInterceptor
-import com.daml.nonrepudiation.{AlgorithmString, NonRepudiationProxy}
+import com.daml.nonrepudiation.{AlgorithmString, MetricsReporterOwner, NonRepudiationProxy}
 import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.platform.sandboxnext.{Runner => Sandbox}
 import com.daml.ports.Port
@@ -85,6 +85,7 @@ final class NonRepudiationProxyConformance
           proxyBuilder,
           db.certificates,
           db.signedPayloads,
+          MetricsReporterOwner.slf4j(period = 5.seconds),
           Clock.systemUTC(),
           CommandService.scalaDescriptor.fullName,
           CommandSubmissionService.scalaDescriptor.fullName,

--- a/runtime-components/non-repudiation/BUILD.bazel
+++ b/runtime-components/non-repudiation/BUILD.bazel
@@ -48,7 +48,6 @@ da_scala_test(
         "//libs-scala/resources",
         "//runtime-components/non-repudiation-client",
         "@maven//:com_google_protobuf_protobuf_java",
-        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_services",

--- a/runtime-components/non-repudiation/BUILD.bazel
+++ b/runtime-components/non-repudiation/BUILD.bazel
@@ -23,6 +23,7 @@ da_scala_library(
         "//libs-scala/resources",
         "//runtime-components/non-repudiation-core",
         "@maven//:com_google_guava_guava",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )
@@ -47,6 +48,7 @@ da_scala_test(
         "//libs-scala/resources",
         "//runtime-components/non-repudiation-client",
         "@maven//:com_google_protobuf_protobuf_java",
+        "@maven//:io_dropwizard_metrics_metrics_core",
         "@maven//:io_grpc_grpc_api",
         "@maven//:io_grpc_grpc_core",
         "@maven//:io_grpc_grpc_services",

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/CertificateRepository.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/CertificateRepository.scala
@@ -5,6 +5,8 @@ package com.daml.nonrepudiation
 
 import java.security.cert.X509Certificate
 
+import com.codahale.metrics.Timer
+
 object CertificateRepository {
 
   trait Read {
@@ -13,6 +15,11 @@ object CertificateRepository {
 
   trait Write {
     def put(certificate: X509Certificate): FingerprintBytes
+  }
+
+  final class Timed(timer: Timer, delegate: Read) extends Read {
+    override def get(fingerprint: FingerprintBytes): Option[X509Certificate] =
+      timer.time(() => delegate.get(fingerprint))
   }
 
 }

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/Metrics.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/Metrics.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.nonrepudiation
+
+import com.codahale.metrics.{Meter, MetricRegistry, Timer}
+
+final class Metrics(registry: MetricRegistry) {
+
+  private val Prefix = "daml.nonrepudiation"
+
+  private def name(suffix: String): String = s"$Prefix.$suffix"
+
+  // For further details on the metrics below, see: https://metrics.dropwizard.io/4.1.2/manual/core.html
+  // Quick reference:
+  // - meters track rates, keeping both historical mean and exponentially-weighted
+  //   moving average over the last 1, 5 and 15 minutes
+  // - timers act as meters and also keep an histogram of the time for the
+  //   measured action, giving exponentially more weight to more recent data
+
+  // daml.nonrepudiation.processing
+  // Overall time taken from interception to forwarding to the participant (or rejecting)
+  val processingTimer: Timer = registry.timer(name("processing"))
+
+  // daml.nonrepudiation.get_key
+  // Time taken to retrieve the key from the certificate store
+  // Part of the time tracked in daml.nonrepudiation.processing
+  val getKeyTimer: Timer = registry.timer(name("get_key"))
+
+  // daml.nonrepudiation.verify_signature
+  // Time taken to verify the signature of a command
+  // Part of the time tracked in daml.nonrepudiation.processing
+  val verifySignatureTimer: Timer = registry.timer(name("verify_signature"))
+
+  // daml.nonrepudiation.add_signed_payload
+  // Time taken to add the signed payload before ultimately forwarding the command
+  // Part of the time tracked in daml.nonrepudiation.processing
+  val addSignedPayloadTimer: Timer = registry.timer(name("add_signed_payload"))
+
+  // daml.nonrepudiation.rejections
+  // Rate of calls that are being rejected before they can be forwarded to the participant
+  // Historical and exponentially-weighted moving average rate over the latest 1, 5 and 15 minutes
+  val rejectionsMeter: Meter = registry.meter(name("rejections"))
+
+}

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/Metrics.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/Metrics.scala
@@ -5,7 +5,17 @@ package com.daml.nonrepudiation
 
 import com.codahale.metrics.{Meter, MetricRegistry, Timer}
 
-final class Metrics(registry: MetricRegistry) {
+object Metrics extends Metrics {
+
+  // We only need a singleton right now
+  // Having multiple registries is useful
+  // "if you want to organize your metrics in particular reporting groups"
+  // See: https://metrics.dropwizard.io/4.1.2/manual/core.html
+  object Registry extends MetricRegistry
+
+}
+
+sealed abstract class Metrics {
 
   private val Prefix = "daml.nonrepudiation"
 
@@ -20,26 +30,26 @@ final class Metrics(registry: MetricRegistry) {
 
   // daml.nonrepudiation.processing
   // Overall time taken from interception to forwarding to the participant (or rejecting)
-  val processingTimer: Timer = registry.timer(name("processing"))
+  val processingTimer: Timer = Metrics.Registry.timer(name("processing"))
 
   // daml.nonrepudiation.get_key
   // Time taken to retrieve the key from the certificate store
   // Part of the time tracked in daml.nonrepudiation.processing
-  val getKeyTimer: Timer = registry.timer(name("get_key"))
+  val getKeyTimer: Timer = Metrics.Registry.timer(name("get_key"))
 
   // daml.nonrepudiation.verify_signature
   // Time taken to verify the signature of a command
   // Part of the time tracked in daml.nonrepudiation.processing
-  val verifySignatureTimer: Timer = registry.timer(name("verify_signature"))
+  val verifySignatureTimer: Timer = Metrics.Registry.timer(name("verify_signature"))
 
   // daml.nonrepudiation.add_signed_payload
   // Time taken to add the signed payload before ultimately forwarding the command
   // Part of the time tracked in daml.nonrepudiation.processing
-  val addSignedPayloadTimer: Timer = registry.timer(name("add_signed_payload"))
+  val addSignedPayloadTimer: Timer = Metrics.Registry.timer(name("add_signed_payload"))
 
   // daml.nonrepudiation.rejections
   // Rate of calls that are being rejected before they can be forwarded to the participant
   // Historical and exponentially-weighted moving average rate over the latest 1, 5 and 15 minutes
-  val rejectionsMeter: Meter = registry.meter(name("rejections"))
+  val rejectionsMeter: Meter = Metrics.Registry.meter(name("rejections"))
 
 }

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/MetricsReporterOwner.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/MetricsReporterOwner.scala
@@ -3,7 +3,7 @@
 
 package com.daml.nonrepudiation
 
-import com.codahale.metrics.{MetricRegistry, ScheduledReporter, Slf4jReporter}
+import com.codahale.metrics.{ScheduledReporter, Slf4jReporter}
 import com.daml.resources._
 
 import scala.concurrent.Future
@@ -16,19 +16,10 @@ sealed abstract class MetricsReporterOwner[Context: HasExecutionContext]
 
 object MetricsReporterOwner {
 
-  def noop[Context: HasExecutionContext](registry: MetricRegistry): MetricsReporterOwner[Context] =
-    new Noop(registry)
-
-  def slf4j[Context: HasExecutionContext](period: FiniteDuration)(
-      registry: MetricRegistry
+  def slf4j[Context: HasExecutionContext](
+      period: FiniteDuration
   ): MetricsReporterOwner[Context] =
-    new Scheduled(period, Slf4jReporter.forRegistry(registry).build())
-
-  private final class Noop[Context: HasExecutionContext](val _ignored: MetricRegistry)
-      extends MetricsReporterOwner[Context] {
-    override def acquire()(implicit context: Context): Resource[Context, Unit] =
-      PureResource(Future.successful(()))
-  }
+    new Scheduled(period, Slf4jReporter.forRegistry(Metrics.Registry).build())
 
   private final class Scheduled[Context: HasExecutionContext, Delegate <: ScheduledReporter](
       period: FiniteDuration,

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/MetricsReporterOwner.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/MetricsReporterOwner.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.nonrepudiation
+
+import com.codahale.metrics.{MetricRegistry, ScheduledReporter, Slf4jReporter}
+import com.daml.resources._
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+// We don't need access to the underlying resource, we use
+// the owner only to manage the reporter's life cycle
+sealed abstract class MetricsReporterOwner[Context: HasExecutionContext]
+    extends AbstractResourceOwner[Context, Unit]
+
+object MetricsReporterOwner {
+
+  def noop[Context: HasExecutionContext](registry: MetricRegistry): MetricsReporterOwner[Context] =
+    new Noop(registry)
+
+  def slf4j[Context: HasExecutionContext](period: FiniteDuration)(
+      registry: MetricRegistry
+  ): MetricsReporterOwner[Context] =
+    new Scheduled(period, Slf4jReporter.forRegistry(registry).build())
+
+  private final class Noop[Context: HasExecutionContext](val _ignored: MetricRegistry)
+      extends MetricsReporterOwner[Context] {
+    override def acquire()(implicit context: Context): Resource[Context, Unit] =
+      PureResource(Future.successful(()))
+  }
+
+  private final class Scheduled[Context: HasExecutionContext, Delegate <: ScheduledReporter](
+      period: FiniteDuration,
+      reporter: Delegate,
+  ) extends MetricsReporterOwner[Context] {
+    override def acquire()(implicit context: Context): Resource[Context, Unit] = {
+      ReleasableResource(Future(reporter.start(period.length, period.unit)))(_ =>
+        Future(reporter.stop())
+      )
+    }
+  }
+
+}

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/NonRepudiationProxy.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/NonRepudiationProxy.scala
@@ -5,34 +5,49 @@ package com.daml.nonrepudiation
 
 import java.time.Clock
 
+import com.codahale.metrics.MetricRegistry
 import com.daml.grpc.ReverseProxy
 import com.daml.resources.{AbstractResourceOwner, HasExecutionContext}
 import io.grpc.{Channel, Server, ServerBuilder}
 
 object NonRepudiationProxy {
 
-  def owner[Context: HasExecutionContext](
+  def owner[Context](
       participant: Channel,
       serverBuilder: ServerBuilder[_],
       certificateRepository: CertificateRepository.Read,
       signedPayloadRepository: SignedPayloadRepository.Write,
+      metricsReporterProvider: MetricRegistry => MetricsReporterOwner[Context],
       timestampProvider: Clock,
       serviceName: String,
       serviceNames: String*
-  ): AbstractResourceOwner[Context, Server] = {
+  )(implicit context: HasExecutionContext[Context]): AbstractResourceOwner[Context, Server] = {
+
+    val metricsRegistry = new MetricRegistry
+    val metrics = new Metrics(metricsRegistry)
+
     val signatureVerification =
       new SignatureVerificationInterceptor(
         certificateRepository,
         signedPayloadRepository,
         timestampProvider,
+        metrics,
       )
-    ReverseProxy.owner(
-      backend = participant,
-      serverBuilder = serverBuilder,
-      interceptors = Iterator(serviceName +: serviceNames: _*)
-        .map(service => service -> Seq(signatureVerification))
-        .toMap,
-    )
+
+    val serverOwner =
+      ReverseProxy.owner(
+        backend = participant,
+        serverBuilder = serverBuilder,
+        interceptors = Iterator(serviceName +: serviceNames: _*)
+          .map(service => service -> Seq(signatureVerification))
+          .toMap,
+      )
+
+    for {
+      _ <- metricsReporterProvider(metricsRegistry)
+      server <- serverOwner
+    } yield server
+
   }
 
 }

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/NonRepudiationProxy.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/NonRepudiationProxy.scala
@@ -5,7 +5,6 @@ package com.daml.nonrepudiation
 
 import java.time.Clock
 
-import com.codahale.metrics.MetricRegistry
 import com.daml.grpc.ReverseProxy
 import com.daml.resources.{AbstractResourceOwner, HasExecutionContext}
 import io.grpc.{Channel, Server, ServerBuilder}
@@ -17,36 +16,25 @@ object NonRepudiationProxy {
       serverBuilder: ServerBuilder[_],
       certificateRepository: CertificateRepository.Read,
       signedPayloadRepository: SignedPayloadRepository.Write,
-      metricsReporterProvider: MetricRegistry => MetricsReporterOwner[Context],
       timestampProvider: Clock,
       serviceName: String,
       serviceNames: String*
   )(implicit context: HasExecutionContext[Context]): AbstractResourceOwner[Context, Server] = {
-
-    val metricsRegistry = new MetricRegistry
-    val metrics = new Metrics(metricsRegistry)
 
     val signatureVerification =
       new SignatureVerificationInterceptor(
         certificateRepository,
         signedPayloadRepository,
         timestampProvider,
-        metrics,
       )
 
-    val serverOwner =
-      ReverseProxy.owner(
-        backend = participant,
-        serverBuilder = serverBuilder,
-        interceptors = Iterator(serviceName +: serviceNames: _*)
-          .map(service => service -> Seq(signatureVerification))
-          .toMap,
-      )
-
-    for {
-      _ <- metricsReporterProvider(metricsRegistry)
-      server <- serverOwner
-    } yield server
+    ReverseProxy.owner(
+      backend = participant,
+      serverBuilder = serverBuilder,
+      interceptors = Iterator(serviceName +: serviceNames: _*)
+        .map(service => service -> Seq(signatureVerification))
+        .toMap,
+    )
 
   }
 

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/SignatureVerification.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/SignatureVerification.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.nonrepudiation
+
+import java.security.Signature
+
+import com.codahale.metrics.Timer
+import org.slf4j.LoggerFactory
+
+import scala.util.Try
+
+object SignatureVerification {
+
+  private val logger = LoggerFactory.getLogger(classOf[SignatureVerification])
+
+  final class Timed(timer: Timer) extends SignatureVerification {
+    override def apply(payload: Array[Byte], signatureData: SignatureData): Try[Boolean] =
+      timer.time(() => super.apply(payload, signatureData))
+  }
+
+}
+
+sealed abstract class SignatureVerification {
+
+  import SignatureVerification.logger
+
+  def apply(payload: Array[Byte], signatureData: SignatureData): Try[Boolean] =
+    Try {
+      logger.trace("Decoding signature bytes from Base64-encoded signature")
+      logger.trace("Initializing signature verifier")
+      val verifier = Signature.getInstance(signatureData.algorithm)
+      verifier.initVerify(signatureData.key)
+      verifier.update(payload)
+      logger.trace("Verifying signature '{}'", signatureData.signature.base64)
+      verifier.verify(signatureData.signature.unsafeArray)
+    }
+
+}

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/SignedPayloadRepository.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/SignedPayloadRepository.scala
@@ -3,6 +3,7 @@
 
 package com.daml.nonrepudiation
 
+import com.codahale.metrics.Timer
 import com.daml.nonrepudiation.SignedPayloadRepository.KeyEncoder
 
 object SignedPayloadRepository {
@@ -28,6 +29,11 @@ object SignedPayloadRepository {
 
   trait Write {
     def put(signedPayload: SignedPayload): Unit
+  }
+
+  final class Timed(timer: Timer, delegate: Write) extends Write {
+    override def put(signedPayload: SignedPayload): Unit =
+      timer.time[Unit](() => delegate.put(signedPayload))
   }
 
 }

--- a/runtime-components/non-repudiation/src/test/scala/com/daml/nonrepudiation/NonRepudiationProxySpec.scala
+++ b/runtime-components/non-repudiation/src/test/scala/com/daml/nonrepudiation/NonRepudiationProxySpec.scala
@@ -19,7 +19,6 @@ import sun.security.tools.keytool.CertAndKeyGen
 import sun.security.x509.X500Name
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.ExecutionContext
 
 final class NonRepudiationProxySpec
     extends AsyncFlatSpec
@@ -48,7 +47,6 @@ final class NonRepudiationProxySpec
         serverBuilder = proxyBuilder,
         certificateRepository = certificates,
         signedPayloadRepository = signedPayloads,
-        metricsReporterProvider = MetricsReporterOwner.noop[ExecutionContext],
         timestampProvider = timestampProvider,
         Health.Name,
       )
@@ -109,7 +107,6 @@ final class NonRepudiationProxySpec
         serverBuilder = proxyBuilder,
         certificateRepository = certificates,
         signedPayloadRepository = signatures,
-        metricsReporterProvider = MetricsReporterOwner.noop[ExecutionContext],
         timestampProvider = Clock.systemUTC(),
         Health.Name,
       )
@@ -135,7 +132,6 @@ final class NonRepudiationProxySpec
         proxyBuilder,
         certificates,
         signatures,
-        MetricsReporterOwner.noop[ExecutionContext],
         Clock.systemUTC(),
         Health.Name,
       )

--- a/runtime-components/non-repudiation/src/test/scala/com/daml/nonrepudiation/NonRepudiationProxySpec.scala
+++ b/runtime-components/non-repudiation/src/test/scala/com/daml/nonrepudiation/NonRepudiationProxySpec.scala
@@ -19,6 +19,7 @@ import sun.security.tools.keytool.CertAndKeyGen
 import sun.security.x509.X500Name
 
 import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
 
 final class NonRepudiationProxySpec
     extends AsyncFlatSpec
@@ -47,6 +48,7 @@ final class NonRepudiationProxySpec
         serverBuilder = proxyBuilder,
         certificateRepository = certificates,
         signedPayloadRepository = signedPayloads,
+        metricsReporterProvider = MetricsReporterOwner.noop[ExecutionContext],
         timestampProvider = timestampProvider,
         Health.Name,
       )
@@ -107,6 +109,7 @@ final class NonRepudiationProxySpec
         serverBuilder = proxyBuilder,
         certificateRepository = certificates,
         signedPayloadRepository = signatures,
+        metricsReporterProvider = MetricsReporterOwner.noop[ExecutionContext],
         timestampProvider = Clock.systemUTC(),
         Health.Name,
       )
@@ -127,7 +130,15 @@ final class NonRepudiationProxySpec
     val (privateKey, certificate) = Setup.generateKeyAndCertificate()
 
     NonRepudiationProxy
-      .owner(channel, proxyBuilder, certificates, signatures, Clock.systemUTC(), Health.Name)
+      .owner(
+        channel,
+        proxyBuilder,
+        certificates,
+        signatures,
+        MetricsReporterOwner.noop[ExecutionContext],
+        Clock.systemUTC(),
+        Health.Name,
+      )
       .use { _ =>
         the[StatusRuntimeException] thrownBy {
           Health.getHealthStatus(


### PR DESCRIPTION
changelog_begin
changelog_end

Contributes to https://github.com/digital-asset/daml/issues/8635

Add a few key metrics for the non-repudiation proxy, with more to follow,
in particular keeping track of the performance overhead associated with
accessing the underlying database.

All metrics can be seen in com.daml.nonrepudiation.Metrics

Running the conformance tests successfully shows a summary of those
metrics with the expected period (five seconds).

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
