### PR TITLE
kvutils: Remove the conversions between `Raw` types.

### DIFF
--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/Raw.scala
@@ -6,8 +6,6 @@ package com.daml.ledger.participant.state.kvutils
 import com.daml.ledger.participant.state.kvutils.DamlKvutils.{DamlLogEntryId, DamlStateKey}
 import com.google.protobuf.ByteString
 
-import scala.language.implicitConversions
-
 object Raw {
 
   trait Bytes {
@@ -16,72 +14,15 @@ object Raw {
     final def size: Long = bytes.size.toLong
   }
 
-  object Bytes {
-
-    /** This implicit conversion exists to aid in migration.
-      * It will be deprecated and subsequently removed in the future.
-      */
-    @deprecated(
-      "Please use `Raw` directly. This will be removed in DAML SDK v1.12.",
-      since = "1.11",
-    )
-    implicit def `ByteString to Raw.Bytes`(bytes: ByteString): Bytes = Unknown(bytes)
-
-    /** This implicit conversion exists to aid in migration.
-      * It will be deprecated and subsequently removed in the future.
-      */
-    @deprecated(
-      "Please use `#bytes` directly. This will be removed in DAML SDK v1.12.",
-      since = "1.11",
-    )
-    implicit def `Raw.Bytes to ByteString`(raw: Bytes): ByteString = raw.bytes
-  }
-
   trait Companion[Self] {
-
     val empty: Self = apply(ByteString.EMPTY)
 
     def apply(bytes: ByteString): Self
-
-    /** This implicit conversion exists to aid in migration.
-      * It will be deprecated and subsequently removed in the future.
-      */
-    @deprecated(
-      "Please use `Raw` directly. This will be removed in DAML SDK v1.12.",
-      since = "1.11",
-    )
-    implicit def `ByteString to Self`(bytes: ByteString): Self = apply(bytes)
-
-    /** This implicit conversion exists to aid in migration.
-      * It will be deprecated and subsequently removed in the future.
-      */
-    @deprecated(
-      "Please use `Raw` directly. This will be removed in DAML SDK v1.12.",
-      since = "1.11",
-    )
-    implicit def `Raw.Bytes to Self`(rawBytes: Bytes): Self = apply(rawBytes.bytes)
-
   }
-
-  /** This case class only exists to preserve some functionality of
-    * [[com.daml.ledger.participant.state.kvutils.Bytes]].
-    */
-  @deprecated(
-    "Please migrate to another `Raw` type. This will be removed in DAML SDK v1.12.",
-    since = "1.11",
-  )
-  private final case class Unknown(override val bytes: ByteString) extends Bytes
 
   trait Key extends Bytes
 
-  object Key extends Companion[Key] {
-    @deprecated(
-      "Please migrate to one of `Raw.LogEntryId` or `Raw.StateKey`. This will be removed in DAML SDK v1.12.",
-      since = "1.11",
-    )
-    def apply(bytes: ByteString): Key =
-      UnknownKey(bytes)
-
+  object Key {
     implicit val `Key Ordering`: Ordering[Key] =
       Ordering.by(_.bytes.asReadOnlyByteBuffer)
   }

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/participant/state/kvutils/package.scala
@@ -28,13 +28,6 @@ import com.daml.metrics.MetricName
   */
 package object kvutils {
 
-  /** Alias for [[Raw.Bytes]] to aid in migration. */
-  @deprecated(
-    "Please migrate to one of the `Raw` types. This will be removed in DAML SDK v1.12.",
-    since = "1.11",
-  )
-  type Bytes = Raw.Bytes
-
   type DamlStateMap = Map[DamlStateKey, Option[DamlStateValue]]
 
   type CorrelationId = String

--- a/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
+++ b/ledger/participant-state/kvutils/src/main/scala/com/daml/ledger/validator/LedgerStateAccess.scala
@@ -87,24 +87,6 @@ trait LedgerStateOperations[+LogResult]
     extends LedgerStateReadOperations
     with LedgerStateWriteOperations[LogResult]
 
-object LedgerStateOperations {
-
-  /** Alias for [[Raw.Key]] to aid in migration. */
-  @deprecated(
-    "Please migrate to one of `Raw.LogEntryId` or `Raw.StateKey`. This will be removed in DAML SDK v1.12.",
-    since = "1.11",
-  )
-  type Key = Raw.Key
-
-  /** Alias for [[Raw.Envelope]] to aid in migration. */
-  @deprecated(
-    "Please migrate to `Raw.Envelope`. This will be removed in DAML SDK v1.12.",
-    since = "1.11",
-  )
-  type Value = Raw.Envelope
-
-}
-
 /** Convenience class for implementing read and write operations on a backing store that supports batched operations.
   */
 abstract class BatchingLedgerStateOperations[LogResult] extends LedgerStateOperations[LogResult] {


### PR DESCRIPTION
They have been deprecated since v1.11 and are due to be removed before the next major release.

### Changelog

- **[Integration Kit]** The implicit conversions between `Raw` types (and the conversions to and from `ByteString`) have been removed. You will need to explicitly convert if necessary. This should not be necessary for most use cases.

### Pull Request Checklist

- [x] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [x] Include appropriate tests
- [x] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [x] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
