### PR TITLE
skip Oracle test on forks

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -249,6 +249,7 @@ jobs:
         ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
         ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PASSWORD)
       displayName: 'Build'
+      condition: eq(variables['System.PullRequest.IsFork'], 'False')
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'

--- a/ci/prs.yml
+++ b/ci/prs.yml
@@ -131,7 +131,10 @@ jobs:
         tell_slack "<@${PR_HANDLER}> <https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|Build $(Build.BuildId)> for release PR <https://github.com/digital-asset/daml/pull/${PR}|#${PR}> $msg"
 
 - job: notify_user
-  condition: and(eq(variables['Build.Reason'], 'PullRequest'), not(canceled()))
+  # No Slack tokens on forks
+  condition: and(eq(variables['Build.Reason'], 'PullRequest'),
+                 not(canceled()),
+                 eq(variables['System.PullRequest.IsFork'], 'False'))
   dependsOn:
     - git_sha
     - collect_build_data


### PR DESCRIPTION
Fork builds do not have the required credentials.

CHANGELOG_BEGIN
CHANGELOG_END