### PR TITLE
Add hash function for hashing contract instances

### DIFF
--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/crypto/Hash.scala
@@ -233,6 +233,7 @@ object Hash {
     val ContractKey = Purpose(2)
     val MaintainerContractKeyUUID = Purpose(4)
     val PrivateKey = Purpose(3)
+    val ContractInstance = Purpose(5)
   }
 
   // package private for testing purpose.
@@ -316,6 +317,23 @@ object Hash {
       key: Value[Value.ContractId],
   ): Either[String, Hash] =
     handleError(assertHashContractKey(templateId, key))
+
+  // This function assumes that `arg` is well typed, i.e. :
+  // 1 - `templateId` is the identifier for a template with a contract argument of type τ
+  // 2 - `arg` is a value of type τ
+  // The hash is not stable under suffixing of contract IDs
+  @throws[HashingError]
+  def assertHashContractInstance(templateId: Ref.Identifier, arg: Value[Value.ContractId]): Hash =
+    builder(Purpose.ContractInstance, aCid2Bytes)
+      .addIdentifier(templateId)
+      .addTypedValue(arg)
+      .build
+
+  def hashContractInstnce(
+      templateId: Ref.Identifier,
+      arg: Value[Value.ContractId],
+  ): Either[String, Hash] =
+    handleError(assertHashContractInstance(templateId, arg))
 
   def deriveSubmissionSeed(
       nonce: Hash,


### PR DESCRIPTION
No need to include the agreement text because the agreement text is derived from the contract instance argument using a DAML function specified in the template

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
