### PR TITLE
Optimize mapOptional and add more efficient findOptional

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Optional.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Optional.daml
@@ -66,10 +66,10 @@ isNone = not . isSome
 -- the result list. If it is `Some b`, then `b` is included in the
 -- result list.
 mapOptional : (a -> Optional b) -> [a] -> [b]
-mapOptional _ [] = []
-mapOptional p (x :: xs) = case p x of
-  None -> mapOptional p xs
-  Some y -> y :: mapOptional p xs
+mapOptional p = foldr f []
+  where f x acc = case p x of
+          None -> acc
+          Some y -> y :: acc
 
 -- | Perform some operation on `Some`, given the field inside the
 -- `Some`.

--- a/compiler/damlc/daml-stdlib-src/DA/Optional.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Optional.daml
@@ -66,10 +66,24 @@ isNone = not . isSome
 -- the result list. If it is `Some b`, then `b` is included in the
 -- result list.
 mapOptional : (a -> Optional b) -> [a] -> [b]
-mapOptional f = catOptionals . map f
+mapOptional _ [] = []
+mapOptional p (x :: xs) = case p x of
+  None -> mapOptional p xs
+  Some y -> y :: mapOptional p xs
 
 -- | Perform some operation on `Some`, given the field inside the
 -- `Some`.
 whenSome : Applicative m => Optional a -> (a -> m ()) -> m ()
 whenSome None _ = pure ()
 whenSome (Some v) f = f v
+
+-- | The `findOptional` returns the value of the predicate at the first
+-- element where it returns `Some`. `findOptional` is similar to `find` but it
+-- allows you to return a value from the predicate. This is useful both as a more
+-- type safe version if the predicate corresponds to a pattern match
+-- and for performance to avoid duplicating work performed in the predicate.
+findOptional : (a -> Optional b) -> [a] -> Optional b
+findOptional _ [] = None
+findOptional p (x :: xs) = case p x of
+  None -> findOptional p xs
+  Some y -> Some y

--- a/compiler/damlc/tests/daml-test-files/Optional.daml
+++ b/compiler/damlc/tests/daml-test-files/Optional.daml
@@ -76,3 +76,13 @@ testWhenSome = scenario do
   submit p (fetch cid)
   whenSome (Some 5) (\x -> submit p $ exercise cid $ ConsumeIfPositive x cid)
   submitMustFail p (fetch cid)
+
+testFindOptional = scenario do
+  findOptional toLeft [] === None
+  findOptional toLeft [Right 1] === None
+  findOptional toLeft [Right 1, Left 2] === Some 2
+  findOptional toLeft [Right 1, Left 2, Left 3] === Some 2
+
+toLeft : Either a b -> Some a
+toLeft (Left a) = Some a
+toLeft (Right _) = None

--- a/compiler/damlc/tests/daml-test-files/Optional.daml
+++ b/compiler/damlc/tests/daml-test-files/Optional.daml
@@ -78,11 +78,11 @@ testWhenSome = scenario do
   submitMustFail p (fetch cid)
 
 testFindOptional = scenario do
-  findOptional toLeft [] === None
-  findOptional toLeft [Right 1] === None
+  findOptional toLeft [] === (None : Optional ())
+  findOptional toLeft [Right 1] === (None : Optional ())
   findOptional toLeft [Right 1, Left 2] === Some 2
   findOptional toLeft [Right 1, Left 2, Left 3] === Some 2
 
-toLeft : Either a b -> Some a
+toLeft : Either a b -> Optional a
 toLeft (Left a) = Some a
 toLeft (Right _) = None


### PR DESCRIPTION
Given that we don’t have list fusion catOptionals . map f is clearly
less efficient than this version.

I also added findOptional which can be pretty handy in certain cases.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
