### PR TITLE
Bump ghcide

### DIFF
--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -17,8 +17,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
-GHCIDE_REV = "a6879b77da2968bae9256bb2f5658b909056d4ef"
-GHCIDE_SHA256 = "94be2607354c7ab111b87fa2b4afe8f6ef50981277864a05e906b7b0a783c58f"
+GHCIDE_REV = "d245b39d22f15631ead0382bc5ca3609be54b253"
+GHCIDE_SHA256 = "031be2d30b099701dc294b8893b8c2c7abb9437a36826a181c6136cfc1e8f316"
 GHCIDE_VERSION = "0.1.0"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"

--- a/bazel-haskell-deps.bzl
+++ b/bazel-haskell-deps.bzl
@@ -17,8 +17,8 @@ load("@os_info//:os_info.bzl", "is_windows")
 load("@dadew//:dadew.bzl", "dadew_tool_home")
 load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 
-GHCIDE_REV = "d245b39d22f15631ead0382bc5ca3609be54b253"
-GHCIDE_SHA256 = "031be2d30b099701dc294b8893b8c2c7abb9437a36826a181c6136cfc1e8f316"
+GHCIDE_REV = "c8818a7d7abf66a4a7302b360857e3a790ab1be4"
+GHCIDE_SHA256 = "999cd7677b0e6747b6ab7a1e503afc23380cd0c12d9781b09f9a905b8f49cca7"
 GHCIDE_VERSION = "0.1.0"
 JS_JQUERY_VERSION = "3.3.1"
 JS_DGTABLE_VERSION = "0.5.2"

--- a/daml-script/test/BUILD.bazel
+++ b/daml-script/test/BUILD.bazel
@@ -35,7 +35,7 @@ dependencies:
   - daml-prim
   - daml-script.dar
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror --ghc-option=-Wno-error=missing-signatures -o $$PWD/$(location script-test.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location script-test.dar)
       rm -rf $$TMP_DIR
     """.format(sdk = sdk_version),
     tools = ["//compiler/damlc"],
@@ -66,7 +66,7 @@ dependencies:
   - daml-prim
   - daml-script-1.dev.dar
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror --ghc-option=-Wno-error=missing-signatures -o $$PWD/$(location script-test-1.dev.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location script-test-1.dev.dar)
       rm -rf $$TMP_DIR
     """.format(sdk = sdk_version),
     tools = ["//compiler/damlc"],
@@ -99,7 +99,7 @@ dependencies:
   - daml-prim
   - daml-script.dar
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror --ghc-option=-Wno-error=missing-signatures -o $$PWD/$(location script-test-no-ledger.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location script-test-no-ledger.dar)
       rm -rf $$TMP_DIR
     """.format(sdk = sdk_version),
     tools = ["//compiler/damlc"],

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -19,9 +19,7 @@ _zipper = attr.label(
     cfg = "host",
 )
 
-# For some reason, -Werror seems to turn on -Wmissing-signatures so we turn
-# it off again.
-ghc_opts = ["--ghc-option=-Werror", "--ghc-option=-Wno-error=missing-signatures"]
+ghc_opts = ["--ghc-option=-Werror"]
 
 def _daml_configure_impl(ctx):
     project_name = ctx.attr.project_name

--- a/triggers/service/BUILD.bazel
+++ b/triggers/service/BUILD.bazel
@@ -211,7 +211,7 @@ dependencies:
   - daml-trigger.dar
   - daml-script.dar
 EOF
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror --ghc-option=-Wno-error=missing-signatures -o $$PWD/$(location test-model.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location test-model.dar)
       rm -rf $$TMP_DIR
     """.format(sdk = sdk_version),
     tools = ["//compiler/damlc"],

--- a/triggers/tests/BUILD.bazel
+++ b/triggers/tests/BUILD.bazel
@@ -59,7 +59,7 @@ dependencies:
   - daml-script.dar
 EOF
       test -z "{lf_version}" || echo "build-options: [--target={lf_version}]" >> $$TMP_DIR/daml.yaml
-      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror --ghc-option=-Wno-error=missing-signatures -o $$PWD/$(location acs{suffix}.dar)
+      $(location //compiler/damlc) build --project-root=$$TMP_DIR --ghc-option=-Werror -o $$PWD/$(location acs{suffix}.dar)
       rm -rf $$TMP_DIR
     """.format(
             sdk = sdk_version,


### PR DESCRIPTION
Includes https://github.com/digital-asset/daml-ghcide/pull/13 meaning
we can now remove the hacks for missing signatures

changelog_begin

- [Daml Compiler] Fix a bug where passing `--ghc-option=-Werror` also
  produced errors for warnings produced by `-Wmissing-signatures` even
  if the user did not explicitly enable this.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
