### PR TITLE
Add a compile-only damlc target

### DIFF
--- a/compiler/damlc/BUILD.bazel
+++ b/compiler/damlc/BUILD.bazel
@@ -23,6 +23,18 @@ damlc_data = [
 ]
 
 add_data(
+    name = "damlc-compile-only",
+    data = [
+        ghc_pkg,
+        "//compiler/damlc:ghcversion",
+        "//compiler/damlc:hpp",
+        "//compiler/damlc/pkg-db",
+    ],
+    executable = ":damlc-bootstrap",
+    visibility = ["//visibility:public"],
+)
+
+add_data(
     name = "damlc",
     data = damlc_data,
     executable = ":damlc-bootstrap",

--- a/daml-lf/tests/BUILD.bazel
+++ b/daml-lf/tests/BUILD.bazel
@@ -38,11 +38,11 @@ daml_compile(
         srcs = ["daml-lf-test.sh"],
         args = [
             "$(location //daml-lf/repl:repl)",
-            "$(location //compiler/damlc)",
+            "$(location //compiler/damlc:damlc-compile-only)",
             "$(location :%s.dar)" % name,
         ],
         data = [
-            "//compiler/damlc",
+            "//compiler/damlc:damlc-compile-only",
             "//daml-lf/repl",
             ":%s.dar" % name,
         ],
@@ -60,13 +60,13 @@ daml_compile(
         srcs = ["scenario/test.sh"],
         args = [
             "$(location //daml-lf/repl:repl)",
-            "$(location //compiler/damlc)",
+            "$(location //compiler/damlc:damlc-compile-only)",
             "$(location :%s)" % file,
             "$(POSIX_DIFF)",
             "false",
         ],
         data = [
-            "//compiler/damlc",
+            "//compiler/damlc:damlc-compile-only",
             "//daml-lf/repl",
             file,
             "%s/EXPECTED.ledger" % "/".join(file.split("/")[0:3]),
@@ -88,13 +88,13 @@ daml_compile(
         srcs = ["scenario/test.sh"],
         args = [
             "$(location //daml-lf/repl:repl)",
-            "$(location //compiler/damlc)",
+            "$(location //compiler/damlc:damlc-compile-only)",
             "$(location :%s)" % file,
             "$(POSIX_DIFF)",
             "true",
         ],
         data = [
-            "//compiler/damlc",
+            "//compiler/damlc:damlc-compile-only",
             "//daml-lf/repl",
             file,
             "%s/EXPECTED.ledger" % "/".join(file.split("/")[0:3]),

--- a/rules_daml/daml.bzl
+++ b/rules_daml/daml.bzl
@@ -6,7 +6,7 @@ load("//bazel_tools/sh:sh.bzl", "sh_inline_test")
 
 _damlc = attr.label(
     allow_single_file = True,
-    default = Label("//compiler/damlc"),
+    default = Label("//compiler/damlc:damlc-compile-only"),
     executable = True,
     cfg = "host",
     doc = "The DAML compiler.",
@@ -213,7 +213,7 @@ def _daml_validate_test(
         name,
         dar,
         **kwargs):
-    damlc = "//compiler/damlc"
+    damlc = "//compiler/damlc:damlc-compile-only"
     sh_inline_test(
         name = name,
         data = [damlc, dar],
@@ -236,10 +236,10 @@ def _inspect_dar(base):
         name = name,
         srcs = [
             dar,
-            "//compiler/damlc",
+            "//compiler/damlc:damlc-compile-only",
         ],
         outs = [pp],
-        cmd = "$(location //compiler/damlc) inspect $(location :" + dar + ") > $@",
+        cmd = "$(location //compiler/damlc:damlc-compile-only) inspect $(location :" + dar + ") > $@",
     )
 
 _default_project_version = "1.0.0"
@@ -323,7 +323,7 @@ def daml_test(
         srcs = [],
         deps = [],
         data_deps = [],
-        damlc = "//compiler/damlc",
+        damlc = "//compiler/damlc:damlc",
         target = None,
         **kwargs):
     sh_inline_test(
@@ -377,7 +377,7 @@ def daml_doc_test(
         ignored_srcs = [],
         flags = [],
         cpp = "@stackage-exe//hpp",
-        damlc = "//compiler/damlc",
+        damlc = "//compiler/damlc:damlc",
         **kwargs):
     sh_inline_test(
         name = name,


### PR DESCRIPTION
This untangles the dependency structure a bit so that //daml-lf no
longer ends up depending on daml script and sandbox and similar crap
which should improve build times in general.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
