### PR TITLE
Recognize (some) exerciseByKey commands in Daml script dumps

### DIFF
--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -227,6 +227,11 @@ private[dump] object Encode {
         cidMap,
         exercisedEvent.getChoiceArgument.sum,
       )
+    case ExerciseByKeyCommand(exercisedEvent, templateId, contractKey) =>
+      val command = "exerciseByKeyCmd @" +: qualifyId(templateId)
+      val key = encodeValue(partyMap, cidMap, contractKey.sum)
+      val choice = encodeValue(partyMap, cidMap, exercisedEvent.getChoiceArgument.sum)
+      command.lineOrSpace(key).lineOrSpace(choice).nested(2)
     case CreateAndExerciseCommand(createdEvent, exercisedEvent) =>
       Doc
         .stack(

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Encode.scala
@@ -219,14 +219,10 @@ private[dump] object Encode {
     case CreateCommand(createdEvent) =>
       encodeCreatedEvent(partyMap, cidMap, createdEvent)
     case ExerciseCommand(exercisedEvent) =>
-      Doc.text("exerciseCmd ") + encodeCid(
-        cidMap,
-        ContractId(exercisedEvent.contractId),
-      ) + Doc.space + encodeValue(
-        partyMap,
-        cidMap,
-        exercisedEvent.getChoiceArgument.sum,
-      )
+      val command = Doc.text("exerciseCmd")
+      val cid = encodeCid(cidMap, ContractId(exercisedEvent.contractId))
+      val choice = encodeValue(partyMap, cidMap, exercisedEvent.getChoiceArgument.sum)
+      command & cid & choice
     case ExerciseByKeyCommand(exercisedEvent, templateId, contractKey) =>
       val command = "exerciseByKeyCmd @" +: qualifyId(templateId)
       val key = encodeValue(partyMap, cidMap, contractKey.sum)

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -137,17 +137,20 @@ object TreeUtils {
     cids
   }
 
-  def treeEventCreatedCids(event: TreeEvent.Kind, tree: TransactionTree): Set[ContractId] = {
-    var creates = Set.empty[ContractId]
+  def treeEventCreatedConsumedCids(
+      event: TreeEvent.Kind,
+      tree: TransactionTree,
+  ): (Set[ContractId], Set[ContractId]) = {
+    var created = Set.empty[ContractId]
     var consumed = Set.empty[ContractId]
     traverseEventInTree(event, tree) {
       case (_, Kind.Created(value)) =>
-        creates += ContractId(value.contractId)
+        created += ContractId(value.contractId)
       case (_, Kind.Exercised(value)) if value.consuming =>
         consumed += ContractId(value.contractId)
       case _ =>
     }
-    creates -- consumed
+    (created, consumed)
   }
 
   def treeReferencedCids(tree: TransactionTree): Set[ContractId] = {
@@ -218,15 +221,19 @@ object TreeUtils {
 
   object SimpleCommand {
     def fromCommand(command: Command, tree: TransactionTree): Option[SimpleCommand] = {
-      def simpleExercise(exercisedEvent: ExercisedEvent): Option[ContractId] = {
+      def simpleExercise(
+          exercisedEvent: ExercisedEvent,
+          extraCreated: Set[ContractId],
+      ): Option[ContractId] = {
         val result = exercisedEvent.exerciseResult.flatMap {
           _.sum match {
             case Sum.ContractId(value) => Some(value)
             case _ => None
           }
         }
-        val creates = treeEventCreatedCids(Kind.Exercised(exercisedEvent), tree).toSeq
-        (result, creates) match {
+        val (created, consumed) = treeEventCreatedConsumedCids(Kind.Exercised(exercisedEvent), tree)
+        val netCreated = (extraCreated ++ created) -- consumed
+        (result, netCreated.toSeq) match {
           case (Some(cid), Seq(createdCid)) if cid == createdCid =>
             Some(ContractId(cid))
           case _ => None
@@ -236,16 +243,12 @@ object TreeUtils {
         case CreateCommand(createdEvent) =>
           Some(SimpleCommand(command, ContractId(createdEvent.contractId)))
         case ExerciseCommand(exercisedEvent) =>
-          simpleExercise(exercisedEvent).map(SimpleCommand(command, _))
-        case CreateAndExerciseCommand(_, exercisedEvent) =>
-          if (exercisedEvent.consuming) {
-            // If the choice is not consuming then we have two resulting contracts:
-            // The created one and the result of the exercise. I.e. not a simple command.
-            // A child exercised event might still consume the contract, but this heuristic is kept simple for now.
-            simpleExercise(exercisedEvent).map(SimpleCommand(command, _))
-          } else {
-            None
-          }
+          simpleExercise(exercisedEvent, Set.empty).map(SimpleCommand(command, _))
+        case CreateAndExerciseCommand(createdEvent, exercisedEvent) =>
+          // We count the contract created by the created event into the set of created contracts.
+          // The command is only considered simple if it only creates one contract overall and returns its id.
+          simpleExercise(exercisedEvent, Set(ContractId(createdEvent.contractId)))
+            .map(SimpleCommand(command, _))
       }
     }
 

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -174,6 +174,8 @@ object TreeUtils {
         exercisedEvent.choiceArgument.foldMap(arg => valueCids(arg.sum)) + ContractId(
           exercisedEvent.contractId
         )
+      case ExerciseByKeyCommand(exercisedEvent, _, _) =>
+        exercisedEvent.choiceArgument.foldMap(arg => valueCids(arg.sum))
       case CreateAndExerciseCommand(createdEvent, exercisedEvent) =>
         createdReferencedCids(createdEvent) ++ exercisedEvent.choiceArgument.foldMap(arg =>
           valueCids(arg.sum)
@@ -184,6 +186,11 @@ object TreeUtils {
   sealed trait Command
   final case class CreateCommand(createdEvent: CreatedEvent) extends Command
   final case class ExerciseCommand(exercisedEvent: ExercisedEvent) extends Command
+  final case class ExerciseByKeyCommand(
+      exercisedEvent: ExercisedEvent,
+      templateId: Identifier,
+      contractKey: Value,
+  ) extends Command
   final case class CreateAndExerciseCommand(
       createdEvent: CreatedEvent,
       exercisedEvent: ExercisedEvent,
@@ -243,6 +250,8 @@ object TreeUtils {
         case CreateCommand(createdEvent) =>
           Some(SimpleCommand(command, ContractId(createdEvent.contractId)))
         case ExerciseCommand(exercisedEvent) =>
+          simpleExercise(exercisedEvent, Set.empty).map(SimpleCommand(command, _))
+        case ExerciseByKeyCommand(exercisedEvent, _, _) =>
           simpleExercise(exercisedEvent, Set.empty).map(SimpleCommand(command, _))
         case CreateAndExerciseCommand(createdEvent, exercisedEvent) =>
           // We count the contract created by the created event into the set of created contracts.
@@ -337,6 +346,7 @@ object TreeUtils {
     cmd match {
       case CreateCommand(createdEvent) => evParties(Kind.Created(createdEvent))
       case ExerciseCommand(exercisedEvent) => evParties(Kind.Exercised(exercisedEvent))
+      case ExerciseByKeyCommand(exercisedEvent, _, _) => evParties(Kind.Exercised(exercisedEvent))
       case CreateAndExerciseCommand(createdEvent, exercisedEvent) =>
         evParties(Kind.Created(createdEvent)) ++ evParties(Kind.Exercised(exercisedEvent))
     }

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -210,7 +210,7 @@ object TreeUtils {
           }
           commands += CreateCommand(createdEvent)
         case Kind.Exercised(exercisedEvent) =>
-          lazy val optCreateAndExercise = commands.lastOption.flatMap {
+          val optCreateAndExercise = commands.lastOption.flatMap {
             case CreateCommand(createdEvent)
                 if createdEvent.contractId == exercisedEvent.contractId =>
               Some(CreateAndExerciseCommand(createdEvent, exercisedEvent))

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
@@ -4,7 +4,8 @@
 package com.daml.script.dump
 
 import com.daml.ledger.api.refinements.ApiTypes.ContractId
-import com.daml.script.dump.TreeUtils.{Command, SimpleCommand}
+import com.daml.ledger.api.v1.value.Value
+import com.daml.script.dump.TreeUtils.{Command, ExerciseByKeyCommand, SimpleCommand}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.OptionValues
@@ -55,6 +56,49 @@ class IdentifySimpleSpec extends AnyFreeSpec with Matchers with OptionValues {
         )
         .toTransactionTree
       val commands = Command.fromTree(events)
+      SimpleCommand.fromCommands(commands, events) should be(None)
+    }
+    "simple exerciseByKeyCommand" in {
+      val events = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1"), contractKey = Some(Value().withParty("Alice"))),
+            TestData.Created(ContractId("cid2")),
+            TestData.Exercised(
+              ContractId("cid1"),
+              Seq(
+                TestData.Created(ContractId("cid3"))
+              ),
+              exerciseResult = Some(ContractId("cid3")),
+            ),
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      commands should have length 3
+      commands(2) shouldBe an[ExerciseByKeyCommand]
+      SimpleCommand.fromCommands(commands, events) should be(Symbol("defined"))
+    }
+    "complex exerciseByKeyCommand" in {
+      val events = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1"), contractKey = Some(Value().withParty("Alice"))),
+            TestData.Created(ContractId("cid2")),
+            TestData.Exercised(
+              ContractId("cid1"),
+              Seq(
+                TestData.Created(ContractId("cid3")),
+                TestData.Created(ContractId("cid4")),
+              ),
+              exerciseResult = Some(ContractId("cid3")),
+            ),
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      commands should have length 3
+      commands(2) shouldBe an[ExerciseByKeyCommand]
       SimpleCommand.fromCommands(commands, events) should be(None)
     }
     "simple createAndExerciseCommand" in {

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/IdentifySimpleSpec.scala
@@ -119,6 +119,29 @@ class IdentifySimpleSpec extends AnyFreeSpec with Matchers with OptionValues {
       val commands = Command.fromTree(events)
       SimpleCommand.fromCommands(commands, events) should be(None)
     }
+    "nested consuming createAndExerciseCommand" in {
+      val events = TestData
+        .Tree(
+          Seq[TestData.Event](
+            TestData.Created(ContractId("cid1")),
+            TestData.Exercised(
+              ContractId("cid1"),
+              Seq[TestData.Event](
+                TestData.Created(ContractId("cid2")),
+                TestData.Exercised(
+                  ContractId("cid1"),
+                  Seq(),
+                ),
+              ),
+              exerciseResult = Some(ContractId("cid2")),
+              consuming = false,
+            ),
+          )
+        )
+        .toTransactionTree
+      val commands = Command.fromTree(events)
+      SimpleCommand.fromCommands(commands, events) should be(Symbol("defined"))
+    }
     "complex createAndExerciseCommand" in {
       val events = TestData
         .Tree(

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/TestData.scala
@@ -27,6 +27,7 @@ object TestData {
       contractId: ContractId,
       createArguments: Seq[RecordField] = Seq.empty,
       submitters: Seq[Party] = defaultParties,
+      contractKey: Option[Value] = None,
   ) extends Event {
     def toCreatedEvent(eventId: String): CreatedEvent = {
       CreatedEvent(
@@ -34,7 +35,9 @@ object TestData {
         templateId = Some(defaultTemplateId),
         contractId = ContractId.unwrap(contractId),
         signatories = Party.unsubst(submitters),
-        createArguments = Some(Record(recordId = Some(defaultTemplateId), fields = createArguments)),
+        createArguments =
+          Some(Record(recordId = Some(defaultTemplateId), fields = createArguments)),
+        contractKey = contractKey,
       )
     }
   }


### PR DESCRIPTION
Addresses https://github.com/digital-asset/daml/pull/9154#discussion_r596678341

- Adds a separate command type for `exerciseByKeyCmd` next to `createCmd`, `exerciseCmd`, and `createAndExerciseCmd`.
- `exerciseByKeyCmd` are used when an exercise event exercises a choice on a contract that was created by the same transaction, is not eligible for `createAndExerciseCmd`, and has a contract key.
- This adds test-cases for recognizing `exerciseByKeyCmd`, distinguishing simple and non-simple commands, and encoding.
- This PR also takes the opportunity to broaden which exercises are considered simple as described in https://github.com/digital-asset/daml/pull/9154#discussion_r596678312. I.e. child events that consume contracts are taken into account when determining whether the command only creates one lasting contract in total.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
