### PR TITLE
Limit SDK/platform tests to the SDK HEAD

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -59,20 +59,27 @@ config_setting(
 # test runs to grow quadratically.
 head = "0.0.0"
 
+# Missing on purpose: do not test the latest SDK with the latest platform
+# That is not a compatibility test, it's just testing the main branch. ;)
+
+# Test all old platform versions with the latest SDK
 [
     sdk_platform_test(
         platform_version = platform_version,
         sdk_version = head,
     )
     for platform_version in platform_versions
+    if platform_version != head
 ]
 
+# Test all old SDK versions with the latest platform
 [
     sdk_platform_test(
         platform_version = head,
         sdk_version = sdk_version,
     )
     for sdk_version in sdk_versions
+    if sdk_version != head
 ]
 
 [

--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -52,13 +52,27 @@ config_setting(
     for sdk_version in sdk_versions
 ]
 
+# Instead of testing the full cartesian product of all SDK versions with
+# all platform (~= Sandbox/JSON API) versions, we test the latest version of
+# each with all versions of the other. This gives us a reasonable feedback
+# with regards to maintaining backwards-compatibility without causing the
+# test runs to grow quadratically.
+head = "0.0.0"
+
 [
     sdk_platform_test(
         platform_version = platform_version,
+        sdk_version = head,
+    )
+    for platform_version in platform_versions
+]
+
+[
+    sdk_platform_test(
+        platform_version = head,
         sdk_version = sdk_version,
     )
     for sdk_version in sdk_versions
-    for platform_version in platform_versions
 ]
 
 [


### PR DESCRIPTION
Hopefully the comment in the code puts it best.

```
# Instead of testing the full cartesian product of all SDK versions with
# all platform (~= Sandbox/JSON API) versions, we test the latest version of
# each with all versions of the other. This gives us a reasonable feedback
# with regards to maintaining backwards-compatibility without causing the
# test runs to grow quadratically.
```

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
