### PR TITLE
Fix protobuf structure for empty import prefix

### DIFF
--- a/bazel_tools/proto.bzl
+++ b/bazel_tools/proto.bzl
@@ -207,12 +207,16 @@ def proto_jars(
         maven_artifact_proto_suffix = "proto",
         maven_artifact_java_suffix = "java-proto",
         maven_artifact_scala_suffix = "scala-proto"):
+    # NOTE (MK) An empty string flattens the whole structure which is
+    # rarely what you want, see https://github.com/bazelbuild/rules_pkg/issues/82
+    tar_strip_prefix = "." if not strip_import_prefix else strip_import_prefix
+
     # Tarball containing the *.proto files.
     pkg_tar(
         name = "%s_tar" % name,
         srcs = srcs,
         extension = "tar.gz",
-        strip_prefix = strip_import_prefix,
+        strip_prefix = tar_strip_prefix,
         visibility = [":__subpackages__", "//release:__subpackages__"],
     )
 


### PR DESCRIPTION
https://github.com/digital-asset/daml/commit/052f69cde93d98eaeefe8938f5d33d2e80ca96eb
broke the structure of our protobufs by changing the import prefix
from "." to an empty string which ends up flattening the whole
file. This PR changes the default for tars to match the old
behavior. We can’t just change the default at the function level since
the prefix is used outside of pkg_tar and in those places an empty
string is required :(

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
