### PR TITLE
Fix ledger API test tool exclusions

### DIFF
--- a/compatibility/bazel_tools/testing.bzl
+++ b/compatibility/bazel_tools/testing.bzl
@@ -33,13 +33,17 @@ first_granular_test_tool = "1.3.0-snapshot.20200623.4546.0.4f68cfc4"
 before_grpc_error_code_breaking_change = "1.12.0-snapshot.20210323.6567.0.90c5ce70"
 after_grpc_error_code_breaking_change = "1.12.0-snapshot.20210323.6567.1.90c5ce70"
 grpc_error_code_breaking_change_exclusions = [
-    "SemanticTests:SemanticDoubleSpendBasic",
     "SemanticTests:SemanticDoubleSpendShared",
     "SemanticTests:SemanticPrivacyProjections",
     "SemanticTests:SemanticDivulgence",
     "ContractKeysIT:CKFetchOrLookup",
     "ContractKeysIT:CKNoFetchUndisclosed",
     "ContractKeysIT:CKMaintainerScoped",
+]
+
+grpc_error_code_breaking_change_exclusions_suites = [
+    "SemanticTests",
+    "ContractKeysIT",
 ]
 
 excluded_test_tool_tests = [
@@ -190,16 +194,35 @@ excluded_test_tool_tests = [
         "platform_ranges": [
             {
                 "end": before_grpc_error_code_breaking_change,
-                "exclusions": grpc_error_code_breaking_change_exclusions,
+                "exclusions": grpc_error_code_breaking_change_exclusions + ["SemanticTests:SemanticDoubleSpendBasic"],
             },
         ],
     },
     {
-        "end": before_grpc_error_code_breaking_change,
+        "end": last_nongranular_test_tool,
         "platform_ranges": [
             {
                 "start": after_grpc_error_code_breaking_change,
-                "exclusions": grpc_error_code_breaking_change_exclusions,
+                "exclusions": grpc_error_code_breaking_change_exclusions_suites,
+            },
+        ],
+    },
+    {
+        "start": first_granular_test_tool,
+        "end": "1.5.0",
+        "platform_ranges": [
+            {
+                "start": after_grpc_error_code_breaking_change,
+                "exclusions": grpc_error_code_breaking_change_exclusions + ["SemanticTests:SemanticDoubleSpend"],
+            },
+        ],
+    },
+    {
+        "start": "1.6.0",
+        "platform_ranges": [
+            {
+                "start": after_grpc_error_code_breaking_change,
+                "exclusions": grpc_error_code_breaking_change_exclusions + ["SemanticTests:SemanticDoubleSpendBasic"],
             },
         ],
     },


### PR DESCRIPTION
This fixes the exclusions added in #9218. There are two issues:

1. Old ledger API test tool versions only support excluding full test
suites.
2. Apparently SDK 1.6.0 renamend SemanticDoubleSpend to SemanticDoubleSpendBasic.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
