### PR TITLE
kvutils/tools: Make it clear that `IntegrityChecker.run` exits.

### DIFF
--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/Main.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/Main.scala
@@ -9,7 +9,7 @@ import scala.concurrent.ExecutionContext
 
 object Main {
   def main(args: Array[String]): Unit =
-    IntegrityChecker.run(args, preExecutionCommitStrategySupportFactory _)
+    IntegrityChecker.runAndExit(args, preExecutionCommitStrategySupportFactory _)
 
   def batchingCommitStrategySupportFactory(
       metrics: Metrics,


### PR DESCRIPTION
By renaming the function to `runAndExit`.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
