### PR TITLE
feature: damlc lints all files in project directory

### DIFF
--- a/compiler/damlc/tests/BUILD.bazel
+++ b/compiler/damlc/tests/BUILD.bazel
@@ -108,6 +108,34 @@ da_haskell_test(
     ],
 )
 
+# Tests for damlc lint
+da_haskell_test(
+    name = "damlc-lint",
+    srcs = ["src/DamlcLint.hs"],
+    data = [
+        "//compiler/damlc",
+    ],
+    hackage_deps = [
+        "base",
+        "bytestring",
+        "directory",
+        "extra",
+        "filepath",
+        "process",
+        "tasty",
+        "tasty-hunit",
+    ],
+    main_function = "DamlcLint.main",
+    src_strip_prefix = "tests",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:sdk-version-hs-lib",
+        "//compiler/damlc:damlc-lib",
+        "//libs-haskell/bazel-runfiles",
+        "//libs-haskell/da-hs-base",
+    ],
+)
+
 da_haskell_library(
     name = "integration-lib",
     srcs = ["src/DA/Test/DamlcIntegration.hs"],

--- a/compiler/damlc/tests/src/DamlcLint.hs
+++ b/compiler/damlc/tests/src/DamlcLint.hs
@@ -1,0 +1,106 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+module DamlcLint
+   ( main
+   ) where
+
+import Data.List.Extra (isSuffixOf)
+import System.Environment.Blank
+import System.Directory
+import System.Exit
+import System.FilePath
+import System.IO.Extra
+import System.Process
+import Test.Tasty
+import Test.Tasty.HUnit
+import qualified Data.Text.Extended as T
+
+import DA.Bazel.Runfiles
+import SdkVersion
+
+main :: IO ()
+main = do
+    setEnv "TASTY_NUM_THREADS" "1" True
+    damlc <- locateRunfiles (mainWorkspace </> "compiler" </> "damlc" </> exe "damlc")
+    defaultMain (tests damlc)
+
+tests :: FilePath -> TestTree
+tests damlc = testGroup "damlc" $ map (\f -> f damlc)
+  [ testsForDamlcLint
+  ]
+
+testsForDamlcLint :: FilePath -> TestTree
+testsForDamlcLint damlc = testGroup "damlc test"
+    [ testCase "Lint all project files" $ do
+        withTempDir $ \dir -> do
+          withCurrentDirectory dir $ do
+            let projDir = "daml"
+            createDirectoryIfMissing True $ dir </> projDir
+            let damlFile = dir </> "daml.yaml"
+            T.writeFileUtf8 damlFile $ T.unlines
+              [ "sdk-version: " <> T.pack sdkVersion
+              , "name: a"
+              , "version: 0.0.1"
+              , "source: " <> T.pack projDir
+              , "dependencies: [daml-prim, daml-stdlib]"
+              ]
+            let fooFile = dir </> projDir </> "Foo.daml"
+            T.writeFileUtf8 fooFile $ T.unlines
+              [ "module Foo where"
+              , "template S with p : Party where"
+              , "  signatory p"
+              , "  choice X : Int with"
+              , "    controller p"
+              , "      do"
+              , "         forA [] $ \\_ -> create S with p"
+              , "         pure 42"
+              ]
+            let barFile = dir </> projDir </> "Bar.daml"
+            T.writeFileUtf8 barFile $ T.unlines
+              [ "module Bar where"
+              , "template T with p : Party where"
+              , "  signatory p"
+              ]
+            (exitCode, _stdout, stderr) <-
+              readProcessWithExitCode damlc ["lint"] ""
+            exitCode @?= ExitFailure 1
+            assertBool
+                ("All project source files are linted: " <> show stderr)
+                (unlines
+                     [ "  Found:"
+                     , "  forA [] $ \\ _ -> create S {p}"
+                     , "  Perhaps:"
+                     , "  forA_ [] $ \\ _ -> create S {p}\ESC[0m"
+                     ] `isSuffixOf` stderr) -- needs escape secenquence for blue output color.
+    , testCase "Lint all project files -- no hints" $ do
+        withTempDir $ \dir -> do
+          withCurrentDirectory dir $ do
+            let projDir = "daml"
+            createDirectoryIfMissing True $ dir </> projDir
+            let damlFile = dir </> "daml.yaml"
+            T.writeFileUtf8 damlFile $ T.unlines
+              [ "sdk-version: " <> T.pack sdkVersion
+              , "name: a"
+              , "version: 0.0.1"
+              , "source: " <> T.pack projDir
+              , "dependencies: [daml-prim, daml-stdlib]"
+              ]
+            let fooFile = dir </> projDir </> "Foo.daml"
+            T.writeFileUtf8 fooFile $ T.unlines
+              [ "module Foo where"
+              , "template S with p : Party where"
+              , "  signatory p"
+              ]
+            let barFile = dir </> projDir </> "Bar.daml"
+            T.writeFileUtf8 barFile $ T.unlines
+              [ "module Bar where"
+              , "template T with p : Party where"
+              , "  signatory p"
+              ]
+            (exitCode, _stdout, stderr) <-
+              readProcessWithExitCode damlc ["lint"] ""
+            exitCode @?= ExitSuccess
+            assertBool
+                ("All project source files are linted: " <> show stderr)
+                (stderr == "No hints\n")
+    ]


### PR DESCRIPTION
fixes #8887.

This changes the input options of `damlc lint` to take several files. If
no file is given, all `.daml` files contained in the directory are
linted.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
