### PR TITLE
qualify Set in Scala codegen output to avoid name collision

### DIFF
--- a/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
+++ b/language-support/scala/codegen-sample-app/src/main/daml/MyMain.daml
@@ -555,6 +555,17 @@ template MapText
     where
       signatory party
 
+-- test that Set doesn't name-collide
+data Set a = Set { runSet : a }
+  deriving (Eq, Show)
+
+template SetInt
+   with
+      party: Party
+      aSet: Set Int
+   where
+      signatory party
+
 data ContractIdNT a = ContractIdNT with unContractIdNT : ContractId a
   deriving (Eq, Show)
 

--- a/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
+++ b/language-support/scala/codegen/src/main/scala/com/digitalasset/codegen/lf/LFUtil.scala
@@ -314,7 +314,8 @@ object LFUtil {
       .collect {
         case (id, ci) if ci.consuming => id
       }
-    q"override val consumingChoices: Set[$domainApiAlias.Primitive.ChoiceId] = $domainApiAlias.Primitive.ChoiceId.subst(Set(..$consumingChoicesIds))"
+    q"""override val consumingChoices: $stdSetType[$domainApiAlias.Primitive.ChoiceId] =
+       $domainApiAlias.Primitive.ChoiceId.subst($stdSetCompanion(..$consumingChoicesIds))"""
   }
 
   final case class TupleNesting[A](run: NonEmptyList[A \/ TupleNesting[A]])
@@ -384,6 +385,8 @@ object LFUtil {
   val primitiveObject: Tree = q"$domainApiAlias.Primitive"
   val stdMapType = tq"_root_.scala.collection.immutable.Map"
   val stdMapCompanion = q"_root_.scala.collection.immutable.Map"
+  private val stdSetType = tq"_root_.scala.collection.immutable.Set"
+  private val stdSetCompanion = q"_root_.scala.collection.immutable.Set"
   val stdVectorType = tq"_root_.scala.collection.immutable.Vector"
   val stdSeqCompanion = q"_root_.scala.collection.immutable.Seq"
   val nothingType = q"_root_.scala.Nothing"


### PR DESCRIPTION
Fixes #8854.

```rst
CHANGELOG_BEGIN
- [Scala codegen] Allow codegen with Set.
  See `issue #8854 <https://github.com/digital-asset/daml/issues/8854>`__.
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
