### PR TITLE
correct notifs for new linux jobs

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -394,6 +394,7 @@ jobs:
   condition: always()
   dependsOn:
     - Linux
+    - Linux_oracle
     - Linux_scala_2_13
     - macOS
     - Windows
@@ -411,6 +412,10 @@ jobs:
     Linux.machine: $[ dependencies.Linux.outputs['start.machine'] ]
     Linux.end: $[ dependencies.Linux.outputs['end.time'] ]
     Linux.status: $[ dependencies.Linux.result ]
+    Linux_oracle.start: $[ dependencies.Linux_oracle.outputs['start.time'] ]
+    Linux_oracle.machine: $[ dependencies.Linux_oracle.outputs['start.machine'] ]
+    Linux_oracle.end: $[ dependencies.Linux_oracle.outputs['end.time'] ]
+    Linux_oracle.status: $[ dependencies.Linux_oracle.result ]
     Linux_scala_2_13.start: $[ dependencies.Linux_scala_2_13.outputs['start.time'] ]
     Linux_scala_2_13.machine: $[ dependencies.Linux_scala_2_13.outputs['start.machine'] ]
     Linux_scala_2_13.end: $[ dependencies.Linux_scala_2_13.outputs['end.time'] ]
@@ -468,6 +473,14 @@ jobs:
                             "machine": "$(Linux.machine)",
                             "end": "$(Linux.end)",
                             "status": "$(Linux.status)"},
+                  "Linux_oracle": {"start": "$(Linux_oracle.start)",
+                            "machine": "$(Linux_oracle.machine)",
+                            "end": "$(Linux_oracle.end)",
+                            "status": "$(Linux_oracle.status)"},
+                  "Linux_scala_2_13": {"start": "$(Linux_scala_2_13.start)",
+                            "machine": "$(Linux_scala_2_13.machine)",
+                            "end": "$(Linux_scala_2_13.end)",
+                            "status": "$(Linux_scala_2_13.status)"},
                   "macOS": {"start": "$(macOS.start)",
                             "machine": "$(macOS.machine)",
                             "end": "$(macOS.end)",
@@ -529,6 +542,8 @@ jobs:
         #
         # release only run on releases and is skipped otherwise.
         if [[ "$(Linux.status)" != "Succeeded"
+            || "$(Linux_oracle.status)" != "Succeeded"
+            || "$(Linux_scala_2_13.status)" != "Succeeded"
             || "$(macOS.status)" != "Succeeded"
             || "$(Windows.status)" != "Succeeded"
             || ("$(is_release)" == "false" && "$(compatibility_linux.status)" != "Succeeded")


### PR DESCRIPTION
Without this we sometimes get success notifications on Slack for failed jobs.

CHANGELOG_BEGIN
CHANGELOG_END