### PR TITLE
Fix flakiness in create-daml-app tests

### DIFF
--- a/compatibility/bazel_tools/create-daml-app/index.test.ts
+++ b/compatibility/bazel_tools/create-daml-app/index.test.ts
@@ -218,9 +218,10 @@ const newUiPage = async (): Promise<Page> => {
 
 const waitForNSelector = async (page: Page, selector: string, n: number) => {
   await page.waitForFunction(
-      (n) => document.querySelectorAll(selector).length == n,
+      (n, selector) => document.querySelectorAll(selector).length == n,
       {},
-      n
+      n,
+      selector
   );
 }
 

--- a/compatibility/bazel_tools/create-daml-app/index.test.ts
+++ b/compatibility/bazel_tools/create-daml-app/index.test.ts
@@ -216,6 +216,14 @@ const newUiPage = async (): Promise<Page> => {
   return page;
 };
 
+const waitForNSelector = async (page: Page, selector: string, n: number) => {
+  await page.waitForFunction(
+      (n) => document.querySelectorAll(string).length == n,
+      {},
+      n
+  );
+}
+
 // Note that Follow is a consuming choice on a contract
 // with a contract key so it is crucial to wait between follows.
 // Otherwise, you get errors due to contention.
@@ -223,11 +231,7 @@ const newUiPage = async (): Promise<Page> => {
 // but that is not the underlying error (the JSON API will
 // output the contention errors as well so look through the log).
 const waitForFollowers = async (page: Page, n: number) => {
-  await page.waitForFunction(
-      (n) => document.querySelectorAll(".test-select-following").length == n,
-      {},
-      n
-  );
+  await waitForNSelector(page, ".test-select-following", n);
 }
 
 // LOGIN_FUNCTION_BEGIN
@@ -391,7 +395,8 @@ test("log in as three different users and start following each other", async () 
   expect(noFollowing3).toEqual([]);
 
   // However, Party 3 should see both Party 1 and Party 2 in the network.
-  await page3.waitForSelector(".test-select-user-in-network");
+  await waitForNSelector(page3, ".test-select-user-in-network", 2);
+
   const network3 = await page3.$$eval(
     ".test-select-user-in-network",
     (following) => following.map((e) => e.innerHTML)

--- a/compatibility/bazel_tools/create-daml-app/index.test.ts
+++ b/compatibility/bazel_tools/create-daml-app/index.test.ts
@@ -218,7 +218,7 @@ const newUiPage = async (): Promise<Page> => {
 
 const waitForNSelector = async (page: Page, selector: string, n: number) => {
   await page.waitForFunction(
-      (n) => document.querySelectorAll(string).length == n,
+      (n) => document.querySelectorAll(selector).length == n,
       {},
       n
   );


### PR DESCRIPTION
waitForSelector doesn’t do the trick here since one selector is enough
to make this return. We need to wait until we actually have the
expected number. This is what waitForFollowers already did.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
