### PR TITLE
Make LedgerDao a pure interface

### DIFF
--- a/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/indexer/ExecuteUpdate.scala
@@ -33,7 +33,7 @@ import com.daml.platform.indexer.ExecuteUpdate.ExecuteUpdateFlow
 import com.daml.platform.indexer.OffsetUpdate.PreparedTransactionInsert
 import com.daml.platform.indexer.PipelinedExecuteUpdate.PipelinedUpdateWithTimer
 import com.daml.platform.store.DbType
-import com.daml.platform.store.dao.{LedgerDao, PersistenceResponse}
+import com.daml.platform.store.dao.{LedgerWriteDao, PersistenceResponse}
 import com.daml.platform.store.entries.{PackageLedgerEntry, PartyLedgerEntry}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -43,7 +43,7 @@ object ExecuteUpdate {
   type FlowOwnerBuilder =
     (
         DbType,
-        LedgerDao,
+        LedgerWriteDao,
         Metrics,
         v1.ParticipantId,
         Int,
@@ -53,7 +53,7 @@ object ExecuteUpdate {
 
   def owner(
       dbType: DbType,
-      ledgerDao: LedgerDao,
+      ledgerDao: LedgerWriteDao,
       metrics: Metrics,
       participantId: v1.ParticipantId,
       updatePreparationParallelism: Int,
@@ -90,7 +90,7 @@ trait ExecuteUpdate {
 
   private[indexer] def participantId: v1.ParticipantId
 
-  private[indexer] def ledgerDao: LedgerDao
+  private[indexer] def ledgerDao: LedgerWriteDao
 
   private[indexer] def metrics: Metrics
 
@@ -350,7 +350,7 @@ trait ExecuteUpdate {
 }
 
 class PipelinedExecuteUpdate(
-    private[indexer] val ledgerDao: LedgerDao,
+    private[indexer] val ledgerDao: LedgerWriteDao,
     private[indexer] val metrics: Metrics,
     private[indexer] val participantId: v1.ParticipantId,
     private[indexer] val updatePreparationParallelism: Int,
@@ -441,7 +441,7 @@ class PipelinedExecuteUpdate(
 
 object PipelinedExecuteUpdate {
   def owner(
-      ledgerDao: LedgerDao,
+      ledgerDao: LedgerWriteDao,
       metrics: Metrics,
       participantId: v1.ParticipantId,
       updatePreparationParallelism: Int,
@@ -463,7 +463,7 @@ object PipelinedExecuteUpdate {
 }
 
 class AtomicExecuteUpdate(
-    private[indexer] val ledgerDao: LedgerDao,
+    private[indexer] val ledgerDao: LedgerWriteDao,
     private[indexer] val metrics: Metrics,
     private[indexer] val participantId: v1.ParticipantId,
     private[indexer] val updatePreparationParallelism: Int,
@@ -523,7 +523,7 @@ class AtomicExecuteUpdate(
 
 object AtomicExecuteUpdate {
   def owner(
-      ledgerDao: LedgerDao,
+      ledgerDao: LedgerWriteDao,
       metrics: Metrics,
       participantId: v1.ParticipantId,
       updatePreparationParallelism: Int,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsReader.scala
@@ -22,14 +22,14 @@ private[dao] final class CommandCompletionsReader(
     dbType: DbType,
     metrics: Metrics,
     executionContext: ExecutionContext,
-) {
+) extends LedgerDaoCommandCompletionsReader {
 
   private val sqlFunctions = SqlFunctions(dbType)
 
   private def offsetFor(response: CompletionStreamResponse): Offset =
     ApiOffset.assertFromString(response.checkpoint.get.offset.get.getAbsolute)
 
-  def getCommandCompletions(
+  override def getCommandCompletions(
       startExclusive: Offset,
       endInclusive: Offset,
       applicationId: ApplicationId,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -77,7 +77,6 @@ private final case class ParsedPackageData(
 private final case class ParsedCommandData(deduplicateUntil: Instant)
 
 private class JdbcLedgerDao(
-    override val maxConcurrentConnections: Int,
     dbDispatcher: DbDispatcher,
     dbType: DbType,
     servicesExecutionContext: ExecutionContext,
@@ -1135,7 +1134,6 @@ private[platform] object JdbcLedgerDao {
         jdbcAsyncCommitMode,
       )
     } yield new JdbcLedgerDao(
-      connectionPoolSize,
       dbDispatcher,
       DbType.jdbcType(jdbcUrl),
       servicesExecutionContext,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -94,8 +94,6 @@ private[platform] trait LedgerDaoCommandCompletionsReader {
 
 private[platform] trait LedgerReadDao extends ReportsHealth {
 
-  def maxConcurrentConnections: Int
-
   /** Looks up the ledger id */
   def lookupLedgerId()(implicit loggingContext: LoggingContext): Future[Option[LedgerId]]
 
@@ -227,7 +225,6 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
 }
 
 private[platform] trait LedgerWriteDao extends ReportsHealth {
-  def maxConcurrentConnections: Int
 
   /** Initializes the ledger. Must be called only once.
     *

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -21,7 +21,7 @@ import com.daml.lf.value.Value.{ContractId, ContractInst}
 import com.daml.logging.LoggingContext
 import com.daml.metrics.{Metrics, Timed}
 import com.daml.platform.indexer.OffsetStep
-import com.daml.platform.store.dao.events.{TransactionsReader, TransactionsWriter}
+import com.daml.platform.store.dao.events.TransactionsWriter
 import com.daml.platform.store.dao.events.TransactionsWriter.PreparedInsert
 import com.daml.platform.store.entries.{
   ConfigurationEntry,
@@ -74,7 +74,7 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
       ledgerDao.lookupMaximumLedgerTime(contractIds),
     )
 
-  override def transactionsReader: TransactionsReader = ledgerDao.transactionsReader
+  override def transactionsReader: LedgerDaoTransactionsReader = ledgerDao.transactionsReader
 
   override def lookupKey(key: GlobalKey, forParties: Set[Party])(implicit
       loggingContext: LoggingContext
@@ -129,7 +129,7 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
   )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed] =
     ledgerDao.getConfigurationEntries(startExclusive, endInclusive)
 
-  override val completions: CommandCompletionsReader = ledgerDao.completions
+  override val completions: LedgerDaoCommandCompletionsReader = ledgerDao.completions
 
   override def deduplicateCommand(
       commandId: CommandId,

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -35,8 +35,6 @@ import scala.concurrent.Future
 private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: Metrics)
     extends LedgerReadDao {
 
-  override def maxConcurrentConnections: Int = ledgerDao.maxConcurrentConnections
-
   override def currentHealth(): HealthStatus = ledgerDao.currentHealth()
 
   override def lookupLedgerId()(implicit loggingContext: LoggingContext): Future[Option[LedgerId]] =

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/TransactionsReader.scala
@@ -25,7 +25,11 @@ import com.daml.metrics._
 import com.daml.platform.ApiOffset
 import com.daml.platform.store.DbType
 import com.daml.platform.store.SimpleSqlAsVectorOf.SimpleSqlAsVectorOf
-import com.daml.platform.store.dao.{DbDispatcher, PaginatingAsyncStream}
+import com.daml.platform.store.dao.{
+  DbDispatcher,
+  LedgerDaoTransactionsReader,
+  PaginatingAsyncStream,
+}
 import io.opentelemetry.api.trace.Span
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -43,7 +47,8 @@ private[dao] final class TransactionsReader(
     pageSize: Int,
     metrics: Metrics,
     lfValueTranslation: LfValueTranslation,
-)(implicit executionContext: ExecutionContext) {
+)(implicit executionContext: ExecutionContext)
+    extends LedgerDaoTransactionsReader {
 
   private val dbMetrics = metrics.daml.index.db
 
@@ -71,7 +76,7 @@ private[dao] final class TransactionsReader(
   )(implicit loggingContext: LoggingContext): Future[EventsTable.Entry[E]] =
     deserializeEvent(verbose)(entry).map(event => entry.copy(event = event))
 
-  def getFlatTransactions(
+  override def getFlatTransactions(
       startExclusive: Offset,
       endInclusive: Offset,
       filter: FilterRelation,
@@ -135,7 +140,7 @@ private[dao] final class TransactionsReader(
       .watchTermination()(endSpanOnTermination(span))
   }
 
-  def lookupFlatTransactionById(
+  override def lookupFlatTransactionById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
   )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]] = {
@@ -157,7 +162,7 @@ private[dao] final class TransactionsReader(
       .map(EventsTable.Entry.toGetFlatTransactionResponse)
   }
 
-  def getTransactionTrees(
+  override def getTransactionTrees(
       startExclusive: Offset,
       endInclusive: Offset,
       requestingParties: Set[Party],
@@ -225,7 +230,7 @@ private[dao] final class TransactionsReader(
       .watchTermination()(endSpanOnTermination(span))
   }
 
-  def lookupTransactionTreeById(
+  override def lookupTransactionTreeById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
   )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]] = {
@@ -247,7 +252,7 @@ private[dao] final class TransactionsReader(
       .map(EventsTable.Entry.toGetTransactionResponse)
   }
 
-  def getActiveContracts(
+  override def getActiveContracts(
       activeAt: Offset,
       filter: FilterRelation,
       verbose: Boolean,

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/sql/SqlLedger.scala
@@ -37,7 +37,7 @@ import com.daml.platform.sandbox.stores.ledger.ScenarioLoader.LedgerEntryOrBump
 import com.daml.platform.sandbox.stores.ledger.sql.SqlLedger._
 import com.daml.platform.sandbox.stores.ledger.{Ledger, SandboxOffset}
 import com.daml.platform.store.dao.events.LfValueTranslation
-import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao}
+import com.daml.platform.store.dao.{JdbcLedgerDao, LedgerDao, LedgerWriteDao}
 import com.daml.platform.store.entries.{LedgerEntry, PackageLedgerEntry, PartyLedgerEntry}
 import com.daml.platform.store.{BaseLedger, FlywayMigrations}
 import com.daml.resources.ProgramResource.StartupException
@@ -118,7 +118,7 @@ private[sandbox] object SqlLedger {
     // Store only the ledger entries (no headref, etc.). This is OK since this initialization
     // step happens before we start up the sql ledger at all, so it's running in isolation.
     private def initialize(
-        dao: LedgerDao
+        dao: LedgerWriteDao
     )(implicit executionContext: ExecutionContext): Future[LedgerId] = {
       val ledgerId = providedLedgerId.or(LedgerIdGenerator.generateRandomId(name))
       logger.info(s"Initializing node with ledger id '$ledgerId'")
@@ -172,7 +172,7 @@ private[sandbox] object SqlLedger {
         initialLedgerEntries: ImmArray[LedgerEntryOrBump],
         timeProvider: TimeProvider,
         packages: InMemoryPackageStore,
-        ledgerDao: LedgerDao,
+        ledgerDao: LedgerWriteDao,
     )(implicit executionContext: ExecutionContext): Future[Unit] = {
       if (initialLedgerEntries.nonEmpty) {
         logger.info(s"Initializing ledger with ${initialLedgerEntries.length} ledger entries.")
@@ -202,7 +202,7 @@ private[sandbox] object SqlLedger {
 
     private def copyPackages(
         store: InMemoryPackageStore,
-        ledgerDao: LedgerDao,
+        ledgerDao: LedgerWriteDao,
         knownSince: Instant,
         newLedgerEnd: Offset,
     ): Future[Unit] = {


### PR DESCRIPTION
This PR is pure refactoring, no functionality was changed.

This PR prepares the `LedgerDao` interface for the implementation of the new index DB schema, mostly by replacing the `TransactionsReader` and `CommandCompletionsReader` concrete classes in the `LedgerDao` interface by equivalent interfaces.