### PR TITLE
Switch canton pruning test to be manual rather than disabling it

### DIFF
--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -132,9 +132,12 @@ conformance_test(
     ],
     runner = "@//bazel_tools/client_server/runner:runner",
     server = ":canton-test-runner-with-dependencies",
+    tags = [
+        "manual",  # pruning test is flaky on canton because of safe-pruning offset reconciliation checks
+    ],
     test_tool_args = [
         "--verbose",
         "--include=ParticipantPruningIT",
         "--exclude=ParticipantPruningIT:PRFailPruneByOutOfBoundsOffset",  # on behalf of bug not yet fixed in canton 0.19.0
     ],
-) if False else None  # if not is_windows else None
+) if not is_windows else None


### PR DESCRIPTION
Per guidance at https://docs.bazel.build/versions/master/test-encyclopedia.html#tag-conventions

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
