### PR TITLE
pkg deps: Move all dalfs to package dependency directory

### DIFF
--- a/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
+++ b/compiler/damlc/daml-ide-core/src/Development/IDE/Core/Rules/Daml.hs
@@ -473,11 +473,13 @@ generateDocTestModuleRule =
 -- TODO (drsk): We might want to change this to load only needed packages in the future.
 generatePackageMap :: LF.Version -> Maybe NormalizedFilePath -> [FilePath] -> IO ([FileDiagnostic], Map.Map UnitId LF.DalfPackage)
 generatePackageMap version mbProjRoot userPkgDbs = do
-    versionedPackageDbs <- getPackageDbs version mbProjRoot userPkgDbs
+    versionedPackageDbs <- getPackageDbs version Nothing userPkgDbs
+    depDbs' <- getDependenciesDbs version mbProjRoot
+    let depDbs = versionedPackageDbs ++ depDbs'
     (diags, pkgs) <-
         fmap (partitionEithers . concat) $
-        forM versionedPackageDbs $ \pkgDb -> do
-            allFiles <- listFilesRecursive pkgDb
+        forM depDbs $ \depDb -> do
+            allFiles <- listFilesRecursive depDb
             let dalfs = filter ((== ".dalf") . takeExtension) allFiles
             forM dalfs $ \dalf -> do
                 dalfPkgOrErr <- readDalfPackage dalf

--- a/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
+++ b/compiler/damlc/daml-opts/daml-opts-types/DA/Daml/Options/Types.hs
@@ -19,11 +19,13 @@ module DA.Daml.Options.Types
     , getBaseDir
     , damlArtifactDir
     , projectPackageDatabase
+    , projectDependenciesDatabase
     , ifaceDir
     , distDir
     , genDir
     , basePackages
     , getPackageDbs
+    , getDependenciesDbs
     , pkgNameVersion
     , fullPkgName
     , optUnitId
@@ -138,6 +140,9 @@ damlArtifactDir = ".daml"
 projectPackageDatabase :: FilePath
 projectPackageDatabase = damlArtifactDir </> "package-database"
 
+projectDependenciesDatabase :: FilePath
+projectDependenciesDatabase = damlArtifactDir </> "dependencies"
+
 ifaceDir :: FilePath
 ifaceDir = damlArtifactDir </> "interfaces"
 
@@ -165,6 +170,17 @@ getPackageDbs :: LF.Version -> Maybe NormalizedFilePath -> [FilePath] -> IO [Fil
 getPackageDbs version mbProjRoot userPkgDbs = do
     builtinPkgDbs <- locateBuiltinPackageDbs mbProjRoot
     pure $ map (</> renderPretty version) (builtinPkgDbs ++ userPkgDbs)
+
+getDependenciesDbs :: LF.Version -> Maybe NormalizedFilePath -> IO [FilePath]
+getDependenciesDbs version =
+    \case
+        Nothing -> pure []
+        Just projRoot -> do
+            let depsDb =
+                    fromNormalizedFilePath projRoot </> projectDependenciesDatabase </>
+                    renderPretty version
+            hasDepsDb <- Dir.doesDirectoryExist depsDb
+            pure $ [depsDb | hasDepsDb]
 
 defaultOptions :: Maybe LF.Version -> Options
 defaultOptions mbVersion =


### PR DESCRIPTION
As a first step for the daml package manager, we move all dalf files
from (data-)dependencies to a new `.daml/dependencies` directory.

CHANGELOG_BEGIN
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
