### PR TITLE
Fix closure references in Daml Repl

### DIFF
--- a/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
+++ b/compiler/damlc/tests/src/DA/Test/Repl/FuncTests.hs
@@ -345,6 +345,15 @@ functionalTests replClient replLogger serviceOut options ideState = describe "re
           , input "1"
           , matchOutput "1"
           ]
+    , testInteraction' "closure"
+          [ input "import qualified DA.Map as Map"
+          , input "let m = Map.fromList [(1, 2)]"
+          , input "m"
+          , matchOutput "Map \\[\\(1,2\\)\\]"
+          , input "let lookup1 k = Map.lookup k m"
+          , input "lookup1 1"
+          , matchOutput "^Some 2$"
+          ]
     ]
   where
     testInteraction' testName steps =

--- a/compiler/repl-service/protos/repl_service.proto
+++ b/compiler/repl-service/protos/repl_service.proto
@@ -4,7 +4,7 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "com.daml.lf.repl";
+option java_package = "com.daml.lf.speedy.repl";
 option java_outer_classname = "ReplServiceProto";
 
 package replservice;

--- a/compiler/repl-service/server/BUILD.bazel
+++ b/compiler/repl-service/server/BUILD.bazel
@@ -21,7 +21,7 @@ repl_scalacopts = ["-P:wartremover:traverser:org.wartremover.warts.%s" % wart fo
 da_scala_binary(
     name = "repl-service-raw",
     srcs = glob(["src/main/scala/**/*.scala"]),
-    main_class = "com.daml.lf.repl.ReplServiceMain",
+    main_class = "com.daml.lf.speedy.repl.ReplServiceMain",
     resources = ["src/main/resources/logback.xml"],
     scala_deps = [
         "@maven//:com_github_scopt_scopt",

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/ReplServiceMain.scala
@@ -13,7 +13,7 @@ import com.daml.lf.engine.script._
 import com.daml.lf.language.Ast._
 import com.daml.lf.language.{Ast, LanguageVersion, Util => AstUtil}
 import com.daml.lf.speedy.SExpr._
-import com.daml.lf.speedy.{Compiler, SDefinition, SValue, SExpr, SError}
+import com.daml.lf.speedy.{Compiler, SDefinition, SError, SExpr, SValue}
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
 import com.daml.ledger.api.tls.{TlsConfiguration, TlsConfigurationCli}
@@ -24,6 +24,8 @@ import io.grpc.stub.StreamObserver
 import java.net.{InetAddress, InetSocketAddress}
 import java.nio.file.{Files, Path, Paths}
 import java.util.logging.{Level, Logger}
+
+import com.daml.lf.speedy.iterable.SExprIterable
 
 import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
@@ -177,6 +179,22 @@ object ReplService {
   private val compilerConfig = Compiler.Config.Default.copy(
     stacktracing = Compiler.FullStackTrace
   )
+  private val homePackageId: PackageId = PackageId.assertFromString("-homePackageId-")
+
+  private def moduleRefs(v: SValue): Set[ModuleName] = {
+    def moduleRefs(acc: Set[ModuleName], e: SExpr): Set[ModuleName] =
+      e match {
+        case SEVal(ref) =>
+          if (ref.packageId == homePackageId) {
+            acc + ref.modName
+          } else {
+            acc
+          }
+        case e => SExprIterable(e).foldLeft(acc)(moduleRefs)
+      }
+
+    SExprIterable(v).foldLeft(Set.empty[ModuleName])(moduleRefs)
+  }
 }
 
 class ReplService(
@@ -190,13 +208,12 @@ class ReplService(
   var signatures: Map[PackageId, PackageSignature] = Map.empty
   var compiledDefinitions: Map[SDefinitionRef, SDefinition] = Map.empty
   var results: Seq[SValue] = Seq()
+  var mainModules: Map[ModuleName, Ast.Module] = Map.empty
   implicit val ec_ = ec
   implicit val esf_ = esf
   implicit val mat_ = mat
 
   import ReplService._
-
-  private val homePackageId: PackageId = PackageId.assertFromString("-homePackageId-")
 
   override def loadPackage(
       req: LoadPackageRequest,
@@ -224,10 +241,7 @@ class ReplService(
     val lfScenarioModule =
       dop.protoScenarioModule(Decode.damlLfCodedInputStream(req.getDamlLf1.newInput))
     val mod: Ast.Module = dop.decodeScenarioModule(homePackageId, lfScenarioModule)
-    // For now we only include the module of the current line
-    // we probably need to extend this to merge the
-    // modules from each line.
-    val pkg = Package(Seq(mod), Seq(), lfVer, None)
+    val pkg = Package((mainModules + (mod.name -> mod)).values, Seq(), lfVer, None)
     // TODO[AH] Provide daml-script package id from REPL client.
     val Some(scriptPackageId) = this.signatures.collectFirst {
       case (pkgId, pkg) if pkg.modules.contains(DottedName.assertFromString("Daml.Script")) => pkgId
@@ -286,7 +300,12 @@ class ReplService(
           println(s"$e")
           respObs.onError(e)
         case Success((v, result)) =>
-          results = results ++ Seq(v)
+          results = results :+ v
+          if (moduleRefs(v).contains(mod.name)) {
+            // If the result is a closure and contains a reference to the
+            // current module, we have to keep that module around.
+            mainModules += mod.name -> mod
+          }
           respObs.onNext(RunScriptResponse.newBuilder.setResult(result).build)
           respObs.onCompleted
       }
@@ -297,6 +316,7 @@ class ReplService(
       respObs: StreamObserver[ClearResultsResponse],
   ): Unit = {
     results = Seq()
+    mainModules = Map.empty
     respObs.onNext(ClearResultsResponse.newBuilder.build)
     respObs.onCompleted
   }

--- a/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
+++ b/compiler/repl-service/server/src/main/scala/com/digitalasset/daml/lf/speedy/ReplServiceMain.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.lf.repl
+package com.daml.lf.speedy.repl
 
 import akka.actor.ActorSystem
 import akka.stream._

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -6,7 +6,9 @@ package com.daml.lf.speedy.iterable
 import com.daml.lf.speedy.{SExpr, SValue}
 import scala.jdk.CollectionConverters._
 
-object SExprIterable {
+// Iterates only over immediate children similar to Haskell’s
+// uniplate.
+private[speedy] object SExprIterable {
   that =>
   private[iterable] def iterator(e: SExpr): Iterator[SExpr] = e match {
     case SExpr.SEVal(_) => Iterator.empty

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SExprIterable.scala
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy.iterable
+
+import com.daml.lf.speedy.{SExpr, SValue}
+import scala.jdk.CollectionConverters._
+
+object SExprIterable {
+  that =>
+  private[iterable] def iterator(e: SExpr): Iterator[SExpr] = e match {
+    case SExpr.SEVal(_) => Iterator.empty
+    case SExpr.SEAppGeneral(fun, args) => Iterator(fun) ++ args.iterator
+    case SExpr.SEAppAtomicFun(fun, args) => Iterator(fun) ++ args.iterator
+    case SExpr.SEAppAtomicGeneral(fun, args) => Iterator(fun) ++ args.iterator
+    case SExpr.SEAppAtomicSaturatedBuiltin(_, args) => args.iterator
+    case SExpr.SEAbs(_, body) => Iterator(body)
+    case SExpr.SEMakeClo(_, _, body) => Iterator(body)
+    case SExpr.SECase(scrut, alts) => Iterator(scrut) ++ alts.iterator.map(_.body)
+    case SExpr.SECaseAtomic(scrut, alts) => Iterator(scrut) ++ alts.iterator.map(_.body)
+    case SExpr.SELet1General(rhs, body) => Iterator(rhs, body)
+    case SExpr.SELet1Builtin(_, args, body) => args.iterator ++ Iterator(body)
+    case SExpr.SELet(bounds, body) => bounds.iterator ++ Iterator(body)
+    case SExpr.SELocation(_, expr) => Iterator(expr)
+    case SExpr.SECatchSubmitMustFail(body) => Iterator(body)
+    case SExpr.SELabelClosure(_, expr) => Iterator(expr)
+    case SExpr.SEDamlException(_) => Iterator.empty
+    case SExpr.SEImportValue(_, _) => Iterator.empty
+    case SExpr.SETryCatch(body, handler) => Iterator(body, handler)
+    case SExpr.SEScopeExercise(body) => Iterator(body)
+    case SExpr.SEBuiltin(_) => Iterator.empty
+    case SExpr.SEBuiltinRecursiveDefinition(_) => Iterator.empty
+    case SExpr.SELocA(_) => Iterator.empty
+    case SExpr.SELocS(_) => Iterator.empty
+    case SExpr.SEValue(v) => iterator(v)
+    case SExpr.SELocF(_) => Iterator.empty
+    case SExpr.SEVar(_) => Iterator.empty
+  }
+  private def iterator(v: SValue): Iterator[SExpr] = v match {
+    case SValue.SPAP(prim, actuals, _) =>
+      iterator(prim) ++ actuals.asScala.iterator.flatMap(iterator(_))
+    case SValue.SAnyException(_, messageFunction, value) =>
+      Iterator(messageFunction) ++ iterator(value)
+    case SValue.SBuiltinException(_, _) | SValue.STNat(_) | _: SValue.SPrimLit |
+        SValue.STypeRep(_) | SValue.SToken | SValue.SAny(_, _) | SValue.SEnum(_, _, _) |
+        SValue.SGenMap(_, _) | SValue.SList(_) | SValue.SOptional(_) | SValue.SRecord(_, _, _) |
+        SValue.SStruct(_, _) | SValue.SVariant(_, _, _, _) =>
+      SValueIterable.iterator(v).flatMap(iterator(_))
+  }
+  private def iterator(v: SValue.Prim): Iterator[SExpr] = v match {
+    case SValue.PBuiltin(_) => Iterator.empty
+    case SValue.PClosure(_, expr, frame) => Iterator(expr) ++ frame.iterator.flatMap(iterator(_))
+  }
+
+  def apply(v: SValue): Iterable[SExpr] =
+    new Iterable[SExpr] {
+      override def iterator = that.iterator(v)
+    }
+
+  def apply(v: SExpr): Iterable[SExpr] =
+    new Iterable[SExpr] {
+      override def iterator = that.iterator(v)
+    }
+}

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
@@ -8,7 +8,7 @@ import scala.jdk.CollectionConverters._
 
 // Iterates only over immediate children similar to Haskell’s
 // uniplate.
-private [speedy] object SValueIterable {
+private[speedy] object SValueIterable {
   that =>
   private[iterable] def iterator(v: SValue): Iterator[SValue] = v match {
     case SValue.SPAP(prim, actuals, _) => iterator(prim) ++ actuals.asScala.iterator

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
@@ -6,7 +6,9 @@ package com.daml.lf.speedy.iterable
 import com.daml.lf.speedy.SValue
 import scala.jdk.CollectionConverters._
 
-object SValueIterable {
+// Iterates only over immediate children similar to Haskell’s
+// uniplate.
+private [speedy] object SValueIterable {
   that =>
   private[iterable] def iterator(v: SValue): Iterator[SValue] = v match {
     case SValue.SPAP(prim, actuals, _) => iterator(prim) ++ actuals.asScala.iterator

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/iterable/SValueIterable.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.speedy.iterable
+
+import com.daml.lf.speedy.SValue
+import scala.jdk.CollectionConverters._
+
+object SValueIterable {
+  that =>
+  private[iterable] def iterator(v: SValue): Iterator[SValue] = v match {
+    case SValue.SPAP(prim, actuals, _) => iterator(prim) ++ actuals.asScala.iterator
+    case SValue.SRecord(_, _, values) => values.asScala.iterator
+    case SValue.SStruct(_, values) => values.asScala.iterator
+    case SValue.SVariant(_, _, _, value) => Iterator(value)
+    case SValue.SEnum(_, _, _) => Iterator.empty
+    case SValue.SOptional(value) => value.iterator
+    case SValue.SList(list) => list.iterator
+    case SValue.SGenMap(_, entries) => entries.iterator.flatMap({ case (k, v) => Iterator(k, v) })
+    case SValue.SAny(_, value) => Iterator(value)
+    case SValue.SAnyException(_, _, value) => Iterator(value)
+    case SValue.SBuiltinException(_, value) => Iterator(value)
+    case SValue.STNat(_) => Iterator.empty
+    case SValue.STypeRep(_) => Iterator.empty
+    case SValue.SToken => Iterator.empty
+    case _: SValue.SPrimLit => Iterator.empty
+  }
+
+  private def iterator(p: SValue.Prim): Iterator[SValue] = p match {
+    case SValue.PBuiltin(_) => Iterator.empty
+    case SValue.PClosure(_, _, frame) => frame.iterator.flatMap(that.iterator(_))
+  }
+
+  def apply(v: SValue): Iterable[SValue] =
+    new Iterable[SValue] {
+      override def iterator = that.iterator(v)
+    }
+}


### PR DESCRIPTION
Turns out the comment "we probably need to extend this to merge the
modules from each line" was exactly correct: If the result evaluates
to a closure (or a value including a closure), it can reference
definitions from the current module. This happens if the simplifier
lifted something out of the current definition (otherwise we have only
one and it cannot be recursive so no chance of leaking a reference).

This PR fixes this by checking whether the result references the
current module and if it does, we keep it around.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
