### PR TITLE
Cache contract fetches in speedy

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Compiler.scala
@@ -292,6 +292,9 @@ private[lf] final class Compiler(
       val identifier = Identifier(pkgId, QualifiedName(module.name, tmplName))
       builder += compileCreate(identifier, tmpl)
       builder += compileFetch(identifier, tmpl)
+      builder += compileKey(identifier, tmpl)
+      builder += compileSignatories(identifier, tmpl)
+      builder += compileObservers(identifier, tmpl)
 
       tmpl.choices.values.foreach(builder += compileChoice(identifier, tmpl, _))
 
@@ -958,17 +961,18 @@ private[lf] final class Compiler(
       cidPos: Position,
       mbKey: Option[Position], // defined for byKey operation
       tokenPos: Position,
-  ) =
-    let(SBUFetch(tmplId)(svar(cidPos))) { tmplArgPos =>
+  ) = {
+    let(
+      SBUFetch(
+        tmplId
+      )(svar(cidPos), mbKey.fold(SEValue.None: SExpr)(pos => SBSome(svar(pos))))
+    ) { tmplArgPos =>
       addExprVar(tmpl.param, tmplArgPos)
       SEScopeExercise(
         let(
           SBUBeginExercise(tmplId, choice.name, choice.consuming, byKey = mbKey.isDefined)(
             svar(choiceArgPos),
-            svar(cidPos),
-            compile(tmpl.signatories),
-            compile(tmpl.observers), //
-            {
+            svar(cidPos), {
               addExprVar(choice.argBinder._1, choiceArgPos)
               compile(choice.controllers)
             }, //
@@ -978,7 +982,6 @@ private[lf] final class Compiler(
                 case None => SEValue.EmptyList
               }
             },
-            mbKey.fold(compileKeyWithMaintainers(tmpl.key))(pos => SBSome(svar(pos))),
           )
         ) { _ =>
           addExprVar(choice.selfBinder, cidPos)
@@ -986,6 +989,7 @@ private[lf] final class Compiler(
         }
       )
     }
+  }
 
   private[this] def compileChoice(
       tmplId: TypeConName,
@@ -1426,14 +1430,15 @@ private[lf] final class Compiler(
       tokenPos: Position,
   ) =
     withEnv { _ =>
-      let(SBUFetch(tmplId)(svar(cidPos))) { tmplArgPos =>
+      let(
+        SBUFetch(
+          tmplId
+        )(svar(cidPos), mbKey.fold(SEValue.None: SExpr)(pos => SBSome(svar(pos))))
+      ) { tmplArgPos =>
         addExprVar(tmpl.param, tmplArgPos)
         let(
           SBUInsertFetchNode(tmplId, byKey = mbKey.isDefined)(
-            svar(cidPos),
-            compile(tmpl.signatories),
-            compile(tmpl.observers),
-            mbKey.fold(compileKeyWithMaintainers(tmpl.key))(p => SBSome(svar(p))),
+            svar(cidPos)
           )
         ) { _ =>
           svar(tmplArgPos)
@@ -1452,6 +1457,33 @@ private[lf] final class Compiler(
     //   in <tmplArg>
     topLevelFunction(FetchDefRef(tmplId), 2) { case List(cidPos, tokenPos) =>
       compileFetchBody(tmplId, tmpl)(cidPos, None, tokenPos)
+    }
+
+  private[this] def compileKey(
+      tmplId: Identifier,
+      tmpl: Template,
+  ): (SDefinitionRef, SDefinition) =
+    topLevelFunction(KeyDefRef(tmplId), 1) { case List(tmplArgPos) =>
+      addExprVar(tmpl.param, tmplArgPos)
+      compileKeyWithMaintainers(tmpl.key)
+    }
+
+  private[this] def compileSignatories(
+      tmplId: Identifier,
+      tmpl: Template,
+  ): (SDefinitionRef, SDefinition) =
+    topLevelFunction(SignatoriesDefRef(tmplId), 1) { case List(tmplArgPos) =>
+      addExprVar(tmpl.param, tmplArgPos)
+      compile(tmpl.signatories)
+    }
+
+  private[this] def compileObservers(
+      tmplId: Identifier,
+      tmpl: Template,
+  ): (SDefinitionRef, SDefinition) =
+    topLevelFunction(ObserversDefRef(tmplId), 1) { case List(tmplArgPos) =>
+      addExprVar(tmpl.param, tmplArgPos)
+      compile(tmpl.observers)
     }
 
   private[this] def compileCreate(

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Profile.scala
@@ -233,6 +233,9 @@ object Profile {
       implicit val anonClosure: Allowed[AnonymousClosure.type] = allowAll
       implicit val lfDefRef: Allowed[LfDefRef] = allowAll
       implicit val createDefRef: Allowed[CreateDefRef] = allowAll
+      implicit val keyDefRef: Allowed[KeyDefRef] = allowAll
+      implicit val signatoriesDefRef: Allowed[SignatoriesDefRef] = allowAll
+      implicit val observersDefRef: Allowed[ObserversDefRef] = allowAll
       implicit val choiceDefRef: Allowed[ChoiceDefRef] = allowAll
       implicit val fetchDefRef: Allowed[FetchDefRef] = allowAll
       implicit val choiceByKeyDefRef: Allowed[ChoiceByKeyDefRef] = allowAll
@@ -252,6 +255,9 @@ object Profile {
           case AnonymousClosure => "<lambda>"
           case LfDefRef(ref) => ref.qualifiedName.toString()
           case CreateDefRef(tmplRef) => s"create @${tmplRef.qualifiedName}"
+          case KeyDefRef(tmplRef) => s"keyAndMaintainers @${tmplRef.qualifiedName}"
+          case SignatoriesDefRef(tmplRef) => s"signatories @${tmplRef.qualifiedName}"
+          case ObserversDefRef(tmplRef) => s"observers @${tmplRef.qualifiedName}"
           case ChoiceDefRef(tmplRef, name) => s"exercise @${tmplRef.qualifiedName} ${name}"
           case FetchDefRef(tmplRef) => s"fetch @${tmplRef.qualifiedName}"
           case ChoiceByKeyDefRef(tmplRef, name) =>

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1830,7 +1830,7 @@ private[lf] object SBuiltin {
     v match {
       case SStruct(_, vals) if vals.size == cachedContractStructFields.size =>
         CachedContract(
-          templateId,
+          templateId = templateId,
           value = vals.get(cachedContractArgIdx),
           signatories = extractParties(vals.get(cachedContractSignatoriesIdx)),
           observers = extractParties(vals.get(cachedContractObserversIdx)),

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -1024,8 +1024,6 @@ private[lf] object SBuiltin {
                     if (actualTmplId != templateId) {
                       machine.ctrl =
                         SEDamlException(DamlEWronglyTypedContract(coid, templateId, actualTmplId))
-                    } else if (onLedger.cachedContracts.contains(coid)) {
-                      machine.ctrl = SEImportValue(typ, arg)
                     } else {
                       val keyExpr = args.get(1) match {
                         // No by-key operation, we have to recompute.

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SBuiltin.scala
@@ -951,7 +951,8 @@ private[lf] object SBuiltin {
         case SContractId(coid) => coid
         case v => crash(s"expected contract id, got: $v")
       }
-      val cached = onLedger.cachedContracts.get(coid).get
+      val cached =
+        onLedger.cachedContracts.get(coid).getOrElse(crash(s"Contract $coid is missing from cache"))
       val sigs = cached.signatories
       val templateObservers = cached.observers
       val ctrls = extractParties(args.get(2))
@@ -1070,7 +1071,8 @@ private[lf] object SBuiltin {
         case SContractId(coid) => coid
         case v => crash(s"expected contract id, got: $v")
       }
-      val cached = onLedger.cachedContracts.get(coid).get
+      val cached =
+        onLedger.cachedContracts.get(coid).getOrElse(crash(s"Contract $coid is missing from cache"))
       val signatories = cached.signatories
       val observers = cached.observers
       val key = cached.key

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/SExpr.scala
@@ -441,6 +441,9 @@ object SExpr {
   final case class FetchByKeyDefRef(ref: DefinitionRef) extends SDefinitionRef
   final case class LookupByKeyDefRef(ref: DefinitionRef) extends SDefinitionRef
   final case class ExceptionMessageDefRef(ref: DefinitionRef) extends SDefinitionRef
+  final case class KeyDefRef(ref: DefinitionRef) extends SDefinitionRef
+  final case class SignatoriesDefRef(ref: DefinitionRef) extends SDefinitionRef
+  final case class ObserversDefRef(ref: DefinitionRef) extends SDefinitionRef
 
   //
   // List builtins (equalList) are implemented as recursive

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -17,7 +17,7 @@ import com.daml.lf.speedy.SError._
 import com.daml.lf.speedy.SExpr._
 import com.daml.lf.speedy.SResult._
 import com.daml.lf.speedy.SBuiltin.checkAborted
-import com.daml.lf.transaction.TransactionVersion
+import com.daml.lf.transaction.{Node, TransactionVersion}
 import com.daml.lf.value.{Value => V}
 import org.slf4j.LoggerFactory
 
@@ -98,6 +98,13 @@ private[lf] object Speedy {
 
   private[lf] sealed trait LedgerMode
 
+  private[lf] final case class CachedContract(
+      value: SValue,
+      signatories: Set[Party],
+      observers: Set[Party],
+      key: Option[Node.KeyWithMaintainers[V[Nothing]]],
+  )
+
   private[lf] final case class OnLedger(
       val validating: Boolean,
       /* Controls if authorization checks are performed during evaluation */
@@ -114,6 +121,7 @@ private[lf] object Speedy {
       var localContracts: Map[V.ContractId, (Ref.TypeConName, SValue)],
       // global contract discriminators, that are discriminators from contract created in previous transactions
       var globalDiscriminators: Set[crypto.Hash],
+      var cachedContracts: Map[V.ContractId, CachedContract],
   ) extends LedgerMode
 
   private[lf] final case object OffLedger extends LedgerMode
@@ -329,7 +337,14 @@ private[lf] object Speedy {
         }
       }
 
-    def addLocalContract(coid: V.ContractId, templateId: Ref.TypeConName, SValue: SValue) =
+    def addLocalContract(
+        coid: V.ContractId,
+        templateId: Ref.TypeConName,
+        SValue: SValue,
+        signatories: Set[Party],
+        observers: Set[Party],
+        key: Option[Node.KeyWithMaintainers[V[Nothing]]],
+    ) =
       withOnLedger("addLocalContract") { onLedger =>
         coid match {
           case V.ContractId.V1(discriminator, _)
@@ -337,6 +352,10 @@ private[lf] object Speedy {
             crash("Conflicting discriminators between a global and local contract ID.")
           case _ =>
             onLedger.localContracts = onLedger.localContracts.updated(coid, templateId -> SValue)
+            onLedger.cachedContracts = onLedger.cachedContracts.updated(
+              coid,
+              CachedContract(SValue, signatories, observers, key),
+            )
         }
       }
 
@@ -808,6 +827,7 @@ private[lf] object Speedy {
           globalDiscriminators = globalCids.collect { case V.ContractId.V1(discriminator, _) =>
             discriminator
           },
+          cachedContracts = Map.empty,
         ),
         traceLog = traceLog,
         compiledPackages = compiledPackages,
@@ -1278,6 +1298,20 @@ private[lf] object Speedy {
       v.setCached(sv, stack_trace)
       defn.setCached(sv, stack_trace)
       machine.returnValue = sv
+    }
+  }
+
+  private[speedy] final case class KCacheContract(
+      machine: Machine,
+      cid: V.ContractId,
+  ) extends Kont {
+
+    def execute(sv: SValue): Unit = {
+      val cached = SBuiltin.extractCachedContract(sv)
+      machine.withOnLedger("KCacheContract") { onLedger =>
+        onLedger.cachedContracts = onLedger.cachedContracts.updated(cid, cached)
+        machine.returnValue = cached.value
+      }
     }
   }
 

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -99,6 +99,7 @@ private[lf] object Speedy {
   private[lf] sealed trait LedgerMode
 
   private[lf] final case class CachedContract(
+      templateId: Ref.TypeConName,
       value: SValue,
       signatories: Set[Party],
       observers: Set[Party],
@@ -354,7 +355,7 @@ private[lf] object Speedy {
             onLedger.localContracts = onLedger.localContracts.updated(coid, templateId -> SValue)
             onLedger.cachedContracts = onLedger.cachedContracts.updated(
               coid,
-              CachedContract(SValue, signatories, observers, key),
+              CachedContract(templateId, SValue, signatories, observers, key),
             )
         }
       }
@@ -1303,11 +1304,12 @@ private[lf] object Speedy {
 
   private[speedy] final case class KCacheContract(
       machine: Machine,
+      templateId: Ref.TypeConName,
       cid: V.ContractId,
   ) extends Kont {
 
     def execute(sv: SValue): Unit = {
-      val cached = SBuiltin.extractCachedContract(sv)
+      val cached = SBuiltin.extractCachedContract(templateId, sv)
       machine.withOnLedger("KCacheContract") { onLedger =>
         onLedger.cachedContracts = onLedger.cachedContracts.updated(cid, cached)
         machine.returnValue = cached.value

--- a/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
+++ b/daml-lf/language/src/main/scala/com/digitalasset/daml/lf/language/Ast.scala
@@ -992,6 +992,8 @@ object Ast {
   val maintainersFieldName = Name.assertFromString("maintainers")
   val contractIdFieldName = Name.assertFromString("contractId")
   val contractFieldName = Name.assertFromString("contract")
+  val signatoriesFieldName = Name.assertFromString("signatories")
+  val observersFieldName = Name.assertFromString("observers")
 
   final case class PackageError(error: String) extends RuntimeException(error)
 

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -150,6 +150,7 @@ class IdeLedgerClient(val compiledPackages: CompiledPackages) extends ScriptLedg
       onLedger.commitLocation = optLocation
       onLedger.localContracts = Map.empty
       onLedger.globalDiscriminators = Set.empty
+      onLedger.cachedContracts = Map.empty
       val speedyCommands = preprocessor.unsafePreprocessCommands(commands.to(ImmArray))._1
       val translated = compiledPackages.compiler.unsafeCompile(speedyCommands)
       machine.setExpressionToEvaluate(SEApp(translated, Array(SEValue.Token)))


### PR DESCRIPTION
This PR adds a cache to speedy to cache contract fetches and
information only derived from the contract argument, namely,
signatories, observers and keys.

The cache is engine-internal so on the first fetch of a global
contract in a transaction, we recompute that information.

This does not change observable semantics:

Ledgers must be consistent within a transaction so caching is safe. We
still recompute signatories, observers & keys the first time so if
they fail, we still blow u.

We also never compute more than before. While `SBUFetch` itself did
not compute that information, it was immediately folowed by either
`SBUBeginExercise` or `SBUInsertFetchNode` which compute that
information.

We also keep the optimization that we do not have to compute key and
maintainers on by-key operations

On the collect authority benchmark, this is around a ~1.48x
improvement which is pretty decent.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
