### PR TITLE
Pick up user-defined exceptions in LFConversion.

### DIFF
--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion/UtilGHC.hs
@@ -121,13 +121,13 @@ splitDFunId v
     | otherwise
     = Nothing
 
--- | Pattern for template desugaring DFuns.
-pattern DesugarDFunId :: [GHC.TyCoVar] -> [GHC.Type] -> FastString -> [GHC.Type] -> GHC.Var
-pattern DesugarDFunId tyCoVars dfunArgs clsName classArgs <-
+-- | Pattern for desugaring DFuns.
+pattern DesugarDFunId :: [GHC.TyCoVar] -> [GHC.Type] -> GHC.Name -> [GHC.Type] -> GHC.Var
+pattern DesugarDFunId tyCoVars dfunArgs name classArgs <-
     (splitDFunId -> Just
         ( tyCoVars
         , dfunArgs
-        , GHC.className -> NameIn DA_Internal_Template_Functions clsName
+        , GHC.className -> name
         , classArgs
         )
     )
@@ -136,31 +136,36 @@ pattern HasSignatoryDFunId, HasEnsureDFunId, HasAgreementDFunId, HasObserverDFun
     HasArchiveDFunId :: TyCon -> GHC.Var
 
 pattern HasSignatoryDFunId templateTyCon <-
-    DesugarDFunId [] [] "HasSignatory"
+    DesugarDFunId [] [] (NameIn DA_Internal_Template_Functions "HasSignatory")
         [splitTyConApp_maybe -> Just (templateTyCon, [])]
 pattern HasEnsureDFunId templateTyCon <-
-    DesugarDFunId [] [] "HasEnsure"
+    DesugarDFunId [] [] (NameIn DA_Internal_Template_Functions "HasEnsure")
         [splitTyConApp_maybe -> Just (templateTyCon, [])]
 pattern HasAgreementDFunId templateTyCon <-
-    DesugarDFunId [] [] "HasAgreement"
+    DesugarDFunId [] [] (NameIn DA_Internal_Template_Functions "HasAgreement")
         [splitTyConApp_maybe -> Just (templateTyCon, [])]
 pattern HasObserverDFunId templateTyCon <-
-    DesugarDFunId [] [] "HasObserver"
+    DesugarDFunId [] [] (NameIn DA_Internal_Template_Functions "HasObserver")
         [splitTyConApp_maybe -> Just (templateTyCon, [])]
 pattern HasArchiveDFunId templateTyCon <-
-    DesugarDFunId [] [] "HasArchive"
+    DesugarDFunId [] [] (NameIn DA_Internal_Template_Functions "HasArchive")
         [splitTyConApp_maybe -> Just (templateTyCon, [])]
 
 pattern HasKeyDFunId, HasMaintainerDFunId :: TyCon -> Type -> GHC.Var
 
 pattern HasKeyDFunId templateTyCon keyTy <-
-    DesugarDFunId [] [] "HasKey"
+    DesugarDFunId [] [] (NameIn DA_Internal_Template_Functions "HasKey")
         [ splitTyConApp_maybe -> Just (templateTyCon, [])
         , keyTy ]
 pattern HasMaintainerDFunId templateTyCon keyTy <-
-    DesugarDFunId [] [] "HasMaintainer"
+    DesugarDFunId [] [] (NameIn DA_Internal_Template_Functions "HasMaintainer")
         [ splitTyConApp_maybe -> Just (templateTyCon, [])
         , keyTy ]
+
+pattern HasMessageDFunId :: TyCon -> GHC.Var
+pattern HasMessageDFunId tyCon <-
+    DesugarDFunId [] [] (NameIn DA_Internal_Exception "HasMessage")
+        [splitTyConApp_maybe -> Just (tyCon, [])]
 
 -- | Break down a constraint tuple projection function name
 -- into an (index, arity) pair. These names have the form
@@ -219,6 +224,16 @@ hasDamlEnumCtx t
     | [theta] <- tyConStupidTheta t
     , TypeCon tycon [] <- theta
     , NameIn GHC_Types "DamlEnum" <- tycon
+    = True
+
+    | otherwise
+    = False
+
+hasDamlExceptionCtx :: TyCon -> Bool
+hasDamlExceptionCtx t
+    | [theta] <- tyConStupidTheta t
+    , TypeCon tycon [] <- theta
+    , NameIn DA_Internal_Exception "DamlException" <- tycon
     = True
 
     | otherwise

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Desugar.daml
@@ -8,6 +8,7 @@
 module DA.Internal.Desugar (
     module DA.Internal.Template,
     module DA.Internal.Template.Functions,
+    module DA.Internal.Exception,
     Eq(..), Show(..),
     Bool(..), Text, Optional(..),
     concat, magic,
@@ -19,6 +20,7 @@ import DA.Internal.Prelude
 import DA.Internal.Template
 import DA.Internal.Template.Functions
 import DA.Internal.LF
+import DA.Internal.Exception
 import GHC.Types (magic)
 
 -- These are only used as markers by desugaring, we do not translate them to LF.

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Exception.daml
@@ -26,6 +26,13 @@ import DA.Internal.Prelude
 
 --------------------------------------------------------------
 
+-- | HIDE DatatypeContexts tag for user-defined exception types.
+-- Used internally by the Daml compiler.
+class DamlException
+instance DamlException
+
+--------------------------------------------------------------
+
 -- | Exception typeclass. This should not be implemented directly,
 -- instead, use the `exception` syntax.
 type Exception e =

--- a/compiler/damlc/tests/daml-test-files/ExceptionDesugared.daml
+++ b/compiler/damlc/tests/daml-test-files/ExceptionDesugared.daml
@@ -1,0 +1,17 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- @SINCE-LF 1.dev
+-- @QUERY-LF [ .modules[].exceptions[] ] | length == 1
+-- @WARN Modules compiled with the DatatypeContexts language extension
+{-# LANGUAGE DatatypeContexts #-}
+
+-- | Test that desugared exceptions are picked up during LF conversion.
+module ExceptionDesugared where
+
+data DA.Internal.Desugar.DamlException => MyException =
+    MyException with
+        m : Text
+
+instance DA.Internal.Desugar.HasMessage MyException where
+    message (MyException m) = m


### PR DESCRIPTION
This uses a "DamlException" tag to annotate which types should
be exported as exceptions. This tag will be added during the
desugaring of exceptions.

The code that scrapes for the HasMessage instance is based on the
corresponding template instance scraping code, but simplified since
we only have to pick up one instance. If we decide to pack more
information into the DefException structure in the future, we can
easily extend this.

This PR also adds a small test to make sure that a user-defined
exception is exported as such.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
