### PR TITLE
Include --target flags in daml script dumps

### DIFF
--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/LanguageVersion.scala
@@ -24,7 +24,7 @@ object LanguageVersion {
 
   private[lf] val All = Major.V1.supportedMinorVersions.map(LanguageVersion(Major.V1, _))
 
-  private[lf] val List(v1_6, v1_7, v1_8, v1_11, v1_12, v1_dev) = All
+  val List(v1_6, v1_7, v1_8, v1_11, v1_12, v1_dev) = All
 
   object Features {
     val default = v1_6

--- a/daml-script/dump/BUILD.bazel
+++ b/daml-script/dump/BUILD.bazel
@@ -45,7 +45,9 @@ da_scala_test(
     visibility = ["//visibility:public"],
     deps = [
         ":dump",
+        "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/data",
+        "//daml-lf/language",
         "//language-support/scala/bindings",
     ],
 )

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Dependencies.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Dependencies.scala
@@ -11,7 +11,7 @@ import com.daml.lf.archive.{Dar, DarWriter, Decode}
 import com.daml.lf.archive.Reader.damlLfCodedInputStreamFromBytes
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.PackageId
-import com.daml.lf.language.Ast
+import com.daml.lf.language.{Ast, LanguageVersion}
 import com.google.protobuf.ByteString
 
 import scala.annotation.tailrec
@@ -47,6 +47,15 @@ object Dependencies {
       }
     go(references, Map.empty)
   }
+
+  def targetLfVersion(dependencies: Seq[Dar[LanguageVersion]]): Option[LanguageVersion] = {
+    val dalfs = dependencies.flatMap(_.all)
+    if (dalfs.isEmpty) { None }
+    else { Some(dalfs.max) }
+  }
+
+  def targetFlag(v: LanguageVersion): String =
+    s"--target=${v.pretty}"
 
   def writeDar(
       sdkVersion: String,

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/DependenciesSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/DependenciesSpec.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.dump
+
+import com.daml.lf.archive.Dar
+import com.daml.lf.language.LanguageVersion._
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class DependenciesSpec extends AnyFreeSpec with Matchers {
+  import Dependencies._
+
+  "targetLfVersion" - {
+    "empty Seq" in {
+      targetLfVersion(Seq.empty) shouldBe None
+    }
+    "single DAR" in {
+      targetLfVersion(Seq(Dar(v1_8, List(v1_11)))) shouldBe Some(v1_11)
+    }
+    "multiple DARs" in {
+      targetLfVersion(Seq(Dar(v1_8, List(v1_11)), Dar(v1_12, List()))) shouldBe Some(v1_12)
+    }
+  }
+  "targetFlag" - {
+    "1.12" in {
+      targetFlag(v1_12) shouldBe "--target=1.12"
+    }
+    "1.dev" in {
+      targetFlag(v1_dev) shouldBe "--target=1.dev"
+    }
+  }
+}


### PR DESCRIPTION
As evidenced by #8856, daml script dumps currently fail to compile if
we generate a dump including templates which are newer than the
default LF version in the compiler. This PR addresses this by
including a --target flag in the generated daml.yaml.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
