### PR TITLE
Generate Scala code compatible with Scala 2.13

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -199,8 +199,6 @@ jobs:
           //daml-script/... \
           //triggers/... \
           -//libs-scala/gatling-utils/... \
-          -//language-support/scala/examples/... \
-          -//language-support/scala/codegen-sample-app/... \
           -//ledger/ledger-api-test-tool/... \
           -//ledger/ledger-api-test-tool-on-canton/...
       displayName: 'Build'

--- a/language-support/scala/bindings/src/main/2.12/com/daml/ledger/client/binding/Compat.scala
+++ b/language-support/scala/bindings/src/main/2.12/com/daml/ledger/client/binding/Compat.scala
@@ -5,7 +5,9 @@ package com.daml.ledger.client.binding
 
 import scala.collection.immutable
 
-private[binding] object CollectionCompat {
-  type MapLike[K, +V, +C <: immutable.MapLike[K, V, C] with immutable.Map[K, V]] =
+object Compat {
+  private[binding] type MapLike[K, +V, +C <: immutable.MapLike[K, V, C] with immutable.Map[K, V]] =
     immutable.MapLike[K, V, C]
+
+  type DummyImplicit = scala.Predef.DummyImplicit
 }

--- a/language-support/scala/bindings/src/main/2.13/com/daml/ledger/client/binding/Compat.scala
+++ b/language-support/scala/bindings/src/main/2.13/com/daml/ledger/client/binding/Compat.scala
@@ -5,7 +5,9 @@ package com.daml.ledger.client.binding
 
 import scala.collection.immutable
 
-private[binding] object CollectionCompat {
-  type MapLike[K, +V, +C <: immutable.MapOps[K, V, immutable.Map, C]] =
+object Compat {
+  private[binding] type MapLike[K, +V, +C <: immutable.MapOps[K, V, immutable.Map, C]] =
     immutable.MapOps[K, V, immutable.Map, C]
+
+  type DummyImplicit = scala.DummyImplicit
 }

--- a/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
+++ b/language-support/scala/bindings/src/main/scala/com/digitalasset/ledger/client/binding/binding/Primitive.scala
@@ -51,7 +51,7 @@ sealed abstract class Primitive extends PrimitiveInstances {
   type Optional[+A] = scala.Option[A]
   val Optional: scala.Option.type = scala.Option
 
-  type TextMap[+V] <: imm.Map[String, V] with CollectionCompat.MapLike[String, V, TextMap[V]]
+  type TextMap[+V] <: imm.Map[String, V] with Compat.MapLike[String, V, TextMap[V]]
   val TextMap: TextMapApi
 
   @deprecated("Use TextMap", since = "0.13.40")

--- a/language-support/scala/codegen-sample-app/BUILD.bazel
+++ b/language-support/scala/codegen-sample-app/BUILD.bazel
@@ -17,6 +17,7 @@ load(
     "lf_dev_version",
     "lf_latest_version",
 )
+load("@scala_version//:index.bzl", "scala_version_suffix")
 
 daml_compile(
     name = "MyMain",
@@ -47,7 +48,11 @@ da_scala_library(
     srcs = [":MyMain.srcjar"] + glob(["src/main/**/*.scala"]),
     plugins = [
         silencer_plugin,
-        "@maven//:org_typelevel_kind_projector_2_12_12",
+        "@maven//:org_typelevel_kind_projector_{}".format(scala_version_suffix),
+    ],
+    scala_deps = [
+        "@maven//:org_scalaz_scalaz_core",
+        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
     scalacopts = [
         "-P:silencer:checkUnused",
@@ -58,6 +63,7 @@ da_scala_library(
         # referenced types, and only occurs here in this source tree, so I don't consider
         # it worth fixing for now. -SC
         "-P:silencer:lineContentFilters=ContractIdNT (Value|LfEncodable).*?implicit .?ev",
+        "-P:silencer:lineContentFilters=import _root_.scala.language.higherKinds;",
     ],
     visibility = [
         "//visibility:public",
@@ -69,11 +75,6 @@ da_scala_library(
     deps = [
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
-        # silencer warns if this is absent, but we don't use it here;
-        # buildozer errors if you add it, so silent_annotations can't be used
-        # "@maven//:com_github_ghik_silencer_lib_2_12_12",
-        "@maven//:org_scalaz_scalaz_core_2_12",
-        "@maven//:org_scala_lang_modules_scala_collection_compat_2_12",
     ],
 )
 
@@ -90,9 +91,11 @@ da_scala_library(
     name = "daml-lf-codegen-sample-app-testing",
     srcs = testing_utils,
     resources = glob(["src/test/resources/**/*"]),
+    scala_deps = [
+        "@maven//:org_scalaz_scalaz_core",
+    ],
     deps = [
         "//bazel_tools/runfiles:scala_runfiles",
-        "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )
 
@@ -107,12 +110,14 @@ da_scala_test(
             "src/test/scala/com/digitalasset/codegen/ScalaCodeGenIT.scala",
         ],
     ),
+    scala_deps = [
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalatestplus_scalacheck_1_14",
+        "@maven//:org_scalaz_scalaz_core",
+    ],
     deps = [
         ":daml-lf-codegen-sample-app",
         "//language-support/scala/bindings",
-        "@maven//:org_scalacheck_scalacheck_2_12",
-        "@maven//:org_scalatestplus_scalacheck_1_14_2_12",
-        "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )
 
@@ -131,6 +136,10 @@ da_scala_test(
     ],
     jvm_flags = [
         "-Dcom.daml.sandbox.jar=ledger/sandbox-classic/sandbox-classic-binary_deploy.jar",
+    ],
+    scala_deps = [
+        "@maven//:org_scalacheck_scalacheck",
+        "@maven//:org_scalaz_scalaz_core",
     ],
     deps = [
         ":daml-lf-codegen-sample-app",
@@ -154,7 +163,5 @@ da_scala_test(
         "//ledger/sandbox-common:sandbox-common-scala-tests-lib",
         "//libs-scala/ports",
         "//libs-scala/resources",
-        "@maven//:org_scalacheck_scalacheck_2_12",
-        "@maven//:org_scalaz_scalaz_core_2_12",
     ],
 )

--- a/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
+++ b/language-support/scala/codegen-sample-app/src/test/scala/com/digitalasset/codegen/GeneratedCommandsUT.scala
@@ -35,7 +35,7 @@ class GeneratedCommandsUT extends AnyWordSpec with Matchers with Inside {
 
   "key" should {
     "make an exercise-by-key command" in {
-      inside((KeyedNumber key alice exerciseIncrement (alice, 42)).command.command) {
+      inside((KeyedNumber.key(alice).exerciseIncrement(alice, 42)).command.command) {
         case rpccmd.Command.Command.ExerciseByKey(
               rpccmd.ExerciseByKeyCommand(Some(tid), Some(k), "Increment", Some(choiceArg))
             ) =>

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlContractTemplateGen.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/DamlContractTemplateGen.scala
@@ -20,7 +20,7 @@ import scala.reflect.runtime.universe._
   *  See the comments below for more details on what classes/methods/types are generated.
   */
 object DamlContractTemplateGen {
-  import LFUtil.rpcValueAlias
+  import LFUtil.{domainApiAlias, rpcValueAlias}
 
   private val logger: Logger = Logger(getClass)
 
@@ -88,7 +88,7 @@ object DamlContractTemplateGen {
     )
 
     def templateClassMembers = Seq(
-      q"protected[this] override def templateCompanion(implicit ` d`: _root_.scala.Predef.DummyImplicit) = ${TermName(templateName.name)}"
+      q"protected[this] override def templateCompanion(implicit ` d`: $domainApiAlias.Compat.DummyImplicit) = ${TermName(templateName.name)}"
     )
 
     DamlDataTypeGen.generate(

--- a/language-support/scala/examples/BUILD.bazel
+++ b/language-support/scala/examples/BUILD.bazel
@@ -5,6 +5,7 @@ load(
     "//bazel_tools:scala.bzl",
     "da_scala_binary",
     "da_scala_library",
+    "silencer_plugin",
 )
 load("//rules_daml:daml.bzl", "daml_compile")
 load("//language-support/scala/codegen:codegen.bzl", "dar_to_scala")
@@ -51,6 +52,10 @@ dar_to_scala(
 da_scala_library(
     name = "quickstart-scala-codegen-lib",
     srcs = [":quickstart-scala-codegen.srcjar"],
+    plugins = [silencer_plugin],
+    scalacopts = [
+        "-P:silencer:lineContentFilters=import _root_.scala.language.higherKinds;",
+    ],
     deps = ["//language-support/scala/bindings"],
 )
 
@@ -59,12 +64,14 @@ da_scala_binary(
     srcs = glob(["quickstart-scala/application/src/main/scala/**/*.scala"]),
     main_class = "com.daml.quickstart.iou.IouMain",
     resources = glob(["quickstart-scala/application/src/main/resources/**/*"]),
+    scala_deps = [
+        "@maven//:org_scala_lang_modules_scala_collection_compat",
+    ],
     deps = [
         ":quickstart-scala-codegen-lib",
         "//language-support/scala/bindings",
         "//language-support/scala/bindings-akka",
         "//ledger-api/rs-grpc-bridge",
-        "@maven//:org_scala_lang_modules_scala_collection_compat_2_12",
     ],
 )
 

--- a/ledger/test-common/BUILD.bazel
+++ b/ledger/test-common/BUILD.bazel
@@ -8,6 +8,7 @@ load(
 load(
     "//bazel_tools:scala.bzl",
     "da_scala_library",
+    "silencer_plugin",
 )
 load(
     "//language-support/scala/codegen:codegen.bzl",
@@ -67,20 +68,25 @@ da_scala_library(
         da_scala_library(
             name = "%s-tests%s.scala" % (test_name, target_suffix),
             srcs = [":%s-tests%s.scala-codegen" % (test_name, target_suffix)],
+            plugins = [silencer_plugin],
+            scala_deps = extra_deps,
+            scalacopts = [
+                "-P:silencer:lineContentFilters=import _root_.scala.language.higherKinds;",
+            ],
             visibility = ["//visibility:public"],
             deps = [
                 "//language-support/scala/bindings",
-            ] + extra_deps,
-        ) if scala_major_version == "2.12" else None,
+            ],
+        ),
     ]
     for (test_name, extra_deps) in [
         (
             "model",
-            ["@maven//:org_scala_lang_modules_scala_collection_compat_2_12"],
+            ["@maven//:org_scala_lang_modules_scala_collection_compat"],
         ),
         (
             "semantic",
-            ["@maven//:org_scala_lang_modules_scala_collection_compat_2_12"],
+            ["@maven//:org_scala_lang_modules_scala_collection_compat"],
         ),
         ("performance", []),
     ]


### PR DESCRIPTION
fixes #8498

This fixes the error in 2.13 wtr to the location change of Predef. It
doesn’t yet address the warning wtr to the import of higherKinds. For
now, our build ignores that warning. Trying to figure out if we can
get away with a breaking change here or if we need to hide that change
behind a flag but either way, no need to block fixing the actual error
on that.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
