### PR TITLE
Small speedy cleanups

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Anf.scala
@@ -328,23 +328,15 @@ private[lf] object Anf {
       case SELet1General(rhs, body) =>
         Bounce(() => transformLet1(depth, env, rhs, body, k, transform))
 
-      case SECatchSubmitMustFail(body0, handler0, fin0) =>
+      case SECatchSubmitMustFail(body0) =>
         Bounce(() =>
           flattenExp(depth, env, body0) { body =>
             Bounce(() =>
-              flattenExp(depth, env, handler0) { handler =>
-                Bounce(() =>
-                  flattenExp(depth, env, fin0) { fin =>
-                    Bounce(() =>
-                      transform(
-                        depth,
-                        SECatchSubmitMustFail(body.wrapped, handler.wrapped, fin.wrapped),
-                        k,
-                      )
-                    )
-                  }
-                )
-              }
+              transform(
+                depth,
+                SECatchSubmitMustFail(body.wrapped),
+                k,
+              )
             )
           }
         )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -854,7 +854,7 @@ private[lf] final class Compiler(
       labeledUnaryFunction("submitMustFail") { tokenPos =>
         let(SBSBeginCommit(optLoc)(compile(party), svar(tokenPos))) { _ =>
           let(
-            SECatchSubmitMustFail(app(compile(update), svar(tokenPos)), SEValue.True, SEValue.False)
+            SECatchSubmitMustFail(app(compile(update), svar(tokenPos)))
           ) { resultPos =>
             SBSEndCommit(mustFail = true)(svar(resultPos), svar(tokenPos))
           }
@@ -1180,11 +1180,9 @@ private[lf] final class Compiler(
           closureConvert(shift(remaps, bounds.length), body),
         )
 
-      case SECatchSubmitMustFail(body, handler, fin) =>
+      case SECatchSubmitMustFail(body) =>
         SECatchSubmitMustFail(
-          closureConvert(remaps, body),
-          closureConvert(remaps, handler),
-          closureConvert(remaps, fin),
+          closureConvert(remaps, body)
         )
 
       case SETryCatch(body, handler) =>
@@ -1278,8 +1276,8 @@ private[lf] final class Compiler(
           bounds.zipWithIndex.foldLeft(go(body, bound + bounds.length, free)) {
             case (acc, (expr, idx)) => go(expr, bound + idx, acc)
           }
-        case SECatchSubmitMustFail(body, handler, fin) =>
-          go(body, bound, go(handler, bound, go(fin, bound, free)))
+        case SECatchSubmitMustFail(body) =>
+          go(body, bound, free)
         case SELabelClosure(_, expr) =>
           go(expr, bound, free)
         case SETryCatch(body, handler) =>
@@ -1379,10 +1377,8 @@ private[lf] final class Compiler(
           goBody(maxS + bounds.length, maxA, maxF)(body)
         case _: SELet1General => goLets(maxS)(expr)
         case _: SELet1Builtin => goLets(maxS)(expr)
-        case SECatchSubmitMustFail(body, handler, fin) =>
+        case SECatchSubmitMustFail(body) =>
           go(body)
-          go(handler)
-          go(fin)
         case SELocation(_, body) =>
           go(body)
         case SELabelClosure(_, expr) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -523,10 +523,8 @@ private[lf] object Pretty {
             text("-> ")
           prettySExpr(index + n)(body).tightBracketBy(prefix, char(')'))
 
-        case SECatchSubmitMustFail(body, handler, fin) =>
-          text("catch-submit-must-fail") + char('(') + prettySExpr(index)(body) + text(", ") +
-            prettySExpr(index)(handler) + text(", ") +
-            prettySExpr(index)(fin) + char(')')
+        case SECatchSubmitMustFail(body) =>
+          text("catch-submit-must-fail") + char('(') + prettySExpr(index)(body) + text(")")
 
         case SELocation(loc @ _, body) =>
           prettySExpr(index)(body)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -331,14 +331,13 @@ object SExpr {
 
   /** catch-submit-must-fail. This is used internally solely for the purpose of implementing
     * mustFailAt. If the evaluation of 'body' causes an exception of type 'DamlException'
-    * (see SError), then the environment and continuation stacks are reset and 'handler'
-    * is executed. If the evaluation is successful, then the 'fin' expression is evaluated.
-    * This is on purpose very limited, with no mechanism to inspect the exception, nor a way
-    * to access the value returned from 'body'.
+    * (see SError), then 'True' is returned. If the evaluation is successful, then 'False'
+    * is returned.  This is on purpose very limited, with no mechanism to inspect the
+    * exception, nor a way to access the value returned from 'body'.
     */
-  final case class SECatchSubmitMustFail(body: SExpr, handler: SExpr, fin: SExpr) extends SExpr {
+  final case class SECatchSubmitMustFail(body: SExpr) extends SExpr {
     def execute(machine: Machine): Unit = {
-      machine.pushKont(KCatchSubmitMustFail(machine, handler, fin))
+      machine.pushKont(KCatchSubmitMustFail(machine))
       machine.ctrl = body
     }
   }


### PR DESCRIPTION
### Small cleanup of Speedy execution code

Specifically w.r.t environment manipulation within continuations.

- remove some stray semi colons
- introduce `private[this]` idiom in continuations which save/restore the environment
- remove unnecessary `val envSize = ` from `KTryCatchHandler`
- degeneralize `KCatchSubmitMustFail` removing the `handler`/`fin` expressions (which are only used as boolean values)...
- making it clear that environment save/restore is unnecessary; so remove it

### No perf impact
```
  23.405 ±(99.9%) 0.163 ms/op [Average] (here)
  23.679 ±(99.9%) 0.117 ms/op [Average] (base)
```

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
