### PR TITLE
skip compat tests on release

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -250,6 +250,8 @@ jobs:
   dependsOn:
     - da_ghc_lib
     - check_for_release
+  condition: and(succeeded(),
+                 not(eq(dependencies.check_for_release.outputs['out.is_release'], 'true')))
   timeoutInMinutes: 360
   pool:
     name: ubuntu_20_04


### PR DESCRIPTION
As requested by @coceature.

Note: skipping the ts_lib job is enough to skip all compat tests because they all depend on it, and in the Azure model if one of your dependencies was skipped you get skipped too.

CHANGELOG_BEGIN
CHANGELOG_END