### PR TITLE
fix poweroff on failure to clean

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -48,7 +48,7 @@ jobs:
         set -euo pipefail
         git checkout $(release_sha)
       name: checkout_release
-      condition: eq(variables.is_release, 'true')
+      condition: and(succeeded(), eq(variables.is_release, 'true'))
     - template: clean-up.yml
     - template: build-unix.yml
       parameters:
@@ -95,7 +95,7 @@ jobs:
         set -euo pipefail
         git checkout $(release_sha)
       name: checkout_release
-      condition: eq(variables.is_release, 'true')
+      condition: and(succeeded(), eq(variables.is_release, 'true'))
     - template: clean-up.yml
     - template: build-unix.yml
       parameters:
@@ -129,7 +129,7 @@ jobs:
         set -euo pipefail
         git checkout $(release_sha)
       name: checkout_release
-      condition: eq(variables.is_release, 'true')
+      condition: and(succeeded(), eq(variables.is_release, 'true'))
     - template: clean-up.yml
     - template: build-unix.yml
       parameters:
@@ -166,7 +166,7 @@ jobs:
         set -euo pipefail
         git checkout $(release_sha)
       name: checkout_release
-      condition: eq(variables.is_release, 'true')
+      condition: and(succeeded(), eq(variables.is_release, 'true'))
     - template: build-windows.yml
       parameters:
         release_tag: $(release_tag)
@@ -198,7 +198,7 @@ jobs:
         source dev-env/lib/ensure-nix
         ci/dev-env-push.py
       displayName: 'Push Developer Environment build results'
-      condition: eq(variables['System.PullRequest.IsFork'], 'False')
+      condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'False'))
       env:
         # to upload to the Nix cache
         GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
@@ -240,7 +240,7 @@ jobs:
         ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
         ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PASSWORD)
       displayName: 'Build'
-      condition: eq(variables['System.PullRequest.IsFork'], 'False')
+      condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'False'))
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -11,7 +11,7 @@ steps:
     # Linux machines don't seem to recover when this script fails, and they get
     # renewed by the instance_group
     if [ "$(uname -s)" == "Linux" ]; then
-        trap "shutdown -h now" EXIT
+        trap "sudo /sbin/poweroff" EXIT
     fi
 
     if [ $(df -m . | sed 1d | awk '{print $4}') -lt 50000 ]; then

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -11,7 +11,7 @@ steps:
     # Linux machines don't seem to recover when this script fails, and they get
     # renewed by the instance_group
     if [ "$(uname -s)" == "Linux" ]; then
-        trap 'echo "error happened, killing node"; nohup bash -c "sleep 10; sudo /sbin/poweroff" &' EXIT
+        trap 'echo "error happened, killing node"; nohup bash -c "sleep 30; sudo /sbin/poweroff" &' EXIT
         exit 1
     fi
 

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -5,10 +5,15 @@ steps:
 - bash: |
     set -euo pipefail
 
+    if [ -f /tmp/shut ]; then
+        cat /tmp/shut
+    fi
+    echo 1 >/tmp/shut
+
     shut_down () {
       echo "error happened, shutting down node"
       sleep 10
-      (sleep 10; sudo /usr/sbin/poweroff) </dev/null &>/dev/null &
+      (sleep 10; sudo /usr/sbin/poweroff &>/tmp/shut ) </dev/null &>/dev/null &
       disown
     }
 

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -4,6 +4,13 @@
 steps:
 - bash: |
     set -euo pipefail
+
+    shut_down () {
+      echo "error happened, shutting down node"
+      nohup bash -c "sleep 10; sudo /sbin/poweroff" &>/dev/null </dev/null &
+      disown
+    }
+
     # Location of the disk cache for CI servers set in their init files:
     # infra/macos/2-common-box/init.sh:echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
     # infra/vsts_agent_linux_startup.sh:echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
@@ -11,7 +18,7 @@ steps:
     # Linux machines don't seem to recover when this script fails, and they get
     # renewed by the instance_group
     if [ "$(uname -s)" == "Linux" ]; then
-        trap 'echo "error happened, killing node"; (nohup bash -c "sleep 30; sudo /sbin/poweroff" &)' EXIT
+        trap shut_down EXIT
         exit 1
     fi
 

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -7,8 +7,8 @@ steps:
 
     shut_down () {
       echo "error happened, shutting down node"
-      nohup bash -c "sleep 10; sudo /sbin/poweroff" &>/dev/null </dev/null &
-      disown
+      sleep 10
+      /sbin/poweroff
     }
 
     # Location of the disk cache for CI servers set in their init files:

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -11,7 +11,7 @@ steps:
     # Linux machines don't seem to recover when this script fails, and they get
     # renewed by the instance_group
     if [ "$(uname -s)" == "Linux" ]; then
-        trap 'echo "error happened, killing node"; nohup bash -c "sleep 30; sudo /sbin/poweroff" &' EXIT
+        trap 'echo "error happened, killing node"; nohup bash -c "nohup bash -c \"(sleep 30; sudo /sbin/poweroff) &\"" &' EXIT
         exit 1
     fi
 

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -8,7 +8,7 @@ steps:
     shut_down () {
       echo "error happened, shutting down node"
       sleep 10
-      /sbin/poweroff
+      sudo /usr/sbin/poweroff
     }
 
     # Location of the disk cache for CI servers set in their init files:

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -13,7 +13,7 @@ steps:
     shut_down () {
       echo "error happened, shutting down node"
       sleep 10
-      (sleep 10; sudo /usr/sbin/poweroff &>/tmp/shut ) </dev/null &>/dev/null &
+      (echo 3 >> /tmp/shut; sleep 10; echo 2 >>/tmp/shut; sudo /usr/sbin/poweroff &>/tmp/shut ) </dev/null &>/dev/null &
       disown
     }
 

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -11,7 +11,7 @@ steps:
     # Linux machines don't seem to recover when this script fails, and they get
     # renewed by the instance_group
     if [ "$(uname -s)" == "Linux" ]; then
-        trap 'echo "error happened, killing node"; nohub bash -c "sleep 10; sudo /sbin/poweroff" &' EXIT
+        trap 'echo "error happened, killing node"; nohup bash -c "sleep 10; sudo /sbin/poweroff" &' EXIT
         exit 1
     fi
 

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -5,28 +5,9 @@ steps:
 - bash: |
     set -euo pipefail
 
-    if [ -f /tmp/shut ]; then
-        cat /tmp/shut
-    fi
-    echo 1 >/tmp/shut
-
-    shut_down () {
-      echo "error happened, shutting down node"
-      sleep 10
-      ( sudo /usr/sbin/poweroff &>/tmp/shut ) </dev/null &>/dev/null &
-      disown
-    }
-
     # Location of the disk cache for CI servers set in their init files:
     # infra/macos/2-common-box/init.sh:echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
     # infra/vsts_agent_linux_startup.sh:echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
-
-    # Linux machines don't seem to recover when this script fails, and they get
-    # renewed by the instance_group
-    if [ "$(uname -s)" == "Linux" ]; then
-        trap shut_down EXIT
-        exit 1
-    fi
 
     if [ $(df -m . | sed 1d | awk '{print $4}') -lt 50000 ]; then
         echo "Disk full, cleaning up..."

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -11,7 +11,7 @@ steps:
     # Linux machines don't seem to recover when this script fails, and they get
     # renewed by the instance_group
     if [ "$(uname -s)" == "Linux" ]; then
-        trap 'echo "error happened, killing node"; nohup bash -c "nohup bash -c \"(sleep 30; sudo /sbin/poweroff) &\"" &' EXIT
+        trap 'echo "error happened, killing node"; (nohup bash -c "sleep 30; sudo /sbin/poweroff" &)' EXIT
         exit 1
     fi
 

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -13,7 +13,7 @@ steps:
     shut_down () {
       echo "error happened, shutting down node"
       sleep 10
-      (echo 3 >> /tmp/shut; sleep 10; echo 2 >>/tmp/shut; sudo /usr/sbin/poweroff &>/tmp/shut ) </dev/null &>/dev/null &
+      ( sudo /usr/sbin/poweroff &>/tmp/shut ) </dev/null &>/dev/null &
       disown
     }
 

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -11,7 +11,8 @@ steps:
     # Linux machines don't seem to recover when this script fails, and they get
     # renewed by the instance_group
     if [ "$(uname -s)" == "Linux" ]; then
-        trap "sudo /sbin/poweroff" EXIT
+        trap 'echo "error happened, killing node"; nohub bash -c "sleep 10; sudo /sbin/poweroff" &' EXIT
+        exit 1
     fi
 
     if [ $(df -m . | sed 1d | awk '{print $4}') -lt 50000 ]; then

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -8,7 +8,7 @@ steps:
     shut_down () {
       echo "error happened, shutting down node"
       sleep 10
-      (sleep 10; bash -c "sudo /usr/sbin/poweroff") </dev/null &>/dev/null &
+      (sleep 10; sudo /usr/sbin/poweroff) </dev/null &>/dev/null &
       disown
     }
 

--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -8,7 +8,8 @@ steps:
     shut_down () {
       echo "error happened, shutting down node"
       sleep 10
-      sudo /usr/sbin/poweroff
+      (sleep 10; bash -c "sudo /usr/sbin/poweroff") </dev/null &>/dev/null &
+      disown
     }
 
     # Location of the disk cache for CI servers set in their init files:

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -93,6 +93,7 @@ useradd \
   --shell /bin/bash \
   --uid 3000 \
   vsts
+echo "vsts ALL=NOPASSWD: /sbin/poweroff" >> /etc/sudoers
 #add docker group to user
 usermod -aG docker vsts
 

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -93,7 +93,6 @@ useradd \
   --shell /bin/bash \
   --uid 3000 \
   vsts
-echo "vsts ALL=NOPASSWD: /usr/sbin/poweroff" >> /etc/sudoers
 #add docker group to user
 usermod -aG docker vsts
 

--- a/infra/vsts_agent_ubuntu_20_04_startup.sh
+++ b/infra/vsts_agent_ubuntu_20_04_startup.sh
@@ -93,7 +93,7 @@ useradd \
   --shell /bin/bash \
   --uid 3000 \
   vsts
-echo "vsts ALL=NOPASSWD: /sbin/poweroff" >> /etc/sudoers
+echo "vsts ALL=NOPASSWD: /usr/sbin/poweroff" >> /etc/sudoers
 #add docker group to user
 usermod -aG docker vsts
 


### PR DESCRIPTION
This requires a redpoyment of the CI fleet, so I'll be doing that later in the day. I'll merge once the new machines are deployed and I've seen the shutdown work (likely by adding an `exit 1` to `ci/clean-up.yml`).

CHANGELOG_BEGIN
CHANGELOG_END