### PR TITLE
ci/clean-up: remove poweroff

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -4,15 +4,10 @@
 steps:
 - bash: |
     set -euo pipefail
+
     # Location of the disk cache for CI servers set in their init files:
     # infra/macos/2-common-box/init.sh:echo "build:darwin --disk_cache=~/.bazel-cache" > ~/.bazelrc
     # infra/vsts_agent_linux_startup.sh:echo "build:linux --disk_cache=~/.bazel-cache" > ~/.bazelrc
-
-    # Linux machines don't seem to recover when this script fails, and they get
-    # renewed by the instance_group
-    if [ "$(uname -s)" == "Linux" ]; then
-        trap "shutdown -h now" EXIT
-    fi
 
     if [ $(df -m . | sed 1d | awk '{print $4}') -lt 50000 ]; then
         echo "Disk full, cleaning up..."


### PR DESCRIPTION
It's not working and I can't make it work (see #9096), so I'd rather just remove it.

CHANGELOG_BEGIN
CHANGELOG_END