### PR TITLE
Avoid submitTree on simple exercise commands

### DIFF
--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -321,10 +321,7 @@ private[dump] object Encode {
       tree: TransactionTree,
   ): Doc = {
     val rootEvs = tree.rootEventIds.map(tree.eventsById(_).kind)
-    val simpleEventsOnly: Option[List[SimpleEvent]] = {
-      import scalaz.Scalaz._
-      rootEvs.toList.traverse(ev => SimpleEvent.fromTreeEvent(ev, tree))
-    }
+    val simpleEventsOnly: Option[Seq[SimpleEvent]] = SimpleEvent.fromTree(tree)
     simpleEventsOnly match {
       case Some(evs) =>
         encodeSubmitSimpleEvents(partyMap, cidMap, cidRefs, evs)

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -265,7 +265,7 @@ private[dump] object Encode {
       cidRefs: Set[ContractId],
       evs: Seq[SimpleEvent],
   ): Doc = {
-    val submitters = evs.flatMap(ev => evParties(ev.event)).toSet
+    val submitters: Set[Party] = evs.foldMap(ev => evParties(ev.event).toSet)
     val cids = evs.map(_.contractId)
     val referencedCids = cids.filter(cid => cidRefs.contains(cid))
     val (bind, returnStmt) = referencedCids match {

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -188,6 +188,13 @@ object TreeUtils {
         case _ => None
       }
     }
+
+    def fromTree(tree: TransactionTree): Option[Seq[SimpleEvent]] = {
+      import scalaz.Scalaz._
+      tree.rootEventIds.toList.traverse(id =>
+        SimpleEvent.fromTreeEvent(tree.eventsById(id).kind, tree)
+      )
+    }
   }
 
   def evParties(ev: TreeEvent.Kind): Seq[Party] = ev match {

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -185,7 +185,7 @@ object TreeUtils {
               Some(SimpleEvent(exercised, ContractId(cid)))
             case _ => None
           }
-        case _ => None
+        case Kind.Empty => None
       }
     }
 

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -17,6 +17,7 @@ import scalaz.std.set._
 import scalaz.syntax.foldable._
 
 import scala.collection.compat._
+import scala.collection.mutable.ListBuffer
 
 object TreeUtils {
   final case class Selector(i: Int)
@@ -173,9 +174,9 @@ object TreeUtils {
             }
           }
           val creates = {
-            var creates = Seq.empty[String]
+            val creates = ListBuffer.empty[String]
             traverseEventInTree(exercised, tree) {
-              case (_, Kind.Created(value)) => creates ++= Seq(value.contractId)
+              case (_, Kind.Created(value)) => creates.addOne(value.contractId)
               case _ =>
             }
             creates

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -140,7 +140,7 @@ object TreeUtils {
   def treeEventCreatedCids(event: TreeEvent.Kind, tree: TransactionTree): Seq[ContractId] = {
     val creates = ListBuffer.empty[ContractId]
     traverseEventInTree(event, tree) {
-      case (_, Kind.Created(value)) => creates.addOne(ContractId(value.contractId))
+      case (_, Kind.Created(value)) => creates += ContractId(value.contractId)
       case _ =>
     }
     creates.toSeq

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -49,20 +49,23 @@ object TreeUtils {
   }
 
   def traverseTree(tree: TransactionTree)(f: (List[Selector], TreeEvent.Kind) => Unit): Unit = {
-    def traverseEv(ev: TreeEvent.Kind, f: (List[Selector], TreeEvent.Kind) => Unit): Unit =
-      ev match {
-        case Kind.Empty =>
-        case created @ Kind.Created(_) =>
-          f(List(), created)
-        case exercised @ Kind.Exercised(value) =>
-          f(List(), exercised)
-          value.childEventIds.map(x => tree.eventsById(x).kind).zipWithIndex.foreach {
-            case (ev, i) =>
-              traverseEv(ev, { case (path, ev) => f(Selector(i) :: path, ev) })
-          }
-      }
     tree.rootEventIds.map(tree.eventsById(_)).zipWithIndex.foreach { case (ev, i) =>
-      traverseEv(ev.kind, { case (path, ev) => f(Selector(i) :: path, ev) })
+      traverseEventInTree(ev.kind, tree) { case (path, ev) => f(Selector(i) :: path, ev) }
+    }
+  }
+
+  def traverseEventInTree(event: TreeEvent.Kind, tree: TransactionTree)(
+      f: (List[Selector], TreeEvent.Kind) => Unit
+  ): Unit = {
+    event match {
+      case Kind.Empty =>
+      case created @ Kind.Created(_) =>
+        f(List(), created)
+      case exercised @ Kind.Exercised(value) =>
+        f(List(), exercised)
+        value.childEventIds.map(x => tree.eventsById(x).kind).zipWithIndex.foreach { case (ev, i) =>
+          traverseEventInTree(ev, tree) { case (path, ev) => f(Selector(i) :: path, ev) }
+        }
     }
   }
 

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -137,6 +137,15 @@ object TreeUtils {
     cids
   }
 
+  def treeEventCreatedCids(event: TreeEvent.Kind, tree: TransactionTree): Seq[ContractId] = {
+    val creates = ListBuffer.empty[ContractId]
+    traverseEventInTree(event, tree) {
+      case (_, Kind.Created(value)) => creates.addOne(ContractId(value.contractId))
+      case _ =>
+    }
+    creates.toSeq
+  }
+
   def treeReferencedCids(tree: TransactionTree): Set[ContractId] = {
     var cids: Set[ContractId] = Set.empty
     traverseTree(tree) { case (_, kind) =>
@@ -173,14 +182,7 @@ object TreeUtils {
               case _ => None
             }
           }
-          val creates = {
-            val creates = ListBuffer.empty[String]
-            traverseEventInTree(exercised, tree) {
-              case (_, Kind.Created(value)) => creates.addOne(value.contractId)
-              case _ =>
-            }
-            creates
-          }
+          val creates = treeEventCreatedCids(exercised, tree)
           (result, creates) match {
             case (Some(cid), Seq(createdCid)) if cid == createdCid =>
               Some(SimpleEvent(exercised, ContractId(cid)))

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeCreatedSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 class EncodeCreatedSpec extends AnyFreeSpec with Matchers {
   import Encode._
-  "encodeCreatedEvent" - {
+  "encodeSubmitCreatedEvents" - {
     "multi party submissions" in {
       val parties = Map(
         Party("Alice") -> "alice_0",

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeSimpleSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeSimpleSpec.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.dump
+
+import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class EncodeSimpleSpec extends AnyFreeSpec with Matchers {
+  import Encode._
+  "encodeSubmitSimpleEvents" - {
+    "mixed create and exercise events" in {
+      val parties = Map(
+        Party("Alice") -> "alice_0",
+        Party("Bob") -> "bob_0",
+      )
+      val cidMap = Map(
+        ContractId("cid1") -> "contract_0_0",
+        ContractId("cid2") -> "contract_0_1",
+        ContractId("cid3") -> "contract_0_2",
+      )
+      val cidRefs = Set(ContractId("cid1"), ContractId("cid3"))
+      val events = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1"), submitters = Seq(Party("Alice"))),
+            TestData.Exercised(
+              ContractId("cid2"),
+              Seq(
+                TestData.Created(ContractId("cid3"))
+              ),
+              exerciseResult = Some(ContractId("cid3")),
+              actingParties = Seq(Party("Bob")),
+            ),
+          )
+        )
+        .toSimpleEvents
+      encodeSubmitSimpleEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
+        """(contract_0_0, contract_0_2) <- submitMulti [alice_0, bob_0] [] do
+          |  contract_0_0 <- createCmd Module.Template
+          |  contract_0_2 <- exerciseCmd contract_0_1 (Module.Choice ())
+          |  pure (contract_0_0, contract_0_2)""".stripMargin.replace(
+          "\r\n",
+          "\n",
+        )
+    }
+  }
+}

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.dump
+
+import com.daml.ledger.api.refinements.ApiTypes.ContractId
+import com.daml.script.dump.TreeUtils.SimpleEvent
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+class IdentifySimpleSpec extends AnyFreeSpec with Matchers with OptionValues {
+  "fromTree" - {
+    "createdEvent" in {
+      val events = TestData
+        .Tree(
+          Seq(
+            TestData.Created(ContractId("cid1"))
+          )
+        )
+        .toTransactionTree
+      SimpleEvent.fromTree(events) should be(Symbol("defined"))
+    }
+    "simple exercisedEvent" in {
+      val events = TestData
+        .Tree(
+          Seq(
+            TestData.Exercised(
+              ContractId("cid1"),
+              Seq(
+                TestData.Created(ContractId("cid2"))
+              ),
+              exerciseResult = Some(ContractId("cid2")),
+            )
+          )
+        )
+        .toTransactionTree
+      SimpleEvent.fromTree(events) should be(Symbol("defined"))
+    }
+  }
+  "complex exercisedEvent" in {
+    val events = TestData
+      .Tree(
+        Seq(
+          TestData.Exercised(
+            ContractId("cid1"),
+            Seq(
+              TestData.Created(ContractId("cid2")),
+              TestData.Created(ContractId("cid3")),
+            ),
+            exerciseResult = Some(ContractId("cid2")),
+          )
+        )
+      )
+      .toTransactionTree
+    SimpleEvent.fromTree(events) should be(None)
+  }
+}

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
@@ -7,6 +7,7 @@ import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
 import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
 import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
 import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value, Variant}
+import com.daml.script.dump.TreeUtils.SimpleEvent
 import com.google.protobuf
 
 object TestData {
@@ -103,6 +104,9 @@ object TestData {
         rootEventIds = rootEventIds,
         traceContext = None,
       )
+    }
+    def toSimpleEvents: Seq[SimpleEvent] = {
+      SimpleEvent.fromTree(this.toTransactionTree).get
     }
   }
 }


### PR DESCRIPTION
Closes #8774
Continuation of #8952 which addressed a sequence of creates.

This avoids `submitTree` in favor of `submit` for a sequence of commands which are either creates or simple exercises which create exactly one contract and return its id as a result. In the code these are referred to as `SimpleEvent`s.
Adds unit-tests for the identification of simple events and their encoding.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
