### PR TITLE
Add unique(on)? to DA.List.BuiltinOrder

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/List/BuiltinOrder.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/List/BuiltinOrder.daml
@@ -27,9 +27,11 @@ module DA.List.BuiltinOrder
   , dedupOnSort
   , sort
   , sortOn
+  , unique
+  , uniqueOn
   ) where
 
--- import DA.Map (Map)
+import DA.Map (Map)
 import qualified DA.Map as Map
 
 -- | `dedup l` removes duplicate elements from a list. In particular,
@@ -122,4 +124,31 @@ sortOn f xs = Map.values (snd (foldl insert (0, Map.empty) xs))
   where
     insert (i, m) x = (i + 1, Map.insert (f x, i) x m)
 
+-- | Returns True if and only if there are no duplicate elements in the given list.
+--
+-- ```
+-- >>> unique [1, 2, 3]
+-- True
+-- ```
+unique : Ord a => [a] -> Bool
+unique = uniqueOn identity
+
+-- | Returns True if and only if there are no duplicate elements in the given list
+-- after applyng function.
+--
+-- ```
+-- >>> uniqueOn fst [(1, 2), (2, 42), (1, 3)]
+-- False
+-- ```
+uniqueOn : Ord k => (a -> k) -> [a] -> Bool
+uniqueOn f = goUniqueOn f Map.empty
+
+-- hand-written recursion to shortcircuit.
+goUniqueOn : Ord k => (a -> k) -> Map k () -> [a] -> Bool
+goUniqueOn _ _ [] = True
+goUniqueOn f m (x :: xs) =
+  let k = f x
+  in case Map.lookup (f x) m of
+    None -> goUniqueOn f (Map.insert k () m) xs
+    Some _ -> False
 #endif

--- a/compiler/damlc/tests/daml-test-files/BuiltinOrd.daml
+++ b/compiler/damlc/tests/daml-test-files/BuiltinOrd.daml
@@ -22,3 +22,8 @@ test = scenario do
   sort [3, 1, 2, 3] === [1, 2, 3, 3]
   sortOn fst [(3, "a"), (1, "b"), (3, "c"), (2, "d")] ===
     [(1, "b"), (2, "d"), (3, "a"), (3, "c")]
+
+  assertMsg "unique" (unique [1, 2, 3])
+  assertMsg "not unique" (not (unique [1, 2, 3, 1]))
+  assertMsg "uniqueOn" (uniqueOn fst [(1, 2), (2, 2)])
+  assertMsg "not uniqueOn" (not (uniqueOn fst [(1, 2), (2, 42), (1, 3)]))


### PR DESCRIPTION
changelog_begin

- [Daml Stdlib] Add unique(on)? as more efficient versions of unique,
  uniqueOn using the builtin daml-lf ordering.

changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
