### PR TITLE
Do not require a JWT token for Health and Reflection services [DPP-277]

### DIFF
--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/package.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/package.scala
@@ -15,7 +15,7 @@ import com.daml.ledger.api.auth.{
   ClaimAdmin,
   ClaimPublic,
   ClaimReadAsParty,
-  Claims,
+  ClaimSet,
 }
 
 package object rxjava {
@@ -40,19 +40,25 @@ package object rxjava {
 
   private[rxjava] val mockedAuthService =
     AuthServiceStatic {
-      case `emptyToken` => Claims(Nil)
-      case `publicToken` => Claims(Seq[Claim](ClaimPublic))
-      case `adminToken` => Claims(Seq[Claim](ClaimAdmin))
+      case `emptyToken` => ClaimSet.Claims(Nil)
+      case `publicToken` => ClaimSet.Claims(Seq[Claim](ClaimPublic))
+      case `adminToken` => ClaimSet.Claims(Seq[Claim](ClaimAdmin))
       case `somePartyReadToken` =>
-        Claims(Seq[Claim](ClaimPublic, ClaimReadAsParty(Ref.Party.assertFromString(someParty))))
+        ClaimSet.Claims(
+          Seq[Claim](ClaimPublic, ClaimReadAsParty(Ref.Party.assertFromString(someParty)))
+        )
       case `somePartyReadWriteToken` =>
-        Claims(Seq[Claim](ClaimPublic, ClaimActAsParty(Ref.Party.assertFromString(someParty))))
+        ClaimSet.Claims(
+          Seq[Claim](ClaimPublic, ClaimActAsParty(Ref.Party.assertFromString(someParty)))
+        )
       case `someOtherPartyReadToken` =>
-        Claims(
+        ClaimSet.Claims(
           Seq[Claim](ClaimPublic, ClaimReadAsParty(Ref.Party.assertFromString(someOtherParty)))
         )
       case `someOtherPartyReadWriteToken` =>
-        Claims(Seq[Claim](ClaimPublic, ClaimActAsParty(Ref.Party.assertFromString(someOtherParty))))
+        ClaimSet.Claims(
+          Seq[Claim](ClaimPublic, ClaimActAsParty(Ref.Party.assertFromString(someOtherParty)))
+        )
     }
 
 }

--- a/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/package.scala
+++ b/language-support/java/bindings-rxjava/src/test/scala/com/daml/ledger/rxjava/package.scala
@@ -40,7 +40,7 @@ package object rxjava {
 
   private[rxjava] val mockedAuthService =
     AuthServiceStatic {
-      case `emptyToken` => ClaimSet.Claims(Nil)
+      case `emptyToken` => ClaimSet.Unauthenticated
       case `publicToken` => ClaimSet.Claims(Seq[Claim](ClaimPublic))
       case `adminToken` => ClaimSet.Claims(Seq[Claim](ClaimAdmin))
       case `somePartyReadToken` =>

--- a/ledger-service/http-json/src/it/scala/http/AuthorizationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/AuthorizationTest.scala
@@ -37,7 +37,7 @@ final class AuthorizationTest extends AsyncFlatSpec with BeforeAndAfterAll with 
   private val emptyToken = "empty"
   private val mockedAuthService = Option(AuthServiceStatic {
     case `publicToken` => ClaimSet.Claims(Seq[Claim](ClaimPublic))
-    case `emptyToken` => ClaimSet.Claims.Empty
+    case `emptyToken` => ClaimSet.Unauthenticated
   })
 
   private val accessTokenFile = Files.createTempFile("Extractor", "AuthSpec")

--- a/ledger-service/http-json/src/it/scala/http/AuthorizationTest.scala
+++ b/ledger-service/http-json/src/it/scala/http/AuthorizationTest.scala
@@ -11,7 +11,7 @@ import com.daml.auth.TokenHolder
 import com.daml.bazeltools.BazelRunfiles.rlocation
 import com.daml.grpc.adapter.{AkkaExecutionSequencerPool, ExecutionSequencerFactory}
 import com.daml.http.util.TestUtil.requiredFile
-import com.daml.ledger.api.auth.{AuthServiceStatic, Claim, ClaimPublic, Claims}
+import com.daml.ledger.api.auth.{AuthServiceStatic, Claim, ClaimPublic, ClaimSet}
 import com.daml.ledger.client.LedgerClient
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -36,8 +36,8 @@ final class AuthorizationTest extends AsyncFlatSpec with BeforeAndAfterAll with 
   private val publicToken = "public"
   private val emptyToken = "empty"
   private val mockedAuthService = Option(AuthServiceStatic {
-    case `publicToken` => Claims(Seq[Claim](ClaimPublic))
-    case `emptyToken` => Claims(Nil)
+    case `publicToken` => ClaimSet.Claims(Seq[Claim](ClaimPublic))
+    case `emptyToken` => ClaimSet.Claims.Empty
   })
 
   private val accessTokenFile = Files.createTempFile("Extractor", "AuthSpec")

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthService.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthService.scala
@@ -10,7 +10,7 @@ import io.grpc.Metadata
 /** An interface for authorizing the ledger API access to a participant.
   *
   * The AuthService is responsible for converting request metadata (such as
-  * the HTTP headers) into a set of [[Claims]].
+  * the HTTP headers) into a [[ClaimSet]].
   * These claims are then used by the ledger API server to check whether the
   * request is authorized.
   *
@@ -25,15 +25,15 @@ import io.grpc.Metadata
   *   with a JWT token as the header value.
   * - Implement `decodeMetadata()` such that it reads the JWT token
   *   from the corresponding HTTP header, validates the token,
-  *   and converts the token payload to [[Claims]].
+  *   and converts the token payload to [[ClaimSet]].
   */
 trait AuthService {
 
-  /** Return empty [[Claims]] to reject requests with a UNAUTHENTICATED error status.
-    * Return [[Claims]] with only a single [[ClaimPublic]] claim to reject all non-public requests with a PERMISSION_DENIED status.
+  /** Return empty [[ClaimSet.Unauthenticated]] to reject requests with a UNAUTHENTICATED error status.
+    * Return [[ClaimSet.Claims]] with only a single [[ClaimPublic]] claim to reject all non-public requests with a PERMISSION_DENIED status.
     * Return a failed future to reject requests with an INTERNAL error status.
     */
-  def decodeMetadata(headers: io.grpc.Metadata): CompletionStage[Claims]
+  def decodeMetadata(headers: io.grpc.Metadata): CompletionStage[ClaimSet]
 
   /** The [[Metadata.Key]] to use for looking up the `Authorization` header in the
     * request metadata.

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceJWT.scala
@@ -25,7 +25,7 @@ class AuthServiceJWT(verifier: JwtVerifierBase) extends AuthService {
   override def decodeMetadata(headers: Metadata): CompletionStage[ClaimSet] =
     CompletableFuture.completedFuture {
       getAuthorizationHeader(headers) match {
-        case None => ClaimSet.Claims.Empty
+        case None => ClaimSet.Unauthenticated
         case Some(header) => parseHeader(header)
       }
     }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceNone.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceNone.scala
@@ -7,9 +7,9 @@ import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 import io.grpc.Metadata
 
-/** An AuthService that rejects all calls by always returning an empty set of [[Claims]] */
+/** An AuthService that rejects all calls by always returning the [[ClaimSet.Unauthenticated]] */
 object AuthServiceNone extends AuthService {
-  override def decodeMetadata(headers: Metadata): CompletionStage[Claims] = {
-    CompletableFuture.completedFuture(Claims.empty)
+  override def decodeMetadata(headers: Metadata): CompletionStage[ClaimSet] = {
+    CompletableFuture.completedFuture(ClaimSet.Unauthenticated)
   }
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceStatic.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceStatic.scala
@@ -8,21 +8,23 @@ import java.util.concurrent.{CompletableFuture, CompletionStage}
 import io.grpc.Metadata
 
 /** An AuthService that matches the value of the `Authorization` HTTP header against
-  * a static map of header values to [[Claims]].
+  * a static map of header values to [[ClaimSet.Claims]].
   *
   * Note: This AuthService is meant to be used for testing purposes only.
   */
-final class AuthServiceStatic(claims: PartialFunction[String, Claims]) extends AuthService {
-  override def decodeMetadata(headers: Metadata): CompletionStage[Claims] = {
+final class AuthServiceStatic(claims: PartialFunction[String, ClaimSet]) extends AuthService {
+  override def decodeMetadata(headers: Metadata): CompletionStage[ClaimSet] = {
     if (headers.containsKey(AUTHORIZATION_KEY)) {
       val authorizationValue = headers.get(AUTHORIZATION_KEY).stripPrefix("Bearer ")
-      CompletableFuture.completedFuture(claims.lift(authorizationValue).getOrElse(Claims.empty))
+      CompletableFuture.completedFuture(
+        claims.lift(authorizationValue).getOrElse(ClaimSet.Unauthenticated)
+      )
     } else {
-      CompletableFuture.completedFuture(Claims.empty)
+      CompletableFuture.completedFuture(ClaimSet.Unauthenticated)
     }
   }
 }
 
 object AuthServiceStatic {
-  def apply(claims: PartialFunction[String, Claims]) = new AuthServiceStatic(claims)
+  def apply(claims: PartialFunction[String, ClaimSet]) = new AuthServiceStatic(claims)
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceWildcard.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/AuthServiceWildcard.scala
@@ -7,9 +7,9 @@ import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 import io.grpc.Metadata
 
-/** An AuthService that authorizes all calls by always returning a wildcard [[Claims]] */
+/** An AuthService that authorizes all calls by always returning a wildcard [[ClaimSet.Claims]] */
 object AuthServiceWildcard extends AuthService {
-  override def decodeMetadata(headers: Metadata): CompletionStage[Claims] = {
-    CompletableFuture.completedFuture(Claims.wildcard)
+  override def decodeMetadata(headers: Metadata): CompletionStage[ClaimSet] = {
+    CompletableFuture.completedFuture(ClaimSet.Claims.Wildcard)
   }
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
@@ -46,119 +46,126 @@ final case class ClaimActAsParty(name: Ref.Party) extends Claim
   */
 final case class ClaimReadAsParty(name: Ref.Party) extends Claim
 
-/** [[Claims]] define what actions an authenticated user can perform on the Ledger API.
-  *
-  * They also optionally specify an expiration epoch time that statically specifies the
-  * time on or after which the token will no longer be considered valid by the Ledger API.
-  *
-  * The following is a full list of services and the corresponding required claims:
-  * +-------------------------------------+----------------------------+------------------------------------------+
-  * | Ledger API service                  | Method                     | Access with                              |
-  * +-------------------------------------+----------------------------+------------------------------------------+
-  * | LedgerIdentityService               | GetLedgerIdentity          | isPublic                                 |
-  * | ActiveContractsService              | GetActiveContracts         | for each requested party p: canReadAs(p) |
-  * | CommandSubmissionService            | Submit                     | for submitting party p: canActAs(p)      |
-  * | CommandCompletionService            | CompletionEnd              | isPublic                                 |
-  * | CommandCompletionService            | CompletionStream           | for each requested party p: canReadAs(p) |
-  * | CommandService                      | *                          | for submitting party p: canActAs(p)      |
-  * | LedgerConfigurationService          | GetLedgerConfiguration     | isPublic                                 |
-  * | PackageService                      | *                          | isPublic                                 |
-  * | PackageManagementService            | *                          | isAdmin                                  |
-  * | PartyManagementService              | *                          | isAdmin                                  |
-  * | ResetService                        | *                          | isAdmin                                  |
-  * | TimeService                         | GetTime                    | isPublic                                 |
-  * | TimeService                         | SetTime                    | isAdmin                                  |
-  * | TransactionService                  | LedgerEnd                  | isPublic                                 |
-  * | TransactionService                  | *                          | for each requested party p: canReadAs(p) |
-  * +-------------------------------------+----------------------------+------------------------------------------+
-  *
-  * @param claims         List of [[Claim]]s describing the authorization this object describes.
-  * @param ledgerId       If set, the claims will only be valid on the given ledger identifier.
-  * @param participantId  If set, the claims will only be valid on the given participant identifier.
-  * @param applicationId  If set, the claims will only be valid on the given application identifier.
-  * @param expiration     If set, the claims will cease to be valid at the given time.
-  */
-final case class Claims(
-    claims: Seq[Claim],
-    ledgerId: Option[String] = None,
-    participantId: Option[String] = None,
-    applicationId: Option[String] = None,
-    expiration: Option[Instant] = None,
-) {
-  def validForLedger(id: String): Either[AuthorizationError, Unit] =
-    Either.cond(ledgerId.forall(_ == id), (), AuthorizationError.InvalidLedger(ledgerId.get, id))
+sealed trait ClaimSet
 
-  def validForParticipant(id: String): Either[AuthorizationError, Unit] =
-    Either.cond(
-      participantId.forall(_ == id),
-      (),
-      AuthorizationError.InvalidParticipant(participantId.get, id),
-    )
+object ClaimSet {
+  object Unauthenticated extends ClaimSet
 
-  def validForApplication(id: String): Either[AuthorizationError, Unit] =
-    Either.cond(
-      applicationId.forall(_ == id),
-      (),
-      AuthorizationError.InvalidApplication(applicationId.get, id),
-    )
+  /** [[Claims]] define what actions an authenticated user can perform on the Ledger API.
+    *
+    * They also optionally specify an expiration epoch time that statically specifies the
+    * time on or after which the token will no longer be considered valid by the Ledger API.
+    *
+    * The following is a full list of services and the corresponding required claims:
+    * +-------------------------------------+----------------------------+------------------------------------------+
+    * | Ledger API service                  | Method                     | Access with                              |
+    * +-------------------------------------+----------------------------+------------------------------------------+
+    * | LedgerIdentityService               | GetLedgerIdentity          | isPublic                                 |
+    * | ActiveContractsService              | GetActiveContracts         | for each requested party p: canReadAs(p) |
+    * | CommandSubmissionService            | Submit                     | for submitting party p: canActAs(p)      |
+    * | CommandCompletionService            | CompletionEnd              | isPublic                                 |
+    * | CommandCompletionService            | CompletionStream           | for each requested party p: canReadAs(p) |
+    * | CommandService                      | *                          | for submitting party p: canActAs(p)      |
+    * | LedgerConfigurationService          | GetLedgerConfiguration     | isPublic                                 |
+    * | PackageService                      | *                          | isPublic                                 |
+    * | PackageManagementService            | *                          | isAdmin                                  |
+    * | PartyManagementService              | *                          | isAdmin                                  |
+    * | ResetService                        | *                          | isAdmin                                  |
+    * | TimeService                         | GetTime                    | isPublic                                 |
+    * | TimeService                         | SetTime                    | isAdmin                                  |
+    * | TransactionService                  | LedgerEnd                  | isPublic                                 |
+    * | TransactionService                  | *                          | for each requested party p: canReadAs(p) |
+    * +-------------------------------------+----------------------------+------------------------------------------+
+    *
+    * @param claims         List of [[Claim]]s describing the authorization this object describes.
+    * @param ledgerId       If set, the claims will only be valid on the given ledger identifier.
+    * @param participantId  If set, the claims will only be valid on the given participant identifier.
+    * @param applicationId  If set, the claims will only be valid on the given application identifier.
+    * @param expiration     If set, the claims will cease to be valid at the given time.
+    */
+  final case class Claims(
+      claims: Seq[Claim],
+      ledgerId: Option[String] = None,
+      participantId: Option[String] = None,
+      applicationId: Option[String] = None,
+      expiration: Option[Instant] = None,
+  ) extends ClaimSet {
+    def validForLedger(id: String): Either[AuthorizationError, Unit] =
+      Either.cond(ledgerId.forall(_ == id), (), AuthorizationError.InvalidLedger(ledgerId.get, id))
 
-  /** Returns false if the expiration timestamp exists and is greater than or equal to the current time */
-  def notExpired(now: Instant): Either[AuthorizationError, Unit] =
-    Either.cond(
-      expiration.forall(now.isBefore),
-      (),
-      AuthorizationError.Expired(expiration.get, now),
-    )
+    def validForParticipant(id: String): Either[AuthorizationError, Unit] =
+      Either.cond(
+        participantId.forall(_ == id),
+        (),
+        AuthorizationError.InvalidParticipant(participantId.get, id),
+      )
 
-  /** Returns true if the set of claims authorizes the user to use admin services, unless the claims expired */
-  def isAdmin: Either[AuthorizationError, Unit] =
-    Either.cond(claims.contains(ClaimAdmin), (), AuthorizationError.MissingAdminClaim)
+    def validForApplication(id: String): Either[AuthorizationError, Unit] =
+      Either.cond(
+        applicationId.forall(_ == id),
+        (),
+        AuthorizationError.InvalidApplication(applicationId.get, id),
+      )
 
-  /** Returns true if the set of claims authorizes the user to use public services, unless the claims expired */
-  def isPublic: Either[AuthorizationError, Unit] =
-    Either.cond(claims.contains(ClaimPublic), (), AuthorizationError.MissingPublicClaim)
+    /** Returns false if the expiration timestamp exists and is greater than or equal to the current time */
+    def notExpired(now: Instant): Either[AuthorizationError, Unit] =
+      Either.cond(
+        expiration.forall(now.isBefore),
+        (),
+        AuthorizationError.Expired(expiration.get, now),
+      )
 
-  /** Returns true if the set of claims authorizes the user to act as the given party, unless the claims expired */
-  def canActAs(party: String): Either[AuthorizationError, Unit] = {
-    Either.cond(
-      claims.exists {
-        case ClaimActAsAnyParty => true
-        case ClaimActAsParty(p) if p == party => true
-        case _ => false
-      },
-      (),
-      AuthorizationError.MissingActClaim(party),
-    )
+    /** Returns true if the set of claims authorizes the user to use admin services, unless the claims expired */
+    def isAdmin: Either[AuthorizationError, Unit] =
+      Either.cond(claims.contains(ClaimAdmin), (), AuthorizationError.MissingAdminClaim)
+
+    /** Returns true if the set of claims authorizes the user to use public services, unless the claims expired */
+    def isPublic: Either[AuthorizationError, Unit] =
+      Either.cond(claims.contains(ClaimPublic), (), AuthorizationError.MissingPublicClaim)
+
+    /** Returns true if the set of claims authorizes the user to act as the given party, unless the claims expired */
+    def canActAs(party: String): Either[AuthorizationError, Unit] = {
+      Either.cond(
+        claims.exists {
+          case ClaimActAsAnyParty => true
+          case ClaimActAsParty(p) if p == party => true
+          case _ => false
+        },
+        (),
+        AuthorizationError.MissingActClaim(party),
+      )
+    }
+
+    /** Returns true if the set of claims authorizes the user to read data for the given party, unless the claims expired */
+    def canReadAs(party: String): Either[AuthorizationError, Unit] = {
+      Either.cond(
+        claims.exists {
+          case ClaimActAsAnyParty => true
+          case ClaimActAsParty(p) if p == party => true
+          case ClaimReadAsParty(p) if p == party => true
+          case _ => false
+        },
+        (),
+        AuthorizationError.MissingReadClaim(party),
+      )
+    }
   }
 
-  /** Returns true if the set of claims authorizes the user to read data for the given party, unless the claims expired */
-  def canReadAs(party: String): Either[AuthorizationError, Unit] = {
-    Either.cond(
-      claims.exists {
-        case ClaimActAsAnyParty => true
-        case ClaimActAsParty(p) if p == party => true
-        case ClaimReadAsParty(p) if p == party => true
-        case _ => false
-      },
-      (),
-      AuthorizationError.MissingReadClaim(party),
+  object Claims {
+
+    /** A set of [[Claims]] that does not have any authorization */
+    val Empty: Claims = Claims(
+      claims = List.empty[Claim],
+      ledgerId = None,
+      participantId = None,
+      applicationId = None,
+      expiration = None,
     )
+
+    /** A set of [[Claims]] that has all possible authorizations */
+    val Wildcard: Claims =
+      Empty.copy(claims = List[Claim](ClaimPublic, ClaimAdmin, ClaimActAsAnyParty))
+
   }
-}
-
-object Claims {
-
-  /** A set of [[Claims]] that does not have any authorization */
-  val empty: Claims = Claims(
-    claims = List.empty[Claim],
-    ledgerId = None,
-    participantId = None,
-    applicationId = None,
-    expiration = None,
-  )
-
-  /** A set of [[Claims]] that has all possible authorizations */
-  val wildcard: Claims =
-    empty.copy(claims = List[Claim](ClaimPublic, ClaimAdmin, ClaimActAsAnyParty))
 
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/Claims.scala
@@ -56,6 +56,8 @@ object ClaimSet {
     * They also optionally specify an expiration epoch time that statically specifies the
     * time on or after which the token will no longer be considered valid by the Ledger API.
     *
+    * Please note that Health and ServerReflection services do NOT require authentication.
+    *
     * The following is a full list of services and the corresponding required claims:
     * +-------------------------------------+----------------------------+------------------------------------------+
     * | Ledger API service                  | Method                     | Access with                              |
@@ -66,11 +68,13 @@ object ClaimSet {
     * | CommandCompletionService            | CompletionEnd              | isPublic                                 |
     * | CommandCompletionService            | CompletionStream           | for each requested party p: canReadAs(p) |
     * | CommandService                      | *                          | for submitting party p: canActAs(p)      |
+    * | Health                              | *                          | N/A (authentication not required)        |
     * | LedgerConfigurationService          | GetLedgerConfiguration     | isPublic                                 |
     * | PackageService                      | *                          | isPublic                                 |
     * | PackageManagementService            | *                          | isAdmin                                  |
     * | PartyManagementService              | *                          | isAdmin                                  |
     * | ResetService                        | *                          | isAdmin                                  |
+    * | ServerReflection                    | *                          | N/A (authentication not required)        |
     * | TimeService                         | GetTime                    | isPublic                                 |
     * | TimeService                         | SetTime                    | isAdmin                                  |
     * | TransactionService                  | LedgerEnd                  | isPublic                                 |

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/OngoingAuthorizationObserver.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/OngoingAuthorizationObserver.scala
@@ -7,8 +7,8 @@ import io.grpc.stub.ServerCallStreamObserver
 
 private[auth] final class OngoingAuthorizationObserver[A](
     observer: ServerCallStreamObserver[A],
-    claims: Claims,
-    authorized: Claims => Either[AuthorizationError, Unit],
+    claims: ClaimSet.Claims,
+    authorized: ClaimSet.Claims => Either[AuthorizationError, Unit],
     throwOnFailure: AuthorizationError => Throwable,
 ) extends ServerCallStreamObserver[A] {
 

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/interceptor/AuthorizationInterceptor.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/interceptor/AuthorizationInterceptor.scala
@@ -4,7 +4,6 @@
 package com.daml.ledger.api.auth.interceptor
 
 import com.daml.ledger.api.auth.{AuthService, ClaimSet}
-import com.daml.platform.server.api.validation.ErrorFactories.unauthenticated
 import io.grpc.{
   Context,
   Contexts,
@@ -18,7 +17,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.compat.java8.FutureConverters
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 /** This interceptor uses the given [[AuthService]] to get [[Claims]] for the current request,
   * and then stores them in the current [[Context]].
@@ -68,12 +67,8 @@ object AuthorizationInterceptor {
 
   private val contextKeyClaimSet = Context.key[ClaimSet]("AuthServiceDecodedClaim")
 
-  def extractClaimsFromContext(): Try[ClaimSet.Claims] = {
-    Option(contextKeyClaimSet.get()).fold[Try[ClaimSet.Claims]](Failure(unauthenticated())) {
-      case ClaimSet.Unauthenticated => Failure(unauthenticated())
-      case claims: ClaimSet.Claims => Success(claims)
-    }
-  }
+  def extractClaimSetFromContext(): Option[ClaimSet] =
+    Option(contextKeyClaimSet.get())
 
   def apply(authService: AuthService, ec: ExecutionContext): AuthorizationInterceptor =
     new AuthorizationInterceptor(authService, ec)

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/interceptor/AuthorizationInterceptor.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/interceptor/AuthorizationInterceptor.scala
@@ -3,7 +3,7 @@
 
 package com.daml.ledger.api.auth.interceptor
 
-import com.daml.ledger.api.auth.{AuthService, Claims}
+import com.daml.ledger.api.auth.{AuthService, ClaimSet}
 import com.daml.platform.server.api.validation.ErrorFactories.unauthenticated
 import io.grpc.{
   Context,
@@ -53,18 +53,21 @@ final class AuthorizationInterceptor(protected val authService: AuthService, ec:
             logger.warn(s"Failed to get claims from request metadata: ${exception.getMessage}")
             call.close(internalAuthenticationError, new Metadata())
             new ServerCall.Listener[Nothing]() {}
-          case Success(Claims.empty) =>
-            logger.debug(s"Auth metadata decoded into empty claims, returning UNAUTHENTICATED")
-            call.close(Status.UNAUTHENTICATED, new Metadata())
-            new ServerCall.Listener[Nothing]() {}
-          case Success(claims) =>
-            val nextCtx = prevCtx.withValue(contextKeyClaim, claims)
-            // Contexts.interceptCall() creates a listener that wraps all methods of `nextListener`
-            // such that `Context.current` returns `nextCtx`.
-            val nextListenerWithContext =
-              Contexts.interceptCall(nextCtx, call, headers, nextListener)
-            setNextListener(nextListenerWithContext)
-            nextListenerWithContext
+          case Success(claimSet) =>
+            claimSet match {
+              case ClaimSet.Unauthenticated =>
+                logger.debug(s"Auth metadata decoded into empty claims, returning UNAUTHENTICATED")
+                call.close(Status.UNAUTHENTICATED, new Metadata())
+                new ServerCall.Listener[Nothing]() {}
+              case claims: ClaimSet.Claims =>
+                val nextCtx = prevCtx.withValue(contextKeyClaim, claims)
+                // Contexts.interceptCall() creates a listener that wraps all methods of `nextListener`
+                // such that `Context.current` returns `nextCtx`.
+                val nextListenerWithContext =
+                  Contexts.interceptCall(nextCtx, call, headers, nextListener)
+                setNextListener(nextListenerWithContext)
+                nextListenerWithContext
+            }
         }(ec)
     }
   }
@@ -72,10 +75,10 @@ final class AuthorizationInterceptor(protected val authService: AuthService, ec:
 
 object AuthorizationInterceptor {
 
-  private val contextKeyClaim = Context.key[Claims]("AuthServiceDecodedClaim")
+  private val contextKeyClaim = Context.key[ClaimSet.Claims]("AuthServiceDecodedClaim")
 
-  def extractClaimsFromContext(): Try[Claims] =
-    Option(contextKeyClaim.get()).fold[Try[Claims]](Failure(unauthenticated()))(Success(_))
+  def extractClaimsFromContext(): Try[ClaimSet.Claims] =
+    Option(contextKeyClaim.get()).fold[Try[ClaimSet.Claims]](Failure(unauthenticated()))(Success(_))
 
   def apply(authService: AuthService, ec: ExecutionContext): AuthorizationInterceptor =
     new AuthorizationInterceptor(authService, ec)

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/AdminServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/AdminServiceCallAuthTests.scala
@@ -5,7 +5,7 @@ package com.daml.platform.sandbox.auth
 
 import java.util.UUID
 
-trait AdminServiceCallAuthTests extends ServiceCallAuthTests {
+trait AdminServiceCallAuthTests extends SecuredServiceCallAuthTests {
 
   private val signedIncorrectly = Option(toHeader(adminToken, UUID.randomUUID.toString))
 

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/MultiPartyServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/MultiPartyServiceCallAuthTests.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
   * They do not test for variations in expiration time, ledger ID, or participant ID.
   * It is expected that [[ReadWriteServiceCallAuthTests]] are run on the same service.
   */
-trait MultiPartyServiceCallAuthTests extends ServiceCallAuthTests {
+trait MultiPartyServiceCallAuthTests extends SecuredServiceCallAuthTests {
 
   // Parties specified in the API request
   sealed case class RequestSubmitters(party: String, actAs: Seq[String], readAs: Seq[String])

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/PublicServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/PublicServiceCallAuthTests.scala
@@ -3,7 +3,7 @@
 
 package com.daml.platform.sandbox.auth
 
-trait PublicServiceCallAuthTests extends ServiceCallAuthTests {
+trait PublicServiceCallAuthTests extends SecuredServiceCallAuthTests {
 
   it should "deny calls with an expired read-only token" in {
     expectUnauthenticated(serviceCallWithToken(canReadAsRandomPartyExpired))

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/SecuredServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/SecuredServiceCallAuthTests.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.platform.sandbox.auth
 
 trait SecuredServiceCallAuthTests extends ServiceCallAuthTests {

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/SecuredServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/SecuredServiceCallAuthTests.scala
@@ -1,0 +1,9 @@
+package com.daml.platform.sandbox.auth
+
+trait SecuredServiceCallAuthTests extends ServiceCallAuthTests {
+  behavior of serviceCallName
+
+  it should "deny unauthenticated calls" in {
+    expectUnauthenticated(serviceCallWithToken(None))
+  }
+}

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/ServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/ServiceCallAuthTests.scala
@@ -59,12 +59,6 @@ trait ServiceCallAuthTests
   protected def ledgerBegin: LedgerOffset =
     LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN))
 
-  behavior of serviceCallName
-
-  it should "deny unauthenticated calls" in {
-    expectUnauthenticated(serviceCallWithToken(None))
-  }
-
   protected val canActAsRandomParty: Option[String] =
     Option(toHeader(readWriteToken(UUID.randomUUID.toString)))
   protected val canActAsRandomPartyExpired: Option[String] =

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/ServiceCallWithMainActorAuthTests.scala
@@ -6,7 +6,7 @@ package com.daml.platform.sandbox.auth
 import java.time.Duration
 import java.util.UUID
 
-trait ServiceCallWithMainActorAuthTests extends ServiceCallAuthTests {
+trait ServiceCallWithMainActorAuthTests extends SecuredServiceCallAuthTests {
 
   protected val mainActor: String = UUID.randomUUID.toString
 

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/UnsecuredServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/UnsecuredServiceCallAuthTests.scala
@@ -3,38 +3,10 @@
 
 package com.daml.platform.sandbox.auth
 
-import com.daml.ledger.api.auth.client.LedgerCallCredentials
-import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
-import com.daml.platform.sandbox.SandboxRequiringAuthorization
-import com.daml.platform.sandbox.services.SandboxFixture
-import io.grpc.stub.AbstractStub
-import org.scalatest.flatspec.AsyncFlatSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.Assertion
-
-import scala.concurrent.Future
-
-trait UnsecuredServiceCallAuthTests
-    extends AsyncFlatSpec
-    with SandboxFixture
-    with SandboxRequiringAuthorization
-    with SuiteResourceManagementAroundAll
-    with Matchers {
-
-  def serviceCallName: String
-
-  def serviceCallWithoutToken(): Future[Any]
-
-  protected def expectSuccess[T](f: Future[T]): Future[Assertion] =
-    f.map(_ => succeed)
-
-  protected def stub[A <: AbstractStub[A]](stub: A, token: Option[String]): A =
-    token.fold(stub)(LedgerCallCredentials.authenticatingStub(stub, _))
-
+trait UnsecuredServiceCallAuthTests extends ServiceCallAuthTests {
   behavior of serviceCallName
 
   it should "allow unauthenticated calls" in {
-    expectSuccess(serviceCallWithoutToken())
+    expectSuccess(serviceCallWithToken(None))
   }
-
 }

--- a/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/UnsecuredServiceCallAuthTests.scala
+++ b/ledger/sandbox-classic/src/test/lib/scala/platform/sandbox/auth/UnsecuredServiceCallAuthTests.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.auth
+
+import com.daml.ledger.api.auth.client.LedgerCallCredentials
+import com.daml.ledger.api.testing.utils.SuiteResourceManagementAroundAll
+import com.daml.platform.sandbox.SandboxRequiringAuthorization
+import com.daml.platform.sandbox.services.SandboxFixture
+import io.grpc.stub.AbstractStub
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.Assertion
+
+import scala.concurrent.Future
+
+trait UnsecuredServiceCallAuthTests
+    extends AsyncFlatSpec
+    with SandboxFixture
+    with SandboxRequiringAuthorization
+    with SuiteResourceManagementAroundAll
+    with Matchers {
+
+  def serviceCallName: String
+
+  def serviceCallWithoutToken(): Future[Any]
+
+  protected def expectSuccess[T](f: Future[T]): Future[Assertion] =
+    f.map(_ => succeed)
+
+  protected def stub[A <: AbstractStub[A]](stub: A, token: Option[String]): A =
+    token.fold(stub)(LedgerCallCredentials.authenticatingStub(stub, _))
+
+  behavior of serviceCallName
+
+  it should "allow unauthenticated calls" in {
+    expectSuccess(serviceCallWithoutToken())
+  }
+
+}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/CheckHealthAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/CheckHealthAuthIT.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.sandbox.auth
+import com.daml.platform.testing.StreamConsumer
+import io.grpc.health.v1.HealthGrpc
+import io.grpc.health.v1.{HealthCheckRequest, HealthCheckResponse}
+
+import scala.concurrent.Future
+
+final class CheckHealthAuthIT extends UnsecuredServiceCallAuthTests {
+  override def serviceCallName: String = "HealthService"
+
+  private lazy val request = HealthCheckRequest.newBuilder().build()
+
+  override def serviceCallWithoutToken(): Future[Any] = {
+    new StreamConsumer[HealthCheckResponse](
+      stub(HealthGrpc.newStub(channel), None).check(request, _)
+    ).first()
+  }
+}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/CheckHealthAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/CheckHealthAuthIT.scala
@@ -13,9 +13,8 @@ final class CheckHealthAuthIT extends UnsecuredServiceCallAuthTests {
 
   private lazy val request = HealthCheckRequest.newBuilder().build()
 
-  override def serviceCallWithoutToken(): Future[Any] = {
+  override def serviceCallWithoutToken(): Future[Any] =
     new StreamConsumer[HealthCheckResponse](
       stub(HealthGrpc.newStub(channel), None).check(request, _)
     ).first()
-  }
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/CheckHealthAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/CheckHealthAuthIT.scala
@@ -13,8 +13,8 @@ final class CheckHealthAuthIT extends UnsecuredServiceCallAuthTests {
 
   private lazy val request = HealthCheckRequest.newBuilder().build()
 
-  override def serviceCallWithoutToken(): Future[Any] =
+  override def serviceCallWithToken(token: Option[String]): Future[Any] =
     new StreamConsumer[HealthCheckResponse](
-      stub(HealthGrpc.newStub(channel), None).check(request, _)
+      stub(HealthGrpc.newStub(channel), token).check(request, _)
     ).first()
 }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/ListServicesAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/ListServicesAuthIT.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.daml.platform.sandbox.auth
 import com.daml.platform.testing.StreamConsumer
 import io.grpc.reflection.v1alpha.{ServerReflectionGrpc, ServerReflectionResponse}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/ListServicesAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/ListServicesAuthIT.scala
@@ -1,0 +1,14 @@
+package com.daml.platform.sandbox.auth
+import com.daml.platform.testing.StreamConsumer
+import io.grpc.reflection.v1alpha.{ServerReflectionGrpc, ServerReflectionResponse}
+
+import scala.concurrent.Future
+
+class ListServicesAuthIT extends UnsecuredServiceCallAuthTests {
+  override def serviceCallName: String = "ServerReflection#List"
+
+  override def serviceCallWithoutToken(): Future[Any] =
+    new StreamConsumer[ServerReflectionResponse](observer =>
+      stub(ServerReflectionGrpc.newStub(channel), None).serverReflectionInfo(observer).onCompleted()
+    ).first()
+}

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/ListServicesAuthIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/auth/ListServicesAuthIT.scala
@@ -10,8 +10,10 @@ import scala.concurrent.Future
 class ListServicesAuthIT extends UnsecuredServiceCallAuthTests {
   override def serviceCallName: String = "ServerReflection#List"
 
-  override def serviceCallWithoutToken(): Future[Any] =
+  override def serviceCallWithToken(token: Option[String]): Future[Any] =
     new StreamConsumer[ServerReflectionResponse](observer =>
-      stub(ServerReflectionGrpc.newStub(channel), None).serverReflectionInfo(observer).onCompleted()
+      stub(ServerReflectionGrpc.newStub(channel), token)
+        .serverReflectionInfo(observer)
+        .onCompleted()
     ).first()
 }


### PR DESCRIPTION
**Motivation**
Currently a JWT token is required for all services if a JWT authorisation is enabled. We would like to loosen this restriction and not require providing a token for Health and Reflection services.

**Main changes**
- ~~Replaced the usage of `Claims.empty` with a new `ClaimSet.Unauthorized` for rejecting a request immediately.~~
- ~~`ClaimSet.Claims` with empty claim list does not cause immediate request rejection. Its used for authorisation validation in appropriate services. Even empty claim list in `ClaimSet.Claims` may result in a successful service response if no explicit restrictions on required claims is specified for a service (this exact mechanism is used for the Health and Reflection services)~~
- Introduced `ClaimSet` trait with `Unauthenticated` object and `Claims` case class. `AuthServiceJWT#decodeMetadata()` returns now `ClaimSet`. `Unauthenticated` is used to signal that the token is missing or was malformed.
- `AuthorizationInterceptor` inserts decoded `ClaimSet` in the request context no matter if the decoded set is `Unauthorized` or `Claims`. The early rejection in `AuthorizationInterceptor` with `UNAUTHENTICATED` status has been removed. This means that all requests (even those without a token) get past this interceptor.
- Authorisation logic is shifted to the service layer and is handled by `*Authorization` services which use `Authorizer` internally. Services now can inspect the context and decide how to handle a request basing on the `ClaimSet` from the request context. Specifically, for `Health` service we handle requests with either `ClaimSet.Unauthenticated` or `ClaimSet.Claims` but for secured services, we require `ClaimSet.Claims` with appropriate claims inside.

**Side comment**
I left testing the `AuthServiceJWT` for the next PR but I'm open to suggestions on that.

```
CHANGELOG_BEGIN
- A JWT token is no longer required to call methods of Health and Reflection services
CHANGELOG_END
```

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
