### PR TITLE
Improve syntax for selecting contract ids from a transaction tree

### DIFF
--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -10,7 +10,6 @@ module Daml.Script
   , submitMultiMustFail
   , submitTree
   , submitTreeMulti
-  , createdCid
   , query
   , queryContractId
   , queryContractKey
@@ -500,34 +499,6 @@ data TransactionTree = TransactionTree
   with
     rootEvents: [TreeEvent]
   deriving Show
-
--- | HIDE Select a contract id using a list of child indices.
--- TODO (MK) Come up with a clearer API for this.
-createdCid : Template t => [Int] -> TransactionTree -> ContractId t
-createdCid [] _ = error "List of selectors passed to createdCid was empty"
-createdCid (i :: ss) (TransactionTree evs) =
-  case evs !! i of
-    None ->
-      error $ "Transaction tree has only " <> show (length evs) <> " root events but selected " <> show i
-    Some t -> createdCidGo ss t
-
-createdCidGo : Template t => [Int] -> TreeEvent -> ContractId t
-createdCidGo [] (CreatedEvent (Created cid _)) =
-  case fromAnyContractId cid of
-    None -> error "createdCid selected a create node of the wrong template type"
-    Some cid -> cid
-createdCidGo [] (ExercisedEvent _) =
-  error "createdCid selected an exercise event"
-createdCidGo ss@(_ :: _) (CreatedEvent _) =
-  error $ "createdCid reached created event before the following selectors have been applied: " <> show ss
-createdCidGo (i :: ss) (ExercisedEvent ex) =
-  case ex.childEvents !! i of
-    None ->
-      error $
-        "Exercised event has only " <>
-        show (length ex.childEvents) <> " child events but selected " <>
-        show i
-    Some e -> createdCidGo ss e
 
 -- | HIDE This is an early access feature.
 data TreeEvent

--- a/daml-script/daml/Daml/Script.daml
+++ b/daml-script/daml/Daml/Script.daml
@@ -39,6 +39,12 @@ module Daml.Script
   , TreeEvent(..)
   , Created(..)
   , Exercised(..)
+  , TreeIndex
+  , fromTree
+  , created
+  , createdN
+  , exercised
+  , exercisedN
   , AnyContractId
   , fromAnyContractId
   ) where
@@ -565,6 +571,81 @@ instance Show Exercised where
     showString "childEvents = " .
     showsPrec 0 childEvents .
     showString "}"
+
+-- | HIDE This is an early access feature.
+data TreeIndex t
+  = CreatedIndex (CreatedIndexPayload t)
+  | ExercisedIndex (ExercisedIndexPayload t)
+
+-- | HIDE This is an early access feature.
+data CreatedIndexPayload t = CreatedIndexPayload
+  with
+    templateId : TemplateTypeRep
+    offset : Int
+
+-- | HIDE This is an early access feature.
+data ExercisedIndexPayload t = ExercisedIndexPayload
+  with
+    templateId : TemplateTypeRep
+    choice : Text
+    offset : Int
+    child : TreeIndex t
+
+-- | HIDE This is an early access feature.
+fromTree : Template t => TransactionTree -> TreeIndex t -> ContractId t
+fromTree tree index = fromTreeGo index tree.rootEvents
+
+fromTreeGo : Template t => TreeIndex t -> [TreeEvent] -> ContractId t
+fromTreeGo (CreatedIndex index) events =
+  case mapOptional fromCreated events of
+    [] -> error "No created events for the requested template id found"
+    contractIds ->
+      let msg = "CreatedIndex out of bound" in
+      fromSomeNote msg $ contractIds !! index.offset
+  where
+    fromCreated : Template t => TreeEvent -> Optional (ContractId t)
+    fromCreated (CreatedEvent created) = fromAnyContractId created.contractId
+    fromCreated (ExercisedEvent _) = None
+fromTreeGo (ExercisedIndex index) events =
+  case mapOptional fromExercised events of
+    [] -> error $ "No exercised events for choice " <> index.choice <> " found"
+    childEventsList ->
+      let msg = "ExercisedIndex on choice " <> index.choice <> " out of bound"
+          childEvents = fromSomeNote msg $ childEventsList !! index.offset in
+      fromTreeGo index.child childEvents
+  where
+    fromExercised : TreeEvent -> Optional [TreeEvent]
+    fromExercised (CreatedEvent _) = None
+    fromExercised (ExercisedEvent exercised)
+      | exercised.contractId.templateId == index.templateId &&
+        exercised.choice == index.choice
+      = Some exercised.childEvents
+      | otherwise
+      = None
+
+-- | HIDE This is an early access feature.
+created : forall t. HasTemplateTypeRep t => TreeIndex t
+created = createdN 0
+
+-- | HIDE This is an early access feature.
+createdN : forall t. HasTemplateTypeRep t => Int -> TreeIndex t
+createdN offset = CreatedIndex CreatedIndexPayload
+  with
+    templateId = templateTypeRep @t
+    offset
+
+-- | HIDE This is an early access feature.
+exercised : forall t t'. HasTemplateTypeRep t => Text -> TreeIndex t' -> TreeIndex t'
+exercised choice = exercisedN @t choice 0
+
+-- | HIDE This is an early access feature.
+exercisedN : forall t t'. HasTemplateTypeRep t => Text -> Int -> TreeIndex t' -> TreeIndex t'
+exercisedN choice offset child = ExercisedIndex ExercisedIndexPayload
+  with
+    templateId = templateTypeRep @t
+    choice
+    offset
+    child
 
 -- | HIDE This is an early access feature
 data AnyContractId = AnyContractId

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/TreeUtils.scala
@@ -3,7 +3,7 @@
 
 package com.daml.script.dump
 
-import com.daml.ledger.api.refinements.ApiTypes.{ContractId, Party}
+import com.daml.ledger.api.refinements.ApiTypes.{Choice, ContractId, Party, TemplateId}
 import com.daml.ledger.api.v1.event.{CreatedEvent, ExercisedEvent}
 import com.daml.ledger.api.v1.transaction.{TransactionTree, TreeEvent}
 import com.daml.ledger.api.v1.transaction.TreeEvent.Kind
@@ -21,7 +21,16 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 object TreeUtils {
-  final case class Selector(i: Int)
+  sealed trait Selector
+  final case class CreatedSelector(
+      templateId: TemplateId,
+      index: Int,
+  ) extends Selector
+  final case class ExercisedSelector(
+      templateId: TemplateId,
+      choice: Choice,
+      index: Int,
+  ) extends Selector
 
   def contractsReferences(contracts: Iterable[CreatedEvent]): Set[PackageId] = {
     contracts
@@ -50,9 +59,29 @@ object TreeUtils {
     }
   }
 
+  private def layerSelectors(events: Seq[TreeEvent.Kind]): Seq[Selector] = {
+    val created = mutable.HashMap.empty[TemplateId, Int].withDefaultValue(0)
+    val exercised = mutable.HashMap.empty[(TemplateId, Choice), Int].withDefaultValue(0)
+    events.collect {
+      case Kind.Created(value) =>
+        val templateId = TemplateId(value.getTemplateId)
+        val index = created(templateId)
+        created(templateId) += 1
+        CreatedSelector(templateId, index): Selector
+      case Kind.Exercised(value) =>
+        val templateId = TemplateId(value.getTemplateId)
+        val choice = Choice(value.choice)
+        val index = exercised((templateId, choice))
+        exercised((templateId, choice)) += 1
+        ExercisedSelector(templateId, choice, index): Selector
+    }
+  }
+
   def traverseTree(tree: TransactionTree)(f: (List[Selector], TreeEvent.Kind) => Unit): Unit = {
-    tree.rootEventIds.map(tree.eventsById(_)).zipWithIndex.foreach { case (ev, i) =>
-      traverseEventInTree(ev.kind, tree) { case (path, ev) => f(Selector(i) :: path, ev) }
+    val rootEvents = tree.rootEventIds.map(id => tree.eventsById(id).kind)
+    val selectors = layerSelectors(rootEvents)
+    rootEvents.zip(selectors).foreach { case (ev, selector) =>
+      traverseEventInTree(ev, tree) { case (path, ev) => f(selector :: path, ev) }
     }
   }
 
@@ -62,11 +91,13 @@ object TreeUtils {
     event match {
       case Kind.Empty =>
       case created @ Kind.Created(_) =>
-        f(List(), created)
+        f(Nil, created)
       case exercised @ Kind.Exercised(value) =>
-        f(List(), exercised)
-        value.childEventIds.map(x => tree.eventsById(x).kind).zipWithIndex.foreach { case (ev, i) =>
-          traverseEventInTree(ev, tree) { case (path, ev) => f(Selector(i) :: path, ev) }
+        f(Nil, exercised)
+        val childEvents = value.childEventIds.map(id => tree.eventsById(id).kind)
+        val selectors = layerSelectors(childEvents)
+        childEvents.zip(selectors).foreach { case (ev, selector) =>
+          traverseEventInTree(ev, tree) { case (path, ev) => f(selector :: path, ev) }
         }
     }
   }

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeSubmitSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/EncodeSubmitSpec.scala
@@ -144,8 +144,11 @@ class EncodeSubmitSpec extends AnyFreeSpec with Matchers {
           ContractId("cid0") -> "contract_0_0",
           ContractId("cid1") -> "contract_1_0",
           ContractId("cid2") -> "contract_1_1",
+          ContractId("cid3") -> "contract_0_1",
+          ContractId("cid4") -> "contract_2_0",
+          ContractId("cid5") -> "contract_2_1",
         )
-        val cidRefs = Set(ContractId("cid1"), ContractId("cid2"))
+        val cidRefs = Set(ContractId("cid1"), ContractId("cid2"), ContractId("cid4"))
         val submit = TestData
           .Tree(
             Seq(
@@ -155,15 +158,30 @@ class EncodeSubmitSpec extends AnyFreeSpec with Matchers {
                   TestData.Created(ContractId("cid1")),
                   TestData.Created(ContractId("cid2")),
                 ),
-              )
+              ),
+              TestData.Exercised(
+                ContractId("cid3"),
+                Seq(
+                  TestData.Created(ContractId("cid4")),
+                  TestData.Created(ContractId("cid5")),
+                ),
+              ),
             )
           )
           .toSubmit
         encodeSubmit(parties, cidMap, cidRefs, submit).render(80) shouldBe
           """tree <- submitTree alice_0 do
             |  exerciseCmd contract_0_0 (Module.Choice ())
-            |let contract_1_0 = createdCid @Module.Template [0, 0] tree
-            |let contract_1_1 = createdCid @Module.Template [0, 1] tree""".stripMargin.replace(
+            |  exerciseCmd contract_0_1 (Module.Choice ())
+            |let contract_1_0 = fromTree tree $
+            |      exercised @Module.Template "Choice" $
+            |      created @Module.Template
+            |let contract_1_1 = fromTree tree $
+            |      exercised @Module.Template "Choice" $
+            |      createdN @Module.Template 1
+            |let contract_2_0 = fromTree tree $
+            |      exercisedN @Module.Template "Choice" 1 $
+            |      created @Module.Template""".stripMargin.replace(
             "\r\n",
             "\n",
           )
@@ -195,8 +213,11 @@ class EncodeSubmitSpec extends AnyFreeSpec with Matchers {
             |  createCmd Module.Template
             |  createCmd Module.Template
             |  exerciseByKeyCmd @Module.Template alice_0 (Module.Choice ())
-            |let contract_1_0 = createdCid @Module.Template [1] tree
-            |let contract_1_1 = createdCid @Module.Template [2, 0] tree""".stripMargin.replace(
+            |let contract_1_0 = fromTree tree $
+            |      createdN @Module.Template 1
+            |let contract_1_1 = fromTree tree $
+            |      exercised @Module.Template "Choice" $
+            |      created @Module.Template""".stripMargin.replace(
             "\r\n",
             "\n",
           )


### PR DESCRIPTION
Closes #9083 

Implements more readable transaction tree accessors. These use the template id and choice name to select a path in a transaction tree instead of plain numerical indices. E.g.

```
let contract_1_0 = fromTree tree $
      exercised @Module.SomeTemplate "Choice" $
      created @Module.OtherTemplate
```

instead of

```
let contract_1_0 = createdCid @Module.OtherTemplate [0, 0]
```

In case multiple events at a given level in the transaction tree match the given template id (and choice name) the generated Daml script dump will use the forms `createdN`/`exercisedN` to index into the list of matching events.

This adapts the test cases and makes sure that all of `created`, `createdN`, `exercised`, and `exercisedN` are covered.

This removes the now unused `createdCid` accessors.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
