### PR TITLE
Avoid warning on empty classpaths

### DIFF
--- a/bazel_tools/scala.bzl
+++ b/bazel_tools/scala.bzl
@@ -412,8 +412,9 @@ def _scaladoc_jar_impl(ctx):
         args = ctx.actions.args()
         args.add_all(["-d", outdir.path])
         args.add_all("-doc-root-content", root_content)
-        args.add("-classpath")
-        args.add_joined(classpath, join_with = ":")
+        if classpath != []:
+            args.add("-classpath")
+            args.add_joined(classpath, join_with = ":")
         args.add_joined(pluginPaths, join_with = ",", format_joined = "-Xplugin:%s")
         args.add_all(common_scalacopts)
         args.add_all(ctx.attr.scalacopts)


### PR DESCRIPTION
Some of our targets, e.g., //ledger/ledger-api-health have no
dependencies. On Scala 2.13, an empty classpath option produces a
bunch of confusing but afaict harmless warnings, on 2.12 it doesn’t
but there is still no point in passing an empty classpath so we can
omit it on both.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
