### PR TITLE
Bump timeout in StaticTimeIT

### DIFF
--- a/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/time/StaticTimeIT.scala
+++ b/ledger/sandbox-classic/src/test/suite/scala/platform/sandbox/services/time/StaticTimeIT.scala
@@ -32,7 +32,7 @@ class StaticTimeIT
     with Matchers {
 
   override implicit val patienceConfig: PatienceConfig =
-    PatienceConfig(timeout = scaled(Span(1, Seconds)))
+    PatienceConfig(timeout = scaled(Span(2, Seconds)))
 
   implicit private def ec: ExecutionContext = materializer.executionContext
 


### PR DESCRIPTION
This times out occasionally on CI on Windows, e.g., https://dev.azure.com/digitalasset/adadc18a-d7df-446a-aacb-86042c1619c6/_apis/build/builds/73358/logs/201.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
