### PR TITLE
Handle createAndExecuteCmd

### DIFF
--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -239,7 +239,7 @@ private[dump] object Encode {
             encodeValue(partyMap, cidMap, exercisedEvent.getChoiceArgument.sum),
           )
         )
-        .hang(2)
+        .nested(2)
   }
 
   private def encodeCreatedEvent(

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -29,7 +29,11 @@ private[dump] object Encode {
     val partyMap = partyMapping(parties)
 
     val acsCidRefs = acs.values.foldMap(createdReferencedCids)
-    val treeCidRefs = trees.foldMap(treeReferencedCids)
+    // TODO[AH] Avoid constructing Commands twice. Currently we do this once here and once more in encodeTree.
+    val treeCidRefs = trees.foldMap { tree =>
+      val cmds = Command.fromTree(tree)
+      cmds.foldMap(cmdReferencedCids)
+    }
     val cidRefs = acsCidRefs ++ treeCidRefs
 
     val unknownCidRefs = acsCidRefs -- acs.keySet

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -8,7 +8,6 @@ import java.time.{LocalDate, ZoneId, ZonedDateTime}
 
 import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
 import com.daml.ledger.api.v1.event.CreatedEvent
-import com.daml.ledger.api.v1.transaction.TreeEvent.Kind
 import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
 import com.daml.ledger.api.v1.value.Value.Sum
 import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value}
@@ -279,11 +278,11 @@ private[dump] object Encode {
       cidRefs: Set[ContractId],
       evs: Seq[CreatedEvent],
   ): Doc = {
-    encodeSubmitSimpleEvents(
+    encodeSubmitSimpleCommands(
       partyMap,
       cidMap,
       cidRefs,
-      evs.map(ev => SimpleEvent(Kind.Created(ev), ContractId(ev.contractId))),
+      evs.map(ev => SimpleCommand(CreateCommand(ev), ContractId(ev.contractId))),
     )
   }
 

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -281,6 +281,15 @@ object TreeUtils {
     case TreeEvent.Kind.Empty => Seq()
   }
 
+  def cmdParties(cmd: Command): Seq[Party] = {
+    cmd match {
+      case CreateCommand(createdEvent) => evParties(Kind.Created(createdEvent))
+      case ExerciseCommand(exercisedEvent) => evParties(Kind.Exercised(exercisedEvent))
+      case CreateAndExerciseCommand(createdEvent, exercisedEvent) =>
+        evParties(Kind.Created(createdEvent)) ++ evParties(Kind.Exercised(exercisedEvent))
+    }
+  }
+
   def treeRefs(t: TransactionTree): Set[Identifier] =
     t.eventsById.values.foldMap(e => evRefs(e.kind))
 

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -202,7 +202,7 @@ object TreeUtils {
               commands += ExerciseCommand(exercisedEvent)
           }
       }
-      commands
+      commands.toSeq
     }
   }
 

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -160,6 +160,21 @@ object TreeUtils {
   def createdReferencedCids(ev: CreatedEvent): Set[ContractId] =
     ev.createArguments.foldMap(args => args.fields.foldMap(f => valueCids(f.getValue.sum)))
 
+  def cmdReferencedCids(cmd: Command): Set[ContractId] = {
+    cmd match {
+      case CreateCommand(createdEvent) =>
+        createdReferencedCids(createdEvent)
+      case ExerciseCommand(exercisedEvent) =>
+        exercisedEvent.choiceArgument.foldMap(arg => valueCids(arg.sum)) + ContractId(
+          exercisedEvent.contractId
+        )
+      case CreateAndExerciseCommand(createdEvent, exercisedEvent) =>
+        createdReferencedCids(createdEvent) ++ exercisedEvent.choiceArgument.foldMap(arg =>
+          valueCids(arg.sum)
+        )
+    }
+  }
+
   sealed trait Command
   final case class CreateCommand(createdEvent: CreatedEvent) extends Command
   final case class ExerciseCommand(exercisedEvent: ExercisedEvent) extends Command

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/CmdReferencedCidsSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/CmdReferencedCidsSpec.scala
@@ -12,7 +12,7 @@ import scalaz.std.iterable._
 import scalaz.std.set._
 import scalaz.syntax.foldable._
 
-class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
+class CmdReferencedCidsSpec extends AnyFreeSpec with Matchers {
   import TreeUtils._
   "cmdReferencedCids" - {
     "empty" in {

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeSimpleSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeSimpleSpec.scala
@@ -9,43 +9,6 @@ import org.scalatest.matchers.should.Matchers
 
 class EncodeSimpleSpec extends AnyFreeSpec with Matchers {
   import Encode._
-  "encodeSubmitSimpleEvents" - {
-    "mixed create and exercise events" in {
-      val parties = Map(
-        Party("Alice") -> "alice_0",
-        Party("Bob") -> "bob_0",
-      )
-      val cidMap = Map(
-        ContractId("cid1") -> "contract_0_0",
-        ContractId("cid2") -> "contract_0_1",
-        ContractId("cid3") -> "contract_0_2",
-      )
-      val cidRefs = Set(ContractId("cid1"), ContractId("cid3"))
-      val events = TestData
-        .Tree(
-          Seq[TestData.Event](
-            TestData.Created(ContractId("cid1"), submitters = Seq(Party("Alice"))),
-            TestData.Exercised(
-              ContractId("cid2"),
-              Seq(
-                TestData.Created(ContractId("cid3"))
-              ),
-              exerciseResult = Some(ContractId("cid3")),
-              actingParties = Seq(Party("Bob")),
-            ),
-          )
-        )
-        .toSimpleEvents
-      encodeSubmitSimpleEvents(parties, cidMap, cidRefs, events).render(80) shouldBe
-        """(contract_0_0, contract_0_2) <- submitMulti [alice_0, bob_0] [] do
-          |  contract_0_0 <- createCmd Module.Template
-          |  contract_0_2 <- exerciseCmd contract_0_1 (Module.Choice ())
-          |  pure (contract_0_0, contract_0_2)""".stripMargin.replace(
-          "\r\n",
-          "\n",
-        )
-    }
-  }
   "encodeSubmitSimpleCommands" - {
     "mixed create and exercise commands" in {
       val parties = Map(

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeSimpleSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeSimpleSpec.scala
@@ -46,4 +46,42 @@ class EncodeSimpleSpec extends AnyFreeSpec with Matchers {
         )
     }
   }
+  "encodeSubmitSimpleCommands" - {
+    "mixed create and exercise commands" in {
+      val parties = Map(
+        Party("Alice") -> "alice_0",
+        Party("Bob") -> "bob_0",
+      )
+      val cidMap = Map(
+        ContractId("cid1") -> "contract_0_0",
+        ContractId("cid2") -> "contract_0_1",
+        ContractId("cid3") -> "contract_0_2",
+      )
+      val cidRefs = Set(ContractId("cid1"), ContractId("cid3"))
+      val commands = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1"), submitters = Seq(Party("Alice"))),
+            TestData.Exercised(
+              ContractId("cid2"),
+              Seq(
+                TestData.Created(ContractId("cid3"))
+              ),
+              exerciseResult = Some(ContractId("cid3")),
+              actingParties = Seq(Party("Bob")),
+            ),
+          )
+        )
+        .toSimpleCommands
+      // TODO[AH] Encode simple createAndExercise commands.
+      encodeSubmitSimpleCommands(parties, cidMap, cidRefs, commands).render(80) shouldBe
+        """(contract_0_0, contract_0_2) <- submitMulti [alice_0, bob_0] [] do
+          |  contract_0_0 <- createCmd Module.Template
+          |  contract_0_2 <- exerciseCmd contract_0_1 (Module.Choice ())
+          |  pure (contract_0_0, contract_0_2)""".stripMargin.replace(
+          "\r\n",
+          "\n",
+        )
+    }
+  }
 }

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeTreeSpec.scala
@@ -166,6 +166,36 @@ class EncodeTreeSpec extends AnyFreeSpec with Matchers {
             "\n",
           )
       }
+      "unreferenced createAndExercise" in {
+        val parties = Map(Party("Alice") -> "alice_0")
+        val cidMap = Map(
+          ContractId("cid0") -> "contract_0_0",
+          ContractId("cid1") -> "contract_1_0",
+          ContractId("cid1") -> "contract_1_1",
+        )
+        val cidRefs = Set.empty[ContractId]
+        val tree = TestData
+          .Tree(
+            Seq[TestData.Event](
+              TestData.Created(ContractId("cid0")),
+              TestData.Exercised(
+                ContractId("cid0"),
+                Seq(
+                  TestData.Created(ContractId("cid1"))
+                ),
+              ),
+            )
+          )
+          .toTransactionTree
+        encodeTree(parties, cidMap, cidRefs, tree).render(80) shouldBe
+          """tree <- submitTree alice_0 do
+            |  createAndExerciseCmd
+            |    Module.Template
+            |    (Module.Choice ())""".stripMargin.replace(
+            "\r\n",
+            "\n",
+          )
+      }
     }
   }
 }

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifyCommandsSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifyCommandsSpec.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.script.dump
+
+import com.daml.ledger.api.refinements.ApiTypes.ContractId
+import com.daml.script.dump.TreeUtils.{
+  Command,
+  CreateAndExerciseCommand,
+  CreateCommand,
+  ExerciseCommand,
+}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+
+class IdentifyCommandsSpec extends AnyFreeSpec with Matchers with OptionValues {
+  "fromTree" - {
+    "CreateCommand" in {
+      val events = TestData
+        .Tree(
+          Seq(
+            TestData.Created(ContractId("cid1"))
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      commands should have length 1
+      commands.head shouldBe a[CreateCommand]
+    }
+    "ExerciseCommand" in {
+      val events = TestData
+        .Tree(
+          Seq(
+            TestData.Exercised(ContractId("cid1"), Seq())
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      commands should have length 1
+      commands.head shouldBe a[ExerciseCommand]
+    }
+    "CreateAndExerciseCommand" in {
+      val events = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1")),
+            TestData.Exercised(ContractId("cid1"), Seq()),
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      commands should have length 1
+      commands.head shouldBe a[CreateAndExerciseCommand]
+    }
+  }
+}

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifyCommandsSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifyCommandsSpec.scala
@@ -53,5 +53,21 @@ class IdentifyCommandsSpec extends AnyFreeSpec with Matchers with OptionValues {
       commands should have length 1
       commands.head shouldBe a[CreateAndExerciseCommand]
     }
+    "non-adjacent Create and Exercise commands" in {
+      val events = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1")),
+            TestData.Created(ContractId("cid2")),
+            TestData.Exercised(ContractId("cid1"), Seq()),
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      commands should have length 3
+      commands(0) shouldBe a[CreateCommand]
+      commands(1) shouldBe a[CreateCommand]
+      commands(2) shouldBe an[ExerciseCommand]
+    }
   }
 }

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
@@ -4,7 +4,7 @@
 package com.daml.script.dump
 
 import com.daml.ledger.api.refinements.ApiTypes.ContractId
-import com.daml.script.dump.TreeUtils.SimpleEvent
+import com.daml.script.dump.TreeUtils.{Command, SimpleCommand, SimpleEvent}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.OptionValues
@@ -53,6 +53,92 @@ class IdentifySimpleSpec extends AnyFreeSpec with Matchers with OptionValues {
         )
         .toTransactionTree
       SimpleEvent.fromTree(events) should be(None)
+    }
+  }
+  "fromCommands" - {
+    "createCommand" in {
+      val events = TestData
+        .Tree(
+          Seq(
+            TestData.Created(ContractId("cid1"))
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      SimpleCommand.fromCommands(commands, events) should be(Symbol("defined"))
+    }
+    "simple exerciseCommand" in {
+      val events = TestData
+        .Tree(
+          Seq(
+            TestData.Exercised(
+              ContractId("cid1"),
+              Seq(
+                TestData.Created(ContractId("cid2"))
+              ),
+              exerciseResult = Some(ContractId("cid2")),
+            )
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      SimpleCommand.fromCommands(commands, events) should be(Symbol("defined"))
+    }
+    "complex exerciseCommand" in {
+      val events = TestData
+        .Tree(
+          Seq(
+            TestData.Exercised(
+              ContractId("cid1"),
+              Seq(
+                TestData.Created(ContractId("cid2")),
+                TestData.Created(ContractId("cid3")),
+              ),
+              exerciseResult = Some(ContractId("cid2")),
+            )
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      SimpleCommand.fromCommands(commands, events) should be(None)
+    }
+    "simple createAndExerciseCommand" in {
+      val events = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1")),
+            TestData.Exercised(
+              ContractId("cid1"),
+              Seq(
+                TestData.Created(ContractId("cid2"))
+              ),
+              exerciseResult = Some(ContractId("cid2")),
+            ),
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      // TODO[AH] Identify simple createAndExercise commands.
+      SimpleCommand.fromCommands(commands, events) should be(None)
+    }
+    "complex createAndExerciseCommand" in {
+      val events = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1")),
+            TestData.Exercised(
+              ContractId("cid1"),
+              Seq(
+                TestData.Created(ContractId("cid2")),
+                TestData.Created(ContractId("cid3")),
+              ),
+              exerciseResult = Some(ContractId("cid2")),
+            ),
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      SimpleCommand.fromCommands(commands, events) should be(None)
     }
   }
 }

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
@@ -37,22 +37,22 @@ class IdentifySimpleSpec extends AnyFreeSpec with Matchers with OptionValues {
         .toTransactionTree
       SimpleEvent.fromTree(events) should be(Symbol("defined"))
     }
-  }
-  "complex exercisedEvent" in {
-    val events = TestData
-      .Tree(
-        Seq(
-          TestData.Exercised(
-            ContractId("cid1"),
-            Seq(
-              TestData.Created(ContractId("cid2")),
-              TestData.Created(ContractId("cid3")),
-            ),
-            exerciseResult = Some(ContractId("cid2")),
+    "complex exercisedEvent" in {
+      val events = TestData
+        .Tree(
+          Seq(
+            TestData.Exercised(
+              ContractId("cid1"),
+              Seq(
+                TestData.Created(ContractId("cid2")),
+                TestData.Created(ContractId("cid3")),
+              ),
+              exerciseResult = Some(ContractId("cid2")),
+            )
           )
         )
-      )
-      .toTransactionTree
-    SimpleEvent.fromTree(events) should be(None)
+        .toTransactionTree
+      SimpleEvent.fromTree(events) should be(None)
+    }
   }
 }

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
@@ -4,57 +4,12 @@
 package com.daml.script.dump
 
 import com.daml.ledger.api.refinements.ApiTypes.ContractId
-import com.daml.script.dump.TreeUtils.{Command, SimpleCommand, SimpleEvent}
+import com.daml.script.dump.TreeUtils.{Command, SimpleCommand}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.OptionValues
 
 class IdentifySimpleSpec extends AnyFreeSpec with Matchers with OptionValues {
-  "fromTree" - {
-    "createdEvent" in {
-      val events = TestData
-        .Tree(
-          Seq(
-            TestData.Created(ContractId("cid1"))
-          )
-        )
-        .toTransactionTree
-      SimpleEvent.fromTree(events) should be(Symbol("defined"))
-    }
-    "simple exercisedEvent" in {
-      val events = TestData
-        .Tree(
-          Seq(
-            TestData.Exercised(
-              ContractId("cid1"),
-              Seq(
-                TestData.Created(ContractId("cid2"))
-              ),
-              exerciseResult = Some(ContractId("cid2")),
-            )
-          )
-        )
-        .toTransactionTree
-      SimpleEvent.fromTree(events) should be(Symbol("defined"))
-    }
-    "complex exercisedEvent" in {
-      val events = TestData
-        .Tree(
-          Seq(
-            TestData.Exercised(
-              ContractId("cid1"),
-              Seq(
-                TestData.Created(ContractId("cid2")),
-                TestData.Created(ContractId("cid3")),
-              ),
-              exerciseResult = Some(ContractId("cid2")),
-            )
-          )
-        )
-        .toTransactionTree
-      SimpleEvent.fromTree(events) should be(None)
-    }
-  }
   "fromCommands" - {
     "createCommand" in {
       val events = TestData

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
@@ -105,9 +105,13 @@ object TestData {
         traceContext = None,
       )
     }
-    def toSimpleCommands: Seq[SimpleCommand] = {
+    def toCommands: (Seq[Command], TransactionTree) = {
       val tree = this.toTransactionTree
-      SimpleCommand.fromCommands(Command.fromTree(tree), tree).get
+      (Command.fromTree(tree), tree)
+    }
+    def toSimpleCommands: Seq[SimpleCommand] = {
+      val (cmds, tree) = this.toCommands
+      SimpleCommand.fromCommands(cmds, tree).get
     }
   }
 }

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
 import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
 import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
 import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value, Variant}
-import com.daml.script.dump.TreeUtils.{Command, SimpleCommand, SimpleEvent}
+import com.daml.script.dump.TreeUtils.{Command, SimpleCommand}
 import com.google.protobuf
 
 object TestData {
@@ -104,9 +104,6 @@ object TestData {
         rootEventIds = rootEventIds,
         traceContext = None,
       )
-    }
-    def toSimpleEvents: Seq[SimpleEvent] = {
-      SimpleEvent.fromTree(this.toTransactionTree).get
     }
     def toSimpleCommands: Seq[SimpleCommand] = {
       val tree = this.toTransactionTree

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
@@ -7,7 +7,7 @@ import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
 import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
 import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
 import com.daml.ledger.api.v1.value.{Identifier, Record, RecordField, Value, Variant}
-import com.daml.script.dump.TreeUtils.SimpleEvent
+import com.daml.script.dump.TreeUtils.{Command, SimpleCommand, SimpleEvent}
 import com.google.protobuf
 
 object TestData {
@@ -107,6 +107,10 @@ object TestData {
     }
     def toSimpleEvents: Seq[SimpleEvent] = {
       SimpleEvent.fromTree(this.toTransactionTree).get
+    }
+    def toSimpleCommands: Seq[SimpleCommand] = {
+      val tree = this.toTransactionTree
+      SimpleCommand.fromCommands(Command.fromTree(tree), tree).get
     }
   }
 }

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TreeReferencedCidsSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TreeReferencedCidsSpec.scala
@@ -36,6 +36,20 @@ class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
         .toCommands
       cmds.foldMap(cmdReferencedCids) shouldBe Set("cid")
     }
+    "createAndExercise" in {
+      val (cmds, _) = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid")),
+            TestData.Exercised(
+              ContractId("cid"),
+              Seq(),
+            ),
+          )
+        )
+        .toCommands
+      cmds.foldMap(cmdReferencedCids) shouldBe Set.empty
+    }
     "referenced" in {
       val variant = v.Value(
         v.Value.Sum.Variant(

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TreeReferencedCidsSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TreeReferencedCidsSpec.scala
@@ -8,19 +8,23 @@ import com.daml.ledger.api.v1.{value => v}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
+import scalaz.std.iterable._
+import scalaz.std.set._
+import scalaz.syntax.foldable._
+
 class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
   import TreeUtils._
-  "treeReferencedCids" - {
+  "cmdReferencedCids" - {
     "empty" in {
-      val tree = TestData.Tree(Seq()).toTransactionTree
-      treeReferencedCids(tree) shouldBe Set.empty
+      val (cmds, _) = TestData.Tree(Seq()).toCommands
+      cmds.foldMap(cmdReferencedCids) shouldBe Set.empty
     }
     "created only" in {
-      val tree = TestData.Tree(Seq(TestData.Created(ContractId("cid")))).toTransactionTree
-      treeReferencedCids(tree) shouldBe Set.empty
+      val (cmds, _) = TestData.Tree(Seq(TestData.Created(ContractId("cid")))).toCommands
+      cmds.foldMap(cmdReferencedCids) shouldBe Set.empty
     }
     "exercised" in {
-      val tree = TestData
+      val (cmds, _) = TestData
         .Tree(
           Seq(
             TestData.Exercised(
@@ -29,8 +33,8 @@ class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
             )
           )
         )
-        .toTransactionTree
-      treeReferencedCids(tree) shouldBe Set("cid")
+        .toCommands
+      cmds.foldMap(cmdReferencedCids) shouldBe Set("cid")
     }
     "referenced" in {
       val variant = v.Value(
@@ -77,7 +81,7 @@ class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
           )
         )
       )
-      val tree = TestData
+      val (cmds, _) = TestData
         .Tree(
           Seq[TestData.Event](
             TestData.Created(
@@ -91,8 +95,8 @@ class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
             ),
           )
         )
-        .toTransactionTree
-      treeReferencedCids(tree) shouldBe Set(
+        .toCommands
+      cmds.foldMap(cmdReferencedCids) shouldBe Set(
         "cid_create_arg",
         "cid_exercise",
         "cid_variant",
@@ -104,7 +108,7 @@ class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
       )
     }
     "only referenced internally" in {
-      val tree = TestData
+      val (cmds, _) = TestData
         .Tree(
           Seq(
             TestData.Exercised(
@@ -118,8 +122,8 @@ class TreeReferencedCidsSpec extends AnyFreeSpec with Matchers {
             )
           )
         )
-        .toTransactionTree
-      treeReferencedCids(tree) shouldBe Set(
+        .toCommands
+      cmds.foldMap(cmdReferencedCids) shouldBe Set(
         "cid_exercise_outer"
       )
     }


### PR DESCRIPTION
Closes #9127

Identifies `createAndExercise` commands in Daml script dumps.
- Adds a new type to distinguish create, exercise, and createAndExercise commands.
- Transaction trees are converted to a sequence of such commands before further processing for encoding.
- Other components, such as `SimpleEvent` are based on commands instead, i.e. `SimpleCommand`.



### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
