### PR TITLE
damlc test: show full coverage report

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -138,10 +138,7 @@ printTestCoverage ShowCoverage {getShowCoverage} dalfs results
         , Just contractInstance <- [node_CreateContractInstance]
         ]
     missingTemplates =
-        [ (LF.moduleNameString $ LF.moduleName m) <> ":" <>
-        (T.intercalate "." $ LF.unTypeConName $ LF.tplTypeCon t)
-        | (m, t) <- templates
-        ] \\
+        [fullTemplateName m t | (m, t) <- templates] \\
         [TL.toStrict $ SS.identifierName tId | Just tId <- coveredTemplates]
     coveredChoices =
         nubSort $
@@ -153,16 +150,15 @@ printTestCoverage ShowCoverage {getShowCoverage} dalfs results
         , Just templateId <- [node_ExerciseTemplateId]
         ]
     missingChoices =
-        [ ( (LF.moduleNameString $ LF.moduleName m) <> ":" <>
-            (T.concat $ LF.unTypeConName $ LF.tplTypeCon t)
-          , LF.unChoiceName n)
-        | (m, t, n) <- choices
-        ] \\
+        [(fullTemplateName m t, LF.unChoiceName n) | (m, t, n) <- choices] \\
         [(TL.toStrict $ SS.identifierName t, TL.toStrict c) | (t, c) <- coveredChoices]
     nrOfTemplates = length templates
     nrOfChoices = length choices
     coveredNrOfChoices = length coveredChoices
     coveredNrOfTemplates = length coveredTemplates
+    fullTemplateName m t =
+        (LF.moduleNameString $ LF.moduleName m) <> ":" <>
+        (T.concat $ LF.unTypeConName $ LF.tplTypeCon t)
 
 printScenarioResults :: [(VirtualResource, SS.ScenarioResult)] -> UseColor -> IO ()
 printScenarioResults results color = do

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -139,7 +139,7 @@ printTestCoverage ShowCoverage {getShowCoverage} dalfs results
         ]
     missingTemplates =
         [ (LF.moduleNameString $ LF.moduleName m) <> ":" <>
-        (T.concat $ LF.unTypeConName $ LF.tplTypeCon t)
+        (T.intercalate "." $ LF.unTypeConName $ LF.tplTypeCon t)
         | (m, t) <- templates
         ] \\
         [TL.toStrict $ SS.identifierName tId | Just tId <- coveredTemplates]

--- a/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Test.hs
@@ -121,7 +121,7 @@ printTestCoverage ShowCoverage {getShowCoverage} dalfs results
               unlines $
               ["templates never created:"] <> map T.unpack missingTemplates <>
               ["choices never executed:"] <>
-              map T.unpack missingChoices
+              [T.unpack t <> ":" <> T.unpack c | (t, c) <- missingChoices]
   where
     templates = [(m, t) | m <- dalfs , t <- NM.toList $ LF.moduleTemplates m]
     choices = [(m, t, n) | (m, t) <- templates, n <- NM.names $ LF.tplChoices t]
@@ -153,13 +153,12 @@ printTestCoverage ShowCoverage {getShowCoverage} dalfs results
         , Just templateId <- [node_ExerciseTemplateId]
         ]
     missingChoices =
-        [ (LF.moduleNameString $ LF.moduleName m) <> ":" <>
-        (T.concat $ LF.unTypeConName $ LF.tplTypeCon t) <>
-        ":" <>
-        LF.unChoiceName n
+        [ ( (LF.moduleNameString $ LF.moduleName m) <> ":" <>
+            (T.concat $ LF.unTypeConName $ LF.tplTypeCon t)
+          , LF.unChoiceName n)
         | (m, t, n) <- choices
         ] \\
-        [TL.toStrict $ SS.identifierName t <> ":" <> c | (t, c) <- coveredChoices]
+        [(TL.toStrict $ SS.identifierName t, TL.toStrict c) | (t, c) <- coveredChoices]
     nrOfTemplates = length templates
     nrOfChoices = length choices
     coveredNrOfChoices = length coveredChoices


### PR DESCRIPTION
We add a flag `show-coverage` to `damlc-test` to show templates that
are never created and choices that are never executed during the tests.

CHANGELOG_BEGIN
[damlc test] A new flag `show-coverage` shows full test coverage
reports.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
