### PR TITLE
remote pkgs: resolve package names in data dependencies via ledger

### DIFF
--- a/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
+++ b/compiler/daml-lf-ast/src/DA/Daml/LF/Ast/Base.hs
@@ -36,7 +36,7 @@ infixr 1 `KArrow`
 -- > [a-zA-Z0-9]+
 newtype PackageId = PackageId{unPackageId :: T.Text}
     deriving stock (Eq, Data, Generic, Ord, Show)
-    deriving newtype (Hashable, NFData, ToJSON, ToJSONKey)
+    deriving newtype (Hashable, NFData, ToJSON, ToJSONKey, FromJSON)
 
 -- | Name for a module. Must match the regex
 --

--- a/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
+++ b/compiler/damlc/lib/DA/Cli/Damlc/DependencyDb.hs
@@ -283,8 +283,8 @@ validatePkgId pkgId = do
 ---------------------
 
 data FullPkgName = FullPkgName
-    { pkgName :: LF.PackageName
-    , pkgVersion :: LF.PackageVersion
+    { pkgName :: !LF.PackageName
+    , pkgVersion :: !LF.PackageVersion
     } deriving (Eq, Ord, Show)
 
 data LockFile = LockFile

--- a/compiler/damlc/tests/src/DamlcPkgManager.hs
+++ b/compiler/damlc/tests/src/DamlcPkgManager.hs
@@ -22,6 +22,7 @@ import System.Process
 import Test.Tasty
 import Data.List
 import Test.Tasty.HUnit
+import System.Directory
 
 main :: IO ()
 main = do
@@ -67,6 +68,77 @@ testsForRemoteDataDependencies damlc dar =
                           , "  signatory p"
                           ]
                   setEnv "DAML_PROJECT" projDir True
+                  (exitCode, _stdout, stderr) <- readProcessWithExitCode damlc ["build"] ""
+                  stderr @?= ""
+                  exitCode @?= ExitSuccess
+            , testCase "package name:version data-dependency" $
+              withTempDir $ \projDir -> do
+                  InspectInfo {mainPackageId} <- getDarInfo dar
+                  let mainPkgId = T.unpack $ LF.unPackageId mainPackageId
+                  sandboxPort <- getSandboxPort
+                  writeFileUTF8 (projDir </> "daml.yaml") $
+                      unlines
+                          [ "sdk-version: " <> sdkVersion
+                          , "name: a"
+                          , "version: 0.0.1"
+                          , "source: ."
+                          , "dependencies: [daml-prim, daml-stdlib]"
+                          , "data-dependencies: [pkg-manager-test:1.0.0]"
+                          , "ledger:"
+                          , "  host: localhost"
+                          , "  port: " <> show sandboxPort
+                          ]
+                  writeFileUTF8 (projDir </> "A.daml") $
+                      unlines
+                          [ "module A where"
+                          , "import PkgManagerTest (S)"
+                          , "type U = S"
+                          , "template T with p : Party where"
+                          , "  signatory p"
+                          ]
+                  setEnv "DAML_PROJECT" projDir True
+                  (exitCode, _stdout, stderr) <- readProcessWithExitCode damlc ["build"] ""
+                  stderr @?= ""
+                  exitCode @?= ExitSuccess
+                  -- check that a lock file is written
+                  let lockFp = projDir </> "daml.lock"
+                  hasLockFile <- doesFileExist lockFp
+                  hasLockFile @?= True
+                  removeFile lockFp
+                  -- check that a lock file is updated when a missing dependency is encountered.
+                  writeFileUTF8 lockFp $ unlines
+                    [
+                        "dependencies:"
+                        , "- pkgId: 51255efad65a1751bcee749d962a135a65d12b87eb81ac961142196d8bbca535"
+                        , "  name: foo"
+                        , "  version: 0.0.1"
+                    ]
+                  removeDirectoryRecursive $ projDir </> ".daml"
+                  (exitCode, _stdout, stderr) <- readProcessWithExitCode damlc ["build"] ""
+                  stderr @?= ""
+                  exitCode @?= ExitSuccess
+                  lock <- readFile lockFp
+                  lines lock @?=
+                    [
+                        "dependencies:"
+                        , "- pkgId: " <> mainPkgId
+                        , "  name: pkg-manager-test"
+                        , "  version: 1.0.0"
+                    ]
+                  -- a second call shouldn't make any network connections. So let's set the sandbox
+                  -- port to a closed one.
+                  writeFileUTF8 (projDir </> "daml.yaml") $
+                      unlines
+                          [ "sdk-version: " <> sdkVersion
+                          , "name: a"
+                          , "version: 0.0.1"
+                          , "source: ."
+                          , "dependencies: [daml-prim, daml-stdlib]"
+                          , "data-dependencies: [pkg-manager-test:1.0.0]"
+                          , "ledger:"
+                          , "  host: localhost"
+                          , "  port: " <> show (sandboxPort + 1)
+                          ]
                   (exitCode, _stdout, stderr) <- readProcessWithExitCode damlc ["build"] ""
                   stderr @?= ""
                   exitCode @?= ExitSuccess

--- a/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
+++ b/daml-assistant/daml-helper/src/DA/Daml/Helper/Ledger.hs
@@ -353,7 +353,7 @@ downloadPackage args pid = do
     convPid (LF.PackageId text) = L.PackageId $ TL.fromStrict text
 
 data RemoteDalf = RemoteDalf
-    { remoteDalfName :: LF.PackageName
+    { remoteDalfName :: Maybe LF.PackageName
     , remoteDalfVersion :: Maybe LF.PackageVersion
     , remoteDalfBs :: BS.ByteString
     , remoteDalfIsMain :: Bool
@@ -379,8 +379,7 @@ runLedgerGetDalfs lflags pkgIds exclPkgIds
             , let (bsl, pid) = LFArchive.encodeArchiveAndHash pkg
             , let LF.Package {packageMetadata} = pkg
             , let remoteDalfPkgId = pid
-            , let remoteDalfName =
-                      maybe (LF.PackageName $ LF.unPackageId pid) LF.packageName packageMetadata
+            , let remoteDalfName = LF.packageName <$> packageMetadata
             , let remoteDalfBs = BSL.toStrict bsl
             , let remoteDalfIsMain = pid `Set.member` Set.fromList pkgIds
             , let remoteDalfVersion = LF.packageVersion <$> packageMetadata

--- a/docs/source/daml/reference/packages.rst
+++ b/docs/source/daml/reference/packages.rst
@@ -184,6 +184,39 @@ When importing packages this way, the Daml compiler will try to reconstruct the 
 
 Because of their flexibility, data-dependencies are a tool that is recommended for performing Daml model upgrades. See the :ref:`upgrade documentation <upgrade-overview>` for more details.
 
+Importing Daml packages from the project ledger
+===============================================
+
+Daml packages that have been uploaded to a ledger can be imported as data dependencies, given you
+have the necessary permissions to download these packages. To import such a package, add the package
+name and version separated by a colon to the data-dependencies stanza as follows:
+
+.. code-block:: yaml
+
+  ledger:
+    host: localhost
+    port: 6865
+  dependencies:
+  - daml-prim
+  - daml-stdlib
+  data-dependencies:
+  - foo:1.0.0
+
+If your ledger runs at the default host and port (``localhost:6865``), the ledger stanza can be
+omitted. This will fetch and install the package ``foo-1.0.0``. A ``daml.lock`` file is created at
+the root of your project directory, pinning the resolved packages to their exact package ID:
+
+.. code-block:: yaml
+
+  dependencies:
+  - pkgId: 51255efad65a1751bcee749d962a135a65d12b87eb81ac961142196d8bbca535
+    name: foo
+    version: 1.0.0
+
+The ``daml.lock`` file needs to be checked into version control of your project. This assures that
+package name/version tuples specified in your data dependencies are always resolved to the same
+package ID. To recreate or update your ``daml.lock`` file, delete it and run ``daml build`` again.
+
 .. _module_collisions:
 
 Handling module name collisions

--- a/docs/source/daml/reference/packages.rst
+++ b/docs/source/daml/reference/packages.rst
@@ -184,7 +184,7 @@ When importing packages this way, the Daml compiler will try to reconstruct the 
 
 Because of their flexibility, data-dependencies are a tool that is recommended for performing Daml model upgrades. See the :ref:`upgrade documentation <upgrade-overview>` for more details.
 
-Importing Daml packages from the project ledger
+Referencing Daml packages already on the ledger
 ===============================================
 
 Daml packages that have been uploaded to a ledger can be imported as data dependencies, given you


### PR DESCRIPTION
This adds the ability to specify package names/versions in daml.yaml in
the data-dependencies stanza. They are being resolved via the project
ledger and a newly introduced daml.lock lock file.

More tests for the caching of dependencies and resolution will be added in a follow-up PR.

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
