### PR TITLE
bump disk cleanup threashold

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -8,7 +8,7 @@ steps:
     # infra/macos/2-common-box/init.sh:echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
     # infra/vsts_agent_linux_startup.sh:echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
 
-    if [ $(df -m . | sed 1d | awk '{print $4}') -lt 40000 ]; then
+    if [ $(df -m . | sed 1d | awk '{print $4}') -lt 50000 ]; then
         echo "Disk full, cleaning up..."
         disk_cache="$HOME/.bazel-cache"
         rm -rf "$disk_cache"


### PR DESCRIPTION
I've seen [a build] failing with "disk full" after starting with 41GB free.

[a build]: https://dev.azure.com/digitalasset/daml/_build/results?buildId=69270&view=logs&j=870bb40c-6da0-5bff-67ed-547f10fa97f2&t=deecee86-545a-596e-8b0d-fb7d606fe9f2

CHANGELOG_BEGIN
CHANGELOG_END