### PR TITLE
Let migrations not explode memory

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V25__Backfill_Participant_Events.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V25__Backfill_Participant_Events.scala
@@ -13,9 +13,12 @@ private[migration] class V25__Backfill_Participant_Events extends BaseJavaMigrat
 
   val SELECT_TRANSACTIONS = "select * from ledger_entries where typ='transaction'"
 
+  val BATCH_SIZE = 500
+
   override def migrate(context: Context): Unit = {
     val conn = context.getConnection
     val loadTransactions = conn.createStatement()
+    loadTransactions.setFetchSize(BATCH_SIZE)
     val rows = loadTransactions.executeQuery(SELECT_TRANSACTIONS)
 
     def getNonEmptyString(name: String): Option[String] =

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V26_1__Fill_create_argument.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V26_1__Fill_create_argument.scala
@@ -21,6 +21,8 @@ private[migration] class V26_1__Fill_create_argument extends BaseJavaMigration {
   private val UPDATE_PARTICIPANT_CONTRACTS =
     "update participant_contracts set create_argument = ?, template_id = ? where contract_id = ?"
 
+  private val BATCH_SIZE = 500
+
   override def migrate(context: Context): Unit = {
     val conn = context.getConnection
     var loadContracts: java.sql.Statement = null
@@ -29,6 +31,7 @@ private[migration] class V26_1__Fill_create_argument extends BaseJavaMigration {
     try {
       updateParticipantContracts = conn.prepareStatement(UPDATE_PARTICIPANT_CONTRACTS)
       loadContracts = conn.createStatement()
+      loadContracts.setFetchSize(BATCH_SIZE)
       rows = loadContracts.executeQuery(SELECT_CONTRACT_DATA)
 
       while (rows.next()) {

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V29__Fix_participant_events.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V29__Fix_participant_events.scala
@@ -17,6 +17,8 @@ private[migration] class V29__Fix_participant_events extends BaseJavaMigration {
   val SELECT_TRANSACTIONS =
     "select * from ledger_entries where typ='transaction' order by ledger_offset asc"
 
+  val BATCH_SIZE = 500
+
   override def migrate(context: Context): Unit = {
     val conn = context.getConnection
 
@@ -25,6 +27,7 @@ private[migration] class V29__Fix_participant_events extends BaseJavaMigration {
     conn.commit()
 
     val loadTransactions = conn.createStatement()
+    loadTransactions.setFetchSize(BATCH_SIZE)
     val rows = loadTransactions.executeQuery(SELECT_TRANSACTIONS)
 
     def getNonEmptyString(name: String): Option[String] =

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V32_1__Fix_key_hashes.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V32_1__Fix_key_hashes.scala
@@ -16,6 +16,8 @@ private[migration] final class V32_1__Fix_key_hashes extends BaseJavaMigration {
   private val FIX_HASH =
     "update participant_contracts set create_key_hash = ? where contract_id = ?"
 
+  private val BATCH_SIZE = 500
+
   override def migrate(context: Context): Unit = {
     val conn = context.getConnection
     var selectKeys: java.sql.Statement = null
@@ -25,7 +27,10 @@ private[migration] final class V32_1__Fix_key_hashes extends BaseJavaMigration {
       fixHash = conn.prepareStatement(FIX_HASH)
 
       selectKeys = conn.createStatement()
+      conn.setFetchSize(BATCH_SIZE)
       keysRows = selectKeys.executeQuery(SELECT_KEYS)
+
+      var currentBatchSize = 0
 
       while (keysRows.next()) {
         val contractId = keysRows.getString("contract_id")
@@ -39,8 +44,17 @@ private[migration] final class V32_1__Fix_key_hashes extends BaseJavaMigration {
         fixHash.setBinaryStream(1, hashBytes)
         fixHash.setString(2, contractId)
         fixHash.addBatch()
+        currentBatchSize += 1
+
+        if (currentBatchSize == BATCH_SIZE) {
+          val _ = fixHash.executeBatch()
+          currentBatchSize = 0
+        }
       }
-      val _ = fixHash.executeBatch()
+
+      if (currentBatchSize > 0) {
+        val _ = fixHash.executeBatch()
+      }
 
     } finally {
       if (keysRows != null) {

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V32_1__Fix_key_hashes.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V32_1__Fix_key_hashes.scala
@@ -27,7 +27,7 @@ private[migration] final class V32_1__Fix_key_hashes extends BaseJavaMigration {
       fixHash = conn.prepareStatement(FIX_HASH)
 
       selectKeys = conn.createStatement()
-      conn.setFetchSize(BATCH_SIZE)
+      selectKeys.setFetchSize(BATCH_SIZE)
       keysRows = selectKeys.executeQuery(SELECT_KEYS)
 
       var currentBatchSize = 0

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V38__Update_value_versions.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V38__Update_value_versions.scala
@@ -10,8 +10,6 @@ import java.sql.{Connection, ResultSet}
 import anorm.{BatchSql, NamedParameter}
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 
-import scala.collection.compat.immutable.LazyList
-
 private[migration] final class V38__Update_value_versions extends BaseJavaMigration {
 
   import com.daml.lf

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V3__Recompute_Key_Hash.scala
@@ -43,7 +43,9 @@ private[migration] class V3__Recompute_Key_Hash extends BaseJavaMigration {
       |  contracts.key is not null
     """.stripMargin
 
-    val rows: ResultSet = connection.createStatement().executeQuery(SQL_SELECT_CONTRACT_KEYS)
+    val statement = connection.createStatement()
+    statement.setFetchSize(batchSize)
+    val rows: ResultSet = statement.executeQuery(SQL_SELECT_CONTRACT_KEYS)
 
     new Iterator[(ContractId, GlobalKey)] {
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V4_1__Collect_Parties.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/postgres/V4_1__Collect_Parties.scala
@@ -41,7 +41,9 @@ private[migration] class V4_1__Collect_Parties extends BaseJavaMigration {
       |WHERE
       |  typ='transaction'""".stripMargin
 
-    val rows: ResultSet = connection.createStatement().executeQuery(SQL_SELECT_LEDGER_ENTRIES)
+    val statement = connection.createStatement()
+    statement.setFetchSize(batchSize)
+    val rows: ResultSet = statement.executeQuery(SQL_SELECT_LEDGER_ENTRIES)
 
     new Iterator[(Long, Tx.Transaction)] {
 

--- a/ledger/participant-integration-api/src/main/scala/db/migration/translation/ValueSerializer.scala
+++ b/ledger/participant-integration-api/src/main/scala/db/migration/translation/ValueSerializer.scala
@@ -39,6 +39,7 @@ private[migration] object ValueSerializer {
         logger.error(
           s"*** Please upgrade your sandbox database by upgrading your SDK to 1.6 first. ***"
         )
+      case _ =>
     }
     x
   }


### PR DESCRIPTION
This is a slightly spicy one, as it touches existing scala DB migrations.

This doesn't cause migration hash conflicts in flyway for existing databases, because java/scala migrations don't have an associated hash.

When running a recent version of daml on sql on a database from last August 2020, I noticed two issues:
1. ValueSerializer ran into a match error for values that weren't deprecated (fixed by 6675887).
2. The database had a bit over 2 million rows in `participant_events`. Without setting the fetch size explicitly, the JDBC driver (un)happily tries to load the entire result set into memory, eventually crashing the participant with an OutOfMemoryError (fixed by 075326a).

I initially suspected the memory explosion in the V38 migration to come from the assembly of the `LazyList` value (`Stream` often caused similar issues by holding on to values too long), so I changed it to `Iterator`. I then kept the `Iterator` based approach, as reasoning about what is kept in memory is easier with `Iterator` than with `Stream`/`LazyList` imho.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
