### PR TITLE
Extend `scalacheck` testing to generate `NodeRollback` nodes

### DIFF
--- a/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
+++ b/daml-lf/engine/src/main/scala/com/digitalasset/daml/lf/engine/ValueEnricher.scala
@@ -109,7 +109,7 @@ final class ValueEnricher(engine: Engine) {
 
   def enrichNode[Nid](node: GenNode[Nid, ContractId]): Result[GenNode[Nid, ContractId]] =
     node match {
-      case rb @ Node.NodeRollback(_) => // forces reconsideration if fields are added
+      case rb @ Node.NodeRollback(_, _) => // reconsider if fields added
         ResultDone(rb)
       case create: Node.NodeCreate[ContractId] =>
         for {

--- a/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
+++ b/daml-lf/interpreter/src/main/scala/com/digitalasset/daml/lf/speedy/Pretty.scala
@@ -109,7 +109,7 @@ private[lf] object Pretty {
   // A minimal pretty-print of an update transaction node, without recursing into child nodes..
   def prettyPartialTransactionNode(node: PartialTransaction.Node): Doc =
     node match {
-      case NodeRollback(_) => // pattern-match forces reconsideration if fields are added
+      case NodeRollback(_, _) => // reconsider if fields added
         text("rollback")
       case create: NodeCreate[Value.ContractId] =>
         "create" &: prettyContractInst(create.coinst)
@@ -254,7 +254,7 @@ private[lf] object Pretty {
     val eventId = EventId(txId.id, nodeId)
     val ni = l.ledgerData.nodeInfos(eventId)
     val ppNode = ni.node match {
-      case NodeRollback(children) => // pattern-match forces reconsideration if fields are added
+      case NodeRollback(children, _) => // reconsider if fields added
         text("rollback:") / stack(children.toList.map(prettyEventInfo(l, txId)))
       case create: NodeCreate[ContractId] =>
         val d = "create" &: prettyVersionedContractInst(create.versionedCoinst)

--- a/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/Normalizer.scala
+++ b/daml-lf/kv-transaction-support/src/main/scala/com/daml/lf/kv/Normalizer.scala
@@ -13,15 +13,9 @@ object Normalizer {
   def normalizeTransaction(
       tx: CommittedTransaction
   ): CommittedTransaction = {
-    // TODO https://github.com/digital-asset/daml/issues/8020
-
-    // We need drop Rollback nodes and all their children. Before we do this we need to
-    // update NormalizerSpec. Which in turn requires we extend our scalagen generators to
-    // generate transactions containing rollback nodes.
     val nodes = tx.nodes.filter {
       case (_, _: Node.NodeRollback[_] | _: Node.NodeFetch[_] | _: Node.NodeLookupByKey[_]) => false
-      case (_, _: Node.NodeExercises[_, _] | _: Node.NodeCreate[_]) =>
-        true
+      case (_, _: Node.NodeExercises[_, _] | _: Node.NodeCreate[_]) => true
     }
     val filteredNodes = nodes.transform {
       case (_, node: Node.NodeExercises[NodeId, ContractId]) =>

--- a/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/NormalizerSpec.scala
+++ b/daml-lf/kv-transaction-support/src/test/scala/com/daml/lf/kv/NormalizerSpec.scala
@@ -13,8 +13,8 @@ class NormalizerSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProp
 
   "normalizerTransaction" should {
 
-    "only drops Fetch and Lookup nodes" in {
-      forAll(noDanglingRefGenVersionedTransaction) { tx =>
+    "only keeps Create and Exercise nodes" in {
+      forAll(noDanglingRefGenVersionedTransaction(allowRollback = true)) { tx =>
         val createIds = tx.nodes.collect { case (nid, _: Node.NodeCreate[_]) => nid }.toSet
         val exeIds = tx.nodes.collect { case (nid, _: Node.NodeExercises[_, _]) => nid }.toSet
         val preservedIds = createIds union exeIds
@@ -38,8 +38,6 @@ class NormalizerSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenProp
           tx.nodes.collect { case (nid, exe: Node.NodeExercises[_, _]) =>
             nid -> exe.copy(children = exe.children.filter(preservedIds))
           }
-      // TODO https://github.com/digital-asset/daml/issues/8020
-      // Rollback nodes and all their children should be dropped
       }
     }
   }

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Node.scala
@@ -56,7 +56,7 @@ object Node {
         f1: A1 => B1,
         f2: A2 => B2,
     ): GenNode[A1, A2] => GenNode[B1, B2] = {
-      case self @ NodeRollback(children) =>
+      case self @ NodeRollback(children, version @ _) =>
         self.copy(
           children = children.map(f1)
         )
@@ -132,7 +132,7 @@ object Node {
         f1: A => Unit,
         f2: B => Unit,
     ): GenNode[A, B] => Unit = {
-      case NodeRollback(children) =>
+      case NodeRollback(children, version @ _) =>
         children.foreach(f1)
       case NodeCreate(
             coid,
@@ -349,7 +349,9 @@ object Node {
       // Figure-out what information needs to be contained in a Rollback node.
       // For the moment, we just have the children.
       // Note: if we add values, we must extend the function which checks they are serializable
-      children: ImmArray[Nid]
+      children: ImmArray[Nid],
+      // For the sake of consistency between types with a version field, keep this field the last.
+      override val version: TransactionVersion,
   ) extends GenNode[Nid, Nothing]
       with NodeInfo.Rollback {
 
@@ -357,13 +359,8 @@ object Node {
       // TODO https://github.com/digital-asset/daml/issues/8020
       sys.error("rollback nodes are not supported")
 
-    override def version: TransactionVersion =
-      // TODO https://github.com/digital-asset/daml/issues/8020
-      sys.error("rollback nodes are not supported")
-
     override private[lf] def updateVersion(version: TransactionVersion): NodeRollback[Nid] =
-      // TODO https://github.com/digital-asset/daml/issues/8020
-      sys.error("rollback nodes are not supported")
+      copy(version = version)
 
     override def byKey: Boolean =
       // TODO https://github.com/digital-asset/daml/issues/8020

--- a/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
+++ b/daml-lf/transaction/src/main/scala/com/digitalasset/daml/lf/transaction/Transaction.scala
@@ -236,7 +236,7 @@ final case class GenTransaction[Nid, +Cid](
   def serializable(f: Value[Cid] => ImmArray[String]): ImmArray[String] = {
     fold(BackStack.empty[String]) { case (errs, (_, node)) =>
       node match {
-        case Node.NodeRollback(_) => // pattern-match forces reconsideration if fields are added
+        case Node.NodeRollback(_, _) => // reconsider if fields added
           errs
         case _: Node.NodeFetch[Cid] => errs
         case nc: Node.NodeCreate[Cid] =>
@@ -254,7 +254,7 @@ final case class GenTransaction[Nid, +Cid](
   def foldValues[Z](z: Z)(f: (Z, Value[Cid]) => Z): Z =
     fold(z) { case (z, (_, n)) =>
       n match {
-        case Node.NodeRollback(_) => // pattern-match forces reconsideration if fields are added
+        case Node.NodeRollback(_, _) => // reconsider if fields added
           z
         case c: Node.NodeCreate[_] =>
           val z1 = f(z, c.arg)

--- a/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
+++ b/daml-lf/transaction/src/test/scala/com/digitalasset/daml/lf/transaction/TransactionCoderSpec.scala
@@ -134,7 +134,9 @@ class TransactionCoderSpec
     }
 
     "do transactions" in
-      forAll(noDanglingRefGenVersionedTransaction, minSuccessful(50)) { tx =>
+      // TODO https://github.com/digital-asset/daml/issues/8020
+      // should work with rollback
+      forAll(noDanglingRefGenVersionedTransaction(allowRollback = false), minSuccessful(50)) { tx =>
         val tx2 = VersionedTransaction(
           tx.version,
           tx.nodes.transform((_, node) => normalizeNode(node.updateVersion(node.version))),
@@ -165,7 +167,9 @@ class TransactionCoderSpec
       }
 
     "transactions decoding should fail when unsupported transaction version received" in
-      forAll(noDanglingRefGenTransaction, minSuccessful(50)) { tx =>
+      // TODO https://github.com/digital-asset/daml/issues/8020
+      // should work with rollback
+      forAll(noDanglingRefGenTransaction(allowRollback = false), minSuccessful(50)) { tx =>
         forAll(stringVersionGen, minSuccessful(20)) { badTxVer =>
           whenever(TransactionVersion.fromString(badTxVer).isLeft) {
             val encodedTxWithBadTxVer: proto.Transaction = assertRight(


### PR DESCRIPTION
Extend `scalacheck` testing to generate `NodeRollback` nodes
- temporarily controlled by `allowRollback`
- set `allowRollback = false` for tests which dont yet work. Marked by `TODO`
- `allowRollback = true` used in `NormalizerSpec` tests
- implement `version` support in `NodeRollback` (so `NormalizerSpec` test will pass)

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
