### PR TITLE
Generate DALFs for data-dependencies in Daml script dump

### DIFF
--- a/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
@@ -133,11 +133,11 @@ installDependencies projRoot opts sdkVer@(PackageSdkVersion thisSdkVer) pDeps pD
         -- install data-dependencies
         ----------------------------
         forM_ dataDepsDars $ extractDar >=> installDar depsDir True
-        forM_ dataDepsDalfs $ \fp -> BS.readFile fp >>= installDataDepDalf depsDir fp
+        forM_ dataDepsDalfs $ \fp -> BS.readFile fp >>= installDataDepDalf False depsDir fp
         exclPkgIds <- queryPkgIds Nothing depsDir
         rdalfs <- getDalfsFromLedger dataDepsPkgIds exclPkgIds
         forM_ rdalfs $ \RemoteDalf {..} -> do
-            installDataDepDalf depsDir (remoteDalfName <.> "dalf") remoteDalfBs
+            installDataDepDalf remoteDalfIsMain depsDir (remoteDalfName <.> "dalf") remoteDalfBs
         -- Mark received packages as well as their transitive dependencies as data dependencies.
         markAsDataRec
             (Set.fromList [remoteDalfPkgId | RemoteDalf {remoteDalfPkgId} <- rdalfs])
@@ -215,13 +215,14 @@ dalfFileName bs fp = do
     let pkgId = T.unpack $ LF.unPackageId $ LF.dalfPackageId decodedDalfPkg
     pure $ pkgId </> takeFileName fp
 
-installDataDepDalf :: FilePath -> FilePath -> BS.ByteString -> IO ()
-installDataDepDalf depsDir fp bs = do
+installDataDepDalf :: Bool -> FilePath -> FilePath -> BS.ByteString -> IO ()
+installDataDepDalf isMain depsDir fp bs = do
     fileName <- dalfFileName bs fp
     let targetFp = depsDir </> fileName
     let targetDir = takeDirectory targetFp
     unlessM (doesDirectoryExist targetDir) $ write targetFp $ BSL.fromStrict bs
     -- if the directory exists, the dalf got already installed as a dependency
+    when isMain $ markDirWith mainMarker targetDir
     markDirWith dataDepMarker targetDir
 
 data DataDeps = DataDeps

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -514,9 +514,9 @@ data DependencyInfo = DependencyInfo
   -- Note that for data-dependencies it is sufficient to list a DAR without
   -- listing all of its dependencies.
   , mainUnitIds :: [UnitId]
-  -- ^ Unit id of the main DALFs specified in dependencies.
-  -- This will be used to generate the --package flags which define which
-  -- packages are exposed by default.
+  -- ^ Unit id of the main DALFs specified in dependencies and the main DALFs
+  -- of DARs specified in data-dependencies. This will be used to generate the
+  -- --package flags which define which packages are exposed by default.
   }
 
 showDeps :: [((LF.PackageId, UnitId), LF.Version)] -> String

--- a/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/Packaging.hs
@@ -514,9 +514,9 @@ data DependencyInfo = DependencyInfo
   -- Note that for data-dependencies it is sufficient to list a DAR without
   -- listing all of its dependencies.
   , mainUnitIds :: [UnitId]
-  -- ^ Unit id of the main DALFs specified in dependencies and
-  -- data-dependencies. This will be used to generate the --package
-  -- flags which define which packages are exposed by default.
+  -- ^ Unit id of the main DALFs specified in dependencies.
+  -- This will be used to generate the --package flags which define which
+  -- packages are exposed by default.
   }
 
 showDeps :: [((LF.PackageId, UnitId), LF.Version)] -> String

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -245,6 +245,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
               , "  - daml-stdlib"
               , "  - " <> show (tmpDir </> "lib" </> "lib.dar")
               , "data-dependencies: [" <> show (tmpDir </> "a" </> "a.dar") <> "]"
+              , "build-options: [--package=a-0.0.1]"
               ]
           writeFileUTF8 (tmpDir </> "b" </> "B.daml") $ unlines
               [ "module B where"
@@ -413,6 +414,7 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
           , "source: ."
           , "dependencies: [daml-prim, daml-stdlib]"
           , "data-dependencies: [simple-dalf-0.0.0.dalf]"
+          , "build-options: [--package=simple-dalf-0.0.0]"
           ]
         writeFileUTF8 (projDir </> "A.daml") $ unlines
             [ "module A where"

--- a/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
+++ b/compiler/damlc/tests/src/DA/Test/DataDependencies.hs
@@ -245,7 +245,6 @@ tests Tools{damlc,repl,validate,davlDar,oldProjDar} = testGroup "Data Dependenci
               , "  - daml-stdlib"
               , "  - " <> show (tmpDir </> "lib" </> "lib.dar")
               , "data-dependencies: [" <> show (tmpDir </> "a" </> "a.dar") <> "]"
-              , "build-options: [--package=a-0.0.1]"
               ]
           writeFileUTF8 (tmpDir </> "b" </> "B.daml") $ unlines
               [ "module B where"

--- a/compiler/damlc/tests/src/DamlcPkgManager.hs
+++ b/compiler/damlc/tests/src/DamlcPkgManager.hs
@@ -53,7 +53,8 @@ testsForRemoteDataDependencies damlc dar =
                           , "version: 0.0.1"
                           , "source: ."
                           , "dependencies: [daml-prim, daml-stdlib]"
-                          , "data-dependencies: [ " ++ mainPkgId ++ "]"
+                          , "data-dependencies: [" ++ mainPkgId ++ "]"
+                          , "build-options: [--package=pkg-manager-test-1.0.0]"
                           , "ledger:"
                           , "  host: localhost"
                           , "  port: " <> show sandboxPort

--- a/compiler/damlc/tests/src/DamlcPkgManager.hs
+++ b/compiler/damlc/tests/src/DamlcPkgManager.hs
@@ -54,7 +54,6 @@ testsForRemoteDataDependencies damlc dar =
                           , "source: ."
                           , "dependencies: [daml-prim, daml-stdlib]"
                           , "data-dependencies: [" ++ mainPkgId ++ "]"
-                          , "build-options: [--package=pkg-manager-test-1.0.0]"
                           , "ledger:"
                           , "  host: localhost"
                           , "  port: " <> show sandboxPort

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -354,6 +354,7 @@ downloadPackage args pid = do
 data RemoteDalf = RemoteDalf
     { remoteDalfName :: String
     , remoteDalfBs :: BS.ByteString
+    , remoteDalfIsMain :: Bool
     , remoteDalfPkgId :: LF.PackageId
     }
 -- | Fetch remote packages.
@@ -377,6 +378,7 @@ runLedgerGetDalfs lflags pkgIds exclPkgIds
             , let remoteDalfPkgId = pid
             , let remoteDalfName = T.unpack $ recoverPackageName pkg pid
             , let remoteDalfBs = BSL.toStrict bsl
+            , let remoteDalfIsMain = pid `Set.member` Set.fromList pkgIds
             ]
 
 listParties :: LedgerArgs -> IO [L.PartyDetails]

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -354,7 +354,6 @@ downloadPackage args pid = do
 data RemoteDalf = RemoteDalf
     { remoteDalfName :: String
     , remoteDalfBs :: BS.ByteString
-    , remoteDalfIsMain :: Bool
     , remoteDalfPkgId :: LF.PackageId
     }
 -- | Fetch remote packages.
@@ -378,7 +377,6 @@ runLedgerGetDalfs lflags pkgIds exclPkgIds
             , let remoteDalfPkgId = pid
             , let remoteDalfName = T.unpack $ recoverPackageName pkg pid
             , let remoteDalfBs = BSL.toStrict bsl
-            , let remoteDalfIsMain = pid `Set.member` Set.fromList pkgIds
             ]
 
 listParties :: LedgerArgs -> IO [L.PartyDetails]

--- a/daml-script/dump/BUILD.bazel
+++ b/daml-script/dump/BUILD.bazel
@@ -28,7 +28,6 @@ da_scala_binary(
     deps = [
         "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/archive:daml_lf_dev_archive_proto_java",
-        "//daml-lf/archive/encoder",
         "//daml-lf/data",
         "//daml-lf/language",
         "//language-support/scala/bindings",
@@ -50,7 +49,6 @@ da_scala_test(
     visibility = ["//visibility:public"],
     deps = [
         ":dump",
-        "//daml-lf/archive:daml_lf_archive_reader",
         "//daml-lf/data",
         "//daml-lf/language",
         "//language-support/scala/bindings",

--- a/daml-script/dump/src/main/scala/com/daml/script/dump/Dependencies.scala
+++ b/daml-script/dump/src/main/scala/com/daml/script/dump/Dependencies.scala
@@ -3,11 +3,12 @@
 
 package com.daml.script.dump
 
+import java.io.FileOutputStream
 import java.nio.file.Path
 
 import com.daml.daml_lf_dev.DamlLf
 import com.daml.ledger.client.LedgerClient
-import com.daml.lf.archive.{Dar, DarWriter, Decode}
+import com.daml.lf.archive.Decode
 import com.daml.lf.archive.Reader.damlLfCodedInputStreamFromBytes
 import com.daml.lf.data.Ref
 import com.daml.lf.data.Ref.PackageId
@@ -16,7 +17,6 @@ import com.google.protobuf.ByteString
 
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
-import scalaz.syntax.traverse._
 
 object Dependencies {
 
@@ -48,8 +48,7 @@ object Dependencies {
     go(references, Map.empty)
   }
 
-  def targetLfVersion(dependencies: Seq[Dar[LanguageVersion]]): Option[LanguageVersion] = {
-    val dalfs = dependencies.flatMap(_.all)
+  def targetLfVersion(dalfs: Seq[LanguageVersion]): Option[LanguageVersion] = {
     if (dalfs.isEmpty) { None }
     else { Some(dalfs.max) }
   }
@@ -57,16 +56,17 @@ object Dependencies {
   def targetFlag(v: LanguageVersion): String =
     s"--target=${v.pretty}"
 
-  def writeDar(
-      sdkVersion: String,
+  def writeDalf(
       file: Path,
-      dar: Dar[(PackageId, ByteString, Ast.Package)],
+      pkgId: PackageId,
+      bs: ByteString,
   ): Unit = {
-    DarWriter.encode(
-      sdkVersion,
-      dar.map { case (pkgId, dalf, _) => (pkgId + ".dalf", encodeDalf(pkgId, dalf).toByteArray) },
-      file,
-    )
+    val os = new FileOutputStream(file.toFile)
+    try {
+      encodeDalf(pkgId, bs).writeTo(os)
+    } finally {
+      os.close()
+    }
   }
 
   private def encodeDalf(pkgId: PackageId, bs: ByteString) =
@@ -80,31 +80,42 @@ object Dependencies {
   private val providedLibraries: Set[Ref.PackageName] =
     Set("daml-stdlib", "daml-prim", "daml-script").map(Ref.PackageName.assertFromString(_))
 
-  // Given the pkg id of a main dalf and the map of all downloaded packages produce
-  // a DAR or return None for builtin packages like daml-stdlib
-  // that don’t need to be listed in data-dependencies.
-  def toDar(
-      pkgId: PackageId,
+  private def isProvidedLibrary(pkg: Ast.Package): Boolean =
+    pkg.metadata.exists(m => providedLibraries.contains(m.name))
+
+  // Return the package-id appropriate for the --package flag if the package is not builtin.
+  def toPackages(
+      mainId: PackageId,
       pkgs: Map[PackageId, (ByteString, Ast.Package)],
-  ): Option[Dar[(PackageId, ByteString, Ast.Package)]] = {
+  ): Option[String] = {
+    for {
+      main <- pkgs.get(mainId) if !isProvidedLibrary(main._2)
+      md <- main._2.metadata
+    } yield s"${md.name}-${md.version}"
+  }
+
+  // Given the pkg id of a main dalf and the map of all downloaded packages produce
+  // a sequence of DALFs or an empty sequence for builtin packages like daml-stdlib
+  // that don’t need to be listed in data-dependencies.
+  def toDalfs(
+      mainId: PackageId,
+      pkgs: Map[PackageId, (ByteString, Ast.Package)],
+  ): Seq[(PackageId, ByteString, Ast.Package)] = {
+    // transitive dependencies including the given package itself, skipping any builtin packages
     def deps(pkgId: PackageId): Set[PackageId] = {
       @tailrec
       def go(todo: List[PackageId], acc: Set[PackageId]): Set[PackageId] =
         todo match {
           case Nil => acc
+          case p :: todo if isProvidedLibrary(pkgs(p)._2) => go(todo, acc)
           case p :: todo if acc.contains(p) => go(todo, acc)
-          case p :: todo =>
-            go(todo ++ pkgs(p)._2.directDeps.toList, acc.union(pkgs(p)._2.directDeps))
+          case p :: todo => go(todo ++ pkgs(p)._2.directDeps.toList, acc + p)
         }
-      go(List(pkgId), Set.empty) - pkgId
+      go(List(pkgId), Set.empty)
     }
     for {
-      pkg <- pkgs.get(pkgId) if !pkg._2.metadata.exists(m => providedLibraries.contains(m.name))
-    } yield {
-      Dar(
-        (pkgId, pkg._1, pkg._2),
-        deps(pkgId).toList.map(pkgId => (pkgId, pkgs(pkgId)._1, pkgs(pkgId)._2)),
-      )
-    }
+      pkgId <- deps(mainId).toList
+      pkg <- pkgs.get(pkgId).toList
+    } yield (pkgId, pkg._1, pkg._2)
   }
 }

--- a/daml-script/dump/src/test/scala/com/daml/script/dump/DependenciesSpec.scala
+++ b/daml-script/dump/src/test/scala/com/daml/script/dump/DependenciesSpec.scala
@@ -3,7 +3,6 @@
 
 package com.daml.script.dump
 
-import com.daml.lf.archive.Dar
 import com.daml.lf.language.LanguageVersion._
 
 import org.scalatest.freespec.AnyFreeSpec
@@ -16,11 +15,11 @@ class DependenciesSpec extends AnyFreeSpec with Matchers {
     "empty Seq" in {
       targetLfVersion(Seq.empty) shouldBe None
     }
-    "single DAR" in {
-      targetLfVersion(Seq(Dar(v1_8, List(v1_11)))) shouldBe Some(v1_11)
+    "single DALF" in {
+      targetLfVersion(Seq(v1_11)) shouldBe Some(v1_11)
     }
-    "multiple DARs" in {
-      targetLfVersion(Seq(Dar(v1_8, List(v1_11)), Dar(v1_12, List()))) shouldBe Some(v1_12)
+    "multiple DALFs" in {
+      targetLfVersion(Seq(v1_8, v1_11, v1_12)) shouldBe Some(v1_12)
     }
   }
   "targetFlag" - {


### PR DESCRIPTION
Closes #9085 

- DALFs in data-dependencies are no longer marked as main DALFs. This caused the LF version consistency check to fail on DALFs that were generated with a different LF version and also occurred in `dalfsFromDependencies`, e.g. `daml-prim-DA-Types`. This means that DALF data-dependencies that are imported directly need an accompanying `--package` flag.
- Daml script dump now generates DALFs for data-dependencies instead of DARs.
- Updates affected test-cases

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [x] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
