### PR TITLE
Stream stdout of verify_signatures

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -344,9 +344,9 @@ download_assets tmp release = do
             IO.withBinaryFile (tmp </> (last $ Network.URI.pathSegments url)) IO.AppendMode $ \handle -> do
                 while (readFrom body) (writeTo handle)
 
-verify_signatures :: FilePath -> FilePath -> String -> IO String
+verify_signatures :: FilePath -> FilePath -> String -> IO ()
 verify_signatures bash_lib tmp version_tag = do
-    shell $ unlines ["bash -c '",
+    System.callCommand $ unlines ["bash -c '",
         "set -euo pipefail",
         "eval \"$(dev-env/bin/dade assist)\"",
         "source \"" <> bash_lib <> "\"",
@@ -420,7 +420,7 @@ check_releases gcp_credentials bash_lib max_releases = do
         putStrLn $ "Checking release " <> v <> " ..."
         IO.withTempDir $ \temp_dir -> do
             download_assets temp_dir release
-            verify_signatures bash_lib temp_dir v >>= putStrLn
+            verify_signatures bash_lib temp_dir v
             Control.Monad.Extra.whenJust gcp_credentials $ \gcred ->
                 Directory.listDirectory temp_dir >>= Data.Foldable.traverse_ (\f -> do
                   let local_github = temp_dir </> f


### PR DESCRIPTION
There is really no reason to first capture this to a String and then
putStrLn it. That only causes issues since if we crash with a non-zero
exitcode we won’t output anything.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
