### PR TITLE
integrity-checker: Reintroduce an interface for comparing write sets. [KVL-822]

### DIFF
--- a/ledger/participant-state/kvutils/tools/BUILD.bazel
+++ b/ledger/participant-state/kvutils/tools/BUILD.bazel
@@ -37,7 +37,6 @@ da_scala_library(
         "//ledger/participant-integration-api",
         "//ledger/participant-state",
         "//ledger/participant-state/kvutils",
-        "//ledger/participant-state/kvutils:daml_kvutils_proto_java",
         "//libs-scala/concurrent",
         "//libs-scala/contextualized-logging",
         "//libs-scala/resources",
@@ -63,8 +62,6 @@ da_scala_test(
         "//ledger/participant-integration-api",
         "//ledger/participant-state/kvutils",
         "//ledger/participant-state/kvutils/tools",
-        "//ledger/participant-state/protobuf:ledger_configuration_proto_java",
-        "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:org_mockito_mockito_core",
     ],
 )

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingCommitStrategySupport.scala
@@ -69,4 +69,7 @@ final class LogAppendingCommitStrategySupport(
 
   override def newReadServiceFactory(): ReplayingReadServiceFactory =
     new LogAppendingReadServiceFactory(metrics)
+
+  override val writeSetComparison: WriteSetComparison =
+    new RawWriteSetComparison(serializationStrategy)
 }

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupport.scala
@@ -81,4 +81,7 @@ final class RawPreExecutingCommitStrategySupport(
 
   override def newReadServiceFactory(): ReplayingReadServiceFactory =
     new LogAppendingReadServiceFactory(metrics)
+
+  override val writeSetComparison: WriteSetComparison =
+    new RawWriteSetComparison(stateKeySerializationStrategy)
 }

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparison.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparison.scala
@@ -1,0 +1,138 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.tools.integritycheck
+
+import com.daml.ledger.participant.state.kvutils
+import com.daml.ledger.participant.state.kvutils.export.WriteSet
+import com.daml.ledger.participant.state.kvutils.tools.integritycheck.WriteSetComparison._
+import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Envelope, Raw}
+import com.daml.ledger.validator.StateKeySerializationStrategy
+
+import scala.PartialFunction.condOpt
+
+final class RawWriteSetComparison(stateKeySerializationStrategy: StateKeySerializationStrategy)
+    extends WriteSetComparison {
+
+  override def compareWriteSets(
+      expectedWriteSet: WriteSet,
+      actualWriteSet: WriteSet,
+  ): Option[String] =
+    if (expectedWriteSet == actualWriteSet) {
+      None
+    } else {
+      if (expectedWriteSet.size == actualWriteSet.size) {
+        compareSameSizeWriteSets(expectedWriteSet, actualWriteSet)
+      } else {
+        Some(
+          Seq(
+            Seq(
+              s"Expected write-set of size ${expectedWriteSet.size} vs. ${actualWriteSet.size}."
+            ),
+            Seq("Expected:"),
+            writeSetToStrings(expectedWriteSet),
+            Seq("Actual:"),
+            writeSetToStrings(actualWriteSet),
+          ).flatten.mkString(System.lineSeparator())
+        )
+      }
+    }
+
+  private def writeSetToStrings(writeSet: WriteSet): Seq[String] =
+    writeSet.view.map((writeItemToString _).tupled).toVector
+
+  private def writeItemToString(key: Raw.Key, value: Raw.Value): String = {
+    val keyString = stateKeySerializationStrategy.deserializeStateKey(key)
+    val valueString = kvutils.Envelope.open(value)
+    s"$keyString -> $valueString"
+  }
+
+  private def compareSameSizeWriteSets(
+      expectedWriteSet: WriteSet,
+      actualWriteSet: WriteSet,
+  ): Option[String] = {
+    val differencesExplained = expectedWriteSet
+      .zip(actualWriteSet)
+      .map { case ((expectedKey, expectedValue), (actualKey, actualValue)) =>
+        if (expectedKey == actualKey && expectedValue != actualValue) {
+          Some(
+            Seq(
+              s"expected value:    ${rawHexString(expectedValue)}",
+              s" vs. actual value: ${rawHexString(actualValue)}",
+              explainDifference(expectedKey, expectedValue, actualValue),
+            )
+          )
+        } else if (expectedKey != actualKey) {
+          Some(
+            Seq(
+              s"expected key:    ${rawHexString(expectedKey)}",
+              s" vs. actual key: ${rawHexString(actualKey)}",
+            )
+          )
+        } else {
+          None
+        }
+      }
+      .map(_.toList)
+      .filterNot(_.isEmpty)
+      .flatten
+      .flatten
+      .mkString(System.lineSeparator())
+    condOpt(differencesExplained.isEmpty) { case false =>
+      differencesExplained
+    }
+  }
+
+  private def explainDifference(
+      key: Raw.Key,
+      expectedValue: Raw.Value,
+      actualValue: Raw.Value,
+  ): String =
+    kvutils.Envelope
+      .openStateValue(expectedValue)
+      .toOption
+      .map { expectedStateValue =>
+        val stateKey = stateKeySerializationStrategy.deserializeStateKey(key)
+        val actualStateValue = kvutils.Envelope.openStateValue(actualValue)
+        s"""|State key: $stateKey
+            |Expected: $expectedStateValue
+            |Actual: $actualStateValue""".stripMargin
+      }
+      .getOrElse(explainMismatchingValue(key, expectedValue, actualValue))
+
+  private def explainMismatchingValue(
+      logEntryId: Raw.Key,
+      expectedValue: Raw.Value,
+      actualValue: Raw.Value,
+  ): String = {
+    val expectedLogEntry = kvutils.Envelope.openLogEntry(expectedValue)
+    val actualLogEntry = kvutils.Envelope.openLogEntry(actualValue)
+    s"Log entry ID: ${rawHexString(logEntryId)}${System.lineSeparator()}" +
+      s"Expected: $expectedLogEntry${System.lineSeparator()}Actual: $actualLogEntry"
+  }
+
+  override def checkEntryIsReadable(rawKey: Raw.Key, rawValue: Raw.Value): Either[String, Unit] =
+    Envelope.open(rawValue) match {
+      case Left(errorMessage) =>
+        Left(s"Invalid value envelope: $errorMessage")
+      case Right(Envelope.LogEntryMessage(logEntry)) =>
+        val _ = DamlKvutils.DamlLogEntryId.parseFrom(rawKey.bytes)
+        if (logEntry.getPayloadCase == DamlKvutils.DamlLogEntry.PayloadCase.PAYLOAD_NOT_SET)
+          Left("Log entry payload not set.")
+        else
+          Right(())
+      case Right(Envelope.StateValueMessage(value)) =>
+        val key = stateKeySerializationStrategy.deserializeStateKey(rawKey)
+        if (key.getKeyCase == DamlKvutils.DamlStateKey.KeyCase.KEY_NOT_SET)
+          Left("State key not set.")
+        else if (value.getValueCase == DamlKvutils.DamlStateValue.ValueCase.VALUE_NOT_SET)
+          Left("State value not set.")
+        else
+          Right(())
+      case Right(Envelope.SubmissionMessage(submission)) =>
+        Left(s"Unexpected submission message: $submission")
+      case Right(Envelope.SubmissionBatchMessage(batch)) =>
+        Left(s"Unexpected submission batch message: $batch")
+    }
+
+}

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
@@ -12,8 +12,8 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils.{
   DamlStateKey,
   DamlStateValue,
 }
+import com.daml.ledger.participant.state.kvutils.tools.integritycheck.RawWriteSetComparisonSpec._
 import com.daml.ledger.participant.state.kvutils.tools.integritycheck.WriteSetComparison.rawHexString
-import com.daml.ledger.participant.state.kvutils.tools.integritycheck.WriteSetComparisonSpec._
 import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Envelope, Raw, Version}
 import com.daml.ledger.participant.state.protobuf.LedgerConfiguration
 import com.daml.ledger.validator.StateKeySerializationStrategy
@@ -22,10 +22,10 @@ import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
-final class WriteSetComparisonSpec extends AsyncWordSpec with Matchers with Inside {
+final class RawWriteSetComparisonSpec extends AsyncWordSpec with Matchers with Inside {
 
   private val writeSetComparison =
-    new WriteSetComparison(StateKeySerializationStrategy.createDefault())
+    new RawWriteSetComparison(StateKeySerializationStrategy.createDefault())
 
   "checking the entries are readable" should {
     "parse a log entry" in {
@@ -212,7 +212,7 @@ final class WriteSetComparisonSpec extends AsyncWordSpec with Matchers with Insi
 
 }
 
-object WriteSetComparisonSpec {
+object RawWriteSetComparisonSpec {
 
   private val noKey: Raw.Key =
     Raw.Key(ByteString.EMPTY)

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/CommitStrategySupport.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/CommitStrategySupport.scala
@@ -5,22 +5,9 @@ package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
 import akka.stream.Materializer
 import com.daml.ledger.participant.state.kvutils.export.{SubmissionInfo, WriteSet}
-import com.daml.ledger.participant.state.v1.ReadService
 import com.daml.ledger.validator.StateKeySerializationStrategy
 
 import scala.concurrent.Future
-
-/** A ReadService that streams back previously recorded state updates */
-trait ReplayingReadService extends ReadService {
-  def updateCount(): Long
-}
-
-/** Records state updates and creates corresponding ReplayingReadService instances */
-trait ReplayingReadServiceFactory {
-  def appendBlock(writeSet: WriteSet): Unit
-
-  def createReadService(implicit materializer: Materializer): ReplayingReadService
-}
 
 trait CommitStrategySupport[LogResult] {
   def stateKeySerializationStrategy: StateKeySerializationStrategy
@@ -30,4 +17,6 @@ trait CommitStrategySupport[LogResult] {
   )(implicit materializer: Materializer): Future[WriteSet]
 
   def newReadServiceFactory(): ReplayingReadServiceFactory
+
+  def writeSetComparison: WriteSetComparison
 }

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/IntegrityChecker.scala
@@ -33,8 +33,7 @@ class IntegrityChecker[LogResult](
   private val metricRegistry = new MetricRegistry
   private val metrics = new Metrics(metricRegistry)
   private val commitStrategySupport = commitStrategySupportBuilder(metrics)
-  private val writeSetComparison =
-    new WriteSetComparison(commitStrategySupport.stateKeySerializationStrategy)
+  private val writeSetComparison = commitStrategySupport.writeSetComparison
 
   import IntegrityChecker._
 

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/ReplayingReadService.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/ReplayingReadService.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.participant.state.kvutils.tools.integritycheck
+
+import akka.stream.Materializer
+import com.daml.ledger.participant.state.kvutils.`export`.WriteSet
+import com.daml.ledger.participant.state.v1.ReadService
+
+/** A ReadService that streams back previously recorded state updates */
+trait ReplayingReadService extends ReadService {
+  def updateCount(): Long
+}
+
+/** Records state updates and creates corresponding ReplayingReadService instances */
+trait ReplayingReadServiceFactory {
+  def appendBlock(writeSet: WriteSet): Unit
+
+  def createReadService(implicit materializer: Materializer): ReplayingReadService
+}

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteSetComparison.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteSetComparison.scala
@@ -3,139 +3,20 @@
 
 package com.daml.ledger.participant.state.kvutils.tools.integritycheck
 
-import com.daml.ledger.participant.state.kvutils
+import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.export.WriteSet
-import com.daml.ledger.participant.state.kvutils.tools.integritycheck.WriteSetComparison._
-import com.daml.ledger.participant.state.kvutils.{DamlKvutils, Envelope, Raw}
-import com.daml.ledger.validator.StateKeySerializationStrategy
 
-import scala.PartialFunction.condOpt
+trait WriteSetComparison {
 
-class WriteSetComparison(stateKeySerializationStrategy: StateKeySerializationStrategy) {
+  def compareWriteSets(expectedWriteSet: WriteSet, actualWriteSet: WriteSet): Option[String]
 
-  def compareWriteSets(expectedWriteSet: WriteSet, actualWriteSet: WriteSet): Option[String] =
-    if (expectedWriteSet == actualWriteSet) {
-      None
-    } else {
-      if (expectedWriteSet.size == actualWriteSet.size) {
-        compareSameSizeWriteSets(expectedWriteSet, actualWriteSet)
-      } else {
-        Some(
-          Seq(
-            Seq(
-              s"Expected write-set of size ${expectedWriteSet.size} vs. ${actualWriteSet.size}."
-            ),
-            Seq("Expected:"),
-            writeSetToStrings(expectedWriteSet),
-            Seq("Actual:"),
-            writeSetToStrings(actualWriteSet),
-          ).flatten.mkString(System.lineSeparator())
-        )
-      }
-    }
-
-  private def writeSetToStrings(writeSet: WriteSet): Seq[String] =
-    writeSet.view.map((writeItemToString _).tupled).toVector
-
-  private def writeItemToString(key: Raw.Key, value: Raw.Value): String = {
-    val keyString = stateKeySerializationStrategy.deserializeStateKey(key)
-    val valueString = kvutils.Envelope.open(value)
-    s"$keyString -> $valueString"
-  }
-
-  private[tools] def compareSameSizeWriteSets(
-      expectedWriteSet: WriteSet,
-      actualWriteSet: WriteSet,
-  ): Option[String] = {
-    val differencesExplained = expectedWriteSet
-      .zip(actualWriteSet)
-      .map { case ((expectedKey, expectedValue), (actualKey, actualValue)) =>
-        if (expectedKey == actualKey && expectedValue != actualValue) {
-          Some(
-            Seq(
-              s"expected value:    ${rawHexString(expectedValue)}",
-              s" vs. actual value: ${rawHexString(actualValue)}",
-              explainDifference(expectedKey, expectedValue, actualValue),
-            )
-          )
-        } else if (expectedKey != actualKey) {
-          Some(
-            Seq(
-              s"expected key:    ${rawHexString(expectedKey)}",
-              s" vs. actual key: ${rawHexString(actualKey)}",
-            )
-          )
-        } else {
-          None
-        }
-      }
-      .map(_.toList)
-      .filterNot(_.isEmpty)
-      .flatten
-      .flatten
-      .mkString(System.lineSeparator())
-    condOpt(differencesExplained.isEmpty) { case false =>
-      differencesExplained
-    }
-  }
-
-  private def explainDifference(
-      key: Raw.Key,
-      expectedValue: Raw.Value,
-      actualValue: Raw.Value,
-  ): String =
-    kvutils.Envelope
-      .openStateValue(expectedValue)
-      .toOption
-      .map { expectedStateValue =>
-        val stateKey = stateKeySerializationStrategy.deserializeStateKey(key)
-        val actualStateValue = kvutils.Envelope.openStateValue(actualValue)
-        s"""|State key: $stateKey
-            |Expected: $expectedStateValue
-            |Actual: $actualStateValue""".stripMargin
-      }
-      .getOrElse(explainMismatchingValue(key, expectedValue, actualValue))
-
-  private def explainMismatchingValue(
-      logEntryId: Raw.Key,
-      expectedValue: Raw.Value,
-      actualValue: Raw.Value,
-  ): String = {
-    val expectedLogEntry = kvutils.Envelope.openLogEntry(expectedValue)
-    val actualLogEntry = kvutils.Envelope.openLogEntry(actualValue)
-    s"Log entry ID: ${rawHexString(logEntryId)}${System.lineSeparator()}" +
-      s"Expected: $expectedLogEntry${System.lineSeparator()}Actual: $actualLogEntry"
-  }
-
-  def checkEntryIsReadable(rawKey: Raw.Key, rawValue: Raw.Value): Either[String, Unit] =
-    Envelope.open(rawValue) match {
-      case Left(errorMessage) =>
-        Left(s"Invalid value envelope: $errorMessage")
-      case Right(Envelope.LogEntryMessage(logEntry)) =>
-        val _ = DamlKvutils.DamlLogEntryId.parseFrom(rawKey.bytes)
-        if (logEntry.getPayloadCase == DamlKvutils.DamlLogEntry.PayloadCase.PAYLOAD_NOT_SET)
-          Left("Log entry payload not set.")
-        else
-          Right(())
-      case Right(Envelope.StateValueMessage(value)) =>
-        val key = stateKeySerializationStrategy.deserializeStateKey(rawKey)
-        if (key.getKeyCase == DamlKvutils.DamlStateKey.KeyCase.KEY_NOT_SET)
-          Left("State key not set.")
-        else if (value.getValueCase == DamlKvutils.DamlStateValue.ValueCase.VALUE_NOT_SET)
-          Left("State value not set.")
-        else
-          Right(())
-      case Right(Envelope.SubmissionMessage(submission)) =>
-        Left(s"Unexpected submission message: $submission")
-      case Right(Envelope.SubmissionBatchMessage(batch)) =>
-        Left(s"Unexpected submission batch message: $batch")
-    }
+  def checkEntryIsReadable(rawKey: Raw.Key, rawValue: Raw.Value): Either[String, Unit]
 
 }
 
 object WriteSetComparison {
 
-  private[tools] def rawHexString(raw: Raw.Bytes): String =
+  def rawHexString(raw: Raw.Bytes): String =
     raw.bytes.toByteArray.map(byte => "%02x".format(byte)).mkString
 
 }


### PR DESCRIPTION
Apparently this is used, just outside of this repository. Sorry for breaking it.

This turns `WriteSetComparison` into a trait to be constructed by the `CommitStrategySupport`, allowing implementors to override how we parse, compare, and render write sets.

This code is only used in testing; it does not run in any production system.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
