### PR TITLE
DPP-313 migration safety check

### DIFF
--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/AppendOnlySchemaMigrationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/AppendOnlySchemaMigrationSpec.scala
@@ -1,0 +1,107 @@
+// Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.platform.store.dao
+
+import com.codahale.metrics.MetricRegistry
+import com.daml.ledger.api.domain.{LedgerId, ParticipantId}
+import com.daml.ledger.api.testing.utils.AkkaBeforeAndAfterAll
+import com.daml.ledger.resources.{Resource, ResourceContext, ResourceOwner}
+import com.daml.lf.data.Ref
+import com.daml.lf.engine.{Engine, ValueEnricher}
+import com.daml.logging.LoggingContext
+import com.daml.logging.LoggingContext.newLoggingContext
+import com.daml.metrics.Metrics
+import com.daml.platform.configuration.ServerRole
+import com.daml.platform.store.dao.events.LfValueTranslation
+import com.daml.platform.store.{DbType, FlywayMigrations}
+import com.daml.testing.postgresql.PostgresResource
+import org.flywaydb.core.api.FlywayException
+import org.scalatest.Succeeded
+import org.scalatest.wordspec.AsyncWordSpec
+
+class AppendOnlySchemaMigrationSpec extends AsyncWordSpec with AkkaBeforeAndAfterAll {
+  "Postgres flyway migration" should {
+
+    // TODO append-only: this test is disabled because the current schema uses the
+    // PARTITION keyword which is not supported in the current Postgres version
+    "successfully migrate to append-only schema if the database is empty" ignore {
+      implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
+      val resource = newLoggingContext { implicit loggingContext =>
+        for {
+          // Create an empty database
+          db <- PostgresResource.owner[ResourceContext]().acquire()
+          // Migrate to the latest stable schema
+          _ <- Resource.fromFuture(
+            new FlywayMigrations(db.url).migrate(enableAppendOnlySchema = false)
+          )
+          // Migrate the empty database to the append-only schema
+          _ <- Resource.fromFuture(
+            new FlywayMigrations(db.url).migrate(enableAppendOnlySchema = true)
+          )
+        } yield ()
+      }
+
+      // Test succeeds if all above steps complete without errors
+      for {
+        _ <- resource.asFuture
+        _ <- resource.release()
+      } yield Succeeded
+    }
+
+    // TODO append-only: remove this test after implementing data migration
+    "refuse to migrate to append-only schema if the database is not empty" in {
+      implicit val resourceContext: ResourceContext = ResourceContext(system.dispatcher)
+      val resource = newLoggingContext { implicit loggingContext =>
+        for {
+          // Create an empty database
+          db <- PostgresResource.owner[ResourceContext]().acquire()
+          // Migrate to the latest stable schema
+          _ <- Resource.fromFuture(
+            new FlywayMigrations(db.url).migrate(enableAppendOnlySchema = false)
+          )
+          // Write some data into the database
+          dao <- daoOwner(100, db.url).acquire()
+          _ <- Resource.fromFuture(dao.initializeLedger(TestLedgerId))
+          _ <- Resource.fromFuture(dao.initializeParticipantId(TestParticipantId))
+          // Attempt to migrate the non-empty database to the append-only schema - this must fail
+          error <- Resource.fromFuture(
+            new FlywayMigrations(db.url).migrate(enableAppendOnlySchema = true).failed
+          )
+        } yield error
+      }
+
+      for {
+        error <- resource.asFuture
+        _ <- resource.release()
+      } yield {
+        assert(error.isInstanceOf[FlywayException])
+      }
+    }
+
+  }
+
+  private[this] val TestLedgerId: LedgerId =
+    LedgerId("test-ledger")
+
+  private[this] val TestParticipantId: ParticipantId =
+    ParticipantId(Ref.ParticipantId.assertFromString("test-participant"))
+
+  private[this] def daoOwner(
+      eventsPageSize: Int,
+      jdbcUrl: String,
+  )(implicit
+      loggingContext: LoggingContext
+  ): ResourceOwner[LedgerDao] =
+    JdbcLedgerDao.writeOwner(
+      serverRole = ServerRole.Testing(getClass),
+      jdbcUrl = jdbcUrl,
+      connectionPoolSize = 16,
+      eventsPageSize = eventsPageSize,
+      servicesExecutionContext = executionContext,
+      metrics = new Metrics(new MetricRegistry),
+      lfValueTranslationCache = LfValueTranslation.Cache.none,
+      jdbcAsyncCommitMode = DbType.AsynchronousCommit,
+      enricher = Some(new ValueEnricher(new Engine())),
+    )
+}

--- a/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/AppendOnlySchemaMigrationSpec.scala
+++ b/ledger/participant-integration-api/src/test/suite/scala/platform/store/dao/AppendOnlySchemaMigrationSpec.scala
@@ -16,7 +16,6 @@ import com.daml.platform.configuration.ServerRole
 import com.daml.platform.store.dao.events.LfValueTranslation
 import com.daml.platform.store.{DbType, FlywayMigrations}
 import com.daml.testing.postgresql.PostgresResource
-import org.flywaydb.core.api.FlywayException
 import org.scalatest.Succeeded
 import org.scalatest.wordspec.AsyncWordSpec
 
@@ -75,7 +74,9 @@ class AppendOnlySchemaMigrationSpec extends AsyncWordSpec with AkkaBeforeAndAfte
         error <- resource.asFuture
         _ <- resource.release()
       } yield {
-        assert(error.isInstanceOf[FlywayException])
+        // safety_check is the name of a table
+        // An insert is attempted into that table which fails if the database is not empty
+        assert(error.getMessage.contains("safety_check"))
       }
     }
 


### PR DESCRIPTION
This PR adds a small test that proves that the flyway migration step that introduces the append-only schema fails if the database is not empty.

Note: This was tested manually in https://github.com/digital-asset/daml/pull/9246, I have opened a separate PR for the automated test to simplify reviews.