### PR TITLE
Support starting script dumps from a given offset

### DIFF
--- a/daml-script/dump/BUILD.bazel
+++ b/daml-script/dump/BUILD.bazel
@@ -6,18 +6,23 @@ load(
     "da_scala_binary",
     "da_scala_library",
     "da_scala_test",
+    "silencer_plugin",
 )
 
 da_scala_binary(
     name = "dump",
     srcs = glob(["src/main/scala/**/*.scala"]),
     main_class = "com.daml.script.dump.Main",
+    plugins = [silencer_plugin],
     resources = glob(["src/main/resources/**/*"]),
     scala_deps = [
         "@maven//:com_github_scopt_scopt",
         "@maven//:com_typesafe_akka_akka_stream",
         "@maven//:org_scalaz_scalaz_core",
         "@maven//:org_typelevel_paiges_core",
+    ],
+    scalacopts = [
+        "-P:silencer:lineContentFilters=import scala.collection.compat.",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/daml-script/dump/src/it/scala/com/daml/script/dump/IT.scala
+++ b/daml-script/dump/src/it/scala/com/daml/script/dump/IT.scala
@@ -16,7 +16,7 @@ import com.daml.lf.data.Ref.PackageId
 import com.daml.lf.engine.script.{GrpcLedgerClient, Participants, Runner, ScriptTimeMode}
 import com.daml.ledger.api.domain
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
-import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundEach}
+import com.daml.ledger.api.testing.utils.{AkkaBeforeAndAfterAll, SuiteResourceManagementAroundAll}
 import com.daml.ledger.api.v1.command_service.SubmitAndWaitRequest
 import com.daml.ledger.api.v1.commands._
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
@@ -49,7 +49,8 @@ final class IT
     extends AsyncFreeSpec
     with Matchers
     with AkkaBeforeAndAfterAll
-    with SuiteResourceManagementAroundEach
+    with BeforeAndAfterEach
+    with SuiteResourceManagementAroundAll
     with SandboxNextFixture
     with TestCommands {
   private val appId = domain.ApplicationId("script-dump")
@@ -63,15 +64,19 @@ final class IT
   val isWindows: Boolean = sys.props("os.name").toLowerCase.contains("windows")
   val exe = if (isWindows) { ".exe" }
   else ""
-  private val tmpDir = Files.createTempDirectory("script_dump")
+  private var tmpDir: Path = null
   private val damlc =
     BazelRunfiles.requiredResource(s"compiler/damlc/damlc$exe")
   private val damlScriptLib = BazelRunfiles.requiredResource("daml-script/daml/daml-script.dar")
   private def iouId(s: String) =
     api.Identifier(packageId, moduleName = "Iou", s)
 
-  override protected def afterAll(): Unit = {
-    super.afterAll()
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    tmpDir = Files.createTempDirectory("script_dump")
+  }
+  override protected def afterEach(): Unit = {
+    super.afterEach()
     deleteRecursively(tmpDir)
   }
 

--- a/daml-script/dump/src/it/scala/com/daml/script/dump/IT.scala
+++ b/daml-script/dump/src/it/scala/com/daml/script/dump/IT.scala
@@ -135,6 +135,9 @@ final class IT
           ledgerHost = "localhost",
           ledgerPort = serverPort.value,
           parties = parties,
+          start =
+            LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)),
+          end = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
           outputPath = tmpDir,
           damlScriptLib = damlScriptLib.toString,
           sdkVersion = SdkVersion.sdkVersion,

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Config.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Config.scala
@@ -25,7 +25,7 @@ object Config {
 
   private def parseLedgerOffset(s: String): LedgerOffset = LedgerOffset {
     s match {
-      case s if s == "start" =>
+      case s if s == "begin" =>
         LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)
       case s if s == "end" => LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END)
       case s => LedgerOffset.Value.Absolute(s)

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Config.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Config.scala
@@ -3,13 +3,17 @@
 
 package com.daml.script.dump
 
-import java.nio.file.{Path}
+import java.nio.file.Path
 import java.io.File
+
+import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 
 final case class Config(
     ledgerHost: String,
     ledgerPort: Int,
     parties: List[String],
+    start: LedgerOffset,
+    end: LedgerOffset,
     outputPath: Path,
     sdkVersion: String,
     damlScriptLib: String,
@@ -18,6 +22,15 @@ final case class Config(
 object Config {
   def parse(args: Array[String]): Option[Config] =
     parser.parse(args, Empty)
+
+  private def parseLedgerOffset(s: String): LedgerOffset = LedgerOffset {
+    s match {
+      case s if s == "start" =>
+        LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)
+      case s if s == "end" => LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END)
+      case s => LedgerOffset.Value.Absolute(s)
+    }
+  }
 
   private val parser = new scopt.OptionParser[Config]("script-dump") {
     opt[String]("host")
@@ -30,6 +43,18 @@ object Config {
       .required()
       .unbounded()
       .action((x, c) => c.copy(parties = x :: c.parties))
+    opt[String]("start")
+      .optional()
+      .action((x, c) => c.copy(start = parseLedgerOffset(x)))
+      .text(
+        "The transaction offset (exclusive) for the start position of the dump. Optional, by default the dump includes the beginning of the ledger."
+      )
+    opt[String]("end")
+      .optional()
+      .action((x, c) => c.copy(start = parseLedgerOffset(x)))
+      .text(
+        "The transaction offset (inclusive) for the end position of the dump. Optional, by default the dump includes the current end of the ledger."
+      )
     opt[File]('o', "output")
       .required()
       .action((x, c) => c.copy(outputPath = x.toPath))
@@ -42,6 +67,8 @@ object Config {
     ledgerHost = "",
     ledgerPort = -1,
     parties = List(),
+    start = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)),
+    end = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
     outputPath = null,
     sdkVersion = "",
     damlScriptLib = "daml-script",

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -30,12 +30,12 @@ private[dump] object Encode {
     val treeCidRefs = trees.toList.foldMap(treeReferencedCids)
     val cidRefs = acsCidRefs ++ treeCidRefs
 
-    val archivedCidRefs = acsCidRefs -- acs.keySet
-    if (archivedCidRefs.nonEmpty) {
+    val unknownCidRefs = acsCidRefs -- acs.keySet
+    if (unknownCidRefs.nonEmpty) {
       // TODO[AH] Support this once the ledger has better support for exposing such "hidden" contracts.
       //   Be it archived or divulged contracts.
       throw new RuntimeException(
-        s"Encountered archived contracts referenced by active contracts: ${archivedCidRefs.mkString(", ")}"
+        s"Encountered archived contracts referenced by active contracts: ${unknownCidRefs.mkString(", ")}"
       )
     }
 

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Main.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Main.scala
@@ -10,9 +10,12 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
+import com.daml.ledger.api.v1.event.CreatedEvent
+import com.daml.ledger.api.v1.event.Event.Event
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
 import com.daml.ledger.api.v1.transaction.TransactionTree
 import com.daml.ledger.api.v1.transaction_filter.{Filters, TransactionFilter}
+import com.daml.ledger.api.v1.value.Value.Sum
 import com.daml.ledger.client.LedgerClient
 import com.daml.ledger.client.configuration.{
   CommandClientConfiguration,
@@ -57,6 +60,46 @@ object Main {
     ()
   }
 
+  private def getACS(
+      client: LedgerClient,
+      parties: List[String],
+      offset: LedgerOffset,
+  )(implicit
+      mat: Materializer
+  ): Future[Map[String, CreatedEvent]] = {
+    val ledgerBegin = LedgerOffset(
+      LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)
+    )
+    if (offset == ledgerBegin) {
+      Future.successful(Map.empty)
+    } else {
+      client.transactionClient
+        .getTransactions(ledgerBegin, Some(offset), filter(parties), verbose = true)
+        .runFold(Map.empty[String, CreatedEvent]) { case (acs, tx) =>
+          tx.events.foldLeft(acs) { case (acs, ev) =>
+            ev.event match {
+              case Event.Empty => acs
+              case Event.Created(value) => acs + (value.contractId -> value)
+              case Event.Archived(value) => acs - value.contractId
+            }
+          }
+        }
+    }
+  }
+
+  private def getTransactionTrees(
+      client: LedgerClient,
+      parties: List[String],
+      start: LedgerOffset,
+      end: LedgerOffset,
+  )(implicit
+      mat: Materializer
+  ): Future[Seq[TransactionTree]] = {
+    client.transactionClient
+      .getTransactionTrees(start, Some(end), filter(parties), verbose = true)
+      .runWith(Sink.seq)
+  }
+
   def run(config: Config)(implicit
       ec: ExecutionContext,
       esf: ExecutionSequencerFactory,
@@ -64,22 +107,21 @@ object Main {
   ): Future[Unit] =
     for {
       client <- LedgerClient.singleHost(config.ledgerHost, config.ledgerPort, clientConfig)
-      trees <- client.transactionClient
-        .getTransactionTrees(
-          LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)),
-          Some(LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END))),
-          filter(config.parties),
-          verbose = true,
-        )
-        .runWith(Sink.seq)
-      pkgRefs: Set[PackageId] = trees.toList
+      acs <- getACS(client, config.parties, config.start)
+      trees <- getTransactionTrees(client, config.parties, config.start, config.end)
+      acsPkgRefs = acs.values.toList
+        .foldMap(ev => valueRefs(Sum.Record(ev.getCreateArguments)))
+        .map(i => PackageId.assertFromString(i.packageId))
+      treePkgRefs = trees.toList
         .foldMap(treeRefs(_))
         .map(i => PackageId.assertFromString(i.packageId))
+      pkgRefs = acsPkgRefs ++ treePkgRefs
       pkgs <- Dependencies.fetchPackages(client, pkgRefs.toList)
       _ = writeDump(
         config.sdkVersion,
         config.damlScriptLib,
         config.outputPath,
+        acs,
         trees,
         pkgRefs,
         pkgs,
@@ -90,6 +132,7 @@ object Main {
       sdkVersion: String,
       damlScriptLib: String,
       targetDir: Path,
+      acs: Map[String, CreatedEvent],
       trees: Seq[TransactionTree],
       pkgRefs: Set[PackageId],
       pkgs: Map[PackageId, (ByteString, Ast.Package)],
@@ -99,7 +142,7 @@ object Main {
     val dir = Files.createDirectories(targetDir)
     Files.write(
       dir.resolve("Dump.daml"),
-      Encode.encodeTransactionTreeStream(trees).render(80).getBytes(StandardCharsets.UTF_8),
+      Encode.encodeTransactionTreeStream(acs, trees).render(80).getBytes(StandardCharsets.UTF_8),
     )
     val dars: Seq[Dar[(PackageId, ByteString, Ast.Package)]] =
       pkgRefs.view.collect(Function.unlift(Dependencies.toDar(_, pkgs))).toSeq

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Main.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Main.scala
@@ -95,9 +95,13 @@ object Main {
   )(implicit
       mat: Materializer
   ): Future[Seq[TransactionTree]] = {
-    client.transactionClient
-      .getTransactionTrees(start, Some(end), filter(parties), verbose = true)
-      .runWith(Sink.seq)
+    if (start == end) {
+      Future.successful(Seq.empty)
+    } else {
+      client.transactionClient
+        .getTransactionTrees(start, Some(end), filter(parties), verbose = true)
+        .runWith(Sink.seq)
+    }
   }
 
   def run(config: Config)(implicit

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -3,10 +3,12 @@
 
 package com.daml.script.dump
 
+import com.daml.ledger.api.v1.event.CreatedEvent
 import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
 import com.daml.ledger.api.v1.transaction.TreeEvent.Kind
 import com.daml.ledger.api.v1.value.{Identifier, Value}
 import com.daml.ledger.api.v1.value.Value.Sum
+import com.daml.lf.language.Graphs
 import scalaz.std.option._
 import scalaz.std.list._
 import scalaz.std.set._
@@ -14,6 +16,21 @@ import scalaz.syntax.foldable._
 
 object TreeUtils {
   final case class Selector(i: Int)
+
+  /** Sort the active contract set topologically,
+    *  such that a contract at a given position in the list
+    *  is only referenced by other contracts later in the list.
+    */
+  def topoSortAcs(acs: Map[String, CreatedEvent]): List[CreatedEvent] = {
+    val graph: Graphs.Graph[String] = acs.mapValues(createdReferencedCids)
+    Graphs
+      .topoSort(graph)
+      .left
+      .map(msg => new RuntimeException(s"Encountered cyclic contract dependencies: $msg"))
+      .toTry
+      .get
+      .map(cid => acs.get(cid).get)
+  }
 
   def traverseTree(tree: TransactionTree)(f: (List[Selector], TreeEvent.Kind) => Unit): Unit = {
     def traverseEv(ev: TreeEvent.Kind, f: (List[Selector], TreeEvent.Kind) => Unit): Unit =
@@ -31,6 +48,14 @@ object TreeUtils {
     tree.rootEventIds.map(tree.eventsById(_)).zipWithIndex.foreach { case (ev, i) =>
       traverseEv(ev.kind, { case (path, ev) => f(Selector(i) :: path, ev) })
     }
+  }
+
+  def partiesInContracts(contracts: Iterable[CreatedEvent]): Set[String] = {
+    var parties: Set[String] = Set()
+    contracts.foreach { value =>
+      parties = parties.union(valueParties(Value.Sum.Record(value.getCreateArguments)))
+    }
+    parties
   }
 
   def partiesInTree(tree: TransactionTree): Set[String] = {
@@ -103,13 +128,14 @@ object TreeUtils {
           cids += value.contractId
           cids ++= value.choiceArgument.foldMap(arg => valueCids(arg.sum))
         case Kind.Created(value) =>
-          cids ++= value.createArguments.foldMap(args =>
-            args.fields.toList.foldMap(f => valueCids(f.getValue.sum))
-          )
+          cids ++= createdReferencedCids(value)
       }
     }
     cids
   }
+
+  def createdReferencedCids(ev: CreatedEvent): Set[String] =
+    ev.createArguments.foldMap(args => args.fields.toList.foldMap(f => valueCids(f.getValue.sum)))
 
   def evParties(ev: TreeEvent.Kind): Seq[String] = ev match {
     case TreeEvent.Kind.Created(create) => create.signatories

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -52,11 +52,7 @@ object TreeUtils {
   }
 
   def partiesInContracts(contracts: Iterable[CreatedEvent]): Set[String] = {
-    var parties: Set[String] = Set()
-    contracts.foreach { value =>
-      parties = parties.union(valueParties(Value.Sum.Record(value.getCreateArguments)))
-    }
-    parties
+    contracts.toList.foldMap(ev => valueParties(Value.Sum.Record(ev.getCreateArguments)))
   }
 
   def partiesInTree(tree: TransactionTree): Set[String] = {

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -28,7 +28,8 @@ object TreeUtils {
   def topoSortAcs(acs: Map[String, CreatedEvent]): List[CreatedEvent] = {
     val graph: Graphs.Graph[String] = acs.view.mapValues(createdReferencedCids).toMap
     Graphs.topoSort(graph) match {
-      case Left(cycle) => throw new IllegalArgumentException(s"Encountered cyclic contract dependencies: $cycle")
+      case Left(cycle) =>
+        throw new IllegalArgumentException(s"Encountered cyclic contract dependencies: $cycle")
       case Right(sorted) => sorted.map(cid => acs.get(cid).get)
     }
   }

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -14,6 +14,8 @@ import scalaz.std.list._
 import scalaz.std.set._
 import scalaz.syntax.foldable._
 
+import scala.collection.compat._
+
 object TreeUtils {
   final case class Selector(i: Int)
 
@@ -22,7 +24,7 @@ object TreeUtils {
     *  is only referenced by other contracts later in the list.
     */
   def topoSortAcs(acs: Map[String, CreatedEvent]): List[CreatedEvent] = {
-    val graph: Graphs.Graph[String] = acs.mapValues(createdReferencedCids)
+    val graph: Graphs.Graph[String] = acs.view.mapValues(createdReferencedCids).toMap
     Graphs
       .topoSort(graph)
       .left

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.dump
+
+import com.daml.ledger.api.v1.event.CreatedEvent
+import com.daml.ledger.api.v1.value.{Identifier, Record}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
+  import Encode._
+  "encodeCreatedEvent" - {
+    "contract id bindings" - {
+      "unreferenced" in {
+        val parties = Map("Alice" -> "alice_0")
+        val cidMap = Map("cid" -> "contract_0_0")
+        val cidRefs = Set.empty[String]
+        val created = CreatedEvent(
+          eventId = "create",
+          templateId = Some(Identifier("package", "Module", "Template")),
+          contractId = "cid",
+          signatories = Seq("Alice"),
+          createArguments = Some(
+            Record(
+              recordId = Some(Identifier("package", "Module", "Template")),
+              fields = Seq.empty,
+            )
+          ),
+        )
+        encodeCreatedEvent(parties, cidMap, cidRefs, created).render(80) shouldBe
+          """submitMulti [alice_0] [] do
+            |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
+      }
+      "referenced" in {
+        val parties = Map("Alice" -> "alice_0")
+        val cidMap = Map("cid" -> "contract_0_0")
+        val cidRefs = Set("cid")
+        val created = CreatedEvent(
+          eventId = "create",
+          templateId = Some(Identifier("package", "Module", "Template")),
+          contractId = "cid",
+          signatories = Seq("Alice"),
+          createArguments = Some(
+            Record(
+              recordId = Some(Identifier("package", "Module", "Template")),
+              fields = Seq.empty,
+            )
+          ),
+        )
+        encodeCreatedEvent(parties, cidMap, cidRefs, created).render(80) shouldBe
+          """contract_0_0 <- submitMulti [alice_0] [] do
+            |  createCmd Module.Template""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #8771

Before this offset we reproduce the ACS with simple `createCmd` command submissions.

This current approach does not support contracts in the ACS that reference other contracts outside the ACS, e.g. archived contracts.

Adds a unit test for encoding single creates to reconstruct the ACS.
Extends the integration test to test at different offsets.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
