### PR TITLE
Only bind contract ids that are used

### DIFF
--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -196,7 +196,7 @@ private[dump] object Encode {
       ) + Doc.text("] tree")
   }
 
-  private def encodeTree(
+  private[dump] def encodeTree(
       partyMap: Map[String, String],
       cidMap: Map[String, String],
       cidRefs: Set[String],

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -22,7 +22,8 @@ private[dump] object Encode {
     val parties = trees.toList.foldMap(partiesInTree(_))
     val partyMap = partyMapping(parties)
     val cids = trees.map(treeCreatedCids(_))
-    val cidMap = cidMapping(cids)
+    val cidRefs = trees.toList.foldMap(treeReferencedCids(_))
+    val cidMap = cidMapping(cids, cidRefs)
     val refs = trees.toList.foldMap(treeRefs(_))
     val moduleRefs = refs.map(_.moduleName).toSet
     Doc.text("module Dump where") /
@@ -40,7 +41,7 @@ private[dump] object Encode {
       Doc.hardLine +
       Doc.text("dump : Parties -> Script ()") /
       (Doc.text("dump Parties{..} = do") /
-        Doc.stack(trees.map(t => encodeTree(partyMap, cidMap, t))) /
+        Doc.stack(trees.map(t => encodeTree(partyMap, cidMap, cidRefs, t))) /
         Doc.text("pure ()")).hang(2)
   }
 
@@ -198,16 +199,18 @@ private[dump] object Encode {
   private def encodeTree(
       partyMap: Map[String, String],
       cidMap: Map[String, String],
+      cidRefs: Set[String],
       tree: TransactionTree,
   ): Doc = {
     val rootEvs = tree.rootEventIds.map(tree.eventsById(_).kind)
     val submitters = rootEvs.flatMap(evParties(_)).toSet
     val cids = treeCreatedCids(tree)
-    (Doc.text("tree <- submitTreeMulti ") + encodeParties(partyMap, submitters) + Doc.text(
-      " [] do"
-    ) /
-      Doc.stack(rootEvs.map(ev => encodeEv(partyMap, cidMap, ev)))).hang(2) /
-      Doc.stack(cids.map(bindCid(cidMap, _)))
+    val treeBind =
+      (Doc.text("tree <- submitTreeMulti ") + encodeParties(partyMap, submitters) + Doc.text(
+        " [] do"
+      ) / Doc.stack(rootEvs.map(ev => encodeEv(partyMap, cidMap, ev)))).hang(2)
+    val cidBinds = cids.filter(c => cidRefs.contains(c.cid)).map(bindCid(cidMap, _))
+    Doc.stack(treeBind +: cidBinds)
   }
 
   private def encodeSelector(selector: Selector): Doc = Doc.str(selector.i)
@@ -237,7 +240,10 @@ private[dump] object Encode {
     partyMap
   }
 
-  private def cidMapping(cids: Seq[Seq[CreatedContract]]): Map[String, String] = {
+  private def cidMapping(
+      cids: Seq[Seq[CreatedContract]],
+      cidRefs: Set[String],
+  ): Map[String, String] = {
     def lowerFirst(s: String) =
       if (s.isEmpty) {
         s
@@ -245,8 +251,9 @@ private[dump] object Encode {
         s.head.toLower.toString + s.tail
       }
     cids.view.zipWithIndex.flatMap { case (cs, treeIndex) =>
-      cs.view.zipWithIndex.map { case (c, i) =>
-        c.cid -> s"${lowerFirst(c.tplId.entityName)}_${treeIndex}_$i"
+      cs.view.zipWithIndex.collect {
+        case (c, i) if cidRefs.contains(c.cid) =>
+          c.cid -> s"${lowerFirst(c.tplId.entityName)}_${treeIndex}_$i"
       }
     }.toMap
   }

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -21,7 +21,7 @@ private[dump] object Encode {
   def encodeTransactionTreeStream(trees: Seq[TransactionTree]): Doc = {
     val parties = trees.toList.foldMap(partiesInTree(_))
     val partyMap = partyMapping(parties)
-    val cids = trees.map(treeCids(_))
+    val cids = trees.map(treeCreatedCids(_))
     val cidMap = cidMapping(cids)
     val refs = trees.toList.foldMap(treeRefs(_))
     val moduleRefs = refs.map(_.moduleName).toSet
@@ -202,7 +202,7 @@ private[dump] object Encode {
   ): Doc = {
     val rootEvs = tree.rootEventIds.map(tree.eventsById(_).kind)
     val submitters = rootEvs.flatMap(evParties(_)).toSet
-    val cids = treeCids(tree)
+    val cids = treeCreatedCids(tree)
     (Doc.text("tree <- submitTreeMulti ") + encodeParties(partyMap, submitters) + Doc.text(
       " [] do"
     ) /

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -81,7 +81,7 @@ object TreeUtils {
 
   case class CreatedContract(cid: String, tplId: Identifier, path: List[Selector])
 
-  def treeCids(tree: TransactionTree): Seq[CreatedContract] = {
+  def treeCreatedCids(tree: TransactionTree): Seq[CreatedContract] = {
     var cids: Seq[CreatedContract] = Seq()
     traverseTree(tree) { case (selectors, kind) =>
       kind match {

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -102,7 +102,10 @@ object TreeUtils {
         case Kind.Exercised(value) =>
           cids += value.contractId
           cids ++= value.choiceArgument.foldMap(arg => valueCids(arg.sum))
-        case Kind.Created(_) =>
+        case Kind.Created(value) =>
+          cids ++= value.createArguments.foldMap(args =>
+            args.fields.toList.foldMap(f => valueCids(f.getValue.sum))
+          )
       }
     }
     cids

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
@@ -1,0 +1,92 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.dump
+
+import com.daml.ledger.api.v1.event.CreatedEvent
+import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
+import com.daml.ledger.api.v1.value.{Identifier, Record}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class EncodeTreeSpec extends AnyFreeSpec with Matchers {
+  import Encode._
+  "encodeTree" - {
+    "contract id bindings" - {
+      "unreferenced" in {
+        val parties = Map("Alice" -> "alice_0")
+        val cidMap = Map("cid" -> "contract_0_0")
+        val cidRefs = Set.empty[String]
+        val tree = TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map(
+            "create" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid",
+                  signatories = Seq("Alice"),
+                  createArguments = Some(
+                    Record(
+                      recordId = Some(Identifier("package", "Module", "Template")),
+                      fields = Seq.empty,
+                    )
+                  ),
+                )
+              )
+            )
+          ),
+          rootEventIds = Seq("create"),
+          traceContext = None,
+        )
+        encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
+          """tree <- submitTreeMulti [alice_0] [] do
+            |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
+      }
+      "referenced" in {
+        val parties = Map("Alice" -> "alice_0")
+        val cidMap = Map("cid" -> "contract_0_0")
+        val cidRefs = Set("cid")
+        val tree = TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map(
+            "create" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid",
+                  signatories = Seq("Alice"),
+                  createArguments = Some(
+                    Record(
+                      recordId = Some(Identifier("package", "Module", "Template")),
+                      fields = Seq.empty,
+                    )
+                  ),
+                )
+              )
+            )
+          ),
+          rootEventIds = Seq("create"),
+          traceContext = None,
+        )
+        encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
+          """tree <- submitTreeMulti [alice_0] [] do
+            |  createCmd Module.Template
+            |let contract_0_0 = createdCid @Module.Template [0] tree""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+    }
+  }
+}

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TreeReferencedCidsSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TreeReferencedCidsSpec.scala
@@ -1,0 +1,152 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.dump
+
+import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
+import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
+import com.daml.ledger.api.v1.{value => v}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
+  import TreeUtils._
+  "treeReferencedCids" - {
+    "empty" in {
+      treeReferencedCids(
+        TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map.empty,
+          rootEventIds = Seq.empty,
+          traceContext = None,
+        )
+      ) shouldBe Set.empty
+    }
+    "created only" in {
+      treeReferencedCids(
+        TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map(
+            "create" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  contractId = "cid",
+                )
+              )
+            )
+          ),
+          rootEventIds = Seq("create"),
+          traceContext = None,
+        )
+      ) shouldBe Set.empty
+    }
+    "exercised" in {
+      treeReferencedCids(
+        TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map(
+            "exercise" -> TreeEvent(
+              TreeEvent.Kind.Exercised(
+                ExercisedEvent(
+                  eventId = "exercise",
+                  contractId = "cid",
+                )
+              )
+            )
+          ),
+          rootEventIds = Seq("exercise"),
+          traceContext = None,
+        )
+      ) shouldBe Set("cid")
+    }
+    "referenced" in {
+      val variant = v.Value(
+        v.Value.Sum.Variant(
+          v.Variant(
+            variantId = Some(v.Identifier("package", "Module", "variant")),
+            constructor = "Variant",
+            value = Some(v.Value(v.Value.Sum.ContractId("cid_variant"))),
+          )
+        )
+      )
+      val list = v.Value(v.Value.Sum.List(v.List(Seq(v.Value(v.Value.Sum.ContractId("cid_list"))))))
+      val optional = v.Value(
+        v.Value.Sum.Optional(v.Optional(Some(v.Value(v.Value.Sum.ContractId("cid_optional")))))
+      )
+      val map = v.Value(
+        v.Value.Sum.Map(
+          v.Map(Seq(v.Map.Entry("entry", Some(v.Value(v.Value.Sum.ContractId("cid_map"))))))
+        )
+      )
+      val genmap = v.Value(
+        v.Value.Sum.GenMap(
+          v.GenMap(
+            Seq(
+              v.GenMap.Entry(
+                key = Some(v.Value(v.Value.Sum.ContractId("cid_genmap_key"))),
+                value = Some(v.Value(v.Value.Sum.ContractId("cid_genmap_value"))),
+              )
+            )
+          )
+        )
+      )
+      val record = v.Value(
+        v.Value.Sum.Record(
+          v.Record(
+            recordId = Some(v.Identifier("package", "Module", "record")),
+            fields = Seq(
+              v.RecordField("variant", Some(variant)),
+              v.RecordField("list", Some(list)),
+              v.RecordField("optional", Some(optional)),
+              v.RecordField("map", Some(map)),
+              v.RecordField("genmap", Some(genmap)),
+            ),
+          )
+        )
+      )
+      treeReferencedCids(
+        TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map(
+            "exercise" -> TreeEvent(
+              TreeEvent.Kind.Exercised(
+                ExercisedEvent(
+                  eventId = "exercise",
+                  contractId = "cid_exercise",
+                  choiceArgument = Some(record),
+                )
+              )
+            )
+          ),
+          rootEventIds = Seq("exercise"),
+          traceContext = None,
+        )
+      ) shouldBe Set(
+        "cid_exercise",
+        "cid_variant",
+        "cid_list",
+        "cid_optional",
+        "cid_map",
+        "cid_genmap_key",
+        "cid_genmap_value",
+      )
+    }
+  }
+}

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TreeReferencedCidsSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TreeReferencedCidsSpec.scala
@@ -125,6 +125,24 @@ class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
           effectiveAt = None,
           offset = "",
           eventsById = Map(
+            "create" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "exercise",
+                  createArguments = Some(
+                    v.Record(
+                      recordId = Some(v.Identifier("package", "Module", "record")),
+                      fields = Seq(
+                        v.RecordField(
+                          "contract_id",
+                          Some(v.Value(v.Value.Sum.ContractId("cid_create_arg"))),
+                        )
+                      ),
+                    )
+                  ),
+                )
+              )
+            ),
             "exercise" -> TreeEvent(
               TreeEvent.Kind.Exercised(
                 ExercisedEvent(
@@ -133,12 +151,13 @@ class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
                   choiceArgument = Some(record),
                 )
               )
-            )
+            ),
           ),
-          rootEventIds = Seq("exercise"),
+          rootEventIds = Seq("create", "exercise"),
           traceContext = None,
         )
       ) shouldBe Set(
+        "cid_create_arg",
         "cid_exercise",
         "cid_variant",
         "cid_list",


### PR DESCRIPTION
Closes #8775 

Adds an additional traversal of the tree to determine all referenced contract ids.
Filters out contract ids that are never referenced before creating bindings for them.
Adds tests for the feature.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
