### PR TITLE
Refactor speedy code for begin/end exercise

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -375,6 +375,10 @@ private[lf] object Anf {
           ).bounce
         Bounce(() => transform(depth, SETryCatch(body, handler), k))
 
+      case SEScopeExercise(body0, end) =>
+        val body: SExpr = flattenExp(depth, env, body0)(anf => Land(anf.wrapped)).bounce
+        Bounce(() => transform(depth, SEScopeExercise(body, end), k))
+
       case x: SEAbs => throw CompilationError(s"flatten: unexpected: $x")
       case x: SEDamlException => throw CompilationError(s"flatten: unexpected: $x")
       case x: SEAppAtomicFun => throw CompilationError(s"flatten: unexpected: $x")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -375,9 +375,9 @@ private[lf] object Anf {
           ).bounce
         Bounce(() => transform(depth, SETryCatch(body, handler), k))
 
-      case SEScopeExercise(body0, end) =>
+      case SEScopeExercise(body0) =>
         val body: SExpr = flattenExp(depth, env, body0)(anf => Land(anf.wrapped)).bounce
-        Bounce(() => transform(depth, SEScopeExercise(body, end), k))
+        Bounce(() => transform(depth, SEScopeExercise(body), k))
 
       case x: SEAbs => throw CompilationError(s"flatten: unexpected: $x")
       case x: SEDamlException => throw CompilationError(s"flatten: unexpected: $x")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -965,8 +965,7 @@ private[lf] final class Compiler(
         ) { _ =>
           addExprVar(choice.selfBinder, cidPos)
           app(compile(choice.update), svar(tokenPos))
-        },
-        tmplId,
+        }
       )
     }
 
@@ -1181,8 +1180,8 @@ private[lf] final class Compiler(
           closureConvert(shift(remaps, 1), handler),
         )
 
-      case SEScopeExercise(body, tmplId) =>
-        SEScopeExercise(closureConvert(remaps, body), tmplId)
+      case SEScopeExercise(body) =>
+        SEScopeExercise(closureConvert(remaps, body))
 
       case SELabelClosure(label, expr) =>
         SELabelClosure(label, closureConvert(remaps, expr))
@@ -1272,7 +1271,7 @@ private[lf] final class Compiler(
           go(expr, bound, free)
         case SETryCatch(body, handler) =>
           go(body, bound, go(handler, 1 + bound, free))
-        case SEScopeExercise(body, _) =>
+        case SEScopeExercise(body) =>
           go(body, bound, free)
 
         case x: SEDamlException =>
@@ -1378,7 +1377,7 @@ private[lf] final class Compiler(
         case SETryCatch(body, handler) =>
           go(body)
           goBody(maxS + 1, maxA, maxF)(handler)
-        case SEScopeExercise(body, _) =>
+        case SEScopeExercise(body) =>
           go(body)
 
         case x: SEDamlException =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -943,32 +943,31 @@ private[lf] final class Compiler(
   ) =
     let(SBUFetch(tmplId)(svar(cidPos))) { tmplArgPos =>
       addExprVar(tmpl.param, tmplArgPos)
-      let(
-        SBUBeginExercise(tmplId, choice.name, choice.consuming, byKey = mbKey.isDefined)(
-          svar(choiceArgPos),
-          svar(cidPos),
-          compile(tmpl.signatories),
-          compile(tmpl.observers), //
-          {
-            addExprVar(choice.argBinder._1, choiceArgPos)
-            compile(choice.controllers)
-          }, //
-          {
-            choice.choiceObservers match {
-              case Some(observers) => compile(observers)
-              case None => SEValue.EmptyList
-            }
-          },
-          mbKey.fold(compileKeyWithMaintainers(tmpl.key))(pos => SBSome(svar(pos))),
-        )
-      ) { _ =>
-        addExprVar(choice.selfBinder, cidPos)
-        let(app(compile(choice.update), svar(tokenPos))) { retValuePos =>
-          let(SBUEndExercise(tmplId)(svar(retValuePos))) { _ =>
-            svar(retValuePos)
-          }
-        }
-      }
+      SEScopeExercise(
+        let(
+          SBUBeginExercise(tmplId, choice.name, choice.consuming, byKey = mbKey.isDefined)(
+            svar(choiceArgPos),
+            svar(cidPos),
+            compile(tmpl.signatories),
+            compile(tmpl.observers), //
+            {
+              addExprVar(choice.argBinder._1, choiceArgPos)
+              compile(choice.controllers)
+            }, //
+            {
+              choice.choiceObservers match {
+                case Some(observers) => compile(observers)
+                case None => SEValue.EmptyList
+              }
+            },
+            mbKey.fold(compileKeyWithMaintainers(tmpl.key))(pos => SBSome(svar(pos))),
+          )
+        ) { _ =>
+          addExprVar(choice.selfBinder, cidPos)
+          app(compile(choice.update), svar(tokenPos))
+        },
+        tmplId,
+      )
     }
 
   private[this] def compileChoice(
@@ -1182,6 +1181,9 @@ private[lf] final class Compiler(
           closureConvert(shift(remaps, 1), handler),
         )
 
+      case SEScopeExercise(body, tmplId) =>
+        SEScopeExercise(closureConvert(remaps, body), tmplId)
+
       case SELabelClosure(label, expr) =>
         SELabelClosure(label, closureConvert(remaps, expr))
 
@@ -1270,6 +1272,8 @@ private[lf] final class Compiler(
           go(expr, bound, free)
         case SETryCatch(body, handler) =>
           go(body, bound, go(handler, 1 + bound, free))
+        case SEScopeExercise(body, _) =>
+          go(body, bound, free)
 
         case x: SEDamlException =>
           throw CompilationError(s"unexpected SEDamlException: $x")
@@ -1374,6 +1378,8 @@ private[lf] final class Compiler(
         case SETryCatch(body, handler) =>
           go(body)
           goBody(maxS + 1, maxA, maxF)(handler)
+        case SEScopeExercise(body, _) =>
+          go(body)
 
         case x: SEDamlException =>
           throw CompilationError(s"unexpected SEDamlException: $x")

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -558,6 +558,9 @@ private[lf] object Pretty {
           text("try-catch") + char('(') + prettySExpr(index)(body) + text(", ") +
             prettySExpr(index)(handler) + char(')')
 
+        case SEScopeExercise(body, _) =>
+          text("exercise") + char('(') + prettySExpr(index)(body) + text(")")
+
         case x: SEBuiltinRecursiveDefinition => str(x)
         case x: SEImportValue => str(x)
         case x: SELabelClosure => str(x)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -558,7 +558,7 @@ private[lf] object Pretty {
           text("try-catch") + char('(') + prettySExpr(index)(body) + text(", ") +
             prettySExpr(index)(handler) + char(')')
 
-        case SEScopeExercise(body, _) =>
+        case SEScopeExercise(body) =>
           text("exercise") + char('(') + prettySExpr(index)(body) + text(")")
 
         case x: SEBuiltinRecursiveDefinition => str(x)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -981,23 +981,6 @@ private[lf] object SBuiltin {
     }
   }
 
-  /** $endExercise[T]
-    *    :: Value   (result of the exercise)
-    *    -> ()
-    */
-  final case class SBUEndExercise(templateId: TypeConName) extends OnLedgerBuiltin(1) {
-    override protected final def execute(
-        args: util.ArrayList[SValue],
-        machine: Machine,
-        onLedger: OnLedger,
-    ): Unit = {
-      val exerciseResult = args.get(0).toValue
-      onLedger.ptx = onLedger.ptx.endExercises(exerciseResult)
-      checkAborted(onLedger.ptx)
-      machine.returnValue = SUnit
-    }
-  }
-
   /** $fetch[T]
     *    :: ContractId a
     *    -> a
@@ -1687,7 +1670,7 @@ private[lf] object SBuiltin {
     * throw if so. The partial transaction abort status must be
     * checked after every operation on it.
     */
-  private[this] def checkAborted(ptx: PartialTransaction): Unit =
+  private[speedy] def checkAborted(ptx: PartialTransaction): Unit =
     ptx.aborted match {
       case Some(Tx.AuthFailureDuringExecution(nid, fa)) =>
         throw DamlEFailedAuthorization(nid, fa)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -382,6 +382,17 @@ object SExpr {
     }
   }
 
+  /** Exercise scope (begin..end) */
+  final case class SEScopeExercise(
+      body: SExpr,
+      end_templateId: TypeConName,
+  ) extends SExpr {
+    def execute(machine: Machine): Unit = {
+      machine.pushKont(KCloseExercise(machine, end_templateId))
+      machine.ctrl = body
+    }
+  }
+
   /** Case patterns */
   sealed trait SCasePat
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -383,12 +383,9 @@ object SExpr {
   }
 
   /** Exercise scope (begin..end) */
-  final case class SEScopeExercise(
-      body: SExpr,
-      end_templateId: TypeConName,
-  ) extends SExpr {
+  final case class SEScopeExercise(body: SExpr) extends SExpr {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KCloseExercise(machine, end_templateId))
+      machine.pushKont(KCloseExercise(machine))
       machine.ctrl = body
     }
   }

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1268,8 +1268,7 @@ private[lf] object Speedy {
   private[speedy] final case class KCloseExercise(
       machine: Machine,
       end_templateId: TypeConName,
-  ) extends Kont
-      with SomeArrayEquals {
+  ) extends Kont {
 
     def execute(exerciseResult: SValue) = {
       machine.withOnLedger("KCloseExercise") { onLedger =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -16,6 +16,7 @@ import com.daml.lf.speedy.PartialTransaction.ExercisesContextInfo
 import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
+import com.daml.lf.speedy.SBuiltin.checkAborted
 import com.daml.lf.transaction.TransactionVersion
 import com.daml.lf.value.{Value => V}
 import org.slf4j.LoggerFactory
@@ -1260,6 +1261,33 @@ private[lf] object Speedy {
     }
   }
 
+  /** KCloseExercise. Marks an open-exercise which needs to be closed. Either:
+    * (1) by 'endExercise' if this continuation is entered normally, or
+    * (2) by 'abortExercise' if we unwind the stack through this continuation (TODO 8020)
+    */
+  private[speedy] final case class KCloseExercise(
+      machine: Machine,
+      end_templateId: TypeConName,
+  ) extends Kont
+      with SomeArrayEquals {
+
+    val envSize = machine.env.size
+
+    private val savedBase = machine.markBase()
+    private val frame = machine.frame
+    private val actuals = machine.actuals
+
+    def execute(exerciseResult: SValue) = {
+      machine.restoreBase(savedBase);
+      machine.restoreFrameAndActuals(frame, actuals)
+      machine.withOnLedger("KCloseExercise") { onLedger =>
+        onLedger.ptx = onLedger.ptx.endExercises(exerciseResult.toValue)
+        checkAborted(onLedger.ptx)
+        machine.returnValue = exerciseResult
+      }
+    }
+  }
+
   /** KTryCatchHandler marks the kont-stack to allow unwinding when throw is executed. If
     * the continuation is entered normally, the environment is restored but the handler is
     * not executed.  When a throw is executed, the kont-stack is unwound to the nearest
@@ -1328,6 +1356,8 @@ private[lf] object Speedy {
     * producing a text message.
     */
   private[speedy] def unwindToHandler(machine: Machine, payload: SValue): Unit = {
+    // TODO https://github.com/digital-asset/daml/issues/8020
+    // Support unwinding through KCloseExercise, aborting the open-exercise
     val catchIndex =
       machine.kontStack.asScala.lastIndexWhere(_.isInstanceOf[KTryCatchHandler])
     if (catchIndex >= 0) {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1265,10 +1265,7 @@ private[lf] object Speedy {
     * (1) by 'endExercise' if this continuation is entered normally, or
     * (2) by 'abortExercise' if we unwind the stack through this continuation (TODO 8020)
     */
-  private[speedy] final case class KCloseExercise(
-      machine: Machine,
-      end_templateId: TypeConName,
-  ) extends Kont {
+  private[speedy] final case class KCloseExercise(machine: Machine) extends Kont {
 
     def execute(exerciseResult: SValue) = {
       machine.withOnLedger("KCloseExercise") { onLedger =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -1271,15 +1271,7 @@ private[lf] object Speedy {
   ) extends Kont
       with SomeArrayEquals {
 
-    val envSize = machine.env.size
-
-    private val savedBase = machine.markBase()
-    private val frame = machine.frame
-    private val actuals = machine.actuals
-
     def execute(exerciseResult: SValue) = {
-      machine.restoreBase(savedBase);
-      machine.restoreFrameAndActuals(frame, actuals)
       machine.withOnLedger("KCloseExercise") { onLedger =>
         onLedger.ptx = onLedger.ptx.endExercises(exerciseResult.toValue)
         checkAborted(onLedger.ptx)


### PR DESCRIPTION
## Refactor `endExercise` in speedy

Refactor code so `endExercise` is performed by a new continuation `KCloseExercise`.

This is in preparation for support of unwinding the continuation stack (when an exception is thrown) through a `KCloseExercise` continuation. In this case we will need to call `abortExercise`.

This change advances the state of #8020

changelog_begin
changelog_end

## performance impact

`collectAuthority` benchmark. 4-way here vs main...
```
  22.922 ±(99.9%) 0.166 ms/op [Average] (here)
  23.261 ±(99.9%) 0.173 ms/op [Average] (main)
  23.062 ±(99.9%) 0.136 ms/op [Average] (here)
  22.884 ±(99.9%) 0.091 ms/op [Average] (main)
```

No impact detected.


### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
