### PR TITLE
Remove contract arguments from localContracts

### DIFF
--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Speedy.scala
@@ -118,8 +118,8 @@ private[lf] object Speedy {
       var commitLocation: Option[Location],
       /* Flag to trace usage of get_time builtins */
       var dependsOnTime: Boolean,
-      // local contracts, that are contracts created in the current transaction)
-      var localContracts: Map[V.ContractId, (Ref.TypeConName, SValue)],
+      // local contracts, that are contracts created in the current transaction, values are stored in cachedContracts
+      var localContracts: Set[V.ContractId],
       // global contract discriminators, that are discriminators from contract created in previous transactions
       var globalDiscriminators: Set[crypto.Hash],
       var cachedContracts: Map[V.ContractId, CachedContract],
@@ -341,7 +341,7 @@ private[lf] object Speedy {
     def addLocalContract(
         coid: V.ContractId,
         templateId: Ref.TypeConName,
-        SValue: SValue,
+        arg: SValue,
         signatories: Set[Party],
         observers: Set[Party],
         key: Option[Node.KeyWithMaintainers[V[Nothing]]],
@@ -352,10 +352,10 @@ private[lf] object Speedy {
               if onLedger.globalDiscriminators.contains(discriminator) =>
             crash("Conflicting discriminators between a global and local contract ID.")
           case _ =>
-            onLedger.localContracts = onLedger.localContracts.updated(coid, templateId -> SValue)
+            onLedger.localContracts = onLedger.localContracts + coid
             onLedger.cachedContracts = onLedger.cachedContracts.updated(
               coid,
-              CachedContract(templateId, SValue, signatories, observers, key),
+              CachedContract(templateId, arg, signatories, observers, key),
             )
         }
       }
@@ -364,7 +364,7 @@ private[lf] object Speedy {
       withOnLedger("addGlobalCid") { onLedger =>
         cid match {
           case V.ContractId.V1(discriminator, _) =>
-            if (onLedger.localContracts.isDefinedAt(V.ContractId.V1(discriminator)))
+            if (onLedger.localContracts.contains(V.ContractId.V1(discriminator)))
               crash("Conflicting discriminators between a global and local contract ID.")
             else
               onLedger.globalDiscriminators = onLedger.globalDiscriminators + discriminator
@@ -824,7 +824,7 @@ private[lf] object Speedy {
           committers = committers,
           commitLocation = None,
           dependsOnTime = false,
-          localContracts = Map.empty,
+          localContracts = Set.empty,
           globalDiscriminators = globalCids.collect { case V.ContractId.V1(discriminator, _) =>
             discriminator
           },

--- a/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
+++ b/daml-script/runner/src/main/scala/com/digitalasset/daml/lf/engine/script/ledgerinteraction/IdeLedgerClient.scala
@@ -148,7 +148,7 @@ class IdeLedgerClient(val compiledPackages: CompiledPackages) extends ScriptLedg
       // Clear state at the beginning like in SBSBeginCommit for scenarios.
       machine.returnValue = null
       onLedger.commitLocation = optLocation
-      onLedger.localContracts = Map.empty
+      onLedger.localContracts = Set.empty
       onLedger.globalDiscriminators = Set.empty
       onLedger.cachedContracts = Map.empty
       val speedyCommands = preprocessor.unsafePreprocessCommands(commands.to(ImmArray))._1


### PR DESCRIPTION
We already store them in cachedContracts, no reason to store them
twice. This should also be slightly more efficient since we only do
one lookup in cachedContracts in the common case and only look at
localContracts if there’s a wrongly typed contract. I doubt it’s
measurable but at least it’s not worse.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
