### PR TITLE
use coreutils `date` on macos

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -5,6 +5,8 @@ steps:
 - bash: |
     set -euo pipefail
 
+    eval $(dev-env/bin/dade-assist)
+
     exec 1> >(while IFS= read -r line; do echo "$(date -Is) [out]: $line"; done)
     exec 2> >(while IFS= read -r line; do echo "$(date -Is) [err]: $line"; done >&2)
 

--- a/dev-env/bin/date
+++ b/dev-env/bin/date
@@ -1,0 +1,1 @@
+../lib/dade-exec-nix-tool

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -182,6 +182,7 @@ in rec {
     # String mangling tooling.
     base64 = pkgs.coreutils;
     bc = pkgs.bc;
+    date = pkgs.coreutils;
     find = pkgs.findutils;
     gawk = bazel_dependencies.gawk;
     grep = pkgs.gnugrep;


### PR DESCRIPTION
macOS uses BSD date by default which has slightly different options.

CHANGELOG_BEGIN
CHANGELOG_END