### PR TITLE
Ledger api pruning helper to aid pruning by time

### DIFF
--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
@@ -38,7 +38,7 @@ service ParticipantPruningService {
   rpc Prune (PruneRequest) returns (PruneResponse);
 
   // Look up offset by timestamp to help determine a suitable pruning offset by ``record_time`` as exposed by the
-  // ``CommandCompletionService`` ``Checkpoint``s.
+  // ``CommandCompletionService`` Checkpoints.
   //
   // Returns the last offset of the "first" event/transaction before or at the specified timestamp.
   // Note that for ledger in which ``record_time`` increases monotonically with respect to offsets the resulting offset

--- a/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
+++ b/ledger-api/grpc-definitions/com/daml/ledger/api/v1/admin/participant_pruning_service.proto
@@ -5,12 +5,13 @@ syntax = "proto3";
 
 package com.daml.ledger.api.v1.admin;
 
+import "com/daml/ledger/api/v1/ledger_offset.proto";
+
+import "google/protobuf/timestamp.proto";
+
 option java_outer_classname = "ParticipantPruningServiceOuterClass";
 option java_package = "com.daml.ledger.api.v1.admin";
 option csharp_namespace = "Com.Daml.Ledger.Api.V1.Admin";
-
-// Status: experimental interface, will change before it is deemed production
-// ready
 
 // Prunes/truncates the "oldest" transactions from the participant (the participant Ledger Api Server plus any other
 // participant-local state) by removing a portion of the ledger in such a way that the set of future, allowed
@@ -36,6 +37,16 @@ service ParticipantPruningService {
   //   offset.
   rpc Prune (PruneRequest) returns (PruneResponse);
 
+  // Look up offset by timestamp to help determine a suitable pruning offset by ``record_time`` as exposed by the
+  // ``CommandCompletionService`` ``Checkpoint``s.
+  //
+  // Returns the last offset of the "first" event/transaction before or at the specified timestamp.
+  // Note that for ledger in which ``record_time`` increases monotonically with respect to offsets the resulting offset
+  // is uniquely defined (assuming events before or at the specified timestamp exist). For ledgers in which ``record_time``
+  // does not increase monotonically, there may be events with lower ``record_time`` at higher offsets than the returned
+  // offset. In such cases this command serves as an approximate heuristic.
+  rpc GetOffsetByTime (GetOffsetByTimeRequest) returns (GetOffsetByTimeResponse);
+
 }
 
 message PruneRequest {
@@ -49,4 +60,14 @@ message PruneRequest {
 
 message PruneResponse {
   // Empty for now, but may contain fields in the future
+}
+
+message GetOffsetByTimeRequest {
+  // Inclusive ``record_time`` timestamp up to and at which the ledger is to be pruned.
+  google.protobuf.Timestamp prune_up_to = 1;
+}
+
+message GetOffsetByTimeResponse {
+  // The absolute, inclusive offset of the last event/transaction at or before the ``prune_up_to`` input timestamp.
+  LedgerOffset offset = 1;
 }

--- a/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/ParticipantPruningServiceAuthorization.scala
+++ b/ledger/ledger-api-auth/src/main/scala/com/digitalasset/ledger/api/auth/services/ParticipantPruningServiceAuthorization.scala
@@ -5,6 +5,8 @@ package com.daml.ledger.api.auth.services
 
 import com.daml.ledger.api.auth.Authorizer
 import com.daml.ledger.api.v1.admin.participant_pruning_service.{
+  GetOffsetByTimeRequest,
+  GetOffsetByTimeResponse,
   ParticipantPruningServiceGrpc,
   PruneRequest,
   PruneResponse,
@@ -32,4 +34,6 @@ class ParticipantPruningServiceAuthorization(
   override def prune(request: PruneRequest): Future[PruneResponse] =
     authorizer.requireAdminClaims(service.prune)(request)
 
+  override def getOffsetByTime(request: GetOffsetByTimeRequest): Future[GetOffsetByTimeResponse] =
+    authorizer.requireAdminClaims(service.getOffsetByTime)(request)
 }

--- a/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
+++ b/ledger/metrics/src/main/scala/com/daml/metrics/Metrics.scala
@@ -27,7 +27,8 @@ final class Metrics(val registry: MetricRegistry) {
 
       val validation: Timer = registry.timer(Prefix :+ "validation")
       val submissions: Timer = registry.timer(Prefix :+ "submissions")
-      val submissionsRunning: Meter = registry.meter(Prefix :+ "submissions_running")
+      val submissionsRunning: Meter =
+        registry.meter(Prefix :+ "submissions_running")
 
       val failedCommandInterpretations: Meter =
         registry.meter(Prefix :+ "failed_command_interpretations")
@@ -53,12 +54,14 @@ final class Metrics(val registry: MetricRegistry) {
     object execution {
       private val Prefix: MetricName = daml.Prefix :+ "execution"
 
-      val lookupActiveContract: Timer = registry.timer(Prefix :+ "lookup_active_contract")
+      val lookupActiveContract: Timer =
+        registry.timer(Prefix :+ "lookup_active_contract")
       val lookupActiveContractPerExecution: Timer =
         registry.timer(Prefix :+ "lookup_active_contract_per_execution")
       val lookupActiveContractCountPerExecution: Histogram =
         registry.histogram(Prefix :+ "lookup_active_contract_count_per_execution")
-      val lookupContractKey: Timer = registry.timer(Prefix :+ "lookup_contract_key")
+      val lookupContractKey: Timer =
+        registry.timer(Prefix :+ "lookup_contract_key")
       val lookupContractKeyPerExecution: Timer =
         registry.timer(Prefix :+ "lookup_contract_key_per_execution")
       val lookupContractKeyCountPerExecution: Histogram =
@@ -141,7 +144,8 @@ final class Metrics(val registry: MetricRegistry) {
           private val Prefix: MetricName = committer.Prefix :+ "transaction"
 
           val runTimer: Timer = registry.timer(Prefix :+ "run_timer")
-          val interpretTimer: Timer = registry.timer(Prefix :+ "interpret_timer")
+          val interpretTimer: Timer =
+            registry.timer(Prefix :+ "interpret_timer")
           val accepts: Counter = registry.counter(Prefix :+ "accepts")
 
           def rejection(name: String): Counter =
@@ -181,35 +185,48 @@ final class Metrics(val registry: MetricRegistry) {
           val fetchInputs: Timer = registry.timer(Prefix :+ "fetch_inputs")
           val validate: Timer = registry.timer(Prefix :+ "validate")
           val commit: Timer = registry.timer(Prefix :+ "commit")
-          val transformSubmission: Timer = registry.timer(Prefix :+ "transform_submission")
+          val transformSubmission: Timer =
+            registry.timer(Prefix :+ "transform_submission")
 
-          val acquireTransactionLock: Timer = registry.timer(Prefix :+ "acquire_transaction_lock")
+          val acquireTransactionLock: Timer =
+            registry.timer(Prefix :+ "acquire_transaction_lock")
           val failedToAcquireTransaction: Timer =
             registry.timer(Prefix :+ "failed_to_acquire_transaction")
-          val releaseTransactionLock: Timer = registry.timer(Prefix :+ "release_transaction_lock")
+          val releaseTransactionLock: Timer =
+            registry.timer(Prefix :+ "release_transaction_lock")
 
-          val stateValueCache = new CacheMetrics(registry, Prefix :+ "state_value_cache")
+          val stateValueCache =
+            new CacheMetrics(registry, Prefix :+ "state_value_cache")
 
           // The below metrics are only generated during parallel validation.
           // The counters track how many submissions we're processing in parallel.
-          val batchSizes: Histogram = registry.histogram(Prefix :+ "batch_sizes")
+          val batchSizes: Histogram =
+            registry.histogram(Prefix :+ "batch_sizes")
           val receivedBatchSubmissionBytes: Histogram =
             registry.histogram(Prefix :+ "received_batch_submission_bytes")
           val receivedSubmissionBytes: Histogram =
             registry.histogram(Prefix :+ "received_submission_bytes")
 
-          val validateAndCommit: Timer = registry.timer(Prefix :+ "validate_and_commit")
+          val validateAndCommit: Timer =
+            registry.timer(Prefix :+ "validate_and_commit")
           val decode: Timer = registry.timer(Prefix :+ "decode")
-          val detectConflicts: Timer = registry.timer(Prefix :+ "detect_conflicts")
+          val detectConflicts: Timer =
+            registry.timer(Prefix :+ "detect_conflicts")
 
-          val decodeRunning: Counter = registry.counter(Prefix :+ "decode_running")
-          val fetchInputsRunning: Counter = registry.counter(Prefix :+ "fetch_inputs_running")
-          val validateRunning: Counter = registry.counter(Prefix :+ "validate_running")
-          val commitRunning: Counter = registry.counter(Prefix :+ "commit_running")
+          val decodeRunning: Counter =
+            registry.counter(Prefix :+ "decode_running")
+          val fetchInputsRunning: Counter =
+            registry.counter(Prefix :+ "fetch_inputs_running")
+          val validateRunning: Counter =
+            registry.counter(Prefix :+ "validate_running")
+          val commitRunning: Counter =
+            registry.counter(Prefix :+ "commit_running")
 
           // The below metrics are only generated for pre-execution.
-          val validatePreExecute: Timer = registry.timer(Prefix :+ "validate_pre_execute")
-          val generateWriteSets: Timer = registry.timer(Prefix :+ "generate_write_sets")
+          val validatePreExecute: Timer =
+            registry.timer(Prefix :+ "validate_pre_execute")
+          val generateWriteSets: Timer =
+            registry.timer(Prefix :+ "generate_write_sets")
 
           val validatePreExecuteRunning: Counter =
             registry.counter(Prefix :+ "validate_pre_execute_running")
@@ -221,10 +238,12 @@ final class Metrics(val registry: MetricRegistry) {
 
         val commit: Timer = registry.timer(Prefix :+ "commit")
 
-        val preExecutedCount: Counter = registry.counter(Prefix :+ "pre_executed_count")
+        val preExecutedCount: Counter =
+          registry.counter(Prefix :+ "pre_executed_count")
         val preExecutedInterpretationCosts: Histogram =
           registry.histogram(Prefix :+ "pre_executed_interpretation_costs")
-        val committedCount: Counter = registry.counter(Prefix :+ "committed_count")
+        val committedCount: Counter =
+          registry.counter(Prefix :+ "committed_count")
         val committedInterpretationCosts: Histogram =
           registry.histogram(Prefix :+ "committed_interpretation_costs")
       }
@@ -270,13 +289,15 @@ final class Metrics(val registry: MetricRegistry) {
         object queries {
           private val Prefix: MetricName = database.Prefix :+ "queries"
 
-          val selectLatestLogEntryId: Timer = registry.timer(Prefix :+ "select_latest_log_entry_id")
+          val selectLatestLogEntryId: Timer =
+            registry.timer(Prefix :+ "select_latest_log_entry_id")
           val selectFromLog: Timer = registry.timer(Prefix :+ "select_from_log")
           val selectStateValuesByKeys: Timer =
             registry.timer(Prefix :+ "select_state_values_by_keys")
           val updateOrRetrieveLedgerId: Timer =
             registry.timer(Prefix :+ "update_or_retrieve_ledger_id")
-          val insertRecordIntoLog: Timer = registry.timer(Prefix :+ "insert_record_into_log")
+          val insertRecordIntoLog: Timer =
+            registry.timer(Prefix :+ "insert_record_into_log")
           val updateState: Timer = registry.timer(Prefix :+ "update_state")
           val truncate: Timer = registry.timer(Prefix :+ "truncate")
         }
@@ -315,61 +336,86 @@ final class Metrics(val registry: MetricRegistry) {
         registry.timer(Prefix :+ "lookup_flat_transaction_by_id")
       val lookupTransactionTreeById: Timer =
         registry.timer(Prefix :+ "lookup_transaction_tree_by_id")
-      val lookupLedgerConfiguration: Timer = registry.timer(Prefix :+ "lookup_ledger_configuration")
-      val lookupMaximumLedgerTime: Timer = registry.timer(Prefix :+ "lookup_maximum_ledger_time")
+      val lookupLedgerConfiguration: Timer =
+        registry.timer(Prefix :+ "lookup_ledger_configuration")
+      val lookupMaximumLedgerTime: Timer =
+        registry.timer(Prefix :+ "lookup_maximum_ledger_time")
       val getParties: Timer = registry.timer(Prefix :+ "get_parties")
-      val listKnownParties: Timer = registry.timer(Prefix :+ "list_known_parties")
+      val listKnownParties: Timer =
+        registry.timer(Prefix :+ "list_known_parties")
       val listLfPackages: Timer = registry.timer(Prefix :+ "list_lf_packages")
       val getLfArchive: Timer = registry.timer(Prefix :+ "get_lf_archive")
       val getLfPackage: Timer = registry.timer(Prefix :+ "get_lf_package")
-      val deduplicateCommand: Timer = registry.timer(Prefix :+ "deduplicate_command")
+      val deduplicateCommand: Timer =
+        registry.timer(Prefix :+ "deduplicate_command")
       val removeExpiredDeduplicationData: Timer =
         registry.timer(Prefix :+ "remove_expired_deduplication_data")
       val stopDeduplicatingCommand: Timer =
         registry.timer(Prefix :+ "stop_deduplicating_command")
       val prune: Timer = registry.timer(Prefix :+ "prune")
+      val getOffsetByTime: Timer =
+        registry.timer(Prefix :+ "get_offset_by_time")
 
-      val publishTransaction: Timer = registry.timer(Prefix :+ "publish_transaction")
-      val publishPartyAllocation: Timer = registry.timer(Prefix :+ "publish_party_allocation")
+      val publishTransaction: Timer =
+        registry.timer(Prefix :+ "publish_transaction")
+      val publishPartyAllocation: Timer =
+        registry.timer(Prefix :+ "publish_party_allocation")
       val uploadPackages: Timer = registry.timer(Prefix :+ "upload_packages")
-      val publishConfiguration: Timer = registry.timer(Prefix :+ "publish_configuration")
+      val publishConfiguration: Timer =
+        registry.timer(Prefix :+ "publish_configuration")
 
       // FIXME Name mushing and inconsistencies here, tracked by https://github.com/digital-asset/daml/issues/5926
       object db {
         private val Prefix: MetricName = index.Prefix :+ "db"
 
-        val storePartyEntry: Timer = registry.timer(Prefix :+ "store_party_entry")
-        val storeInitialState: Timer = registry.timer(Prefix :+ "store_initial_state")
-        val storePackageEntry: Timer = registry.timer(Prefix :+ "store_package_entry")
+        val storePartyEntry: Timer =
+          registry.timer(Prefix :+ "store_party_entry")
+        val storeInitialState: Timer =
+          registry.timer(Prefix :+ "store_initial_state")
+        val storePackageEntry: Timer =
+          registry.timer(Prefix :+ "store_package_entry")
 
-        val storeTransaction: Timer = registry.timer(Prefix :+ "store_ledger_entry")
-        val storeTransactionEvents: Timer = registry.timer(Prefix :+ "store_ledger_entry_events")
-        val storeTransactionState: Timer = registry.timer(Prefix :+ "store_ledger_entry_state")
+        val storeTransaction: Timer =
+          registry.timer(Prefix :+ "store_ledger_entry")
+        val storeTransactionEvents: Timer =
+          registry.timer(Prefix :+ "store_ledger_entry_events")
+        val storeTransactionState: Timer =
+          registry.timer(Prefix :+ "store_ledger_entry_state")
         val storeTransactionCompletion: Timer =
           registry.timer(Prefix :+ "store_ledger_entry_completion")
 
         val storeRejection: Timer = registry.timer(Prefix :+ "store_rejection")
-        val storeConfigurationEntry: Timer = registry.timer(Prefix :+ "store_configuration_entry")
+        val storeConfigurationEntry: Timer =
+          registry.timer(Prefix :+ "store_configuration_entry")
 
         val lookupLedgerId: Timer = registry.timer(Prefix :+ "lookup_ledger_id")
-        val lookupParticipantId: Timer = registry.timer(Prefix :+ "lookup_participant_id")
-        val lookupLedgerEnd: Timer = registry.timer(Prefix :+ "lookup_ledger_end")
-        val lookupTransaction: Timer = registry.timer(Prefix :+ "lookup_transaction")
+        val lookupParticipantId: Timer =
+          registry.timer(Prefix :+ "lookup_participant_id")
+        val lookupLedgerEnd: Timer =
+          registry.timer(Prefix :+ "lookup_ledger_end")
+        val lookupTransaction: Timer =
+          registry.timer(Prefix :+ "lookup_transaction")
         val lookupLedgerConfiguration: Timer =
           registry.timer(Prefix :+ "lookup_ledger_configuration")
         val lookupKey: Timer = registry.timer(Prefix :+ "lookup_key")
-        val lookupActiveContract: Timer = registry.timer(Prefix :+ "lookup_active_contract")
-        val lookupMaximumLedgerTime: Timer = registry.timer(Prefix :+ "lookup_maximum_ledger_time")
+        val lookupActiveContract: Timer =
+          registry.timer(Prefix :+ "lookup_active_contract")
+        val lookupMaximumLedgerTime: Timer =
+          registry.timer(Prefix :+ "lookup_maximum_ledger_time")
         val getParties: Timer = registry.timer(Prefix :+ "get_parties")
-        val listKnownParties: Timer = registry.timer(Prefix :+ "list_known_parties")
+        val listKnownParties: Timer =
+          registry.timer(Prefix :+ "list_known_parties")
         val listLfPackages: Timer = registry.timer(Prefix :+ "list_lf_packages")
         val getLfArchive: Timer = registry.timer(Prefix :+ "get_lf_archive")
-        val deduplicateCommand: Timer = registry.timer(Prefix :+ "deduplicate_command")
+        val deduplicateCommand: Timer =
+          registry.timer(Prefix :+ "deduplicate_command")
         val removeExpiredDeduplicationData: Timer =
           registry.timer(Prefix :+ "remove_expired_deduplication_data")
         val stopDeduplicatingCommand: Timer =
           registry.timer(Prefix :+ "stop_deduplicating_command")
         val prune: Timer = registry.timer(Prefix :+ "prune")
+        val getOffsetByTime: Timer =
+          registry.timer(Prefix :+ "get_offset_by_time")
 
         private val createDbMetrics: String => DatabaseMetrics =
           new DatabaseMetrics(registry, Prefix, _)
@@ -402,20 +448,26 @@ final class Metrics(val registry: MetricRegistry) {
         object storeTransactionDbMetrics
             extends DatabaseMetrics(registry, Prefix, "store_ledger_entry") {
           // outside of SQL transaction
-          val prepareBatches: Timer = registry.timer(dbPrefix :+ "prepare_batches")
+          val prepareBatches: Timer =
+            registry.timer(dbPrefix :+ "prepare_batches")
 
           // in order within SQL transaction
-          val commitValidation: Timer = registry.timer(dbPrefix :+ "commit_validation")
+          val commitValidation: Timer =
+            registry.timer(dbPrefix :+ "commit_validation")
           val eventsBatch: Timer = registry.timer(dbPrefix :+ "events_batch")
           val deleteContractWitnessesBatch: Timer =
             registry.timer(dbPrefix :+ "delete_contract_witnesses_batch")
-          val deleteContractsBatch: Timer = registry.timer(dbPrefix :+ "delete_contracts_batch")
-          val insertContractsBatch: Timer = registry.timer(dbPrefix :+ "insert_contracts_batch")
+          val deleteContractsBatch: Timer =
+            registry.timer(dbPrefix :+ "delete_contracts_batch")
+          val insertContractsBatch: Timer =
+            registry.timer(dbPrefix :+ "insert_contracts_batch")
           val insertContractWitnessesBatch: Timer =
             registry.timer(dbPrefix :+ "insert_contract_witnesses_batch")
 
-          val insertCompletion: Timer = registry.timer(dbPrefix :+ "insert_completion")
-          val updateLedgerEnd: Timer = registry.timer(dbPrefix :+ "update_ledger_end")
+          val insertCompletion: Timer =
+            registry.timer(dbPrefix :+ "insert_completion")
+          val updateLedgerEnd: Timer =
+            registry.timer(dbPrefix :+ "update_ledger_end")
         }
         val storeRejectionDbMetrics: DatabaseMetrics = createDbMetrics(
           "store_rejection"
@@ -434,22 +486,28 @@ final class Metrics(val registry: MetricRegistry) {
         val deduplicateCommandDbMetrics: DatabaseMetrics = createDbMetrics(
           "deduplicate_command"
         ) // FIXME Base name conflicts with deduplicateCommand
-        val removeExpiredDeduplicationDataDbMetrics: DatabaseMetrics = createDbMetrics(
-          "remove_expired_deduplication_data"
-        ) // FIXME Base name conflicts with removeExpiredDeduplicationData
-        val stopDeduplicatingCommandDbMetrics: DatabaseMetrics = createDbMetrics(
-          "stop_deduplicating_command"
-        ) // FIXME Base name conflicts with stopDeduplicatingCommand
+        val removeExpiredDeduplicationDataDbMetrics: DatabaseMetrics =
+          createDbMetrics(
+            "remove_expired_deduplication_data"
+          ) // FIXME Base name conflicts with removeExpiredDeduplicationData
+        val stopDeduplicatingCommandDbMetrics: DatabaseMetrics =
+          createDbMetrics(
+            "stop_deduplicating_command"
+          ) // FIXME Base name conflicts with stopDeduplicatingCommand
         val pruneDbMetrics: DatabaseMetrics = createDbMetrics(
           "prune"
         ) // FIXME Base name conflicts with prune
+        val getOffsetByTimeDbMetrics: DatabaseMetrics = createDbMetrics(
+          "getOffsetByTime"
+        ) // FIXME Base name conflicts with getOffsetByTime
         val truncateAllTables: DatabaseMetrics = createDbMetrics("truncate_all_tables")
         val lookupActiveContractDbMetrics: DatabaseMetrics = createDbMetrics(
           "lookup_active_contract"
         ) // FIXME Base name conflicts with lookupActiveContract
-        val lookupActiveContractWithCachedArgumentDbMetrics: DatabaseMetrics = createDbMetrics(
-          "lookup_active_contract_with_cached_argument"
-        )
+        val lookupActiveContractWithCachedArgumentDbMetrics: DatabaseMetrics =
+          createDbMetrics(
+            "lookup_active_contract_with_cached_argument"
+          )
         val lookupContractByKey: DatabaseMetrics = createDbMetrics("lookup_contract_by_key")
         val lookupMaximumLedgerTimeDbMetrics: DatabaseMetrics = createDbMetrics(
           "lookup_maximum_ledger_time"
@@ -513,7 +571,8 @@ final class Metrics(val registry: MetricRegistry) {
         registry,
       )
 
-      val stateUpdateProcessing: Timer = registry.timer(Prefix :+ "processed_state_updates")
+      val stateUpdateProcessing: Timer =
+        registry.timer(Prefix :+ "processed_state_updates")
     }
 
     object services {
@@ -526,27 +585,44 @@ final class Metrics(val registry: MetricRegistry) {
         val getLfArchive: Timer = registry.timer(Prefix :+ "get_lf_archive")
         val getLfPackage: Timer = registry.timer(Prefix :+ "get_lf_package")
         val packageEntries: Timer = registry.timer(Prefix :+ "package_entries")
-        val getLedgerConfiguration: Timer = registry.timer(Prefix :+ "get_ledger_configuration")
-        val currentLedgerEnd: Timer = registry.timer(Prefix :+ "current_ledger_end")
+        val getLedgerConfiguration: Timer =
+          registry.timer(Prefix :+ "get_ledger_configuration")
+        val currentLedgerEnd: Timer =
+          registry.timer(Prefix :+ "current_ledger_end")
         val getCompletions: Timer = registry.timer(Prefix :+ "get_completions")
         val transactions: Timer = registry.timer(Prefix :+ "transactions")
-        val transactionTrees: Timer = registry.timer(Prefix :+ "transaction_trees")
-        val getTransactionById: Timer = registry.timer(Prefix :+ "get_transaction_by_id")
-        val getTransactionTreeById: Timer = registry.timer(Prefix :+ "get_transaction_tree_by_id")
-        val getActiveContracts: Timer = registry.timer(Prefix :+ "get_active_contracts")
-        val lookupActiveContract: Timer = registry.timer(Prefix :+ "lookup_active_contract")
-        val lookupContractKey: Timer = registry.timer(Prefix :+ "lookup_contract_key")
-        val lookupMaximumLedgerTime: Timer = registry.timer(Prefix :+ "lookup_maximum_ledger_time")
+        val transactionTrees: Timer =
+          registry.timer(Prefix :+ "transaction_trees")
+        val getTransactionById: Timer =
+          registry.timer(Prefix :+ "get_transaction_by_id")
+        val getTransactionTreeById: Timer =
+          registry.timer(Prefix :+ "get_transaction_tree_by_id")
+        val getActiveContracts: Timer =
+          registry.timer(Prefix :+ "get_active_contracts")
+        val lookupActiveContract: Timer =
+          registry.timer(Prefix :+ "lookup_active_contract")
+        val lookupContractKey: Timer =
+          registry.timer(Prefix :+ "lookup_contract_key")
+        val lookupMaximumLedgerTime: Timer =
+          registry.timer(Prefix :+ "lookup_maximum_ledger_time")
         val getLedgerId: Timer = registry.timer(Prefix :+ "get_ledger_id")
-        val getParticipantId: Timer = registry.timer(Prefix :+ "get_participant_id")
+        val getParticipantId: Timer =
+          registry.timer(Prefix :+ "get_participant_id")
         val getParties: Timer = registry.timer(Prefix :+ "get_parties")
-        val listKnownParties: Timer = registry.timer(Prefix :+ "list_known_parties")
+        val listKnownParties: Timer =
+          registry.timer(Prefix :+ "list_known_parties")
         val partyEntries: Timer = registry.timer(Prefix :+ "party_entries")
-        val lookupConfiguration: Timer = registry.timer(Prefix :+ "lookup_configuration")
-        val configurationEntries: Timer = registry.timer(Prefix :+ "configuration_entries")
-        val deduplicateCommand: Timer = registry.timer(Prefix :+ "deduplicate_command")
-        val stopDeduplicateCommand: Timer = registry.timer(Prefix :+ "stop_deduplicating_command")
+        val lookupConfiguration: Timer =
+          registry.timer(Prefix :+ "lookup_configuration")
+        val configurationEntries: Timer =
+          registry.timer(Prefix :+ "configuration_entries")
+        val deduplicateCommand: Timer =
+          registry.timer(Prefix :+ "deduplicate_command")
+        val stopDeduplicateCommand: Timer =
+          registry.timer(Prefix :+ "stop_deduplicating_command")
         val prune: Timer = registry.timer(Prefix :+ "prune")
+        val getOffsetByTime: Timer =
+          registry.timer(Prefix :+ "get_offset_by_time")
       }
 
       object read {
@@ -560,11 +636,14 @@ final class Metrics(val registry: MetricRegistry) {
       object write {
         private val Prefix: MetricName = services.Prefix :+ "write"
 
-        val submitTransaction: Timer = registry.timer(Prefix :+ "submit_transaction")
-        val submitTransactionRunning: Meter = registry.meter(Prefix :+ "submit_transaction_running")
+        val submitTransaction: Timer =
+          registry.timer(Prefix :+ "submit_transaction")
+        val submitTransactionRunning: Meter =
+          registry.meter(Prefix :+ "submit_transaction_running")
         val uploadPackages: Timer = registry.timer(Prefix :+ "upload_packages")
         val allocateParty: Timer = registry.timer(Prefix :+ "allocate_party")
-        val submitConfiguration: Timer = registry.timer(Prefix :+ "submit_configuration")
+        val submitConfiguration: Timer =
+          registry.timer(Prefix :+ "submit_configuration")
         val prune: Timer = registry.timer(Prefix :+ "prune")
       }
     }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/SpannedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/SpannedIndexService.scala
@@ -198,6 +198,11 @@ private[daml] final class SpannedIndexService(delegate: IndexService) extends In
   ): Future[Unit] =
     delegate.prune(pruneUpToInclusive)
 
+  override def getOffsetByTime(pruneUpToInclusive: Instant)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Offset]] =
+    delegate.getOffsetByTime(pruneUpToInclusive)
+
   override def currentHealth(): HealthStatus =
     delegate.currentHealth()
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/TimedIndexService.scala
@@ -228,6 +228,14 @@ private[daml] final class TimedIndexService(delegate: IndexService, metrics: Met
       delegate.prune(pruneUpToInclusive),
     )
 
+  override def getOffsetByTime(
+      pruneUpToInclusive: Instant
+  )(implicit loggingContext: LoggingContext): Future[Option[Offset]] =
+    Timed.future(
+      metrics.daml.services.index.getOffsetByTime,
+      delegate.getOffsetByTime(pruneUpToInclusive),
+    )
+
   override def currentHealth(): HealthStatus =
     delegate.currentHealth()
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/apiserver/services/logging/package.scala
@@ -86,5 +86,7 @@ package object logging {
       )
     cmds.workflowId.fold(context)(context + workflowId(_))
   }
+  private[services] def pruneUpToTimestamp(ts: Instant): (String, String) =
+    "pruneUpToTimestamp" -> ts.toString
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/index/MeteredReadOnlyLedger.scala
@@ -59,7 +59,8 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
   ): Source[(Offset, GetTransactionTreesResponse), NotUsed] =
     ledger.transactionTrees(startExclusive, endInclusive, requestingParties, verbose)
 
-  override def ledgerEnd()(implicit loggingContext: LoggingContext): Offset = ledger.ledgerEnd()
+  override def ledgerEnd()(implicit loggingContext: LoggingContext): Offset =
+    ledger.ledgerEnd()
 
   override def completions(
       startExclusive: Option[Offset],
@@ -176,9 +177,9 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
       ledger.deduplicateCommand(commandId, submitters, submittedAt, deduplicateUntil),
     )
 
-  override def removeExpiredDeduplicationData(currentTime: Instant)(implicit
-      loggingContext: LoggingContext
-  ): Future[Unit] =
+  override def removeExpiredDeduplicationData(
+      currentTime: Instant
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
     Timed.future(
       metrics.daml.index.removeExpiredDeduplicationData,
       ledger.removeExpiredDeduplicationData(currentTime),
@@ -199,6 +200,14 @@ private[platform] class MeteredReadOnlyLedger(ledger: ReadOnlyLedger, metrics: M
     Timed.future(
       metrics.daml.index.prune,
       ledger.prune(pruneUpToInclusive),
+    )
+
+  override def getOffsetByTime(
+      pruneUpToInclusive: Instant
+  )(implicit loggingContext: LoggingContext): Future[Option[Offset]] =
+    Timed.future(
+      metrics.daml.index.getOffsetByTime,
+      ledger.getOffsetByTime(pruneUpToInclusive),
     )
 }
 

--- a/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/BaseLedger.scala
@@ -64,7 +64,10 @@ private[platform] abstract class BaseLedger(
   )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionsResponse), NotUsed] =
     dispatcher.startingAt(
       startExclusive.getOrElse(Offset.beforeBegin),
-      RangeSource(ledgerDao.transactionsReader.getFlatTransactions(_, _, filter, verbose)),
+      RangeSource(
+        ledgerDao.transactionsReader
+          .getFlatTransactions(_, _, filter, verbose)
+      ),
       endInclusive,
     )
 
@@ -84,7 +87,8 @@ private[platform] abstract class BaseLedger(
       endInclusive,
     )
 
-  override def ledgerEnd()(implicit loggingContext: LoggingContext): Offset = dispatcher.getHead()
+  override def ledgerEnd()(implicit loggingContext: LoggingContext): Offset =
+    dispatcher.getHead()
 
   override def completions(
       startExclusive: Option[Offset],
@@ -94,7 +98,10 @@ private[platform] abstract class BaseLedger(
   )(implicit loggingContext: LoggingContext): Source[(Offset, CompletionStreamResponse), NotUsed] =
     dispatcher.startingAt(
       startExclusive.getOrElse(Offset.beforeBegin),
-      RangeSource(ledgerDao.completions.getCommandCompletions(_, _, applicationId.unwrap, parties)),
+      RangeSource(
+        ledgerDao.completions
+          .getCommandCompletions(_, _, applicationId.unwrap, parties)
+      ),
       endInclusive,
     )
 
@@ -120,13 +127,15 @@ private[platform] abstract class BaseLedger(
       transactionId: TransactionId,
       requestingParties: Set[Party],
   )(implicit loggingContext: LoggingContext): Future[Option[GetFlatTransactionResponse]] =
-    ledgerDao.transactionsReader.lookupFlatTransactionById(transactionId, requestingParties)
+    ledgerDao.transactionsReader
+      .lookupFlatTransactionById(transactionId, requestingParties)
 
   override def lookupTransactionTreeById(
       transactionId: TransactionId,
       requestingParties: Set[Party],
   )(implicit loggingContext: LoggingContext): Future[Option[GetTransactionResponse]] =
-    ledgerDao.transactionsReader.lookupTransactionTreeById(transactionId, requestingParties)
+    ledgerDao.transactionsReader
+      .lookupTransactionTreeById(transactionId, requestingParties)
 
   override def lookupMaximumLedgerTime(
       contractIds: Set[ContractId]
@@ -158,9 +167,9 @@ private[platform] abstract class BaseLedger(
   ): Future[Option[DamlLf.Archive]] =
     ledgerDao.getLfArchive(packageId)
 
-  override def getLfPackage(packageId: PackageId)(implicit
-      loggingContext: LoggingContext
-  ): Future[Option[Ast.Package]] =
+  override def getLfPackage(
+      packageId: PackageId
+  )(implicit loggingContext: LoggingContext): Future[Option[Ast.Package]] =
     ledgerDao
       .getLfArchive(packageId)
       .flatMap(archiveO =>
@@ -204,6 +213,10 @@ private[platform] abstract class BaseLedger(
       loggingContext: LoggingContext
   ): Future[Unit] =
     ledgerDao.prune(pruneUpToInclusive)
+
+  override def getOffsetByTime(pruneUpToInclusive: Instant)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Offset]] = ???
 
   override def close(): Unit = ()
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/ReadOnlyLedger.scala
@@ -170,4 +170,10 @@ private[platform] trait ReadOnlyLedger extends ReportsHealth with AutoCloseable 
   /** Performs participant ledger pruning up to and including the specified offset.
     */
   def prune(pruneUpToInclusive: Offset)(implicit loggingContext: LoggingContext): Future[Unit]
+
+  /** Enables looking up a pruning offset based on an instant in record time.
+    */
+  def getOffsetByTime(pruneUpToInclusive: Instant)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Offset]]
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsReader.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsReader.scala
@@ -3,6 +3,8 @@
 
 package com.daml.platform.store.dao
 
+import java.time.Instant
+
 import akka.NotUsed
 import akka.stream.scaladsl.Source
 import com.daml.ledger.participant.state.v1.Offset
@@ -60,4 +62,13 @@ private[dao] final class CommandCompletionsReader(
       .mapConcat(_.map(response => offsetFor(response) -> response))
   }
 
+  override def getOffsetFromTime(
+      pruneUpToInclusive: Instant
+  )(implicit loggingContext: LoggingContext): Future[Option[Offset]] = {
+    dispatcher.executeSql(metrics.daml.index.db.getOffsetByTimeDbMetrics) { implicit conn =>
+      CommandCompletionsTable
+        .prepareGetOffsetFromTime(pruneUpToInclusive)
+        .as(CommandCompletionsTable.offsetParser.singleOpt)
+    }
+  }
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsTable.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/CommandCompletionsTable.scala
@@ -43,6 +43,8 @@ private[platform] object CommandCompletionsTable {
 
   val parser: RowParser[CompletionStreamResponse] = acceptedCommandParser | rejectedCommandParser
 
+  val offsetParser: RowParser[Offset] = offset("completion_offset")
+
   def prepareGet(
       startExclusive: Offset,
       endInclusive: Offset,
@@ -75,5 +77,9 @@ private[platform] object CommandCompletionsTable {
 
   def prepareCompletionsDelete(endInclusive: Offset): SimpleSql[Row] =
     SQL"delete from participant_command_completions where completion_offset <= $endInclusive"
+
+  def prepareGetOffsetFromTime(pruneUpToInclusive: Instant): SimpleSql[Row] =
+    SQL"""select max(completion_offset) from participant_command_completions where completion_offset < (
+            select min(completion_offset) from participant_command_completions where record_time > ${pruneUpToInclusive})"""
 
 }

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/JdbcLedgerDao.scala
@@ -924,6 +924,11 @@ private class JdbcLedgerDao(
       logger.info(s"Pruned ledger api server index db up to ${pruneUpToInclusive.toHexString}")
     }
 
+  override def getOffsetByTime(pruneUpToInclusive: Instant)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Offset]] =
+    completions.getOffsetFromTime(pruneUpToInclusive)
+
   override def reset()(implicit loggingContext: LoggingContext): Future[Unit] =
     dbDispatcher.executeSql(metrics.daml.index.db.truncateAllTables) { implicit conn =>
       val _ = SQL(queries.SQL_TRUNCATE_TABLES).execute()

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/LedgerDao.scala
@@ -65,9 +65,7 @@ private[platform] trait LedgerDaoTransactionsReader {
       endInclusive: Offset,
       requestingParties: Set[Party],
       verbose: Boolean,
-  )(implicit
-      loggingContext: LoggingContext
-  ): Source[(Offset, GetTransactionTreesResponse), NotUsed]
+  )(implicit loggingContext: LoggingContext): Source[(Offset, GetTransactionTreesResponse), NotUsed]
 
   def lookupTransactionTreeById(
       transactionId: TransactionId,
@@ -87,9 +85,11 @@ private[platform] trait LedgerDaoCommandCompletionsReader {
       endInclusive: Offset,
       applicationId: ApplicationId,
       parties: Set[Ref.Party],
-  )(implicit
+  )(implicit loggingContext: LoggingContext): Source[(Offset, CompletionStreamResponse), NotUsed]
+
+  def getOffsetFromTime(pruneUpToInclusive: Instant)(implicit
       loggingContext: LoggingContext
-  ): Source[(Offset, CompletionStreamResponse), NotUsed]
+  ): Future[Option[Offset]]
 }
 
 private[platform] trait LedgerReadDao extends ReportsHealth {
@@ -222,6 +222,15 @@ private[platform] trait LedgerReadDao extends ReportsHealth {
     * @return
     */
   def prune(pruneUpToInclusive: Offset)(implicit loggingContext: LoggingContext): Future[Unit]
+
+  /** Looks up a participant pruning offset based on a provided instant in record time.
+    *
+    * @param pruneUpToInclusive instant in record time to look up an offset for up to which to prune inclusively
+    * @return offset up to which to prune archived history inclusively for use in conjunction with [[prune]]
+    */
+  def getOffsetByTime(pruneUpToInclusive: Instant)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Offset]]
 }
 
 private[platform] trait LedgerWriteDao extends ReportsHealth {

--- a/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
+++ b/ledger/participant-integration-api/src/main/scala/platform/store/dao/MeteredLedgerDao.scala
@@ -72,7 +72,8 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
       ledgerDao.lookupMaximumLedgerTime(contractIds),
     )
 
-  override def transactionsReader: LedgerDaoTransactionsReader = ledgerDao.transactionsReader
+  override def transactionsReader: LedgerDaoTransactionsReader =
+    ledgerDao.transactionsReader
 
   override def lookupKey(key: GlobalKey, forParties: Set[Party])(implicit
       loggingContext: LoggingContext
@@ -127,7 +128,8 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
   )(implicit loggingContext: LoggingContext): Source[(Offset, ConfigurationEntry), NotUsed] =
     ledgerDao.getConfigurationEntries(startExclusive, endInclusive)
 
-  override val completions: LedgerDaoCommandCompletionsReader = ledgerDao.completions
+  override val completions: LedgerDaoCommandCompletionsReader =
+    ledgerDao.completions
 
   override def deduplicateCommand(
       commandId: CommandId,
@@ -140,9 +142,9 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
       ledgerDao.deduplicateCommand(commandId, submitters, submittedAt, deduplicateUntil),
     )
 
-  override def removeExpiredDeduplicationData(currentTime: Instant)(implicit
-      loggingContext: LoggingContext
-  ): Future[Unit] =
+  override def removeExpiredDeduplicationData(
+      currentTime: Instant
+  )(implicit loggingContext: LoggingContext): Future[Unit] =
     Timed.future(
       metrics.daml.index.db.removeExpiredDeduplicationData,
       ledgerDao.removeExpiredDeduplicationData(currentTime),
@@ -160,6 +162,14 @@ private[platform] class MeteredLedgerReadDao(ledgerDao: LedgerReadDao, metrics: 
       loggingContext: LoggingContext
   ): Future[Unit] =
     Timed.future(metrics.daml.index.db.prune, ledgerDao.prune(pruneUpToInclusive))
+
+  override def getOffsetByTime(
+      pruneUpToInclusive: Instant
+  )(implicit loggingContext: LoggingContext): Future[Option[Offset]] =
+    Timed.future(
+      metrics.daml.index.db.getOffsetByTime,
+      ledgerDao.getOffsetByTime(pruneUpToInclusive),
+    )
 }
 
 private[platform] class MeteredLedgerDao(ledgerDao: LedgerDao, metrics: Metrics)

--- a/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexParticipantPruningService.scala
+++ b/ledger/participant-state-index/src/main/scala/com/daml/ledger/participant/state/index/v2/IndexParticipantPruningService.scala
@@ -3,6 +3,8 @@
 
 package com.daml.ledger.participant.state.index.v2
 
+import java.time.Instant
+
 import com.daml.ledger.participant.state.v1.Offset
 import com.daml.logging.LoggingContext
 
@@ -15,4 +17,7 @@ trait IndexParticipantPruningService {
 
   def prune(pruneUpToInclusive: Offset)(implicit loggingContext: LoggingContext): Future[Unit]
 
+  def getOffsetByTime(pruneUpToInclusive: Instant)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Offset]]
 }

--- a/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
+++ b/ledger/sandbox-classic/src/main/scala/platform/sandbox/stores/ledger/inmemory/InMemoryLedger.scala
@@ -654,8 +654,20 @@ private[sandbox] final class InMemoryLedger(
   override def prune(pruneUpToInclusive: Offset)(implicit
       loggingContext: LoggingContext
   ): Future[Unit] =
-    // sandbox-classic in-memory ledger does not support pruning
-    Future.failed(Status.UNIMPLEMENTED.asRuntimeException())
+    Future.failed(
+      Status.UNIMPLEMENTED
+        .withDescription("sandbox-classic in-memory ledger does not support pruning")
+        .asRuntimeException()
+    )
+
+  override def getOffsetByTime(pruneUpToInclusive: Instant)(implicit
+      loggingContext: LoggingContext
+  ): Future[Option[Offset]] =
+    Future.failed(
+      Status.UNIMPLEMENTED
+        .withDescription("sandbox-classic in-memory ledger does not support pruning")
+        .asRuntimeException()
+    )
 }
 
 private[sandbox] object InMemoryLedger {


### PR DESCRIPTION
Pruning by offset puts the burden of finding a suitable offset on the user
(see https://docs.daml.com/ops/index.html#determining-a-suitable-pruning-offset)
whereas reasoning in terms of time is more meaningful intuitively abeit
more ambiguous particularly against ledger that don't produce monotonically
increasing record time where time can "jump around" making ambiguous the
assignment of an offset to a timestamp.

This adds a "get_offset_from_time" command to the ParticipantPruningService that
returns the largest offset for which no lower offset exists with a record time
larger than the provided input timestamp.

Marked as a draft pending:
- consensus on this helper command
- adding tests to `ParticipantPruningIT`

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
