### PR TITLE
Stop pretending strings are booleans

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -110,7 +110,7 @@ jobs:
         ./bazel-bin/release/release --release-dir "$(mktemp -d)"
       env:
         DAML_SCALA_VERSION: "2.13.3"
-      name: Maven check
+      name: maven_check
       condition: and(succeeded(), ne(variables['is_release'], 'true'))
     - template: tell-slack-failed.yml
       parameters:

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -109,7 +109,7 @@ jobs:
         bazel build //release:release
         ./bazel-bin/release/release --release-dir "$(mktemp -d)"
       env:
-        DAML_SCALA_VERSION: ${{parameters.scala_version}}
+        DAML_SCALA_VERSION: "2.13.3"
       name: Maven check
       condition: and(succeeded(), ne(variables['is_release'], 'true'))
     - template: tell-slack-failed.yml

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -82,7 +82,7 @@ jobs:
     # The easiest option seems to be to still run the Scala 2.13 job but
     # pretend it’s not a release build and thereby just run it against main
     # so that’s what we do here.
-    is_release: $[ and(dependencies.check_for_release.outputs['out.is_release'], eq(dependencies.check_for_release.outputs['out.scala_2_13'], 'true')) ]
+    is_release: $[ and(eq(dependencies.check_for_release.outputs['out.is_release'], 'true'), eq(dependencies.check_for_release.outputs['out.scala_2_13'], 'true')) ]
     scala_2_13: $[ dependencies.check_for_release.outputs['out.scala_2_13'] ]
   timeoutInMinutes: 360
   pool:

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -110,6 +110,7 @@ jobs:
         ./bazel-bin/release/release --release-dir "$(mktemp -d)"
       env:
         DAML_SCALA_VERSION: ${{parameters.scala_version}}
+      name: Maven check
       condition: and(succeeded(), ne(variables['is_release'], 'true'))
     - template: tell-slack-failed.yml
       parameters:


### PR DESCRIPTION
Sorry for all the mess here. I’m not capable of programming in yaml.

It turns out is_release is a string not a boolean and

```
and('false', eq('true', 'true'))
```

is true.

I hate everything about this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
