### PR TITLE
Non-Consuming Choice Subscriptions - Ledger API changes [DPP-253]

### DIFF
--- a/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Event.scala
+++ b/extractor/src/main/scala/com/digitalasset/extractor/ledger/types/Event.scala
@@ -47,8 +47,9 @@ object Event {
   final implicit class ApiEventOps(val apiEvent: api.event.Event.Event) extends AnyVal {
     def convert: String \/ Event = apiEvent match {
       case api.event.Event.Event.Archived(event) =>
-        s"Unexpected `Archived` event: $event. Only `Created` events are expected.".left
+        s"Unexpected `Archived` event: $event.".left
       case api.event.Event.Event.Created(event) => event.convert
+      case api.event.Event.Event.Exercised(event) => event.convert
       case api.event.Event.Event.Empty => "Unexpected `Empty` event.".left
     }
   }

--- a/language-support/hs/bindings/src/DA/Ledger/Convert.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Convert.hs
@@ -340,6 +340,9 @@ raiseEvent = \case
         signatories <- raiseList raiseParty createdEventSignatories
         observers <- raiseList raiseParty createdEventObservers
         return CreatedEvent{eid,cid,tid,key,createArgs,witness,signatories,observers}
+    LL.Event (Just (LL.EventEventExercised LL.ExercisedEvent{..})) -> do
+      eid <- raiseEventId exercisedEventEventId
+      return ExercisedEvent{eid}
 
 raiseRecord :: LL.Record -> Perhaps Record
 raiseRecord = \case

--- a/language-support/hs/bindings/src/DA/Ledger/Services/TransactionService.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Services/TransactionService.hs
@@ -158,7 +158,8 @@ lowerRequest = \case
         getTransactionsRequestEnd = fmap lowerLedgerOffset end,
         getTransactionsRequestFilter = Just filter,
         getTransactionsRequestVerbose = unVerbosity verbose,
-        getTransactionsRequestTraceContext = noTrace
+        getTransactionsRequestTraceContext = noTrace,
+        getTransactionsRequestIncludeNonConsumingExerciseEvents = False
         }
 
 mkByEventIdRequest :: LedgerId -> EventId -> [Party] -> LL.GetTransactionByEventIdRequest

--- a/language-support/hs/bindings/src/DA/Ledger/Types.hs
+++ b/language-support/hs/bindings/src/DA/Ledger/Types.hs
@@ -187,6 +187,9 @@ data Event
       , tid     :: TemplateId
       , witness :: [Party]
       }
+    | ExercisedEvent
+      { eid :: EventId
+      }
     deriving (Eq,Ord,Show)
 
 -- value.proto

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionsServiceImpl.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/grpc/helpers/TransactionsServiceImpl.scala
@@ -12,7 +12,7 @@ import com.daml.ledger.rxjava.grpc.helpers.TransactionsServiceImpl.{
 import com.daml.ledger.api.auth.Authorizer
 import com.daml.ledger.api.auth.services.TransactionServiceAuthorization
 import com.daml.ledger.api.v1.event.Event
-import com.daml.ledger.api.v1.event.Event.Event.{Archived, Created, Empty}
+import com.daml.ledger.api.v1.event.Event.Event.{Archived, Created, Exercised, Empty}
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.LedgerBoundary.{
   LEDGER_BEGIN,
@@ -150,6 +150,7 @@ object TransactionsServiceImpl {
   def eventId(event: Event): String = event.event match {
     case Archived(archivedEvent) => archivedEvent.eventId
     case Created(createdEvent) => createdEvent.eventId
+    case Exercised(exercisedEvent) => exercisedEvent.eventId
     case Empty => ""
   }
 

--- a/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/DomainTransactionMapper.scala
+++ b/language-support/scala/bindings-akka/src/main/scala/com/digitalasset/ledger/client/binding/DomainTransactionMapper.scala
@@ -6,7 +6,7 @@ package com.daml.ledger.client.binding
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.daml.ledger.api.refinements.ApiTypes._
-import com.daml.ledger.api.v1.event.Event.Event.{Archived, Created, Empty}
+import com.daml.ledger.api.v1.event.Event.Event.{Archived, Created, Exercised, Empty}
 import com.daml.ledger.api.v1.event._
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset.Value.Absolute
@@ -93,6 +93,7 @@ class DomainTransactionMapper(decoder: DecoderType) extends LazyLogging {
           .fold(logAndDiscard(createdEvent), mapCreatedEvent(createdEvent, _).map(Some.apply))
       case Archived(archivedEvent) =>
         mapArchivedEvent(archivedEvent).map(Some.apply)
+      case Exercised(_) => ??? // TODO
       case Empty =>
         Left(EmptyEvent)
     }

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -30,8 +30,8 @@ message Event {
     // This field was removed in https://github.com/digital-asset/daml/issues/960 and has been re-introduced
     // to make it possible for consumers to access exercised events without being forced to subscribe to
     // the expensive transaction trees stream.
-    // ExercisedEvent items emitted in the flat transactions stream are identical to items in transaction trees
-    // stream except for:
+    // Only non-consuming exercised events are emitted.
+    // They are identical to items in transaction trees stream except for:
     // - child_event_ids field being empty
     // - witness_parties field containing union of the signatories and actors
     ExercisedEvent exercised = 2;

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/event.proto
@@ -13,8 +13,8 @@ option java_outer_classname = "EventOuterClass";
 option java_package = "com.daml.ledger.api.v1";
 option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 
-// An event in the flat transaction stream can either be the creation
-// or the archiving of a contract.
+// An event in the flat transaction stream can be the creation of a contract,
+// the archiving of a contract or an exercising an action on a contract.
 //
 // In the transaction service the events are restricted to the events
 // visible for the parties specified in the transaction filter. Each
@@ -24,12 +24,20 @@ option csharp_namespace = "Com.Daml.Ledger.Api.V1";
 // that have witnesses.
 message Event {
   oneof event {
+
     CreatedEvent created = 1;
+
+    // This field was removed in https://github.com/digital-asset/daml/issues/960 and has been re-introduced
+    // to make it possible for consumers to access exercised events without being forced to subscribe to
+    // the expensive transaction trees stream.
+    // ExercisedEvent items emitted in the flat transactions stream are identical to items in transaction trees
+    // stream except for:
+    // - child_event_ids field being empty
+    // - witness_parties field containing union of the signatories and actors
+    ExercisedEvent exercised = 2;
+
     ArchivedEvent archived = 3;
  }
-  // see https://github.com/digital-asset/daml/issues/960
-  reserved 2;
-  reserved "exercised";
 }
 
 // Records that a contract has been created, and choices may now be exercised on it.

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/transaction_service.proto
@@ -115,6 +115,9 @@ message GetTransactionsRequest {
   // Optional
   TraceContext trace_context = 1000;
 
+  // If set to True, the flat transactions stream events will contain exercised events matching given filters.
+  // Optional
+  bool include_non_consuming_exercise_events = 6;
 }
 
 message GetTransactionsResponse {

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/ContractsFetch.scala
@@ -322,6 +322,7 @@ private[http] object ContractsFetch {
     txes foreach {
       case Event(Created(c)) => discard { csb += c }
       case Event(Archived(a)) => discard { asb += ((a.contractId, a)) }
+      case Event(Exercised(_)) => ??? // TODO
       case Event(Empty) => () // nonsense
     }
     val as = asb.result()

--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -265,6 +265,8 @@ object domain {
           ActiveContract.fromLedgerApi(created).map(a => Contract(\/-(a)))
         case lav1.event.Event.Event.Archived(archived) =>
           ArchivedContract.fromLedgerApi(archived).map(a => Contract(-\/(a)))
+        case lav1.event.Event.Event.Exercised(_) =>
+          ??? // TODO
         case lav1.event.Event.Event.Empty =>
           val errorMsg = s"Expected either Created or Archived event, got: Empty"
           -\/(Error(Symbol("Contract_fromLedgerApi"), errorMsg))

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/validation/TransactionServiceRequestValidator.scala
@@ -93,6 +93,7 @@ class TransactionServiceRequestValidator(
         convertedFilter,
         req.verbose,
         req.traceContext.map(toBrave),
+        req.includeNonConsumingExerciseEvents,
       )
     }
   }

--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/api/v1/event/EventOps.scala
+++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/platform/api/v1/event/EventOps.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.api.v1.event
 
-import com.daml.ledger.api.v1.event.Event.Event.{Archived, Created, Empty}
+import com.daml.ledger.api.v1.event.Event.Event.{Archived, Created, Exercised, Empty}
 import com.daml.ledger.api.v1.event.{CreatedEvent, Event, ExercisedEvent}
 import com.daml.ledger.api.v1.transaction.TreeEvent
 import com.daml.ledger.api.v1.transaction.TreeEvent.Kind.{
@@ -38,30 +38,35 @@ object EventOps {
     def eventId: String = event match {
       case Archived(value) => value.eventId
       case Created(value) => value.eventId
+      case Exercised(value) => value.eventId
       case Empty => throw new IllegalArgumentException("Cannot extract Event ID from Empty event.")
     }
 
     def witnessParties: Seq[String] = event match {
       case Archived(value) => value.witnessParties
       case Created(value) => value.witnessParties
+      case Exercised(value) => value.witnessParties
       case Empty => Seq.empty
     }
 
     def updateWitnessParties(set: Seq[String]): Event.Event = event match {
       case Archived(value) => Archived(value.copy(witnessParties = set))
       case Created(value) => Created(value.copy(witnessParties = set))
+      case Exercised(value) => Exercised(value.copy(witnessParties = set))
       case Empty => Empty
     }
 
     def modifyWitnessParties(f: Seq[String] => Seq[String]): Event.Event = event match {
       case Archived(value) => Archived(value.copy(witnessParties = f(value.witnessParties)))
       case Created(value) => Created(value.copy(witnessParties = f(value.witnessParties)))
+      case Exercised(value) => Exercised(value.copy(witnessParties = f(value.witnessParties)))
       case Empty => Empty
     }
 
     def templateId: Identifier = event match {
       case Archived(value) => value.templateId.get
       case Created(value) => value.templateId.get
+      case Exercised(value) => value.templateId.get
       case Empty =>
         throw new IllegalArgumentException("Cannot extract Template ID from Empty event.")
     }
@@ -69,6 +74,7 @@ object EventOps {
     def contractId: String = event match {
       case Archived(value) => value.contractId
       case Created(value) => value.contractId
+      case Exercised(value) => value.contractId
       case Empty =>
         throw new IllegalArgumentException("Cannot extract contractId from Empty event.")
     }

--- a/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionsRequest.scala
+++ b/ledger/ledger-api-domain/src/main/scala/com/digitalasset/ledger/api/messages/transaction/GetTransactionsRequest.scala
@@ -13,4 +13,5 @@ final case class GetTransactionsRequest(
     filter: TransactionFilter,
     verbose: Boolean,
     traceContext: Option[TraceContext],
+    includeNonConsumingExerciseEvents: Boolean,
 )

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/SpannedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/SpannedIndexService.scala
@@ -82,9 +82,10 @@ private[daml] final class SpannedIndexService(delegate: IndexService) extends In
       endAt: Option[domain.LedgerOffset],
       filter: domain.TransactionFilter,
       verbose: Boolean,
+      includeNonConsumingExerciseEvents: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed] =
     delegate
-      .transactions(begin, endAt, filter, verbose)
+      .transactions(begin, endAt, filter, verbose, includeNonConsumingExerciseEvents)
       .wireTap(
         _.transactions
           .map(transaction =>

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -92,10 +92,11 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
       endAt: Option[domain.LedgerOffset],
       filter: domain.TransactionFilter,
       verbose: Boolean,
+      includeNonConsumingExerciseEvents: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed] =
     Timed.source(
       metrics.daml.services.index.transactions,
-      delegate.transactions(begin, endAt, filter, verbose),
+      delegate.transactions(begin, endAt, filter, verbose, includeNonConsumingExerciseEvents),
     )
 
   override def transactionTrees(

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/transaction/ApiTransactionService.scala
@@ -71,7 +71,13 @@ private[apiserver] final class ApiTransactionService private (
       val subscriptionId = subscriptionIdCounter.incrementAndGet().toString
       logger.debug(s"Received request for transaction subscription $subscriptionId: $request")
       transactionsService
-        .transactions(request.startExclusive, request.endInclusive, request.filter, request.verbose)
+        .transactions(
+          request.startExclusive,
+          request.endInclusive,
+          request.filter,
+          request.verbose,
+          request.includeNonConsumingExerciseEvents,
+        )
         .via(logger.debugStream(transactionsLoggable))
         .via(logger.logErrorsOnStream)
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/LedgerBackedIndexService.scala
@@ -97,6 +97,7 @@ private[platform] final class LedgerBackedIndexService(
       endInclusive: Option[domain.LedgerOffset],
       filter: domain.TransactionFilter,
       verbose: Boolean,
+      includeNonConsumingExerciseEvents: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed] =
     between(startExclusive, endInclusive)((from, to) => {
       from.foreach(offset =>
@@ -111,6 +112,7 @@ private[platform] final class LedgerBackedIndexService(
           endInclusive = to,
           filter = convertFilter(filter),
           verbose = verbose,
+          includeNonConsumingExerciseEvents = includeNonConsumingExerciseEvents,
         )
         .map(_._2)
     })

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -46,8 +46,15 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
       endInclusive: Option[Offset],
       filter: Map[Party, Set[Identifier]],
       verbose: Boolean,
+      includeNonConsumingExerciseEvents: Boolean,
   )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] =
-    ledger.flatTransactions(startExclusive, endInclusive, filter, verbose)
+    ledger.flatTransactions(
+      startExclusive,
+      endInclusive,
+      filter,
+      verbose,
+      includeNonConsumingExerciseEvents,
+    )
 
   override def transactionTrees(
       startExclusive: Option[Offset],

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -61,10 +61,14 @@ private[platform] abstract class BaseLedger(
       endInclusive: Option[Offset],
       filter: Map[Party, Set[Identifier]],
       verbose: Boolean,
+      includeNonConsumingExerciseEvents: Boolean,
   )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] =
     dispatcher.startingAt(
       startExclusive.getOrElse(Offset.beforeBegin),
-      RangeSource(ledgerDao.transactionsReader.getFlatTransactions(_, _, filter, verbose)),
+      RangeSource(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(_, _, filter, verbose, includeNonConsumingExerciseEvents)
+      ),
       endInclusive,
     )
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
@@ -42,6 +42,7 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
       endInclusive: Option[Offset],
       filter: Map[Party, Set[Identifier]],
       verbose: Boolean,
+      includeNonConsumingExerciseEvents: Boolean,
   )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed]
 
   def transactionTrees(

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/LfValueTranslation.scala
@@ -261,8 +261,8 @@ final class LfValueTranslation(
     }
   }
 
-  def deserialize(
-      raw: Raw.TreeEvent.Exercised,
+  def deserialize[E](
+      raw: Raw.Exercised[E],
       verbose: Boolean,
   )(implicit
       ec: ExecutionContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionIndexing.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionIndexing.scala
@@ -178,11 +178,9 @@ object TransactionIndexing {
           addEventAndDisclosure(event)
           addVisibility(exercise.targetCoid, blinding.disclosure(nodeId))
           addDivulgence(exercise.targetCoid)
+          addStakeholders(nodeId, exercise.signatories ++ exercise.actingParties)
           if (exercise.consuming) {
-            addStakeholders(nodeId, exercise.stakeholders)
             addArchive(exercise.targetCoid)
-          } else {
-            addStakeholders(nodeId, Set.empty)
           }
         case _ =>
           () // ignore anything else

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
@@ -76,6 +76,7 @@ private[dao] final class TransactionsReader(
       endInclusive: Offset,
       filter: FilterRelation,
       verbose: Boolean,
+      includeNonConsumingExerciseEvents: Boolean,
   )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] = {
     val span =
       ParticipantTracer
@@ -97,6 +98,7 @@ private[dao] final class TransactionsReader(
               range = EventsRange(range.startExclusive._2, range.endInclusive._2),
               filter = filter,
               pageSize = pageSize,
+              includeNonConsumingExerciseEvents = includeNonConsumingExerciseEvents,
             )
             .executeSql,
           range.startExclusive._1,

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoTransactionsSpec.scala
@@ -177,6 +177,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             endInclusive = to,
             filter = Map(alice -> Set.empty, bob -> Set.empty, charlie -> Set.empty),
             verbose = true,
+            includeNonConsumingExerciseEvents = false,
           )
       )
     } yield {
@@ -207,6 +208,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             endInclusive = to,
             filter = Map(alice -> Set.empty),
             verbose = true,
+            includeNonConsumingExerciseEvents = false,
           )
       )
       resultForBob <- transactionsOf(
@@ -216,6 +218,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             endInclusive = to,
             filter = Map(bob -> Set.empty),
             verbose = true,
+            includeNonConsumingExerciseEvents = false,
           )
       )
       resultForCharlie <- transactionsOf(
@@ -225,6 +228,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             endInclusive = to,
             filter = Map(charlie -> Set.empty),
             verbose = true,
+            includeNonConsumingExerciseEvents = false,
           )
       )
     } yield {
@@ -255,6 +259,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
             endInclusive = to,
             filter = Map(alice -> Set(otherTemplateId)),
             verbose = true,
+            includeNonConsumingExerciseEvents = false,
           )
       )
     } yield {
@@ -289,6 +294,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
               bob -> Set(otherTemplateId),
             ),
             verbose = true,
+            includeNonConsumingExerciseEvents = false,
           )
       )
     } yield {
@@ -329,6 +335,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
               bob -> Set(otherTemplateId),
             ),
             verbose = true,
+            includeNonConsumingExerciseEvents = false,
           )
       )
     } yield {
@@ -369,6 +376,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
               bob -> Set.empty,
             ),
             verbose = true,
+            includeNonConsumingExerciseEvents = false,
           )
       )
     } yield {
@@ -397,6 +405,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
           offset,
           exercise.actAs.map(submitter => submitter -> Set.empty[Identifier]).toMap,
           verbose = true,
+          includeNonConsumingExerciseEvents = false,
         )
         .runWith(Sink.seq)
     } yield {
@@ -429,6 +438,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
           offset2,
           exercise.actAs.map(submitter => submitter -> Set.empty[Identifier]).toMap,
           verbose = true,
+          includeNonConsumingExerciseEvents = false,
         )
         .runWith(Sink.seq)
 
@@ -459,6 +469,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
           endOffsetFromTheFuture,
           Map(alice -> Set.empty[Identifier]),
           verbose = true,
+          includeNonConsumingExerciseEvents = false,
         )
         .runWith(Sink.seq)
 
@@ -503,6 +514,7 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
           endOffset,
           Map(alice -> Set.empty[Identifier]),
           verbose = true,
+          includeNonConsumingExerciseEvents = false,
         )
         .runWith(Sink.seq)
 
@@ -546,7 +558,13 @@ private[dao] trait JdbcLedgerDaoTransactionsSpec extends OptionValues with Insid
           }
           to <- ledgerDao.lookupLedgerEnd()
           response <- ledgerDao.transactionsReader
-            .getFlatTransactions(from, to, cp.filter, verbose = false)
+            .getFlatTransactions(
+              from,
+              to,
+              cp.filter,
+              verbose = false,
+              includeNonConsumingExerciseEvents = false,
+            )
             .runWith(Sink.seq)
           readOffsets = response flatMap { case (_, gtr) => gtr.transactions map (_.offset) }
           readCreates = extractAllTransactions(response) flatMap (_.events)

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexTransactionsService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexTransactionsService.scala
@@ -26,6 +26,7 @@ trait IndexTransactionsService extends LedgerEndService {
       endAt: Option[LedgerOffset],
       filter: TransactionFilter,
       verbose: Boolean,
+      includeNonConsumingExerciseEvents: Boolean,
   )(implicit loggingContext: LoggingContext): Source[GetTransactionsResponse, NotUsed]
 
   def transactionTrees(

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -108,6 +108,7 @@ private[sandbox] final class InMemoryLedger(
       endInclusive: Option[Offset],
       filter: Map[Party, Set[Ref.Identifier]],
       verbose: Boolean,
+      includeNonConsumingExerciseEvents: Boolean,
   )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] =
     entries
       .getSource(startExclusive, endInclusive)


### PR DESCRIPTION
**Motivation**
This is a draft of changes to the Ledger API and the event storing mechanism which enables including non-consuming `ExercisedEvent` events in the flat transactions stream.
The motivation behind this change is to enable consumers to access non-consuming exercise events with filtering, which enables efficiently using specific non-consuming choices as signals to Ledger API clients. An example use-case of this kind of signalling is the integration with an outbound off-ledger message queue.

**Key changes**
- add the `include_non_consuming_exercise_events` flag to  the `GetTransactionsRequest` Ledger API request - this flag enables streaming non-consuming exercise events in the flat transactions stream
- add the `ExercisedEvent exercised = 2;` event type in the Ledger API
- store witnesses of non-consuming exercise events in the `participant_events` table - this change allows to query non-consuming exercise events

**Additional comment**
Please see comments below for more detailed explanation of changes introduced with this draft.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
