### PR TITLE
Factor out "parsing" of ScriptF constructors

### DIFF
--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Converter.scala
@@ -559,6 +559,12 @@ object Converter {
       case _ => Left(s"Expected SList but got $v")
     }
 
+  def toParticipantName(v: SValue): Either[String, Option[Participant]] = v match {
+    case SOptional(Some(SText(t))) => Right(Some(Participant(t)))
+    case SOptional(None) => Right(None)
+    case _ => Left(s"Expected optional participant name but got $v")
+  }
+
   def fromApiIdentifier(id: value.Identifier): Either[String, Identifier] =
     for {
       packageId <- PackageId.fromString(id.packageId)

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/Runner.scala
@@ -12,7 +12,7 @@ import com.typesafe.scalalogging.StrictLogging
 import java.time.Clock
 
 import scala.concurrent.{ExecutionContext, Future}
-import scalaz.{Applicative, Foldable, NonEmptyList, OneAnd, Traverse, \/-}
+import scalaz.{Applicative, NonEmptyList, OneAnd, Traverse, \/-}
 import scalaz.OneAnd._
 import scalaz.std.either._
 import scalaz.std.list._
@@ -21,7 +21,6 @@ import scalaz.std.map._
 import scalaz.std.scalaFuture._
 import scalaz.std.set._
 import scalaz.syntax.traverse._
-import scalaz.syntax.std.option._
 
 import spray.json._
 import com.daml.lf.archive.Dar
@@ -54,7 +53,7 @@ import com.daml.ledger.client.configuration.LedgerClientConfiguration
 import ParticipantsJsonProtocol.ContractIdFormat
 import com.daml.lf.language.LanguageVersion
 import com.daml.lf.value.Value
-import com.daml.script.converter.Converter.{JavaList, toContractId, unrollFree}
+import com.daml.script.converter.Converter.{JavaList, unrollFree}
 import com.daml.script.converter.ConverterException
 
 object LfValueCodec extends ApiCodecCompressed[ContractId](false, false)
@@ -327,60 +326,6 @@ object Runner {
     val runner = new Runner(compiledPackages, scriptAction, timeMode)
     runner.runWithClients(initialClients)._2
   }
-
-  private case class SubmitPayload(
-      actAs: OneAnd[List, SValue],
-      readAs: List[SValue],
-      freeAp: SValue,
-      continue: SValue,
-      loc: Option[SValue],
-  )
-
-  private def submitPayload: SValue PartialFunction SubmitPayload = {
-    // no location
-    case SRecord(_, _, JavaList(sParty, SRecord(_, _, JavaList(freeAp)), continue)) =>
-      SubmitPayload(OneAnd(sParty, List()), List(), freeAp, continue, None)
-    // location
-    case SRecord(_, _, JavaList(sParty, SRecord(_, _, JavaList(freeAp)), continue, loc)) =>
-      SubmitPayload(OneAnd(sParty, List()), List(), freeAp, continue, Some(loc))
-
-    // multi-party actAs/readAs + location
-    case SRecord(
-          _,
-          _,
-          JavaList(
-            SRecord(_, _, JavaList(hdAct, SList(tlAct))),
-            SList(read),
-            SRecord(_, _, JavaList(freeAp)),
-            continue,
-            loc,
-          ),
-        ) =>
-      SubmitPayload(OneAnd(hdAct, tlAct.toList), read.toList, freeAp, continue, Some(loc))
-
-  }
-
-  private def toOneAndSet[F[_], A](x: OneAnd[F, A])(implicit fF: Foldable[F]): OneAnd[Set, A] =
-    OneAnd(x.head, x.tail.toSet - x.head)
-
-  // used to help scalac propagate the expected `B` type into `f`, which doesn't
-  // work with the literal tuple syntax.  The curried form also indents much
-  // more nicely with scalafmt, with far less horizontal space used
-  private def m2c[B, Z](expect: String)(f: B PartialFunction Z): (String, B PartialFunction Z) =
-    (expect, f)
-
-  // a variant of match2 specifically for our run function that lets us
-  // put the unique error message content right next to the pattern that
-  // must have failed
-  private def match2[A, B, Z](a: A, b: B)(
-      f: A => (String, B PartialFunction Future[Z])
-  ): Future[Z] = {
-    val (expect, bz) = f(a)
-    bz.applyOrElse(
-      b,
-      (b: B) => Future failed (new ConverterException(s"Expected $expect but got $b")),
-    )
-  }
 }
 
 class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode: ScriptTimeMode)
@@ -490,250 +435,186 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
 
     def run(expr: SExpr): Future[SValue] = {
       machine.setExpressionToEvaluate(expr)
-      import Runner.{match2, m2c, submitPayload, toOneAndSet}
       stepToValue()
         .fold(Future.failed, Future.successful)
         .flatMap(fsu => Converter toFuture unrollFree(fsu))
         .flatMap {
           case Right((vv, v)) =>
-            match2(vv, v) {
-              case "Submit" =>
-                m2c("record with 3,4 or 5 fields") {
-                  submitPayload.andThen { payload =>
-                    for {
-                      actAs <- Converter
-                        .toFuture(payload.actAs.traverse(Converter.toParty(_)))
-                        .map(toOneAndSet(_))
-                      readAs <- Converter
-                        .toFuture(payload.readAs.traverse(Converter.toParty(_)))
-                        .map(_.toSet)
-                      commands <- Converter.toFuture(
-                        Converter
-                          .toCommands(extendedCompiledPackages, payload.freeAp)
-                      )
-                      client <- Converter.toFuture(
-                        clients
-                          .getPartiesParticipant(actAs)
-                      )
-                      commitLocation <- payload.loc.cata(
-                        sLoc => Converter.toFuture(Converter.toOptionLocation(knownPackages, sLoc)),
-                        Future(None),
-                      )
-                      submitRes <- client.submit(actAs, readAs, commands, commitLocation)
-                      _ = copyTracelog(client)
-                      v <- submitRes match {
-                        case Right(results) => {
-                          for {
-                            filled <- Converter.toFuture(
-                              Converter
-                                .fillCommandResults(
-                                  extendedCompiledPackages,
-                                  lookupChoice,
-                                  valueTranslator,
-                                  payload.freeAp,
-                                  results,
-                                )
-                            )
-                            v <- {
-                              run(filled)
-                            }
-                          } yield v
-                        }
-                        case Left(statusEx) => {
-                          // This branch is superseded by SubmitMustFail below,
-                          // however, it is maintained for backwards
-                          // compatibility with DAML script DARs generated by
-                          // older SDK versions that didn't distinguish Submit
-                          // and SubmitMustFail.
-                          for {
-                            res <- Converter.toFuture(
-                              Converter
-                                .fromStatusException(script.scriptIds, statusEx)
-                            )
-                            v <- {
-                              run(SEApp(SEValue(payload.continue), Array(SEValue(res))))
-                            }
-                          } yield v
-                        }
-                      }
-                    } yield v
-
-                  }
-                }
-              case "SubmitMustFail" =>
-                m2c("record with 3 or 4 fields") {
-                  submitPayload.andThen { payload =>
-                    for {
-                      actAs <- Converter
-                        .toFuture(payload.actAs.traverse(Converter.toParty(_)))
-                        .map(toOneAndSet(_))
-                      readAs <- Converter
-                        .toFuture(payload.readAs.traverse(Converter.toParty(_)))
-                        .map(_.toSet)
-                      commands <- Converter.toFuture(
-                        Converter
-                          .toCommands(extendedCompiledPackages, payload.freeAp)
-                      )
-                      client <- Converter.toFuture(
-                        clients
-                          .getPartiesParticipant(actAs)
-                      )
-                      commitLocation <- payload.loc.cata(
-                        sLoc => Converter.toFuture(Converter.toOptionLocation(knownPackages, sLoc)),
-                        Future(None),
-                      )
-                      submitRes <- client.submitMustFail(actAs, readAs, commands, commitLocation)
-                      _ = copyTracelog(client)
-                      v <- submitRes match {
-                        case Right(()) =>
-                          run(SEApp(SEValue(payload.continue), Array(SEValue(SUnit))))
-                        case Left(()) =>
-                          Future.failed(
-                            new DamlEUserError("Expected submit to fail but it succeeded")
-                          )
-                      }
-                    } yield v
-                  }
-                }
-              case "SubmitTree" =>
-                m2c("record with 4 fields") {
-                  submitPayload.andThen { payload =>
-                    for {
-                      actAs <- Converter
-                        .toFuture(payload.actAs.traverse(Converter.toParty(_)))
-                        .map(toOneAndSet(_))
-                      readAs <- Converter
-                        .toFuture(payload.readAs.traverse(Converter.toParty(_)))
-                        .map(_.toSet)
-                      commands <- Converter.toFuture(
-                        Converter
-                          .toCommands(extendedCompiledPackages, payload.freeAp)
-                      )
-                      client <- Converter.toFuture(
-                        clients
-                          .getPartiesParticipant(actAs)
-                      )
-                      commitLocation <- payload.loc.cata(
-                        sLoc => Converter.toFuture(Converter.toOptionLocation(knownPackages, sLoc)),
-                        Future(None),
-                      )
-                      submitRes <- client.submitTree(actAs, readAs, commands, commitLocation)
-                      res <- Converter.toFuture(
-                        Converter.translateTransactionTree(
-                          lookupChoice,
-                          valueTranslator,
-                          script.scriptIds,
-                          submitRes,
-                        )
-                      )
-                      _ = copyTracelog(client)
-                      v <- run(SEApp(SEValue(payload.continue), Array(SEValue(res))))
-                    } yield v
-                  }
-                }
-              case "Query" =>
-                m2c("record with 3 fields") {
-                  case SRecord(_, _, JavaList(sParties, sTplId, continue)) =>
-                    for {
-                      parties <- Converter.toFuture(
-                        Converter
-                          .toParties(sParties)
-                      )
-                      tplId <- Converter.toFuture(
-                        Converter
-                          .typeRepToIdentifier(sTplId)
-                      )
-                      client <- Converter.toFuture(
-                        clients
-                          .getPartiesParticipant(parties)
-                      )
-                      acs <- client.query(parties, tplId)
-                      res <- Converter.toFuture(
-                        FrontStack(acs)
-                          .traverse(
+            Converter
+              .toFuture(ScriptF.parse(ScriptF.Ctx(knownPackages, extendedCompiledPackages), vv, v))
+              .flatMap {
+                case ScriptF.Submit(data) =>
+                  for {
+                    client <- Converter.toFuture(
+                      clients
+                        .getPartiesParticipant(data.actAs)
+                    )
+                    submitRes <- client.submit(
+                      data.actAs,
+                      data.readAs,
+                      data.cmds,
+                      data.commitLocation,
+                    )
+                    _ = copyTracelog(client)
+                    v <- submitRes match {
+                      case Right(results) => {
+                        for {
+                          filled <- Converter.toFuture(
                             Converter
-                              .fromCreated(valueTranslator, _)
-                          )
-                      )
-                      v <- {
-                        run(SEApp(SEValue(continue), Array(SEValue(SList(res)))))
-                      }
-                    } yield v
-                }
-              case "AllocParty" =>
-                m2c("record with 4 fields") {
-                  case SRecord(
-                        _,
-                        _,
-                        JavaList(
-                          SText(displayName),
-                          SText(partyIdHint),
-                          SOptional(sParticipantName),
-                          continue,
-                        ),
-                      ) =>
-                    for {
-                      participantName <- sParticipantName match {
-                        case Some(SText(t)) => Future.successful(Some(Participant(t)))
-                        case None => Future.successful(None)
-                        case v =>
-                          Future.failed(
-                            new ConverterException(s"Expected Option(SText) but got $v")
-                          )
-                      }
-                      client <- clients.getParticipant(participantName) match {
-                        case Right(client) => Future.successful(client)
-                        case Left(err) => Future.failed(new RuntimeException(err))
-                      }
-                      party <- client.allocateParty(partyIdHint, displayName)
-                      v <- {
-                        participantName match {
-                          case None => {
-                            // If no participant is specified, we use default_participant so we don’t need to change anything.
-                          }
-                          case Some(participant) =>
-                            clients = clients
-                              .copy(
-                                party_participants =
-                                  clients.party_participants + (party -> participant)
+                              .fillCommandResults(
+                                extendedCompiledPackages,
+                                lookupChoice,
+                                valueTranslator,
+                                data.freeAp,
+                                results,
                               )
-                        }
-                        run(SEApp(SEValue(continue), Array(SEValue(SParty(party)))))
-                      }
-                    } yield v
-                }
-              case "ListKnownParties" =>
-                m2c("record with 2 fields") {
-                  case SRecord(_, _, JavaList(SOptional(sParticipantName), continue)) => {
-                    for {
-                      participantName <- sParticipantName match {
-                        case Some(SText(t)) => Future.successful(Some(Participant(t)))
-                        case None => Future.successful(None)
-                        case v =>
-                          Future.failed(
-                            new ConverterException(s"Expected Option(SText) but got $v")
                           )
+                          v <- {
+                            run(filled)
+                          }
+                        } yield v
                       }
-                      client <- clients.getParticipant(participantName) match {
-                        case Right(client) => Future.successful(client)
-                        case Left(err) => Future.failed(new RuntimeException(err))
+                      case Left(statusEx) => {
+                        // This branch is superseded by SubmitMustFail below,
+                        // however, it is maintained for backwards
+                        // compatibility with DAML script DARs generated by
+                        // older SDK versions that didn't distinguish Submit
+                        // and SubmitMustFail.
+                        for {
+                          res <- Converter.toFuture(
+                            Converter
+                              .fromStatusException(script.scriptIds, statusEx)
+                          )
+                          v <- {
+                            run(SEApp(SEValue(data.continue), Array(SEValue(res))))
+                          }
+                        } yield v
                       }
-                      partyDetails <- client.listKnownParties()
-                      partyDetails_ <- Converter.toFuture(
-                        partyDetails.traverse(details =>
-                          Converter.fromPartyDetails(script.scriptIds, details)
+                    }
+                  } yield v
+                case ScriptF.SubmitMustFail(data) =>
+                  for {
+                    client <- Converter.toFuture(
+                      clients
+                        .getPartiesParticipant(data.actAs)
+                    )
+                    submitRes <- client.submitMustFail(
+                      data.actAs,
+                      data.readAs,
+                      data.cmds,
+                      data.commitLocation,
+                    )
+                    _ = copyTracelog(client)
+                    v <- submitRes match {
+                      case Right(()) =>
+                        run(SEApp(SEValue(data.continue), Array(SEValue(SUnit))))
+                      case Left(()) =>
+                        Future.failed(
+                          new DamlEUserError("Expected submit to fail but it succeeded")
                         )
+                    }
+                  } yield v
+
+                case ScriptF.SubmitTree(data) =>
+                  for {
+                    client <- Converter.toFuture(
+                      clients
+                        .getPartiesParticipant(data.actAs)
+                    )
+                    submitRes <- client.submitTree(
+                      data.actAs,
+                      data.readAs,
+                      data.cmds,
+                      data.commitLocation,
+                    )
+                    res <- Converter.toFuture(
+                      Converter.translateTransactionTree(
+                        lookupChoice,
+                        valueTranslator,
+                        script.scriptIds,
+                        submitRes,
                       )
-                      v <- {
-                        run(
-                          SEApp(SEValue(continue), Array(SEValue(SList(FrontStack(partyDetails_)))))
+                    )
+                    _ = copyTracelog(client)
+                    v <- run(SEApp(SEValue(data.continue), Array(SEValue(res))))
+                  } yield v
+                case ScriptF.Query(parties, tplId, continue) =>
+                  for {
+                    client <- Converter.toFuture(
+                      clients
+                        .getPartiesParticipant(parties)
+                    )
+                    acs <- client.query(parties, tplId)
+                    res <- Converter.toFuture(
+                      FrontStack(acs)
+                        .traverse(
+                          Converter
+                            .fromCreated(valueTranslator, _)
                         )
+                    )
+                    v <- {
+                      run(SEApp(SEValue(continue), Array(SEValue(SList(res)))))
+                    }
+                  } yield v
+                case ScriptF.QueryContractId(parties, tplId, cid, continue) =>
+                  for {
+                    client <- Converter.toFuture(clients.getPartyParticipant(parties.head))
+                    optR <- client.queryContractId(parties, tplId, cid)
+                    optR <- Converter.toFuture(
+                      optR.traverse(Converter.fromContract(valueTranslator, _))
+                    )
+                    v <- run(SEApp(SEValue(continue), Array(SEValue(SOptional(optR)))))
+                  } yield v
+                case ScriptF.QueryContractKey(parties, tplId, key, continue) =>
+                  for {
+                    client <- Converter.toFuture(clients.getPartiesParticipant(parties))
+                    optR <- client.queryContractKey(parties, tplId, key.key, translateKey)
+                    optR <- Converter.toFuture(
+                      optR.traverse(Converter.fromCreated(valueTranslator, _))
+                    )
+                    v <- run(SEApp(SEValue(continue), Array(SEValue(SOptional(optR)))))
+                  } yield v
+
+                case ScriptF.AllocParty(displayName, idHint, participant, continue) =>
+                  for {
+                    client <- clients.getParticipant(participant) match {
+                      case Right(client) => Future.successful(client)
+                      case Left(err) => Future.failed(new RuntimeException(err))
+                    }
+                    party <- client.allocateParty(idHint, displayName)
+                    v <- {
+                      participant match {
+                        case None => {
+                          // If no participant is specified, we use default_participant so we don’t need to change anything.
+                        }
+                        case Some(participant) =>
+                          clients = clients
+                            .copy(
+                              party_participants =
+                                clients.party_participants + (party -> participant)
+                            )
                       }
-                    } yield v
-                  }
-                }
-              case "GetTime" =>
-                m2c("a function") { case continue =>
+                      run(SEApp(SEValue(continue), Array(SEValue(SParty(party)))))
+                    }
+                  } yield v
+                case ScriptF.ListKnownParties(participant, continue) =>
+                  for {
+                    client <- clients.getParticipant(participant) match {
+                      case Right(client) => Future.successful(client)
+                      case Left(err) => Future.failed(new RuntimeException(err))
+                    }
+                    partyDetails <- client.listKnownParties()
+                    partyDetails_ <- Converter.toFuture(
+                      partyDetails
+                        .traverse(details => Converter.fromPartyDetails(script.scriptIds, details))
+                    )
+                    v <- {
+                      run(
+                        SEApp(SEValue(continue), Array(SEValue(SList(FrontStack(partyDetails_)))))
+                      )
+                    }
+                  } yield v
+                case ScriptF.GetTime(continue) =>
                   for {
                     time <- timeMode match {
                       case ScriptTimeMode.Static => {
@@ -753,10 +634,7 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
                     v <- run(SEApp(SEValue(continue), Array(SEValue(STimestamp(time)))))
 
                   } yield v
-
-                }
-              case "SetTime" =>
-                m2c("SetTimePayload") { case SRecord(_, _, JavaList(sT, continue)) =>
+                case ScriptF.SetTime(time, continue) =>
                   timeMode match {
                     case ScriptTimeMode.Static =>
                       for {
@@ -764,8 +642,7 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
                         // is only useful in static time mode and using the time
                         // service with multiple participants is very dodgy.
                         client <- Converter.toFuture(clients.getParticipant(None))
-                        t <- Converter.toFuture(Converter.toTimestamp(sT))
-                        _ <- client.setStaticTime(t)
+                        _ <- client.setStaticTime(time)
                         v <- run(SEApp(SEValue(continue), Array(SEValue(SUnit))))
                       } yield v
                     case ScriptTimeMode.WallClock =>
@@ -774,51 +651,12 @@ class Runner(compiledPackages: CompiledPackages, script: Script.Action, timeMode
                       )
 
                   }
-                }
-              case "Sleep" =>
-                m2c("record with 2 fields") {
-                  case SRecord(
-                        _,
-                        _,
-                        JavaList(SRecord(_, _, JavaList(SInt64(sleepMicros))), continue),
-                      ) =>
-                    val sleepMillis = sleepMicros / 1000
-                    val sleepNanos = (sleepMicros % 1000) * 1000
-                    Thread.sleep(sleepMillis, sleepNanos.toInt)
-                    run(SEApp(SEValue(continue), Array(SEValue(SUnit))))
-                }
-              case "QueryContractId" =>
-                m2c("record with 4 fields") {
-                  case SRecord(_, _, JavaList(sParty, sTplId, sCid, continue)) =>
-                    for {
-                      parties <- Converter.toFuture(Converter.toParties(sParty))
-                      tplId <- Converter.toFuture(Converter.typeRepToIdentifier(sTplId))
-                      cid <- Converter.toFuture(toContractId(sCid))
-                      client <- Converter.toFuture(clients.getPartyParticipant(parties.head))
-                      optR <- client.queryContractId(parties, tplId, cid)
-                      optR <- Converter.toFuture(
-                        optR.traverse(Converter.fromContract(valueTranslator, _))
-                      )
-                      v <- run(SEApp(SEValue(continue), Array(SEValue(SOptional(optR)))))
-                    } yield v
-                }
-              case "QueryContractKey" =>
-                m2c("record with 4 fields") {
-                  case SRecord(_, _, JavaList(sParties, sTplId, sKey, continue)) =>
-                    for {
-                      parties <- Converter.toFuture(Converter.toParties(sParties))
-                      tplId <- Converter.toFuture(Converter.typeRepToIdentifier(sTplId))
-                      key <- Converter.toFuture(Converter.toAnyContractKey(sKey))
-                      client <- Converter.toFuture(clients.getPartiesParticipant(parties))
-                      optR <- client.queryContractKey(parties, tplId, key.key, translateKey)
-                      optR <- Converter.toFuture(
-                        optR.traverse(Converter.fromCreated(valueTranslator, _))
-                      )
-                      v <- run(SEApp(SEValue(continue), Array(SEValue(SOptional(optR)))))
-                    } yield v
-                }
-              case _ => m2c("Submit, Query or AllocParty")(PartialFunction.empty)
-            }
+                case ScriptF.Sleep(micros, continue) =>
+                  val sleepMillis = micros / 1000
+                  val sleepNanos = (micros % 1000) * 1000
+                  Thread.sleep(sleepMillis, sleepNanos.toInt)
+                  run(SEApp(SEValue(continue), Array(SEValue(SUnit))))
+              }
           case Left(v) =>
             v match {
               case SRecord(_, _, JavaList(newState, _)) => {

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ScriptF.scala
@@ -1,0 +1,220 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.lf.engine.script
+
+import com.daml.lf.command
+import com.daml.lf.CompiledPackages
+import com.daml.lf.data.Ref.{Identifier, Location, PackageId, Party}
+import com.daml.lf.data.Time.Timestamp
+import com.daml.lf.language.Ast
+import com.daml.lf.speedy.SValue
+import com.daml.lf.speedy.SValue.{SInt64, SList, SRecord, SText}
+import com.daml.lf.value.Value.ContractId
+import com.daml.script.converter.Converter.JavaList
+import scalaz.{Foldable, OneAnd}
+import scalaz.syntax.traverse._
+import scalaz.std.list._
+import scalaz.std.either._
+import com.daml.script.converter.Converter.toContractId
+
+object ScriptF {
+  sealed trait Cmd
+  final case class Submit(data: SubmitData) extends Cmd
+  final case class SubmitMustFail(data: SubmitData) extends Cmd
+  final case class SubmitTree(data: SubmitData) extends Cmd
+  final case class Query(parties: OneAnd[Set, Party], tplId: Identifier, continue: SValue)
+      extends Cmd
+  final case class QueryContractId(
+      parties: OneAnd[Set, Party],
+      tplId: Identifier,
+      cid: ContractId,
+      continue: SValue,
+  ) extends Cmd
+  final case class QueryContractKey(
+      parties: OneAnd[Set, Party],
+      tplId: Identifier,
+      key: AnyContractKey,
+      continue: SValue,
+  ) extends Cmd
+  final case class AllocParty(
+      displayName: String,
+      idHint: String,
+      participant: Option[Participant],
+      continue: SValue,
+  ) extends Cmd
+  final case class ListKnownParties(participant: Option[Participant], continue: SValue) extends Cmd
+  final case class GetTime(continue: SValue) extends Cmd
+  final case class SetTime(time: Timestamp, continue: SValue) extends Cmd
+  final case class Sleep(micros: Long, continue: SValue) extends Cmd
+
+  // Shared between Submit, SubmitMustFail and SubmitTree
+  final case class SubmitData(
+      actAs: OneAnd[Set, Party],
+      readAs: Set[Party],
+      cmds: List[command.Command],
+      freeAp: SValue,
+      commitLocation: Option[Location],
+      continue: SValue,
+  )
+
+  final case class Ctx(knownPackages: Map[String, PackageId], compiledPackages: CompiledPackages)
+
+  def parseSubmit(ctx: Ctx, v: SValue): Either[String, SubmitData] = {
+    def convert(
+        actAs: OneAnd[List, SValue],
+        readAs: List[SValue],
+        freeAp: SValue,
+        continue: SValue,
+        loc: Option[SValue],
+    ) =
+      for {
+        actAs <- actAs.traverse(Converter.toParty(_)).map(toOneAndSet(_))
+        readAs <- readAs.traverse(Converter.toParty(_))
+        cmds <- Converter.toCommands(ctx.compiledPackages, freeAp)
+        commitLocation <- loc.fold(Right(None): Either[String, Option[Location]])(sLoc =>
+          Converter.toOptionLocation(ctx.knownPackages, sLoc)
+        )
+      } yield SubmitData(actAs, readAs.toSet, cmds, freeAp, commitLocation, continue)
+    v match {
+      // no location
+      case SRecord(_, _, JavaList(sParty, SRecord(_, _, JavaList(freeAp)), continue)) =>
+        convert(OneAnd(sParty, List()), List(), freeAp, continue, None)
+      // location
+      case SRecord(_, _, JavaList(sParty, SRecord(_, _, JavaList(freeAp)), continue, loc)) =>
+        convert(OneAnd(sParty, List()), List(), freeAp, continue, Some(loc))
+      // multi-party actAs/readAs + location
+      case SRecord(
+            _,
+            _,
+            JavaList(
+              SRecord(_, _, JavaList(hdAct, SList(tlAct))),
+              SList(read),
+              SRecord(_, _, JavaList(freeAp)),
+              continue,
+              loc,
+            ),
+          ) =>
+        convert(OneAnd(hdAct, tlAct.toList), read.toList, freeAp, continue, Some(loc))
+      case _ => Left(s"Expected Submit payload but got $v")
+    }
+  }
+
+  def parseQuery(v: SValue): Either[String, Query] = {
+    def convert(readAs: SValue, tplId: SValue, continue: SValue) =
+      for {
+        readAs <- Converter.toParties(readAs)
+        tplId <- Converter
+          .typeRepToIdentifier(tplId)
+      } yield Query(readAs, tplId, continue)
+    v match {
+      case SRecord(_, _, JavaList(actAs, tplId, continue)) =>
+        convert(actAs, tplId, continue)
+      case _ => Left(s"Expected Query payload but got $v")
+    }
+  }
+
+  def parseQueryContractId(v: SValue): Either[String, QueryContractId] = {
+    def convert(actAs: SValue, tplId: SValue, cid: SValue, continue: SValue) =
+      for {
+        actAs <- Converter.toParties(actAs)
+        tplId <- Converter.typeRepToIdentifier(tplId)
+        cid <- toContractId(cid)
+      } yield QueryContractId(actAs, tplId, cid, continue)
+    v match {
+      case SRecord(_, _, JavaList(actAs, tplId, cid, continue)) =>
+        convert(actAs, tplId, cid, continue)
+      case _ => Left(s"Expected QueryContractId payload but got $v")
+    }
+  }
+
+  def parseQueryContractKey(v: SValue): Either[String, QueryContractKey] = {
+    def convert(actAs: SValue, tplId: SValue, key: SValue, continue: SValue) =
+      for {
+        actAs <- Converter.toParties(actAs)
+        tplId <- Converter.typeRepToIdentifier(tplId)
+        key <- Converter.toAnyContractKey(key)
+      } yield QueryContractKey(actAs, tplId, key, continue)
+    v match {
+      case SRecord(_, _, JavaList(actAs, tplId, key, continue)) =>
+        convert(actAs, tplId, key, continue)
+      case _ => Left(s"Expected QueryContractKey payload but got $v")
+    }
+  }
+
+  def parseAllocParty(v: SValue): Either[String, AllocParty] = {
+    def convert(displayName: String, idHint: String, participantName: SValue, continue: SValue) =
+      for {
+        participantName <- Converter.toParticipantName(participantName)
+      } yield AllocParty(displayName, idHint, participantName, continue)
+    v match {
+      case SRecord(
+            _,
+            _,
+            JavaList(
+              SText(displayName),
+              SText(idHint),
+              participantName,
+              continue,
+            ),
+          ) =>
+        convert(displayName, idHint, participantName, continue)
+      case _ => Left(s"Expected AllocParty payload but got $v")
+    }
+  }
+
+  def parseListKnownParties(v: SValue): Either[String, ListKnownParties] = {
+    def convert(participantName: SValue, continue: SValue) =
+      for {
+        participantName <- Converter.toParticipantName(participantName)
+      } yield ListKnownParties(participantName, continue)
+    v match {
+      case SRecord(_, _, JavaList(participantName, continue)) => convert(participantName, continue)
+      case _ => Left(s"Expected ListKnownParties payload but got $v")
+    }
+  }
+
+  def parseGetTime(v: SValue): Either[String, GetTime] = {
+    Right(GetTime(v))
+  }
+
+  def parseSetTime(v: SValue): Either[String, SetTime] = {
+    def convert(time: SValue, continue: SValue) =
+      for {
+        time <- Converter.toTimestamp(time)
+      } yield SetTime(time, continue)
+    v match {
+      case SRecord(_, _, JavaList(time, continue)) => convert(time, continue)
+      case _ => Left(s"Expected SetTime payload but got $v")
+    }
+  }
+
+  def parseSleep(v: SValue): Either[String, Sleep] = {
+    def convert(micros: Long, continue: SValue) =
+      Right(Sleep(micros, continue))
+    v match {
+      case SRecord(_, _, JavaList(SRecord(_, _, JavaList(SInt64(micros))), continue)) =>
+        convert(micros, continue)
+      case _ => Left(s"Expected Sleep payload but got $v")
+    }
+
+  }
+
+  def parse(ctx: Ctx, constr: Ast.VariantConName, v: SValue): Either[String, Cmd] = constr match {
+    case "Submit" => parseSubmit(ctx, v).map(Submit(_))
+    case "SubmitMustFail" => parseSubmit(ctx, v).map(SubmitMustFail(_))
+    case "SubmitTree" => parseSubmit(ctx, v).map(SubmitTree(_))
+    case "Query" => parseQuery(v)
+    case "QueryContractId" => parseQueryContractId(v)
+    case "QueryContractKey" => parseQueryContractKey(v)
+    case "AllocParty" => parseAllocParty(v)
+    case "ListKnownParties" => parseListKnownParties(v)
+    case "GetTime" => parseGetTime(v)
+    case "SetTime" => parseSetTime(v)
+    case "Sleep" => parseSleep(v)
+    case _ => Left(s"Unknown contructor $constr")
+  }
+
+  private def toOneAndSet[F[_], A](x: OneAnd[F, A])(implicit fF: Foldable[F]): OneAnd[Set, A] =
+    OneAnd(x.head, x.tail.toSet - x.head)
+}


### PR DESCRIPTION
I was trying to add stacktraces and this giant pattern match got
really annoying so this PR tries to improve the situation somewhat by
factoring out the parsing into a separate module. There is more stuff
we can do here but this is at least a start.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
