### PR TITLE
Port non-repudiation middleware to Scala 2.13

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -178,12 +178,12 @@ jobs:
         bazel build --config scala_2_13 -- \
           //... \
           -//ledger/ledger-api-test-tool/... \
-          -//runtime-components/...
+          -//runtime-components/non-repudiation-postgresql:test
         # gatling-utils tests fail with a ClassNotFoundException for scala.collection.SeqLike
         bazel test --config scala_2_13 -- \
           //... \
           -//ledger/ledger-api-test-tool/... \
-          -//runtime-components/... \
+          -//runtime-components/non-repudiation-postgresql:test \
           -//libs-scala/gatling-utils/...
       displayName: 'Build'
     - template: tell-slack-failed.yml

--- a/runtime-components/non-repudiation-postgresql/BUILD.bazel
+++ b/runtime-components/non-repudiation-postgresql/BUILD.bazel
@@ -22,10 +22,8 @@ da_scala_library(
         "@maven//:org_typelevel_cats_effect",
         "@maven//:org_typelevel_cats_free",
         "@maven//:org_typelevel_cats_kernel",
+        "@maven//:org_scala_lang_modules_scala_collection_compat",
     ],
-    versioned_scala_deps = {
-        "2.12": ["@maven//:org_scala_lang_modules_scala_collection_compat"],
-    },
     deps = [
         "//runtime-components/non-repudiation",
         "@maven//:com_zaxxer_HikariCP",

--- a/runtime-components/non-repudiation-postgresql/src/main/scala/com/daml/nonrepudiation/postgresql/package.scala
+++ b/runtime-components/non-repudiation-postgresql/src/main/scala/com/daml/nonrepudiation/postgresql/package.scala
@@ -12,10 +12,10 @@ import scala.collection.compat.immutable.ArraySeq
 
 package object postgresql {
 
-  implicit def getBytes[Bytes <: ArraySeq[Byte]]: Get[Bytes] =
+  implicit def getBytes[Bytes <: ArraySeq.ofByte]: Get[Bytes] =
     Get[Array[Byte]].map(ArraySeq.unsafeWrapArray(_).asInstanceOf[Bytes])
 
-  implicit def putBytes[Bytes <: ArraySeq[Byte]]: Put[Bytes] =
+  implicit def putBytes[Bytes <: ArraySeq.ofByte]: Put[Bytes] =
     Put[Array[Byte]].contramap(_.unsafeArray)
 
   implicit val getAlgorithmString: Get[AlgorithmString] =

--- a/runtime-components/non-repudiation/BUILD.bazel
+++ b/runtime-components/non-repudiation/BUILD.bazel
@@ -10,9 +10,8 @@ load(
 da_scala_library(
     name = "non-repudiation",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    versioned_scala_deps = {
-        "2.12": ["@maven//:org_scala_lang_modules_scala_collection_compat"],
-    },
+    scala_deps =
+        ["@maven//:org_scala_lang_modules_scala_collection_compat"],
     visibility = [
         "//:__subpackages__",
     ],

--- a/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/package.scala
+++ b/runtime-components/non-repudiation/src/main/scala/com/daml/nonrepudiation/package.scala
@@ -53,7 +53,7 @@ package object nonrepudiation {
       fromPayload(payload).get
   }
 
-  type FingerprintBytes <: ArraySeq[Byte]
+  type FingerprintBytes <: ArraySeq.ofByte
 
   object FingerprintBytes {
     def wrap(bytes: Array[Byte]): FingerprintBytes =
@@ -62,23 +62,23 @@ package object nonrepudiation {
       wrap(Fingerprints.compute(certificate))
   }
 
-  type PayloadBytes <: ArraySeq[Byte]
+  type PayloadBytes <: ArraySeq.ofByte
 
   object PayloadBytes {
     def wrap(bytes: Array[Byte]): PayloadBytes =
-      ArraySeq.unsafeWrapArray(bytes).asInstanceOf[PayloadBytes]
+      new ArraySeq.ofByte(bytes).asInstanceOf[PayloadBytes]
   }
 
-  type SignatureBytes <: ArraySeq[Byte]
+  type SignatureBytes <: ArraySeq.ofByte
 
   object SignatureBytes {
     def wrap(bytes: Array[Byte]): SignatureBytes =
-      ArraySeq.unsafeWrapArray(bytes).asInstanceOf[SignatureBytes]
+      new ArraySeq.ofByte(bytes).asInstanceOf[SignatureBytes]
     def sign(algorithm: AlgorithmString, key: PrivateKey, payload: PayloadBytes): SignatureBytes =
       wrap(Signatures.sign(algorithm, key, payload.unsafeArray))
   }
 
-  implicit final class BytesToBase64[Bytes <: ArraySeq[Byte]](val bytes: Bytes) extends AnyVal {
+  implicit final class BytesToBase64[Bytes <: ArraySeq.ofByte](val bytes: Bytes) extends AnyVal {
     def base64: String = BaseEncoding.base64().encode(bytes.unsafeArray)
   }
 


### PR DESCRIPTION
Tests are still missing and blocked on #8821.

The main change here is the switch from `ArraySeq[Byte]` to
`ArraySeq.ofByte`. `ArraySeq` allows for boxed and unboxed
representaitons. That means that `ArraySeq[Byte]unsafeArray` does not always return
an Array[Byte] (boxed version would be Array[AnyRef]).

Apparently collection-compat has taken the yolo approach and pretends
it can give you an Array[Byte] anyway :shrug: Scala 2.13 on the other
hand, does things properly in this regard which means the code relying
on `unsafeArray` fails to compile.

`ArraySeq.ofByte` is the specialized unboxed version where none of
this is an issue on both 2.13 and 2.12.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
