### PR TITLE
Only walk list once in splitAt

### DIFF
--- a/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
+++ b/compiler/damlc/daml-stdlib-src/DA/Internal/Prelude.daml
@@ -422,7 +422,11 @@ drop n (_ :: xs)       =  drop (n-1) xs
 
 -- | Split a list at a given index.
 splitAt : Int -> [a] -> ([a], [a])
-splitAt i x = (take i x, drop i x)
+splitAt _ [] = ([], [])
+splitAt i ys@(x :: xs)
+  | i <= 0 = ([], ys)
+  | otherwise = case splitAt (i - 1) xs of
+      (a, b) -> (x :: a, b)
 
 -- | Take elements from a list while the predicate holds.
 takeWhile : (a -> Bool) -> [a] -> [a]

--- a/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
+++ b/daml-script/test/src/test-utils/com/daml/lf/engine/script/test/AbstractFuncIT.scala
@@ -269,7 +269,10 @@ abstract class AbstractFuncIT
     }
     "traceOrder" should {
       "emit trace statements in correct order" in {
-        def traceMsg(msg: String) = s"""[DA.Internal.Prelude:540]: "$msg""""
+        val msgRegex = raw"""\[DA.Internal.Prelude:\d+]: "(.*)"""".r
+        def stripLoc(msg: String) = msg match {
+          case msgRegex(msg_) => msg_
+        }
         for {
           clients <- participantClients()
           _ = LogCollector.clear()
@@ -281,7 +284,7 @@ abstract class AbstractFuncIT
         } yield {
           assert(v == SUnit)
           val logMsgs = LogCollector.events.map(_.getMessage)
-          assert(logMsgs == Seq(traceMsg("abc"), traceMsg("def"), traceMsg("abc"), traceMsg("def")))
+          assert(logMsgs.map(stripLoc(_)) == Seq("abc", "def", "abc", "def"))
         }
       }
     }


### PR DESCRIPTION
No idea if that makes a significant difference anywhere but walking
the list twice is definitely not faster.

changelog_begin
changelog_end

### Pull Request Checklist

- [ ] Read and understand the [contribution guidelines](https://github.com/digital-asset/daml/blob/main/CONTRIBUTING.md)
- [ ] Include appropriate tests
- [ ] Set a descriptive title and thorough description
- [ ] Add a reference to the [issue this PR will solve](https://github.com/digital-asset/daml/issues), if appropriate
- [ ] Include changelog additions in one or more commit message bodies between the `CHANGELOG_BEGIN` and `CHANGELOG_END` tags
- [ ] Normal production system change, include purpose of change in description

NOTE: CI is not automatically run on non-members pull-requests for security
reasons. The reviewer will have to comment with `/AzurePipelines run` to
trigger the build.
