### PR TITLE
Make async commit configurable and add "LOCAL" async commit option

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/IndexerConfig.scala
@@ -6,6 +6,7 @@ package com.daml.platform.indexer
 import com.daml.ledger.participant.state.v1.ParticipantId
 import com.daml.platform.configuration.IndexConfiguration
 import com.daml.platform.indexer.IndexerConfig._
+import com.daml.platform.store.DbType
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
@@ -18,6 +19,7 @@ case class IndexerConfig(
     eventsPageSize: Int = IndexConfiguration.DefaultEventsPageSize,
     updatePreparationParallelism: Int = DefaultUpdatePreparationParallelism,
     allowExistingSchema: Boolean = false,
+    asyncCommitMode: DbType.AsyncCommitMode = DefaultAsyncCommitMode,
 )
 
 object IndexerConfig {
@@ -26,5 +28,6 @@ object IndexerConfig {
   val DefaultRestartDelay: FiniteDuration = 10.seconds
   // Should be greater than or equal to the number of pipline stages
   val DefaultDatabaseConnectionPoolSize: Int = 3
+  val DefaultAsyncCommitMode: DbType.AsyncCommitMode = DbType.AsynchronousCommit
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/JdbcIndexer.scala
@@ -59,7 +59,7 @@ object JdbcIndexer {
           servicesExecutionContext,
           metrics,
           lfValueTranslationCache,
-          jdbcAsyncCommits = true,
+          jdbcAsyncCommitMode = config.asyncCommitMode,
           enricher = None,
         ),
         new FlywayMigrations(config.jdbcUrl),

--- a/ledger/participant-integration-api/src/main/scala/platform/store/DbType.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/DbType.scala
@@ -40,4 +40,17 @@ private[platform] object DbType {
     case _ =>
       sys.error(s"JDBC URL doesn't match any supported databases (h2, pg)")
   }
+
+  sealed trait AsyncCommitMode {
+    def setting: String
+  }
+  object SynchronousCommit extends AsyncCommitMode {
+    override val setting: String = "ON"
+  }
+  object AsynchronousCommit extends AsyncCommitMode {
+    override val setting: String = "OFF"
+  }
+  object LocalSynchronousCommit extends AsyncCommitMode {
+    override val setting: String = "LOCAL"
+  }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/FlywayMigrations.scala
@@ -65,7 +65,7 @@ private[platform] class FlywayMigrations(jdbcUrl: String)(implicit loggingContex
       maxPoolSize = 2,
       connectionTimeout = 5.seconds,
       metrics = None,
-      connectionAsyncCommit = false,
+      connectionAsyncCommitMode = DbType.SynchronousCommit,
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/DbDispatcher.scala
@@ -13,6 +13,7 @@ import com.daml.logging.LoggingContext.withEnrichedLoggingContext
 import com.daml.logging.{ContextualizedLogger, LoggingContext}
 import com.daml.metrics.{DatabaseMetrics, Metrics}
 import com.daml.platform.configuration.ServerRole
+import com.daml.platform.store.DbType
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -87,7 +88,7 @@ private[platform] object DbDispatcher {
       connectionPoolSize: Int,
       connectionTimeout: FiniteDuration,
       metrics: Metrics,
-      connectionAsyncCommit: Boolean,
+      connectionAsyncCommitMode: DbType.AsyncCommitMode,
   )(implicit loggingContext: LoggingContext): ResourceOwner[DbDispatcher] =
     for {
       connectionProvider <- HikariJdbcConnectionProvider.owner(
@@ -96,7 +97,7 @@ private[platform] object DbDispatcher {
         connectionPoolSize,
         connectionTimeout,
         metrics.registry,
-        connectionAsyncCommit,
+        connectionAsyncCommitMode,
       )
       threadPoolName = s"daml.index.db.threadpool.connection.${serverRole.threadPoolSuffix}"
       executor <- ResourceOwner.forExecutorService(() =>

--- a/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
+++ b/ledger/participant-integration-api/src/test/lib/scala/platform/store/dao/JdbcLedgerDaoBackend.scala
@@ -51,7 +51,7 @@ private[dao] trait JdbcLedgerDaoBackend extends AkkaBeforeAndAfterAll {
       servicesExecutionContext = executionContext,
       metrics = new Metrics(new MetricRegistry),
       lfValueTranslationCache = LfValueTranslation.Cache.none,
-      jdbcAsyncCommits = true,
+      jdbcAsyncCommitMode = DbType.AsynchronousCommit,
       enricher = Some(new ValueEnricher(new Engine())),
     )
 

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/HikariConnectionSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/HikariConnectionSpec.scala
@@ -6,6 +6,7 @@ package com.daml.platform.store.dao
 import com.daml.ledger.resources.TestResourceContext
 import com.daml.logging.LoggingContext
 import com.daml.platform.configuration.ServerRole
+import com.daml.platform.store.DbType
 import com.daml.testing.postgresql.PostgresAroundAll
 import org.mockito.MockitoSugar
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -45,6 +46,7 @@ class HikariConnectionSpec
       maxPoolSize = 2,
       connectionTimeout = 5.seconds,
       metrics = None,
-      connectionAsyncCommit = asyncCommitEnabled,
+      connectionAsyncCommitMode =
+        if (asyncCommitEnabled) DbType.AsynchronousCommit else DbType.SynchronousCommit,
     )(LoggingContext.ForTesting)
 }

--- a/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
+++ b/ledger/recovering-indexer-integration-tests/src/test/suite/scala/com/digitalasset/platform/indexer/RecoveringIndexerIntegrationSpec.scala
@@ -26,6 +26,7 @@ import com.daml.logging.LoggingContext.newLoggingContext
 import com.daml.metrics.Metrics
 import com.daml.platform.configuration.ServerRole
 import com.daml.platform.indexer.RecoveringIndexerIntegrationSpec._
+import com.daml.platform.store.DbType
 import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao}
 import com.daml.platform.testing.LogCollector
@@ -227,7 +228,7 @@ class RecoveringIndexerIntegrationSpec
       servicesExecutionContext = executionContext,
       metrics = new Metrics(new MetricRegistry),
       lfValueTranslationCache = LfValueTranslation.Cache.none,
-      jdbcAsyncCommits = true,
+      jdbcAsyncCommitMode = DbType.AsynchronousCommit,
       enricher = None,
     )
   }

--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/stores/ledger/sql/SqlLedgerSpec.scala
@@ -224,7 +224,7 @@ final class SqlLedgerSpec
         val hikariDataSourceLogs =
           LogCollector.read[this.type]("com.daml.platform.store.dao.HikariConnection")
         hikariDataSourceLogs should contain(
-          Level.INFO -> "Creating Hikari connections with asynchronous commit disabled"
+          Level.INFO -> "Creating Hikari connections with synchronous commit ON"
         )
       }
     }


### PR DESCRIPTION
In replicated Postgres setups, running with SYNCHRONOUS_COMMIT=LOCAL is a
suitable option as it is a trade off to only locally commit synchronously
but not to wait for a replication / network ack.

Therefore we'd like to make the async-commit configurable and also change it to an enum.

cc @matthiasS-da 

### Pull Request Checklist

- [X] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [X] Include appropriate tests
- [X] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [X] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
