### PR TITLE
Adding first draw of sandbox-on-x concept

### DIFF
--- a/ledger/sandbox-on-x/BUILD.bazel
+++ b/ledger/sandbox-on-x/BUILD.bazel
@@ -1,0 +1,189 @@
+# Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//bazel_tools:scala.bzl",
+    "da_scala_binary",
+    "da_scala_library",
+    "da_scala_test_suite",
+)
+load("//ledger/ledger-api-test-tool:conformance.bzl", "conformance_test")
+load("@os_info//:os_info.bzl", "is_windows")
+
+da_scala_library(
+    name = "sandbox-on-x",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    resources = glob(["src/main/resources/**/*"]),
+    scala_deps = [
+        "@maven//:com_github_scopt_scopt",
+        "@maven//:com_typesafe_akka_akka_actor",
+        "@maven//:com_typesafe_akka_akka_stream",
+    ],
+    tags = ["maven_coordinates=com.daml:sandbox-on-x:__VERSION__"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//daml-lf/archive:daml_lf_dev_archive_proto_java",
+        "//daml-lf/data",
+        "//daml-lf/engine",
+        "//daml-lf/transaction",
+        "//language-support/scala/bindings",
+        "//ledger/caching",
+        "//ledger/ledger-api-auth",
+        "//ledger/ledger-api-common",
+        "//ledger/ledger-api-health",
+        "//ledger/ledger-resources",
+        "//ledger/metrics",
+        "//ledger/participant-integration-api",
+        "//ledger/participant-state",
+        "//ledger/participant-state/kvutils",
+        "//ledger/participant-state/kvutils/app",
+        "//libs-scala/contextualized-logging",
+        "//libs-scala/resources",
+        "//libs-scala/resources-akka",
+        "//libs-scala/resources-grpc",
+        "@maven//:com_google_guava_guava",
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)
+
+da_scala_test_suite(
+    name = "sandbox-on-x-tests",
+    size = "small",
+    srcs = glob(["src/test/suite/**/*.scala"]),
+    data = [
+        "//ledger/test-common:model-tests.dar",
+    ],
+    resources = glob(["src/test/resources/**/*"]),
+    scala_deps = [
+        "@maven//:com_typesafe_akka_akka_actor",
+        "@maven//:com_typesafe_akka_akka_stream",
+        "@maven//:org_mockito_mockito_scala",
+        "@maven//:org_scalactic_scalactic",
+        "@maven//:org_scalatest_scalatest",
+    ],
+    runtime_deps = [
+        "@maven//:ch_qos_logback_logback_classic",
+        "@maven//:ch_qos_logback_logback_core",
+    ],
+    deps = [
+        ":sandbox-on-x",
+        "//daml-lf/data",
+        "//daml-lf/engine",
+        "//language-support/scala/bindings",
+        "//ledger-api/rs-grpc-bridge",
+        "//ledger-api/testing-utils",
+        "//ledger/caching",
+        "//ledger/ledger-api-common",
+        "//ledger/ledger-api-health",
+        "//ledger/ledger-resources",
+        "//ledger/ledger-resources:ledger-resources-test-lib",
+        "//ledger/metrics",
+        "//ledger/participant-state",
+        "//ledger/participant-state/kvutils",
+        "//ledger/participant-state/kvutils:kvutils-tests-lib",
+        "//libs-scala/contextualized-logging",
+        "//libs-scala/resources",
+        "//libs-scala/resources-akka",
+        "//libs-scala/resources-grpc",
+        "@maven//:io_dropwizard_metrics_metrics_core",
+        "@maven//:org_mockito_mockito_core",
+    ],
+)
+
+da_scala_library(
+    name = "sandbox-on-x-app",
+    srcs = glob(["src/app/scala/**/*.scala"]),
+    resources = glob(["src/app/resources/**/*"]),
+    scala_deps = [
+    ],
+    tags = ["maven_coordinates=com.daml:sandbox-on-x-app:__VERSION__"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":sandbox-on-x",
+        "//ledger/ledger-api-common",
+        "//ledger/ledger-api-health",
+        "//ledger/ledger-resources",
+        "//ledger/participant-state",
+        "//ledger/participant-state/kvutils",
+        "//ledger/participant-state/kvutils/app",
+        "//libs-scala/contextualized-logging",
+        "//libs-scala/resources",
+    ],
+)
+
+da_scala_binary(
+    name = "app",
+    main_class = "com.daml.ledger.sandbox.Main",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "@maven//:ch_qos_logback_logback_classic",
+        "@maven//:ch_qos_logback_logback_core",
+        "@maven//:com_h2database_h2",
+    ],
+    deps = [
+        ":sandbox-on-x-app",
+    ],
+)
+
+conformance_test(
+    name = "conformance-test",
+    ports = [6865],
+    server = ":app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant participant-id=example,port=6865",
+    ],
+    test_tool_args = [
+        "--verbose",
+        "--exclude=ClosedWorldIT",
+        "--exclude=CommandDeduplicationIT",
+        "--exclude=ContractKeysIT",
+        "--exclude=SemanticTests",
+    ],
+)
+
+conformance_test(
+    name = "conformance-test-participant-pruning",
+    ports = [6865],
+    server = ":app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant=participant-id=example,port=6865",
+    ],
+    test_tool_args = [
+        "--verbose",
+        "--include=ParticipantPruningIT",
+    ],
+)
+
+conformance_test(
+    name = "conformance-test-multi-party-submission",
+    ports = [6865],
+    server = ":app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant=participant-id=example,port=6865",
+    ],
+    test_tool_args = [
+        "--verbose",
+        "--include=MultiPartySubmissionIT",
+    ],
+)
+
+conformance_test(
+    name = "benchmark-performance-envelope",
+    ports = [6865],
+    server = ":app",
+    server_args = [
+        "--contract-id-seeding=testing-weak",
+        "--participant=participant-id=example,port=6865",
+    ],
+    test_tool_args = [
+        "--verbose",
+        "--perf-tests=PerformanceEnvelope.Throughput.TwentyOPS",
+        "--perf-tests=PerformanceEnvelope.Latency.1000ms",
+        "--perf-tests=PerformanceEnvelope.TransactionSize.1000KB",
+    ],
+)

--- a/ledger/sandbox-on-x/README.md
+++ b/ledger/sandbox-on-x/README.md
@@ -1,0 +1,12 @@
+# Overview
+
+Sandbox on X - Proof of Concept
+
+This is a proof-of-concept of the sandbox-on-x architecture, which is a Daml ledger with persistency that uses the on-X architecture while being backed by an IndexDB only. This architecture is DB compatible with the sandbox-classic, while using the very same `participant.state.api.v1.ReadService` and `.WriteService` interfaces that all Daml ledger other than sandbox-classic use.
+
+We pursue several goals with the implementation of the sandbox-on-x architecture:
+1. Use it as a drop-in-replacement of the implementation of daml-on-sql and sandbox-classic; and thereby enable a massive code cleanup due to removing the direct DB-access code used in daml-on-sql and sandbox-classic.
+2. Use it as the regression test for both functional and non-functional properties of the Ledger API server components built in the `daml` repo. We expect this implementation to satisfy the 1k CHESS+ trade/s throughput requirement.
+3. Lower Spider's CI times by providing them with a high-throughput single-process Daml ledger.
+
+The proof-of-concept should have the same throughput as any other Daml ledger, and can be used for testing the throughput of Ledger API server components. Its main limitation is that it does not do conflict-checking. We plan to resolve that in the future using a two-stage approach, which first checks conflicts against a fixed ledger end and then against in-flight transactions. We expect this approach to scale to very large active contracts sets.

--- a/ledger/sandbox-on-x/src/app/resources/application.conf
+++ b/ledger/sandbox-on-x/src/app/resources/application.conf
@@ -1,0 +1,10 @@
+akka {
+    stream {
+        materializer {
+            subscription-timeout {
+                # We increase it (default is 5s) in order to allow early materialization of the bridge.
+                timeout = 60s
+            }
+        }
+    }
+}

--- a/ledger/sandbox-on-x/src/app/resources/logback.xml
+++ b/ledger/sandbox-on-x/src/app/resources/logback.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<configuration>
+    <include resource="com/daml/ledger/participant/state/kvutils/app/logback.base.xml"/>
+</configuration>

--- a/ledger/sandbox-on-x/src/app/scala/com/daml/ledger/sandbox/Main.scala
+++ b/ledger/sandbox-on-x/src/app/scala/com/daml/ledger/sandbox/Main.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.sandbox
+
+import com.daml.ledger.participant.state.kvutils.app.Runner
+import com.daml.ledger.resources.ResourceContext
+import com.daml.resources.ProgramResource
+
+object Main {
+  val RunnerName = "sandbox-on-x"
+
+  def main(args: Array[String]): Unit =
+    new ProgramResource(
+      owner = new Runner(RunnerName, BridgeLedgerFactory).owner(args)
+    ).run(ResourceContext.apply)
+}

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeLedgerFactory.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/BridgeLedgerFactory.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.sandbox
+
+import akka.stream.Materializer
+import com.daml.ledger.participant.state.kvutils.app.{Config, LedgerFactory, ParticipantConfig}
+import com.daml.ledger.resources.ResourceOwner
+import com.daml.lf.engine.Engine
+import com.daml.logging.LoggingContext
+import com.daml.platform.configuration.LedgerConfiguration
+import scopt.OptionParser
+
+case class BridgeConfig(maxDedupSeconds: Int, submissionBufferSize: Int)
+
+object BridgeLedgerFactory extends LedgerFactory[ReadWriteServiceBridge, BridgeConfig] {
+  override final def readWriteServiceOwner(
+      config: Config[BridgeConfig],
+      participantConfig: ParticipantConfig,
+      engine: Engine,
+  )(implicit
+      materializer: Materializer,
+      loggingContext: LoggingContext,
+  ): ResourceOwner[ReadWriteServiceBridge] =
+    ResourceOwner.forCloseable(() =>
+      ReadWriteServiceBridge(
+        participantId = participantConfig.participantId,
+        ledgerId = config.ledgerId,
+        maxDedupSeconds = config.extra.maxDedupSeconds,
+        submissionBufferSize = config.extra.submissionBufferSize,
+      )
+    )
+
+  override def ledgerConfig(config: Config[BridgeConfig]): LedgerConfiguration =
+    LedgerConfiguration.defaultLocalLedger
+
+  override def extraConfigParser(parser: OptionParser[Config[BridgeConfig]]): Unit = {
+    parser
+      .opt[Int]("sandbox-on-x-bridge-max-dedup-seconds")
+      .text("Maximum deduplication time in seconds. Defaults to 30.")
+      .action((p, c) => c.copy(extra = c.extra.copy(maxDedupSeconds = p)))
+
+    parser
+      .opt[Int]("sandbox-on-x-bridge-submission-buffer-size")
+      .text("Submission buffer size. Defaults to 200.")
+      .action((p, c) => c.copy(extra = c.extra.copy(submissionBufferSize = p)))
+
+    parser
+      .opt[Unit]("sandbox-on-x-bridge")
+      .text("Placeholder for the configuration turning on the sandbox-on-x bridge.")
+
+    ()
+  }
+
+  override val defaultExtraConfig: BridgeConfig = BridgeConfig(
+    maxDedupSeconds = 30,
+    submissionBufferSize = 200,
+  )
+}

--- a/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
+++ b/ledger/sandbox-on-x/src/main/scala/com/daml/ledger/sandbox/ReadWriteServiceBridge.scala
@@ -1,0 +1,243 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.ledger.sandbox
+
+import java.util.UUID
+import java.util.concurrent.{CompletableFuture, CompletionStage}
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import akka.stream.{BoundedSourceQueue, Materializer, QueueOfferResult}
+import com.daml.daml_lf_dev.DamlLf.Archive
+import com.daml.ledger.api.health.HealthStatus
+import com.daml.ledger.participant.state.v1._
+import com.daml.lf.data.Time
+import com.daml.lf.data.Time.Timestamp
+import com.daml.logging.{ContextualizedLogger, LoggingContext}
+import com.google.common.primitives.Longs
+
+case class ReadWriteServiceBridge(
+    participantId: ParticipantId,
+    ledgerId: LedgerId,
+    maxDedupSeconds: Int,
+    submissionBufferSize: Int,
+)(implicit mat: Materializer, loggingContext: LoggingContext)
+    extends ReadService
+    with WriteService
+    with AutoCloseable {
+  import ReadWriteServiceBridge._
+
+  private[this] val logger = ContextualizedLogger.get(getClass)
+
+  override def submitTransaction(
+      submitterInfo: SubmitterInfo,
+      transactionMeta: TransactionMeta,
+      transaction: SubmittedTransaction,
+      estimatedInterpretationCost: Long,
+  ): CompletionStage[SubmissionResult] =
+    submit(
+      Submission.Transaction(
+        submitterInfo = submitterInfo,
+        transactionMeta = transactionMeta,
+        transaction = transaction,
+        estimatedInterpretationCost = estimatedInterpretationCost,
+      )
+    )
+
+  override def submitConfiguration(
+      maxRecordTime: Time.Timestamp,
+      submissionId: SubmissionId,
+      config: Configuration,
+  ): CompletionStage[SubmissionResult] =
+    submit(
+      Submission.Config(
+        maxRecordTime = maxRecordTime,
+        submissionId = submissionId,
+        config = config,
+      )
+    )
+
+  override def currentHealth(): HealthStatus = HealthStatus.healthy
+
+  override def allocateParty(
+      hint: Option[Party],
+      displayName: Option[String],
+      submissionId: SubmissionId,
+  ): CompletionStage[SubmissionResult] =
+    submit(
+      Submission.AllocateParty(
+        hint = hint,
+        displayName = displayName,
+        submissionId = submissionId,
+      )
+    )
+
+  override def uploadPackages(
+      submissionId: SubmissionId,
+      archives: List[Archive],
+      sourceDescription: Option[String],
+  ): CompletionStage[SubmissionResult] =
+    submit(
+      Submission.UploadPackages(
+        submissionId = submissionId,
+        archives = archives,
+        sourceDescription = sourceDescription,
+      )
+    )
+
+  override def prune(
+      pruneUpToInclusive: Offset,
+      submissionId: SubmissionId,
+  ): CompletionStage[PruningResult] =
+    CompletableFuture.completedFuture(
+      PruningResult.ParticipantPruned
+    )
+
+  override def getLedgerInitialConditions(): Source[LedgerInitialConditions, NotUsed] =
+    Source.single(
+      LedgerInitialConditions(
+        ledgerId = ledgerId,
+        config = Configuration(
+          generation = 1L,
+          timeModel = TimeModel.reasonableDefault,
+          maxDeduplicationTime = java.time.Duration.ofSeconds(maxDedupSeconds.toLong),
+        ),
+        initialRecordTime = Timestamp.now(),
+      )
+    )
+
+  var stateUpdatesWasCalledAlready = false
+  override def stateUpdates(beginAfter: Option[Offset]): Source[(Offset, Update), NotUsed] = {
+    // TODO for PoC purposes:
+    //   no beginAfter supported
+    //   neither multiple subscriptions
+    //   neither bootstrapping the bridge from indexer persistence
+    assert(
+      beginAfter.isEmpty,
+      "Re-subscribing not supported. Only supported to subscribe once, and from inception.",
+    )
+    synchronized {
+      if (stateUpdatesWasCalledAlready)
+        throw new IllegalStateException("not allowed to call this twice")
+      else stateUpdatesWasCalledAlready = true
+    }
+    logger.info("Indexer subscribed to state updates.")
+    queueSource
+  }
+
+  val (queue: BoundedSourceQueue[Submission], queueSource: Source[(Offset, Update), NotUsed]) =
+    Source
+      .queue[Submission](submissionBufferSize)
+      .zipWithIndex
+      .map { case (submission, index) =>
+        (toOffset(index), successMapper(submission, index, participantId))
+      }
+      .preMaterialize()
+
+  logger.info(
+    s"BridgeLedgerFactory initialized. Configuration: [maxDedupSeconds: $maxDedupSeconds, submissionBufferSize: $submissionBufferSize]"
+  )
+
+  private def submit(submission: Submission): CompletionStage[SubmissionResult] =
+    toSubmissionResult(queue.offer(submission))
+
+  override def close(): Unit = {
+    logger.info("Shutting down BridgeLedgerFactory.")
+    queue.complete()
+  }
+}
+
+object ReadWriteServiceBridge {
+  trait Submission
+  object Submission {
+    case class Transaction(
+        submitterInfo: SubmitterInfo,
+        transactionMeta: TransactionMeta,
+        transaction: SubmittedTransaction,
+        estimatedInterpretationCost: Long,
+    ) extends Submission
+    case class Config(
+        maxRecordTime: Time.Timestamp,
+        submissionId: SubmissionId,
+        config: Configuration,
+    ) extends Submission
+    case class AllocateParty(
+        hint: Option[Party],
+        displayName: Option[String],
+        submissionId: SubmissionId,
+    ) extends Submission
+    case class UploadPackages(
+        submissionId: SubmissionId,
+        archives: List[Archive],
+        sourceDescription: Option[String],
+    ) extends Submission
+  }
+
+  private[this] val logger = ContextualizedLogger.get(getClass)
+
+  def successMapper(s: Submission, index: Long, participantId: ParticipantId): Update = s match {
+    case s: Submission.AllocateParty =>
+      val party = s.hint.getOrElse(UUID.randomUUID().toString)
+      Update.PartyAddedToParticipant(
+        party = party.asInstanceOf[Party],
+        displayName = s.displayName.getOrElse(party),
+        participantId = participantId,
+        recordTime = Time.Timestamp.now(),
+        submissionId = Some(s.submissionId),
+      )
+
+    case s: Submission.Config =>
+      Update.ConfigurationChanged(
+        recordTime = Time.Timestamp.now(),
+        submissionId = s.submissionId,
+        participantId = participantId,
+        newConfiguration = s.config,
+      )
+
+    case s: Submission.UploadPackages =>
+      Update.PublicPackageUpload(
+        archives = s.archives,
+        sourceDescription = s.sourceDescription,
+        recordTime = Time.Timestamp.now(),
+        submissionId = Some(s.submissionId),
+      )
+
+    case s: Submission.Transaction =>
+      Update.TransactionAccepted(
+        optSubmitterInfo = Some(s.submitterInfo),
+        transactionMeta = s.transactionMeta,
+        transaction = s.transaction.asInstanceOf[CommittedTransaction],
+        transactionId = index.toString.asInstanceOf[TransactionId],
+        recordTime = Time.Timestamp.now(),
+        divulgedContracts = Nil,
+        blindingInfo = None,
+      )
+  }
+
+  def toOffset(index: Long): Offset = Offset.fromByteArray(Longs.toByteArray(index))
+
+  def toSubmissionResult(
+      queueOfferResult: QueueOfferResult
+  )(implicit loggingContext: LoggingContext): CompletableFuture[SubmissionResult] =
+    CompletableFuture.completedFuture(
+      queueOfferResult match {
+        case QueueOfferResult.Enqueued =>
+          SubmissionResult.Acknowledged
+
+        case QueueOfferResult.Dropped =>
+          logger.warn(
+            "Buffer overflow: new submission is not added, signalized `Overloaded` for caller."
+          )
+          SubmissionResult.Overloaded
+
+        case QueueOfferResult.Failure(throwable) =>
+          logger.error("Error enqueueing new submission.", throwable)
+          SubmissionResult.InternalError(throwable.getMessage)
+
+        case QueueOfferResult.QueueClosed =>
+          logger.error("Error enqueueing new submission: queue is closed.")
+          SubmissionResult.InternalError("Service is shutting down.")
+      }
+    )
+}

--- a/ledger/sandbox-on-x/src/test/resources/logback-test.xml
+++ b/ledger/sandbox-on-x/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%level %logger{10}: %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/release/artifacts.yaml
+++ b/release/artifacts.yaml
@@ -155,6 +155,10 @@
   type: jar-scala
 - target: //ledger/sandbox-classic:sandbox-classic-ce
   type: jar-scala
+- target: //ledger/sandbox-on-x:sandbox-on-x
+  type: jar-scala
+- target: //ledger/sandbox-on-x:sandbox-on-x-app
+  type: jar-scala
 - target: //ledger/test-common:dar-files-1.12-lib
   type: jar-scala
 - target: //ledger/test-common:dar-files-1.dev-lib


### PR DESCRIPTION
Content:
-adds ReadWriteServiceBridge
-adds BridgeLedgerFactory with extra configuration
-conformance test suits

Limitations:
-no conflict checking, just replaying all submissions
-no bootstrapping from indexer persistence
-no multiple/subsequent subscription support
-conformance tests, which rely on correctness features were excluded
 -ClosedWorldIT: test should fail referencing unallocated party
 -CommandDeduplicationIT:CDStopOnCompletionFailure: creates error conditions based on racing key updates (rest is green)
 -ContractKeysIT:CKFetchOrLookup, CKNoFetchUndisclosed: these are failing due to lack of validation/conflict checking in the bridge
 -SemanticConcurrentDoubleSpend:SemanticConcurrentDoubleSpend: this is failing due to lack of validation/conflict checking in the bridge

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [-] Include appropriate tests -- PoC code, stabilisation will come as it matures
- [x] Set a descriptive title and thorough description
- [X] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [-] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
