### PR TITLE
Temporarily cut compatibility tests with incompatible versions of Daml-LF

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -373,6 +373,18 @@ def create_daml_app_test(
         **kwargs
     )
 
+# FIXME
+#
+# From version 1.11.0-snapshot.20210217.6338.1 of the SDK, the Ledger API
+# Test Tool uses Daml-LF 1.11, which requires platform versions starting from
+# 1.10.0.
+#
+# This predicate is used to filter Ledger API Test Tool tests in the
+# sdk_platform_test macro as a temporary measure to prevent spurious errors on CI.
+# The proper fix is to use the appropriate version of Daml-LF for every SDK/platform pair.
+def ledger_api_test_tool_compatible(sdk_version, platform_version):
+    return in_range(sdk_version, {"end": "1.11.0-snapshot.20210217.6338.1"}) or (in_range(sdk_version, {"start": "1.11.0-snapshot.20210217.6338.1"}) and in_range(platform_version, {"start": "1.10.0"}))
+
 def sdk_platform_test(sdk_version, platform_version):
     # SDK components
     daml_assistant = "@daml-sdk-{sdk_version}//:daml".format(
@@ -427,7 +439,7 @@ def sdk_platform_test(sdk_version, platform_version):
             dar_files = dar_files,
         )],
         tags = ["exclusive", sdk_version, platform_version] + extra_tags(sdk_version, platform_version),
-    )
+    ) if ledger_api_test_tool_compatible(sdk_version, platform_version) else None
 
     client_server_test(
         name = name + "-classic",
@@ -445,7 +457,7 @@ def sdk_platform_test(sdk_version, platform_version):
             dar_files = dar_files,
         )],
         tags = ["exclusive", sdk_version, platform_version] + extra_tags(sdk_version, platform_version),
-    )
+    ) if ledger_api_test_tool_compatible(sdk_version, platform_version) else None
 
     client_server_test(
         name = name + "-postgresql",
@@ -462,7 +474,7 @@ def sdk_platform_test(sdk_version, platform_version):
             dar_files = dar_files,
         )],
         tags = ["exclusive"] + extra_tags(sdk_version, platform_version),
-    ) if not is_windows else None
+    ) if not is_windows and ledger_api_test_tool_compatible(sdk_version, platform_version) else None
 
     client_server_test(
         name = name + "-classic-postgresql",
@@ -481,7 +493,7 @@ def sdk_platform_test(sdk_version, platform_version):
             dar_files = dar_files,
         )],
         tags = ["exclusive"] + extra_tags(sdk_version, platform_version),
-    ) if not is_windows else None
+    ) if not is_windows and ledger_api_test_tool_compatible(sdk_version, platform_version) else None
 
     # daml-ledger test-cases
     name = "daml-ledger-{sdk_version}-platform-{platform_version}".format(


### PR DESCRIPTION
These cause spurious failures on CI.

As described in the code, the proper fix is to use the correct Daml-LF version for every pair.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
