### PR TITLE
LF: reduce recursion depth in Archive decoder.

### DIFF
--- a/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
+++ b/daml-lf/archive/src/main/scala/com/digitalasset/daml/lf/archive/DecodeV1.scala
@@ -797,14 +797,8 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         ImmArray(lfTyConApp.getArgsList.asScala.map(decodeType)),
       )
 
-    private[lf] def decodeExpr(lfExpr: PLF.Expr, definition: String): Expr =
-      decodeLocation(lfExpr, definition) match {
-        case None => decodeExprBody(lfExpr, definition)
-        case Some(loc) => ELocation(loc, decodeExprBody(lfExpr, definition))
-      }
-
-    private[this] def decodeExprBody(lfExpr: PLF.Expr, definition: String): Expr =
-      lfExpr.getSumCase match {
+    private[lf] def decodeExpr(lfExpr: PLF.Expr, definition: String): Expr = {
+      val expr = lfExpr.getSumCase match {
         case PLF.Expr.SumCase.VAR_STR =>
           assertUntil(LV.Features.internedStrings, "Expr.var_str")
           EVar(toName(lfExpr.getVarStr))
@@ -1058,6 +1052,11 @@ private[archive] class DecodeV1(minor: LV.Minor) extends Decode.OfPackage[PLF.Pa
         case PLF.Expr.SumCase.SUM_NOT_SET =>
           throw ParseError("Expr.SUM_NOT_SET")
       }
+      decodeLocation(lfExpr, definition) match {
+        case None => expr
+        case Some(loc) => ELocation(loc, expr)
+      }
+    }
 
     private[this] def decodeCaseAlt(lfCaseAlt: PLF.CaseAlt, definition: String): CaseAlt = {
       val pat: CasePat = lfCaseAlt.getSumCase match {


### PR DESCRIPTION
We inline the unnecessary decodeExprBody call inside decodeExpr.  This
reduces the recursion depth of decoding expression inside archive,
increasing hence the depth of expression the scala part of the stack
can handle without blowing off the stack.

Before the change the test
//daml-lf/tests:test-scenario-stable-many-fields crashed 25 out of 100
runs.  After the changes the test crashed not once out of 100 runs.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
