### PR TITLE
Upgrade canton to 0.21.0 which supports lf-version 1.11

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -939,7 +939,7 @@ java_import(
     jars = glob(["lib/**/*.jar"]),
 )
 """,
-    sha256 = "3c6ff12b65d9e6e85686383b811094d8b04d3f4033e725951fba95cc35bd804c",
-    strip_prefix = "canton-community-0.19.0",
-    urls = ["https://www.canton.io/releases/canton-community-0.19.0.tar.gz"],
+    sha256 = "81e590a6854eaaf724356c0b7068502174de6457af6ec2a24624b0698eeb7362",
+    strip_prefix = "canton-community-0.21.0",
+    urls = ["https://www.canton.io/releases/canton-community-0.21.0.tar.gz"],
 )

--- a/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
+++ b/ledger/ledger-api-test-tool-on-canton/BUILD.bazel
@@ -49,6 +49,7 @@ sh_binary(
 
 conformance_test(
     name = "conformance-test",
+    # Ideally these would be part of the script definition above, but that doesn't seem to work.
     extra_data = [
         ":bootstrap.canton",
         ":canton",
@@ -59,10 +60,6 @@ conformance_test(
         "@grpcurl_nix//:bin/grpcurl",
         "@jq_dev_env//:jq",
     ],
-    # Ideally these would be part of the script definition above, but that doesn't seem to work.
-    # FIXME: drop the following line once canton-test-runner supports LF 1.11 or newer
-    lf_versions = ["legacy"],
-    # lf_versions = ["stable", "latest"]
     ports = [
         5011,
         5021,
@@ -78,9 +75,7 @@ conformance_test(
         "--exclude=ContractKeysIT,ContractKeysIT:CKFetchOrLookup,ContractKeysIT:CKNoFetchUndisclosed,ContractKeysIT:CKMaintainerScoped" +
         ",ParticipantPruningIT" +  # see "conformance-test-participant-pruning" below
         ",ConfigManagementServiceIT,LedgerConfigurationServiceIT" +  # dynamic config management not supported by Canton
-        ",ClosedWorldIT" +  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
-        # The following tests fail because Canton raises a different error (see https://github.com/digital-asset/daml/pull/8642)
-        ",PartyManagementServiceIT:PMRejectLongPartyHints,PartyManagementServiceIT:PMRejectInvalidPartyHints",
+        ",ClosedWorldIT",  # Canton currently fails this test with a different error (missing namespace in "unallocated" party id)
     ],
 ) if not is_windows else None
 
@@ -98,8 +93,6 @@ conformance_test(
         "@grpcurl_nix//:bin/grpcurl",
         "@jq_dev_env//:jq",
     ],
-    # FIXME: drop the following line once canton-test-runner supports LF 1.11 or newer
-    lf_versions = ["legacy"],
     ports = [
         5011,
         5021,
@@ -129,8 +122,6 @@ conformance_test(
         "@grpcurl_nix//:bin/grpcurl",
         "@jq_dev_env//:jq",
     ],
-    # FIXME: drop the following line once canton-test-runner supports LF 1.11 or newer
-    lf_versions = ["legacy"],
     ports = [
         5011,
         5021,
@@ -145,6 +136,5 @@ conformance_test(
     test_tool_args = [
         "--verbose",
         "--include=ParticipantPruningIT",
-        "--exclude=ParticipantPruningIT:PRFailPruneByOutOfBoundsOffset",  # on behalf of bug not yet fixed in canton 0.19.0
     ],
 ) if not is_windows else None

--- a/ledger/ledger-api-test-tool-on-canton/canton.conf
+++ b/ledger/ledger-api-test-tool-on-canton/canton.conf
@@ -16,7 +16,7 @@ canton {
         type = memory
       }
 
-      crypto.type = tink
+      crypto.provider = tink
 
       public-api.port = 4011
       admin-api.port = 4012
@@ -42,7 +42,7 @@ canton {
         }
       }
 
-      crypto.type = tink
+      crypto.provider = tink
 
       ledger-api.port = 5011
       admin-api.port = 5012
@@ -59,7 +59,7 @@ canton {
         }
       }
 
-      crypto.type = tink
+      crypto.provider = tink
 
       ledger-api.port = 5021
       admin-api.port = 5022
@@ -76,7 +76,7 @@ canton {
         }
       }
 
-      crypto.type = tink
+      crypto.provider = tink
 
       ledger-api.port = 5031
       admin-api.port = 5032
@@ -93,7 +93,7 @@ canton {
         }
       }
 
-      crypto.type = tink
+      crypto.provider = tink
 
       ledger-api.port = 5041
       admin-api.port = 5042


### PR DESCRIPTION
Updated crypto config and enabling two sets of tests that had been
disabled against canton 0.19.0

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
