### PR TITLE
Renaming, prep for exceptions in speedy PR.

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -328,7 +328,7 @@ private[lf] object Anf {
       case SELet1General(rhs, body) =>
         Bounce(() => transformLet1(depth, env, rhs, body, k, transform))
 
-      case SECatch(body0, handler0, fin0) =>
+      case SECatchSubmitMustFail(body0, handler0, fin0) =>
         Bounce(() =>
           flattenExp(depth, env, body0) { body =>
             Bounce(() =>
@@ -336,7 +336,11 @@ private[lf] object Anf {
                 Bounce(() =>
                   flattenExp(depth, env, fin0) { fin =>
                     Bounce(() =>
-                      transform(depth, SECatch(body.wrapped, handler.wrapped, fin.wrapped), k)
+                      transform(
+                        depth,
+                        SECatchSubmitMustFail(body.wrapped, handler.wrapped, fin.wrapped),
+                        k,
+                      )
                     )
                   }
                 )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -521,8 +521,8 @@ private[lf] object Pretty {
             text("-> ")
           prettySExpr(index + n)(body).tightBracketBy(prefix, char(')'))
 
-        case SECatch(body, handler, fin) =>
-          text("$catch") + char('(') + prettySExpr(index)(body) + text(", ") +
+        case SECatchSubmitMustFail(body, handler, fin) =>
+          text("catch-submit-must-fail") + char('(') + prettySExpr(index)(body) + text(", ") +
             prettySExpr(index)(handler) + text(", ") +
             prettySExpr(index)(fin) + char(')')
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1026,7 +1026,7 @@ private[lf] object SBuiltin {
               coid,
               templateId,
               onLedger.committers,
-              cbMissing = _ => machine.tryHandleException(),
+              cbMissing = _ => machine.tryHandleSubmitMustFail(),
               cbPresent = { case V.ContractInst(actualTmplId, V.VersionedValue(_, arg), _) =>
                 // Note that we cannot throw in this continuation -- instead
                 // set the control appropriately which will crash the machine
@@ -1122,7 +1122,7 @@ private[lf] object SBuiltin {
                   machine.returnValue = SV.None
                   true
                 case SKeyLookupResult.NotVisible =>
-                  machine.tryHandleException()
+                  machine.tryHandleSubmitMustFail()
               },
             )
           )
@@ -1204,7 +1204,7 @@ private[lf] object SBuiltin {
                   true
                 case SKeyLookupResult.NotFound | SKeyLookupResult.NotVisible =>
                   onLedger.ptx = onLedger.ptx.copy(keys = onLedger.ptx.keys + (gkey -> None))
-                  machine.tryHandleException()
+                  machine.tryHandleSubmitMustFail()
               },
             )
           )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -329,16 +329,16 @@ object SExpr {
     }
   }
 
-  /** A catch expression. This is used internally solely for the purpose of implementing
+  /** catch-submit-must-fail. This is used internally solely for the purpose of implementing
     * mustFailAt. If the evaluation of 'body' causes an exception of type 'DamlException'
     * (see SError), then the environment and continuation stacks are reset and 'handler'
     * is executed. If the evaluation is successful, then the 'fin' expression is evaluated.
     * This is on purpose very limited, with no mechanism to inspect the exception, nor a way
     * to access the value returned from 'body'.
     */
-  final case class SECatch(body: SExpr, handler: SExpr, fin: SExpr) extends SExpr {
+  final case class SECatchSubmitMustFail(body: SExpr, handler: SExpr, fin: SExpr) extends SExpr {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KCatch(machine, handler, fin))
+      machine.pushKont(KCatchSubmitMustFail(machine, handler, fin))
       machine.ctrl = body
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -369,7 +369,7 @@ private[lf] object Speedy {
       // Most iterations are performed by the inner-loop, thus avoiding the work of to
       // wrap the exception handler on each of these steps. This is a performace gain.
       // However, we still need the outer loop because of the case:
-      //    case _:SErrorDamlException if tryHandleException =>
+      //    case _:SErrorDamlException if tryHandleSubmitMustFail =>
       // where we must continue iteration.
       var result: SResult = null
       while (result == null) {
@@ -406,7 +406,8 @@ private[lf] object Speedy {
             result = res //stop
           case serr: SError =>
             serr match {
-              case _: SErrorDamlException if tryHandleException() => () // outer loop will run again
+              case _: SErrorDamlException if tryHandleSubmitMustFail() =>
+                () // outer loop will run again
               case _ => result = SResultError(serr) //stop
             }
           case ex: RuntimeException =>
@@ -420,11 +421,11 @@ private[lf] object Speedy {
       * the catch handler. Returns true if the exception
       * was catched.
       */
-    def tryHandleException(): Boolean = {
+    private[speedy] def tryHandleSubmitMustFail(): Boolean = {
       val catchIndex =
-        kontStack.asScala.lastIndexWhere(_.isInstanceOf[KCatch])
+        kontStack.asScala.lastIndexWhere(_.isInstanceOf[KCatchSubmitMustFail])
       if (catchIndex >= 0) {
-        val kcatch = kontStack.get(catchIndex).asInstanceOf[KCatch]
+        val kcatch = kontStack.get(catchIndex).asInstanceOf[KCatchSubmitMustFail]
         kontStack.subList(catchIndex, kontStack.size).clear()
         env.subList(kcatch.envSize, env.size).clear()
         ctrl = kcatch.handler
@@ -1259,10 +1260,10 @@ private[lf] object Speedy {
 
   /** A catch frame marks the point to which an exception (of type 'SErrorDamlException')
     * is unwound. The 'envSize' specifies the size to which the environment must be pruned.
-    * If an exception is raised and 'KCatch' is found from kont-stack, then 'handler' is
-    * evaluated. If 'KCatch' is encountered naturally, then 'fin' is evaluated.
+    * If an exception is raised and 'KCatchSubmitMustFail' is found from kont-stack, then 'handler' is
+    * evaluated. If 'KCatchSubmitMustFail' is encountered naturally, then 'fin' is evaluated.
     */
-  private[speedy] final case class KCatch(
+  private[speedy] final case class KCatchSubmitMustFail(
       machine: Machine,
       handler: SExpr,
       fin: SExpr,
@@ -1270,7 +1271,7 @@ private[lf] object Speedy {
       with SomeArrayEquals {
 
     // We call [markBase] (as standard) so the continuation may access its temporaries.
-    // In addition [env.size] is recorded for use in [tryHandleException] to allow the
+    // In addition [env.size] is recorded for use in [tryHandleSubmitMustFail] to allow the
     // env-stack to be unwound correctly when an exception is thrown.
 
     val envSize = machine.env.size


### PR DESCRIPTION
Split out from  https://github.com/digital-asset/daml/pull/8612

Renaming:

    `SECatch` --> `SECatchSubmitMustFail`
    `tryHandleException` --> `tryHandleSubmitMustFail`
    `KCatch` --> `KCatchSubmitMustFail`

These existing types/functions are renamed to make it clear they *dont* relate to our _new_ exceptions, but are part of the legacy mechanism for handling _scenario/submit-must-fail_.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
