### PR TITLE
Fix the help text in KV Runner's config parser

### DIFF
--- a/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
+++ b/ledger/participant-state/kvutils/app/src/main/scala/com/daml/ledger/participant/state/kvutils/app/Config.scala
@@ -117,7 +117,7 @@ object Config {
               "port-file, " +
               "server-jdbc-url, " +
               "api-server-connection-pool-size" +
-              "indexer-server-connection-pool-size" +
+              "indexer-connection-pool-size" +
               "max-commands-in-flight, " +
               "management-service-timeout, " +
               "run-mode, " +


### PR DESCRIPTION
The parameter is looked up as `indexer-connection-pool-size`, so the help text should say the same.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
