### PR TITLE
Add more shared infrastructure for non-repudiation testing

### DIFF
--- a/runtime-components/non-repudiation-perf/src/main/scala/com/daml/nonrepudiation/perf/StubOwner.scala
+++ b/runtime-components/non-repudiation-perf/src/main/scala/com/daml/nonrepudiation/perf/StubOwner.scala
@@ -3,7 +3,6 @@
 
 package com.daml.nonrepudiation.perf
 
-import java.net.{InetAddress, InetSocketAddress, SocketAddress}
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 import java.time.Clock
@@ -11,19 +10,15 @@ import java.time.Clock
 import com.daml.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc
 import com.daml.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc.CommandSubmissionServiceBlockingStub
 import com.daml.nonrepudiation.client.SigningInterceptor
+import com.daml.nonrepudiation.testing.DummyTestSetup
 import com.daml.nonrepudiation.{
   CertificateRepository,
   CommandIdString,
   NonRepudiationProxy,
   SignedPayloadRepository,
 }
-import com.daml.ports.FreePort
 import com.daml.resources.grpc.{GrpcResourceOwnerFactories => Resources}
 import com.daml.resources.{AbstractResourceOwner, Resource}
-import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
-import io.grpc.netty.{NettyChannelBuilder, NettyServerBuilder}
-import io.grpc.protobuf.services.ProtoReflectionService
-import io.grpc.{ManagedChannelBuilder, ServerBuilder}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
@@ -33,17 +28,12 @@ final class StubOwner private (
     certificate: X509Certificate,
     certificates: CertificateRepository,
     signedPayloads: SignedPayloadRepository[CommandIdString],
-    builders: StubOwner.Builders,
-    serviceExecutionContext: ExecutionContext,
+    builders: DummyTestSetup.Builders,
 ) extends AbstractResourceOwner[ExecutionContext, CommandSubmissionServiceBlockingStub] {
 
   override def acquire()(implicit
       context: ExecutionContext
   ): Resource[ExecutionContext, CommandSubmissionServiceBlockingStub] = {
-
-    builders.participantServer
-      .addService(DummyCommandSubmissionService.bind(serviceExecutionContext))
-      .addService(ProtoReflectionService.newInstance())
 
     val stubOwner =
       for {
@@ -69,42 +59,6 @@ final class StubOwner private (
 
 object StubOwner {
 
-  final class Builders(
-      val participantServer: ServerBuilder[_ <: ServerBuilder[_]],
-      val participantChannel: ManagedChannelBuilder[_ <: ManagedChannelBuilder[_]],
-      val proxyServer: ServerBuilder[_ <: ServerBuilder[_]],
-      val proxyChannel: ManagedChannelBuilder[_ <: ManagedChannelBuilder[_]],
-  )
-
-  object Builders {
-
-    def apply(useNetworkStack: Boolean): StubOwner.Builders =
-      if (useNetworkStack) {
-        val participantPort: Int = FreePort.find().value
-        val participantAddress: SocketAddress =
-          new InetSocketAddress(InetAddress.getLoopbackAddress, participantPort)
-        val proxyPort: Int = FreePort.find().value
-        val proxyAddress: SocketAddress =
-          new InetSocketAddress(InetAddress.getLoopbackAddress, proxyPort)
-        new Builders(
-          NettyServerBuilder.forPort(participantPort),
-          NettyChannelBuilder.forAddress(participantAddress).usePlaintext(),
-          NettyServerBuilder.forPort(proxyPort),
-          NettyChannelBuilder.forAddress(proxyAddress).usePlaintext(),
-        )
-      } else {
-        val participantName: String = InProcessServerBuilder.generateName()
-        val proxyName: String = InProcessServerBuilder.generateName()
-        new Builders(
-          InProcessServerBuilder.forName(participantName),
-          InProcessChannelBuilder.forName(participantName),
-          InProcessServerBuilder.forName(proxyName),
-          InProcessChannelBuilder.forName(proxyName),
-        )
-      }
-
-  }
-
   def apply(
       useNetworkStack: Boolean,
       key: PrivateKey,
@@ -118,8 +72,7 @@ object StubOwner {
       certificate,
       certificates,
       signedPayloads,
-      Builders(useNetworkStack),
-      serviceExecutionContext,
+      DummyTestSetup.Builders(useNetworkStack, serviceExecutionContext),
     )
 
 }

--- a/runtime-components/non-repudiation-testing/BUILD.bazel
+++ b/runtime-components/non-repudiation-testing/BUILD.bazel
@@ -24,6 +24,7 @@ da_scala_library(
         "//ledger/ledger-api-common",
         "//ledger/ledger-resources",
         "//libs-scala/doobie-slf4j",
+        "//libs-scala/ports",
         "//libs-scala/resources",
         "//libs-scala/resources-akka",
         "//libs-scala/resources-grpc",
@@ -31,6 +32,8 @@ da_scala_library(
         "//runtime-components/non-repudiation-postgresql",
         "//runtime-components/non-repudiation-resources",
         "@maven//:com_zaxxer_HikariCP",
+        "@maven//:io_grpc_grpc_netty",
+        "@maven//:io_grpc_grpc_services",
         "@maven//:org_slf4j_slf4j_api",
     ],
 )

--- a/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/DummyCommandService.scala
+++ b/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/DummyCommandService.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.nonrepudiation.testing
+
+import com.daml.ledger.api.v1.command_service.CommandServiceGrpc.CommandService
+import com.daml.ledger.api.v1.command_service.{
+  CommandServiceGrpc,
+  SubmitAndWaitForTransactionIdResponse,
+  SubmitAndWaitForTransactionResponse,
+  SubmitAndWaitForTransactionTreeResponse,
+  SubmitAndWaitRequest,
+}
+import com.google.protobuf.empty.Empty
+import io.grpc.ServerServiceDefinition
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object DummyCommandService {
+
+  def bind(executionContext: ExecutionContext): ServerServiceDefinition =
+    CommandServiceGrpc.bindService(new DummyCommandService, executionContext)
+
+}
+
+final class DummyCommandService private extends CommandService {
+
+  override def submitAndWait(request: SubmitAndWaitRequest): Future[Empty] =
+    Future.successful(Empty.defaultInstance)
+
+  override def submitAndWaitForTransactionId(
+      request: SubmitAndWaitRequest
+  ): Future[SubmitAndWaitForTransactionIdResponse] =
+    Future.successful(SubmitAndWaitForTransactionIdResponse.defaultInstance)
+
+  override def submitAndWaitForTransaction(
+      request: SubmitAndWaitRequest
+  ): Future[SubmitAndWaitForTransactionResponse] =
+    Future.successful(SubmitAndWaitForTransactionResponse.defaultInstance)
+
+  override def submitAndWaitForTransactionTree(
+      request: SubmitAndWaitRequest
+  ): Future[SubmitAndWaitForTransactionTreeResponse] =
+    Future.successful(SubmitAndWaitForTransactionTreeResponse.defaultInstance)
+
+}

--- a/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/DummyCommandSubmissionService.scala
+++ b/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/DummyCommandSubmissionService.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package com.daml.nonrepudiation.perf
+package com.daml.nonrepudiation.testing
 
 import com.daml.ledger.api.v1.command_submission_service.CommandSubmissionServiceGrpc.CommandSubmissionService
 import com.daml.ledger.api.v1.command_submission_service.{
@@ -15,8 +15,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object DummyCommandSubmissionService {
 
-  private val Success = Future.successful(Empty.defaultInstance)
-
   def bind(executionContext: ExecutionContext): ServerServiceDefinition =
     CommandSubmissionServiceGrpc.bindService(new DummyCommandSubmissionService, executionContext)
 
@@ -25,6 +23,6 @@ object DummyCommandSubmissionService {
 final class DummyCommandSubmissionService private extends CommandSubmissionService {
 
   override def submit(request: SubmitRequest): Future[Empty] =
-    DummyCommandSubmissionService.Success
+    Future.successful(Empty.defaultInstance)
 
 }

--- a/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/DummyLedgerIdentityService.scala
+++ b/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/DummyLedgerIdentityService.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.nonrepudiation.testing
+
+import com.daml.ledger.api.v1.ledger_identity_service.LedgerIdentityServiceGrpc.LedgerIdentityService
+import com.daml.ledger.api.v1.ledger_identity_service.{
+  GetLedgerIdentityRequest,
+  GetLedgerIdentityResponse,
+  LedgerIdentityServiceGrpc,
+}
+import io.grpc.ServerServiceDefinition
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object DummyLedgerIdentityService {
+
+  def bind(executionContext: ExecutionContext): ServerServiceDefinition =
+    LedgerIdentityServiceGrpc.bindService(new DummyLedgerIdentityService, executionContext)
+
+}
+
+final class DummyLedgerIdentityService private extends LedgerIdentityService {
+  override def getLedgerIdentity(
+      request: GetLedgerIdentityRequest
+  ): Future[GetLedgerIdentityResponse] =
+    Future.successful(GetLedgerIdentityResponse.of("dummy"))
+}

--- a/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/DummyTestSetup.scala
+++ b/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/DummyTestSetup.scala
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.nonrepudiation.testing
+
+import java.net.{InetAddress, InetSocketAddress, SocketAddress}
+
+import com.daml.ports.FreePort
+import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
+import io.grpc.netty.{NettyChannelBuilder, NettyServerBuilder}
+import io.grpc.protobuf.services.ProtoReflectionService
+import io.grpc.{ManagedChannelBuilder, ServerBuilder}
+
+import scala.concurrent.ExecutionContext
+
+object DummyTestSetup {
+
+  final class Builders(
+      val participantServer: ServerBuilder[_ <: ServerBuilder[_]],
+      val participantChannel: ManagedChannelBuilder[_ <: ManagedChannelBuilder[_]],
+      val proxyServer: ServerBuilder[_ <: ServerBuilder[_]],
+      val proxyChannel: ManagedChannelBuilder[_ <: ManagedChannelBuilder[_]],
+  )
+
+  object Builders {
+
+    private def withRequiredServices[Builder <: ServerBuilder[Builder]](
+        builder: Builder,
+        executionContext: ExecutionContext,
+    ): Builder =
+      builder
+        .addService(DummyLedgerIdentityService.bind(executionContext))
+        .addService(DummyCommandSubmissionService.bind(executionContext))
+        .addService(DummyCommandService.bind(executionContext))
+        .addService(ProtoReflectionService.newInstance())
+
+    def apply(useNetworkStack: Boolean, serviceExecutionContext: ExecutionContext): Builders = {
+      if (useNetworkStack) {
+        val participantPort: Int = FreePort.find().value
+        val participantAddress: SocketAddress =
+          new InetSocketAddress(InetAddress.getLoopbackAddress, participantPort)
+        val proxyPort: Int = FreePort.find().value
+        val proxyAddress: SocketAddress =
+          new InetSocketAddress(InetAddress.getLoopbackAddress, proxyPort)
+        new Builders(
+          withRequiredServices(
+            NettyServerBuilder.forPort(participantPort),
+            serviceExecutionContext,
+          ),
+          NettyChannelBuilder.forAddress(participantAddress).usePlaintext(),
+          NettyServerBuilder.forPort(proxyPort),
+          NettyChannelBuilder.forAddress(proxyAddress).usePlaintext(),
+        )
+      } else {
+        val participantName: String = InProcessServerBuilder.generateName()
+        val proxyName: String = InProcessServerBuilder.generateName()
+        new Builders(
+          withRequiredServices(
+            InProcessServerBuilder.forName(participantName),
+            serviceExecutionContext,
+          ),
+          InProcessChannelBuilder.forName(participantName),
+          InProcessServerBuilder.forName(proxyName),
+          InProcessChannelBuilder.forName(proxyName),
+        )
+      }
+    }
+
+  }
+
+}

--- a/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/package.scala
+++ b/runtime-components/non-repudiation-testing/src/main/scala/com/daml/nonrepudiation/testing/package.scala
@@ -11,7 +11,7 @@ import cats.effect.{ContextShift, IO}
 import com.daml.doobie.logging.Slf4jLogHandler
 import com.daml.ledger.api.v1.command_submission_service.SubmitRequest
 import com.daml.ledger.api.v1.commands.{Command, Commands, CreateCommand}
-import com.daml.ledger.api.v1.value.{Record, RecordField, Value}
+import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value}
 import com.daml.ledger.resources.{ResourceContext, ResourceOwner}
 import com.daml.nonrepudiation.postgresql.Tables
 import com.daml.nonrepudiation.resources.HikariTransactorResourceOwner
@@ -67,7 +67,7 @@ package object testing {
             Command(
               Command.Command.Create(
                 CreateCommand(
-                  templateId = None,
+                  templateId = Some(Identifier("Package", "Module", "Entity")),
                   createArguments = Some(
                     Record(
                       recordId = None,


### PR DESCRIPTION
More dummy participant components, shared across the non-repudiation sub-tree.

These will also be used in client bindings tests.

changelog_begin
changelog_end

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
