### PR TITLE
slack: reduce @here mentions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -226,7 +226,7 @@ jobs:
         if [ "$msg" = "This PR has been created by a script, which is not very smart and does not have all the context. Please do double-check that the version prefix is correct before merging." ]; then
             pr_handler=@$(head -1 release/rotation | awk '{print $1}')
         else
-            pr_handler="!here"
+            pr_handler=""
         fi
         curl -XPOST \
              -i \

--- a/ci/daily_tell_slack.yml
+++ b/ci/daily_tell_slack.yml
@@ -15,7 +15,7 @@ steps:
     COMMIT_TITLE="$(escape_slack "$(git log --pretty=format:%s -n1 ${{ parameters.trigger_sha }})")"
     COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|${COMMIT_TITLE}>"
     if [ "$(Agent.JobStatus)" != "Succeeded" ]; then
-        MESSAGE="\":fire: :fire: <!here> :fire: :fire:\n$(Agent.JobName) *FAILED*: $COMMIT_LINK\n:fire: :fire:\""
+        MESSAGE="\":fire: :fire: :fire: :fire:\n$(Agent.JobName) [$(Agent.MachineName)] *FAILED*: $COMMIT_LINK\n:fire: :fire:\""
     else
         MESSAGE="${{ parameters['success-message'] }}"
     fi

--- a/ci/tell-slack-failed.yml
+++ b/ci/tell-slack-failed.yml
@@ -14,9 +14,9 @@ steps:
       COMMIT_TITLE="$(escape_slack "$(git log --pretty=format:%s -n1 ${{ parameters.trigger_sha }})")"
       COMMIT_LINK="<https://dev.azure.com/digitalasset/daml/_build/results?buildId=$(Build.BuildId)|${COMMIT_TITLE}>"
       if [ -z "${{ parameters.trigger_sha }}" ]; then
-          WARNING="<!here> *FAILED* $(Build.SourceBranchName)/$(Agent.JobName): $COMMIT_LINK"
+          WARNING="*FAILED* $(Build.SourceBranchName)/$(Agent.JobName) [$(Agent.MachineName)]: $COMMIT_LINK"
       else
-          WARNING=":fire: :fire: :fire: :fire: :fire:\n<!here> *RELEASE FAILED* $(Build.SourceBranchName)/$(Agent.JobName): $COMMIT_LINK\n:fire: :fire: :fire: :fire: :fire:"
+          WARNING=":fire: :fire: :fire: :fire: :fire:\n*RELEASE FAILED* $(Build.SourceBranchName)/$(Agent.JobName): $COMMIT_LINK\n:fire: :fire: :fire: :fire: :fire:"
       fi
       curl -XPOST \
            -i \


### PR DESCRIPTION
The people who care about these alerts monitor the channel closely enough anyway, and having frequent automated @here bells ringing makes it harder for individuals to highlight important messages.

CHANGELOG_BEGIN
CHANGELOG_END