### PR TITLE
Fix heartbeating in the JSON API when starting from offset

### DIFF
--- a/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
+++ b/ledger-service/http-json/src/main/scala/com/digitalasset/http/domain.scala
@@ -193,6 +193,11 @@ object domain {
     ): Option[Offset] =
       Option(gacr.offset).filter(_.nonEmpty).map(x => Offset(x))
 
+    def fromLedgerApi(
+        gler: lav1.transaction_service.GetLedgerEndResponse
+    ): Option[Offset] =
+      gler.offset.flatMap(_.value.absolute).filter(_.nonEmpty).map(x => Offset(x))
+
     def fromLedgerApi(tx: lav1.transaction.Transaction): Offset = Offset(tx.offset)
 
     def toLedgerApi(o: Offset): lav1.ledger_offset.LedgerOffset =


### PR DESCRIPTION
We filter heartbeat ticks until we get the first step message. This is
when starting from the ACS but it is incorrect when starting from an
existing offset where this results in us not emitting heartbeats until
we get the first step message. This PR fixes this by passing along the
initial offset and adds a test for this.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
