### PR TITLE
macos cache cleaning 

### DIFF
--- a/ci/clean-up.yml
+++ b/ci/clean-up.yml
@@ -17,21 +17,8 @@ steps:
     df -h .
     if [ $(df -m . | sed 1d | awk '{print $4}') -lt 50000 ]; then
         echo "Disk full, cleaning up..."
-        case $(uname) in
-        Linux)
-            $HOME/reset_caches.sh
-        ;;
-        Darwin)
-            # Only clean up disk cache
-            disk_cache="$HOME/.bazel-cache"
-            rm -rf "$disk_cache"
-            echo "removed '$disk_cache'"
-        ;;
-        *)
-            echo "Unknown uname: '$(uname)'."
-            exit 1
-        ;;
-        esac
+        $HOME/reset_caches.sh
+        echo "Done."
         df -h .
     fi
   displayName: clean-up disk cache

--- a/infra/macos/3-running-box/init.sh
+++ b/infra/macos/3-running-box/init.sh
@@ -70,6 +70,45 @@ AGENT_SETUP
 ## Remount Nix partition
 sudo hdiutil attach /System/Volumes/Data/Nix.dmg.sparseimage -mountpoint /nix
 
+## cache
+
+CACHE_SCRIPT=/Users/vsts/reset_caches.sh
+
+cat <<'RESET_CACHES' > $CACHE_SCRIPT
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+set -x
+
+reset_cache() {
+    local file mount_point
+    file=$1
+    mount_point=$2
+
+    echo "Cleaning up '$mount_point'..."
+    if [ -d "$mount_point" ]; then
+        for pid in $(pgrep -a -f bazel | awk '{print $1}'); do
+            echo "Killing $pid..."
+            kill -s KILL $pid
+        done
+        hdiutil detach "$mount_point"
+    fi
+
+    rm -f "${file}.sparseimage"
+    hdiutil create -size 200g -fs 'Case-sensitive APFS' -volname "$file" -type SPARSE "$file"
+    mkdir -p $mount_point
+    hdiutil attach "${file}.sparseimage" -mountpoint "$mount_point"
+    echo "Done."
+}
+
+reset_cache /var/tmp/bazel_cache.dmg /var/tmp/_bazel_vsts
+reset_cache /var/tmp/disk_cache.dmg /Users/vsts/.bazel-cache
+RESET_CACHES
+chown vsts:vsts $CACHE_SCRIPT
+chmod +x $CACHE_SCRIPT
+
+
 ## Hardening
 chown -R root:wheel /Users/vsts/agent/{*.sh,bin,externals}
 

--- a/infra/macos/3-running-box/init.sh
+++ b/infra/macos/3-running-box/init.sh
@@ -105,7 +105,7 @@ reset_cache() {
 reset_cache /var/tmp/bazel_cache.dmg /var/tmp/_bazel_vsts
 reset_cache /var/tmp/disk_cache.dmg /Users/vsts/.bazel-cache
 RESET_CACHES
-chown vsts:vsts $CACHE_SCRIPT
+chown vsts:staff $CACHE_SCRIPT
 chmod +x $CACHE_SCRIPT
 
 


### PR DESCRIPTION
This is adapting the same approach as #9137 to the macOS machines. The setup is very similar, except macOS apparently doesn't require any kind of `sudo` access in the process.

The main reason for the chance here is that while `~/.bazel-cache` is reasonably fast to clean, cleaning just that has finally caught up to us with a recent cleanup step that proudly claimed:

```
before: 638Mi free
after: 1.2Gi free
```

So we do need to start cleaning the other one after all.

CHANGELOG_BEGIN
CHANGELOG_END