### PR TITLE
Temporarily cut compatibility tests with incompatible versions of Daml-LF

### DIFF
--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@os_info//:os_info.bzl", "is_windows")
-load("//bazel_tools:testing.bzl", "create_daml_app_codegen", "create_daml_app_dar", "sdk_platform_test")
+load("//bazel_tools:testing.bzl", "create_daml_app_codegen", "create_daml_app_dar", "in_range", "sdk_platform_test")
 load(
     "//bazel_tools/daml_script:daml_script.bzl",
     "daml_script_dar",
@@ -59,6 +59,23 @@ config_setting(
 # test runs to grow quadratically.
 head = "0.0.0"
 
+# FIXME
+#
+# From version 1.11.0-snapshot.20210217.6338.0.ba6ba901 of the SDK components default to
+# Daml-LF 1.11, which requires platform versions starting from 1.10.0.
+#
+# This predicate can be used to filter sdk_platform_test rules as a temporary
+# measure to prevent spurious errors on CI.
+#
+# The proper fix is to use the appropriate version of Daml-LF for every SDK/platform pair.
+
+switch_to_lf_1_11_inclusive = "1.11.0-snapshot.20210217.6338.0.ba6ba901"
+
+switch_to_lf_1_11_exclusive = "1.11.0-snapshot.20210217.6338.1"
+
+def daml_lf_compatible(sdk_version, platform_version):
+    return in_range(sdk_version, {"end": switch_to_lf_1_11_inclusive}) or (in_range(sdk_version, {"start": switch_to_lf_1_11_exclusive}) and in_range(platform_version, {"start": "1.10.0"}))
+
 # Missing on purpose: do not test the latest SDK with the latest platform
 # That is not a compatibility test, it's just testing the main branch. ;)
 
@@ -69,7 +86,7 @@ head = "0.0.0"
         sdk_version = head,
     )
     for platform_version in platform_versions
-    if platform_version != head
+    if platform_version != head and daml_lf_compatible(sdk_version, platform_version)
 ]
 
 # Test all old SDK versions with the latest platform
@@ -79,7 +96,7 @@ head = "0.0.0"
         sdk_version = sdk_version,
     )
     for sdk_version in sdk_versions
-    if sdk_version != head
+    if sdk_version != head and daml_lf_compatible(sdk_version, platform_version)
 ]
 
 [

--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@os_info//:os_info.bzl", "is_windows")
-load("//bazel_tools:testing.bzl", "create_daml_app_codegen", "create_daml_app_dar", "in_range", "sdk_platform_test")
+load("//bazel_tools:testing.bzl", "create_daml_app_codegen", "create_daml_app_dar", "daml_lf_compatible", "sdk_platform_test")
 load(
     "//bazel_tools/daml_script:daml_script.bzl",
     "daml_script_dar",
@@ -59,23 +59,6 @@ config_setting(
 # test runs to grow quadratically.
 head = "0.0.0"
 
-# FIXME
-#
-# From version 1.11.0-snapshot.20210217.6338.0.ba6ba901 of the SDK components default to
-# Daml-LF 1.11, which requires platform versions starting from 1.10.0.
-#
-# This predicate can be used to filter sdk_platform_test rules as a temporary
-# measure to prevent spurious errors on CI.
-#
-# The proper fix is to use the appropriate version of Daml-LF for every SDK/platform pair.
-
-switch_to_lf_1_11_inclusive = "1.11.0-snapshot.20210217.6338.0.ba6ba901"
-
-switch_to_lf_1_11_exclusive = "1.11.0-snapshot.20210217.6338.1"
-
-def daml_lf_compatible(sdk_version, platform_version):
-    return in_range(sdk_version, {"end": switch_to_lf_1_11_inclusive}) or (in_range(sdk_version, {"start": switch_to_lf_1_11_exclusive}) and in_range(platform_version, {"start": "1.10.0"}))
-
 # Missing on purpose: do not test the latest SDK with the latest platform
 # That is not a compatibility test, it's just testing the main branch. ;)
 
@@ -86,7 +69,7 @@ def daml_lf_compatible(sdk_version, platform_version):
         sdk_version = head,
     )
     for platform_version in platform_versions
-    if platform_version != head and daml_lf_compatible(sdk_version, platform_version)
+    if platform_version != head and daml_lf_compatible(head, platform_version)
 ]
 
 # Test all old SDK versions with the latest platform
@@ -96,7 +79,7 @@ def daml_lf_compatible(sdk_version, platform_version):
         sdk_version = sdk_version,
     )
     for sdk_version in sdk_versions
-    if sdk_version != head and daml_lf_compatible(sdk_version, platform_version)
+    if sdk_version != head and daml_lf_compatible(sdk_version, head)
 ]
 
 [

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -373,6 +373,23 @@ def create_daml_app_test(
         **kwargs
     )
 
+# FIXME
+#
+# From version 1.11.0-snapshot.20210217.6338.0.ba6ba901 of the SDK components default to
+# Daml-LF 1.11, which requires platform versions starting from 1.10.0.
+#
+# This predicate can be used to filter sdk_platform_test rules as a temporary
+# measure to prevent spurious errors on CI.
+#
+# The proper fix is to use the appropriate version of Daml-LF for every SDK/platform pair.
+
+switch_to_lf_1_11_inclusive = "1.11.0-snapshot.20210217.6338.0.ba6ba901"
+
+switch_to_lf_1_11_exclusive = "1.11.0-snapshot.20210217.6338.1"
+
+def daml_lf_compatible(sdk_version, platform_version):
+    return in_range(sdk_version, {"end": switch_to_lf_1_11_inclusive}) or (in_range(sdk_version, {"start": switch_to_lf_1_11_exclusive}) and in_range(platform_version, {"start": "1.10.0"}))
+
 def sdk_platform_test(sdk_version, platform_version):
     # SDK components
     daml_assistant = "@daml-sdk-{sdk_version}//:daml".format(

--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -373,18 +373,6 @@ def create_daml_app_test(
         **kwargs
     )
 
-# FIXME
-#
-# From version 1.11.0-snapshot.20210217.6338.1 of the SDK, the Ledger API
-# Test Tool uses Daml-LF 1.11, which requires platform versions starting from
-# 1.10.0.
-#
-# This predicate is used to filter Ledger API Test Tool tests in the
-# sdk_platform_test macro as a temporary measure to prevent spurious errors on CI.
-# The proper fix is to use the appropriate version of Daml-LF for every SDK/platform pair.
-def ledger_api_test_tool_compatible(sdk_version, platform_version):
-    return in_range(sdk_version, {"end": "1.11.0-snapshot.20210217.6338.1"}) or (in_range(sdk_version, {"start": "1.11.0-snapshot.20210217.6338.1"}) and in_range(platform_version, {"start": "1.10.0"}))
-
 def sdk_platform_test(sdk_version, platform_version):
     # SDK components
     daml_assistant = "@daml-sdk-{sdk_version}//:daml".format(
@@ -439,7 +427,7 @@ def sdk_platform_test(sdk_version, platform_version):
             dar_files = dar_files,
         )],
         tags = ["exclusive", sdk_version, platform_version] + extra_tags(sdk_version, platform_version),
-    ) if ledger_api_test_tool_compatible(sdk_version, platform_version) else None
+    )
 
     client_server_test(
         name = name + "-classic",
@@ -457,7 +445,7 @@ def sdk_platform_test(sdk_version, platform_version):
             dar_files = dar_files,
         )],
         tags = ["exclusive", sdk_version, platform_version] + extra_tags(sdk_version, platform_version),
-    ) if ledger_api_test_tool_compatible(sdk_version, platform_version) else None
+    )
 
     client_server_test(
         name = name + "-postgresql",
@@ -474,7 +462,7 @@ def sdk_platform_test(sdk_version, platform_version):
             dar_files = dar_files,
         )],
         tags = ["exclusive"] + extra_tags(sdk_version, platform_version),
-    ) if not is_windows and ledger_api_test_tool_compatible(sdk_version, platform_version) else None
+    ) if not is_windows else None
 
     client_server_test(
         name = name + "-classic-postgresql",
@@ -493,7 +481,7 @@ def sdk_platform_test(sdk_version, platform_version):
             dar_files = dar_files,
         )],
         tags = ["exclusive"] + extra_tags(sdk_version, platform_version),
-    ) if not is_windows and ledger_api_test_tool_compatible(sdk_version, platform_version) else None
+    ) if not is_windows else None
 
     # daml-ledger test-cases
     name = "daml-ledger-{sdk_version}-platform-{platform_version}".format(


### PR DESCRIPTION
This adds more tests to the exclusions added as part of #8957

All SDK/platform compatibility tests are not filtered to use compatible
Daml-LF versions, not just those involving the Ledger API Test Tool.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
