### PR TITLE
damlc: fix: catch UserError instead  IOException

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -214,7 +214,7 @@ dbNeedsReinitialization projectRoot allDeps sdkVersion damlLfVersion = do
     errOrmetaData <- tryAny $ readMetadata projectRoot
     pure $
         case errOrmetaData of
-            Left (_err :: SomeException)-> (True, depsFingerprint)
+            Left _err -> (True, depsFingerprint)
             Right metaData -> (fingerprintDependencies metaData /= depsFingerprint, depsFingerprint)
 
 disableScenarioService :: Options -> Options

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -211,7 +211,7 @@ dbNeedsReinitialization projectRoot allDeps sdkVersion damlLfVersion = do
     let depsFingerprint =
             fingerprintFingerprints $ sdkVersionFingerprint : damlLfFingerprint : fileFingerprints
     -- Read the metadata of an already existing package database and see if wee need to reinitialize.
-    errOrmetaData <- try $ readMetadata projectRoot
+    errOrmetaData <- tryAny $ readMetadata projectRoot
     pure $
         case errOrmetaData of
             Left (_err :: SomeException)-> (True, depsFingerprint)

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -8,7 +8,7 @@ module DA.Cli.Damlc.Packaging
   ) where
 
 import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
-import Control.Exception.Safe (try, SomeException)
+import Control.Exception.Safe (tryAny)
 import Control.Lens (toListOf)
 import Control.Monad.Extra
 import Control.Monad.Trans.Maybe

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -8,7 +8,7 @@ module DA.Cli.Damlc.Packaging
   ) where
 
 import qualified "zip-archive" Codec.Archive.Zip as ZipArchive
-import Control.Exception.Safe (tryIO)
+import Control.Exception.Safe (try, SomeException)
 import Control.Lens (toListOf)
 import Control.Monad.Extra
 import Control.Monad.Trans.Maybe
@@ -211,10 +211,10 @@ dbNeedsReinitialization projectRoot allDeps sdkVersion damlLfVersion = do
     let depsFingerprint =
             fingerprintFingerprints $ sdkVersionFingerprint : damlLfFingerprint : fileFingerprints
     -- Read the metadata of an already existing package database and see if wee need to reinitialize.
-    errOrmetaData <- tryIO $ readMetadata projectRoot
+    errOrmetaData <- try $ readMetadata projectRoot
     pure $
         case errOrmetaData of
-            Left _err -> (True, depsFingerprint)
+            Left (_err :: SomeException)-> (True, depsFingerprint)
             Right metaData -> (fingerprintDependencies metaData /= depsFingerprint, depsFingerprint)
 
 disableScenarioService :: Options -> Options


### PR DESCRIPTION
When the package-db metadata can not be parsed, an exception is thrown
and needs to be catched.  Previously we were catching IOException, but
in this case it's actually a UserError that is thrown.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
