### PR TITLE
update Terraform files to match reality

### DIFF
--- a/infra/bazel_cache.tf
+++ b/infra/bazel_cache.tf
@@ -11,10 +11,10 @@ locals {
 module "bazel_cache" {
   source = "./modules/gcp_cdn_bucket"
 
-  labels               = "${local.labels}"
-  name                 = "${local.bazel_cache_name}"
-  project              = "${local.project}"
-  region               = "${local.region}"
+  labels               = local.labels
+  name                 = local.bazel_cache_name
+  project              = local.project
+  region               = local.region
   ssl_certificate      = "https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/bazel-cache"
   cache_retention_days = 60
 }
@@ -23,7 +23,7 @@ module "bazel_cache" {
 // Note: it looks like the Bazel cache does not work properly if it does not
 // have delete permission, wich is a bit scary.
 resource "google_storage_bucket_iam_member" "bazel_cache_writer" {
-  bucket = "${module.bazel_cache.bucket_name}"
+  bucket = module.bazel_cache.bucket_name
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
   role   = "roles/storage.objectAdmin"
@@ -31,5 +31,5 @@ resource "google_storage_bucket_iam_member" "bazel_cache_writer" {
 }
 
 output "bazel_cache_ip" {
-  value = "${module.bazel_cache.external_ip}"
+  value = module.bazel_cache.external_ip
 }

--- a/infra/binaries.tf
+++ b/infra/binaries.tf
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 resource "google_storage_bucket" "binaries" {
-  project = "${local.project}"
+  project = local.project
   name    = "daml-binaries"
-  labels  = "${local.labels}"
+  labels  = local.labels
 
   # SLA is enough for a cache and is cheaper than MULTI_REGIONAL
   # see https://cloud.google.com/storage/docs/storage-classes
   storage_class = "REGIONAL"
 
   # Use a normal region since the storage_class is regional
-  location = "${local.region}"
+  location = local.region
 
   versioning {
     enabled = true
@@ -19,7 +19,7 @@ resource "google_storage_bucket" "binaries" {
 }
 
 resource "google_storage_bucket_acl" "binaries" {
-  bucket      = "${google_storage_bucket.binaries.name}"
+  bucket      = google_storage_bucket.binaries.name
   default_acl = "publicread"
   role_entity = [
     "OWNER:project-owners-${data.google_project.current.number}",
@@ -31,14 +31,14 @@ resource "google_storage_bucket_acl" "binaries" {
 
 // allow rw access for CI writer (see writer.tf)
 resource "google_storage_bucket_iam_member" "binaries-ci-create" {
-  bucket = "${google_storage_bucket.binaries.name}"
+  bucket = google_storage_bucket.binaries.name
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
   role   = "roles/storage.objectCreator"
   member = "serviceAccount:${google_service_account.writer.email}"
 }
 resource "google_storage_bucket_iam_member" "binaries-ci-read" {
-  bucket = "${google_storage_bucket.binaries.name}"
+  bucket = google_storage_bucket.binaries.name
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
   role   = "roles/storage.objectViewer"
@@ -48,55 +48,55 @@ resource "google_storage_bucket_iam_member" "binaries-ci-read" {
 
 output binaries_ip {
   description = "The external IP assigned to the global fowarding rule."
-  value       = "${google_compute_global_address.binaries.address}"
+  value       = google_compute_global_address.binaries.address
 }
 
 resource "google_compute_backend_bucket" "binaries" {
-  project     = "${local.project}"
+  project     = local.project
   name        = "binaries-backend"
-  bucket_name = "${google_storage_bucket.binaries.name}"
+  bucket_name = google_storage_bucket.binaries.name
   enable_cdn  = true
 }
 
 resource "google_compute_global_address" "binaries" {
-  project    = "${local.project}"
+  project    = local.project
   name       = "binaries-address"
   ip_version = "IPV4"
 }
 
 resource "google_compute_url_map" "binaries" {
-  project         = "${local.project}"
+  project         = local.project
   name            = "binaries"
-  default_service = "${google_compute_backend_bucket.binaries.self_link}"
+  default_service = google_compute_backend_bucket.binaries.self_link
 }
 
 resource "google_compute_target_http_proxy" "binaries" {
-  project = "${local.project}"
+  project = local.project
   name    = "binaries-http-proxy"
-  url_map = "${google_compute_url_map.binaries.self_link}"
+  url_map = google_compute_url_map.binaries.self_link
 }
 
 resource "google_compute_global_forwarding_rule" "binaries-http" {
-  project    = "${local.project}"
+  project    = local.project
   name       = "binaries-http"
-  target     = "${google_compute_target_http_proxy.binaries.self_link}"
-  ip_address = "${google_compute_global_address.binaries.address}"
+  target     = google_compute_target_http_proxy.binaries.self_link
+  ip_address = google_compute_global_address.binaries.address
   port_range = "80"
-  depends_on = ["google_compute_global_address.binaries"]
+  depends_on = [google_compute_global_address.binaries]
 }
 
 resource "google_compute_target_https_proxy" "binaries" {
-  project          = "${local.project}"
+  project          = local.project
   name             = "binaries-https-proxy"
-  url_map          = "${google_compute_url_map.binaries.self_link}"
+  url_map          = google_compute_url_map.binaries.self_link
   ssl_certificates = ["https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/daml-binaries"]
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  project    = "${local.project}"
+  project    = local.project
   name       = "binaries-https"
-  target     = "${google_compute_target_https_proxy.binaries.self_link}"
-  ip_address = "${google_compute_global_address.binaries.address}"
+  target     = google_compute_target_https_proxy.binaries.self_link
+  ip_address = google_compute_global_address.binaries.address
   port_range = "443"
-  depends_on = ["google_compute_global_address.binaries"]
+  depends_on = [google_compute_global_address.binaries]
 }

--- a/infra/data_bucket.tf
+++ b/infra/data_bucket.tf
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 resource "google_storage_bucket" "data" {
-  project = "${local.project}"
+  project = local.project
   name    = "daml-data"
-  labels  = "${local.labels}"
+  labels  = local.labels
 
   # SLA is enough for a cache and is cheaper than MULTI_REGIONAL
   # see https://cloud.google.com/storage/docs/storage-classes
   storage_class = "REGIONAL"
 
   # Use a normal region since the storage_class is regional
-  location = "${local.region}"
+  location = local.region
 
   versioning {
     enabled = true
@@ -19,7 +19,7 @@ resource "google_storage_bucket" "data" {
 }
 
 resource "google_storage_bucket_acl" "data" {
-  bucket = "${google_storage_bucket.data.name}"
+  bucket = google_storage_bucket.data.name
 
   role_entity = [
     "OWNER:project-owners-${data.google_project.current.number}",
@@ -30,7 +30,7 @@ resource "google_storage_bucket_acl" "data" {
 
 // allow rw access for CI writer (see writer.tf)
 resource "google_storage_bucket_iam_member" "data_create" {
-  bucket = "${google_storage_bucket.data.name}"
+  bucket = google_storage_bucket.data.name
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
   role   = "roles/storage.objectCreator"
@@ -38,7 +38,7 @@ resource "google_storage_bucket_iam_member" "data_create" {
 }
 
 resource "google_storage_bucket_iam_member" "data_read" {
-  bucket = "${google_storage_bucket.data.name}"
+  bucket = google_storage_bucket.data.name
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
   role   = "roles/storage.objectViewer"
@@ -59,8 +59,8 @@ variable "appr" {
 }
 
 resource "google_storage_bucket_iam_member" "appr" {
-  count  = "${length(var.appr)}"
-  bucket = "${google_storage_bucket.data.name}"
+  count  = length(var.appr)
+  bucket = google_storage_bucket.data.name
   role   = "roles/storage.objectViewer"
-  member = "${var.appr[count.index]}"
+  member = var.appr[count.index]
 }

--- a/infra/dumps_bucket.tf
+++ b/infra/dumps_bucket.tf
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 resource "google_storage_bucket" "dumps" {
-  project = "${local.project}"
+  project = local.project
   name    = "daml-dumps"
-  labels  = "${local.labels}"
+  labels  = local.labels
 
   # SLA is enough for a cache and is cheaper than MULTI_REGIONAL
   # see https://cloud.google.com/storage/docs/storage-classes
   storage_class = "REGIONAL"
 
   # Use a normal region since the storage_class is regional
-  location = "${local.region}"
+  location = local.region
 
   # Enable versioning in case we accidentally delete/overwrite something
   versioning {
@@ -20,7 +20,7 @@ resource "google_storage_bucket" "dumps" {
 }
 
 resource "google_storage_bucket_acl" "dumps" {
-  bucket = "${google_storage_bucket.dumps.name}"
+  bucket = google_storage_bucket.dumps.name
 
   role_entity = [
     "OWNER:project-owners-${data.google_project.current.number}",
@@ -34,14 +34,14 @@ resource "google_storage_bucket_acl" "dumps" {
 
 # allow rw access for CI writer (see writer.tf)
 resource "google_storage_bucket_iam_member" "dumps_create" {
-  bucket = "${google_storage_bucket.dumps.name}"
+  bucket = google_storage_bucket.dumps.name
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
   role   = "roles/storage.objectCreator"
   member = "serviceAccount:${google_service_account.writer.email}"
 }
 resource "google_storage_bucket_iam_member" "dumps_read" {
-  bucket = "${google_storage_bucket.dumps.name}"
+  bucket = google_storage_bucket.dumps.name
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
   role   = "roles/storage.objectViewer"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -23,11 +23,11 @@ provider "secret" {
 }
 
 provider "template" {
-  version = "2.1.2"
+  version = "~>2.2"
 }
 
 data "google_project" "current" {
-  project_id = "${local.project}"
+  project_id = local.project
 }
 
 locals {
@@ -36,12 +36,10 @@ locals {
     host-group      = "buildpipeline"
     infra-owner     = "daml-language"
     managed         = "true"
-
-    # default the target name to be the name of the folder
-    target = "${basename(path.module)}"
+    target          = "infra"
   }
 
-  machine-labels = "${merge(local.labels, map("env", "production"))}"
+  machine-labels = merge(local.labels, map("env", "production"))
 
   project = "da-dev-gcp-daml-language"
   region  = "us-east4"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -45,7 +45,7 @@ locals {
   region  = "us-east4"
   zone    = "us-east4-a"
 
-  ssl_certificate_hoogle = "https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/daml-lang-hoogle-app-service-https-cert"
+  ssl_certificate_hoogle = "https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/hoogle-google-cert"
 }
 
 resource "secret_resource" "vsts-token" {}

--- a/infra/modules/gcp_cdn_bucket/google_compute.tf
+++ b/infra/modules/gcp_cdn_bucket/google_compute.tf
@@ -2,51 +2,51 @@
 # SPDX-License-Identifier: Apache-2.0
 
 resource "google_compute_backend_bucket" "default" {
-  project     = "${var.project}"
+  project     = var.project
   name        = "${var.name}-backend"
-  bucket_name = "${google_storage_bucket.default.name}"
+  bucket_name = google_storage_bucket.default.name
   enable_cdn  = true
 }
 
 resource "google_compute_global_address" "default" {
-  project    = "${var.project}"
+  project    = var.project
   name       = "${var.name}-address"
   ip_version = "IPV4"
 }
 
 resource "google_compute_url_map" "default" {
-  project         = "${var.project}"
-  name            = "${var.name}"
-  default_service = "${google_compute_backend_bucket.default.self_link}"
+  project         = var.project
+  name            = var.name
+  default_service = google_compute_backend_bucket.default.self_link
 }
 
 resource "google_compute_target_http_proxy" "default" {
-  project = "${var.project}"
+  project = var.project
   name    = "${var.name}-http-proxy"
-  url_map = "${google_compute_url_map.default.self_link}"
+  url_map = google_compute_url_map.default.self_link
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
-  project    = "${var.project}"
+  project    = var.project
   name       = "${var.name}-http"
-  target     = "${google_compute_target_http_proxy.default.self_link}"
-  ip_address = "${google_compute_global_address.default.address}"
+  target     = google_compute_target_http_proxy.default.self_link
+  ip_address = google_compute_global_address.default.address
   port_range = "80"
-  depends_on = ["google_compute_global_address.default"]
+  depends_on = [google_compute_global_address.default]
 }
 
 resource "google_compute_target_https_proxy" "default" {
-  project          = "${var.project}"
+  project          = var.project
   name             = "${var.name}-https-proxy"
-  url_map          = "${google_compute_url_map.default.self_link}"
-  ssl_certificates = ["${var.ssl_certificate}"]
+  url_map          = google_compute_url_map.default.self_link
+  ssl_certificates = [var.ssl_certificate]
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  project    = "${var.project}"
+  project    = var.project
   name       = "${var.name}-https"
-  target     = "${google_compute_target_https_proxy.default.self_link}"
-  ip_address = "${google_compute_global_address.default.address}"
+  target     = google_compute_target_https_proxy.default.self_link
+  ip_address = google_compute_global_address.default.address
   port_range = "443"
-  depends_on = ["google_compute_global_address.default"]
+  depends_on = [google_compute_global_address.default]
 }

--- a/infra/modules/gcp_cdn_bucket/google_storage.tf
+++ b/infra/modules/gcp_cdn_bucket/google_storage.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 data "google_project" "current" {
-  project_id = "${var.project}"
+  project_id = var.project
 }
 
 locals {
@@ -17,16 +17,16 @@ locals {
 }
 
 resource "google_storage_bucket" "default" {
-  project = "${var.project}"
-  name    = "${var.name}"
-  labels  = "${var.labels}"
+  project = var.project
+  name    = var.name
+  labels  = var.labels
 
   # SLA is enough for a cache and is cheaper than MULTI_REGIONAL
   # see https://cloud.google.com/storage/docs/storage-classes
   storage_class = "REGIONAL"
 
   # Use a normal region since the storage_class is regional
-  location = "${var.region}"
+  location = var.region
 
   # cleanup the cache after ${var.cache_retention_days} days
   lifecycle_rule {
@@ -35,7 +35,7 @@ resource "google_storage_bucket" "default" {
     }
 
     condition {
-      age = "${var.cache_retention_days}" # days
+      age = var.cache_retention_days # days
     }
   }
 
@@ -50,7 +50,7 @@ resource "google_storage_bucket" "default" {
 }
 
 resource "google_storage_bucket_acl" "default" {
-  bucket      = "${google_storage_bucket.default.name}"
+  bucket      = google_storage_bucket.default.name
   default_acl = "publicread"
-  role_entity = ["${local.default_role_entities}"]
+  role_entity = local.default_role_entities
 }

--- a/infra/modules/gcp_cdn_bucket/variables.tf
+++ b/infra/modules/gcp_cdn_bucket/variables.tf
@@ -7,7 +7,7 @@ variable "name" {
 
 variable "labels" {
   description = "Labels to apply on all the resources"
-  type        = "map"
+  type        = map
   default     = {}
 }
 

--- a/infra/nix_cache.tf
+++ b/infra/nix_cache.tf
@@ -11,24 +11,24 @@ locals {
 module "nix_cache" {
   source = "./modules/gcp_cdn_bucket"
 
-  labels               = "${local.labels}"
-  name                 = "${local.nix_cache_name}"
-  project              = "${local.project}"
-  region               = "${local.region}"
+  labels               = local.labels
+  name                 = local.nix_cache_name
+  project              = local.project
+  region               = local.region
   ssl_certificate      = "https://www.googleapis.com/compute/v1/projects/da-dev-gcp-daml-language/global/sslCertificates/nix-cache"
   cache_retention_days = 360
 }
 
 // allow rw access for CI writer (see writer.tf)
 resource "google_storage_bucket_iam_member" "nix_cache_writer_create" {
-  bucket = "${module.nix_cache.bucket_name}"
+  bucket = module.nix_cache.bucket_name
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
   role   = "roles/storage.objectCreator"
   member = "serviceAccount:${google_service_account.writer.email}"
 }
 resource "google_storage_bucket_iam_member" "nix_cache_writer_read" {
-  bucket = "${module.nix_cache.bucket_name}"
+  bucket = module.nix_cache.bucket_name
 
   # https://cloud.google.com/storage/docs/access-control/iam-roles
   role   = "roles/storage.objectViewer"
@@ -36,5 +36,5 @@ resource "google_storage_bucket_iam_member" "nix_cache_writer_read" {
 }
 
 output "nix_cache_ip" {
-  value = "${module.nix_cache.external_ip}"
+  value = module.nix_cache.external_ip
 }

--- a/infra/periodic_killer.tf
+++ b/infra/periodic_killer.tf
@@ -31,16 +31,16 @@ locals {
 }
 
 resource "google_project_iam_member" "periodic-killer" {
-  count  = "${length(local.accounts_that_can_kill_machines)}"
-  role   = "${google_project_iam_custom_role.periodic-killer.id}"
-  member = "${local.accounts_that_can_kill_machines[count.index]}"
+  count  = length(local.accounts_that_can_kill_machines)
+  role   = google_project_iam_custom_role.periodic-killer.id
+  member = local.accounts_that_can_kill_machines[count.index]
 }
 
 resource "google_compute_instance" "periodic-killer" {
   name         = "periodic-killer"
   machine_type = "g1-small"
   zone         = "us-east4-a"
-  labels       = "${local.machine-labels}"
+  labels       = local.machine-labels
 
   boot_disk {
     initialize_params {
@@ -56,7 +56,7 @@ resource "google_compute_instance" "periodic-killer" {
   }
 
   service_account {
-    email  = "${google_service_account.periodic-killer.email}"
+    email  = google_service_account.periodic-killer.email
     scopes = ["cloud-platform"]
   }
   allow_stopping_for_update = true

--- a/infra/vsts_agent_windows.tf
+++ b/infra/vsts_agent_windows.tf
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 locals {
-  vsts_token   = "${secret_resource.vsts-token.value}"
+  vsts_token   = secret_resource.vsts-token.value
   vsts_account = "digitalasset"
   vsts_pool    = "windows-pool"
 }
 
 resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
-  provider = "google-beta"
+  provider = google-beta
   name     = "vsts-agent-windows"
 
   # keep the name short. windows hostnames are limited to 12(?) chars.
@@ -20,7 +20,7 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
 
   version {
     name              = "vsts-agent-windows"
-    instance_template = "${google_compute_instance_template.vsts-agent-windows.self_link}"
+    instance_template = google_compute_instance_template.vsts-agent-windows.self_link
   }
 
   update_policy {
@@ -39,7 +39,7 @@ resource "google_compute_region_instance_group_manager" "vsts-agent-windows" {
 resource "google_compute_instance_template" "vsts-agent-windows" {
   name_prefix  = "vsts-agent-windows-"
   machine_type = "c2-standard-8"
-  labels       = "${local.machine-labels}"
+  labels       = local.machine-labels
 
   disk {
     disk_size_gb = 200
@@ -59,7 +59,7 @@ resource "google_compute_instance_template" "vsts-agent-windows" {
     create_before_destroy = true
   }
 
-  metadata {
+  metadata = {
     // Prepare the machine
     windows-startup-script-ps1 = <<SYSPREP_SPECIALIZE
 Set-StrictMode -Version latest
@@ -85,8 +85,8 @@ Invoke-WebRequest https://dl.google.com/cloudagents/windows/StackdriverLogging-v
 iex (New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')
 
 # Install git, bash
-& choco install git --no-progress --yes 2>&1 | %{ "$_" }
-& choco install windows-sdk-10.1 --no-progress --yes 2>&1 | %{ "$_" }
+& choco install git --no-progress --yes 2>&1 | %%{ "$_" }
+& choco install windows-sdk-10.1 --no-progress --yes 2>&1 | %%{ "$_" }
 
 # Add tools to the PATH
 $OldPath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
@@ -104,7 +104,7 @@ format fs=ntfs quick
 assign letter="D"
 "@
 $partition | Set-Content C:\diskpart.txt
-& diskpart /s C:\diskpart.txt 2>&1 | %{ "$_" }
+& diskpart /s C:\diskpart.txt 2>&1 | %%{ "$_" }
 
 # Create a temporary and random password for the VSTS user, forget about it once this script has finished running
 $Username = "u"

--- a/infra/writer.tf
+++ b/infra/writer.tf
@@ -7,5 +7,5 @@
 resource "google_service_account" "writer" {
   account_id   = "daml-ci-writer"
   display_name = "CI Writer"
-  project      = "${local.project}"
+  project      = local.project
 }


### PR DESCRIPTION
Two changes have happened recently that have invalidated the current Terraform files:

1. The Terraform version has gone through a major, incompatible upgrade (#8190); the required updates for this are reflected in the first commit of this PR.
2. The certificate used to serve [Hoogle](https://hoogle.daml.com) was about to expire, so Edward created a new one and updated the config directly. The second commit in this PR updates the Terraform config to match that new, already-in-prod setting.

Note: This PR applies cleanly, as there are no resulting changes in Terraform's perception of the target state from 1, and the change from 2 has already been applied through other channels.

CHANGELOG_BEGIN
CHANGELOG_END