### PR TITLE
Fixup scala 2.13 check

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -387,7 +387,7 @@ jobs:
         # This is the last snapshot that does not support Scala 2.13.
         CMP="$(semver compare "$RELEASE_TAG" '1.11.0-snapshot.20210212.6300.0.ad161d7f')"
 
-        if [[ $CMP == "1" || "$RELEASE_TAG" == "0.0.0" ]]; then
+        if [[ $CMP == '1' || "$RELEASE_TAG" == '0.0.0' ]]; then
             setvar scala_2_13 true
         else
             setvar scala_2_13 false

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -384,10 +384,10 @@ jobs:
             setvar is_release false
         fi
 
-        ret=0
         # This is the last snapshot that does not support Scala 2.13.
-        semver compare "$RELEASE_TAG" "1.11.0-snapshot.20210212.6300.0.ad161d7f" || ret=$?
-        if [[ $ret -eq 1 || "$RELEASE_TAG" == "0.0.0" ]]; then
+        CMP="$(semver compare "$RELEASE_TAG" "1.11.0-snapshot.20210212.6300.0.ad161d7f")"
+
+        if [[ $CMP == "1" || "$RELEASE_TAG" == "0.0.0" ]]; then
             setvar scala_2_13 true
         else
             setvar scala_2_13 false

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -385,7 +385,7 @@ jobs:
         fi
 
         # This is the last snapshot that does not support Scala 2.13.
-        CMP="$(semver compare "$RELEASE_TAG" "1.11.0-snapshot.20210212.6300.0.ad161d7f")"
+        CMP="$(semver compare "$RELEASE_TAG" '1.11.0-snapshot.20210212.6300.0.ad161d7f')"
 
         if [[ $CMP == "1" || "$RELEASE_TAG" == "0.0.0" ]]; then
             setvar scala_2_13 true
@@ -546,4 +546,3 @@ jobs:
         # value or empty string, but not $(Azure.Variable.Name)).
         PR_NUM: $(pr.num)
         PR_BRANCH: $(pr.branch)
-


### PR DESCRIPTION
Somehow I managed to misread the helpcheck and get confused by my
experiments and thought semver produces an exit code of 1,0,-1 but
actually it writes that to stdout.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
