### PR TITLE
Use single party submit/submitTree where appropriate

### DIFF
--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -269,7 +269,7 @@ private[dump] object Encode {
         val encodedCids = referencedCids.map(encodeCid(cidMap, _))
         (tuple(encodedCids) :+ " <- ", "pure " +: tuple(encodedCids))
     }
-    val submit = "submitMulti " +: encodeParties(partyMap, submitters)
+    val submit = "submitMulti " +: encodeParties(partyMap, submitters) :+ " []"
     val actions = Doc.stack(evs.map { ev =>
       val cid = ContractId(ev.contractId)
       val bind = if (returnStmt.nonEmpty) {
@@ -284,7 +284,7 @@ private[dump] object Encode {
       bind + encodeCreatedEvent(partyMap, cidMap, ev)
     })
     val body = Doc.stack(Seq(actions, returnStmt).filter(d => d.nonEmpty))
-    ((bind + submit :+ " [] do") / body).hang(2)
+    ((bind + submit :+ " do") / body).hang(2)
   }
 
   private[dump] def encodeACS(

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -269,10 +269,6 @@ private[dump] object Encode {
         val encodedCids = referencedCids.map(encodeCid(cidMap, _))
         (tuple(encodedCids) :+ " <- ", "pure " +: tuple(encodedCids))
     }
-    val submit = submitters.toList match {
-      case ::(submitter, Nil) => "submit " +: encodeParty(partyMap, submitter)
-      case _ => "submitMulti " +: encodeParties(partyMap, submitters) :+ " []"
-    }
     val actions = Doc.stack(evs.map { ev =>
       val cid = ContractId(ev.contractId)
       val bind = if (returnStmt.nonEmpty) {
@@ -287,7 +283,7 @@ private[dump] object Encode {
       bind + encodeCreatedEvent(partyMap, cidMap, ev)
     })
     val body = Doc.stack(Seq(actions, returnStmt).filter(d => d.nonEmpty))
-    ((bind + submit :+ " do") / body).hang(2)
+    ((bind + submit(partyMap, submitters, isTree = false) :+ " do") / body).hang(2)
   }
 
   private[dump] def encodeACS(
@@ -326,12 +322,8 @@ private[dump] object Encode {
         val submitters = rootEvs.flatMap(evParties(_)).toSet
         val cids = treeCreatedCids(tree)
         val referencedCids = cids.filter(c => cidRefs.contains(c.cid))
-        val submit = submitters.toList match {
-          case ::(submitter, Nil) => "submitTree " +: encodeParty(partyMap, submitter)
-          case _ => "submitTreeMulti " +: encodeParties(partyMap, submitters) :+ " []"
-        }
         val treeBind =
-          (("tree <- " +: submit :+ " do") /
+          (("tree <- " +: submit(partyMap, submitters, isTree = true) :+ " do") /
             Doc.stack(rootEvs.map(ev => encodeEv(partyMap, cidMap, ev)))).hang(2)
         val cidBinds = referencedCids.map(bindCid(cidMap, _))
         Doc.stack(treeBind +: cidBinds)
@@ -340,6 +332,15 @@ private[dump] object Encode {
   }
 
   private def encodeSelector(selector: Selector): Doc = Doc.str(selector.i)
+
+  private def submit(partyMap: Map[Party, String], submitters: Set[Party], isTree: Boolean): Doc = {
+    val tree = if (isTree) { Doc.text("Tree") }
+    else { Doc.empty }
+    submitters.toList match {
+      case ::(submitter, Nil) => "submit" +: tree & encodeParty(partyMap, submitter)
+      case _ => "submit" +: tree :+ "Multi" & encodeParties(partyMap, submitters) :+ " []"
+    }
+  }
 
   private def encodeImport(moduleName: String) =
     Doc.text("import qualified ") + Doc.text(moduleName)

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeAcsSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeAcsSpec.scala
@@ -31,13 +31,13 @@ class EncodeAcsSpec extends AnyFreeSpec with Matchers {
         .toCreatedEvents
       "batch size 1" in {
         encodeACS(parties, cidMap, cidRefs, events, 1).render(80) shouldBe
-          """_ <- submitMulti [alice_0] [] do
+          """_ <- submit alice_0 do
             |  createCmd Module.Template
-            |_ <- submitMulti [alice_0] [] do
+            |_ <- submit alice_0 do
             |  createCmd Module.Template
-            |_ <- submitMulti [alice_0] [] do
+            |_ <- submit alice_0 do
             |  createCmd Module.Template
-            |_ <- submitMulti [alice_0] [] do
+            |_ <- submit alice_0 do
             |  createCmd Module.Template""".stripMargin.replace(
             "\r\n",
             "\n",
@@ -45,11 +45,11 @@ class EncodeAcsSpec extends AnyFreeSpec with Matchers {
       }
       "batch size 2 - divides evenly" in {
         encodeACS(parties, cidMap, cidRefs, events, 2).render(80) shouldBe
-          """submitMulti [alice_0] [] do
+          """submit alice_0 do
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
             |  pure ()
-            |submitMulti [alice_0] [] do
+            |submit alice_0 do
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
             |  pure ()""".stripMargin.replace(
@@ -59,12 +59,12 @@ class EncodeAcsSpec extends AnyFreeSpec with Matchers {
       }
       "batch size 3 - does not divide evenly" in {
         encodeACS(parties, cidMap, cidRefs, events, 3).render(80) shouldBe
-          """submitMulti [alice_0] [] do
+          """submit alice_0 do
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
             |  pure ()
-            |_ <- submitMulti [alice_0] [] do
+            |_ <- submit alice_0 do
             |  createCmd Module.Template""".stripMargin.replace(
             "\r\n",
             "\n",
@@ -72,7 +72,7 @@ class EncodeAcsSpec extends AnyFreeSpec with Matchers {
       }
       "batch size 4 - equals total size" in {
         encodeACS(parties, cidMap, cidRefs, events, 4).render(80) shouldBe
-          """submitMulti [alice_0] [] do
+          """submit alice_0 do
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
@@ -84,7 +84,7 @@ class EncodeAcsSpec extends AnyFreeSpec with Matchers {
       }
       "batch size 5 - greater than total size" in {
         encodeACS(parties, cidMap, cidRefs, events, 5).render(80) shouldBe
-          """submitMulti [alice_0] [] do
+          """submit alice_0 do
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
@@ -23,7 +23,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
           )
           .toCreatedEvents
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
-          """_ <- submitMulti [alice_0] [] do
+          """_ <- submit alice_0 do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
       }
       "referenced" in {
@@ -38,7 +38,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
           )
           .toCreatedEvents
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
-          """contract_0_0 <- submitMulti [alice_0] [] do
+          """contract_0_0 <- submit alice_0 do
             |  createCmd Module.Template""".stripMargin.replace(
             "\r\n",
             "\n",
@@ -62,7 +62,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
           )
           .toCreatedEvents
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
-          """submitMulti [alice_0] [] do
+          """submit alice_0 do
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
@@ -89,7 +89,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
           )
           .toCreatedEvents
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
-          """(contract_0_0, contract_0_2) <- submitMulti [alice_0] [] do
+          """(contract_0_0, contract_0_2) <- submit alice_0 do
             |  contract_0_0 <- createCmd Module.Template
             |  _ <- createCmd Module.Template
             |  contract_0_2 <- createCmd Module.Template
@@ -114,7 +114,7 @@ class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
           )
           .toCreatedEvents
         encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
-          """contract_0_1 <- submitMulti [alice_0] [] do
+          """contract_0_1 <- submit alice_0 do
             |  _ <- createCmd Module.Template
             |  contract_0_1 <- createCmd Module.Template
             |  pure contract_0_1""".stripMargin.replace(

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
@@ -10,6 +10,33 @@ import org.scalatest.matchers.should.Matchers
 class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
   import Encode._
   "encodeCreatedEvent" - {
+    "multi party submissions" in {
+      val parties = Map(
+        Party("Alice") -> "alice_0",
+        Party("Bob") -> "bob_0",
+      )
+      val cidMap = Map(
+        ContractId("cid1") -> "contract_0_0",
+        ContractId("cid2") -> "contract_0_1",
+      )
+      val cidRefs = Set.empty[ContractId]
+      val events = TestData
+        .ACS(
+          Seq(
+            TestData.Created(ContractId("cid1"), submitters = Seq(Party("Alice"))),
+            TestData.Created(ContractId("cid2"), submitters = Seq(Party("Bob"))),
+          )
+        )
+        .toCreatedEvents
+      encodeSubmitCreatedEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
+        """submitMulti [alice_0, bob_0] [] do
+          |  _ <- createCmd Module.Template
+          |  _ <- createCmd Module.Template
+          |  pure ()""".stripMargin.replace(
+          "\r\n",
+          "\n",
+        )
+    }
     "contract id bindings" - {
       "unreferenced" in {
         val parties = Map(Party("Alice") -> "alice_0")

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
@@ -10,6 +10,29 @@ import org.scalatest.matchers.should.Matchers
 class EncodeTreeSpec extends AnyFreeSpec with Matchers {
   import Encode._
   "encodeTree" - {
+    "multi-party submissions" in {
+      val parties = Map(
+        Party("Alice") -> "alice_0",
+        Party("Bob") -> "bob_0",
+      )
+      val cidMap = Map(
+        ContractId("cid1") -> "contract_0_0",
+        ContractId("cid2") -> "contract_0_1",
+      )
+      val cidRefs = Set.empty[ContractId]
+      val tree = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1"), submitters = Seq(Party("Alice"))),
+            TestData.Exercised(ContractId("cid2"), Seq.empty, actingParties = Seq(Party("Bob"))),
+          )
+        )
+        .toTransactionTree
+      encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
+        """tree <- submitTreeMulti [alice_0, bob_0] [] do
+          |  createCmd Module.Template
+          |  exerciseCmd contract_0_1 (Module.Choice ())""".stripMargin.replace("\r\n", "\n")
+    }
     "contract id bindings" - {
       "unreferenced create" in {
         val parties = Map(Party("Alice") -> "alice_0")

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
@@ -23,7 +23,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           )
           .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
-          """_ <- submitMulti [alice_0] [] do
+          """_ <- submit alice_0 do
             |  createCmd Module.Template""".stripMargin.replace("\r\n", "\n")
       }
       "unreferenced creates" in {
@@ -42,7 +42,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           )
           .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
-          """submitMulti [alice_0] [] do
+          """submit alice_0 do
             |  _ <- createCmd Module.Template
             |  _ <- createCmd Module.Template
             |  pure ()""".stripMargin.replace("\r\n", "\n")
@@ -68,7 +68,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           )
           .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
-          """tree <- submitTreeMulti [alice_0] [] do
+          """tree <- submitTree alice_0 do
             |  exerciseCmd contract_0_0 (Module.Choice ())""".stripMargin.replace("\r\n", "\n")
       }
       "referenced create" in {
@@ -83,7 +83,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           )
           .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
-          """contract_0_0 <- submitMulti [alice_0] [] do
+          """contract_0_0 <- submit alice_0 do
             |  createCmd Module.Template""".stripMargin.replace(
             "\r\n",
             "\n",
@@ -105,7 +105,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           )
           .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
-          """(contract_1_0, contract_1_1) <- submitMulti [alice_0] [] do
+          """(contract_1_0, contract_1_1) <- submit alice_0 do
             |  contract_1_0 <- createCmd Module.Template
             |  contract_1_1 <- createCmd Module.Template
             |  pure (contract_1_0, contract_1_1)""".stripMargin.replace(
@@ -135,7 +135,7 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
           )
           .toTransactionTree
         encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
-          """tree <- submitTreeMulti [alice_0] [] do
+          """tree <- submitTree alice_0 do
             |  exerciseCmd contract_0_0 (Module.Choice ())
             |let contract_1_0 = createdCid @Module.Template [0, 0] tree
             |let contract_1_1 = createdCid @Module.Template [0, 1] tree""".stripMargin.replace(


### PR DESCRIPTION
Part of #8774 

If the list of submitters is a singleton set we can use `submit`/`submitTree` instead of `submitMulti`/`submitTreeMulti`.
This extends the test cases to cover multi-party submissions.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
