### PR TITLE
Use DA.Map in triggers if available

### DIFF
--- a/docs/source/upgrade/example/carbon-upgrade-trigger/daml/UpgradeTrigger.daml
+++ b/docs/source/upgrade/example/carbon-upgrade-trigger/daml/UpgradeTrigger.daml
@@ -1,11 +1,16 @@
 -- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE CPP #-}
 
 module UpgradeTrigger where
 
 import DA.Assert
 import DA.Foldable
+#ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
+import qualified DA.Map as Map
+#else
 import qualified DA.Next.Map as Map
+#endif
 import Daml.Trigger
 import Daml.Trigger.Assert
 import qualified Daml.Script as Script

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -52,9 +52,6 @@ import DA.Action.State (execState)
 import DA.Foldable (any)
 import DA.Functor ((<&>))
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
-import qualified DA.Map as GMap
-#endif
-#ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
 import DA.Map (Map)
 import qualified DA.Map as Map
 #else
@@ -74,8 +71,8 @@ getContracts : forall a. Template a => ACS -> [(ContractId a, a)]
 getContracts (ACS tpls pending) = mapOptional fromAny
                                 $ filter (\(cid, _) -> not $ cid `elem` allPending)
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
-                                $ optional [] GMap.toList
-                                $ GMap.lookup (templateTypeRep @a)
+                                $ optional [] Map.toList
+                                $ Map.lookup (templateTypeRep @a)
 #endif
                                   tpls
   where
@@ -86,7 +83,7 @@ getContractById : forall a. Template a => ContractId a -> ACS -> Optional a
 getContractById id (ACS tpls pending) = do
   let aid = toAnyContractId id
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
-      implSpecific = GMap.lookup aid <=< GMap.lookup (templateTypeRep @a)
+      implSpecific = Map.lookup aid <=< Map.lookup (templateTypeRep @a)
 #else
       implSpecific = fmap snd . find ((aid ==) . fst)
 #endif

--- a/triggers/daml/Daml/Trigger.daml
+++ b/triggers/daml/Daml/Trigger.daml
@@ -1,7 +1,7 @@
 -- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 
 module Daml.Trigger
  ( query
@@ -54,8 +54,13 @@ import DA.Functor ((<&>))
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
 import qualified DA.Map as GMap
 #endif
+#ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
+import DA.Map (Map)
+import qualified DA.Map as Map
+#else
 import DA.Next.Map (Map)
 import qualified DA.Next.Map as Map
+#endif
 import DA.Optional
 
 import Daml.Trigger.Internal

--- a/triggers/daml/Daml/Trigger/Assert.daml
+++ b/triggers/daml/Daml/Trigger/Assert.daml
@@ -1,6 +1,7 @@
 -- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 
 module Daml.Trigger.Assert
  ( ACSBuilder
@@ -13,8 +14,13 @@ module Daml.Trigger.Assert
  ) where
 
 import qualified DA.List as List
+#ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
+import DA.Map (Map)
+import qualified DA.Map as Map
+#else
 import DA.Next.Map (Map)
 import qualified DA.Next.Map as Map
+#endif
 import qualified DA.Text as Text
 
 import Daml.Trigger hiding (queryContractId)

--- a/triggers/daml/Daml/Trigger/Internal.daml
+++ b/triggers/daml/Daml/Trigger/Internal.daml
@@ -27,13 +27,10 @@ import DA.Functor ((<&>))
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
 import DA.Map (Map)
 import qualified DA.Map as Map
+import DA.Optional (fromOptional)
 #else
 import DA.Next.Map (Map)
 import qualified DA.Next.Map as Map
-#endif
-#ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
-import qualified DA.Map as GMap
-import DA.Optional (fromOptional)
 #endif
 
 import Daml.Trigger.LowLevel hiding (Trigger)
@@ -47,8 +44,8 @@ import Daml.Trigger.LowLevel hiding (Trigger)
 data ACS = ACS
   { activeContracts :
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
-      GMap.Map TemplateTypeRep
-        (GMap.Map AnyContractId AnyTemplate)
+      Map.Map TemplateTypeRep
+        (Map.Map AnyContractId AnyTemplate)
 #else
       [(AnyContractId, AnyTemplate)]
 #endif
@@ -117,8 +114,8 @@ addCommands m (Commands cid cmds) = Map.insert cid cmds m
 -- | HIDE
 insertTpl : AnyContractId -> AnyTemplate -> ACS -> ACS
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
-insertTpl cid tpl acs = acs { activeContracts = GMap.alter addct cid.templateId acs.activeContracts }
-  where addct = Some . GMap.insert cid tpl . fromOptional mempty
+insertTpl cid tpl acs = acs { activeContracts = Map.alter addct cid.templateId acs.activeContracts }
+  where addct = Some . Map.insert cid tpl . fromOptional mempty
 #else
 insertTpl cid tpl acs = acs { activeContracts = (cid, tpl) :: acs.activeContracts }
 #endif
@@ -126,9 +123,9 @@ insertTpl cid tpl acs = acs { activeContracts = (cid, tpl) :: acs.activeContract
 -- | HIDE
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
 groupActiveContracts :
-  [(AnyContractId, AnyTemplate)] -> GMap.Map TemplateTypeRep (GMap.Map AnyContractId AnyTemplate)
-groupActiveContracts = foldr (\v@(cid, _) -> GMap.alter (addct v) cid.templateId) GMap.empty
-  where addct (cid, tpl) = Some . GMap.insert cid tpl . fromOptional mempty
+  [(AnyContractId, AnyTemplate)] -> Map.Map TemplateTypeRep (Map.Map AnyContractId AnyTemplate)
+groupActiveContracts = foldr (\v@(cid, _) -> Map.alter (addct v) cid.templateId) Map.empty
+  where addct (cid, tpl) = Some . Map.insert cid tpl . fromOptional mempty
 #else
 groupActiveContracts : forall a. a -> a
 groupActiveContracts a = a
@@ -137,11 +134,11 @@ groupActiveContracts a = a
 -- | HIDE
 deleteTpl : AnyContractId -> ACS -> ACS
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
-deleteTpl cid acs = acs { activeContracts = GMap.alter rmct cid.templateId acs.activeContracts }
+deleteTpl cid acs = acs { activeContracts = Map.alter rmct cid.templateId acs.activeContracts }
   where rmct om = do
           m <- om
-          let m' = GMap.delete cid m
-          if GMap.null m' then None else Some m'
+          let m' = Map.delete cid m
+          if Map.null m' then None else Some m'
 #else
 deleteTpl cid acs = acs { activeContracts = filter (\(cid', _) -> cid /= cid') acs.activeContracts }
 #endif
@@ -150,7 +147,7 @@ deleteTpl cid acs = acs { activeContracts = filter (\(cid', _) -> cid /= cid') a
 lookupTpl : Template a => AnyContractId -> ACS -> Optional a
 lookupTpl cid acs = do
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
-  tpl <- GMap.lookup cid =<< GMap.lookup cid.templateId acs.activeContracts
+  tpl <- Map.lookup cid =<< Map.lookup cid.templateId acs.activeContracts
 #else
   (_, tpl) <- find ((cid ==) . fst) acs.activeContracts
 #endif

--- a/triggers/daml/Daml/Trigger/Internal.daml
+++ b/triggers/daml/Daml/Trigger/Internal.daml
@@ -24,8 +24,13 @@ module Daml.Trigger.Internal
 
 import DA.Action.State
 import DA.Functor ((<&>))
+#ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
+import DA.Map (Map)
+import qualified DA.Map as Map
+#else
 import DA.Next.Map (Map)
 import qualified DA.Next.Map as Map
+#endif
 #ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
 import qualified DA.Map as GMap
 import DA.Optional (fromOptional)

--- a/triggers/daml/Daml/Trigger/LowLevel.daml
+++ b/triggers/daml/Daml/Trigger/LowLevel.daml
@@ -47,7 +47,9 @@ module Daml.Trigger.LowLevel
 import DA.Action.State
 import DA.Action.State.Class
 import DA.Functor ((<&>))
+#ifndef DAML_GENMAP && DAML_GENERIC_COMPARISON
 import DA.Next.Map (MapKey(..))
+#endif
 import DA.Time (RelTime(..))
 import Daml.Script.Free (Free(..), lift, foldFree)
 
@@ -91,7 +93,11 @@ newtype EventId = EventId Text
   deriving (Show, Eq)
 
 newtype CommandId = CommandId Text
+#ifndef DAML_GENMAP && DAML_GENERIC_COMPARISON
   deriving (Show, Eq, Ord, MapKey)
+#else
+  deriving (Show, Eq, Ord)
+#endif
 
 data Transaction = Transaction
  { transactionId : TransactionId

--- a/triggers/tests/daml/TemplateIdFilter.daml
+++ b/triggers/tests/daml/TemplateIdFilter.daml
@@ -1,11 +1,15 @@
 -- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-
+{-# LANGUAGE CPP #-}
 
 module TemplateIdFilter where
 
 import Prelude hiding (test)
+#ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
+import qualified DA.Map as Map
+#else
 import qualified DA.Next.Map as Map
+#endif
 import Daml.Trigger
 
 test : RegisteredTemplates -> Trigger ()

--- a/triggers/tests/scenarios/Rule.daml
+++ b/triggers/tests/scenarios/Rule.daml
@@ -1,12 +1,16 @@
 -- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-
+{-# LANGUAGE CPP #-}
 
 module Rule where
 
 import DA.Action
 import DA.Assert
+#ifdef DAML_GENMAP && DAML_GENERIC_COMPARISON
+import qualified DA.Map as Map
+#else
 import qualified DA.Next.Map as Map
+#endif
 import Daml.Trigger
 import Daml.Trigger.Assert
 import qualified Daml.Script as Script


### PR DESCRIPTION
As discussed internally, this transitions the trigger library to use `DA.Map` instead of the deprecated `DA.Next.Map`, if available. This is to avoid deprecation warnings if users import the triggers library. This is a breaking change, but was deemed the best available option.

changelog_begin
- [Triggers] The trigger library now uses `DA.Map` instead of the deprecated `DA.Next.Map` if the targeted Daml-LF version supports it. This is a breaking change: Code that interfaced with the triggers library using `DA.Next.Map`, e.g. with `Daml.Trigger.getCommandsInFlight` or `Daml.Trigger.Assert.testRule`, will need to be changed to use `DA.Map` instead.

changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
