### PR TITLE
Bump JdbcLedgerDao resource acquisition timeout

### DIFF
--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -72,7 +72,7 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll {
         _ <- Resource.fromFuture(dao.initializeParticipantId(TestParticipantId))
       } yield dao
     }
-    ledgerDao = Await.result(resource.asFuture, 10.seconds)
+    ledgerDao = Await.result(resource.asFuture, 30.seconds)
   }
 
   override protected def afterAll(): Unit = {


### PR DESCRIPTION
I’ve seen this timeout several times on CI. It seems somewhat expected
that migrations get slower as we add more, so I don’t think this is
necessarily worth investigating but if someone wants to do so, be my
guest. I don’t know enough about those tests to do so myself.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
