### PR TITLE
daml start: less scary colors for rebuild message

### DIFF
--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Start.hs
@@ -302,9 +302,11 @@ runStart
           doCodegen projectConfig
           doUploadDar darPath sandboxPort
           doRunInitScript
+          setSGR [SetColor Foreground Dull Green]
           putStrLn "Rebuild complete."
+          setSGR [Reset]
         printRebuildInstructions = do
-          setSGR [SetColor Foreground Vivid Red]
+          setSGR [SetColor Foreground Vivid Yellow]
           putStrLn reloadInstructions
           setSGR [Reset]
           hFlush stdout


### PR DESCRIPTION
We change the color from red to yellow to inform about the possibility
to rebuild and also output the success message in green.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
