### PR TITLE
PoC: Cache signatories and observers on exercises

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,61 +27,8 @@ if [ -n "$SANDBOX_PID" ]; then
     kill "$SANDBOX_PID"
 fi
 
-# Bazel test only builds targets that are dependencies of a test suite so do a full build first.
-bazel build //... --build_tag_filters "$tag_filter"
+bazel run daml-lf/scenario-interpreter:scenario-perf
 
-# Set up a shared PostgreSQL instance.
-export POSTGRESQL_ROOT_DIR="${TMPDIR:-/tmp}/daml/postgresql"
-export POSTGRESQL_DATA_DIR="${POSTGRESQL_ROOT_DIR}/data"
-export POSTGRESQL_LOG_FILE="${POSTGRESQL_ROOT_DIR}/postgresql.log"
-export POSTGRESQL_HOST='localhost'
-export POSTGRESQL_PORT=54321
-export POSTGRESQL_USERNAME='test'
-export POSTGRESQL_PASSWORD=''
-function start_postgresql() {
-  mkdir -p "$POSTGRESQL_DATA_DIR"
-  bazel run -- @postgresql_dev_env//:initdb --auth=trust --encoding=UNICODE --locale=en_US.UTF-8 --username="$POSTGRESQL_USERNAME" "$POSTGRESQL_DATA_DIR"
-  eval "echo \"$(cat ci/postgresql.conf)\"" > "$POSTGRESQL_DATA_DIR/postgresql.conf"
-  bazel run -- @postgresql_dev_env//:pg_ctl -w --pgdata="$POSTGRESQL_DATA_DIR" --log="$POSTGRESQL_LOG_FILE" start || {
-    if [[ -f "$POSTGRESQL_LOG_FILE" ]]; then
-      echo >&2 'PostgreSQL logs:'
-      cat >&2 "$POSTGRESQL_LOG_FILE"
-    fi
-    return 1
-  }
-}
-function stop_postgresql() {
-  if [[ -e "$POSTGRESQL_DATA_DIR" ]]; then
-    bazel run -- @postgresql_dev_env//:pg_ctl -w --pgdata="$POSTGRESQL_DATA_DIR" --mode=immediate stop || :
-    rm -rf "$POSTGRESQL_ROOT_DIR"
-  fi
-}
-trap stop_postgresql EXIT
-stop_postgresql # in case it's running from a previous build
-start_postgresql
+git checkout dbd8806848786d3588b71fb50122c5746dc0eb0e
 
-# Run the tests.
-bazel test //... \
-  --build_tag_filters "$tag_filter" \
-  --test_tag_filters "$tag_filter" \
-  --test_env "POSTGRESQL_HOST=${POSTGRESQL_HOST}" \
-  --test_env "POSTGRESQL_PORT=${POSTGRESQL_PORT}" \
-  --test_env "POSTGRESQL_USERNAME=${POSTGRESQL_USERNAME}" \
-  --test_env "POSTGRESQL_PASSWORD=${POSTGRESQL_PASSWORD}" \
-  --experimental_execution_log_file "$ARTIFACT_DIRS/test_execution${execution_log_postfix}.log"
-
-# Make sure that Bazel query works.
-bazel query 'deps(//...)' >/dev/null
-
-# Check that we can load damlc in ghci
-# Disabled on darwin since it sometimes seem to hang and this only
-# tests our dev setup rather than our code so issues are not critical.
-if [[ "$(uname)" != "Darwin" ]]; then
-  da-ghci --data yes //compiler/damlc:damlc -e ':main --help'
-fi
-
-# Test that ghcide at least builds starts, we don’t run it since it
-# adds 2-5 minutes to each CI run with relatively little benefit. If
-# you want to test it manually on upgrades, run
-# ghcide compiler/damlc/exe/Main.hs.
-ghcide --help
+bazel run daml-lf/scenario-interpreter:scenario-perf

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
@@ -101,6 +101,8 @@ class ContractDiscriminatorFreshnessCheckSpec
       tmplId,
       TransactionBuilder.assertAsVersionedValue(contractRecord(party, idx, cids)),
       "Agreement",
+      None,
+      None
     )
 
   private def globalKey(party: Ref.Party, idx: Int) =

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/ContractDiscriminatorFreshnessCheckSpec.scala
@@ -102,7 +102,7 @@ class ContractDiscriminatorFreshnessCheckSpec
       TransactionBuilder.assertAsVersionedValue(contractRecord(party, idx, cids)),
       "Agreement",
       None,
-      None
+      None,
     )
 
   private def globalKey(party: Ref.Party, idx: Int) =

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -103,6 +103,8 @@ class EngineTest
         )
       ),
       "",
+      None,
+      None
     )
 
   val defaultContracts: Map[ContractId, ContractInst[Value.VersionedValue[ContractId]]] =
@@ -117,6 +119,8 @@ class EngineTest
             )
           ),
           "",
+          None,
+          None
         ),
       toContractId("#BasicTests:CallablePayout:1") ->
         ContractInst(
@@ -131,6 +135,8 @@ class EngineTest
             )
           ),
           "",
+          None,
+          None
         ),
       toContractId("#BasicTests:WithKey:1") ->
         withKeyContractInst,
@@ -1381,6 +1387,8 @@ class EngineTest
         TypeConName(basicTestsPkgId, tid),
         assertAsVersionedValue(ValueRecord(Some(Identifier(basicTestsPkgId, tid)), targs)),
         "",
+        None,
+        None
       )
 
     def lookupContract(id: ContractId): Option[ContractInst[Value.VersionedValue[ContractId]]] = {
@@ -1496,6 +1504,8 @@ class EngineTest
         )
       ),
       "",
+      None,
+      None
     )
 
     def lookupContract(id: ContractId): Option[ContractInst[Value.VersionedValue[ContractId]]] = {
@@ -1546,6 +1556,8 @@ class EngineTest
         ValueRecord(Some(lookerUpTemplateId), ImmArray((Some[Name]("p"), ValueParty(alice))))
       ),
       "",
+      None,
+      None
     )
 
     def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] = {
@@ -1751,6 +1763,8 @@ class EngineTest
           ValueRecord(Some(fetcherTemplateId), ImmArray((Some[Name]("p"), ValueParty(alice))))
         ),
         "",
+        None,
+        None
       )
 
       def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] = {

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/EngineTest.scala
@@ -104,7 +104,7 @@ class EngineTest
       ),
       "",
       None,
-      None
+      None,
     )
 
   val defaultContracts: Map[ContractId, ContractInst[Value.VersionedValue[ContractId]]] =
@@ -120,7 +120,7 @@ class EngineTest
           ),
           "",
           None,
-          None
+          None,
         ),
       toContractId("#BasicTests:CallablePayout:1") ->
         ContractInst(
@@ -136,7 +136,7 @@ class EngineTest
           ),
           "",
           None,
-          None
+          None,
         ),
       toContractId("#BasicTests:WithKey:1") ->
         withKeyContractInst,
@@ -1388,7 +1388,7 @@ class EngineTest
         assertAsVersionedValue(ValueRecord(Some(Identifier(basicTestsPkgId, tid)), targs)),
         "",
         None,
-        None
+        None,
       )
 
     def lookupContract(id: ContractId): Option[ContractInst[Value.VersionedValue[ContractId]]] = {
@@ -1505,7 +1505,7 @@ class EngineTest
       ),
       "",
       None,
-      None
+      None,
     )
 
     def lookupContract(id: ContractId): Option[ContractInst[Value.VersionedValue[ContractId]]] = {
@@ -1557,7 +1557,7 @@ class EngineTest
       ),
       "",
       None,
-      None
+      None,
     )
 
     def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] = {
@@ -1764,7 +1764,7 @@ class EngineTest
         ),
         "",
         None,
-        None
+        None,
       )
 
       def lookupKey(key: GlobalKeyWithMaintainers): Option[ContractId] = {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -960,33 +960,32 @@ private[lf] final class Compiler(
       tokenPos: Position,
   ) =
     let(SBUMyFetch(tmplId)(svar(cidPos))) { tmplArgPos0 =>
-    let(SBStructProj(0)(svar(tmplArgPos0))) { tmplArgPos =>
-      addExprVar(tmpl.param, tmplArgPos)
-      SEScopeExercise(
-        let(
-          SBUBeginExercise(tmplId, choice.name, choice.consuming, byKey = mbKey.isDefined)(
-            svar(choiceArgPos),
-            svar(cidPos),
-            SBStructProj(1)(svar(tmplArgPos0)),
-            SBStructProj(2)(svar(tmplArgPos0)),
-            {
-              addExprVar(choice.argBinder._1, choiceArgPos)
-              compile(choice.controllers)
-            }, //
-            {
-              choice.choiceObservers match {
-                case Some(observers) => compile(observers)
-                case None => SEValue.EmptyList
-              }
-            },
-            mbKey.fold(compileKeyWithMaintainers(tmpl.key))(pos => SBSome(svar(pos))),
-          )
-        ) { _ =>
-          addExprVar(choice.selfBinder, cidPos)
-          app(compile(choice.update), svar(tokenPos))
-        }
-      )
-    }
+      let(SBStructProj(0)(svar(tmplArgPos0))) { tmplArgPos =>
+        addExprVar(tmpl.param, tmplArgPos)
+        SEScopeExercise(
+          let(
+            SBUBeginExercise(tmplId, choice.name, choice.consuming, byKey = mbKey.isDefined)(
+              svar(choiceArgPos),
+              svar(cidPos),
+              SBStructProj(1)(svar(tmplArgPos0)),
+              SBStructProj(2)(svar(tmplArgPos0)), {
+                addExprVar(choice.argBinder._1, choiceArgPos)
+                compile(choice.controllers)
+              }, //
+              {
+                choice.choiceObservers match {
+                  case Some(observers) => compile(observers)
+                  case None => SEValue.EmptyList
+                }
+              },
+              mbKey.fold(compileKeyWithMaintainers(tmpl.key))(pos => SBSome(svar(pos))),
+            )
+          ) { _ =>
+            addExprVar(choice.selfBinder, cidPos)
+            app(compile(choice.update), svar(tokenPos))
+          }
+        )
+      }
     }
 
   private[this] def compileChoice(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -959,15 +959,16 @@ private[lf] final class Compiler(
       mbKey: Option[Position], // defined for byKey operation
       tokenPos: Position,
   ) =
-    let(SBUFetch(tmplId)(svar(cidPos))) { tmplArgPos =>
+    let(SBUMyFetch(tmplId)(svar(cidPos))) { tmplArgPos0 =>
+    let(SBStructProj(0)(svar(tmplArgPos0))) { tmplArgPos =>
       addExprVar(tmpl.param, tmplArgPos)
       SEScopeExercise(
         let(
           SBUBeginExercise(tmplId, choice.name, choice.consuming, byKey = mbKey.isDefined)(
             svar(choiceArgPos),
             svar(cidPos),
-            compile(tmpl.signatories),
-            compile(tmpl.observers), //
+            SBStructProj(1)(svar(tmplArgPos0)),
+            SBStructProj(2)(svar(tmplArgPos0)),
             {
               addExprVar(choice.argBinder._1, choiceArgPos)
               compile(choice.controllers)
@@ -985,6 +986,7 @@ private[lf] final class Compiler(
           app(compile(choice.update), svar(tokenPos))
         }
       )
+    }
     }
 
   private[this] def compileChoice(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1050,8 +1050,8 @@ private[lf] object SBuiltin {
           else {
             val args = new util.ArrayList[SValue](3)
             args.add(contract)
-            args.add(signatories)
-            args.add(stakeholders)
+            args.add(SList(signatories.view.map(SParty(_)).to(FrontStack)))
+            args.add(SList(stakeholders.view.map(SParty(_)).to(FrontStack)))
             machine.returnValue = SStruct(fetchStructNames, args)
           }
         case None =>
@@ -1078,8 +1078,8 @@ private[lf] object SBuiltin {
                     else
                       fetchStructCon(
                         SEImportValue(typ, arg),
-                        SEValue(SList(signatories.get.map(SParty(_)).to(FrontStack))),
-                        SEValue(SList(stakeholders.get.map(SParty(_)).to(FrontStack))),
+                        SEValue(SList(signatories.get.view.map(SParty(_)).to(FrontStack))),
+                        SEValue(SList(stakeholders.get.view.map(SParty(_)).to(FrontStack))),
                       )
               },
             )

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -329,7 +329,13 @@ private[lf] object Speedy {
         }
       }
 
-    def addLocalContract(coid: V.ContractId, templateId: Ref.TypeConName, v: SValue, signatories: Set[Party], observers: Set[Party]) =
+    def addLocalContract(
+        coid: V.ContractId,
+        templateId: Ref.TypeConName,
+        v: SValue,
+        signatories: Set[Party],
+        observers: Set[Party],
+    ) =
       withOnLedger("addLocalContract") { onLedger =>
         coid match {
           case V.ContractId.V1(discriminator, _)
@@ -338,7 +344,8 @@ private[lf] object Speedy {
           case _ =>
             val sigs = SValue.SList(signatories.map(SValue.SParty(_)).to(FrontStack))
             val obs = SValue.SList(observers.map(SValue.SParty(_)).to(FrontStack))
-            onLedger.localContracts = onLedger.localContracts.updated(coid, (templateId, v, sigs, obs))
+            onLedger.localContracts =
+              onLedger.localContracts.updated(coid, (templateId, v, sigs, obs))
         }
       }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -111,7 +111,7 @@ private[lf] object Speedy {
       /* Flag to trace usage of get_time builtins */
       var dependsOnTime: Boolean,
       // local contracts, that are contracts created in the current transaction)
-      var localContracts: Map[V.ContractId, (Ref.TypeConName, SValue, SValue, SValue)],
+      var localContracts: Map[V.ContractId, (Ref.TypeConName, SValue, Set[Party], Set[Party])],
       // global contract discriminators, that are discriminators from contract created in previous transactions
       var globalDiscriminators: Set[crypto.Hash],
   ) extends LedgerMode
@@ -342,10 +342,8 @@ private[lf] object Speedy {
               if onLedger.globalDiscriminators.contains(discriminator) =>
             crash("Conflicting discriminators between a global and local contract ID.")
           case _ =>
-            val sigs = SValue.SList(signatories.map(SValue.SParty(_)).to(FrontStack))
-            val obs = SValue.SList(observers.map(SValue.SParty(_)).to(FrontStack))
             onLedger.localContracts =
-              onLedger.localContracts.updated(coid, (templateId, v, sigs, obs))
+              onLedger.localContracts.updated(coid, (templateId, v, signatories, observers))
         }
       }
 

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -32,7 +32,7 @@ class CollectAuthorityState {
 
   @Param(Array("//daml-lf/scenario-interpreter/CollectAuthority.dar"))
   private[perf] var dar: String = _
-  @Param(Array("CollectAuthority:test"))
+  @Param(Array("CollectAuthority:testNew"))
   private[perf] var scenario: String = _
 
   var machine: Machine = null

--- a/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
+++ b/daml-lf/scenario-interpreter/src/perf/benches/scala/com/digitalasset/daml/lf/speedy/perf/CollectAuthority.scala
@@ -32,7 +32,7 @@ class CollectAuthorityState {
 
   @Param(Array("//daml-lf/scenario-interpreter/CollectAuthority.dar"))
   private[perf] var dar: String = _
-  @Param(Array("CollectAuthority:testNew"))
+  @Param(Array("CollectAuthority:test"))
   private[perf] var scenario: String = _
 
   var machine: Machine = null

--- a/daml-lf/scenario-interpreter/src/perf/resources/damls/CollectAuthority.daml
+++ b/daml-lf/scenario-interpreter/src/perf/resources/damls/CollectAuthority.daml
@@ -50,3 +50,32 @@ test = scenario do
   agreementId <- submit operator do create Agreement with operator; signatories = []
   agreementId <- submit operator do exercise agreementId (AddTokens with tokenIds)
   pure ()
+
+template T
+  with
+    p : Party
+  where
+    signatory p, p
+    observer p, p
+    nonconsuming choice Noop : ()
+      controller p
+      do pure ()
+
+template Worker
+  with
+    p : Party
+  where
+    signatory p
+    choice Do : ()
+      controller p
+      do cid <- create T with ..
+         doN 1000 (exercise cid Noop)
+         archive cid
+
+doN : Int -> Update () -> Update ()
+doN 0 x = pure ()
+doN n x = x >>= \_ -> doN (n - 1) x
+
+testNew = scenario do
+  p <- getParty "p"
+  submit p $ createAndExercise (Worker p) Do

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/value/test/ValueGenerators.scala
@@ -285,7 +285,7 @@ object ValueGenerators {
       template <- idGen
       arg <- valueGen
       agreement <- Arbitrary.arbitrary[String]
-    } yield ContractInst(template, arg, agreement)
+    } yield ContractInst(template, arg, agreement, None, None)
   }
 
   val versionedContractInstanceGen: Gen[ContractInst[Value.VersionedValue[Value.ContractId]]] =
@@ -293,7 +293,7 @@ object ValueGenerators {
       template <- idGen
       arg <- versionedValueGen
       agreement <- Arbitrary.arbitrary[String]
-    } yield ContractInst(template, arg, agreement)
+    } yield ContractInst(template, arg, agreement, None, None)
 
   val keyWithMaintainersGen: Gen[KeyWithMaintainers[Value[Value.ContractId]]] = {
     for {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -213,10 +213,10 @@ object Node {
       copy(version = version)
 
     def coinst: Value.ContractInst[Value[Cid]] =
-      Value.ContractInst(templateId, arg, agreementText)
+      Value.ContractInst(templateId, arg, agreementText, Some(signatories), Some(stakeholders))
 
     def versionedCoinst: Value.ContractInst[Value.VersionedValue[Cid]] =
-      Value.ContractInst(templateId, versionValue(arg), agreementText)
+      Value.ContractInst(templateId, versionValue(arg), agreementText, Some(signatories), Some(stakeholders))
 
     def versionedKey: Option[KeyWithMaintainers[Value.VersionedValue[Cid]]] =
       key.map(KeyWithMaintainers.map1(versionValue))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -216,7 +216,13 @@ object Node {
       Value.ContractInst(templateId, arg, agreementText, Some(signatories), Some(stakeholders))
 
     def versionedCoinst: Value.ContractInst[Value.VersionedValue[Cid]] =
-      Value.ContractInst(templateId, versionValue(arg), agreementText, Some(signatories), Some(stakeholders))
+      Value.ContractInst(
+        templateId,
+        versionValue(arg),
+        agreementText,
+        Some(signatories),
+        Some(stakeholders),
+      )
 
     def versionedKey: Option[KeyWithMaintainers[Value.VersionedValue[Cid]]] =
       key.map(KeyWithMaintainers.map1(versionValue))

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/TransactionCoder.scala
@@ -154,7 +154,7 @@ object TransactionCoder {
     for {
       id <- ValueCoder.decodeIdentifier(protoCoinst.getTemplateId)
       value <- ValueCoder.decodeValue(decodeCid, protoCoinst.getArgVersioned)
-    } yield Value.ContractInst(id, value, (protoCoinst.getAgreement))
+    } yield Value.ContractInst(id, value, (protoCoinst.getAgreement), None, None)
 
   private[this] def decodeContractInstance[Cid](
       decodeCid: ValueCoder.DecodeCid[Cid],
@@ -164,7 +164,7 @@ object TransactionCoder {
     for {
       id <- ValueCoder.decodeIdentifier(protoCoinst.getTemplateId)
       value <- decodeValue(decodeCid, nodeVersion, protoCoinst.getArgVersioned)
-    } yield Value.ContractInst(id, value, protoCoinst.getAgreement)
+    } yield Value.ContractInst(id, value, protoCoinst.getAgreement, None, None)
 
   def decodeVersionedContractInstance[Cid](
       decodeCid: ValueCoder.DecodeCid[Cid],
@@ -173,7 +173,7 @@ object TransactionCoder {
     for {
       id <- ValueCoder.decodeIdentifier(protoCoinst.getTemplateId)
       value <- ValueCoder.decodeVersionedValue(decodeCid, protoCoinst.getArgVersioned)
-    } yield Value.ContractInst(id, value, (protoCoinst.getAgreement))
+    } yield Value.ContractInst(id, value, (protoCoinst.getAgreement), None, None)
 
   private[this] def encodeKeyWithMaintainers[Cid](
       encodeCid: ValueCoder.EncodeCid[Cid],
@@ -458,7 +458,7 @@ object TransactionCoder {
               for {
                 tmplId <- ValueCoder.decodeIdentifier(protoCreate.getTemplateId)
                 arg <- ValueCoder.decodeValue(decodeCid, nodeVersion, protoCreate.getArgUnversioned)
-              } yield Value.ContractInst(tmplId, arg, protoCreate.getAgreement)
+              } yield Value.ContractInst(tmplId, arg, protoCreate.getAgreement, None, None)
             }
           stakeholders <- toPartySet(protoCreate.getStakeholdersList)
           signatories <- toPartySet(protoCreate.getSignatoriesList)

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -315,7 +315,7 @@ object Value extends CidContainer1[Value] {
     new `Value Equal instance`
 
   /** A contract instance is a value plus the template that originated it. */
-  final case class ContractInst[+Val](template: Identifier, arg: Val, agreementText: String)
+  final case class ContractInst[+Val](template: Identifier, arg: Val, agreementText: String, signatories: Option[Set[Ref.Party]], stakeholders: Option[Set[Ref.Party]])
       extends value.CidContainer[ContractInst[Val]] {
 
     override protected def self: this.type = this
@@ -331,7 +331,7 @@ object Value extends CidContainer1[Value] {
     implicit def equalInstance[Val: Equal]: Equal[ContractInst[Val]] =
       ScalazEqual.withNatural(Equal[Val].equalIsNatural) { (a, b) =>
         import a._
-        val ContractInst(bTemplate, bArg, bAgreementText) = b
+        val ContractInst(bTemplate, bArg, bAgreementText, _, _) = b
         template == bTemplate && arg === bArg && agreementText == bAgreementText
       }
 

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/value/Value.scala
@@ -315,8 +315,13 @@ object Value extends CidContainer1[Value] {
     new `Value Equal instance`
 
   /** A contract instance is a value plus the template that originated it. */
-  final case class ContractInst[+Val](template: Identifier, arg: Val, agreementText: String, signatories: Option[Set[Ref.Party]], stakeholders: Option[Set[Ref.Party]])
-      extends value.CidContainer[ContractInst[Val]] {
+  final case class ContractInst[+Val](
+      template: Identifier,
+      arg: Val,
+      agreementText: String,
+      signatories: Option[Set[Ref.Party]],
+      stakeholders: Option[Set[Ref.Party]],
+  ) extends value.CidContainer[ContractInst[Val]] {
 
     override protected def self: this.type = this
 

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/value/ValueSpec.scala
@@ -60,7 +60,7 @@ class ValueSpec
 
       "ensureNoCid is used " in {
         val value = VersionedValue[ContractId](TransactionVersion.minVersion, ValueUnit)
-        val contract = ContractInst(tmplId, value, "agreed")
+        val contract = ContractInst(tmplId, value, "agreed", None, None)
         value.ensureNoCid.map(_.version) shouldBe Right(TransactionVersion.minVersion)
         contract.ensureNoCid.map(_.arg.version) shouldBe Right(TransactionVersion.minVersion)
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -174,6 +174,8 @@ private[dao] object ContractsReader {
       template = Identifier.assertFromString(templateId),
       arg = deserialized,
       agreementText = "",
+      None,
+      None
     )
   }
 
@@ -185,5 +187,7 @@ private[dao] object ContractsReader {
       template = Identifier.assertFromString(templateId),
       arg = createArgument,
       agreementText = "",
+      None,
+      None
     )
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/events/ContractsReader.scala
@@ -175,7 +175,7 @@ private[dao] object ContractsReader {
       arg = deserialized,
       agreementText = "",
       None,
-      None
+      None,
     )
   }
 
@@ -188,6 +188,6 @@ private[dao] object ContractsReader {
       arg = createArgument,
       agreementText = "",
       None,
-      None
+      None,
     )
 }


### PR DESCRIPTION
On the extremely artifical benchmark the results look much better than I expected:

before: CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:testNew  avgt  200  16.470 ± 0.184  ms/op

After: CollectAuthority.bench  //daml-lf/scenario-interpreter/CollectAuthority.dar  CollectAuthority:testNew  avgt  200  9.531 ± 0.149  ms/op
### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
