### PR TITLE
Add DA.List.BuiltinOrder module

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/List/BuiltinOrder.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/List/BuiltinOrder.daml
@@ -1,0 +1,125 @@
+-- Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE CPP #-}
+
+#ifndef DAML_GENMAP
+module DA.List.BuiltinOrder where
+#else
+
+-- | Note: This is only supported in DAML-LF 1.11 or later.
+--
+-- This module provides variants of other standard library
+-- functions that are based on the builtin Daml-LF ordering rather
+-- than user-defined ordering. This is the same order also used
+-- by `DA.Map`.
+--
+-- These functions are usually much more efficient than their
+-- `Ord`-based counterparts.
+--
+-- Note that the functions in this module still require `Ord`
+-- constraints. This is purely to enforce that you don’t
+-- pass in values that cannot be compared, e.g., functions. The
+-- implementation of those instances is not used.
+module DA.List.BuiltinOrder
+  ( dedup
+  , dedupOn
+  , dedupSort
+  , dedupOnSort
+  , sort
+  , sortOn
+  ) where
+
+-- import DA.Map (Map)
+import qualified DA.Map as Map
+
+-- | `dedup l` removes duplicate elements from a list. In particular,
+-- it keeps only the first occurence of each element.
+--
+-- `dedup` is stable so the elements in the output are ordered
+-- by their first occurence in the input. If you do not need
+-- stability, consider using `dedupSort` which is more efficient.
+--
+-- ```
+-- >>> dedup [3, 1, 1, 3]
+-- [3, 1]
+-- ```
+dedup : Ord a => [a] -> [a]
+dedup = dedupOn identity
+
+-- | A version of `dedup` where deduplication is done
+-- after applying the given function. Example use: `dedupOn (.employeeNo) employees`.
+--
+-- `dedupOn` is stable so the elements in the output are ordered
+-- by their first occurence in the input. If you do not need
+-- stability, consider using `dedupOnSort` which is more efficient.
+--
+-- ```
+-- >>> dedupOn fst [(3, "a"), (1, "b"), (1, "c"), (3, "d")]
+-- [(3, "a"), (1, "b")]
+-- ```
+dedupOn f xs = Map.values (Map.fromList (Map.values deduped))
+  where
+    -- Fused Map.fromListWith + map/fold
+    deduped = snd (foldl insert (0, Map.empty) xs)
+    insert (i, m) x =
+      let k = f x
+          m' = case Map.lookup k m of
+            Some prev@(j, _)
+              | j <= i -> m
+            _ -> Map.insert k (i, x) m
+      in (i + 1, m')
+
+-- | `dedupSort` is a more efficient variant of `dedup`
+-- that does not preserve the order of the input elements.
+-- Instead the output will be sorted acoording to the builtin Daml-LF
+-- ordering.
+--
+-- ```
+-- >>> dedupSort [3, 1, 1, 3]
+-- [1, 3]
+-- ```
+dedupSort : Ord a => [a] -> [a]
+dedupSort = dedupOnSort identity
+
+-- | `dedupOnSort` is a more efficient variant of `dedupOn`
+-- that does not preserve the order of the input elements.
+-- Instead the output will be sorted on the values returned by the function.
+--
+-- For duplicates, the first element in the list will be included in the output.
+--
+-- ```
+-- >>> dedupOnSort fst [(3, "a"), (1, "b"), (1, "c"), (3, "d")]
+-- [(1, "b"), (3, "a")]
+-- ```
+dedupOnSort f xs =
+  let deduped = foldr (\x acc -> Map.insert (f x) x acc) Map.empty xs
+  in Map.values deduped
+
+-- | Sort the list according to the Daml-LF ordering.
+--
+-- Values that are identical according to the builtin Daml-LF ordering
+-- are indistinguishable so stability is not relevant here.
+--
+-- ```
+-- >>> sort [3,1,2]
+-- [1,2,3]
+-- ```
+sort : Ord a => [a] -> [a]
+sort = sortOn identity
+
+-- | `sortOn f` is a version of sort that allows sorting
+-- on the result of the given function.
+--
+-- `sortOn` is stable so elements that map to the same sort key
+-- will be ordered by their position in the input.
+--
+-- ```
+-- >>> sortOn fst [(3, "a"), (1, "b"), (3, "c"), (2, "d")]
+-- [(1, "b"), (2, "d"), (3, "a"), (3, "c")]
+-- ```
+sortOn : Ord b => (a -> b) -> [a] -> [a]
+sortOn f xs = Map.values (snd (foldl insert (0, Map.empty) xs))
+  where
+    insert (i, m) x = (i + 1, Map.insert (f x, i) x m)
+
+#endif

--- a/compiler/damlc/daml-stdlib-src/LibraryModules.daml
+++ b/compiler/damlc/daml-stdlib-src/LibraryModules.daml
@@ -32,6 +32,7 @@ import DA.Internal.Time
 import DA.Internal.Exception
 import DA.List.Total
 import DA.List
+import DA.List.BuiltinOrder
 import DA.Logic
 import DA.Map
 import DA.Math

--- a/compiler/damlc/tests/daml-test-files/BuiltinOrd.daml
+++ b/compiler/damlc/tests/daml-test-files/BuiltinOrd.daml
@@ -1,0 +1,24 @@
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- All rights reserved.
+
+-- @SINCE-LF 1.9
+
+module BuiltinOrd where
+
+import DA.Assert
+import DA.List.BuiltinOrder
+
+test = scenario do
+  dedupOn fst [(3, "a"), (1, "b"), (1, "c"), (3, "d")]
+    === [(3, "a"), (1, "b")]
+  dedupOn fst [(3, "d"), (1, "b"), (1, "c"), (3, "a")]
+    === [(3, "d"), (1, "b")]
+  dedup [3, 1, 1, 3] === [3, 1]
+
+  dedupOnSort fst [(3, "d"), (1, "b"), (1, "c"), (3, "a")]
+    === [(1, "b"), (3, "d")]
+  dedupSort [3, 1, 1, 3] === [1, 3]
+
+  sort [3, 1, 2, 3] === [1, 2, 3, 3]
+  sortOn fst [(3, "a"), (1, "b"), (3, "c"), (2, "d")] ===
+    [(1, "b"), (2, "d"), (3, "a"), (3, "c")]


### PR DESCRIPTION
This provides variants of `dedup*` and `sort*` which rely on Daml-LF’s
builtin ordering (using Map internally). I don’t have microbenchmarks
but even in macrobenchmarks this is a measurable improvement which
isn’t particularly surprising.

changelog_begin

- [Daml Stdlib] Add `DA.List.BuiltinOrder` module. This module provides
  variants of `sort*` and `dedup*` which rely on Daml-LF’s builtin
  ordering and are significantly more efficient in some cases.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
