### PR TITLE
More manual list fusion in stdlib

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -397,7 +397,7 @@ infixr 1 =<<
 
 -- | Map a function over each element of a list, and concatenate all the results.
 concatMap : (a -> [b]) -> [a] -> [b]
-concatMap f = concat . map f
+concatMap f xs = foldr (\x acc -> f x ++ acc) [] xs
 
 -- | `replicate i x` gives the list `[x, x, x, ..., x]` with `i` copies of `x`.
 replicate : Int -> a -> [a]

--- a/compiler/damlc/daml-stdlib-src/DA/Optional.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Optional.daml
@@ -29,7 +29,9 @@ fromSomeNote n None = error n
 -- | The `catOptionals` function takes a list of `Optionals` and returns a
 -- list of all the `Some` values.
 catOptionals : [Optional a] -> [a]
-catOptionals = concatMap optionalToList
+catOptionals = foldr f []
+  where f None acc = acc
+        f (Some x) acc = x :: acc
 
 -- | The `listToOptional` function returns `None` on an empty list or
 -- `Some` a where a is the first element of the list.


### PR DESCRIPTION
Both of these seem sufficiently common that it seems worth optimizing
them.

I realize I’m switching somewhat randomly between foldr and
hand-written recursion. Either should be better than traversing the
list twice but I think it’s a clear sign that we need some benchmarks
to establish the benefits or downsides of one over the other properly.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
