### PR TITLE
Backport Daml Driver for PostgreSQL additional startup options to main

### DIFF
--- a/ledger/daml-on-sql/README.rst
+++ b/ledger/daml-on-sql/README.rst
@@ -31,6 +31,24 @@ To specify the PostgreSQL instance you wish to connect, use the
 valid JDBC URL containing the username, password and database name to connect
 to (for example, ``jdbc:postgresql://localhost/test?user=fred&password=secret``).
 
+If you do not want to pass the jdbc credentials on the command line, you can also
+define them in an environment variable and then specify the environment variable to
+use through the  ``--sql-backend-jdbcurl-env <environment-variable>`` option where
+``<environment-variable>`` is the name of the environment variable where the connection
+string string has been specified.  The connection string you store in the environment
+variable should be of the same form as mentioned above (for example,
+``jdbc:postgresql://localhost/test?user=fred&password=secret``).
+
+If you want to setup the database schema for the *Daml Driver for PostgreSQL* with a
+more highly permissioned database service account that is able to create database schemas
+and tables but only run your application with an account with lesser permissions, you
+can leverage the combination of the connection string specifying the account to use
+and the ``--sql-start-mode <value>`` parameter specifying the mode to run the driver.
+
+The possible modes available are
+``migrate-only`` - Create database schema but do not start the driver
+``migrate-and-start`` - Create database schema and start the driver.  If the database already exists, this will simply validate and start.  This is the default mode
+
 You will also need to provide a ledger ID with the ``--ledgerid`` flag, which
 must be the same upon restart. This value is expected in many API endpoints, to
 ensure ledger clients are connecting to the correct ledger.

--- a/ledger/daml-on-sql/src/main/scala/on/sql/Main.scala
+++ b/ledger/daml-on-sql/src/main/scala/on/sql/Main.scala
@@ -3,10 +3,15 @@
 
 package com.daml.on.sql
 
+import java.util.concurrent.Executors
+
 import com.daml.ledger.resources.ResourceContext
-import com.daml.platform.sandbox.config.SandboxConfig
+import com.daml.platform.sandbox.config.{PostgresStartupMode, SandboxConfig}
 import com.daml.platform.sandbox.{GlobalLogLevel, SandboxServer}
 import com.daml.resources.ProgramResource
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
 
 object Main {
 
@@ -17,5 +22,24 @@ object Main {
   }
 
   private[sql] def run(config: SandboxConfig): Unit =
-    new ProgramResource(SandboxServer.owner(Name, config)).run(ResourceContext.apply)
+    config.sqlStartMode.foreach {
+      case PostgresStartupMode.MigrateOnly =>
+        val cachedThreadPool = Executors.newCachedThreadPool()
+        implicit val executionContext: ExecutionContext =
+          ExecutionContext.fromExecutorService(cachedThreadPool)
+        implicit val resourceContext: ResourceContext = ResourceContext(executionContext)
+
+        SandboxServer.migrateOnly(config).onComplete {
+          case Success(_) =>
+            cachedThreadPool.shutdown()
+            sys.exit(0)
+          case Failure(exception) =>
+            System.err.println(exception.getMessage)
+            cachedThreadPool.shutdown()
+            sys.exit(1)
+        }
+
+      case _ =>
+        new ProgramResource(SandboxServer.owner(Name, config)).run(ResourceContext.apply)
+    }
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxMain.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/SandboxMain.scala
@@ -4,13 +4,14 @@
 package com.daml.platform.sandbox
 
 import com.daml.ledger.resources.ResourceContext
+import com.daml.platform.sandbox.config.SandboxConfig
 import com.daml.resources.ProgramResource
 
 object SandboxMain {
 
   def main(args: Array[String]): Unit =
     new ProgramResource({
-      val config = Cli.parse(args).getOrElse(sys.exit(1))
+      val config: SandboxConfig = Cli.parse(args).getOrElse(sys.exit(1))
       config.logLevel.foreach(GlobalLogLevel.set)
       SandboxServer.owner(Name, config)
     }).run(ResourceContext.apply)

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -75,7 +75,7 @@ private[sandbox] object SqlLedger {
       initialLedgerEntries: ImmArray[LedgerEntryOrBump],
       queueDepth: Int,
       transactionCommitter: TransactionCommitter,
-      startMode: SqlStartMode = SqlStartMode.ContinueIfExists,
+      startMode: SqlStartMode,
       eventsPageSize: Int,
       servicesExecutionContext: ExecutionContext,
       metrics: Metrics,
@@ -92,9 +92,9 @@ private[sandbox] object SqlLedger {
         _ <- Resource.fromFuture(new FlywayMigrations(jdbcUrl).migrate())
         dao <- ledgerDaoOwner(servicesExecutionContext).acquire()
         _ <- startMode match {
-          case SqlStartMode.AlwaysReset =>
+          case SqlStartMode.ResetAndStart =>
             Resource.fromFuture(dao.reset())
-          case SqlStartMode.ContinueIfExists =>
+          case SqlStartMode.MigrateAndStart =>
             Resource.unit
         }
         retrievedLedgerId <- Resource.fromFuture(dao.lookupLedgerId())

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlStartMode.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlStartMode.scala
@@ -6,11 +6,15 @@ package com.daml.platform.sandbox.stores.ledger.sql
 private[sandbox] sealed abstract class SqlStartMode extends Product with Serializable
 
 private[sandbox] object SqlStartMode {
+  /* We do not allow ResetAndStart to be set from options bubbled up to config to avoid mishaps */
+  def fromString(value: String): Option[SqlStartMode] = {
+    Vector(MigrateAndStart, ResetAndStart).find(_.toString == value)
+  }
 
   /** Will continue using an initialised ledger, otherwise initialize a new one */
-  final case object ContinueIfExists extends SqlStartMode
+  final case object MigrateAndStart extends SqlStartMode
 
   /** Will always reset and initialize the ledger, even if it has data. */
-  final case object AlwaysReset extends SqlStartMode
+  final case object ResetAndStart extends SqlStartMode
 
 }

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/LedgerResource.scala
@@ -85,7 +85,7 @@ private[sandbox] object LedgerResource {
           initialLedgerEntries = ImmArray.empty,
           queueDepth = 128,
           transactionCommitter = StandardTransactionCommitter,
-          startMode = SqlStartMode.AlwaysReset,
+          startMode = SqlStartMode.ResetAndStart,
           eventsPageSize = 100,
           servicesExecutionContext = servicesExecutionContext,
           metrics = new Metrics(metrics),

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -300,7 +300,7 @@ final class SqlLedgerSpec
         initialLedgerEntries = ImmArray.empty,
         queueDepth = queueDepth,
         transactionCommitter = LegacyTransactionCommitter,
-        startMode = SqlStartMode.ContinueIfExists,
+        startMode = SqlStartMode.MigrateAndStart,
         eventsPageSize = 100,
         servicesExecutionContext = executionContext,
         metrics = new Metrics(metrics),

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/PostgresStartupMode.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/PostgresStartupMode.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.config
+
+sealed trait PostgresStartupMode extends Product with Serializable
+
+object PostgresStartupMode {
+  def fromString(value: String): Option[PostgresStartupMode] = {
+    Vector(MigrateOnly, MigrateAndStart).find(_.toString == value)
+  }
+  case object MigrateOnly extends PostgresStartupMode {
+    override def toString = "migrate-only"
+  }
+
+  case object MigrateAndStart extends PostgresStartupMode {
+    override def toString = "migrate-and-start"
+  }
+
+}

--- a/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
+++ b/ledger/sandbox-common/src/main/scala/platform/sandbox/config/SandboxConfig.scala
@@ -49,6 +49,7 @@ final case class SandboxConfig(
     stackTraces: Boolean,
     engineMode: SandboxConfig.EngineMode,
     managementServiceTimeout: Duration,
+    sqlStartMode: Option[PostgresStartupMode],
 )
 
 object SandboxConfig {
@@ -69,6 +70,8 @@ object SandboxConfig {
     v1.ParticipantId.assertFromString("sandbox-participant")
 
   val DefaultManagementServiceTimeout: Duration = Duration.ofMinutes(2)
+
+  val DefaultSqlStartupMode: PostgresStartupMode = PostgresStartupMode.MigrateAndStart
 
   lazy val defaultConfig: SandboxConfig =
     SandboxConfig(
@@ -100,6 +103,7 @@ object SandboxConfig {
       stackTraces = true,
       engineMode = EngineMode.Stable,
       managementServiceTimeout = DefaultManagementServiceTimeout,
+      sqlStartMode = Some(DefaultSqlStartupMode),
     )
 
   sealed abstract class EngineMode extends Product with Serializable


### PR DESCRIPTION
 Enable sql-start-mode option for daml-on-sql (backported from 1.10.1 release)

CHANGELOG_BEGIN
[Daml Driver for PostgreSQL] Enable migrate only option at startup
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
