### PR TITLE
Include table view for failed scripts

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -1123,6 +1123,14 @@ getOpenVirtualResourcesRule = do
         openVRs <- liftIO $ readVar envOpenVirtualResources
         pure (Just $ BS.fromString $ show openVRs, ([], Just openVRs))
 
+formatHtmlScenarioError :: LF.World -> SS.Error -> T.Text
+formatHtmlScenarioError world  err = case err of
+    SS.BackendError err ->
+        Pretty.renderHtmlDocumentText 128 $ Pretty.pretty $ "Scenario service backend error: " <> show err
+    SS.ScenarioError err -> LF.renderScenarioError world err
+    SS.ExceptionError err ->
+        Pretty.renderHtmlDocumentText 128 $ Pretty.pretty $ "Exception during scenario execution: " <> show err
+
 formatScenarioError :: LF.World -> SS.Error -> Pretty.Doc Pretty.SyntaxClass
 formatScenarioError world  err = case err of
     SS.BackendError err -> Pretty.pretty $ "Scenario service backend error: " <> show err
@@ -1133,7 +1141,7 @@ formatScenarioResult :: LF.World -> Either SS.Error SS.ScenarioResult -> T.Text
 formatScenarioResult world errOrRes =
     case errOrRes of
         Left err ->
-            Pretty.renderHtmlDocumentText 128 (formatScenarioError world err)
+            formatHtmlScenarioError world err
         Right res ->
             LF.renderScenarioResult world res
 


### PR DESCRIPTION
fixes #8966

changelog_begin

- [Daml Studio] Failed scripts (and scenarios) now also offer the
  option to view the table view at the state before the failing
  transaction to ease debugging.

changelog_end
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
