### PR TITLE
ci/build: fix conditions

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -48,7 +48,7 @@ jobs:
         set -euo pipefail
         git checkout $(release_sha)
       name: checkout_release
-      condition: eq(variables.is_release, 'true')
+      condition: and(succeeded(), eq(variables.is_release, 'true'))
     - template: clean-up.yml
     - template: build-unix.yml
       parameters:
@@ -95,7 +95,7 @@ jobs:
         set -euo pipefail
         git checkout $(release_sha)
       name: checkout_release
-      condition: eq(variables.is_release, 'true')
+      condition: and(succeeded(), eq(variables.is_release, 'true'))
     - template: clean-up.yml
     - template: build-unix.yml
       parameters:
@@ -129,7 +129,7 @@ jobs:
         set -euo pipefail
         git checkout $(release_sha)
       name: checkout_release
-      condition: eq(variables.is_release, 'true')
+      condition: and(succeeded(), eq(variables.is_release, 'true'))
     - template: clean-up.yml
     - template: build-unix.yml
       parameters:
@@ -166,7 +166,7 @@ jobs:
         set -euo pipefail
         git checkout $(release_sha)
       name: checkout_release
-      condition: eq(variables.is_release, 'true')
+      condition: and(succeeded(), eq(variables.is_release, 'true'))
     - template: build-windows.yml
       parameters:
         release_tag: $(release_tag)
@@ -198,7 +198,7 @@ jobs:
         source dev-env/lib/ensure-nix
         ci/dev-env-push.py
       displayName: 'Push Developer Environment build results'
-      condition: eq(variables['System.PullRequest.IsFork'], 'False')
+      condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'False'))
       env:
         # to upload to the Nix cache
         GOOGLE_APPLICATION_CREDENTIALS_CONTENT: $(GOOGLE_APPLICATION_CREDENTIALS_CONTENT)
@@ -240,7 +240,7 @@ jobs:
         ARTIFACTORY_USERNAME: $(ARTIFACTORY_USERNAME)
         ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PASSWORD)
       displayName: 'Build'
-      condition: eq(variables['System.PullRequest.IsFork'], 'False')
+      condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'False'))
     - template: tell-slack-failed.yml
       parameters:
         trigger_sha: '$(trigger_sha)'


### PR DESCRIPTION
In Azure Yaml, by defualt, a step runs only if the previous step was successful. However, that default _disappears if the step has an explicit condition_. I believe we have a number of conditional steps that have been written without that intention, and this is thus restoring what I believe to be the original intention, i.e. _adding_ an additional condition rather than _replacing_ the default one.

CHANGELOG_BEGIN
CHANGELOG_END