### PR TITLE
ci/cron/check: remove dade-assist calls

### DIFF
--- a/ci/cron/src/Main.hs
+++ b/ci/cron/src/Main.hs
@@ -344,8 +344,6 @@ verify_signatures :: FilePath -> FilePath -> String -> IO ()
 verify_signatures bash_lib tmp version_tag = do
     System.callCommand $ unlines ["bash -c '",
         "set -euo pipefail",
-        "export DADE_SKIP_JAVA=1",
-        "eval \"$(dev-env/bin/dade assist)\"",
         "source \"" <> bash_lib <> "\"",
         "shopt -s extglob", -- enable !() pattern: things that _don't_ match
         "cd \"" <> tmp <> "\"",
@@ -371,8 +369,6 @@ does_backup_exist :: String -> FilePath -> FilePath -> IO Bool
 does_backup_exist gcp_credentials bash_lib path = do
     out <- shell $ unlines ["bash -c '",
         "set -euo pipefail",
-        "export DADE_SKIP_JAVA=1",
-        "eval \"$(dev-env/bin/dade assist)\"",
         "source \"" <> bash_lib <> "\"",
         "GCRED=$(cat <<END",
         gcp_credentials,
@@ -390,8 +386,6 @@ gcs_cp :: String -> FilePath -> FilePath  -> FilePath -> IO ()
 gcs_cp gcp_credentials bash_lib local_path remote_path = do
     shell_ $ unlines ["bash -c '",
         "set -euo pipefail",
-        "export DADE_SKIP_JAVA=1",
-        "eval \"$(dev-env/bin/dade assist)\"",
         "source \"" <> bash_lib <> "\"",
         "GCRED=$(cat <<END",
         gcp_credentials,

--- a/dev-env/bin/dade-assist
+++ b/dev-env/bin/dade-assist
@@ -2,7 +2,7 @@
 
 DADE_CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$DADE_CURRENT_SCRIPT_DIR/../lib/dade-common"
-if [ -z "${DADE_SKIP_JAVA+1}" ]; then
-    linkTool java out "${DADE_DEVENV_DIR}/jdk"
-fi
+
+linkTool java out "${DADE_DEVENV_DIR}/jdk"
+
 exec "${DADE_DEVENV_DIR}/lib/dade-dump-profile"


### PR DESCRIPTION
We can only run this in a context where the dev-env is already set up anyway, as that's how we get Bazel to build the script in the first place.

CHANGELOG_BEGIN
CHANGELOG_END