### PR TITLE
BigNumeric in the stdlib cleanup.

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Version.hs
@@ -152,7 +152,7 @@ featureBigNumeric :: Feature
 featureBigNumeric = Feature
     { featureName = "BigNumeric type"
       -- TODO https://github.com/digital-asset/daml/issues/8719
-      -- Update LF version number when we stabilize exceptions.
+      -- Update LF version number when we stabilize big numeric.
     , featureMinVersion = versionDev
     , featureCppFlag = Just "DAML_BIGNUMERIC"
     }

--- a/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
+++ b/compiler/daml-lf-tools/src/DA/Daml/LF/Simplifier.hs
@@ -125,17 +125,15 @@ safetyStep = \case
       BERoundNumeric      -> Safe 1
       BECastNumeric       -> Safe 0
       BEShiftNumeric      -> Safe 1
-      -- TODO https://github.com/digital-asset/daml/issues/8719
-      --  review carfully BitNumeric functions
-      BEScaleBigNumeric     -> Safe 1
-      BEPrecisionBigNumeric -> Safe 1
-      BEAddBigNumeric       -> Safe 1
-      BESubBigNumeric       -> Safe 1
-      BEMulBigNumeric       -> Safe 1
-      BEDivBigNumeric       -> Safe 1
-      BEShiftBigNumeric     -> Safe 1
-      BEToNumericBigNumeric -> Safe 0
-      BEFromNumericBigNumeric -> Safe 0
+      BEScaleBigNumeric     -> Safe 1 -- doesn't fail
+      BEPrecisionBigNumeric -> Safe 1 -- doesn't fail
+      BEAddBigNumeric       -> Safe 1 -- fails on overflow
+      BESubBigNumeric       -> Safe 1 -- fails on overflow
+      BEMulBigNumeric       -> Safe 1 -- fails on overflow
+      BEDivBigNumeric       -> Safe 3 -- takes 4 arguments, fails on division by 0
+      BEShiftBigNumeric     -> Safe 1 -- fails on overflow (shift too large)
+      BEToNumericBigNumeric -> Safe 0 -- fails on overflow (numeric doesn't fit)
+      BEFromNumericBigNumeric -> Safe 1 -- doesn't fail
       BEAddInt64          -> Safe 1
       BESubInt64          -> Safe 1
       BEMulInt64          -> Safe 1

--- a/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
+++ b/compiler/damlc/daml-lf-conversion/src/DA/Daml/LFConversion.hs
@@ -1714,8 +1714,6 @@ convertTyCon env t
                 pure $ if envLfVersion env `supports` featureTypeRep
                     then TTypeRep
                     else TUnit
-            "RoundingMode" -> pure TRoundingMode
-            "BigNumeric" -> pure TBigNumeric
             "AnyException" -> pure (TBuiltin BTAnyException)
             "GeneralError" -> pure (TBuiltin BTGeneralError)
             "ArithmeticError" -> pure (TBuiltin BTArithmeticError)

--- a/compiler/damlc/daml-prim-src/GHC/Classes.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Classes.daml
@@ -208,6 +208,13 @@ instance Eq Decimal where
     (==) = primitive @"BEEqual"
 #endif
 
+#ifdef DAML_BIGNUMERIC
+instance Eq BigNumeric where
+    (==) = primitive @"BEEqual"
+instance Eq RoundingMode where
+    (==) = primitive @"BEEqual"
+#endif
+
 instance Eq Text where
     (==) = primitive @"BEEqual"
 
@@ -334,6 +341,19 @@ instance Ord (Numeric n) where
     (>)  = primitive @"BEGreaterNumeric"
 #else
 instance Ord Decimal where
+    (<)  = primitive @"BELess"
+    (<=) = primitive @"BELessEq"
+    (>=) = primitive @"BEGreaterEq"
+    (>)  = primitive @"BEGreater"
+#endif
+
+#ifdef DAML_BIGNUMERIC
+instance Ord BigNumeric where
+    (<)  = primitive @"BELess"
+    (<=) = primitive @"BELessEq"
+    (>=) = primitive @"BEGreaterEq"
+    (>)  = primitive @"BEGreater"
+instance Ord RoundingMode where
     (<)  = primitive @"BELess"
     (<=) = primitive @"BELessEq"
     (>=) = primitive @"BEGreaterEq"

--- a/compiler/damlc/daml-prim-src/GHC/Num.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Num.daml
@@ -148,6 +148,32 @@ instance Signed IF_NUMERIC((Numeric n), Decimal) where
     signum x = if x == aunit then aunit else if x <= aunit then negate munit else munit
     abs x = if x <= aunit then negate x else x
 
+#ifdef DAML_BIGNUMERIC
+
+instance Additive BigNumeric where
+    (+) = primitive @"BEAddBigNumeric"
+    (-) = primitive @"BESubBigNumeric"
+    negate x = aunit - x
+    aunit = (primitive @"BEFromNumericBigNumeric" : Numeric 0 -> BigNumeric) (0.0 : Numeric 0)
+
+instance Multiplicative BigNumeric where
+    (*) = primitive @"BEMulBigNumeric"
+    munit = (primitive @"BEFromNumericBigNumeric" : Numeric 0 -> BigNumeric) (1.0 : Numeric 0)
+    x ^ n
+        | n == 0 = munit
+        | n == 2 = x * x
+        | n < 0 = munit / x ^ (negate n)
+        | n % 2 == 0 = (x ^ (n / 2)) ^ 2
+        | otherwise = x * x ^ (n - 1)
+
+instance Number BigNumeric
+
+instance Signed BigNumeric where
+    signum x = if x == aunit then aunit else if x <= aunit then negate munit else munit
+    abs x = if x <= aunit then negate x else x
+
+#endif
+
 -- | Use the `Divisible` class for types that can be divided.
 -- Instances should respect that division is the inverse of
 -- multiplication, i.e. `x * y / y` is equal to `x` whenever

--- a/compiler/damlc/daml-prim-src/GHC/Types.daml
+++ b/compiler/damlc/daml-prim-src/GHC/Types.daml
@@ -27,7 +27,10 @@ module GHC.Types (
 #ifdef DAML_NUMERIC
         Nat, Numeric,
 #endif
-
+#ifdef DAML_BIGNUMERIC
+        BigNumeric,
+        RoundingMode,
+#endif
     ) where
 
 import GHC.Prim
@@ -196,5 +199,22 @@ data Decimal =
   -- | HIDE
   Decimal Opaque
 
+
+#endif
+
+#ifdef DAML_BIGNUMERIC
+
+-- TODO https://github.com/digital-asset/daml/issues/8719
+--  Better documentation for BigNumeric and RoundingMode.
+
+-- | A big numeric type, capable of holding large decimal values with many digits.
+data BigNumeric =
+  -- | HIDE
+  BigNumeric Opaque
+
+-- | Represents a rounding mode for `BigNumeric` operations. See `DA.BigNumeric`.
+data RoundingMode =
+  -- | HIDE
+  RoundingMode Opaque
 
 #endif

--- a/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/BigNumeric.daml
@@ -3,16 +3,25 @@
 
 {-# LANGUAGE CPP #-}
 
+#ifndef DAML_BIGNUMERIC
+
 -- | HIDE
 module DA.BigNumeric where
 
-#ifdef DAML_BIGNUMERIC
+#else
+
 -- TODO https://github.com/digital-asset/daml/issues/8719
---  clean this module
+--  Better documentation for BigNumeric module.
+
+-- | Big Numeric type
+module DA.BigNumeric where
 
 import GHC.Types (primitive)
 
-roundingUp, roundingDown, roundingCeiling, roundingFloor, roundingHalfUp, roundingHalfDown, roundingHalfEven, roundingUnnecessary: RoundingMode
+
+-- TODO https://github.com/digital-asset/daml/issues/8719
+--  Expose these as constructors.
+roundingUp, roundingDown, roundingCeiling, roundingFloor, roundingHalfUp, roundingHalfDown, roundingHalfEven, roundingUnnecessary : RoundingMode
 roundingUp = primitive @"BERoundingUp"
 roundingDown = primitive @"BERoundingDown"
 roundingCeiling = primitive @"BERoundingCeiling"
@@ -22,6 +31,9 @@ roundingHalfDown = primitive @"BERoundingHalfDown"
 roundingHalfEven = primitive @"BERoundingHalfEven"
 roundingUnnecessary = primitive @"BERoundingUnnecessary"
 
+
+-- TODO https://github.com/digital-asset/daml/issues/8719
+--  Remove once we have literals.
 zero, one, ten: BigNumeric
 zero = fromNumeric (0.0: Numeric 0)
 one = fromNumeric (1.0: Numeric 0)
@@ -30,11 +42,6 @@ ten = fromNumeric (10.0: Numeric 0)
 scale, precision: BigNumeric -> Int
 scale = primitive @"BEScaleBigNumeric"
 precision = primitive @"BEPrecisionBigNumeric"
-
-add, sub, mul : BigNumeric -> BigNumeric -> BigNumeric
-add = primitive @"BEAddBigNumeric"
-sub = primitive @"BESubBigNumeric"
-mul = primitive @"BEMulBigNumeric"
 
 div : Int -> RoundingMode -> BigNumeric -> BigNumeric -> BigNumeric
 div = primitive @"BEDivBigNumeric"

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/LF.daml
@@ -46,11 +46,6 @@ module DA.Internal.LF
   , Any
   , TypeRep
 
-  #ifdef DAML_BIGNUMERIC
-  , RoundingMode
-  , BigNumeric
-  #endif
-
   #ifdef DAML_EXCEPTIONS
   , AnyException
   , GeneralError
@@ -278,11 +273,6 @@ instance Ord TypeRep where
   (<) = primitive @"BELess"
   (>) = primitive @"BEGreater"
 #endif -- DAML_GENERIC_COMPARISON
-#endif
-
-#ifdef DAML_BIGNUMERIC
-data RoundingMode
-data BigNumeric
 #endif
 
 #ifdef DAML_EXCEPTIONS

--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -28,6 +28,10 @@ import GHC.Types as GHC (Bool (..), Int, Ordering (..), Text, Decimal, DamlEnum,
 #ifdef DAML_NUMERIC
   , Numeric
 #endif
+#ifdef DAML_BIGNUMERIC
+  , BigNumeric
+  , RoundingMode
+#endif
   )
 -- Not reexported
 import GHC.Types (primitive)


### PR DESCRIPTION
Done in this PR:
- Moved BigNumeric and RoundingMode to GHC.Types to be alongside Numeric and Decimal
- Additive, Multiplicative, Number instances for BigNumeric
- Eq, Ord instances for BigNumeric and RoundingMode

Todo:
- BigNumeric literals in Daml
- Constructors and pattern matching for rounding mode
- Better documentation

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
