### PR TITLE
Avoid submitTree for a sequence of creates

### DIFF
--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -261,7 +261,7 @@ private[dump] object Encode {
       case _ => (tuple(encodedCids) :+ " <- ", "pure " +: tuple(encodedCids))
     }
     val submit = "submitMulti " +: encodeParties(partyMap, submitters)
-    val actions = Doc.stack(evs.map { case ev =>
+    val actions = Doc.stack(evs.map { ev =>
       val cid = ContractId(ev.contractId)
       val bind = if (returnStmt.nonEmpty && cidRefs.contains(cid)) {
         encodeCid(cidMap, cid) :+ " <- "

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -216,7 +216,6 @@ private[dump] object Encode {
   ): Doc = ev match {
     case TreeEvent.Kind.Created(created) =>
       encodeCreatedEvent(partyMap, cidMap, created)
-      Doc.text("createCmd ") + encodeRecord(partyMap, cidMap, created.getCreateArguments)
     case TreeEvent.Kind.Exercised(exercised @ _) =>
       Doc.text("exerciseCmd ") + encodeCid(
         cidMap,

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -288,12 +288,10 @@ private[dump] object Encode {
     val rootEvs = tree.rootEventIds.map(tree.eventsById(_).kind)
     val createsOnly = {
       import scalaz.Scalaz._
-      rootEvs.toList
-        .map {
-          case Kind.Created(value) => Some(value)
-          case _ => None
-        }
-        .sequence[Option, CreatedEvent]
+      rootEvs.toList.traverse {
+        case Kind.Created(value) => Some(value)
+        case _ => None
+      }
     }
     createsOnly match {
       case Some(evs) =>

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -15,7 +15,7 @@ import com.daml.lf.data.Time.{Date, Timestamp}
 import com.daml.script.dump.TreeUtils._
 import org.apache.commons.text.StringEscapeUtils
 import org.typelevel.paiges.Doc
-import scalaz.std.list._
+import scalaz.std.iterable._
 import scalaz.std.set._
 import scalaz.syntax.foldable._
 
@@ -24,11 +24,11 @@ private[dump] object Encode {
       acs: Map[ContractId, CreatedEvent],
       trees: Seq[TransactionTree],
   ): Doc = {
-    val parties = partiesInContracts(acs.values) ++ trees.toList.foldMap(partiesInTree(_))
+    val parties = partiesInContracts(acs.values) ++ trees.foldMap(partiesInTree(_))
     val partyMap = partyMapping(parties)
 
-    val acsCidRefs = acs.values.toList.foldMap(createdReferencedCids)
-    val treeCidRefs = trees.toList.foldMap(treeReferencedCids)
+    val acsCidRefs = acs.values.foldMap(createdReferencedCids)
+    val treeCidRefs = trees.foldMap(treeReferencedCids)
     val cidRefs = acsCidRefs ++ treeCidRefs
 
     val unknownCidRefs = acsCidRefs -- acs.keySet
@@ -46,9 +46,10 @@ private[dump] object Encode {
     val treeCids = trees.map(treeCreatedCids(_))
     val cidMap = cidMapping(acsCids +: treeCids, cidRefs)
 
-    val refs = acs.values.toList.foldMap(ev =>
-      valueRefs(Sum.Record(ev.getCreateArguments))
-    ) ++ trees.toList.foldMap(treeRefs(_))
+    val refs =
+      acs.values.foldMap(ev => valueRefs(Sum.Record(ev.getCreateArguments))) ++ trees.foldMap(
+        treeRefs(_)
+      )
     val moduleRefs = refs.map(_.moduleName).toSet
     Doc.text("module Dump where") /
       Doc.text("import Daml.Script") /

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -70,7 +70,7 @@ private[dump] object Encode {
       (Doc.text("dump Parties{..} = do") /
         Doc.stack(
           sortedAcs.map(createdEvent =>
-            encodeSubmitCreatedEvent(partyMap, cidMap, cidRefs, createdEvent)
+            encodeSubmitCreatedEvents(partyMap, cidMap, cidRefs, Seq(createdEvent))
           ) ++
             trees.map(t => encodeTree(partyMap, cidMap, cidRefs, t))
         ) /
@@ -242,23 +242,6 @@ private[dump] object Encode {
         Doc.text(", "),
         c.path.map(encodeSelector(_)),
       ) + Doc.text("] tree")
-  }
-
-  private[dump] def encodeSubmitCreatedEvent(
-      partyMap: Map[Party, String],
-      cidMap: Map[ContractId, String],
-      cidRefs: Set[ContractId],
-      createdEvent: CreatedEvent,
-  ): Doc = {
-    val createCmd =
-      Doc.text("createCmd ") + encodeRecord(partyMap, cidMap, createdEvent.getCreateArguments)
-    val cid = ContractId(createdEvent.contractId)
-    val bind = if (cidRefs.contains(cid)) { Doc.text(cidMap(cid)) + Doc.text(" <- ") }
-    else { Doc.empty }
-    val submitters = Party.subst(createdEvent.signatories)
-    (bind + Doc.text("submitMulti ") + encodeParties(partyMap, submitters) + Doc.text(
-      " [] do"
-    ) / createCmd).hang(2)
   }
 
   private[dump] def encodeSubmitCreatedEvents(

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
@@ -29,7 +29,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
             )
           ),
         )
-        encodeSubmitCreatedEvent(parties, cidMap, cidRefs, created).render(80) shouldBe
+        encodeSubmitCreatedEvents(parties, cidMap, cidRefs, Seq(created)).render(80) shouldBe
           """submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
       }
@@ -49,7 +49,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
             )
           ),
         )
-        encodeSubmitCreatedEvent(parties, cidMap, cidRefs, created).render(80) shouldBe
+        encodeSubmitCreatedEvents(parties, cidMap, cidRefs, Seq(created)).render(80) shouldBe
           """contract_0_0 <- submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace(
             "\r\n",

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
@@ -32,7 +32,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
         val cidRefs = Set.empty[ContractId]
         val created = mkCreated(1)
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, Seq(created)).render(80) shouldBe
-          """submitMulti [alice_0] [] do
+          """_ <- submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
       }
       "referenced" in {
@@ -43,6 +43,25 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, Seq(created)).render(80) shouldBe
           """contract_0_0 <- submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+      "multiple unreferenced" in {
+        val parties = Map(Party("Alice") -> "alice_0")
+        val cidMap = Map(
+          ContractId("cid1") -> "contract_0_0",
+          ContractId("cid2") -> "contract_0_1",
+          ContractId("cid3") -> "contract_0_2",
+        )
+        val cidRefs = Set.empty[ContractId]
+        val events = Seq(mkCreated(1), mkCreated(2), mkCreated(3))
+        encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
+          """submitMulti [alice_0] [] do
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  pure ()""".stripMargin.replace(
             "\r\n",
             "\n",
           )
@@ -59,7 +78,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
           """(contract_0_0, contract_0_2) <- submitMulti [alice_0] [] do
             |  contract_0_0 <- createCmd Module.Template
-            |  createCmd Module.Template
+            |  _ <- createCmd Module.Template
             |  contract_0_2 <- createCmd Module.Template
             |  pure (contract_0_0, contract_0_2)""".stripMargin.replace(
             "\r\n",
@@ -76,8 +95,9 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
         val events = Seq(mkCreated(1), mkCreated(2))
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
           """contract_0_1 <- submitMulti [alice_0] [] do
-            |  createCmd Module.Template
-            |  createCmd Module.Template""".stripMargin.replace(
+            |  _ <- createCmd Module.Template
+            |  contract_0_1 <- createCmd Module.Template
+            |  pure contract_0_1""".stripMargin.replace(
             "\r\n",
             "\n",
           )

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
@@ -29,7 +29,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
             )
           ),
         )
-        encodeCreatedEvent(parties, cidMap, cidRefs, created).render(80) shouldBe
+        encodeSubmitCreatedEvent(parties, cidMap, cidRefs, created).render(80) shouldBe
           """submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
       }
@@ -49,7 +49,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
             )
           ),
         )
-        encodeCreatedEvent(parties, cidMap, cidRefs, created).render(80) shouldBe
+        encodeSubmitCreatedEvent(parties, cidMap, cidRefs, created).render(80) shouldBe
           """contract_0_0 <- submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace(
             "\r\n",

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
@@ -11,46 +11,72 @@ import org.scalatest.matchers.should.Matchers
 
 class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
   import Encode._
+  private def mkCreated(i: Int) =
+    CreatedEvent(
+      eventId = s"create$i",
+      templateId = Some(Identifier("package", "Module", "Template")),
+      contractId = s"cid$i",
+      signatories = Seq("Alice"),
+      createArguments = Some(
+        Record(
+          recordId = Some(Identifier("package", "Module", "Template")),
+          fields = Seq.empty,
+        )
+      ),
+    )
   "encodeCreatedEvent" - {
     "contract id bindings" - {
       "unreferenced" in {
         val parties = Map(Party("Alice") -> "alice_0")
-        val cidMap = Map(ContractId("cid") -> "contract_0_0")
+        val cidMap = Map(ContractId("cid1") -> "contract_0_0")
         val cidRefs = Set.empty[ContractId]
-        val created = CreatedEvent(
-          eventId = "create",
-          templateId = Some(Identifier("package", "Module", "Template")),
-          contractId = "cid",
-          signatories = Seq("Alice"),
-          createArguments = Some(
-            Record(
-              recordId = Some(Identifier("package", "Module", "Template")),
-              fields = Seq.empty,
-            )
-          ),
-        )
+        val created = mkCreated(1)
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, Seq(created)).render(80) shouldBe
           """submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
       }
       "referenced" in {
         val parties = Map(Party("Alice") -> "alice_0")
-        val cidMap = Map(ContractId("cid") -> "contract_0_0")
-        val cidRefs = Set(ContractId("cid"))
-        val created = CreatedEvent(
-          eventId = "create",
-          templateId = Some(Identifier("package", "Module", "Template")),
-          contractId = "cid",
-          signatories = Seq("Alice"),
-          createArguments = Some(
-            Record(
-              recordId = Some(Identifier("package", "Module", "Template")),
-              fields = Seq.empty,
-            )
-          ),
-        )
+        val cidMap = Map(ContractId("cid1") -> "contract_0_0")
+        val cidRefs = Set(ContractId("cid1"))
+        val created = mkCreated(1)
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, Seq(created)).render(80) shouldBe
           """contract_0_0 <- submitMulti [alice_0] [] do
+            |  createCmd Module.Template""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+      "multiple referenced" in {
+        val parties = Map(Party("Alice") -> "alice_0")
+        val cidMap = Map(
+          ContractId("cid1") -> "contract_0_0",
+          ContractId("cid2") -> "contract_0_1",
+          ContractId("cid3") -> "contract_0_2",
+        )
+        val cidRefs = Set(ContractId("cid1"), ContractId("cid3"))
+        val events = Seq(mkCreated(1), mkCreated(2), mkCreated(3))
+        encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
+          """(contract_0_0, contract_0_2) <- submitMulti [alice_0] [] do
+            |  contract_0_0 <- createCmd Module.Template
+            |  createCmd Module.Template
+            |  contract_0_2 <- createCmd Module.Template
+            |  pure (contract_0_0, contract_0_2)""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+      "last referenced" in {
+        val parties = Map(Party("Alice") -> "alice_0")
+        val cidMap = Map(
+          ContractId("cid1") -> "contract_0_0",
+          ContractId("cid2") -> "contract_0_1",
+        )
+        val cidRefs = Set(ContractId("cid2"))
+        val events = Seq(mkCreated(1), mkCreated(2))
+        encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
+          """contract_0_1 <- submitMulti [alice_0] [] do
+            |  createCmd Module.Template
             |  createCmd Module.Template""".stripMargin.replace(
             "\r\n",
             "\n",

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
@@ -31,6 +31,31 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
       )
     )
   }
+  private def mkExercised(i: Int, cid: ContractId, result: Value, childEventIds: Seq[String]) = {
+    s"exercise$i" -> TreeEvent(
+      TreeEvent.Kind.Exercised(
+        ExercisedEvent(
+          eventId = s"exercise$i",
+          templateId = Some(Identifier("package", "Module", "Template")),
+          contractId = ContractId.unwrap(cid),
+          actingParties = Seq("Alice"),
+          choice = "Choice",
+          choiceArgument = Some(
+            Value()
+              .withVariant(
+                Variant(
+                  Some(Identifier("package", "Module", "Choice")),
+                  "Choice",
+                  Some(Value().withUnit(protobuf.empty.Empty())),
+                )
+              )
+          ),
+          childEventIds = childEventIds,
+          exerciseResult = Some(result),
+        )
+      )
+    )
+  }
 
   "encodeTree" - {
     "contract id bindings" - {
@@ -96,31 +121,9 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           offset = "",
           eventsById = Map(
             mkCreated(1),
-            "exercise" -> TreeEvent(
-              TreeEvent.Kind.Exercised(
-                ExercisedEvent(
-                  eventId = "exercise",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid0",
-                  actingParties = Seq("Alice"),
-                  choice = "Choice",
-                  choiceArgument = Some(
-                    Value()
-                      .withVariant(
-                        Variant(
-                          Some(Identifier("package", "Module", "Choice")),
-                          "Choice",
-                          Some(Value().withUnit(protobuf.empty.Empty())),
-                        )
-                      )
-                  ),
-                  childEventIds = Seq("create1"),
-                  exerciseResult = Some(Value().withContractId("cid2")),
-                )
-              )
-            ),
+            mkExercised(2, ContractId("cid0"), Value().withContractId("cid2"), Seq("create1")),
           ),
-          rootEventIds = Seq("exercise"),
+          rootEventIds = Seq("exercise2"),
           traceContext = None,
         )
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
@@ -196,31 +199,14 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           eventsById = Map(
             mkCreated(1),
             mkCreated(2),
-            "exercise" -> TreeEvent(
-              TreeEvent.Kind.Exercised(
-                ExercisedEvent(
-                  eventId = "exercise",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid0",
-                  actingParties = Seq("Alice"),
-                  choice = "Choice",
-                  choiceArgument = Some(
-                    Value()
-                      .withVariant(
-                        Variant(
-                          Some(Identifier("package", "Module", "Choice")),
-                          "Choice",
-                          Some(Value().withUnit(protobuf.empty.Empty())),
-                        )
-                      )
-                  ),
-                  childEventIds = Seq("create1", "create2"),
-                  exerciseResult = Some(Value().withContractId("cid2")),
-                )
-              )
+            mkExercised(
+              3,
+              ContractId("cid0"),
+              Value().withContractId("cid2"),
+              Seq("create1", "create2"),
             ),
           ),
-          rootEventIds = Seq("exercise"),
+          rootEventIds = Seq("exercise3"),
           traceContext = None,
         )
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
@@ -13,11 +13,30 @@ import org.scalatest.matchers.should.Matchers
 
 class EncodeTreeSpec extends AnyFreeSpec with Matchers {
   import Encode._
+  private def mkCreated(i: Int) = {
+    s"create$i" -> TreeEvent(
+      TreeEvent.Kind.Created(
+        CreatedEvent(
+          eventId = s"create$i",
+          templateId = Some(Identifier("package", "Module", "Template")),
+          contractId = s"cid$i",
+          signatories = Seq("Alice"),
+          createArguments = Some(
+            Record(
+              recordId = Some(Identifier("package", "Module", "Template")),
+              fields = Seq.empty,
+            )
+          ),
+        )
+      )
+    )
+  }
+
   "encodeTree" - {
     "contract id bindings" - {
       "unreferenced create" in {
         val parties = Map(Party("Alice") -> "alice_0")
-        val cidMap = Map(ContractId("cid") -> "contract_0_0")
+        val cidMap = Map(ContractId("cid1") -> "contract_0_0")
         val cidRefs = Set.empty[ContractId]
         val tree = TransactionTree(
           transactionId = "txid",
@@ -26,24 +45,9 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           effectiveAt = None,
           offset = "",
           eventsById = Map(
-            "create" -> TreeEvent(
-              TreeEvent.Kind.Created(
-                CreatedEvent(
-                  eventId = "create",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid",
-                  signatories = Seq("Alice"),
-                  createArguments = Some(
-                    Record(
-                      recordId = Some(Identifier("package", "Module", "Template")),
-                      fields = Seq.empty,
-                    )
-                  ),
-                )
-              )
-            )
+            mkCreated(1)
           ),
-          rootEventIds = Seq("create"),
+          rootEventIds = Seq("create1"),
           traceContext = None,
         )
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
@@ -64,38 +68,8 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           effectiveAt = None,
           offset = "",
           eventsById = Map(
-            "create1" -> TreeEvent(
-              TreeEvent.Kind.Created(
-                CreatedEvent(
-                  eventId = "create",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid1",
-                  signatories = Seq("Alice"),
-                  createArguments = Some(
-                    Record(
-                      recordId = Some(Identifier("package", "Module", "Template")),
-                      fields = Seq.empty,
-                    )
-                  ),
-                )
-              )
-            ),
-            "create2" -> TreeEvent(
-              TreeEvent.Kind.Created(
-                CreatedEvent(
-                  eventId = "create",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid2",
-                  signatories = Seq("Alice"),
-                  createArguments = Some(
-                    Record(
-                      recordId = Some(Identifier("package", "Module", "Template")),
-                      fields = Seq.empty,
-                    )
-                  ),
-                )
-              )
-            ),
+            mkCreated(1),
+            mkCreated(2),
           ),
           rootEventIds = Seq("create1", "create2"),
           traceContext = None,
@@ -121,22 +95,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           effectiveAt = None,
           offset = "",
           eventsById = Map(
-            "create" -> TreeEvent(
-              TreeEvent.Kind.Created(
-                CreatedEvent(
-                  eventId = "create",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid1",
-                  signatories = Seq("Alice"),
-                  createArguments = Some(
-                    Record(
-                      recordId = Some(Identifier("package", "Module", "Template")),
-                      fields = Seq.empty,
-                    )
-                  ),
-                )
-              )
-            ),
+            mkCreated(1),
             "exercise" -> TreeEvent(
               TreeEvent.Kind.Exercised(
                 ExercisedEvent(
@@ -155,7 +114,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
                         )
                       )
                   ),
-                  childEventIds = Seq("create"),
+                  childEventIds = Seq("create1"),
                   exerciseResult = Some(Value().withContractId("cid2")),
                 )
               )
@@ -170,8 +129,8 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
       }
       "referenced create" in {
         val parties = Map(Party("Alice") -> "alice_0")
-        val cidMap = Map(ContractId("cid") -> "contract_0_0")
-        val cidRefs = Set(ContractId("cid"))
+        val cidMap = Map(ContractId("cid1") -> "contract_0_0")
+        val cidRefs = Set(ContractId("cid1"))
         val tree = TransactionTree(
           transactionId = "txid",
           commandId = "cmdid",
@@ -179,24 +138,9 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           effectiveAt = None,
           offset = "",
           eventsById = Map(
-            "create" -> TreeEvent(
-              TreeEvent.Kind.Created(
-                CreatedEvent(
-                  eventId = "create",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid",
-                  signatories = Seq("Alice"),
-                  createArguments = Some(
-                    Record(
-                      recordId = Some(Identifier("package", "Module", "Template")),
-                      fields = Seq.empty,
-                    )
-                  ),
-                )
-              )
-            )
+            mkCreated(1)
           ),
-          rootEventIds = Seq("create"),
+          rootEventIds = Seq("create1"),
           traceContext = None,
         )
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
@@ -220,38 +164,8 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           effectiveAt = None,
           offset = "",
           eventsById = Map(
-            "create1" -> TreeEvent(
-              TreeEvent.Kind.Created(
-                CreatedEvent(
-                  eventId = "create",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid1",
-                  signatories = Seq("Alice"),
-                  createArguments = Some(
-                    Record(
-                      recordId = Some(Identifier("package", "Module", "Template")),
-                      fields = Seq.empty,
-                    )
-                  ),
-                )
-              )
-            ),
-            "create2" -> TreeEvent(
-              TreeEvent.Kind.Created(
-                CreatedEvent(
-                  eventId = "create",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid2",
-                  signatories = Seq("Alice"),
-                  createArguments = Some(
-                    Record(
-                      recordId = Some(Identifier("package", "Module", "Template")),
-                      fields = Seq.empty,
-                    )
-                  ),
-                )
-              )
-            ),
+            mkCreated(1),
+            mkCreated(2),
           ),
           rootEventIds = Seq("create1", "create2"),
           traceContext = None,
@@ -280,38 +194,8 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           effectiveAt = None,
           offset = "",
           eventsById = Map(
-            "create1" -> TreeEvent(
-              TreeEvent.Kind.Created(
-                CreatedEvent(
-                  eventId = "create",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid1",
-                  signatories = Seq("Alice"),
-                  createArguments = Some(
-                    Record(
-                      recordId = Some(Identifier("package", "Module", "Template")),
-                      fields = Seq.empty,
-                    )
-                  ),
-                )
-              )
-            ),
-            "create2" -> TreeEvent(
-              TreeEvent.Kind.Created(
-                CreatedEvent(
-                  eventId = "create",
-                  templateId = Some(Identifier("package", "Module", "Template")),
-                  contractId = "cid2",
-                  signatories = Seq("Alice"),
-                  createArguments = Some(
-                    Record(
-                      recordId = Some(Identifier("package", "Module", "Template")),
-                      fields = Seq.empty,
-                    )
-                  ),
-                )
-              )
-            ),
+            mkCreated(1),
+            mkCreated(2),
             "exercise" -> TreeEvent(
               TreeEvent.Kind.Exercised(
                 ExercisedEvent(

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
@@ -47,7 +47,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           traceContext = None,
         )
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
-          """submitMulti [alice_0] [] do
+          """_ <- submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
       }
       "unreferenced creates" in {
@@ -102,8 +102,9 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
         )
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
           """submitMulti [alice_0] [] do
-            |  createCmd Module.Template
-            |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  pure ()""".stripMargin.replace("\r\n", "\n")
       }
       "unreferenced exercise" in {
         val parties = Map(Party("Alice") -> "alice_0")

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
@@ -4,9 +4,10 @@
 package com.daml.script.dump
 
 import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
-import com.daml.ledger.api.v1.event.CreatedEvent
+import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
 import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
-import com.daml.ledger.api.v1.value.{Identifier, Record}
+import com.daml.ledger.api.v1.value.{Identifier, Record, Value, Variant}
+import com.google.protobuf
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -14,7 +15,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
   import Encode._
   "encodeTree" - {
     "contract id bindings" - {
-      "unreferenced" in {
+      "unreferenced create" in {
         val parties = Map(Party("Alice") -> "alice_0")
         val cidMap = Map(ContractId("cid") -> "contract_0_0")
         val cidRefs = Set.empty[ContractId]
@@ -46,10 +47,127 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           traceContext = None,
         )
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
-          """tree <- submitTreeMulti [alice_0] [] do
+          """submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
       }
-      "referenced" in {
+      "unreferenced creates" in {
+        val parties = Map(Party("Alice") -> "alice_0")
+        val cidMap = Map(
+          ContractId("cid1") -> "contract_1_0",
+          ContractId("cid2") -> "contract_1_1",
+        )
+        val cidRefs = Set.empty[ContractId]
+        val tree = TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map(
+            "create1" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid1",
+                  signatories = Seq("Alice"),
+                  createArguments = Some(
+                    Record(
+                      recordId = Some(Identifier("package", "Module", "Template")),
+                      fields = Seq.empty,
+                    )
+                  ),
+                )
+              )
+            ),
+            "create2" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid2",
+                  signatories = Seq("Alice"),
+                  createArguments = Some(
+                    Record(
+                      recordId = Some(Identifier("package", "Module", "Template")),
+                      fields = Seq.empty,
+                    )
+                  ),
+                )
+              )
+            ),
+          ),
+          rootEventIds = Seq("create1", "create2"),
+          traceContext = None,
+        )
+        encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
+          """submitMulti [alice_0] [] do
+            |  createCmd Module.Template
+            |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
+      }
+      "unreferenced exercise" in {
+        val parties = Map(Party("Alice") -> "alice_0")
+        val cidMap = Map(
+          ContractId("cid0") -> "contract_0_0",
+          ContractId("cid1") -> "contract_1_0",
+          ContractId("cid1") -> "contract_1_1",
+        )
+        val cidRefs = Set.empty[ContractId]
+        val tree = TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map(
+            "create" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid1",
+                  signatories = Seq("Alice"),
+                  createArguments = Some(
+                    Record(
+                      recordId = Some(Identifier("package", "Module", "Template")),
+                      fields = Seq.empty,
+                    )
+                  ),
+                )
+              )
+            ),
+            "exercise" -> TreeEvent(
+              TreeEvent.Kind.Exercised(
+                ExercisedEvent(
+                  eventId = "exercise",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid0",
+                  actingParties = Seq("Alice"),
+                  choice = "Choice",
+                  choiceArgument = Some(
+                    Value()
+                      .withVariant(
+                        Variant(
+                          Some(Identifier("package", "Module", "Choice")),
+                          "Choice",
+                          Some(Value().withUnit(protobuf.empty.Empty())),
+                        )
+                      )
+                  ),
+                  childEventIds = Seq("create"),
+                  exerciseResult = Some(Value().withContractId("cid2")),
+                )
+              )
+            ),
+          ),
+          rootEventIds = Seq("exercise"),
+          traceContext = None,
+        )
+        encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
+          """tree <- submitTreeMulti [alice_0] [] do
+            |  exerciseCmd contract_0_0 (Module.Choice ())""".stripMargin.replace("\r\n", "\n")
+      }
+      "referenced create" in {
         val parties = Map(Party("Alice") -> "alice_0")
         val cidMap = Map(ContractId("cid") -> "contract_0_0")
         val cidRefs = Set(ContractId("cid"))
@@ -81,9 +199,150 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           traceContext = None,
         )
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
+          """contract_0_0 <- submitMulti [alice_0] [] do
+            |  createCmd Module.Template""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+      "referenced creates" in {
+        val parties = Map(Party("Alice") -> "alice_0")
+        val cidMap = Map(
+          ContractId("cid1") -> "contract_1_0",
+          ContractId("cid2") -> "contract_1_1",
+        )
+        val cidRefs = Set(ContractId("cid1"), ContractId("cid2"))
+        val tree = TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map(
+            "create1" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid1",
+                  signatories = Seq("Alice"),
+                  createArguments = Some(
+                    Record(
+                      recordId = Some(Identifier("package", "Module", "Template")),
+                      fields = Seq.empty,
+                    )
+                  ),
+                )
+              )
+            ),
+            "create2" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid2",
+                  signatories = Seq("Alice"),
+                  createArguments = Some(
+                    Record(
+                      recordId = Some(Identifier("package", "Module", "Template")),
+                      fields = Seq.empty,
+                    )
+                  ),
+                )
+              )
+            ),
+          ),
+          rootEventIds = Seq("create1", "create2"),
+          traceContext = None,
+        )
+        encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
+          """(contract_1_0, contract_1_1) <- submitMulti [alice_0] [] do
+            |  contract_1_0 <- createCmd Module.Template
+            |  contract_1_1 <- createCmd Module.Template
+            |  pure (contract_1_0, contract_1_1)""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+      "referenced exercise" in {
+        val parties = Map(Party("Alice") -> "alice_0")
+        val cidMap = Map(
+          ContractId("cid0") -> "contract_0_0",
+          ContractId("cid1") -> "contract_1_0",
+          ContractId("cid2") -> "contract_1_1",
+        )
+        val cidRefs = Set(ContractId("cid1"), ContractId("cid2"))
+        val tree = TransactionTree(
+          transactionId = "txid",
+          commandId = "cmdid",
+          workflowId = "flowid",
+          effectiveAt = None,
+          offset = "",
+          eventsById = Map(
+            "create1" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid1",
+                  signatories = Seq("Alice"),
+                  createArguments = Some(
+                    Record(
+                      recordId = Some(Identifier("package", "Module", "Template")),
+                      fields = Seq.empty,
+                    )
+                  ),
+                )
+              )
+            ),
+            "create2" -> TreeEvent(
+              TreeEvent.Kind.Created(
+                CreatedEvent(
+                  eventId = "create",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid2",
+                  signatories = Seq("Alice"),
+                  createArguments = Some(
+                    Record(
+                      recordId = Some(Identifier("package", "Module", "Template")),
+                      fields = Seq.empty,
+                    )
+                  ),
+                )
+              )
+            ),
+            "exercise" -> TreeEvent(
+              TreeEvent.Kind.Exercised(
+                ExercisedEvent(
+                  eventId = "exercise",
+                  templateId = Some(Identifier("package", "Module", "Template")),
+                  contractId = "cid0",
+                  actingParties = Seq("Alice"),
+                  choice = "Choice",
+                  choiceArgument = Some(
+                    Value()
+                      .withVariant(
+                        Variant(
+                          Some(Identifier("package", "Module", "Choice")),
+                          "Choice",
+                          Some(Value().withUnit(protobuf.empty.Empty())),
+                        )
+                      )
+                  ),
+                  childEventIds = Seq("create1", "create2"),
+                  exerciseResult = Some(Value().withContractId("cid2")),
+                )
+              )
+            ),
+          ),
+          rootEventIds = Seq("exercise"),
+          traceContext = None,
+        )
+        encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
           """tree <- submitTreeMulti [alice_0] [] do
-            |  createCmd Module.Template
-            |let contract_0_0 = createdCid @Module.Template [0] tree""".stripMargin.replace(
+            |  exerciseCmd contract_0_0 (Module.Choice ())
+            |let contract_1_0 = createdCid @Module.Template [0, 0] tree
+            |let contract_1_1 = createdCid @Module.Template [0, 1] tree""".stripMargin.replace(
             "\r\n",
             "\n",
           )


### PR DESCRIPTION
Addresses part of #8774 

This avoids `submitTreeMulti` if a transaction only consists of a sequence of creates, instead it uses `submitMulti`.
It avoids binding contract ids that are not referenced later and keeps the binds of contract ids within the submit body minimal.
This factors out some common functionality between encoding the ACS and encoding transactions.
The tests are extended to cover more relevant cases.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
