### PR TITLE
Implement structural cases for NodeRollback

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Blinding.scala
@@ -66,9 +66,8 @@ object Blinding {
             go(filteredRoots :+ root, remainingRoots)
           } else {
             tx.nodes(root) match {
-              case _: NodeRollback[_] =>
-                // TODO https://github.com/digital-asset/daml/issues/8020
-                sys.error("rollback nodes are not supported")
+              case nr: NodeRollback[Nid] =>
+                go(filteredRoots, nr.children ++: remainingRoots)
               case _: NodeFetch[Cid] | _: NodeCreate[Cid] | _: NodeLookupByKey[Cid] =>
                 go(filteredRoots, remainingRoots)
               case ne: NodeExercises[Nid, Cid] =>

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/Engine.scala
@@ -471,9 +471,7 @@ object Engine {
       val makeDesc = (kind: String, tmpl: Ref.Identifier, extra: Option[String]) =>
         s"$kind:${tmpl.qualifiedName.name}${extra.map(extra => s":$extra").getOrElse("")}"
       tx.nodes.get(tx.roots(0)).toList.head match {
-        case _: NodeRollback[_] =>
-          // TODO https://github.com/digital-asset/daml/issues/8020
-          sys.error("rollback nodes are not supported")
+        case _: NodeRollback[_] => "rollback"
         case create: NodeCreate[_] => makeDesc("create", create.coinst.template, None)
         case exercise: NodeExercises[_, _] =>
           makeDesc("exercise", exercise.templateId, Some(exercise.choiceId))

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -109,9 +109,8 @@ final class ValueEnricher(engine: Engine) {
 
   def enrichNode[Nid](node: GenNode[Nid, ContractId]): Result[GenNode[Nid, ContractId]] =
     node match {
-      case _: Node.NodeRollback[_] =>
-        // TODO https://github.com/digital-asset/daml/issues/8020
-        sys.error("rollback nodes are not supported")
+      case rb @ Node.NodeRollback(_) => // forces reconsidation if fields are added
+        ResultDone(rb)
       case create: Node.NodeCreate[ContractId] =>
         for {
           arg <- enrichValue(TTyCon(create.templateId), create.arg)

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -109,7 +109,7 @@ final class ValueEnricher(engine: Engine) {
 
   def enrichNode[Nid](node: GenNode[Nid, ContractId]): Result[GenNode[Nid, ContractId]] =
     node match {
-      case rb @ Node.NodeRollback(_) => // forces reconsidation if fields are added
+      case rb @ Node.NodeRollback(_) => // forces reconsideration if fields are added
         ResultDone(rb)
       case create: Node.NodeCreate[ContractId] =>
         for {

--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/preprocessing/TransactionPreprocessor.scala
@@ -37,6 +37,7 @@ private[preprocessing] final class TransactionPreprocessor(
     node match {
       case _: Node.NodeRollback[_] =>
         // TODO https://github.com/digital-asset/daml/issues/8020
+        // how on earth can we turn a rollback node back into a speedy command?
         sys.error("rollback nodes are not supported")
       case Node.NodeCreate(
             coid @ _,

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
@@ -37,8 +37,12 @@ private[engine] class InMemoryPrivateLedgerData extends PrivateLedgerData {
         case FrontStackCons(nodeId, nodeIds) =>
           val node = tx.nodes(nodeId)
           node match {
-            case nr: NodeRollback[NodeId] =>
-              go(nr.children ++: nodeIds)
+            case _: NodeRollback[NodeId] =>
+              // TODO https://github.com/digital-asset/daml/issues/8020
+              // do we traverse children here?
+              //go(nr.children ++: nodeIds) //?
+              //go(nodeIds) //?
+              sys.error("rollback nodes are not supported")
             case nc: NodeCreate[ContractId] =>
               pcs.put(nc.coid, nc.versionedCoinst)
               go(nodeIds)

--- a/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
+++ b/daml-lf/engine/src/test/scala/com/digitalasset/daml/lf/engine/InMemoryPrivateLedgerData.scala
@@ -37,9 +37,8 @@ private[engine] class InMemoryPrivateLedgerData extends PrivateLedgerData {
         case FrontStackCons(nodeId, nodeIds) =>
           val node = tx.nodes(nodeId)
           node match {
-            // TODO https://github.com/digital-asset/daml/issues/8020
-            case _: NodeRollback[_] =>
-              sys.error("rollback nodes are not supported")
+            case nr: NodeRollback[NodeId] =>
+              go(nr.children ++: nodeIds)
             case nc: NodeCreate[ContractId] =>
               pcs.put(nc.coid, nc.versionedCoinst)
               go(nodeIds)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/ledger/BlindingTransaction.scala
@@ -80,7 +80,8 @@ object BlindingTransaction {
       node match {
         case _: NodeRollback[_] =>
           // TODO https://github.com/digital-asset/daml/issues/8020
-          sys.error("rollback nodes are not supported")
+          // can rollback nodes also cause divulgence?
+          state
 
         case _: NodeCreate[ContractId] => state
         case _: NodeLookupByKey[ContractId] => state

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -108,7 +108,7 @@ private[lf] object Pretty {
   // A minimal pretty-print of an update transaction node, without recursing into child nodes..
   def prettyPartialTransactionNode(node: PartialTransaction.Node): Doc =
     node match {
-      case NodeRollback(_) => // pattern-match forces reconsidation if fields are added
+      case NodeRollback(_) => // pattern-match forces reconsideration if fields are added
         text("rollback")
       case create: NodeCreate[Value.ContractId] =>
         "create" &: prettyContractInst(create.coinst)
@@ -253,7 +253,7 @@ private[lf] object Pretty {
     val eventId = EventId(txId.id, nodeId)
     val ni = l.ledgerData.nodeInfos(eventId)
     val ppNode = ni.node match {
-      case NodeRollback(children) => // pattern-match forces reconsidation if fields are added
+      case NodeRollback(children) => // pattern-match forces reconsideration if fields are added
         text("rollback:") / stack(children.toList.map(prettyEventInfo(l, txId)))
       case create: NodeCreate[ContractId] =>
         val d = "create" &: prettyVersionedContractInst(create.versionedCoinst)

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -108,9 +108,8 @@ private[lf] object Pretty {
   // A minimal pretty-print of an update transaction node, without recursing into child nodes..
   def prettyPartialTransactionNode(node: PartialTransaction.Node): Doc =
     node match {
-      case _: NodeRollback[_] =>
-        // TODO https://github.com/digital-asset/daml/issues/8020
-        sys.error("rollback nodes are not supported")
+      case NodeRollback(_) => // pattern-match forces reconsidation if fields are added
+        text("rollback")
       case create: NodeCreate[Value.ContractId] =>
         "create" &: prettyContractInst(create.coinst)
       case fetch: NodeFetch[Value.ContractId] =>
@@ -254,9 +253,8 @@ private[lf] object Pretty {
     val eventId = EventId(txId.id, nodeId)
     val ni = l.ledgerData.nodeInfos(eventId)
     val ppNode = ni.node match {
-      case _: NodeRollback[_] =>
-        // TODO https://github.com/digital-asset/daml/issues/8020
-        sys.error("rollback nodes are not supported")
+      case NodeRollback(children) => // pattern-match forces reconsidation if fields are added
+        text("rollback:") / stack(children.toList.map(prettyEventInfo(l, txId)))
       case create: NodeCreate[ContractId] =>
         val d = "create" &: prettyVersionedContractInst(create.versionedCoinst)
         create.versionedKey match {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/transaction/PartialTransaction.scala
@@ -214,11 +214,7 @@ private[lf] case class PartialTransaction(
       // so we need to compute them.
       val rootNodes = {
         val allChildNodeIds: Set[NodeId] = nodes.values.iterator.flatMap {
-
-          case _: Node.NodeRollback[_] =>
-            // TODO https://github.com/digital-asset/daml/issues/8020
-            sys.error("rollback nodes are not supported")
-
+          case rb: Node.NodeRollback[NodeId] => rb.children.toSeq
           case _: Node.LeafOnlyNode[_] => Nil
           case ex: Node.NodeExercises[NodeId, _] => ex.children.toSeq
         }.toSet

--- a/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/Normalizer.scala
+++ b/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/Normalizer.scala
@@ -9,13 +9,13 @@ import com.daml.lf.value.Value.ContractId
 object Normalizer {
 
   // KV specific normalization.
-  // drops Fetch and Lookup nodes from a transaction. keeping Create, Exercise and Rollback
+  // Drop Fetch, Lookup and Rollback nodes from a transaction, keeping Create and Exercise.
   def normalizeTransaction(
       tx: CommittedTransaction
   ): CommittedTransaction = {
     val nodes = tx.nodes.filter {
-      case (_, _: Node.NodeFetch[_] | _: Node.NodeLookupByKey[_]) => false
-      case (_, _: Node.NodeRollback[_] | _: Node.NodeExercises[_, _] | _: Node.NodeCreate[_]) =>
+      case (_, _: Node.NodeRollback[_] | _: Node.NodeFetch[_] | _: Node.NodeLookupByKey[_]) => false
+      case (_, _: Node.NodeExercises[_, _] | _: Node.NodeCreate[_]) =>
         true
     }
     val filteredNodes = nodes.transform {

--- a/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/Normalizer.scala
+++ b/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/Normalizer.scala
@@ -13,6 +13,11 @@ object Normalizer {
   def normalizeTransaction(
       tx: CommittedTransaction
   ): CommittedTransaction = {
+    // TODO https://github.com/digital-asset/daml/issues/8020
+
+    // We need drop Rollback nodes and all their children. Before we do this we need to
+    // update NormalizerSpec. Which in turn requires we extend our scalagen generators to
+    // generate transactions containing rollback nodes.
     val nodes = tx.nodes.filter {
       case (_, _: Node.NodeRollback[_] | _: Node.NodeFetch[_] | _: Node.NodeLookupByKey[_]) => false
       case (_, _: Node.NodeExercises[_, _] | _: Node.NodeCreate[_]) =>

--- a/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/Normalizer.scala
+++ b/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/Normalizer.scala
@@ -9,16 +9,14 @@ import com.daml.lf.value.Value.ContractId
 object Normalizer {
 
   // KV specific normalization.
-  // drops Fetch and Lookup nodes from a transaction.
+  // drops Fetch and Lookup nodes from a transaction. keeping Create, Exercise and Rollback
   def normalizeTransaction(
       tx: CommittedTransaction
   ): CommittedTransaction = {
     val nodes = tx.nodes.filter {
-      case (_, _: Node.NodeRollback[_]) =>
-        // TODO https://github.com/digital-asset/daml/issues/8020
-        sys.error("rollback nodes are not supported")
       case (_, _: Node.NodeFetch[_] | _: Node.NodeLookupByKey[_]) => false
-      case (_, _: Node.NodeExercises[_, _] | _: Node.NodeCreate[_]) => true
+      case (_, _: Node.NodeRollback[_] | _: Node.NodeExercises[_, _] | _: Node.NodeCreate[_]) =>
+        true
     }
     val filteredNodes = nodes.transform {
       case (_, node: Node.NodeExercises[NodeId, ContractId]) =>

--- a/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/NormalizerSpec.scala
+++ b/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/NormalizerSpec.scala
@@ -38,6 +38,8 @@ class NormalizerSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProp
           tx.nodes.collect { case (nid, exe: Node.NodeExercises[_, _]) =>
             nid -> exe.copy(children = exe.children.filter(preservedIds))
           }
+      // TODO https://github.com/digital-asset/daml/issues/8020
+      // Rollback nodes and all their children should be dropped
       }
     }
   }

--- a/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
+++ b/daml-lf/transaction-test-lib/src/main/scala/lf/transaction/test/TransactionBuilder.scala
@@ -60,9 +60,8 @@ final class TransactionBuilder(
   def build(): Tx.Transaction = ids.synchronized {
     import TransactionVersion.Ordering
     val finalNodes = nodes.transform {
-      case (_, _: Node.NodeRollback[_]) =>
-        // TODO https://github.com/digital-asset/daml/issues/8020
-        sys.error("rollback nodes are not supported")
+      case (nid, rb: Node.NodeRollback[NodeId]) =>
+        rb.copy(children = children(nid).toImmArray)
       case (nid, exe: TxExercise) =>
         exe.copy(children = children(nid).toImmArray)
       case (_, node: Node.LeafOnlyNode[ContractId]) =>

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -56,9 +56,10 @@ object Node {
         f1: A1 => B1,
         f2: A2 => B2,
     ): GenNode[A1, A2] => GenNode[B1, B2] = {
-      case _: NodeRollback[_] =>
-        // TODO https://github.com/digital-asset/daml/issues/8020
-        sys.error("rollback nodes are not supported")
+      case self @ NodeRollback(children) =>
+        self.copy(
+          children = children.map(f1)
+        )
       case self @ NodeCreate(
             coid,
             _,
@@ -131,9 +132,8 @@ object Node {
         f1: A => Unit,
         f2: B => Unit,
     ): GenNode[A, B] => Unit = {
-      case _: NodeRollback[_] =>
-        // TODO https://github.com/digital-asset/daml/issues/8020
-        sys.error("rollback nodes are not supported")
+      case NodeRollback(children) =>
+        children.foreach(f1)
       case NodeCreate(
             coid,
             templateI @ _,
@@ -348,6 +348,7 @@ object Node {
       // TODO https://github.com/digital-asset/daml/issues/8020
       // Figure-out what information needs to be contained in a Rollback node.
       // For the moment, we just have the children.
+      // Note: if we add values, we must extend the function which checks they are serializable
       children: ImmArray[Nid]
   ) extends GenNode[Nid, Nothing]
       with NodeInfo.Rollback {

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -236,7 +236,7 @@ final case class GenTransaction[Nid, +Cid](
   def serializable(f: Value[Cid] => ImmArray[String]): ImmArray[String] = {
     fold(BackStack.empty[String]) { case (errs, (_, node)) =>
       node match {
-        case Node.NodeRollback(_) => // pattern-match forces reconsidation if fields are added
+        case Node.NodeRollback(_) => // pattern-match forces reconsideration if fields are added
           errs
         case _: Node.NodeFetch[Cid] => errs
         case nc: Node.NodeCreate[Cid] =>
@@ -254,7 +254,7 @@ final case class GenTransaction[Nid, +Cid](
   def foldValues[Z](z: Z)(f: (Z, Value[Cid]) => Z): Z =
     fold(z) { case (z, (_, n)) =>
       n match {
-        case Node.NodeRollback(_) => // pattern-match forces reconsidation if fields are added
+        case Node.NodeRollback(_) => // pattern-match forces reconsideration if fields are added
           z
         case c: Node.NodeCreate[_] =>
           val z1 = f(z, c.arg)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionSpec.scala
@@ -149,9 +149,8 @@ class TransactionSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPro
       for {
         entry <- danglingRefGenNode
         node = entry match {
-          case (_, _: Node.NodeRollback[_]) =>
-            // TODO https://github.com/digital-asset/daml/issues/8020
-            sys.error("rollback nodes are not supported")
+          case (_, nr: Node.NodeRollback[_]) =>
+            nr.copy(children = ImmArray.empty)
           case (_, n: Node.LeafOnlyNode[V.ContractId]) => n
           case (_, ne: Node.NodeExercises[_, V.ContractId]) =>
             ne.copy(children = ImmArray.empty)


### PR DESCRIPTION
Implement match-handling for `NodeRollback` in _structural cases_
- where the code does not have to understand the semantics of rollback
- this PR implements 19 of the original 43 `sys.error("rollback nodes are not supported")`
- leaving 24 more _interesting_ cases to think about

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
