### PR TITLE
Fix double push in CommandTracker

### DIFF
--- a/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
+++ b/ledger/ledger-api-client/src/main/scala/com/digitalasset/ledger/client/services/commands/tracker/CommandTracker.scala
@@ -167,7 +167,7 @@ private[commands] class CommandTracker[Context](maxDeduplicationTime: () => JDur
       )
 
       private def pushResultOrPullCommandResultIn(compl: Option[Ctx[Context, Completion]]): Unit = {
-        compl.fold(pull(commandResultIn))(push(resultOut, _))
+        compl.fold(if (!hasBeenPulled(commandResultIn)) pull(commandResultIn))(emit(resultOut, _))
       }
 
       private def completeStageIfTerminal(): Unit = {


### PR DESCRIPTION
The command tracker detects timeouts outside the regular pull/push
mechanism of the custom akka graph stage. Basically the timeout
detection jumps the line when emitting outputs on `resultOut`. If it
then processes a regular completion, it tries to push to `resultOut`
even though it hasn't been pulled again in the meantime. Using `emit`
instead of `push` when a completion arrives makes akka take care of
handling the signaling properly.

Fixes DPP-285

CHANGELOG_BEGIN
[Integration Kit, Sandbox, Daml on SQL, Scala Ledger Bindings]:
Fixed a bug that caused the CommandTracker used by the synchronous
CommandService to crash in case of a lot of timeouts.
CHANGELOG_END

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
