### PR TITLE
Batch creation of ACS

### DIFF
--- a/daml-script/dump/src/it/scala/com/daml/script/dump/IT.scala
+++ b/daml-script/dump/src/it/scala/com/daml/script/dump/IT.scala
@@ -149,6 +149,7 @@ final class IT
         parties = parties,
         start = offset,
         end = ledgerEnd,
+        acsBatchSize = 2,
         outputPath = tmpDir,
         damlScriptLib = damlScriptLib.toString,
         sdkVersion = SdkVersion.sdkVersion,

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Config.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Config.scala
@@ -14,6 +14,7 @@ final case class Config(
     parties: List[String],
     start: LedgerOffset,
     end: LedgerOffset,
+    acsBatchSize: Int,
     outputPath: Path,
     sdkVersion: String,
     damlScriptLib: String,
@@ -55,6 +56,14 @@ object Config {
       .text(
         "The transaction offset (inclusive) for the end position of the dump. Optional, by default the dump includes the current end of the ledger."
       )
+    opt[Int]("acs-batch-size")
+      .optional()
+      .action((x, c) => c.copy(acsBatchSize = x))
+      .validate(x =>
+        if (x <= 0) { failure("ACS batch size must be greater than zero") }
+        else { success }
+      )
+      .text("Batch this many create commands into one transaction when recreating the ACS.")
     opt[File]('o', "output")
       .required()
       .action((x, c) => c.copy(outputPath = x.toPath))
@@ -69,6 +78,7 @@ object Config {
     parties = List(),
     start = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)),
     end = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
+    acsBatchSize = 1,
     outputPath = null,
     sdkVersion = "",
     damlScriptLib = "daml-script",

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Config.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Config.scala
@@ -78,7 +78,7 @@ object Config {
     parties = List(),
     start = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_BEGIN)),
     end = LedgerOffset(LedgerOffset.Value.Boundary(LedgerOffset.LedgerBoundary.LEDGER_END)),
-    acsBatchSize = 1,
+    acsBatchSize = 10,
     outputPath = null,
     sdkVersion = "",
     damlScriptLib = "daml-script",

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Dump.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Dump.scala
@@ -24,13 +24,17 @@ object Dump {
       trees: Seq[TransactionTree],
       pkgRefs: Set[PackageId],
       pkgs: Map[PackageId, (ByteString, Ast.Package)],
+      acsBatchSize: Int,
   ) = {
     // Needed for map on Dar
     import scalaz.syntax.traverse._
     val dir = Files.createDirectories(targetDir)
     Files.write(
       dir.resolve("Dump.daml"),
-      Encode.encodeTransactionTreeStream(acs, trees).render(80).getBytes(StandardCharsets.UTF_8),
+      Encode
+        .encodeTransactionTreeStream(acs, trees, acsBatchSize)
+        .render(80)
+        .getBytes(StandardCharsets.UTF_8),
     )
     val dars: Seq[Dar[(PackageId, ByteString, Ast.Package)]] =
       pkgRefs.view.collect(Function.unlift(Dependencies.toDar(_, pkgs))).toSeq

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -24,6 +24,7 @@ private[dump] object Encode {
   def encodeTransactionTreeStream(
       acs: Map[ContractId, CreatedEvent],
       trees: Seq[TransactionTree],
+      acsBatchSize: Int,
   ): Doc = {
     val parties = partiesInContracts(acs.values) ++ trees.foldMap(partiesInTree(_))
     val partyMap = partyMapping(parties)
@@ -68,7 +69,7 @@ private[dump] object Encode {
       Doc.hardLine +
       Doc.text("dump : Parties -> Script ()") /
       (Doc.text("dump Parties{..} = do") /
-        encodeACS(partyMap, cidMap, cidRefs, sortedAcs, batchSize = 1) /
+        encodeACS(partyMap, cidMap, cidRefs, sortedAcs, batchSize = acsBatchSize) /
         Doc.stack(trees.map(t => encodeTree(partyMap, cidMap, cidRefs, t))) /
         Doc.text("pure ()")).hang(2)
   }

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -19,6 +19,8 @@ import org.typelevel.paiges.Doc
 import scalaz.std.iterable._
 import scalaz.std.set._
 import scalaz.syntax.foldable._
+import scala.collection.compat.immutable.LazyList
+
 
 private[dump] object Encode {
   def encodeTransactionTreeStream(
@@ -301,7 +303,7 @@ private[dump] object Encode {
       acsSize / batchSize + 1
     }
     Doc.stack(
-      Stream
+      LazyList
         .range(0, numBatches)
         .map(i => acs.slice(i * batchSize, (i + 1) * batchSize))
         .map(batch => encodeSubmitCreatedEvents(partyMap, cidMap, cidRefs, batch))

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -19,8 +19,6 @@ import org.typelevel.paiges.Doc
 import scalaz.std.iterable._
 import scalaz.std.set._
 import scalaz.syntax.foldable._
-import scala.collection.compat.immutable.LazyList
-
 
 private[dump] object Encode {
   def encodeTransactionTreeStream(
@@ -296,17 +294,11 @@ private[dump] object Encode {
       acs: Seq[CreatedEvent],
       batchSize: Int,
   ): Doc = {
-    val acsSize = acs.length
-    val numBatches: Int = if (acsSize % batchSize == 0) {
-      acsSize / batchSize
-    } else {
-      acsSize / batchSize + 1
-    }
     Doc.stack(
-      LazyList
-        .range(0, numBatches)
-        .map(i => acs.slice(i * batchSize, (i + 1) * batchSize))
-        .map(batch => encodeSubmitCreatedEvents(partyMap, cidMap, cidRefs, batch))
+      acs
+        .grouped(batchSize)
+        .map(encodeSubmitCreatedEvents(partyMap, cidMap, cidRefs, _))
+        .toSeq
     )
   }
 

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -69,9 +69,11 @@ private[dump] object Encode {
       Doc.hardLine +
       Doc.text("dump : Parties -> Script ()") /
       (Doc.text("dump Parties{..} = do") /
-        encodeACS(partyMap, cidMap, cidRefs, sortedAcs, batchSize = acsBatchSize) /
-        Doc.stack(trees.map(t => encodeTree(partyMap, cidMap, cidRefs, t))) /
-        Doc.text("pure ()")).hang(2)
+        stackNonEmpty(
+          encodeACS(partyMap, cidMap, cidRefs, sortedAcs, batchSize = acsBatchSize)
+            +: trees.map(t => encodeTree(partyMap, cidMap, cidRefs, t))
+            :+ Doc.text("pure ()")
+        )).hang(2)
   }
 
   private def encodeAllocateParties(partyMap: Map[Party, String]): Doc =
@@ -170,6 +172,9 @@ private[dump] object Encode {
 
   private def pair(v1: Doc, v2: Doc) =
     parens(v1 + Doc.text(", ") + v2)
+
+  private def stackNonEmpty(docs: Seq[Doc]): Doc =
+    Doc.stack(docs.filter(_.nonEmpty))
 
   private def encodeRecord(
       partyMap: Map[Party, String],

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Main.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Main.scala
@@ -62,6 +62,7 @@ object Main {
         trees,
         pkgRefs,
         pkgs,
+        config.acsBatchSize,
       )
     } yield ()
 

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeAcsSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeAcsSpec.scala
@@ -1,0 +1,99 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.dump
+
+import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class EncodeAcsSpec extends AnyFreeSpec with Matchers {
+  import Encode._
+  "encodeACS" - {
+    "command batching" - {
+      val parties = Map(Party("Alice") -> "alice_0")
+      val cidMap = Map(
+        ContractId("cid1") -> "contract_0_0",
+        ContractId("cid2") -> "contract_0_1",
+        ContractId("cid3") -> "contract_0_2",
+        ContractId("cid4") -> "contract_0_3",
+      )
+      val cidRefs = Set.empty[ContractId]
+      val events = TestData
+        .ACS(
+          Seq(
+            TestData.Created(ContractId("cid1")),
+            TestData.Created(ContractId("cid2")),
+            TestData.Created(ContractId("cid3")),
+            TestData.Created(ContractId("cid4")),
+          )
+        )
+        .toCreatedEvents
+      "batch size 1" in {
+        encodeACS(parties, cidMap, cidRefs, events, 1).render(80) shouldBe
+          """_ <- submitMulti [alice_0] [] do
+            |  createCmd Module.Template
+            |_ <- submitMulti [alice_0] [] do
+            |  createCmd Module.Template
+            |_ <- submitMulti [alice_0] [] do
+            |  createCmd Module.Template
+            |_ <- submitMulti [alice_0] [] do
+            |  createCmd Module.Template""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+      "batch size 2 - divides evenly" in {
+        encodeACS(parties, cidMap, cidRefs, events, 2).render(80) shouldBe
+          """submitMulti [alice_0] [] do
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  pure ()
+            |submitMulti [alice_0] [] do
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  pure ()""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+      "batch size 3 - does not divide evenly" in {
+        encodeACS(parties, cidMap, cidRefs, events, 3).render(80) shouldBe
+          """submitMulti [alice_0] [] do
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  pure ()
+            |_ <- submitMulti [alice_0] [] do
+            |  createCmd Module.Template""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+      "batch size 4 - equals total size" in {
+        encodeACS(parties, cidMap, cidRefs, events, 4).render(80) shouldBe
+          """submitMulti [alice_0] [] do
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  pure ()""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+      "batch size 5 - greater than total size" in {
+        encodeACS(parties, cidMap, cidRefs, events, 5).render(80) shouldBe
+          """submitMulti [alice_0] [] do
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  _ <- createCmd Module.Template
+            |  pure ()""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #8954 

Let's the user configure the size by which to batch create commands into a single transaction when recreating the ACS in a Daml script dump.
Adds test cases to cover the various edge-cases of batch size compared to ACS size.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
