### PR TITLE
ci/cron/check: low-hanging perf improvement

### DIFF
--- a/ci/bash-lib.yml
+++ b/ci/bash-lib.yml
@@ -81,9 +81,11 @@ steps:
         key=$(mktemp)
         # There may already be a trap; this will save it
         restore_trap=$(trap -p EXIT)
-        cleanup="rm -rf $key ~/.config/gcloud"
-        trap "$cleanup" EXIT
+        config_dir=$(mktemp -d)
+        cleanup="rm -rf $key $config_dir"
+        trap "$cleanup; $restore_trap" EXIT
         echo "$cred" > $key
+        export CLOUDSDK_CONFIG="$config_dir"
         gcloud auth activate-service-account --key-file=$key
 
         BOTO_CONFIG=/dev/null gsutil $cmd "${args[@]}"

--- a/dev-env/bin/dade-assist
+++ b/dev-env/bin/dade-assist
@@ -2,7 +2,7 @@
 
 DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
-
-linkTool java out "${DADE_DEVENV_DIR}/jdk"
-
+if [ -z "${DADE_SKIP_JAVA+1}" ]; then
+    linkTool java out "${DADE_DEVENV_DIR}/jdk"
+fi
 exec "${DADE_DEVENV_DIR}/lib/dade-dump-profile"


### PR DESCRIPTION
Two quick improvements I made while waiting on #9039:
- Avoid loading Java. When looking at the logs flow by this seemed to be taking a huge amount of time.
- Isolate the gcloud config files, which allows for running gcloud downloads in parallel.

Together these reduce the `check_releases` runtime from about 5 hours to about 2. There's much more (and smarter) work needed on this, but this was really easy to do.

CHANGELOG_BEGIN
CHANGELOG_END