### PR TITLE
Expose unhandled exception values and types

### DIFF
--- a/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
+++ b/compiler/scenario-service/server/src/main/scala/com/digitalasset/daml/lf/scenario/Conversions.scala
@@ -87,8 +87,10 @@ final class Conversions(
         setCrash(reason)
       case SError.DamlEArithmeticError(reason) =>
         setCrash(reason)
-      case SError.DamlEUnhandledException(message) =>
-        setCrash(message)
+      case SError.DamlEUnhandledException(_, exc) =>
+        // TODO https://github.com/digital-asset/daml/issues/8020
+        // Add an error case for unhandled exceptions to the scenario proto.
+        setCrash(exc.toString)
       case SError.DamlEUserError(msg) =>
         builder.setUserError(msg)
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -56,8 +56,8 @@ private[lf] object Pretty {
         text(prettyFailedAuthorization(nid, fa))
       case DamlEArithmeticError(message) =>
         text(message)
-      case DamlEUnhandledException(message) =>
-        text(s"unhandled exception: $message")
+      case DamlEUnhandledException(_, exc) =>
+        text(s"unhandled exception:") & prettyValue(true)(exc)
       case DamlEUserError(message) =>
         text(s"User abort: $message")
       case DamlETransactionError(reason) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SError.scala
@@ -5,6 +5,7 @@ package com.daml.lf.speedy
 
 import com.daml.lf.data.Ref._
 import com.daml.lf.data.Time
+import com.daml.lf.language.Ast
 import com.daml.lf.ledger.EventId
 import com.daml.lf.ledger.FailedAuthorization
 import com.daml.lf.transaction.{GlobalKey, NodeId, Transaction => Tx}
@@ -42,11 +43,9 @@ object SError {
   sealed abstract class SErrorDamlException extends SError
 
   /** Unhandled exceptions */
-  // TODO https://github.com/digital-asset/daml/issues/8020
-  // Have the unhandled-exception contain directly the original payload value & type
-  // as well as (or perhaps instead of) the computed message text
-  final case class DamlEUnhandledException(message: String) extends SErrorDamlException {
-    override def toString: String = message
+  final case class DamlEUnhandledException(ty: Ast.Type, exception: Value[ContractId])
+      extends SErrorDamlException {
+    override def toString: String = s"Unhandled exception: $exception of type $ty"
   }
 
   /** Arithmetic error such as division by zero */


### PR DESCRIPTION
This PR addresses the TODO to expose the actual exception values and
type instead of the message. This allows us to simply speedy a bit by
removing the continuation used for that but more importantly it means
we can now catch and handle the exception in Daml script.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
