### PR TITLE
Helpers to create test ACS and TransactionTree

### DIFF
--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
@@ -4,34 +4,25 @@
 package com.daml.script.dump
 
 import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
-import com.daml.ledger.api.v1.event.CreatedEvent
-import com.daml.ledger.api.v1.value.{Identifier, Record}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
   import Encode._
-  private def mkCreated(i: Int) =
-    CreatedEvent(
-      eventId = s"create$i",
-      templateId = Some(Identifier("package", "Module", "Template")),
-      contractId = s"cid$i",
-      signatories = Seq("Alice"),
-      createArguments = Some(
-        Record(
-          recordId = Some(Identifier("package", "Module", "Template")),
-          fields = Seq.empty,
-        )
-      ),
-    )
   "encodeCreatedEvent" - {
     "contract id bindings" - {
       "unreferenced" in {
         val parties = Map(Party("Alice") -> "alice_0")
         val cidMap = Map(ContractId("cid1") -> "contract_0_0")
         val cidRefs = Set.empty[ContractId]
-        val created = mkCreated(1)
-        encodeSubmitCreatedEvents(parties, cidMap, cidRefs, Seq(created)).render(80) shouldBe
+        val events = TestData
+          .ACS(
+            Seq(
+              TestData.Created(ContractId("cid1"))
+            )
+          )
+          .toCreatedEvents
+        encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
           """_ <- submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
       }
@@ -39,8 +30,14 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
         val parties = Map(Party("Alice") -> "alice_0")
         val cidMap = Map(ContractId("cid1") -> "contract_0_0")
         val cidRefs = Set(ContractId("cid1"))
-        val created = mkCreated(1)
-        encodeSubmitCreatedEvents(parties, cidMap, cidRefs, Seq(created)).render(80) shouldBe
+        val events = TestData
+          .ACS(
+            Seq(
+              TestData.Created(ContractId("cid1"))
+            )
+          )
+          .toCreatedEvents
+        encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
           """contract_0_0 <- submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace(
             "\r\n",
@@ -55,7 +52,15 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
           ContractId("cid3") -> "contract_0_2",
         )
         val cidRefs = Set.empty[ContractId]
-        val events = Seq(mkCreated(1), mkCreated(2), mkCreated(3))
+        val events = TestData
+          .ACS(
+            Seq(
+              TestData.Created(ContractId("cid1")),
+              TestData.Created(ContractId("cid2")),
+              TestData.Created(ContractId("cid3")),
+            )
+          )
+          .toCreatedEvents
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
           """submitMulti [alice_0] [] do
             |  _ <- createCmd Module.Template
@@ -74,7 +79,15 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
           ContractId("cid3") -> "contract_0_2",
         )
         val cidRefs = Set(ContractId("cid1"), ContractId("cid3"))
-        val events = Seq(mkCreated(1), mkCreated(2), mkCreated(3))
+        val events = TestData
+          .ACS(
+            Seq(
+              TestData.Created(ContractId("cid1")),
+              TestData.Created(ContractId("cid2")),
+              TestData.Created(ContractId("cid3")),
+            )
+          )
+          .toCreatedEvents
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
           """(contract_0_0, contract_0_2) <- submitMulti [alice_0] [] do
             |  contract_0_0 <- createCmd Module.Template
@@ -92,7 +105,14 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
           ContractId("cid2") -> "contract_0_1",
         )
         val cidRefs = Set(ContractId("cid2"))
-        val events = Seq(mkCreated(1), mkCreated(2))
+        val events = TestData
+          .ACS(
+            Seq(
+              TestData.Created(ContractId("cid1")),
+              TestData.Created(ContractId("cid2")),
+            )
+          )
+          .toCreatedEvents
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
           """contract_0_1 <- submitMulti [alice_0] [] do
             |  _ <- createCmd Module.Template

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
@@ -4,77 +4,24 @@
 package com.daml.script.dump
 
 import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
-import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
-import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
-import com.daml.ledger.api.v1.value.{Identifier, Record, Value, Variant}
-import com.google.protobuf
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class EncodeTreeSpec extends AnyFreeSpec with Matchers {
   import Encode._
-  private def mkCreated(i: Int) = {
-    s"create$i" -> TreeEvent(
-      TreeEvent.Kind.Created(
-        CreatedEvent(
-          eventId = s"create$i",
-          templateId = Some(Identifier("package", "Module", "Template")),
-          contractId = s"cid$i",
-          signatories = Seq("Alice"),
-          createArguments = Some(
-            Record(
-              recordId = Some(Identifier("package", "Module", "Template")),
-              fields = Seq.empty,
-            )
-          ),
-        )
-      )
-    )
-  }
-  private def mkExercised(i: Int, cid: ContractId, result: Value, childEventIds: Seq[String]) = {
-    s"exercise$i" -> TreeEvent(
-      TreeEvent.Kind.Exercised(
-        ExercisedEvent(
-          eventId = s"exercise$i",
-          templateId = Some(Identifier("package", "Module", "Template")),
-          contractId = ContractId.unwrap(cid),
-          actingParties = Seq("Alice"),
-          choice = "Choice",
-          choiceArgument = Some(
-            Value()
-              .withVariant(
-                Variant(
-                  Some(Identifier("package", "Module", "Choice")),
-                  "Choice",
-                  Some(Value().withUnit(protobuf.empty.Empty())),
-                )
-              )
-          ),
-          childEventIds = childEventIds,
-          exerciseResult = Some(result),
-        )
-      )
-    )
-  }
-
   "encodeTree" - {
     "contract id bindings" - {
       "unreferenced create" in {
         val parties = Map(Party("Alice") -> "alice_0")
         val cidMap = Map(ContractId("cid1") -> "contract_0_0")
         val cidRefs = Set.empty[ContractId]
-        val tree = TransactionTree(
-          transactionId = "txid",
-          commandId = "cmdid",
-          workflowId = "flowid",
-          effectiveAt = None,
-          offset = "",
-          eventsById = Map(
-            mkCreated(1)
-          ),
-          rootEventIds = Seq("create1"),
-          traceContext = None,
-        )
+        val tree = TestData
+          .Tree(
+            Seq(
+              TestData.Created(ContractId("cid1"))
+            )
+          )
+          .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
           """_ <- submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
@@ -86,19 +33,14 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           ContractId("cid2") -> "contract_1_1",
         )
         val cidRefs = Set.empty[ContractId]
-        val tree = TransactionTree(
-          transactionId = "txid",
-          commandId = "cmdid",
-          workflowId = "flowid",
-          effectiveAt = None,
-          offset = "",
-          eventsById = Map(
-            mkCreated(1),
-            mkCreated(2),
-          ),
-          rootEventIds = Seq("create1", "create2"),
-          traceContext = None,
-        )
+        val tree = TestData
+          .Tree(
+            Seq(
+              TestData.Created(ContractId("cid1")),
+              TestData.Created(ContractId("cid2")),
+            )
+          )
+          .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
           """submitMulti [alice_0] [] do
             |  _ <- createCmd Module.Template
@@ -113,19 +55,18 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           ContractId("cid1") -> "contract_1_1",
         )
         val cidRefs = Set.empty[ContractId]
-        val tree = TransactionTree(
-          transactionId = "txid",
-          commandId = "cmdid",
-          workflowId = "flowid",
-          effectiveAt = None,
-          offset = "",
-          eventsById = Map(
-            mkCreated(1),
-            mkExercised(2, ContractId("cid0"), Value().withContractId("cid2"), Seq("create1")),
-          ),
-          rootEventIds = Seq("exercise2"),
-          traceContext = None,
-        )
+        val tree = TestData
+          .Tree(
+            Seq(
+              TestData.Exercised(
+                ContractId("cid0"),
+                Seq(
+                  TestData.Created(ContractId("cid1"))
+                ),
+              )
+            )
+          )
+          .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
           """tree <- submitTreeMulti [alice_0] [] do
             |  exerciseCmd contract_0_0 (Module.Choice ())""".stripMargin.replace("\r\n", "\n")
@@ -134,18 +75,13 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
         val parties = Map(Party("Alice") -> "alice_0")
         val cidMap = Map(ContractId("cid1") -> "contract_0_0")
         val cidRefs = Set(ContractId("cid1"))
-        val tree = TransactionTree(
-          transactionId = "txid",
-          commandId = "cmdid",
-          workflowId = "flowid",
-          effectiveAt = None,
-          offset = "",
-          eventsById = Map(
-            mkCreated(1)
-          ),
-          rootEventIds = Seq("create1"),
-          traceContext = None,
-        )
+        val tree = TestData
+          .Tree(
+            Seq(
+              TestData.Created(ContractId("cid1"))
+            )
+          )
+          .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
           """contract_0_0 <- submitMulti [alice_0] [] do
             |  createCmd Module.Template""".stripMargin.replace(
@@ -160,19 +96,14 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           ContractId("cid2") -> "contract_1_1",
         )
         val cidRefs = Set(ContractId("cid1"), ContractId("cid2"))
-        val tree = TransactionTree(
-          transactionId = "txid",
-          commandId = "cmdid",
-          workflowId = "flowid",
-          effectiveAt = None,
-          offset = "",
-          eventsById = Map(
-            mkCreated(1),
-            mkCreated(2),
-          ),
-          rootEventIds = Seq("create1", "create2"),
-          traceContext = None,
-        )
+        val tree = TestData
+          .Tree(
+            Seq(
+              TestData.Created(ContractId("cid1")),
+              TestData.Created(ContractId("cid2")),
+            )
+          )
+          .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
           """(contract_1_0, contract_1_1) <- submitMulti [alice_0] [] do
             |  contract_1_0 <- createCmd Module.Template
@@ -190,25 +121,19 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           ContractId("cid2") -> "contract_1_1",
         )
         val cidRefs = Set(ContractId("cid1"), ContractId("cid2"))
-        val tree = TransactionTree(
-          transactionId = "txid",
-          commandId = "cmdid",
-          workflowId = "flowid",
-          effectiveAt = None,
-          offset = "",
-          eventsById = Map(
-            mkCreated(1),
-            mkCreated(2),
-            mkExercised(
-              3,
-              ContractId("cid0"),
-              Value().withContractId("cid2"),
-              Seq("create1", "create2"),
-            ),
-          ),
-          rootEventIds = Seq("exercise3"),
-          traceContext = None,
-        )
+        val tree = TestData
+          .Tree(
+            Seq(
+              TestData.Exercised(
+                ContractId("cid0"),
+                Seq(
+                  TestData.Created(ContractId("cid1")),
+                  TestData.Created(ContractId("cid2")),
+                ),
+              )
+            )
+          )
+          .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
           """tree <- submitTreeMulti [alice_0] [] do
             |  exerciseCmd contract_0_0 (Module.Choice ())

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.dump
+
+import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
+import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
+import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
+import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value, Variant}
+import com.google.protobuf
+
+object TestData {
+  val defaultTemplateId = Identifier("package", "Module", "Template")
+  val defaultParties = Party.subst(Seq("Alice"))
+  val defaultChoiceArgument = Value().withVariant(
+    Variant(
+      Some(Identifier("package", "Module", "Choice")),
+      "Choice",
+      Some(Value().withUnit(protobuf.empty.Empty())),
+    )
+  )
+
+  sealed trait Event
+  sealed case class Created(
+      contractId: ContractId,
+      createArguments: Seq[RecordField] = Seq.empty,
+  ) extends Event {
+    def toCreatedEvent(eventId: String): CreatedEvent = {
+      CreatedEvent(
+        eventId = eventId,
+        templateId = Some(defaultTemplateId),
+        contractId = ContractId.unwrap(contractId),
+        signatories = Party.unsubst(defaultParties),
+        createArguments = Some(Record(recordId = Some(defaultTemplateId), fields = createArguments)),
+      )
+    }
+  }
+  sealed case class Exercised(
+      contractId: ContractId,
+      childEvents: Seq[Event],
+      choiceArgument: Value = defaultChoiceArgument,
+  ) extends Event
+
+  sealed case class ACS(contracts: Seq[Created]) {
+    def toCreatedEvents: Seq[CreatedEvent] = {
+      contracts.zipWithIndex.map { case (created, i) =>
+        created.toCreatedEvent(s"create$i")
+      }
+    }
+  }
+
+  sealed case class Tree(rootEvents: Seq[Event]) {
+    def toTransactionTree: TransactionTree = {
+      def go(
+          acc: (Int, Seq[String], Map[String, TreeEvent]),
+          event: Event,
+      ): (Int, Seq[String], Map[String, TreeEvent]) = {
+        val (curr, rootEventIds, eventsById) = acc
+        val eventId = s"ev$curr"
+        event match {
+          case event: Created =>
+            val treeEvent = TreeEvent(TreeEvent.Kind.Created(event.toCreatedEvent(eventId)))
+            (curr + 1, rootEventIds :+ eventId, eventsById + (eventId -> treeEvent))
+          case Exercised(contractId, childEvents, choiceArgument) =>
+            val (next, childEventIds, childEventsById) =
+              childEvents.foldLeft((curr + 1, Seq.empty[String], Map.empty[String, TreeEvent]))(go)
+            val treeEvent = TreeEvent(
+              TreeEvent.Kind.Exercised(
+                ExercisedEvent(
+                  eventId = eventId,
+                  templateId = Some(defaultTemplateId),
+                  contractId = ContractId.unwrap(contractId),
+                  actingParties = Party.unsubst(defaultParties),
+                  choice = "Choice",
+                  choiceArgument = Some(choiceArgument),
+                  childEventIds = childEventIds,
+                  exerciseResult = Some(Value().withUnit(protobuf.empty.Empty())),
+                )
+              )
+            )
+            (next, rootEventIds :+ eventId, eventsById + (eventId -> treeEvent) ++ childEventsById)
+        }
+      }
+      val (_, rootEventIds, eventsById) =
+        rootEvents.foldLeft((0, Seq.empty[String], Map.empty[String, TreeEvent]))(go)
+      TransactionTree(
+        transactionId = "txid",
+        commandId = "cmdid",
+        workflowId = "flowid",
+        effectiveAt = None,
+        offset = "",
+        eventsById = eventsById,
+        rootEventIds = rootEventIds,
+        traceContext = None,
+      )
+    }
+  }
+}


### PR DESCRIPTION
Adds helpers to construct `TransactionTree` and `Seq[CreatedEvent]` for daml script dump tests.
As suggested in https://github.com/digital-asset/daml/pull/8952#discussion_r583560043.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
