### PR TITLE
bump check_releases timeout

### DIFF
--- a/ci/cron/daily-compat.yml
+++ b/ci/cron/daily-compat.yml
@@ -177,7 +177,7 @@ jobs:
           GCRED: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
 
   - job: check_releases
-    timeoutInMinutes: 240
+    timeoutInMinutes: 360
     pool:
       name: ubuntu_20_04
       demands: assignment -equals default


### PR DESCRIPTION
It's become quite flaky at just 4h.

Yes, I do plan to actually fix it, but it may take a while.

CHANGELOG_BEGIN
CHANGELOG_END