### PR TITLE
send CI failures on separate channel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
                    -i \
                    -H 'Content-Type: application/json' \
                    --data "{\"text\":\"<!here> Perf tests seem to have changed. Please manually check:\n\`\`\`\ngit diff $TEST_SHA $LAST_CHANGES -- daml-lf/scenario-interpreter/src/perf\n\`\`\`\nand update accordingly. If the change is benign, update \`ci/cron/perf/test_sha\` to \`$LAST_CHANGES\`. With no intervention, you will no longer get performance reports.\"}" \
-                   $(Slack.team-daml)
+                   $(Slack.ci-failures-daml)
           else
               echo "Changes detected, but not from this commit."
           fi

--- a/ci/daily_tell_slack.yml
+++ b/ci/daily_tell_slack.yml
@@ -25,7 +25,7 @@ steps:
              -i \
              -H 'Content-type: application/json' \
              --data "$PAYLOAD" \
-             $(Slack.team-daml)
+             $(Slack.ci-failures-daml)
     fi
   displayName: report
   condition: always()

--- a/ci/tell-slack-failed.yml
+++ b/ci/tell-slack-failed.yml
@@ -22,7 +22,7 @@ steps:
            -i \
            -H 'Content-type: application/json' \
            --data "{\"text\":\"$WARNING\n\"}" \
-           $(Slack.team-daml)
+           $(Slack.ci-failures-daml)
     condition: and(failed(),
                    or(eq(variables['Build.SourceBranchName'], 'main'),
                       startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))


### PR DESCRIPTION
This will send CI failures to `#ci-failures-daml`.

CHANGELOG_BEGIN
CHANGELOG_END