### PR TITLE
Fix daml-sdk-head Maven install

### DIFF
--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -62,7 +62,7 @@
 - target: //language-support/codegen-common:codegen-common
   type: jar-scala
 - target: //language-support/codegen-main:shaded_binary
-  type: jar-scala
+  type: jar-jarjar
 - target: //language-support/java/bindings:bindings-java
   type: jar-lib
 - target: //language-support/java/bindings-rxjava:bindings-rxjava
@@ -70,7 +70,7 @@
 - target: //language-support/java/codegen:lib
   type: jar-scala
 - target: //language-support/java/codegen:shaded_binary
-  type: jar-scala
+  type: jar-jarjar
 - target: //language-support/scala/bindings:bindings
   type: jar-scala
 - target: //language-support/scala/bindings-akka:bindings-akka

--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -164,7 +164,7 @@ main = do
                       [ x | isSnapshot mvnVersion, x <- ["--tag", "next"] ])
 
           | optsLocallyInstallJars -> do
-              pom <- generateAggregatePom bazelLocations allArtifacts
+              pom <- generateAggregatePom releaseDir allArtifacts
               pomPath <- (releaseDir </>) <$> parseRelFile "pom.xml"
               liftIO $ T.IO.writeFile (toFilePath pomPath) pom
               exitCode <- liftIO $ withCreateProcess ((proc "mvn" ["initialize"]) { cwd = Just (toFilePath releaseDir) }) $ \_ _ _ mvnHandle ->

--- a/release/src/Maven.hs
+++ b/release/src/Maven.hs
@@ -37,7 +37,7 @@ generateAggregatePom releaseDir artifacts = do
     where
     execution :: (MonadFail m, E.MonadThrow m) => Artifact PomData -> m Text
     execution artifact = do
-        (mainArtifactFile:pomFile:rest) <- snd . unzip <$> artifactFiles artifact
+        (mainArtifactFile:pomFile:rest) <- map snd <$> artifactFiles artifact
         let (javadocFile, sourcesFile) = case rest of
               [javadoc, sources] -> (Just javadoc, Just sources)
               _ -> (Nothing, Nothing)

--- a/release/src/Maven.hs
+++ b/release/src/Maven.hs
@@ -30,22 +30,19 @@ validateMavenArtifacts releaseDir artifacts =
             $logError $ T.pack $ show file <> " is required for publishing to Maven"
             liftIO exitFailure
 
-generateAggregatePom :: E.MonadThrow m => BazelLocations -> [Artifact PomData] -> m Text
-generateAggregatePom BazelLocations{bazelBin} artifacts = do
+generateAggregatePom :: (MonadFail m, E.MonadThrow m) => Path Abs Dir -> [Artifact PomData] -> m Text
+generateAggregatePom releaseDir artifacts = do
     executions <- T.concat <$> mapM execution artifacts
     return (aggregatePomStart <> executions <> aggregatePomEnd)
     where
-    execution :: E.MonadThrow m => Artifact PomData -> m Text
+    execution :: (MonadFail m, E.MonadThrow m) => Artifact PomData -> m Text
     execution artifact = do
-        let (directoryText, name) = splitBazelTarget (artTarget artifact)
-        directory <- parseRelDir (T.unpack directoryText)
-        let prefix = bazelBin </> directory
-        mainArtifactFile <- mainArtifactPath name artifact
-        pomFile <- pomFilePath name
-        javadocFile <- javadocJarPath artifact
-        sourcesFile <- sourceJarPath artifact
+        (mainArtifactFile:pomFile:rest) <- snd . unzip <$> artifactFiles artifact
+        let (javadocFile, sourcesFile) = case rest of
+              [javadoc, sources] -> (Just javadoc, Just sources)
+              _ -> (Nothing, Nothing)
         let configuration =
-                map (\(name, value) -> (name, pathToText (prefix </> value))) $
+                map (\(name, value) -> (name, pathToText (releaseDir </> value))) $
                     Maybe.catMaybes
                         [ Just ("pomFile", pomFile)
                         , Just ("file", mainArtifactFile)

--- a/release/src/Util.hs
+++ b/release/src/Util.hs
@@ -81,6 +81,8 @@ data JarType
       -- ^ A java protobuf library (*-speed.jar).
     | Scala
       -- ^ A scala library jar, with source and scaladoc jars.
+    | JarJar
+      -- ^ A scala library jar, with source and scaladoc jars.
     deriving (Eq, Show)
 
 instance FromJSON ReleaseType where
@@ -90,6 +92,7 @@ instance FromJSON ReleaseType where
             "jar-deploy" -> pure $ Jar Deploy
             "jar-proto" -> pure $ Jar Proto
             "jar-scala" -> pure $ Jar Scala
+            "jar-jarjar" -> pure $ Jar JarJar
             _ -> fail ("Could not parse release type: " <> unpack t)
 
 data Artifact c = Artifact
@@ -213,6 +216,7 @@ mainFileName (Jar jarTy) name = case jarTy of
     Deploy -> name <> "_deploy.jar"
     Proto -> "lib" <> T.replace "_java" "" name <> "-speed.jar"
     Scala -> name <> ".jar"
+    JarJar -> name <> ".jar"
 
 sourceJarName :: Artifact a -> Maybe Text
 sourceJarName Artifact{..}
@@ -221,7 +225,7 @@ sourceJarName Artifact{..}
 
 scalaSourceJarName :: Artifact a -> Maybe Text
 scalaSourceJarName Artifact{..}
-  | Jar Scala <- artReleaseType = Just $ snd (splitBazelTarget artTarget) <> "_src.jar"
+  | artReleaseType `elem` [Jar Scala, Jar JarJar] = Just $ snd (splitBazelTarget artTarget) <> "_src.jar"
   | otherwise = Nothing
 
 deploySourceJarName :: Artifact a -> Maybe Text
@@ -239,7 +243,7 @@ customSourceJarName Artifact{..} = T.pack . toFilePath <$> artSourceJar
 
 scaladocJarName :: Artifact a -> Maybe Text
 scaladocJarName Artifact{..}
-   | Jar Scala <- artReleaseType = Just $ snd (splitBazelTarget artTarget) <> "_scaladoc.jar"
+   | artReleaseType `elem` [Jar Scala, Jar JarJar] = Just $ snd (splitBazelTarget artTarget) <> "_scaladoc.jar"
    | otherwise = Nothing
 
 javadocDeployJarName :: Artifact a -> Maybe Text

--- a/release/src/Util.hs
+++ b/release/src/Util.hs
@@ -82,7 +82,8 @@ data JarType
     | Scala
       -- ^ A scala library jar, with source and scaladoc jars.
     | JarJar
-      -- ^ A scala library jar, with source and scaladoc jars.
+      -- ^ A shaded jar built with jarjar. This is similar to a deploy jar
+      -- but the names of the targets are slightly different.
     deriving (Eq, Show)
 
 instance FromJSON ReleaseType where


### PR DESCRIPTION
There were two issues:

1. The generated pom.xml used to install everything in one step
referenced the source files in the bazel directory rather than the
released artifacts. This luckily worked so far but falls apart now
since the 2.13 build overwrites the 2.12 build. Same issues that also
blew up the actual release on Thursday.

2. Two artifacts are published as shaded jars. We treated those like
Scala artifacts while they should be treated more like fat
jars. They’re not quite like those since the file paths are different
so I gave them a new release type.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
