### PR TITLE
LF: (fix) compute exercise node seed is only once.

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -64,7 +64,7 @@ private[lf] object PartialTransaction {
     */
   final case class Context(info: ContextInfo, children: BackStack[NodeId], nextChildIdx: Int) {
     def addChild(child: NodeId): Context = Context(info, children :+ child, nextChildIdx + 1)
-    // This function may be costly, it must be call at most one for each node.
+    // This function may be costly, it must be call at most once for each node.
     def nextChildSeed: crypto.Hash = info.childSeed(nextChildIdx)
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -64,7 +64,7 @@ private[lf] object PartialTransaction {
     */
   final case class Context(info: ContextInfo, children: BackStack[NodeId], nextChildIdx: Int) {
     def addChild(child: NodeId): Context = Context(info, children :+ child, nextChildIdx + 1)
-    // needs to be lazy as info.childrenSeeds may be undefined on children.length
+    // This function may be costly, it must be call at most one for each node.
     def nextChildSeed: crypto.Hash = info.childSeed(nextChildIdx)
   }
 
@@ -118,8 +118,8 @@ private[lf] object PartialTransaction {
       parent: Context,
       byKey: Boolean,
   ) extends ContextInfo {
-    val childSeed =
-      crypto.Hash.deriveNodeSeed(parent.nextChildSeed, _)
+    val nodeSeed = parent.nextChildSeed
+    val childSeed = crypto.Hash.deriveNodeSeed(nodeSeed, _)
   }
 
   final case class TryContextInfo(parent: Context) extends ContextInfo {
@@ -445,11 +445,10 @@ private[lf] case class PartialTransaction(
           version = packageToTransactionVersion(ec.templateId.packageId),
         )
         val nodeId = ec.nodeId
-        val nodeSeed = ec.parent.nextChildSeed
         copy(
           context = ec.parent.addChild(nodeId),
           nodes = nodes.updated(nodeId, exerciseNode),
-          nodeSeeds = nodeSeeds :+ (nodeId -> nodeSeed),
+          nodeSeeds = nodeSeeds :+ (nodeId -> ec.nodeSeed),
         )
       case _ =>
         noteAbort(Tx.NonExerciseContext)


### PR DESCRIPTION
This PR fix a regression performence intoriduce in #8804, were we
calculate exercise node seed twice.

Here is the result of a benchmark:

before:
CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt   20  48.968 ± 0.667  ms/op

after:
CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:test  avgt   20  41.772 ± 0.374  ms/op

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
