### PR TITLE
Removing Git as a prerequisit from the GSG

### DIFF
--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -31,7 +31,6 @@ Please make sure that you have the DAML Connect SDK, Java 8 or higher, and Visua
 
 You will also need some common software tools to build and interact with the template project.
 
-- `Git <https://git-scm.com/downloads>`_ version control system
 - `Node <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_ package manager for JavaScript.
   Note: On Ubuntu 18.04, NodeJS 8.10 will be installed but its too old.
 - A terminal application for command line interaction

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -3,10 +3,10 @@
 
 .. _new-quickstart:
 
-Getting Started with DAML
+Getting Started with Daml
 #########################
 
-The goal of this tutorial is to get you up and running with full-stack DAML development.
+The goal of this tutorial is to get you up and running with full-stack Daml development.
 We do this through the example of a simple social networking application,
 showing you three things:
 
@@ -14,20 +14,20 @@ showing you three things:
     2. The design of its different components (:doc:`app-architecture`)
     3. How to write a new feature for the app (:doc:`first-feature`)
 
-We do not aim to be comprehensive in all DAML concepts and tools (covered in :doc:`Writing DAML </daml/intro/0_Intro>`) or in all deployment options (see :doc:`Deploying </deploy/index>`).
-**For a quick overview of the most important DAML concepts used in this tutorial open** `the DAML cheat-sheet <https://docs.daml.com/cheat-sheet/>`_ **in a separate tab**. The goal is that by the end of this tutorial,
+We do not aim to be comprehensive in all Daml concepts and tools (covered in :doc:`Writing Daml </daml/intro/0_Intro>`) or in all deployment options (see :doc:`Deploying </deploy/index>`).
+**For a quick overview of the most important Daml concepts used in this tutorial open** `the Daml cheat-sheet <https://docs.daml.com/cheat-sheet/>`_ **in a separate tab**. The goal is that by the end of this tutorial,
 you'll have a good idea of the following:
 
-    1. What DAML contracts and ledgers are
-    2. How a user interface (UI) interacts with a DAML ledger
-    3. How DAML helps you build a real-life application fast.
+    1. What Daml contracts and ledgers are
+    2. How a user interface (UI) interacts with a Daml ledger
+    3. How Daml helps you build a real-life application fast.
 
 With that, let's get started!
 
 Prerequisites
 *************
 
-Please make sure that you have the DAML Connect SDK, Java 8 or higher, and Visual Studio Code (the only supported IDE) installed as per instructions from our :doc:`installation` page.
+Please make sure that you have the Daml Connect SDK, Java 8 or higher, and Visual Studio Code (the only supported IDE) installed as per instructions from our :doc:`installation` page.
 
 You will also need some common software tools to build and interact with the template project.
 
@@ -61,15 +61,15 @@ In one terminal, at the root of the ``create-daml-app`` directory, run the comma
 
     daml start
 
-Any commands starting with ``daml`` are using the :doc:`DAML Assistant </tools/assistant>`, a
-command line tool in the SDK for building and running DAML apps.
+Any commands starting with ``daml`` are using the :doc:`Daml Assistant </tools/assistant>`, a
+command line tool in the SDK for building and running Daml apps.
 
 You will know that the command has started successfully when you see the ``INFO  com.daml.http.Main$ - Started server: ServerBinding(/127.0.0.1:7575)`` message in the terminal. The command does a few things:
 
-    1. Compiles the DAML code to a DAR (DAML Archive) file.
-    2. Generates a JavaScript library in ``ui/daml.js`` to connect the UI with your DAML code.
+    1. Compiles the Daml code to a DAR (Daml Archive) file.
+    2. Generates a JavaScript library in ``ui/daml.js`` to connect the UI with your Daml code.
     3. Starts an instance of the :doc:`Sandbox </tools/sandbox>`, an in-memory ledger useful for development, loaded with our DAR.
-    4. Starts a server for the :doc:`HTTP JSON API </json-api/index>`, a simple way to run commands against a DAML ledger (in this case the running Sandbox).
+    4. Starts a server for the :doc:`HTTP JSON API </json-api/index>`, a simple way to run commands against a Daml ledger (in this case the running Sandbox).
 
 We'll leave these processes running to serve requests from our UI.
 
@@ -109,7 +109,7 @@ You'll notice that the users you just started following appear in the *Following
 However they do *not* yet appear in the *Network* panel.
 This is either because they have not signed up and are not parties on the ledger or they have not yet started followiong you.
 This social network is similar to Twitter and Instagram, where by following someone, say Alice, you make yourself visible to her but not vice versa.
-We will see how we encode this in DAML in the next section.
+We will see how we encode this in Daml in the next section.
 
    .. figure:: images/create-daml-app-bob-follows-alice.png
       :alt: In the create-daml-app users can follow each other in a similiar fashion as in Twitter or Instagram
@@ -130,7 +130,7 @@ Just switch to the window where you are logged in as yourself - the network shou
       :alt: In the create-daml-app when the user you are following follows you back s/he reveals the list of people they are following
 
 Play around more with the app at your leisure: create new users and start following more users.
-Observe when a user becomes visible to others - this will be important to understanding DAML's privacy model later.
+Observe when a user becomes visible to others - this will be important to understanding Daml's privacy model later.
 When you're ready, let's move on to the :doc:`architecture of our app <app-architecture>`.
 
 .. tip:: Congratulations on completing the first part of the Getting Started Guide! `Join our forum <https://discuss.daml.com>`_ and share a screenshot of your accomplishment to `get your first of 3 getting started badges <https://discuss.daml.com/badges/125/it-works>`_! You can get the next one by :doc:`implementing your first feature </getting-started/first-feature>`.


### PR DESCRIPTION
CHANGELOG_BEGIN
Removing `Git` as a prerequisit from the GSG in the docs. The request came through our feedback form on the docs and was discussed [on the forum ](https://discuss.daml.com/t/complete-walk-through-installing-daml-vs-code-on-debian-buster-10/2226/2?u=quidagis)
CHANGELOG_END

Removing `Git` as a prerequisit from the GSG in the docs. Got this feedback through our feedback form

> This page states that you will require Git. However in a response to the tutorial that I posted about 'Daml install on Debian Buster', @cocreature said that Git was not necessary. https://discuss.daml.com/t/complete-walk-through-installing-daml-vs-code-on-debian-buster-10/2226/2?u=quidagis I have no issues with that, however it now seems there is a difference in the Documentation (On this page) and one of your lead Developers in relation to the Daml build process on GNU/Linux. Please forward this for review and evaluation by the DA Technical experts.
