### PR TITLE
kvutils: Split `Raw.Key` into two, and rename `Raw.Value` to `Raw.Envelope`.

### DIFF
--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
@@ -19,7 +19,7 @@ final class InMemoryLedgerStateOperations(
 
   override def readState(
       keys: Iterable[Raw.StateKey]
-  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
+  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Envelope]]] =
     Future.successful(keys.view.map(state.get).toSeq)
 
   override def writeState(
@@ -31,7 +31,7 @@ final class InMemoryLedgerStateOperations(
 
   override def appendToLog(
       key: Raw.LogEntryId,
-      value: Raw.Value,
+      value: Raw.Envelope,
   )(implicit executionContext: ExecutionContext): Future[Index] =
     Future.successful(appendEntry(log, LedgerRecord(_, key, value)))
 

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerStateOperations.scala
@@ -18,20 +18,21 @@ final class InMemoryLedgerStateOperations(
 ) extends BatchingLedgerStateOperations[Index] {
 
   override def readState(
-      keys: Iterable[Raw.Key]
+      keys: Iterable[Raw.StateKey]
   )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
     Future.successful(keys.view.map(state.get).toSeq)
 
   override def writeState(
-      keyValuePairs: Iterable[Raw.KeyValuePair]
+      keyValuePairs: Iterable[Raw.StateEntry]
   )(implicit executionContext: ExecutionContext): Future[Unit] = {
     state ++= keyValuePairs
     Future.unit
   }
 
-  override def appendToLog(key: Raw.Key, value: Raw.Value)(implicit
-      executionContext: ExecutionContext
-  ): Future[Index] =
+  override def appendToLog(
+      key: Raw.LogEntryId,
+      value: Raw.Value,
+  )(implicit executionContext: ExecutionContext): Future[Index] =
     Future.successful(appendEntry(log, LedgerRecord(_, key, value)))
 
 }

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerWriter.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryLedgerWriter.scala
@@ -45,7 +45,7 @@ final class InMemoryLedgerWriter private[memory] (
 ) extends LedgerWriter {
   override def commit(
       correlationId: String,
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       metadata: CommitMetadata,
   ): Future[SubmissionResult] =
     committer

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
@@ -42,14 +42,14 @@ private[memory] class InMemoryState private (log: MutableLog, state: MutableStat
 
 object InMemoryState {
   type ImmutableLog = collection.IndexedSeq[LedgerRecord]
-  type ImmutableState = collection.Map[Raw.Key, Raw.Value]
+  type ImmutableState = collection.Map[Raw.StateKey, Raw.Value]
 
   type MutableLog = mutable.Buffer[LedgerRecord] with ImmutableLog
-  type MutableState = mutable.Map[Raw.Key, Raw.Value] with ImmutableState
+  type MutableState = mutable.Map[Raw.StateKey, Raw.Value] with ImmutableState
 
   // The first element will never be read because begin offsets are exclusive.
   private val Beginning =
-    LedgerRecord(Offset.beforeBegin, Raw.Key(ByteString.EMPTY), Raw.Value(ByteString.EMPTY))
+    LedgerRecord(Offset.beforeBegin, Raw.LogEntryId.empty, Raw.Value(ByteString.EMPTY))
 
   def empty =
     new InMemoryState(

--- a/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
+++ b/ledger/ledger-on-memory/src/main/scala/com/daml/ledger/on/memory/InMemoryState.scala
@@ -9,7 +9,6 @@ import com.daml.ledger.on.memory.InMemoryState._
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.kvutils.api.LedgerRecord
 import com.daml.ledger.participant.state.v1.Offset
-import com.google.protobuf.ByteString
 
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future, blocking}
@@ -42,14 +41,14 @@ private[memory] class InMemoryState private (log: MutableLog, state: MutableStat
 
 object InMemoryState {
   type ImmutableLog = collection.IndexedSeq[LedgerRecord]
-  type ImmutableState = collection.Map[Raw.StateKey, Raw.Value]
+  type ImmutableState = collection.Map[Raw.StateKey, Raw.Envelope]
 
   type MutableLog = mutable.Buffer[LedgerRecord] with ImmutableLog
-  type MutableState = mutable.Map[Raw.StateKey, Raw.Value] with ImmutableState
+  type MutableState = mutable.Map[Raw.StateKey, Raw.Envelope] with ImmutableState
 
   // The first element will never be read because begin offsets are exclusive.
   private val Beginning =
-    LedgerRecord(Offset.beforeBegin, Raw.LogEntryId.empty, Raw.Value(ByteString.EMPTY))
+    LedgerRecord(Offset.beforeBegin, Raw.LogEntryId.empty, Raw.Envelope.empty)
 
   def empty =
     new InMemoryState(

--- a/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerWriterSpec.scala
+++ b/ledger/ledger-on-memory/src/test/suite/scala/com/daml/ledger/on/memory/InMemoryLedgerWriterSpec.scala
@@ -35,7 +35,7 @@ class InMemoryLedgerWriterSpec
         mockCommitter.commit(
           any[ParticipantId],
           any[String],
-          any[Raw.Value],
+          any[Raw.Envelope],
           any[Instant],
           any[LedgerStateAccess[Any]],
         )(any[ExecutionContext])
@@ -56,7 +56,7 @@ class InMemoryLedgerWriterSpec
       instance
         .commit(
           "correlation ID",
-          Raw.Value(ByteString.copyFromUtf8("some bytes")),
+          Raw.Envelope(ByteString.copyFromUtf8("some bytes")),
           CommitMetadata.Empty,
         )
         .map { actual =>

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -210,17 +210,17 @@ object SqlLedgerReaderWriter {
   private final class SqlLedgerStateOperations(queries: Queries)
       extends BatchingLedgerStateOperations[Index] {
     override def readState(
-        keys: Iterable[Raw.Key]
+        keys: Iterable[Raw.StateKey]
     )(implicit executionContext: sc.ExecutionContext): sc.Future[Seq[Option[Raw.Value]]] =
       Future.fromTry(queries.selectStateValuesByKeys(keys)).removeExecutionContext
 
     override def writeState(
-        keyValuePairs: Iterable[Raw.KeyValuePair]
+        keyValuePairs: Iterable[Raw.StateEntry]
     )(implicit executionContext: sc.ExecutionContext): sc.Future[Unit] =
       Future.fromTry(queries.updateState(keyValuePairs)).removeExecutionContext
 
     override def appendToLog(
-        key: Raw.Key,
+        key: Raw.LogEntryId,
         value: Raw.Value,
     )(implicit executionContext: sc.ExecutionContext): sc.Future[Index] =
       Future.fromTry(queries.insertRecordIntoLog(key, value)).removeExecutionContext

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/SqlLedgerReaderWriter.scala
@@ -75,7 +75,7 @@ final class SqlLedgerReaderWriter(
 
   override def commit(
       correlationId: String,
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       metadata: CommitMetadata,
   ): sc.Future[SubmissionResult] =
     committer.commit(correlationId, envelope, participantId)(committerExecutionContext)
@@ -211,7 +211,7 @@ object SqlLedgerReaderWriter {
       extends BatchingLedgerStateOperations[Index] {
     override def readState(
         keys: Iterable[Raw.StateKey]
-    )(implicit executionContext: sc.ExecutionContext): sc.Future[Seq[Option[Raw.Value]]] =
+    )(implicit executionContext: sc.ExecutionContext): sc.Future[Seq[Option[Raw.Envelope]]] =
       Future.fromTry(queries.selectStateValuesByKeys(keys)).removeExecutionContext
 
     override def writeState(
@@ -221,7 +221,7 @@ object SqlLedgerReaderWriter {
 
     override def appendToLog(
         key: Raw.LogEntryId,
-        value: Raw.Value,
+        value: Raw.Envelope,
     )(implicit executionContext: sc.ExecutionContext): sc.Future[Index] =
       Future.fromTry(queries.insertRecordIntoLog(key, value)).removeExecutionContext
   }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/CommonQueries.scala
@@ -30,26 +30,26 @@ trait CommonQueries extends Queries {
       endInclusive: Index,
   ): Try[immutable.Seq[(Index, LedgerRecord)]] = Try {
     SQL"SELECT sequence_no, entry_id, envelope FROM #$LogTable WHERE sequence_no > $startExclusive AND sequence_no <= $endInclusive ORDER BY sequence_no"
-      .as((long("sequence_no") ~ rawKey("entry_id") ~ rawValue("envelope")).map {
+      .as((long("sequence_no") ~ rawLogEntryId("entry_id") ~ rawValue("envelope")).map {
         case index ~ entryId ~ envelope =>
           index -> LedgerRecord(OffsetBuilder.fromLong(index), entryId, envelope)
       }.*)
   }
 
   override final def selectStateValuesByKeys(
-      keys: Iterable[Raw.Key]
+      keys: Iterable[Raw.StateKey]
   ): Try[immutable.Seq[Option[Raw.Value]]] =
     Try {
       val results =
         SQL"SELECT key, value FROM #$StateTable WHERE key IN (${keys.toSeq})"
-          .fold(Map.newBuilder[Raw.Key, Raw.Value], ColumnAliaser.empty) { (builder, row) =>
-            builder += row("key")(columnToRawKey) -> row("value")(columnToRawValue)
+          .fold(Map.newBuilder[Raw.StateKey, Raw.Value], ColumnAliaser.empty) { (builder, row) =>
+            builder += row("key")(columnToRawStateKey) -> row("value")(columnToRawValue)
           }
           .fold(exceptions => throw exceptions.head, _.result())
       keys.view.map(results.get).to(immutable.Seq)
     }
 
-  override final def updateState(stateUpdates: Iterable[Raw.KeyValuePair]): Try[Unit] = Try {
+  override final def updateState(stateUpdates: Iterable[Raw.StateEntry]): Try[Unit] = Try {
     executeBatchSql(
       updateStateQuery,
       stateUpdates.map { case (key, value) =>

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
@@ -24,7 +24,7 @@ final class H2Queries(override protected implicit val connection: Connection)
       .as(str("ledger_id").single)
   }
 
-  override def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index] =
+  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index] =
     Try {
       SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value)"
         .executeInsert()

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/H2Queries.scala
@@ -24,7 +24,7 @@ final class H2Queries(override protected implicit val connection: Connection)
       .as(str("ledger_id").single)
   }
 
-  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index] =
+  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Envelope): Try[Index] =
     Try {
       SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value)"
         .executeInsert()

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
@@ -24,7 +24,7 @@ final class PostgresqlQueries(override protected implicit val connection: Connec
       .as(str("ledger_id").single)
   }
 
-  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index] = Try {
+  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Envelope): Try[Index] = Try {
     SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value) RETURNING sequence_no"
       .as(long("sequence_no").single)
   }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/PostgresqlQueries.scala
@@ -24,7 +24,7 @@ final class PostgresqlQueries(override protected implicit val connection: Connec
       .as(str("ledger_id").single)
   }
 
-  override def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index] = Try {
+  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index] = Try {
     SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value) RETURNING sequence_no"
       .as(long("sequence_no").single)
   }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
@@ -51,7 +51,7 @@ object Queries {
   implicit val rawStateKeyToStatement: ToStatement[Raw.StateKey] =
     byteStringToStatement.contramap(_.bytes)
 
-  implicit val rawValueToStatement: ToStatement[Raw.Value] =
+  implicit val rawEnvelopeToStatement: ToStatement[Raw.Envelope] =
     byteStringToStatement.contramap(_.bytes)
 
   private val columnToByteString: Column[ByteString] =
@@ -73,13 +73,13 @@ object Queries {
   implicit val columnToRawStateKey: Column[Raw.StateKey] =
     columnToByteString.map(Raw.StateKey.apply)
 
-  implicit val columnToRawValue: Column[Raw.Value] =
-    columnToByteString.map(Raw.Value.apply)
+  implicit val columnToRawEnvelope: Column[Raw.Envelope] =
+    columnToByteString.map(Raw.Envelope.apply)
 
   def rawLogEntryId(columnName: String): RowParser[Raw.LogEntryId] =
     SqlParser.get(columnName)(columnToRawLogEntryId)
 
-  def rawValue(columnName: String): RowParser[Raw.Value] =
-    SqlParser.get(columnName)(columnToRawValue)
+  def rawEnvelope(columnName: String): RowParser[Raw.Envelope] =
+    SqlParser.get(columnName)(columnToRawEnvelope)
 
 }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/Queries.scala
@@ -45,7 +45,10 @@ object Queries {
     (s: PreparedStatement, index: Int, v: ByteString) =>
       s.setBinaryStream(index, v.newInput(), v.size())
 
-  implicit val rawKeyToStatement: ToStatement[Raw.Key] =
+  implicit val rawLogEntryIdToStatement: ToStatement[Raw.LogEntryId] =
+    byteStringToStatement.contramap(_.bytes)
+
+  implicit val rawStateKeyToStatement: ToStatement[Raw.StateKey] =
     byteStringToStatement.contramap(_.bytes)
 
   implicit val rawValueToStatement: ToStatement[Raw.Value] =
@@ -64,14 +67,17 @@ object Queries {
       }
     }
 
-  implicit val columnToRawKey: Column[Raw.Key] =
-    columnToByteString.map(Raw.Key.apply)
+  implicit val columnToRawLogEntryId: Column[Raw.LogEntryId] =
+    columnToByteString.map(Raw.LogEntryId.apply)
+
+  implicit val columnToRawStateKey: Column[Raw.StateKey] =
+    columnToByteString.map(Raw.StateKey.apply)
 
   implicit val columnToRawValue: Column[Raw.Value] =
     columnToByteString.map(Raw.Value.apply)
 
-  def rawKey(columnName: String): RowParser[Raw.Key] =
-    SqlParser.get(columnName)(columnToRawKey)
+  def rawLogEntryId(columnName: String): RowParser[Raw.LogEntryId] =
+    SqlParser.get(columnName)(columnToRawLogEntryId)
 
   def rawValue(columnName: String): RowParser[Raw.Value] =
     SqlParser.get(columnName)(columnToRawValue)

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
@@ -15,5 +15,7 @@ trait ReadQueries {
 
   def selectFromLog(start: Index, end: Index): Try[immutable.Seq[(Index, LedgerRecord)]]
 
-  def selectStateValuesByKeys(keys: Iterable[Raw.StateKey]): Try[immutable.Seq[Option[Raw.Value]]]
+  def selectStateValuesByKeys(
+      keys: Iterable[Raw.StateKey]
+  ): Try[immutable.Seq[Option[Raw.Envelope]]]
 }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/ReadQueries.scala
@@ -15,5 +15,5 @@ trait ReadQueries {
 
   def selectFromLog(start: Index, end: Index): Try[immutable.Seq[(Index, LedgerRecord)]]
 
-  def selectStateValuesByKeys(keys: Iterable[Raw.Key]): Try[immutable.Seq[Option[Raw.Value]]]
+  def selectStateValuesByKeys(keys: Iterable[Raw.StateKey]): Try[immutable.Seq[Option[Raw.Value]]]
 }

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
@@ -24,7 +24,7 @@ final class SqliteQueries(override protected implicit val connection: Connection
       .as(str("ledger_id").single)
   }
 
-  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index] =
+  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Envelope): Try[Index] =
     Try {
       SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value)"
         .executeInsert()

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/SqliteQueries.scala
@@ -24,7 +24,7 @@ final class SqliteQueries(override protected implicit val connection: Connection
       .as(str("ledger_id").single)
   }
 
-  override def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index] =
+  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index] =
     Try {
       SQL"INSERT INTO #$LogTable (entry_id, envelope) VALUES ($key, $value)"
         .executeInsert()

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
@@ -28,7 +28,7 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
 
   override def selectStateValuesByKeys(
       keys: Iterable[Raw.StateKey]
-  ): Try[immutable.Seq[Option[Raw.Value]]] =
+  ): Try[immutable.Seq[Option[Raw.Envelope]]] =
     Timed.value(
       metrics.daml.ledger.database.queries.selectStateValuesByKeys,
       delegate.selectStateValuesByKeys(keys),
@@ -40,7 +40,7 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
       delegate.updateOrRetrieveLedgerId(providedLedgerId),
     )
 
-  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index] =
+  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Envelope): Try[Index] =
     Timed.value(
       metrics.daml.ledger.database.queries.insertRecordIntoLog,
       delegate.insertRecordIntoLog(key, value),

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/TimedQueries.scala
@@ -27,7 +27,7 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
     )
 
   override def selectStateValuesByKeys(
-      keys: Iterable[Raw.Key]
+      keys: Iterable[Raw.StateKey]
   ): Try[immutable.Seq[Option[Raw.Value]]] =
     Timed.value(
       metrics.daml.ledger.database.queries.selectStateValuesByKeys,
@@ -40,13 +40,13 @@ final class TimedQueries(delegate: Queries, metrics: Metrics) extends Queries {
       delegate.updateOrRetrieveLedgerId(providedLedgerId),
     )
 
-  override def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index] =
+  override def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index] =
     Timed.value(
       metrics.daml.ledger.database.queries.insertRecordIntoLog,
       delegate.insertRecordIntoLog(key, value),
     )
 
-  override def updateState(stateUpdates: Iterable[Raw.KeyValuePair]): Try[Unit] =
+  override def updateState(stateUpdates: Iterable[Raw.StateEntry]): Try[Unit] =
     Timed.value(
       metrics.daml.ledger.database.queries.updateState,
       delegate.updateState(stateUpdates),

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 trait WriteQueries {
   def updateOrRetrieveLedgerId(providedLedgerId: LedgerId): Try[LedgerId]
 
-  def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index]
+  def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Envelope): Try[Index]
 
   def updateState(stateUpdates: Iterable[Raw.StateEntry]): Try[Unit]
 

--- a/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
+++ b/ledger/ledger-on-sql/src/main/scala/com/daml/ledger/on/sql/queries/WriteQueries.scala
@@ -12,9 +12,9 @@ import scala.util.Try
 trait WriteQueries {
   def updateOrRetrieveLedgerId(providedLedgerId: LedgerId): Try[LedgerId]
 
-  def insertRecordIntoLog(key: Raw.Key, value: Raw.Value): Try[Index]
+  def insertRecordIntoLog(key: Raw.LogEntryId, value: Raw.Value): Try[Index]
 
-  def updateState(stateUpdates: Iterable[Raw.KeyValuePair]): Try[Unit]
+  def updateState(stateUpdates: Iterable[Raw.StateEntry]): Try[Unit]
 
   def truncate(): Try[Unit]
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Envelope.scala
@@ -32,8 +32,8 @@ object Envelope {
       kind: Proto.Envelope.MessageKind,
       bytes: ByteString,
       compression: Boolean,
-  ): Raw.Value =
-    Raw.Value(
+  ): Raw.Envelope =
+    Raw.Envelope(
       Proto.Envelope.newBuilder
         .setVersion(Version.version)
         .setKind(kind)
@@ -45,31 +45,30 @@ object Envelope {
             Proto.Envelope.CompressionSchema.NONE
         )
         .build
-        .toByteString
     )
 
-  def enclose(sub: Proto.DamlSubmission): Raw.Value =
+  def enclose(sub: Proto.DamlSubmission): Raw.Envelope =
     enclose(sub, compression = DefaultCompression)
 
-  def enclose(sub: Proto.DamlSubmission, compression: Boolean): Raw.Value =
+  def enclose(sub: Proto.DamlSubmission, compression: Boolean): Raw.Envelope =
     enclose(Proto.Envelope.MessageKind.SUBMISSION, sub.toByteString, compression)
 
-  def enclose(logEntry: Proto.DamlLogEntry): Raw.Value =
+  def enclose(logEntry: Proto.DamlLogEntry): Raw.Envelope =
     enclose(logEntry, compression = DefaultCompression)
 
-  def enclose(logEntry: Proto.DamlLogEntry, compression: Boolean): Raw.Value =
+  def enclose(logEntry: Proto.DamlLogEntry, compression: Boolean): Raw.Envelope =
     enclose(Proto.Envelope.MessageKind.LOG_ENTRY, logEntry.toByteString, compression)
 
-  def enclose(stateValue: Proto.DamlStateValue): Raw.Value =
+  def enclose(stateValue: Proto.DamlStateValue): Raw.Envelope =
     enclose(stateValue, compression = DefaultCompression)
 
-  def enclose(stateValue: Proto.DamlStateValue, compression: Boolean): Raw.Value =
+  def enclose(stateValue: Proto.DamlStateValue, compression: Boolean): Raw.Envelope =
     enclose(Proto.Envelope.MessageKind.STATE_VALUE, stateValue.toByteString, compression)
 
-  def enclose(batch: Proto.DamlSubmissionBatch): Raw.Value =
+  def enclose(batch: Proto.DamlSubmissionBatch): Raw.Envelope =
     enclose(Proto.Envelope.MessageKind.SUBMISSION_BATCH, batch.toByteString, compression = false)
 
-  def open(envelopeBytes: Raw.Value): Either[String, Message] =
+  def open(envelopeBytes: Raw.Envelope): Either[String, Message] =
     openWithParser(() => Proto.Envelope.parseFrom(envelopeBytes.bytes))
 
   def open(envelopeBytes: Array[Byte]): Either[String, Message] =
@@ -109,13 +108,13 @@ object Envelope {
       }
     } yield message
 
-  def openLogEntry(envelopeBytes: Raw.Value): Either[String, Proto.DamlLogEntry] =
+  def openLogEntry(envelopeBytes: Raw.Envelope): Either[String, Proto.DamlLogEntry] =
     open(envelopeBytes).flatMap {
       case LogEntryMessage(entry) => Right(entry)
       case msg => Left(s"Expected log entry, got ${msg.getClass}")
     }
 
-  def openSubmission(envelopeBytes: Raw.Value): Either[String, Proto.DamlSubmission] =
+  def openSubmission(envelopeBytes: Raw.Envelope): Either[String, Proto.DamlSubmission] =
     open(envelopeBytes).flatMap {
       case SubmissionMessage(entry) => Right(entry)
       case msg => Left(s"Expected submission, got ${msg.getClass}")
@@ -127,7 +126,7 @@ object Envelope {
       case msg => Left(s"Expected submission, got ${msg.getClass}")
     }
 
-  def openStateValue(envelopeBytes: Raw.Value): Either[String, Proto.DamlStateValue] =
+  def openStateValue(envelopeBytes: Raw.Envelope): Either[String, Proto.DamlStateValue] =
     open(envelopeBytes).flatMap {
       case StateValueMessage(entry) => Right(entry)
       case msg => Left(s"Expected state value, got ${msg.getClass}")

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -21,11 +21,19 @@ object Raw {
     /** This implicit conversion exists to aid in migration.
       * It will be deprecated and subsequently removed in the future.
       */
+    @deprecated(
+      "Please use `Raw` directly. This will be removed in DAML SDK v1.12.",
+      since = "1.11",
+    )
     implicit def `ByteString to Raw.Bytes`(bytes: ByteString): Bytes = Unknown(bytes)
 
     /** This implicit conversion exists to aid in migration.
       * It will be deprecated and subsequently removed in the future.
       */
+    @deprecated(
+      "Please use `#bytes` directly. This will be removed in DAML SDK v1.12.",
+      since = "1.11",
+    )
     implicit def `Raw.Bytes to ByteString`(raw: Bytes): ByteString = raw.bytes
   }
 
@@ -38,25 +46,39 @@ object Raw {
     /** This implicit conversion exists to aid in migration.
       * It will be deprecated and subsequently removed in the future.
       */
+    @deprecated(
+      "Please use `Raw` directly. This will be removed in DAML SDK v1.12.",
+      since = "1.11",
+    )
     implicit def `ByteString to Self`(bytes: ByteString): Self = apply(bytes)
 
     /** This implicit conversion exists to aid in migration.
       * It will be deprecated and subsequently removed in the future.
       */
+    @deprecated(
+      "Please use `Raw` directly. This will be removed in DAML SDK v1.12.",
+      since = "1.11",
+    )
     implicit def `Raw.Bytes to Self`(rawBytes: Bytes): Self = apply(rawBytes.bytes)
 
   }
 
   /** This case class only exists to preserve some functionality of
     * [[com.daml.ledger.participant.state.kvutils.Bytes]].
-    *
-    * It will be removed in the future.
     */
+  @deprecated(
+    "Please migrate to another `Raw` type. This will be removed in DAML SDK v1.12.",
+    since = "1.11",
+  )
   private final case class Unknown(override val bytes: ByteString) extends Bytes
 
   trait Key extends Bytes
 
   object Key extends Companion[Key] {
+    @deprecated(
+      "Please migrate to one of `Raw.LogEntryId` or `Raw.StateKey`. This will be removed in DAML SDK v1.12.",
+      since = "1.11",
+    )
     def apply(bytes: ByteString): Key =
       UnknownKey(bytes)
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -85,12 +85,22 @@ object Raw {
       Key.`Key Ordering`.on(identity)
   }
 
-  final case class Value(override val bytes: ByteString) extends Bytes
+  trait Value extends Bytes
 
-  object Value extends Companion[Value]
+  object Value extends Companion[Value] {
+    def apply(bytes: ByteString): Value =
+      Envelope(bytes)
+  }
 
-  type LogEntry = (LogEntryId, Value)
+  final case class Envelope(override val bytes: ByteString) extends Value
 
-  type StateEntry = (StateKey, Value)
+  object Envelope extends Companion[Envelope] {
+    def apply(envelope: DamlKvutils.Envelope): Envelope =
+      apply(envelope.toByteString)
+  }
+
+  type LogEntry = (LogEntryId, Envelope)
+
+  type StateEntry = (StateKey, Envelope)
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/BatchingLedgerWriter.scala
@@ -43,7 +43,7 @@ class BatchingLedgerWriter(val queue: BatchingQueue, val writer: LedgerWriter)(
     */
   override def commit(
       correlationId: String,
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       metadata: CommitMetadata,
   ): Future[SubmissionResult] =
     queueHandle.offer(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/CommitMetadata.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/CommitMetadata.scala
@@ -19,9 +19,9 @@ sealed trait CommitMetadata {
     */
   def estimatedInterpretationCost: Option[Long]
 
-  def inputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Raw.Key]
+  def inputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Raw.StateKey]
 
-  def outputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Raw.Key]
+  def outputKeys(serializationStrategy: StateKeySerializationStrategy): Iterable[Raw.StateKey]
 }
 
 object CommitMetadata {
@@ -31,11 +31,11 @@ object CommitMetadata {
 
       override def inputKeys(
           serializationStrategy: StateKeySerializationStrategy
-      ): Iterable[Raw.Key] = Iterable.empty
+      ): Iterable[Raw.StateKey] = Iterable.empty
 
       override def outputKeys(
           serializationStrategy: StateKeySerializationStrategy
-      ): Iterable[Raw.Key] = Iterable.empty
+      ): Iterable[Raw.StateKey] = Iterable.empty
     }
 
   def apply(
@@ -46,7 +46,7 @@ object CommitMetadata {
 
     override def inputKeys(
         serializationStrategy: StateKeySerializationStrategy
-    ): Iterable[Raw.Key] =
+    ): Iterable[Raw.StateKey] =
       submission.getInputDamlStateList.asScala
         .map(serializationStrategy.serializeStateKey)
 
@@ -54,7 +54,7 @@ object CommitMetadata {
 
     override def outputKeys(
         serializationStrategy: StateKeySerializationStrategy
-    ): Iterable[Raw.Key] =
+    ): Iterable[Raw.StateKey] =
       submissionOutputs.map(serializationStrategy.serializeStateKey)
   }
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooser.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooser.scala
@@ -33,7 +33,7 @@ final class InterpretationCostBasedLedgerWriterChooser(
 
   override def commit(
       correlationId: String,
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       metadata: CommitMetadata,
   ): Future[SubmissionResult] = {
     val estimatedInterpretationCost = metadata.estimatedInterpretationCost.getOrElse(0L)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerRecord.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerRecord.scala
@@ -12,4 +12,4 @@ import com.daml.ledger.participant.state.v1.Offset
   * @param entryId  opaque ID of log entry
   * @param envelope opaque contents of log entry
   */
-final case class LedgerRecord(offset: Offset, entryId: Raw.LogEntryId, envelope: Raw.Value)
+final case class LedgerRecord(offset: Offset, entryId: Raw.LogEntryId, envelope: Raw.Envelope)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerRecord.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerRecord.scala
@@ -12,4 +12,4 @@ import com.daml.ledger.participant.state.v1.Offset
   * @param entryId  opaque ID of log entry
   * @param envelope opaque contents of log entry
   */
-final case class LedgerRecord(offset: Offset, entryId: Raw.Key, envelope: Raw.Value)
+final case class LedgerRecord(offset: Offset, entryId: Raw.LogEntryId, envelope: Raw.Value)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/LedgerWriter.scala
@@ -30,7 +30,7 @@ trait LedgerWriter extends ReportsHealth {
     */
   def commit(
       correlationId: String,
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       metadata: CommitMetadata,
   ): Future[SubmissionResult]
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/TimedLedgerWriter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/TimedLedgerWriter.scala
@@ -17,7 +17,7 @@ class TimedLedgerWriter(delegate: LedgerWriter, metrics: Metrics) extends Ledger
 
   override def commit(
       correlationId: String,
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       metadata: CommitMetadata,
   ): Future[SubmissionResult] =
     Timed.future(

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/api/package.scala
@@ -66,7 +66,7 @@ package object api {
 
       override def commit(
           correlationId: String,
-          envelope: Raw.Value,
+          envelope: Raw.Envelope,
           metadata: CommitMetadata,
       ): Future[SubmissionResult] =
         writer.commit(correlationId, envelope, metadata)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
@@ -49,7 +49,7 @@ final class ProtobufBasedLedgerDataImporter(input: InputStream)
 
   private def parseWriteSet(entry: LedgerExportEntry): WriteSet =
     entry.getWriteSetList.asScala.view
-      .map(writeEntry => Raw.Key(writeEntry.getKey) -> Raw.Value(writeEntry.getValue))
+      .map(writeEntry => Raw.UnknownKey(writeEntry.getKey) -> Raw.Value(writeEntry.getValue))
       .toVector
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/ProtobufBasedLedgerDataImporter.scala
@@ -42,14 +42,14 @@ final class ProtobufBasedLedgerDataImporter(input: InputStream)
     SubmissionInfo(
       ParticipantId.assertFromString(entrySubmissionInfo.getParticipantId),
       entrySubmissionInfo.getCorrelationId,
-      Raw.Value(entrySubmissionInfo.getSubmissionEnvelope),
+      Raw.Envelope(entrySubmissionInfo.getSubmissionEnvelope),
       Conversions.parseInstant(entrySubmissionInfo.getRecordTime),
     )
   }
 
   private def parseWriteSet(entry: LedgerExportEntry): WriteSet =
     entry.getWriteSetList.asScala.view
-      .map(writeEntry => Raw.UnknownKey(writeEntry.getKey) -> Raw.Value(writeEntry.getValue))
+      .map(writeEntry => Raw.UnknownKey(writeEntry.getKey) -> Raw.Envelope(writeEntry.getValue))
       .toVector
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregatorWriteOperations.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregatorWriteOperations.scala
@@ -12,7 +12,7 @@ final class SubmissionAggregatorWriteOperations(builder: SubmissionAggregator.Wr
     extends LedgerStateWriteOperations[Unit] {
 
   override def writeState(
-      key: Raw.Key,
+      key: Raw.StateKey,
       value: Raw.Value,
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     Future {
@@ -20,14 +20,14 @@ final class SubmissionAggregatorWriteOperations(builder: SubmissionAggregator.Wr
     }
 
   override def writeState(
-      keyValuePairs: Iterable[(Raw.Key, Raw.Value)]
+      keyValuePairs: Iterable[Raw.StateEntry]
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     Future {
       builder ++= keyValuePairs
     }
 
   override def appendToLog(
-      key: Raw.Key,
+      key: Raw.LogEntryId,
       value: Raw.Value,
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     Future {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregatorWriteOperations.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionAggregatorWriteOperations.scala
@@ -13,7 +13,7 @@ final class SubmissionAggregatorWriteOperations(builder: SubmissionAggregator.Wr
 
   override def writeState(
       key: Raw.StateKey,
-      value: Raw.Value,
+      value: Raw.Envelope,
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     Future {
       builder += key -> value
@@ -28,7 +28,7 @@ final class SubmissionAggregatorWriteOperations(builder: SubmissionAggregator.Wr
 
   override def appendToLog(
       key: Raw.LogEntryId,
-      value: Raw.Value,
+      value: Raw.Envelope,
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     Future {
       builder += key -> value

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/SubmissionInfo.scala
@@ -11,6 +11,6 @@ import com.daml.ledger.participant.state.v1.ParticipantId
 case class SubmissionInfo(
     participantId: ParticipantId,
     correlationId: CorrelationId,
-    submissionEnvelope: Raw.Value,
+    submissionEnvelope: Raw.Envelope,
     recordTimeInstant: Instant,
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
@@ -7,7 +7,7 @@ package object export {
 
   val header = new Header(version = "v2")
 
-  type WriteItem = (Raw.Key, Raw.Value)
+  type WriteItem = (Raw.Key, Raw.Envelope)
 
   type WriteSet = collection.Seq[WriteItem]
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/export/package.scala
@@ -7,7 +7,7 @@ package object export {
 
   val header = new Header(version = "v2")
 
-  type WriteItem = Raw.KeyValuePair
+  type WriteItem = (Raw.Key, Raw.Value)
 
   type WriteSet = collection.Seq[WriteItem]
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -28,9 +28,11 @@ import com.daml.metrics.MetricName
   */
 package object kvutils {
 
-  /** Alias for [[Raw.Bytes]] to aid in migration.
-    * It will be deprecated and subsequently removed in the future.
-    */
+  /** Alias for [[Raw.Bytes]] to aid in migration. */
+  @deprecated(
+    "Please migrate to one of the `Raw` types. This will be removed in DAML SDK v1.12.",
+    since = "1.11",
+  )
   type Bytes = Raw.Bytes
 
   type DamlStateMap = Map[DamlStateKey, Option[DamlStateValue]]

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CombinedLedgerStateWriteOperations.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CombinedLedgerStateWriteOperations.scala
@@ -15,7 +15,7 @@ final class CombinedLedgerStateWriteOperations[ALogResult, BLogResult, LogResult
 
   override def writeState(
       key: Raw.StateKey,
-      value: Raw.Value,
+      value: Raw.Envelope,
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     inParallel(a.writeState(key, value), b.writeState(key, value)).map(_ => ())
 
@@ -26,7 +26,7 @@ final class CombinedLedgerStateWriteOperations[ALogResult, BLogResult, LogResult
 
   override def appendToLog(
       key: Raw.LogEntryId,
-      value: Raw.Value,
+      value: Raw.Envelope,
   )(implicit executionContext: ExecutionContext): Future[LogResult] =
     inParallel(a.appendToLog(key, value), b.appendToLog(key, value)).map {
       case (aResult, bResult) => combineLogResults(aResult, bResult)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CombinedLedgerStateWriteOperations.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/CombinedLedgerStateWriteOperations.scala
@@ -14,18 +14,18 @@ final class CombinedLedgerStateWriteOperations[ALogResult, BLogResult, LogResult
 ) extends LedgerStateWriteOperations[LogResult] {
 
   override def writeState(
-      key: Raw.Key,
+      key: Raw.StateKey,
       value: Raw.Value,
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     inParallel(a.writeState(key, value), b.writeState(key, value)).map(_ => ())
 
   override def writeState(
-      keyValuePairs: Iterable[(Raw.Key, Raw.Value)]
+      keyValuePairs: Iterable[Raw.StateEntry]
   )(implicit executionContext: ExecutionContext): Future[Unit] =
     inParallel(a.writeState(keyValuePairs), b.writeState(keyValuePairs)).map(_ => ())
 
   override def appendToLog(
-      key: Raw.Key,
+      key: Raw.LogEntryId,
       value: Raw.Value,
   )(implicit executionContext: ExecutionContext): Future[LogResult] =
     inParallel(a.appendToLog(key, value), b.appendToLog(key, value)).map {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DefaultStateKeySerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/DefaultStateKeySerializationStrategy.scala
@@ -9,9 +9,9 @@ import com.daml.ledger.participant.state.kvutils.Raw
 /** Default state key serialization strategy that does not prefix keys.
   */
 object DefaultStateKeySerializationStrategy extends StateKeySerializationStrategy {
-  override def serializeStateKey(key: DamlStateKey): Raw.Key =
-    Raw.Key(key.toByteString)
+  override def serializeStateKey(key: DamlStateKey): Raw.StateKey =
+    Raw.StateKey(key)
 
-  override def deserializeStateKey(input: Raw.Key): DamlStateKey =
+  override def deserializeStateKey(input: Raw.StateKey): DamlStateKey =
     DamlStateKey.parseFrom(input.bytes)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -89,14 +89,18 @@ trait LedgerStateOperations[+LogResult]
 
 object LedgerStateOperations {
 
-  /** Alias for [[Raw.Key]] to aid in migration.
-    * It will be deprecated and subsequently removed in the future.
-    */
+  /** Alias for [[Raw.Key]] to aid in migration. */
+  @deprecated(
+    "Please migrate to one of `Raw.LogEntryId` or `Raw.StateKey`. This will be removed in DAML SDK v1.12.",
+    since = "1.11",
+  )
   type Key = Raw.Key
 
-  /** Alias for [[Raw.Envelope]] to aid in migration.
-    * It will be deprecated and subsequently removed in the future.
-    */
+  /** Alias for [[Raw.Envelope]] to aid in migration. */
+  @deprecated(
+    "Please migrate to `Raw.Envelope`. This will be removed in DAML SDK v1.12.",
+    since = "1.11",
+  )
   type Value = Raw.Envelope
 
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LogAppendingCommitStrategy.scala
@@ -31,7 +31,7 @@ class LogAppendingCommitStrategy[Index](
       outputState: Map[DamlStateKey, DamlStateValue],
       writeSetBuilder: Option[SubmissionAggregator.WriteSetBuilder] = None,
   ): Future[Index] = {
-    val logEntryKey = Raw.Key(entryId.toByteString)
+    val rawLogEntryId = Raw.LogEntryId(entryId)
     for {
       (serializedKeyValuePairs, envelopedLogEntry) <- inParallel(
         Future(stateSerializationStrategy.serializeStateUpdates(outputState)),
@@ -46,10 +46,10 @@ class LogAppendingCommitStrategy[Index](
         Future {
           writeSetBuilder.foreach { builder =>
             builder ++= serializedKeyValuePairs
-            builder += logEntryKey -> envelopedLogEntry
+            builder += rawLogEntryId -> envelopedLogEntry
           }
         },
-        ledgerStateOperations.appendToLog(logEntryKey, envelopedLogEntry),
+        ledgerStateOperations.appendToLog(rawLogEntryId, envelopedLogEntry),
       )
     } yield index
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapter.scala
@@ -25,7 +25,7 @@ final class RawToDamlLedgerStateReaderAdapter(
 }
 
 object RawToDamlLedgerStateReaderAdapter {
-  private[validator] val deserializeDamlStateValue: Raw.Value => DamlStateValue =
+  private[validator] val deserializeDamlStateValue: Raw.Envelope => DamlStateValue =
     Envelope
       .openStateValue(_)
       .getOrElse(sys.error("Opening enveloped DamlStateValue failed"))

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateKeySerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateKeySerializationStrategy.scala
@@ -9,9 +9,9 @@ import com.daml.ledger.participant.state.kvutils.Raw
 /** Determines how we namespace and serialize state keys.
   */
 trait StateKeySerializationStrategy {
-  def serializeStateKey(key: DamlStateKey): Raw.Key
+  def serializeStateKey(key: DamlStateKey): Raw.StateKey
 
-  def deserializeStateKey(input: Raw.Key): DamlStateKey
+  def deserializeStateKey(input: Raw.StateKey): DamlStateKey
 }
 
 object StateKeySerializationStrategy {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
@@ -15,8 +15,8 @@ final class StateSerializationStrategy(keyStrategy: StateKeySerializationStrateg
 
   def serializeStateUpdates(
       state: Map[DamlStateKey, DamlStateValue]
-  ): SortedMap[Raw.StateKey, Raw.Value] =
-    implicitly[Factory[Raw.StateEntry, SortedMap[Raw.StateKey, Raw.Value]]]
+  ): SortedMap[Raw.StateKey, Raw.Envelope] =
+    implicitly[Factory[Raw.StateEntry, SortedMap[Raw.StateKey, Raw.Envelope]]]
       .fromSpecific(state.view.map { case (key, value) =>
         serializeState(key, value)
       })

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/StateSerializationStrategy.scala
@@ -6,17 +6,17 @@ package com.daml.ledger.validator
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlStateKey, DamlStateValue}
 import com.daml.ledger.participant.state.kvutils.{Envelope, Raw}
 
-import scala.collection.compat._
 import scala.collection.SortedMap
+import scala.collection.compat._
 
 final class StateSerializationStrategy(keyStrategy: StateKeySerializationStrategy) {
-  def serializeState(key: DamlStateKey, value: DamlStateValue): Raw.KeyValuePair =
+  def serializeState(key: DamlStateKey, value: DamlStateValue): Raw.StateEntry =
     (keyStrategy.serializeStateKey(key), Envelope.enclose(value))
 
   def serializeStateUpdates(
       state: Map[DamlStateKey, DamlStateValue]
-  ): SortedMap[Raw.Key, Raw.Value] =
-    implicitly[Factory[Raw.KeyValuePair, SortedMap[Raw.Key, Raw.Value]]]
+  ): SortedMap[Raw.StateKey, Raw.Value] =
+    implicitly[Factory[Raw.StateEntry, SortedMap[Raw.StateKey, Raw.Value]]]
       .fromSpecific(state.view.map { case (key, value) =>
         serializeState(key, value)
       })

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/SubmissionValidator.scala
@@ -51,7 +51,7 @@ class SubmissionValidator[LogResult] private[validator] (
   private val timedLedgerStateAccess = new TimedLedgerStateAccess(ledgerStateAccess)
 
   def validate(
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       correlationId: String,
       recordTime: Timestamp,
       participantId: ParticipantId,
@@ -68,7 +68,7 @@ class SubmissionValidator[LogResult] private[validator] (
     }
 
   def validateAndCommit(
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       correlationId: String,
       recordTime: Timestamp,
       participantId: ParticipantId,
@@ -78,7 +78,7 @@ class SubmissionValidator[LogResult] private[validator] (
     }
 
   private[validator] def validateAndCommitWithContext(
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       correlationId: String,
       recordTime: Timestamp,
       participantId: ParticipantId,
@@ -96,7 +96,7 @@ class SubmissionValidator[LogResult] private[validator] (
     )
 
   def validateAndTransform[U](
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       correlationId: String,
       recordTime: Timestamp,
       participantId: ParticipantId,
@@ -140,7 +140,7 @@ class SubmissionValidator[LogResult] private[validator] (
 
   @tailrec
   private def runValidation[T](
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       correlationId: String,
       recordTime: Timestamp,
       participantId: ParticipantId,
@@ -165,7 +165,7 @@ class SubmissionValidator[LogResult] private[validator] (
         batch.getSubmissionsList.asScala.toList match {
           case correlatedSubmission :: Nil =>
             runValidation(
-              Raw.Value(correlatedSubmission.getSubmission),
+              Raw.Envelope(correlatedSubmission.getSubmission),
               correlatedSubmission.getCorrelationId,
               recordTime,
               participantId,
@@ -380,12 +380,12 @@ object SubmissionValidator {
 
   private[validator] def serializeProcessedSubmission(
       logEntryAndState: LogEntryAndState
-  ): (Raw.Value, Seq[Raw.StateEntry]) = {
+  ): (Raw.Envelope, Seq[Raw.StateEntry]) = {
     val (logEntry, damlStateUpdates) = logEntryAndState
     val rawStateUpdates =
       damlStateUpdates
         .map { case (key, value) =>
-          rawKey(key) -> rawValue(value)
+          rawKey(key) -> rawEnvelope(value)
         }
         .toSeq
         .sortBy(_._1)
@@ -395,10 +395,10 @@ object SubmissionValidator {
   private[validator] def rawKey(damlStateKey: DamlStateKey): Raw.StateKey =
     Raw.StateKey(damlStateKey)
 
-  private[validator] def rawValue(value: DamlStateValue): Raw.Value =
+  private[validator] def rawEnvelope(value: DamlStateValue): Raw.Envelope =
     Envelope.enclose(value)
 
-  private[validator] def stateValueFromRaw(value: Raw.Value): DamlStateValue =
+  private[validator] def stateValueFromRaw(value: Raw.Envelope): DamlStateValue =
     Envelope
       .openStateValue(value)
       .fold(message => throw new IllegalStateException(message), identity)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidatingCommitter.scala
@@ -11,8 +11,8 @@ import com.daml.ledger.validator.ValidationFailed.{MissingInputState, Validation
 import com.daml.lf.data.Time.Timestamp
 import com.daml.logging.LoggingContext.newLoggingContext
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 
 /** Orchestrates committing to a ledger after validating the submission.
   * Example usage, assuming a [[com.daml.ledger.participant.state.kvutils.api.LedgerWriter]] sends the submission over
@@ -46,7 +46,7 @@ class ValidatingCommitter[LogResult](
 ) {
   def commit(
       correlationId: String,
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       submittingParticipantId: ParticipantId,
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =
     newLoggingContext("correlationId" -> correlationId) { implicit loggingContext =>

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidationFailed.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/ValidationFailed.scala
@@ -11,7 +11,7 @@ sealed trait ValidationFailed extends RuntimeException with NoStackTrace
 
 object ValidationFailed {
 
-  final case class MissingInputState(keys: Seq[Raw.Key]) extends ValidationFailed
+  final case class MissingInputState(keys: Seq[Raw.StateKey]) extends ValidationFailed
 
   final case class ValidationError(reason: String) extends ValidationFailed
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidator.scala
@@ -66,7 +66,7 @@ object BatchedSubmissionValidator {
   // instead and remove the whole concept of log entry identifiers.
   // For now this implementation uses a sha256 hash of the submission envelope in order to generate
   // deterministic log entry IDs.
-  private[validator] def rawToLogEntryId(value: Raw.Value): DamlLogEntryId = {
+  private[validator] def rawToLogEntryId(value: Raw.Envelope): DamlLogEntryId = {
     val messageDigest = MessageDigest
       .getInstance("SHA-256")
     messageDigest.update(value.bytes.asReadOnlyByteBuffer())
@@ -115,7 +115,7 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
     * been committed. It is up to the caller to discard, or not to, a partially successful batch.
     */
   def validateAndCommit(
-      submissionEnvelope: Raw.Value,
+      submissionEnvelope: Raw.Envelope,
       correlationId: CorrelationId,
       recordTimeInstant: Instant,
       participantId: ParticipantId,
@@ -176,7 +176,7 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
     }
 
   private def singleSubmissionSource(
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
       submission: DamlSubmission,
       correlationId: CorrelationId,
   ): Source[Inputs, NotUsed] = {
@@ -201,7 +201,7 @@ class BatchedSubmissionValidator[CommitResult] private[validator] (
             metrics.decode,
             metrics.decodeRunning,
             Future {
-              val rawEnvelope = Raw.Value(submissionEnvelope)
+              val rawEnvelope = Raw.Envelope(submissionEnvelope)
               val submission = Envelope
                 .openSubmission(rawEnvelope)
                 .fold(error => throw validator.ValidationFailed.ValidationError(error), identity)

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -37,7 +37,7 @@ object BatchedSubmissionValidatorFactory {
   class LedgerStateReaderAdapter[LogResult](delegate: LedgerStateOperations[LogResult])
       extends LedgerStateReader {
     override def read(
-        keys: Iterable[Raw.Key]
+        keys: Iterable[Raw.StateKey]
     )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
       delegate.readState(keys)
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorFactory.scala
@@ -38,7 +38,7 @@ object BatchedSubmissionValidatorFactory {
       extends LedgerStateReader {
     override def read(
         keys: Iterable[Raw.StateKey]
-    )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
+    )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Envelope]]] =
       delegate.readState(keys)
   }
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitter.scala
@@ -57,7 +57,7 @@ class BatchedValidatingCommitter[LogResult](
 
   def commit(
       correlationId: String,
-      submissionEnvelope: Raw.Value,
+      submissionEnvelope: Raw.Envelope,
       submittingParticipantId: ParticipantId,
       ledgerStateOperations: LedgerStateOperations[LogResult],
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] = {

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/package.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 package object validator {
   type SubmittingParticipantId = ParticipantId
 
-  type StateValueCache = ConcurrentCache[Raw.Value, DamlStateValue]
+  type StateValueCache = ConcurrentCache[Raw.Envelope, DamlStateValue]
 
   // At some point, someone much smarter than the author of this code will reimplement the usages of
   // `inParallel` using Cats or Scalaz.

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidator.scala
@@ -40,7 +40,7 @@ class PreExecutingSubmissionValidator[StateValue, ReadSet, WriteSet](
   private val logger = ContextualizedLogger.get(getClass)
 
   def validate(
-      submissionEnvelope: Raw.Value,
+      submissionEnvelope: Raw.Envelope,
       submittingParticipantId: ParticipantId,
       ledgerStateReader: StateReader[DamlStateKey, StateValue],
   )(implicit
@@ -82,7 +82,7 @@ class PreExecutingSubmissionValidator[StateValue, ReadSet, WriteSet](
       },
     )
 
-  private def decodeSubmission(submissionEnvelope: Raw.Value)(implicit
+  private def decodeSubmission(submissionEnvelope: Raw.Envelope)(implicit
       executionContext: ExecutionContext,
       loggingContext: LoggingContext,
   ): Future[DamlSubmission] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/PreExecutingValidatingCommitter.scala
@@ -58,7 +58,7 @@ class PreExecutingValidatingCommitter[StateValue, ReadSet, WriteSet](
   def commit(
       submittingParticipantId: ParticipantId,
       correlationId: String,
-      submissionEnvelope: Raw.Value,
+      submissionEnvelope: Raw.Envelope,
       exportRecordTime: Instant,
       ledgerStateAccess: LedgerStateAccess[Any],
   )(implicit executionContext: ExecutionContext): Future[SubmissionResult] =

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.participant.state.kvutils.Raw
 /** Raw key-value pairs with a distinct log entry.
   */
 case class RawKeyValuePairsWithLogEntry(
-    state: Iterable[Raw.KeyValuePair],
-    logEntryKey: Raw.Key,
+    state: Iterable[Raw.StateEntry],
+    logEntryKey: Raw.LogEntryId,
     logEntryValue: Raw.Value,
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/preexecution/RawKeyValuePairsWithLogEntry.scala
@@ -10,5 +10,5 @@ import com.daml.ledger.participant.state.kvutils.Raw
 case class RawKeyValuePairsWithLogEntry(
     state: Iterable[Raw.StateEntry],
     logEntryKey: Raw.LogEntryId,
-    logEntryValue: Raw.Value,
+    logEntryValue: Raw.Envelope,
 )

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
@@ -10,9 +10,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 final class LedgerStateOperationsReaderAdapter[LogResult](
     operations: LedgerStateOperations[LogResult]
-) extends StateReader[Raw.StateKey, Option[Raw.Value]] {
+) extends StateReader[Raw.StateKey, Option[Raw.Envelope]] {
   override def read(
       keys: Iterable[Raw.StateKey]
-  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
+  )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Envelope]]] =
     operations.readState(keys)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/LedgerStateOperationsReaderAdapter.scala
@@ -10,9 +10,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 final class LedgerStateOperationsReaderAdapter[LogResult](
     operations: LedgerStateOperations[LogResult]
-) extends StateReader[Raw.Key, Option[Raw.Value]] {
+) extends StateReader[Raw.StateKey, Option[Raw.Value]] {
   override def read(
-      keys: Iterable[Raw.Key]
+      keys: Iterable[Raw.StateKey]
   )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
     operations.readState(keys)
 }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.participant.state.kvutils.Raw
 
 package object reading {
 
-  type LedgerStateReader = StateReader[Raw.StateKey, Option[Raw.Value]]
+  type LedgerStateReader = StateReader[Raw.StateKey, Option[Raw.Envelope]]
 
   type DamlLedgerStateReader = StateReader[DamlStateKey, Option[DamlStateValue]]
 

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/reading/package.scala
@@ -8,7 +8,7 @@ import com.daml.ledger.participant.state.kvutils.Raw
 
 package object reading {
 
-  type LedgerStateReader = StateReader[Raw.Key, Option[Raw.Value]]
+  type LedgerStateReader = StateReader[Raw.StateKey, Option[Raw.Value]]
 
   type DamlLedgerStateReader = StateReader[DamlStateKey, Option[DamlStateValue]]
 

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
@@ -84,6 +84,6 @@ object LedgerDataExportSpecBase {
     recordTimeInstant = Instant.ofEpochSecond(123456, 123456789),
   )
 
-  private def keyValuePairOf(key: String, value: String): Raw.KeyValuePair =
-    Raw.Key(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
+  private def keyValuePairOf(key: String, value: String): (Raw.Key, Raw.Value) =
+    Raw.UnknownKey(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
@@ -84,6 +84,6 @@ object LedgerDataExportSpecBase {
     recordTimeInstant = Instant.ofEpochSecond(123456, 123456789),
   )
 
-  private def keyValuePairOf(key: String, value: String): (Raw.Key, Raw.Value) =
+  private def keyValuePairOf(key: String, value: String): (Raw.Key, Raw.Envelope) =
     Raw.UnknownKey(ByteString.copyFromUtf8(key)) -> Raw.Envelope(ByteString.copyFromUtf8(value))
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/participant/state/kvutils/export/LedgerDataExportSpecBase.scala
@@ -80,10 +80,10 @@ object LedgerDataExportSpecBase {
   private def someSubmissionInfo(): SubmissionInfo = SubmissionInfo(
     participantId = v1.ParticipantId.assertFromString("id"),
     correlationId = "parent",
-    submissionEnvelope = Raw.Value(ByteString.copyFromUtf8("an envelope")),
+    submissionEnvelope = Raw.Envelope(ByteString.copyFromUtf8("an envelope")),
     recordTimeInstant = Instant.ofEpochSecond(123456, 123456789),
   )
 
   private def keyValuePairOf(key: String, value: String): (Raw.Key, Raw.Value) =
-    Raw.UnknownKey(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
+    Raw.UnknownKey(ByteString.copyFromUtf8(key)) -> Raw.Envelope(ByteString.copyFromUtf8(value))
 }

--- a/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
+++ b/ledger/participant-state/kvutils/src/test/lib/scala/com/daml/ledger/validator/TestHelper.scala
@@ -41,7 +41,7 @@ private[validator] object TestHelper {
       .setSubmissionDedup(DamlSubmissionDedupKey.newBuilder.setSubmissionId("a submission ID")),
   ).map(_.build)
 
-  lazy val anInvalidEnvelope: Raw.Value = Raw.Value(ByteString.copyFromUtf8("invalid data"))
+  lazy val anInvalidEnvelope: Raw.Envelope = Raw.Envelope(ByteString.copyFromUtf8("invalid data"))
 
   def makePartySubmission(party: String): DamlSubmission = {
     val builder = DamlSubmission.newBuilder

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooserSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/InterpretationCostBasedLedgerWriterChooserSpec.scala
@@ -6,7 +6,6 @@ package com.daml.ledger.participant.state.kvutils.api
 import com.daml.ledger.api.health.{Healthy, Unhealthy}
 import com.daml.ledger.participant.state.kvutils.Raw
 import com.daml.ledger.participant.state.v1.SubmissionResult.Acknowledged
-import com.google.protobuf.ByteString
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
@@ -22,13 +21,14 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     "delegate to cheap writer in case of no estimated interpretation cost" in {
       val commitMetadata = simpleCommitMetadata(estimatedInterpretationCost = None)
       val mockWriterCheap = mock[LedgerWriter]
-      when(mockWriterCheap.commit(any[String], any[Raw.Value], any[CommitMetadata]))
+      when(mockWriterCheap.commit(any[String], any[Raw.Envelope], any[CommitMetadata]))
         .thenReturn(Future.successful(Acknowledged))
       val instance =
         new InterpretationCostBasedLedgerWriterChooser(1L, mockWriterCheap, mock[LedgerWriter])
 
       instance.commit(aCorrelationId, anEnvelope, commitMetadata).map { _ =>
-        verify(mockWriterCheap, times(1)).commit(any[String], any[Raw.Value], any[CommitMetadata])
+        verify(mockWriterCheap, times(1))
+          .commit(any[String], any[Raw.Envelope], any[CommitMetadata])
         succeed
       }
     }
@@ -36,13 +36,14 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     "delegate to cheap writer in case estimated interpretation cost is below threshold" in {
       val commitMetadata = simpleCommitMetadata(estimatedInterpretationCost = Some(1))
       val mockWriterCheap = mock[LedgerWriter]
-      when(mockWriterCheap.commit(any[String], any[Raw.Value], any[CommitMetadata]))
+      when(mockWriterCheap.commit(any[String], any[Raw.Envelope], any[CommitMetadata]))
         .thenReturn(Future.successful(Acknowledged))
       val instance =
         new InterpretationCostBasedLedgerWriterChooser(2L, mockWriterCheap, mock[LedgerWriter])
 
       instance.commit(aCorrelationId, anEnvelope, commitMetadata).map { _ =>
-        verify(mockWriterCheap, times(1)).commit(any[String], any[Raw.Value], any[CommitMetadata])
+        verify(mockWriterCheap, times(1))
+          .commit(any[String], any[Raw.Envelope], any[CommitMetadata])
         succeed
       }
     }
@@ -50,14 +51,14 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     "delegate to expensive writer in case estimated interpretation cost reaches the threshold" in {
       val commitMetadata = simpleCommitMetadata(estimatedInterpretationCost = Some(1))
       val mockWriterExpensive = mock[LedgerWriter]
-      when(mockWriterExpensive.commit(any[String], any[Raw.Value], any[CommitMetadata]))
+      when(mockWriterExpensive.commit(any[String], any[Raw.Envelope], any[CommitMetadata]))
         .thenReturn(Future.successful(Acknowledged))
       val instance =
         new InterpretationCostBasedLedgerWriterChooser(1L, mock[LedgerWriter], mockWriterExpensive)
 
       instance.commit(aCorrelationId, anEnvelope, commitMetadata).map { _ =>
         verify(mockWriterExpensive, times(1))
-          .commit(any[String], any[Raw.Value], any[CommitMetadata])
+          .commit(any[String], any[Raw.Envelope], any[CommitMetadata])
         succeed
       }
     }
@@ -65,14 +66,14 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     "delegate to expensive writer in case threshold is 0" in {
       val commitMetadata = simpleCommitMetadata(estimatedInterpretationCost = None)
       val mockWriterExpensive = mock[LedgerWriter]
-      when(mockWriterExpensive.commit(any[String], any[Raw.Value], any[CommitMetadata]))
+      when(mockWriterExpensive.commit(any[String], any[Raw.Envelope], any[CommitMetadata]))
         .thenReturn(Future.successful(Acknowledged))
       val instance =
         new InterpretationCostBasedLedgerWriterChooser(0L, mock[LedgerWriter], mockWriterExpensive)
 
       instance.commit(aCorrelationId, anEnvelope, commitMetadata).map { _ =>
         verify(mockWriterExpensive, times(1))
-          .commit(any[String], any[Raw.Value], any[CommitMetadata])
+          .commit(any[String], any[Raw.Envelope], any[CommitMetadata])
         succeed
       }
     }
@@ -95,9 +96,9 @@ class InterpretationCostBasedLedgerWriterChooserSpec
     }
   }
 
-  private def aCorrelationId = ""
+  private def aCorrelationId: String = ""
 
-  private def anEnvelope = Raw.Value(ByteString.EMPTY)
+  private def anEnvelope: Raw.Envelope = Raw.Envelope.empty
 
   private def simpleCommitMetadata(estimatedInterpretationCost: Option[Long]): CommitMetadata = {
     val mockCommitMetadata = mock[CommitMetadata]

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
@@ -158,7 +158,7 @@ class KeyValueParticipantStateReaderSpec
     }
 
     "throw in case of an invalid log entry received" in {
-      val anInvalidEnvelope = Raw.Value(ByteString.copyFrom(Array[Byte](0, 1, 2)))
+      val anInvalidEnvelope = Raw.Envelope(ByteString.copyFrom(Array[Byte](0, 1, 2)))
       val reader = readerStreamingFrom(
         offset = None,
         LedgerRecord(toOffset(0), aLogEntryId(0), anInvalidEnvelope),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/api/KeyValueParticipantStateReaderSpec.scala
@@ -261,12 +261,11 @@ object KeyValueParticipantStateReaderSpec {
         recordTime,
       )
 
-  private def aLogEntryId(index: Int): Raw.Key =
-    Raw.Key(
+  private def aLogEntryId(index: Int): Raw.LogEntryId =
+    Raw.LogEntryId(
       DamlLogEntryId.newBuilder
         .setEntryId(ByteString.copyFrom(s"id-$index".getBytes))
         .build
-        .toByteString
     )
 
   private def readerStreamingFrom(offset: Option[Offset], items: LedgerRecord*): LedgerReader = {

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -43,6 +43,6 @@ final class InMemorySubmissionAggregatorSpec extends AnyWordSpec with Matchers w
     }
   }
 
-  private def keyValuePairOf(key: String, value: String): Raw.KeyValuePair =
-    Raw.Key(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
+  private def keyValuePairOf(key: String, value: String): Raw.StateEntry =
+    Raw.StateKey(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/participant/state/kvutils/export/InMemorySubmissionAggregatorSpec.scala
@@ -18,7 +18,7 @@ final class InMemorySubmissionAggregatorSpec extends AnyWordSpec with Matchers w
       val submissionInfo = SubmissionInfo(
         ParticipantId.assertFromString("participant-id"),
         "correlation ID",
-        Raw.Value(ByteString.copyFromUtf8("the envelope")),
+        Raw.Envelope(ByteString.copyFromUtf8("the envelope")),
         Instant.now(),
       )
       val writer = mock[LedgerDataWriter]
@@ -44,5 +44,5 @@ final class InMemorySubmissionAggregatorSpec extends AnyWordSpec with Matchers w
   }
 
   private def keyValuePairOf(key: String, value: String): Raw.StateEntry =
-    Raw.StateKey(ByteString.copyFromUtf8(key)) -> Raw.Value(ByteString.copyFromUtf8(value))
+    Raw.StateKey(ByteString.copyFromUtf8(key)) -> Raw.Envelope(ByteString.copyFromUtf8(value))
 }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/LogAppendingCommitStrategySpec.scala
@@ -27,7 +27,7 @@ final class LogAppendingCommitStrategySpec
       when(
         mockLedgerStateOperations.appendToLog(
           any[Raw.LogEntryId],
-          any[Raw.Value],
+          any[Raw.Envelope],
         )(anyExecutionContext)
       ).thenReturn(Future.successful(expectedIndex))
       val instance =
@@ -40,7 +40,7 @@ final class LogAppendingCommitStrategySpec
         .commit(aParticipantId, "a correlation ID", aLogEntryId(), aLogEntry, Map.empty, Map.empty)
         .map { actualIndex =>
           verify(mockLedgerStateOperations, times(1))
-            .appendToLog(any[Raw.LogEntryId], any[Raw.Value])(anyExecutionContext)
+            .appendToLog(any[Raw.LogEntryId], any[Raw.Envelope])(anyExecutionContext)
           verify(mockLedgerStateOperations, times(0))
             .writeState(any[Iterable[Raw.StateEntry]])(anyExecutionContext)
           actualIndex should be(expectedIndex)
@@ -56,7 +56,7 @@ final class LogAppendingCommitStrategySpec
       when(
         mockLedgerStateOperations.appendToLog(
           any[Raw.LogEntryId],
-          any[Raw.Value],
+          any[Raw.Envelope],
         )(anyExecutionContext)
       ).thenReturn(Future.successful(0L))
       val mockStateKeySerializationStrategy = mock[StateKeySerializationStrategy]

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/RawToDamlLedgerStateReaderAdapterSpec.scala
@@ -31,7 +31,7 @@ class RawToDamlLedgerStateReaderAdapterSpec
         .setParty(DamlPartyAllocation.newBuilder.setDisplayName("aParty"))
         .build
       val mockReader = mock[LedgerStateReader]
-      when(mockReader.read(any[Seq[Raw.Key]])(anyExecutionContext))
+      when(mockReader.read(any[Seq[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(Envelope.enclose(expectedValue)))))
       val instance =
         new RawToDamlLedgerStateReaderAdapter(mockReader, DefaultStateKeySerializationStrategy)
@@ -44,7 +44,7 @@ class RawToDamlLedgerStateReaderAdapterSpec
 
     "throw in case of an invalid envelope returned from underlying reader" in {
       val mockReader = mock[LedgerStateReader]
-      when(mockReader.read(any[Seq[Raw.Key]])(anyExecutionContext))
+      when(mockReader.read(any[Seq[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(anInvalidEnvelope))))
       val instance =
         new RawToDamlLedgerStateReaderAdapter(mockReader, DefaultStateKeySerializationStrategy)
@@ -58,7 +58,7 @@ class RawToDamlLedgerStateReaderAdapterSpec
     "throw in case an enveloped value other than a DamlStateValue is returned from underlying reader" in {
       val notADamlStateValue = makePartySubmission("aParty")
       val mockReader = mock[LedgerStateReader]
-      when(mockReader.read(any[Seq[Raw.Key]])(anyExecutionContext))
+      when(mockReader.read(any[Seq[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(Envelope.enclose(notADamlStateValue)))))
       val instance =
         new RawToDamlLedgerStateReaderAdapter(mockReader, DefaultStateKeySerializationStrategy)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -76,7 +76,7 @@ class SubmissionValidatorSpec
       )
       instance
         .validate(
-          Raw.Value(ByteString.copyFrom(Array[Byte](1, 2, 3))),
+          Raw.Envelope(ByteString.copyFrom(Array[Byte](1, 2, 3))),
           "aCorrelationId",
           newRecordTime(),
           aParticipantId(),
@@ -119,7 +119,7 @@ class SubmissionValidatorSpec
       when(mockStateOperations.readState(any[Iterable[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val logEntryIdCaptor = ArgCaptor[Raw.LogEntryId]
-      val logEntryValueCaptor = ArgCaptor[Raw.Value]
+      val logEntryValueCaptor = ArgCaptor[Raw.Envelope]
       when(
         mockStateOperations.appendToLog(logEntryIdCaptor.capture, logEntryValueCaptor.capture)(
           anyExecutionContext
@@ -159,7 +159,7 @@ class SubmissionValidatorSpec
       val writtenKeyValuesCaptor = ArgCaptor[Seq[Raw.StateEntry]]
       when(mockStateOperations.writeState(writtenKeyValuesCaptor.capture)(anyExecutionContext))
         .thenReturn(Future.unit)
-      val logEntryCaptor = ArgCaptor[Raw.Value]
+      val logEntryCaptor = ArgCaptor[Raw.Envelope]
       when(
         mockStateOperations.appendToLog(
           any[Raw.LogEntryId],
@@ -199,7 +199,7 @@ class SubmissionValidatorSpec
       val writtenKeyValuesCaptor = ArgCaptor[Seq[Raw.StateEntry]]
       when(mockStateOperations.writeState(writtenKeyValuesCaptor.capture)(anyExecutionContext))
         .thenReturn(Future.unit)
-      val logEntryCaptor = ArgCaptor[Raw.Value]
+      val logEntryCaptor = ArgCaptor[Raw.Envelope]
       when(
         mockStateOperations.appendToLog(
           any[Raw.LogEntryId],
@@ -285,7 +285,7 @@ class SubmissionValidatorSpec
       when(
         mockStateOperations.appendToLog(
           any[Raw.LogEntryId],
-          any[Raw.Value],
+          any[Raw.Envelope],
         )(anyExecutionContext)
       ).thenReturn(Future.successful(99))
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates)
@@ -330,10 +330,10 @@ object SubmissionValidatorSpec {
     Map(key -> value)
   }
 
-  private def aStateValue(): Raw.Value =
-    SubmissionValidator.rawValue(DamlStateValue.getDefaultInstance)
+  private def aStateValue(): Raw.Envelope =
+    SubmissionValidator.rawEnvelope(DamlStateValue.getDefaultInstance)
 
-  private def anEnvelope(): Raw.Value = {
+  private def anEnvelope(): Raw.Envelope = {
     val submission = DamlSubmission
       .newBuilder()
       .setConfigurationSubmission(DamlConfigurationSubmission.getDefaultInstance)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/SubmissionValidatorSpec.scala
@@ -11,7 +11,6 @@ import com.daml.ledger.participant.state.kvutils.DamlKvutils._
 import com.daml.ledger.participant.state.kvutils.{Envelope, KeyValueCommitting, Raw}
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.ledger.validator.ArgumentMatchers.anyExecutionContext
-import com.daml.ledger.validator.SubmissionValidator.RawKeyValuePairs
 import com.daml.ledger.validator.SubmissionValidatorSpec._
 import com.daml.ledger.validator.ValidationFailed.{MissingInputState, ValidationError}
 import com.daml.lf.data.Time.Timestamp
@@ -36,7 +35,7 @@ class SubmissionValidatorSpec
   "validate" should {
     "return success in case of no errors during processing of submission" in {
       val mockStateOperations = mock[LedgerStateOperations[Unit]]
-      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
       val instance = SubmissionValidator.create(
         new FakeStateAccess(mockStateOperations),
@@ -53,7 +52,7 @@ class SubmissionValidatorSpec
 
     "signal missing input in case state cannot be retrieved" in {
       val mockStateOperations = mock[LedgerStateOperations[Unit]]
-      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(None)))
       val instance = SubmissionValidator.create(
         ledgerStateAccess = new FakeStateAccess(mockStateOperations),
@@ -91,7 +90,7 @@ class SubmissionValidatorSpec
 
     "return invalid submission in case exception is thrown during processing of submission" in {
       val mockStateOperations = mock[BatchingLedgerStateOperations[Unit]]
-      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
 
       val failingProcessSubmission: SubmissionValidator.ProcessSubmission =
@@ -117,9 +116,9 @@ class SubmissionValidatorSpec
     "write marshalled log entry to ledger" in {
       val mockStateOperations = mock[LedgerStateOperations[Int]]
       val expectedLogResult: Int = 3
-      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
-      val logEntryIdCaptor = ArgCaptor[Raw.Key]
+      val logEntryIdCaptor = ArgCaptor[Raw.LogEntryId]
       val logEntryValueCaptor = ArgCaptor[Raw.Value]
       when(
         mockStateOperations.appendToLog(logEntryIdCaptor.capture, logEntryValueCaptor.capture)(
@@ -145,9 +144,9 @@ class SubmissionValidatorSpec
             actualLogResult should be(expectedLogResult)
             verify(mockLogEntryIdGenerator, times(1)).apply()
             verify(mockStateOperations, times(0))
-              .writeState(any[Iterable[Raw.KeyValuePair]])(anyExecutionContext)
+              .writeState(any[Iterable[Raw.StateEntry]])(anyExecutionContext)
             logEntryValueCaptor.values should have size 1
-            logEntryIdCaptor.values should be(List(Raw.Key(expectedLogEntryId.toByteString)))
+            logEntryIdCaptor.values should be(List(Raw.LogEntryId(expectedLogEntryId)))
           }
         }
     }
@@ -155,16 +154,18 @@ class SubmissionValidatorSpec
     "write marshalled key-value pairs to ledger" in {
       val mockStateOperations = mock[LedgerStateOperations[Int]]
       val expectedLogResult: Int = 7
-      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
-      val writtenKeyValuesCaptor = ArgCaptor[RawKeyValuePairs]
+      val writtenKeyValuesCaptor = ArgCaptor[Seq[Raw.StateEntry]]
       when(mockStateOperations.writeState(writtenKeyValuesCaptor.capture)(anyExecutionContext))
         .thenReturn(Future.unit)
       val logEntryCaptor = ArgCaptor[Raw.Value]
       when(
-        mockStateOperations.appendToLog(any[Raw.Key], logEntryCaptor.capture)(anyExecutionContext)
-      )
-        .thenReturn(Future.successful(expectedLogResult))
+        mockStateOperations.appendToLog(
+          any[Raw.LogEntryId],
+          logEntryCaptor.capture,
+        )(anyExecutionContext)
+      ).thenReturn(Future.successful(expectedLogResult))
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates)
       val instance = new SubmissionValidator(
         ledgerStateAccess = new FakeStateAccess(mockStateOperations),
@@ -193,16 +194,18 @@ class SubmissionValidatorSpec
     "support batch with single submission" in {
       val mockStateOperations = mock[LedgerStateOperations[Int]]
       val expectedLogResult: Int = 7
-      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
-      val writtenKeyValuesCaptor = ArgCaptor[RawKeyValuePairs]
+      val writtenKeyValuesCaptor = ArgCaptor[Seq[Raw.StateEntry]]
       when(mockStateOperations.writeState(writtenKeyValuesCaptor.capture)(anyExecutionContext))
         .thenReturn(Future.unit)
       val logEntryCaptor = ArgCaptor[Raw.Value]
       when(
-        mockStateOperations.appendToLog(any[Raw.Key], logEntryCaptor.capture)(anyExecutionContext)
-      )
-        .thenReturn(Future.successful(expectedLogResult))
+        mockStateOperations.appendToLog(
+          any[Raw.LogEntryId],
+          logEntryCaptor.capture,
+        )(anyExecutionContext)
+      ).thenReturn(Future.successful(expectedLogResult))
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates)
       val instance = new SubmissionValidator(
         ledgerStateAccess = new FakeStateAccess(mockStateOperations),
@@ -275,12 +278,16 @@ class SubmissionValidatorSpec
 
     "return invalid submission if state cannot be written" in {
       val mockStateOperations = mock[LedgerStateOperations[Int]]
-      when(mockStateOperations.writeState(any[Iterable[Raw.KeyValuePair]])(anyExecutionContext))
+      when(mockStateOperations.writeState(any[Iterable[Raw.StateEntry]])(anyExecutionContext))
         .thenThrow(new IllegalArgumentException("Write error"))
-      when(mockStateOperations.readState(any[Iterable[Raw.Key]])(anyExecutionContext))
+      when(mockStateOperations.readState(any[Iterable[Raw.StateKey]])(anyExecutionContext))
         .thenReturn(Future.successful(Seq(Some(aStateValue()))))
-      when(mockStateOperations.appendToLog(any[Raw.Key], any[Raw.Value])(anyExecutionContext))
-        .thenReturn(Future.successful(99))
+      when(
+        mockStateOperations.appendToLog(
+          any[Raw.LogEntryId],
+          any[Raw.Value],
+        )(anyExecutionContext)
+      ).thenReturn(Future.successful(99))
       val logEntryAndStateResult = (aLogEntry(), someStateUpdates)
       val instance = new SubmissionValidator(
         ledgerStateAccess = new FakeStateAccess(mockStateOperations),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedSubmissionValidatorSpec.scala
@@ -350,7 +350,7 @@ object BatchedSubmissionValidatorSpec {
 
   private def createBatchSubmissionOf(
       nSubmissions: Int
-  ): (Seq[DamlSubmission], DamlSubmissionBatch, Raw.Value) = {
+  ): (Seq[DamlSubmission], DamlSubmissionBatch, Raw.Envelope) = {
     val submissions = (1 to nSubmissions).map { n =>
       makePartySubmission(s"party-$n")
     }

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitterSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/batch/BatchedValidatingCommitterSpec.scala
@@ -12,7 +12,6 @@ import com.daml.ledger.participant.state.v1.{ParticipantId, SubmissionResult}
 import com.daml.ledger.validator.TestHelper.aParticipantId
 import com.daml.ledger.validator.reading.DamlLedgerStateReader
 import com.daml.ledger.validator.{CommitStrategy, LedgerStateOperations}
-import com.google.protobuf.ByteString
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.MockitoSugar
 import org.mockito.stubbing.ScalaFirstStubbing
@@ -37,7 +36,7 @@ class BatchedValidatingCommitterSpec
       instance
         .commit(
           correlationId = "",
-          submissionEnvelope = Raw.Value(ByteString.EMPTY),
+          submissionEnvelope = Raw.Envelope.empty,
           submittingParticipantId = aParticipantId,
           ledgerStateOperations = mock[LedgerStateOperations[Unit]],
         )
@@ -55,7 +54,7 @@ class BatchedValidatingCommitterSpec
       instance
         .commit(
           correlationId = "",
-          submissionEnvelope = Raw.Value(ByteString.EMPTY),
+          submissionEnvelope = Raw.Envelope.empty,
           submittingParticipantId = aParticipantId,
           ledgerStateOperations = mock[LedgerStateOperations[Unit]],
         )
@@ -70,7 +69,7 @@ class BatchedValidatingCommitterSpec
   ): ScalaFirstStubbing[Future[Unit]] =
     when(
       mockValidator.validateAndCommit(
-        any[Raw.Value](),
+        any[Raw.Envelope](),
         anyString(),
         any[Instant](),
         any[ParticipantId](),

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/PreExecutingSubmissionValidatorSpec.scala
@@ -155,7 +155,7 @@ object PreExecutingSubmissionValidatorSpec {
 
   private final case class TestWriteSet(value: String)
 
-  private def anEnvelope(expectedReadSet: Set[DamlStateKey] = Set.empty): Raw.Value = {
+  private def anEnvelope(expectedReadSet: Set[DamlStateKey] = Set.empty): Raw.Envelope = {
     val submission = DamlSubmission
       .newBuilder()
       .setConfigurationSubmission(DamlConfigurationSubmission.getDefaultInstance)

--- a/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategySpec.scala
+++ b/ledger/participant-state/kvutils/src/test/suite/scala/com/daml/ledger/validator/preexecution/RawPreExecutingCommitStrategySpec.scala
@@ -63,7 +63,7 @@ final class RawPreExecutingCommitStrategySpec
   "generateWriteSets" should {
     "serialize keys according to strategy" in {
       val logEntryId = aLogEntryId()
-      val expectedLogEntryKey = Raw.Key(logEntryId.toByteString)
+      val expectedLogEntryKey = Raw.LogEntryId(logEntryId)
       val preExecutionResult = PreExecutionResult(
         readSet = Set.empty,
         successfulLogEntry = aLogEntry,
@@ -96,7 +96,7 @@ final class RawPreExecutingCommitStrategySpec
     val mockStateKeySerializationStrategy = mock[StateKeySerializationStrategy]
     when(mockStateKeySerializationStrategy.serializeStateKey(any[DamlStateKey]()))
       .thenAnswer((invocation: InvocationOnMock) =>
-        Raw.Key(invocation.getArgument[DamlStateKey](0).getContractIdBytes)
+        Raw.StateKey(invocation.getArgument[DamlStateKey](0).getContractIdBytes)
       )
     mockStateKeySerializationStrategy
   }

--- a/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/BenchmarkWithLedgerExport.scala
+++ b/ledger/participant-state/kvutils/tools/codec-benchmark/src/benchmark/scala/com/daml/lf/benchmark/BenchmarkWithLedgerExport.scala
@@ -37,7 +37,7 @@ abstract class BenchmarkWithLedgerExport {
 
     val builder = Submissions.newBuilder()
 
-    def decodeEnvelope(envelope: Raw.Value): Unit =
+    def decodeEnvelope(envelope: Raw.Envelope): Unit =
       Envelope.open(envelope).fold(sys.error, identity) match {
         case Envelope.SubmissionMessage(submission)
             if submission.getPayloadCase == DamlSubmission.PayloadCase.PACKAGE_UPLOAD_ENTRY =>
@@ -49,7 +49,7 @@ abstract class BenchmarkWithLedgerExport {
           builder += submission.getTransactionEntry.getTransaction
         case Envelope.SubmissionBatchMessage(batch) =>
           for (submission <- batch.getSubmissionsList.asScala) {
-            decodeEnvelope(Raw.Value(submission.getSubmission))
+            decodeEnvelope(Raw.Envelope(submission.getSubmission))
           }
         case _ =>
           ()

--- a/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
+++ b/ledger/participant-state/kvutils/tools/engine-benchmark/src/benchmark/scala/ledger/participant/state/kvutils/tools/engine/benchmark/Replay.scala
@@ -195,7 +195,7 @@ object Replay {
 
   private[this] def decodeEnvelope(
       participantId: Ref.ParticipantId,
-      envelope: Raw.Value,
+      envelope: Raw.Envelope,
   ): LazyList[TxEntry] =
     assertRight(Envelope.open(envelope)) match {
       case Envelope.SubmissionMessage(submission) =>
@@ -205,7 +205,7 @@ object Replay {
           .to(LazyList)
           .map(_.getSubmission)
           .flatMap(submissionEnvelope =>
-            decodeEnvelope(participantId, Raw.Value(submissionEnvelope))
+            decodeEnvelope(participantId, Raw.Envelope(submissionEnvelope))
           )
       case Envelope.LogEntryMessage(_) | Envelope.StateValueMessage(_) =>
         LazyList.empty

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactory.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactory.scala
@@ -7,13 +7,13 @@ import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.daml.ledger.api.health.HealthStatus
-import com.daml.ledger.participant.state.kvutils.OffsetBuilder
 import com.daml.ledger.participant.state.kvutils.api.{
   KeyValueParticipantStateReader,
   LedgerReader,
   LedgerRecord,
 }
 import com.daml.ledger.participant.state.kvutils.export.WriteSet
+import com.daml.ledger.participant.state.kvutils.{OffsetBuilder, Raw}
 import com.daml.ledger.participant.state.v1.{LedgerId, LedgerInitialConditions, Offset, Update}
 import com.daml.metrics.Metrics
 
@@ -29,7 +29,8 @@ final class LogAppendingReadServiceFactory(
     this.synchronized {
       writeSet.foreach { case (key, value) =>
         val offset = OffsetBuilder.fromLong(recordedBlocks.length.toLong)
-        recordedBlocks.append(LedgerRecord(offset, key, value))
+        val logEntryId = Raw.LogEntryId(key.bytes) // `key` is of an unknown type.
+        recordedBlocks.append(LedgerRecord(offset, logEntryId, value))
       }
     }
 

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparison.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparison.scala
@@ -54,7 +54,10 @@ final class RawWriteSetComparison(stateKeySerializationStrategy: StateKeySeriali
     val differencesExplained = expectedWriteSet
       .zip(actualWriteSet)
       .map { case ((expectedKey, expectedValue), (actualKey, actualValue)) =>
-        if (expectedKey == actualKey && expectedValue != actualValue) {
+        // We need to compare `.bytes` because the type will be different.
+        // Unfortunately, the export format doesn't differentiate between log and state entries.
+        // We don't want to change this because it will break backwards-compatibility.
+        if (expectedKey.bytes == actualKey.bytes && expectedValue != actualValue) {
           Some(
             Seq(
               s"expected value:    ${rawHexString(expectedValue)}",
@@ -62,7 +65,7 @@ final class RawWriteSetComparison(stateKeySerializationStrategy: StateKeySeriali
               explainDifference(expectedKey, expectedValue, actualValue),
             )
           )
-        } else if (expectedKey != actualKey) {
+        } else if (expectedKey.bytes != actualKey.bytes) {
           Some(
             Seq(
               s"expected key:    ${rawHexString(expectedKey)}",

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparison.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparison.scala
@@ -88,8 +88,8 @@ final class RawWriteSetComparison(stateKeySerializationStrategy: StateKeySeriali
 
   private def explainDifference(
       key: Raw.Key,
-      expectedValue: Raw.Value,
-      actualValue: Raw.Value,
+      expectedValue: Raw.Envelope,
+      actualValue: Raw.Envelope,
   ): String =
     kvutils.Envelope
       .openStateValue(expectedValue)
@@ -105,8 +105,8 @@ final class RawWriteSetComparison(stateKeySerializationStrategy: StateKeySeriali
 
   private def explainMismatchingValue(
       logEntryId: Raw.Key,
-      expectedValue: Raw.Value,
-      actualValue: Raw.Value,
+      expectedValue: Raw.Envelope,
+      actualValue: Raw.Envelope,
   ): String = {
     val expectedLogEntry = kvutils.Envelope.openLogEntry(expectedValue)
     val actualLogEntry = kvutils.Envelope.openLogEntry(actualValue)
@@ -114,8 +114,11 @@ final class RawWriteSetComparison(stateKeySerializationStrategy: StateKeySeriali
       s"Expected: $expectedLogEntry${System.lineSeparator()}Actual: $actualLogEntry"
   }
 
-  override def checkEntryIsReadable(rawKey: Raw.Key, rawValue: Raw.Value): Either[String, Unit] =
-    Envelope.open(rawValue) match {
+  override def checkEntryIsReadable(
+      rawKey: Raw.Key,
+      rawEnvelope: Raw.Envelope,
+  ): Either[String, Unit] =
+    Envelope.open(rawEnvelope) match {
       case Left(errorMessage) =>
         Left(s"Invalid value envelope: $errorMessage")
       case Right(Envelope.LogEntryMessage(logEntry)) =>

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateAccess.scala
@@ -31,17 +31,17 @@ object WriteRecordingLedgerStateAccess {
       delegate: LedgerStateOperations[LogResult],
   ) extends LedgerStateOperations[LogResult] {
     override def readState(
-        key: Raw.Key
+        key: Raw.StateKey
     )(implicit executionContext: ExecutionContext): Future[Option[Raw.Value]] =
       delegate.readState(key)
 
     override def readState(
-        keys: Iterable[Raw.Key]
+        keys: Iterable[Raw.StateKey]
     )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
       delegate.readState(keys)
 
     override def writeState(
-        key: Raw.Key,
+        key: Raw.StateKey,
         value: Raw.Value,
     )(implicit executionContext: ExecutionContext): Future[Unit] = {
       this.synchronized(recordedWriteSet.append((key, value)))
@@ -49,14 +49,14 @@ object WriteRecordingLedgerStateAccess {
     }
 
     override def writeState(
-        keyValuePairs: Iterable[Raw.KeyValuePair]
+        keyValuePairs: Iterable[Raw.StateEntry]
     )(implicit executionContext: ExecutionContext): Future[Unit] = {
       this.synchronized(recordedWriteSet.appendAll(keyValuePairs))
       delegate.writeState(keyValuePairs)
     }
 
     override def appendToLog(
-        key: Raw.Key,
+        key: Raw.LogEntryId,
         value: Raw.Value,
     )(implicit executionContext: ExecutionContext): Future[LogResult] = {
       this.synchronized(recordedWriteSet.append((key, value)))

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteRecordingLedgerStateAccess.scala
@@ -32,17 +32,17 @@ object WriteRecordingLedgerStateAccess {
   ) extends LedgerStateOperations[LogResult] {
     override def readState(
         key: Raw.StateKey
-    )(implicit executionContext: ExecutionContext): Future[Option[Raw.Value]] =
+    )(implicit executionContext: ExecutionContext): Future[Option[Raw.Envelope]] =
       delegate.readState(key)
 
     override def readState(
         keys: Iterable[Raw.StateKey]
-    )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Value]]] =
+    )(implicit executionContext: ExecutionContext): Future[Seq[Option[Raw.Envelope]]] =
       delegate.readState(keys)
 
     override def writeState(
         key: Raw.StateKey,
-        value: Raw.Value,
+        value: Raw.Envelope,
     )(implicit executionContext: ExecutionContext): Future[Unit] = {
       this.synchronized(recordedWriteSet.append((key, value)))
       delegate.writeState(key, value)
@@ -57,7 +57,7 @@ object WriteRecordingLedgerStateAccess {
 
     override def appendToLog(
         key: Raw.LogEntryId,
-        value: Raw.Value,
+        value: Raw.Envelope,
     )(implicit executionContext: ExecutionContext): Future[LogResult] = {
       this.synchronized(recordedWriteSet.append((key, value)))
       delegate.appendToLog(key, value)

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactorySpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/LogAppendingReadServiceFactorySpec.scala
@@ -96,6 +96,6 @@ final class LogAppendingReadServiceFactorySpec extends AsyncWordSpec with Matche
     None,
   )
 
-  private lazy val aSerializedLogEntryId = Raw.Key(aLogEntryId.toByteString)
+  private lazy val aSerializedLogEntryId = Raw.LogEntryId(aLogEntryId)
   private lazy val aWrappedLogEntry = Envelope.enclose(aLogEntry)
 }

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupportSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawPreExecutingCommitStrategySupportSpec.scala
@@ -61,13 +61,13 @@ class RawPreExecutingCommitStrategySupportSpec
           DamlLogEntry.PayloadCase.PARTY_ALLOCATION_ENTRY
         )
         writeSetA.map(_._1) should contain(
-          Raw.Key(DamlStateKey.newBuilder.setParty("Alice").build().toByteString)
+          Raw.StateKey(DamlStateKey.newBuilder.setParty("Alice").build)
         )
         extractLogEntry(writeSetB).getPayloadCase should be(
           DamlLogEntry.PayloadCase.PARTY_ALLOCATION_ENTRY
         )
         writeSetB.map(_._1) should contain(
-          Raw.Key(DamlStateKey.newBuilder.setParty("Bob").build().toByteString)
+          Raw.StateKey(DamlStateKey.newBuilder.setParty("Bob").build)
         )
       }
     }
@@ -108,9 +108,7 @@ class RawPreExecutingCommitStrategySupportSpec
         writeSet2 <- support.commit(updateConfigurationWithInvalidMrt)
       } yield {
         writeSet1.map(_._1) should contain(
-          Raw.Key(
-            DamlStateKey.newBuilder.setConfiguration(Empty.getDefaultInstance).build().toByteString
-          )
+          Raw.StateKey(DamlStateKey.newBuilder.setConfiguration(Empty.getDefaultInstance).build)
         )
         extractLogEntry(writeSet1).getPayloadCase should be(
           DamlLogEntry.PayloadCase.CONFIGURATION_ENTRY

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
@@ -68,7 +68,7 @@ final class RawWriteSetComparisonSpec extends AsyncWordSpec with Matchers with I
         DamlKvutils.Envelope.newBuilder
           .setVersion(Version.version)
           .setKind(DamlKvutils.Envelope.MessageKind.SUBMISSION)
-          .build()
+          .build
           .toByteString
       )
       inside(writeSetComparison.checkEntryIsReadable(noKey, value)) { case Left(message) =>
@@ -91,14 +91,14 @@ final class RawWriteSetComparisonSpec extends AsyncWordSpec with Matchers with I
 
     "fail on a log entry with an invalid payload" in {
       val key = aValidLogEntryId
-      val value = Envelope.enclose(DamlLogEntry.newBuilder.build())
+      val value = Envelope.enclose(DamlLogEntry.newBuilder.build)
       inside(writeSetComparison.checkEntryIsReadable(key, value)) { case Left(message) =>
         message should be("Log entry payload not set.")
       }
     }
 
     "fail on a state entry with an invalid key" in {
-      val key = Raw.Key(DamlStateKey.newBuilder.build().toByteString)
+      val key = Raw.StateKey(DamlStateKey.newBuilder.build)
       val value = aValidStateValue
       inside(writeSetComparison.checkEntryIsReadable(key, value)) { case Left(message) =>
         message should be("State key not set.")
@@ -214,32 +214,30 @@ final class RawWriteSetComparisonSpec extends AsyncWordSpec with Matchers with I
 
 object RawWriteSetComparisonSpec {
 
-  private val noKey: Raw.Key =
-    Raw.Key(ByteString.EMPTY)
+  private val noKey: Raw.Key = Raw.UnknownKey.empty
 
-  private val aValidLogEntryId: Raw.Key =
-    Raw.Key(
+  private val aValidLogEntryId: Raw.LogEntryId =
+    Raw.LogEntryId(
       DamlLogEntryId.newBuilder
         .setEntryId(ByteString.copyFromUtf8("entry-id"))
-        .build()
-        .toByteString
+        .build
     )
 
   private val aValidLogEntry: Raw.Value =
     Envelope.enclose(
       DamlLogEntry.newBuilder
         .setPartyAllocationEntry(DamlPartyAllocationEntry.newBuilder.setParty("Alice"))
-        .build()
+        .build
     )
 
-  private val aValidStateKey: Raw.Key =
+  private val aValidStateKey: Raw.StateKey =
     aConfigurationStateKey
 
-  private def aConfigurationStateKey =
-    Raw.Key(DamlStateKey.newBuilder.setConfiguration(Empty.getDefaultInstance).build().toByteString)
+  private def aConfigurationStateKey: Raw.StateKey =
+    Raw.StateKey(DamlStateKey.newBuilder.setConfiguration(Empty.getDefaultInstance).build)
 
-  private def aPartyAllocationStateKey(partyId: String): Raw.Key =
-    Raw.Key(DamlStateKey.newBuilder.setParty(partyId).build().toByteString)
+  private def aPartyAllocationStateKey(partyId: String): Raw.StateKey =
+    Raw.StateKey(DamlStateKey.newBuilder.setParty(partyId).build)
 
   private val aValidStateValue: Raw.Value =
     Envelope.enclose(aConfigurationStateValue(generation = 1))

--- a/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
+++ b/ledger/participant-state/kvutils/tools/integrity-check/src/test/scala/ledger/participant/state/kvutils/tools/integritycheck/RawWriteSetComparisonSpec.scala
@@ -45,70 +45,67 @@ final class RawWriteSetComparisonSpec extends AsyncWordSpec with Matchers with I
     }
 
     "fail on an invalid envelope" in {
-      val value = Raw.Value(ByteString.copyFromUtf8("invalid envelope"))
-      inside(writeSetComparison.checkEntryIsReadable(noKey, value)) { case Left(message) =>
+      val envelope = Raw.Envelope(ByteString.copyFromUtf8("invalid envelope"))
+      inside(writeSetComparison.checkEntryIsReadable(noKey, envelope)) { case Left(message) =>
         message should startWith("Invalid value envelope:")
       }
     }
 
     "fail on an unknown entry" in {
-      val value = Raw.Value(
+      val envelope = Raw.Envelope(
         DamlKvutils.Envelope.newBuilder
           .setVersion(Version.version)
-          .build()
-          .toByteString
+          .build
       )
-      inside(writeSetComparison.checkEntryIsReadable(noKey, value)) { case Left(_) =>
+      inside(writeSetComparison.checkEntryIsReadable(noKey, envelope)) { case Left(_) =>
         succeed
       }
     }
 
     "fail on a submission entry" in {
-      val value = Raw.Value(
+      val envelope = Raw.Envelope(
         DamlKvutils.Envelope.newBuilder
           .setVersion(Version.version)
           .setKind(DamlKvutils.Envelope.MessageKind.SUBMISSION)
           .build
-          .toByteString
       )
-      inside(writeSetComparison.checkEntryIsReadable(noKey, value)) { case Left(message) =>
+      inside(writeSetComparison.checkEntryIsReadable(noKey, envelope)) { case Left(message) =>
         message should startWith("Unexpected submission message:")
       }
     }
 
     "fail on a submission batch entry" in {
-      val value = Raw.Value(
+      val envelope = Raw.Envelope(
         DamlKvutils.Envelope.newBuilder
           .setVersion(Version.version)
           .setKind(DamlKvutils.Envelope.MessageKind.SUBMISSION_BATCH)
-          .build()
-          .toByteString
+          .build
       )
-      inside(writeSetComparison.checkEntryIsReadable(noKey, value)) { case Left(message) =>
+      inside(writeSetComparison.checkEntryIsReadable(noKey, envelope)) { case Left(message) =>
         message should startWith("Unexpected submission batch message:")
       }
     }
 
     "fail on a log entry with an invalid payload" in {
       val key = aValidLogEntryId
-      val value = Envelope.enclose(DamlLogEntry.newBuilder.build)
-      inside(writeSetComparison.checkEntryIsReadable(key, value)) { case Left(message) =>
+      val envelope = Envelope.enclose(DamlLogEntry.newBuilder.build)
+      inside(writeSetComparison.checkEntryIsReadable(key, envelope)) { case Left(message) =>
         message should be("Log entry payload not set.")
       }
     }
 
     "fail on a state entry with an invalid key" in {
       val key = Raw.StateKey(DamlStateKey.newBuilder.build)
-      val value = aValidStateValue
-      inside(writeSetComparison.checkEntryIsReadable(key, value)) { case Left(message) =>
+      val envelope = aValidStateValue
+      inside(writeSetComparison.checkEntryIsReadable(key, envelope)) { case Left(message) =>
         message should be("State key not set.")
       }
     }
 
-    "fail on a state entry with an invalid value" in {
+    "fail on a state entry with an invalid envelope" in {
       val key = aValidStateKey
-      val value = Envelope.enclose(DamlStateValue.newBuilder.build())
-      inside(writeSetComparison.checkEntryIsReadable(key, value)) { case Left(message) =>
+      val envelope = Envelope.enclose(DamlStateValue.newBuilder.build())
+      inside(writeSetComparison.checkEntryIsReadable(key, envelope)) { case Left(message) =>
         message should be("State value not set.")
       }
     }
@@ -119,16 +116,16 @@ final class RawWriteSetComparisonSpec extends AsyncWordSpec with Matchers with I
 
     "unfortunately, allow a log entry ID with a state value" in {
       val key = aValidLogEntryId
-      val value = aValidStateValue
-      inside(writeSetComparison.checkEntryIsReadable(key, value)) { case Right(()) =>
+      val envelope = aValidStateValue
+      inside(writeSetComparison.checkEntryIsReadable(key, envelope)) { case Right(()) =>
         succeed
       }
     }
 
     "unfortunately, allow a state key with a log entry" in {
       val key = aValidStateKey
-      val value = aValidLogEntry
-      inside(writeSetComparison.checkEntryIsReadable(key, value)) { case Right(()) =>
+      val envelope = aValidLogEntry
+      inside(writeSetComparison.checkEntryIsReadable(key, envelope)) { case Right(()) =>
         succeed
       }
     }
@@ -223,7 +220,7 @@ object RawWriteSetComparisonSpec {
         .build
     )
 
-  private val aValidLogEntry: Raw.Value =
+  private val aValidLogEntry: Raw.Envelope =
     Envelope.enclose(
       DamlLogEntry.newBuilder
         .setPartyAllocationEntry(DamlPartyAllocationEntry.newBuilder.setParty("Alice"))
@@ -239,7 +236,7 @@ object RawWriteSetComparisonSpec {
   private def aPartyAllocationStateKey(partyId: String): Raw.StateKey =
     Raw.StateKey(DamlStateKey.newBuilder.setParty(partyId).build)
 
-  private val aValidStateValue: Raw.Value =
+  private val aValidStateValue: Raw.Envelope =
     Envelope.enclose(aConfigurationStateValue(generation = 1))
 
   private def aPartyAllocationStateValue(displayName: String): DamlStateValue =

--- a/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteSetComparison.scala
+++ b/ledger/participant-state/kvutils/tools/src/main/scala/ledger/participant/state/kvutils/tools/integritycheck/WriteSetComparison.scala
@@ -10,7 +10,7 @@ trait WriteSetComparison {
 
   def compareWriteSets(expectedWriteSet: WriteSet, actualWriteSet: WriteSet): Option[String]
 
-  def checkEntryIsReadable(rawKey: Raw.Key, rawValue: Raw.Value): Either[String, Unit]
+  def checkEntryIsReadable(rawKey: Raw.Key, rawEnvelope: Raw.Envelope): Either[String, Unit]
 
 }
 


### PR DESCRIPTION
`Key` was a bit too generic: it could refer to either a log entry ID or a state key.

This splits `Raw.Key` into `Raw.LogEntryId` and `Raw.StateKey`, and changes all usages to use one of the two. `Raw.Key` is now a supertype of both of these new types, with an implicit conversion to a third subtype, `Raw.UnknownKey`, to maintain some backwards-compatibility.

The only exception is the integrity checker. Because of the way we export data, we don't know if any given item is a log entry or a state key-value pair. We therefore parse everything as a `Raw.UnknownKey`, and then convert based on usage. This means the type safety is about the same as before in this particular case.

`Raw.Value` is renamed to `Raw.Envelope`, because it's always a serialized envelope. `Raw.Value` is kept as a supertype for now to parallel the `Raw.Key` trait, but might be removed in the future.

Finally, `@deprecated` annotations are added for all conversions between `Raw` types, as well as conversions to and from `ByteString`. Users will have until DAML SDK v1.12 to migrate.

### Changelog

- **[Integration Kit]** The various uses of `ByteString` in kvutils are now strongly typed. Users of kvutils will need to use the `Raw.Bytes` subtypes to represent the various keys and values that flow through a kvutils-based driver. ByteStrings representing keys need to be wrapped in either `Raw.LogEntryId` or `Raw.StateKey`, and ByteStrings representing value envelopes need to be wrapped in `Raw.Envelope`. This prevents accidentally confusing one for the other.

  Implicit conversions have been provided for Scala users, which should ease the transition. There are marked `@deprecated` and will be removed before the release of DAML SDK v1.12.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
