### PR TITLE
Check the exact names of type read in Java codegen tests

### DIFF
--- a/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
+++ b/language-support/java/codegen/src/test/scala/com/digitalasset/daml/lf/codegen/CodeGenRunnerTests.scala
@@ -37,7 +37,63 @@ class CodeGenRunnerTests extends AnyFlatSpec with Matchers with BazelRunfiles {
 
     val (interfaces, pkgPrefixes) = CodeGenRunner.collectDamlLfInterfaces(conf)
 
-    assert(interfaces.length == 19)
+    interfaces.flatMap(
+      _.typeDecls.keys.map(_.qualifiedName)
+    ) should contain theSameElementsAs List(
+      "DA.Date.Types:DayOfWeek",
+      "DA.Date.Types:Month",
+      "DA.Generics:Associativity",
+      "DA.Generics:DecidedStrictness",
+      "DA.Generics:Fixity",
+      "DA.Generics:Infix0",
+      "DA.Generics:K1",
+      "DA.Generics:Par1",
+      "DA.Generics:SourceStrictness",
+      "DA.Generics:SourceUnpackedness",
+      "DA.Generics:U1",
+      "DA.Internal.Down:Down",
+      "DA.Internal.Template:Archive",
+      "DA.Logic.Types:Formula",
+      "DA.Monoid.Types:All",
+      "DA.Monoid.Types:Any",
+      "DA.Monoid.Types:Product",
+      "DA.Monoid.Types:Sum",
+      "DA.Next.Map:Map",
+      "DA.Next.Set:Set",
+      "DA.NonEmpty.Types:NonEmpty",
+      "DA.Random:Minstd",
+      "DA.Semigroup.Types:Max",
+      "DA.Semigroup.Types:Min",
+      "DA.Stack:SrcLoc",
+      "DA.Time.Types:RelTime",
+      "DA.Types:Either",
+      "DA.Types:Tuple10",
+      "DA.Types:Tuple11",
+      "DA.Types:Tuple12",
+      "DA.Types:Tuple13",
+      "DA.Types:Tuple14",
+      "DA.Types:Tuple15",
+      "DA.Types:Tuple16",
+      "DA.Types:Tuple17",
+      "DA.Types:Tuple18",
+      "DA.Types:Tuple19",
+      "DA.Types:Tuple2",
+      "DA.Types:Tuple20",
+      "DA.Types:Tuple3",
+      "DA.Types:Tuple4",
+      "DA.Types:Tuple5",
+      "DA.Types:Tuple6",
+      "DA.Types:Tuple7",
+      "DA.Types:Tuple8",
+      "DA.Types:Tuple9",
+      "DA.Validation.Types:Validation",
+      "Foo:Foo",
+      "GHC.Stack.Types:CallStack",
+      "GHC.Stack.Types:SrcLoc",
+      "GHC.Tuple:Unit",
+      "GHC.Types:Ordering",
+    )
+
     assert(pkgPrefixes == Map.empty)
   }
 


### PR DESCRIPTION
Closes #8920

As raised initially in https://github.com/digital-asset/daml/pull/8856#discussion_r581072132

This should make the test itself more self-explanatory.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
