### PR TITLE
Merge Maven uploads for different Scala versions

### DIFF
--- a/bazel_tools/scala_version.bzl
+++ b/bazel_tools/scala_version.bzl
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Keep in sync with /release/src/Main.hs
 default_scala_version = "2.12.12"
 
 def _impl(ctx):

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -48,13 +48,7 @@ steps:
   - bash: |
       set -euo pipefail
       eval "$(./dev-env/bin/dade-assist)"
-
-      EXTRA_FLAGS=""
-      if [[ -n "$DAML_SCALA_VERSION" ]]; then
-        EXTRA_FLAGS="--only-scala"
-      fi
-
-      ./bazel-bin/release/release --release-dir "$(mktemp -d)" --upload $EXTRA_FLAGS
+      ./bazel-bin/release/release --release-dir "$(mktemp -d)" --upload
     env:
       DAML_SDK_RELEASE_VERSION: ${{parameters.release_tag}}
       DAML_SCALA_VERSION: ${{parameters.scala_version}}
@@ -66,6 +60,7 @@ steps:
     name: publish_npm_mvn
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
+                   eq(${{parameters.scala_version}}, ''),
                    eq(variables['Build.SourceBranchName'], 'main'),
                    in('${{parameters.name}}', 'linux', 'linux-scala-2.13'))
   - template: bash-lib.yml

--- a/ci/build-unix.yml
+++ b/ci/build-unix.yml
@@ -60,7 +60,7 @@ steps:
     name: publish_npm_mvn
     condition: and(succeeded(),
                    eq(${{parameters.is_release}}, 'true'),
-                   eq(${{parameters.scala_version}}, ''),
+                   eq('${{parameters.scala_version}}', ''),
                    eq(variables['Build.SourceBranchName'], 'main'),
                    in('${{parameters.name}}', 'linux', 'linux-scala-2.13'))
   - template: bash-lib.yml

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -55,7 +55,6 @@ jobs:
         release_tag: $(release_tag)
         name: 'linux'
         is_release: variables.is_release
-        scala_version: ''
     - bash: |
         set -euo pipefail
         eval "$(./dev-env/bin/dade-assist)"
@@ -137,7 +136,6 @@ jobs:
         release_tag: $(release_tag)
         name: macos
         is_release: variables.is_release
-        scala_version: ''
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -55,6 +55,7 @@ jobs:
         release_tag: $(release_tag)
         name: 'linux'
         is_release: variables.is_release
+        scala_version: ''
     - bash: |
         set -euo pipefail
         eval "$(./dev-env/bin/dade-assist)"
@@ -103,15 +104,6 @@ jobs:
         name: 'linux-scala-2.13'
         is_release: variables.is_release
         scala_version: "2.13.3"
-    - bash: |
-        set -euo pipefail
-        eval "$(./dev-env/bin/dade-assist)"
-        bazel build //release:release
-        ./bazel-bin/release/release --release-dir "$(mktemp -d)"
-      env:
-        DAML_SCALA_VERSION: "2.13.3"
-      name: maven_check
-      condition: and(succeeded(), ne(variables['is_release'], 'true'))
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'
@@ -145,6 +137,7 @@ jobs:
         release_tag: $(release_tag)
         name: macos
         is_release: variables.is_release
+        scala_version: ''
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'

--- a/libs-haskell/test-utils/BUILD.bazel
+++ b/libs-haskell/test-utils/BUILD.bazel
@@ -24,6 +24,8 @@ da_haskell_library(
         "tasty",
         "tasty-hunit",
         "text",
+        "unliftio",
+        "unliftio-core",
         "unordered-containers",
     ],
     visibility = ["//visibility:public"],

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -57,8 +57,8 @@ da_haskell_binary(
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
     deps = [
-      "//libs-haskell/test-utils",
-      "//:sdk-version-hs-lib",
+        "//:sdk-version-hs-lib",
+        "//libs-haskell/test-utils",
     ],
 )
 

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -8,7 +8,7 @@ load("@os_info//:os_info.bzl", "is_windows")
 
 da_haskell_binary(
     name = "release",
-    srcs = glob(["src/**/*.hs"]) + ["//:SdkVersion.hs"],
+    srcs = glob(["src/**/*.hs"]),
     hackage_deps = [
         "aeson",
         "async",
@@ -26,7 +26,6 @@ da_haskell_binary(
         "extra",
         "fast-logger",
         "filepath",
-        "ghc",
         "http-client",
         "http-client-tls",
         "http-conduit",
@@ -57,7 +56,10 @@ da_haskell_binary(
     ],
     src_strip_prefix = "src",
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = [
+      "//libs-haskell/test-utils",
+      "//:sdk-version-hs-lib",
+    ],
 )
 
 # Disabled on Windows since directory outputs can cause issues.

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -24,6 +24,8 @@ import qualified System.Directory as Dir
 import System.Exit
 import System.Process
 
+import DA.Test.Util (withEnv)
+
 import Maven
 import Options
 import Types
@@ -32,30 +34,72 @@ import Util
 
 import qualified SdkVersion
 
+-- Keep in sync with /bazel_tools/scala_version.bzl
+scalaVersions :: [T.Text]
+scalaVersions = ["2.12.12", "2.13.3"]
+
+buildArtifacts :: (MonadLogger m, MonadIO m) => SemVer.Version -> BazelLocations -> [Artifact (Maybe ArtifactLocation)] -> m [Artifact PomData]
+buildArtifacts mvnVersion bazelLocations artifacts = do
+      let targets = concatMap buildTargets artifacts
+      liftIO $ callProcess "bazel" ("build" : map (T.unpack . getBazelTarget) targets)
+      $logInfo "Reading metadata from pom files"
+      liftIO $ mapM (resolvePomData bazelLocations mvnVersion) artifacts
+
+checkForMissingDeps :: (MonadLogger m, MonadIO m) => [Artifact c] -> m ()
+checkForMissingDeps jars = do
+   -- run a Bazel query to find all internal Java and Scala library dependencies
+   let targets = map (getBazelTarget . artTarget) jars
+   internalDeps <- bazelQueryDeps ("set(" <> T.unpack (T.intercalate " " targets) <> ")")
+   let missingDeps = filter (`Set.notMember` allArtifacts) internalDeps
+   unless (null missingDeps) $ do
+     -- if there's a missing artifact, find out what depends on it by querying each
+     -- artifact separately, one by one, so that the error message is more useful
+     -- (this is slow, so we don't do it unless we have to)
+     maybeMissingDeps <- forM jars $ \a -> do
+       internalDeps <- bazelQueryDeps (T.unpack (getBazelTarget (artTarget a)))
+       let missingDeps = filter (`Set.notMember` allArtifacts) internalDeps
+       if null missingDeps then return Nothing else return (Just (a, missingDeps))
+     let missingDepsForAllArtifacts = Maybe.catMaybes maybeMissingDeps
+     $logError "Some internal dependencies are not published to Maven Central!"
+     forM_ missingDepsForAllArtifacts $ \(artifact, missingDeps) -> do
+       $logError (getBazelTarget (artTarget artifact))
+       forM_ missingDeps $ \dep -> $logError ("\t- "# T.pack dep)
+     liftIO exitFailure
+  where
+    allArtifacts = Set.fromList $ fmap (T.unpack . getBazelTarget . artTarget) jars
+    bazelQueryDeps target =
+      let query = "kind(\"(java|scala)_library\", deps(" <> target <> ")) intersect //..."
+      in liftIO $ lines <$> readCreateProcess (proc "bazel" ["query", query]) ""
+
 main :: IO ()
 main = do
   Options{..} <- parseOptions
   runLog $ do
       releaseDir <- parseAbsDir =<< liftIO (Dir.makeAbsolute optsReleaseDir)
       liftIO $ createDirIfMissing True releaseDir
-      mvnArtifacts :: [Artifact (Maybe ArtifactLocation)] <- decodeFileThrow "release/artifacts.yaml"
 
       Right mvnVersion <- pure $ SemVer.fromText $ T.pack SdkVersion.mvnVersion
-      let mvnTargets = concatMap buildTargets mvnArtifacts
-      $logInfo "Building all targets"
-      liftIO $ callProcess "bazel" ("build" : map (T.unpack . getBazelTarget) mvnTargets)
-
       bazelLocations <- liftIO getBazelLocations
-      $logInfo "Reading metadata from pom files"
-      mvnArtifacts <- liftIO $ mapM (resolvePomData bazelLocations mvnVersion) mvnArtifacts
+
+      mvnArtifacts :: [Artifact (Maybe ArtifactLocation)] <- decodeFileThrow "release/artifacts.yaml"
+      let (scalaArtifacts, nonScalaArtifacts) = List.partition (isScalaJar . artReleaseType) mvnArtifacts
 
       -- all known targets uploaded to maven, that are not deploy Jars
       -- we don't check dependencies for deploy jars as they are single-executable-jars
       let nonDeployJars = filter (not . isDeployJar . artReleaseType) mvnArtifacts
-      let allMavenTargets = Set.fromList $ fmap (T.unpack . getBazelTarget . artTarget) mvnArtifacts
+
+      nonScalaArtifacts <- buildArtifacts mvnVersion bazelLocations nonScalaArtifacts
+
+      scalaArtifacts <- forM scalaVersions $ \ver -> withEnv [("DAML_SCALA_VERSION", Just (T.unpack ver))] $ do
+          as <- buildArtifacts mvnVersion bazelLocations scalaArtifacts
+          -- Check for missing deps once per Scala version since bazel query depends on DAML_SCALA_VERSION.
+          checkForMissingDeps (nonDeployJars ++ scalaArtifacts)
+          pure as
+
+      let allArtifacts = concat (nonScalaArtifacts : scalaArtifacts)
 
       -- check that all maven artifacts use com.daml as groupId
-      let nonComDamlGroupId = filter (\a -> "com.daml" /= (groupIdString $ pomGroupId $ artMetadata a)) mvnArtifacts
+      let nonComDamlGroupId = filter (\a -> "com.daml" /= (groupIdString $ pomGroupId $ artMetadata a)) allArtifacts
       when (not (null nonComDamlGroupId)) $ do
           $logError "Some artifacts don't use com.daml as groupId!"
           forM_ nonComDamlGroupId $ \artifact -> do
@@ -63,7 +107,7 @@ main = do
           liftIO exitFailure
 
       -- check that no artifact id is used more than once
-      let groupedArtifacts = List.groupOn (pomArtifactId . artMetadata) mvnArtifacts
+      let groupedArtifacts = List.groupOn (pomArtifactId . artMetadata) allArtifacts
       let duplicateArtifactIds = filter (\artifacts -> length artifacts > 1) groupedArtifacts
       when (not (null duplicateArtifactIds)) $ do
           $logError "Some artifacts use the same artifactId!"
@@ -73,46 +117,13 @@ main = do
                   $logError ("\t- "# getBazelTarget (artTarget artifact))
           liftIO exitFailure
 
-      -- find out all the missing internal dependencies
-      missingDepsForAllArtifacts <- do
-          let bazelQueryDeps target = do
-              let query = "kind(\"(java|scala)_library\", deps(" <> target <> ")) intersect //..."
-              liftIO $ lines <$> readCreateProcess (proc "bazel" ["query", query]) ""
-
-          -- run a Bazel query to find all internal Java and Scala library dependencies
-          let targets = map (getBazelTarget . artTarget) nonDeployJars
-          internalDeps <- bazelQueryDeps ("set(" <> T.unpack (T.intercalate " " targets) <> ")")
-          -- check if a dependency is not already a maven target from artifacts.yaml
-          let missingDeps = filter (`Set.notMember` allMavenTargets) internalDeps
-          if null missingDeps
-              then
-                  return []
-              else do
-                  -- if there's a missing artifact, find out what depends on it by querying each
-                  -- artifact separately, one by one, so that the error message is more useful
-                  -- (this is slow, so we don't do it unless we have to)
-                  maybeMissingDeps <- forM nonDeployJars $ \a -> do
-                      internalDeps <- bazelQueryDeps (T.unpack (getBazelTarget (artTarget a)))
-                      let missingDeps = filter (`Set.notMember` allMavenTargets) internalDeps
-                      if null missingDeps then return Nothing else return (Just (a, missingDeps))
-                  return $ Maybe.catMaybes maybeMissingDeps
-
-      -- now we can report all the missing dependencies per artifact
-      when (not (null missingDepsForAllArtifacts)) $ do
-          $logError "Some internal dependencies are not published to Maven Central!"
-          forM_ missingDepsForAllArtifacts $ \(artifact, missingDeps) -> do
-              $logError (getBazelTarget (artTarget artifact))
-              forM_ missingDeps $ \dep -> $logError ("\t- "# T.pack dep)
-          liftIO exitFailure
-
-      mvnFiles <- fmap concat $ forM mvnArtifacts $ \artifact ->
+      mvnFiles <- fmap concat $ forM allArtifacts $ \artifact ->
           map (artifact,) <$> artifactFiles artifact
       forM_ mvnFiles $ \(_, (inp, outp)) ->
           copyToReleaseDir bazelLocations releaseDir inp outp
 
-      mvnUploadArtifacts <- concatMapM (mavenArtifactCoords optsOnlyScala) mvnArtifacts
-      unless (getOnlyScala optsOnlyScala) $
-        validateMavenArtifacts releaseDir mvnUploadArtifacts
+      mvnUploadArtifacts <- concatMapM mavenArtifactCoords allArtifacts
+      validateMavenArtifacts releaseDir mvnUploadArtifacts
 
       -- NPM packages we want to publish
       let npmPackages =
@@ -133,22 +144,21 @@ main = do
                   else
                     $logInfo "No artifacts to upload to Maven Central"
 
-              unless (getOnlyScala optsOnlyScala) $ do
-                $logDebug "Uploading npm packages"
-                -- We can't put an .npmrc file in the root of the directory because other bazel npm
-                -- code picks it up and looks for the token which is not yet set before the release
-                -- phase.
-                let npmrcPath = ".npmrc"
-                liftIO $ bracket_
-                  (writeFile npmrcPath "//registry.npmjs.org/:_authToken=${NPM_TOKEN}")
-                  (Dir.removeFile npmrcPath)
-                  (forM_ npmPackages
-                    $ \rule -> liftIO $ callCommand $ unwords $
-                        ["bazel", "run", rule <> ":npm_package.publish", "--", "--access", "public"] <>
-                        [ x | isSnapshot mvnVersion, x <- ["--tag", "next"] ])
+              $logDebug "Uploading npm packages"
+              -- We can't put an .npmrc file in the root of the directory because other bazel npm
+              -- code picks it up and looks for the token which is not yet set before the release
+              -- phase.
+              let npmrcPath = ".npmrc"
+              liftIO $ bracket_
+                (writeFile npmrcPath "//registry.npmjs.org/:_authToken=${NPM_TOKEN}")
+                (Dir.removeFile npmrcPath)
+                (forM_ npmPackages
+                  $ \rule -> liftIO $ callCommand $ unwords $
+                      ["bazel", "run", rule <> ":npm_package.publish", "--", "--access", "public"] <>
+                      [ x | isSnapshot mvnVersion, x <- ["--tag", "next"] ])
 
           | optsLocallyInstallJars -> do
-              pom <- generateAggregatePom bazelLocations mvnArtifacts
+              pom <- generateAggregatePom bazelLocations allArtifacts
               pomPath <- (releaseDir </>) <$> parseRelFile "pom.xml"
               liftIO $ T.IO.writeFile (toFilePath pomPath) pom
               exitCode <- liftIO $ withCreateProcess ((proc "mvn" ["initialize"]) { cwd = Just (toFilePath releaseDir) }) $ \_ _ _ mvnHandle ->

--- a/release/src/Options.hs
+++ b/release/src/Options.hs
@@ -16,7 +16,6 @@ parseOptions =
 
 data Options = Options
   { optsPerformUpload :: PerformUpload
-  , optsOnlyScala :: OnlyScala
   , optsReleaseDir :: FilePath
   , optsLocallyInstallJars :: Bool
   } deriving (Eq, Show)
@@ -24,6 +23,5 @@ data Options = Options
 optsParser :: Parser Options
 optsParser = Options
   <$> (PerformUpload <$> switch (long "upload" <> help "upload java/scala artifacts to Maven Central and typescript artifacts to the npm registry."))
-  <*> (OnlyScala <$> switch (long "only-scala" <> help "only upload Scala libraries"))
   <*> option str (long "release-dir" <> help "specify full path to release directory")
   <*> switch (long "install-head-jars" <> help "install jars to ~/.m2")

--- a/release/src/Util.hs
+++ b/release/src/Util.hs
@@ -20,6 +20,7 @@ module Util (
     buildTargets,
     copyToReleaseDir,
     getBazelLocations,
+    isScalaJar,
     isDeployJar,
     loggedProcess_,
     mavenArtifactCoords,
@@ -323,8 +324,8 @@ releasePomPath PomData{..} =
 
 -- | Given an artifact, produce a list of pairs of an input file and the Maven coordinates.
 -- This corresponds to the files uploaded to Maven Central.
-mavenArtifactCoords :: E.MonadThrow m => OnlyScala -> Artifact PomData -> m [(MavenCoords, Path Rel File)]
-mavenArtifactCoords onlyScala Artifact{..} = do
+mavenArtifactCoords :: E.MonadThrow m => Artifact PomData -> m [(MavenCoords, Path Rel File)]
+mavenArtifactCoords Artifact{..} = do
     let PomData{..} = artMetadata
     outDir <- parseRelDir $ unpack $
         T.intercalate "/" pomGroupId #"/"# pomArtifactId #"/"# SemVer.toText pomVersion #"/"
@@ -336,14 +337,11 @@ mavenArtifactCoords onlyScala Artifact{..} = do
 
     let mavenCoords classifier artifactType =
            MavenCoords { groupId = pomGroupId, artifactId = pomArtifactId, version = pomVersion, classifier, artifactType }
-    pure $
-      if getOnlyScala onlyScala && artReleaseType /= Jar Scala
-        then []
-        else [ (mavenCoords Nothing $ mainExt artReleaseType, outDir </> mainArtifactFile)
-             , (mavenCoords Nothing "pom",  outDir </> pomFile)
-             , (mavenCoords (Just "sources") "jar", outDir </> sourcesFile)
-             , (mavenCoords (Just "javadoc") "jar", outDir </> javadocFile)
-             ]
+    pure $ [ (mavenCoords Nothing $ mainExt artReleaseType, outDir </> mainArtifactFile)
+           , (mavenCoords Nothing "pom",  outDir </> pomFile)
+           , (mavenCoords (Just "sources") "jar", outDir </> sourcesFile)
+           , (mavenCoords (Just "javadoc") "jar", outDir </> javadocFile)
+           ]
 
 copyToReleaseDir :: (MonadLogger m, MonadIO m) => BazelLocations -> Path Abs Dir -> Path Rel File -> Path Rel File -> m ()
 copyToReleaseDir BazelLocations{..} releaseDir inp out = do
@@ -354,10 +352,10 @@ copyToReleaseDir BazelLocations{..} releaseDir inp out = do
     copyFile absIn absOut
 
 isDeployJar :: ReleaseType -> Bool
-isDeployJar t =
-    case t of
-        Jar Deploy -> True
-        _ -> False
+isDeployJar = (Jar Deploy ==)
+
+isScalaJar :: ReleaseType -> Bool
+isScalaJar = (Jar Scala ==)
 
 osName ::  Text
 osName

--- a/release/src/Util.hs
+++ b/release/src/Util.hs
@@ -337,11 +337,11 @@ mavenArtifactCoords Artifact{..} = do
 
     let mavenCoords classifier artifactType =
            MavenCoords { groupId = pomGroupId, artifactId = pomArtifactId, version = pomVersion, classifier, artifactType }
-    pure $ [ (mavenCoords Nothing $ mainExt artReleaseType, outDir </> mainArtifactFile)
-           , (mavenCoords Nothing "pom",  outDir </> pomFile)
-           , (mavenCoords (Just "sources") "jar", outDir </> sourcesFile)
-           , (mavenCoords (Just "javadoc") "jar", outDir </> javadocFile)
-           ]
+    pure [ (mavenCoords Nothing $ mainExt artReleaseType, outDir </> mainArtifactFile)
+         , (mavenCoords Nothing "pom",  outDir </> pomFile)
+         , (mavenCoords (Just "sources") "jar", outDir </> sourcesFile)
+         , (mavenCoords (Just "javadoc") "jar", outDir </> javadocFile)
+         ]
 
 copyToReleaseDir :: (MonadLogger m, MonadIO m) => BazelLocations -> Path Abs Dir -> Path Rel File -> Path Rel File -> m ()
 copyToReleaseDir BazelLocations{..} releaseDir inp out = do


### PR DESCRIPTION
It turns out Maven will abort an existing staging operation if you
create a new one. This means our jobs race against each other. We
could try to fix that by either sequencing the jobs in a clever
way (annoying and can break things like rerunning if only parts
failed), or by creating more profiles (unclear if you can even have
two profiles for the same group id, even if you do, it’s annoying to
merge).

So in this PR I (grudgingly) merged both uploads into the Haskell
script. This isn’t all bad:

1. It moves some logic from bash embedded in yaml string literals into
Haskell code.
2. It duplicates some versions but it removes duplication in other
places so overall not too much worse.
3. It does however, make things slower. We don’t run this stuff in
parallel. That said, the release step is relatively small (< 5min) and
it only runs on Linux.

We could add CLI arguments to make the Scala versions configurable for
local development. Given that this is blocking releases, I wanted to
get something in that works first and then see what we need in that regard.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
