### PR TITLE
Fix javadocs & sources in daml-sdk-head

### DIFF
--- a/release/src/Main.hs
+++ b/release/src/Main.hs
@@ -11,6 +11,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Logger
 import Control.Exception
 import qualified Control.Exception.Safe as E
+import Data.Foldable (toList)
 import qualified Data.SemVer as SemVer
 import Data.Yaml
 import qualified Data.Set as Set
@@ -78,7 +79,7 @@ copyArtifacts :: (MonadIO m, MonadLogger m, E.MonadThrow m) => BazelLocations ->
 copyArtifacts bazelLocations releaseDir as = do
   mvnFiles <-
     fmap concat $ forM as $ \artifact ->
-    map (artifact,) <$> artifactFiles artifact
+    map (artifact,) . toList <$> artifactFiles artifact
   forM_ mvnFiles $ \(_, (inp, outp)) ->
     copyToReleaseDir bazelLocations releaseDir inp outp
 

--- a/release/src/Maven.hs
+++ b/release/src/Maven.hs
@@ -37,17 +37,14 @@ generateAggregatePom releaseDir artifacts = do
     where
     execution :: (MonadFail m, E.MonadThrow m) => Artifact PomData -> m Text
     execution artifact = do
-        (mainArtifactFile:pomFile:rest) <- map snd <$> artifactFiles artifact
-        let (javadocFile, sourcesFile) = case rest of
-              [javadoc, sources] -> (Just javadoc, Just sources)
-              _ -> (Nothing, Nothing)
+        ArtifactFiles{..} <- fmap snd <$> artifactFiles artifact
         let configuration =
                 map (\(name, value) -> (name, pathToText (releaseDir </> value))) $
                     Maybe.catMaybes
-                        [ Just ("pomFile", pomFile)
-                        , Just ("file", mainArtifactFile)
-                        , ("javadoc", ) <$> javadocFile
-                        , ("sources", ) <$> sourcesFile
+                        [ Just ("pomFile", artifactPom)
+                        , Just ("file", artifactMain)
+                        , ("javadoc", ) <$> artifactJavadoc
+                        , ("sources", ) <$> artifactSources
                         ]
         return $ T.unlines $ map ("                    " <>) $
             [ "<execution>"


### PR DESCRIPTION
The order of the list elements was swapped. I don’t trust myself to
not get this wrong in the future so rather than relying on list order,
I added a proper datatype.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
