### PR TITLE
Support fetching SDK EE tarball in the assistant

### DIFF
--- a/daml-assistant/exe/DA/Daml/Assistant.hs
+++ b/daml-assistant/exe/DA/Daml/Assistant.hs
@@ -135,6 +135,7 @@ autoInstall env@Env{..} = do
     damlConfigE <- tryConfig $ readDamlConfig envDamlPath
     let doAutoInstallE = queryDamlConfigRequired ["auto-install"] =<< damlConfigE
         doAutoInstall = fromRight True doAutoInstallE
+        artifactoryApiKeyM = queryArtifactoryApiKey =<< eitherToMaybe damlConfigE
 
     if doAutoInstall && isJust envSdkVersion && isNothing envSdkPath then do
         -- sdk is missing, so let's install it!
@@ -158,6 +159,7 @@ autoInstall env@Env{..} = do
                 , installingFromOutside = False
                 , projectPathM = Nothing
                 , assistantVersion = envDamlAssistantSdkVersion
+                , artifactoryApiKeyM
                 , output = hPutStrLn stderr
                     -- Print install messages to stderr since the install
                     -- is only happening because of some other command,

--- a/daml-assistant/src/DA/Daml/Assistant/Install/Artifactory.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/Artifactory.hs
@@ -1,0 +1,42 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+
+-- | Discover releases from the artifactory.
+module DA.Daml.Assistant.Install.Artifactory
+    ( versionLocation
+    , queryArtifactoryApiKey
+    , ArtifactoryApiKey(..)
+    ) where
+
+import DA.Daml.Assistant.Install.Github hiding (versionLocation)
+import DA.Daml.Assistant.Types
+import DA.Daml.Project.Config
+import Data.Aeson
+import Data.Either.Extra
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+newtype ArtifactoryApiKey = ArtifactoryApiKey
+    { unwrapArtifactoryApiKey :: Text
+    } deriving (Eq, Show, FromJSON)
+
+queryArtifactoryApiKey :: DamlConfig -> Maybe ArtifactoryApiKey
+queryArtifactoryApiKey damlConfig =
+     eitherToMaybe (queryDamlConfigRequired ["artifactory-api-key"] damlConfig)
+
+-- | Install location for particular version.
+versionLocation :: SdkVersion -> ArtifactoryApiKey -> InstallLocation
+versionLocation v apiKey = InstallLocation
+    { ilUrl = T.concat
+        [ "https://digitalasset.jfrog.io/artifactory/sdk-ee/"
+        , versionToText v
+        , "/daml-sdk-"
+        , versionToText v
+        , "-"
+        , osName
+        , "-ee.tar.gz"
+        ]
+    , ilHeaders =
+        [("X-JFrog-Art-Api", T.encodeUtf8 (unwrapArtifactoryApiKey apiKey))]
+    }

--- a/daml-assistant/src/DA/Daml/Assistant/Install/Github.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Install/Github.hs
@@ -4,8 +4,9 @@
 
 -- | Discover releases from the digital-asset/daml github.
 module DA.Daml.Assistant.Install.Github
-    ( versionURL
+    ( versionLocation
     , tagToVersion
+    , osName
     ) where
 
 import DA.Daml.Assistant.Types
@@ -45,14 +46,17 @@ osName = case System.Info.os of
     "mingw32" -> "windows"
     p -> error ("daml: Unknown operating system " ++ p)
 
--- | Install URL for particular version.
-versionURL :: SdkVersion -> InstallURL
-versionURL v = InstallURL $ T.concat
-    [ "https://github.com/digital-asset/daml/releases/download/"
-    , unTag (versionToTag v)
-    , "/daml-sdk-"
-    , versionToText v
-    , "-"
-    , osName
-    , ".tar.gz"
-    ]
+-- | Install location for particular version.
+versionLocation :: SdkVersion -> InstallLocation
+versionLocation v = InstallLocation
+    { ilUrl = T.concat
+        [ "https://github.com/digital-asset/daml/releases/download/"
+        , unTag (versionToTag v)
+        , "/daml-sdk-"
+        , versionToText v
+        , "-"
+        , osName
+        , ".tar.gz"
+        ]
+    , ilHeaders = []
+    }

--- a/daml-assistant/src/DA/Daml/Assistant/Types.hs
+++ b/daml-assistant/src/DA/Daml/Assistant/Types.hs
@@ -11,9 +11,9 @@ module DA.Daml.Assistant.Types
 
 import DA.Daml.Project.Types
 import qualified Data.Text as T
-import Data.Aeson (FromJSON)
 import Data.Text (Text, pack, unpack)
 import Data.Maybe
+import Network.HTTP.Types.Header
 import Options.Applicative.Extended (YesNoAuto (..))
 import Control.Exception.Safe
 
@@ -98,11 +98,13 @@ data InstallOptions = InstallOptions
     , iZshCompletions :: ZshCompletions -- ^ install Zsh completions for the daml assistant
     } deriving (Eq, Show)
 
--- | An install URL is a fully qualified HTTP[S] URL to an SDK release tarball. For example:
+-- | An install locations is a pair of fully qualified HTTP[S] URL to an SDK release tarball and headers
+-- required to access that URL. For example:
 -- "https://github.com/digital-asset/daml/releases/download/v0.11.1/daml-sdk-0.11.1-macos.tar.gz"
-newtype InstallURL = InstallURL
-    { unwrapInstallURL :: Text
-    } deriving (Eq, Show, FromJSON)
+data InstallLocation = InstallLocation
+    { ilUrl :: Text
+    , ilHeaders :: RequestHeaders
+    } deriving (Eq, Show)
 
 newtype RawInstallTarget = RawInstallTarget String deriving (Eq, Show)
 newtype ForceInstall = ForceInstall { unForceInstall :: Bool } deriving (Eq, Show)

--- a/docs/configs/html/conf.py
+++ b/docs/configs/html/conf.py
@@ -173,6 +173,7 @@ texinfo_documents = [
 
 rst_prolog = """
 .. _installer: https://github.com/digital-asset/daml/releases/download/v{release}/daml-sdk-{release}-windows.exe
+.. _Artifactory: https://digitalasset.jfrog.io/ui/repos/tree/General/sdk-ee
 .. _protobufs: https://github.com/digital-asset/daml/releases/download/v{release}/protobufs-{release}.zip
 .. _api-test-tool: https://repo1.maven.org/maven2/com/daml/ledger-api-test-tool/{release}/ledger-api-test-tool-{release}.jar
 """.format(release = release)

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -38,6 +38,29 @@ To install the SDK on Mac or Linux open a terminal and run:
 The installer will setup the ``PATH`` variable for you. In order for it to take effect, you will have to
 log out and log in again.
 
+Installing the Enterprise Edition
+*********************************
+
+If you have a license for the enterprise edition of Daml Connect, you
+can install it as follows:
+
+On Windows, download the installer from Artifactory_ instead of Github
+releases. On Linux and MacOS download the corresponding tarball,
+extract it and run ``./install.sh``. Afterwards, modify the
+:ref:`global daml-config.yaml <global_daml_config>` and add an entry
+with your Artifactory API key. The API key can be found in your
+Artifactory user profile.
+
+.. code-block:: yaml
+
+   artifactory-api-key: YOUR_API_KEY
+
+This will be used by the assistant to download other versions automatically from artifactory.
+
+If you already have an existing installation, you only need to add
+this entry to ``daml-config.yaml``. To overwrite a previously
+installed version with the corresponding enterprise edition, use
+``daml install --force VERSION``.
 
 Next steps
 **********

--- a/docs/source/tools/assistant.rst
+++ b/docs/source/tools/assistant.rst
@@ -47,6 +47,8 @@ The Daml assistant and the SDK are configured using two files:
 - The global config file, one per installation, which controls some options regarding SDK installation and updates
 - The project config file, one per Daml project, which controls how the SDK builds and interacts with the project
 
+.. _global_daml_config:
+
 Global config file (``daml-config.yaml``)
 =========================================
 
@@ -60,6 +62,10 @@ By default it's blank, and you usually won't need to edit it. It recognizes the 
    This setting is only used to inform you when an update is available.
 
    Set ``update-check: <number>`` to check for new versions every N seconds. Set ``update-check: never`` to never check for new versions.
+- ``artifactory-api-key``: If you have a license for Daml Connect EE,
+  you can use this to specify the Artifactory API key displayed in
+  your user profile. The assistant will use this to download the EE
+  edition.
 
 Here is an example ``daml-config.yaml``:
 


### PR DESCRIPTION
This PR adds an `artifactory-api-key` field to `daml-config.yaml`. If
this is set, we will download the SDK EE tarball if it exists, falling
back to GH releases on 404s (for old releases).

changelog_begin

- [Daml Assistant] The assistant now supports an `artifactory-api-key`
  field in `daml-config.yaml`. If you have a license for Daml Connect
  EE you can specify this and the assistant will automatically fetch
  the EE edition which provides additional functionality.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
