### PR TITLE
release job: remove extra bash-lib

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,9 +135,6 @@ jobs:
       env:
         AUTH: $(ARTIFACTORY_USERNAME):$(ARTIFACTORY_PASSWORD)
       condition: not(eq(variables['skip-github'], 'TRUE'))
-    - template: ci/bash-lib.yml
-      parameters:
-        var_name: bash-lib
     - bash: |
         set -euo pipefail
 


### PR DESCRIPTION
The filesystem is not reset between steps in the same job, so there is
no need to add the `bash-lib` multiple times.

CHANGELOG_BEGIN
CHANGELOG_END