### PR TITLE
damlc: show test coverage

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc.hs
@@ -197,7 +197,7 @@ runTestsInProjectOrFiles projectOpts Nothing color mbJUnitOutput cliOptions init
         initPackageDb cliOptions initPkgDb
         withPackageConfig (ProjectPath pPath) $ \PackageConfigFields{..} -> do
             -- TODO: We set up one scenario service context per file that
-            -- we pass to execTest and scenario cnotexts are quite expensive.
+            -- we pass to execTest and scenario contexts are quite expensive.
             -- Therefore we keep the behavior of only passing the root file
             -- if source points to a specific file.
             files <- getDamlRootFiles pSrc

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -61,8 +61,7 @@ testRun h inFiles lfVersion color mbJUnitOutput  = do
     let files = nubOrd $ concat $ inFiles : catMaybes deps
 
     results <- runActionSync h $ do
-        dalfs <- Shake.forP files $
-          \file -> dalfForScenario file
+        dalfs <- Shake.forP files dalfForScenario
         let templates = [t | m <- dalfs , t <- NM.toList $ LF.moduleTemplates m]
         let nrOfTemplates = length templates
         let nrOfChoices = length [n | t <- templates, n <- NM.names $ LF.tplChoices t]

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -178,7 +178,7 @@ testsForDamlcTest damlc = testGroup "damlc test" $
               , "x = scenario $ assert False"
               ]
             (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ["test", "--files", file] ""
-            stdout @?= ""
+            stdout @?= "test coverage: templates 100%, choices 100%\n"
             assertInfixOf "Scenario execution failed" stderr
             exitCode @?= ExitFailure 1
     , testCase "damlc test --files outside of project" $ withTempDir $ \projDir -> do

--- a/compiler/damlc/tests/src/DamlcTest.hs
+++ b/compiler/damlc/tests/src/DamlcTest.hs
@@ -198,7 +198,7 @@ testsForDamlcTest damlc = testGroup "damlc test" $
               , "x = scenario $ assert False"
               ]
             (exitCode, stdout, stderr) <- readProcessWithExitCode damlc ["test", "--files", file] ""
-            stdout @?= "test coverage: templates 100%, choices 100%\n"
+            stdout @?= ""
             assertInfixOf "Scenario execution failed" stderr
             exitCode @?= ExitFailure 1
     , testCase "damlc test --files outside of project" $ withTempDir $ \projDir -> do


### PR DESCRIPTION
We add output to show percentage of created templates and executed
choices for `damlc test`.

This fixes #6370.

CHANGELOG_BEGIN
[damlc] Feature: Test coverage is reported for `damlc test`.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
